### PR TITLE
[PORT] Akka/Akka#27266 - Propagate stream cancellation causes

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Core.verified.txt
@@ -723,6 +723,10 @@ namespace Akka.Streams
     {
         Akka.Streams.Dsl.Source<TOut, Akka.NotUsed> Source { get; }
     }
+    public interface ISubscriptionWithCancelException : Reactive.Streams.ISubscription
+    {
+        void Cancel(System.Exception cause);
+    }
     public interface ITransformerLike<in TIn, out TOut>
     {
         bool IsComplete { get; }
@@ -919,6 +923,7 @@ namespace Akka.Streams
         public static readonly Akka.Streams.StreamDetachedException Instance;
         public StreamDetachedException() { }
         public StreamDetachedException(string message) { }
+        public StreamDetachedException(string message, System.Exception innerException) { }
     }
     public class StreamLimitReachedException : System.Exception
     {
@@ -996,6 +1001,23 @@ namespace Akka.Streams
         public StreamTcpException(string message) { }
         public StreamTcpException(string message, System.Exception innerException) { }
         protected StreamTcpException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class static SubscriptionWithCancelException
+    {
+        public sealed class NoMoreElementsNeeded : Akka.Streams.SubscriptionWithCancelException.NonFailureCancellation
+        {
+            public static readonly Akka.Streams.SubscriptionWithCancelException.NoMoreElementsNeeded Instance;
+        }
+        [Akka.Annotations.DoNotInheritAttribute()]
+        public abstract class NonFailureCancellation : System.Exception
+        {
+            protected NonFailureCancellation() { }
+            public virtual string StackTrace { get; }
+        }
+        public sealed class StageWasCompleted : Akka.Streams.SubscriptionWithCancelException.NonFailureCancellation
+        {
+            public static readonly Akka.Streams.SubscriptionWithCancelException.StageWasCompleted Instance;
+        }
     }
     public enum SubstreamCancelStrategy
     {
@@ -3461,7 +3483,7 @@ namespace Akka.Streams.Implementation
         public static void RequireNonNullException(System.Exception exception) { }
         public static void RequireNonNullSubscriber<T>(Reactive.Streams.ISubscriber<T> subscriber) { }
         public static void RequireNonNullSubscription(Reactive.Streams.ISubscription subscription) { }
-        public static void TryCancel(Reactive.Streams.ISubscription subscription) { }
+        public static void TryCancel(Reactive.Streams.ISubscription subscription, System.Exception cause) { }
         public static void TryOnComplete<T>(Reactive.Streams.ISubscriber<T> subscriber) { }
         public static void TryOnError<T>(Reactive.Streams.ISubscriber<T> subscriber, System.Exception cause) { }
         public static void TryOnNext<T>(Reactive.Streams.ISubscriber<T> subscriber, T element) { }
@@ -3835,7 +3857,7 @@ namespace Akka.Streams.Implementation.Fusing
         {
             public BatchingActorInputBoundary(int size, int id) { }
             public override Akka.Streams.Outlet Out { get; }
-            public void Cancel() { }
+            public void Cancel(System.Exception cause) { }
             public void OnComplete() { }
             public void OnError(System.Exception reason) { }
             public void OnInternalError(System.Exception reason) { }
@@ -3856,17 +3878,19 @@ namespace Akka.Streams.Implementation.Fusing
             public void OnNext(T element) { }
             public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
         }
-        public sealed class BoundarySubscription : Reactive.Streams.ISubscription
+        public sealed class BoundarySubscription : Akka.Streams.ISubscriptionWithCancelException, Reactive.Streams.ISubscription
         {
             public BoundarySubscription(Akka.Actor.IActorRef parent, Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
             public void Cancel() { }
+            public void Cancel(System.Exception cause) { }
             public void Request(long elements) { }
             public override string ToString() { }
         }
         public struct Cancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
-            public Cancel(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
+            public Cancel(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, System.Exception cause) { }
+            public System.Exception Cause { get; }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public struct ExposedPublisher : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
@@ -4063,6 +4087,11 @@ namespace Akka.Streams.Implementation.Fusing
         public void SetHandler(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Stage.IInHandler handler) { }
         public void SetHandler(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Stage.IOutHandler handler) { }
         public override string ToString() { }
+        public sealed class Cancelled
+        {
+            public readonly System.Exception Cause;
+            public Cancelled(System.Exception cause) { }
+        }
         [Akka.Annotations.InternalApiAttribute()]
         public sealed class Connection
         {
@@ -4627,7 +4656,7 @@ namespace Akka.Streams.Stage
         protected AbstractStage() { }
         protected virtual bool IsDetached { get; }
         public virtual Akka.Streams.Supervision.Directive Decide(System.Exception cause) { }
-        public abstract Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context);
+        public abstract Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context, System.Exception cause);
         public abstract Akka.Streams.Stage.IDirective OnPull(Akka.Streams.Stage.IContext context);
         public abstract Akka.Streams.Stage.IDirective OnPush(TIn element, Akka.Streams.Stage.IContext context);
         public abstract Akka.Streams.Stage.ITerminationDirective OnUpstreamFailure(System.Exception cause, Akka.Streams.Stage.IContext context);
@@ -4644,8 +4673,8 @@ namespace Akka.Streams.Stage
     {
         protected TContext Context;
         protected AbstractStage() { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context) { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(TContext context) { }
+        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context, System.Exception cause) { }
+        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(TContext context, System.Exception cause) { }
         public abstract TPullDirective OnPull(TContext context);
         public override Akka.Streams.Stage.IDirective OnPull(Akka.Streams.Stage.IContext context) { }
         public abstract TPushDirective OnPush(TIn element, TContext context);
@@ -4666,7 +4695,7 @@ namespace Akka.Streams.Stage
     public class ConditionalTerminateOutput : Akka.Streams.Stage.OutHandler
     {
         public ConditionalTerminateOutput(System.Func<bool> predicate) { }
-        public override void OnDownstreamFinish() { }
+        public override void OnDownstreamFinish(System.Exception cause) { }
         public override void OnPull() { }
     }
     [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
@@ -4713,7 +4742,9 @@ namespace Akka.Streams.Stage
         protected void AbortReading<T>(Akka.Streams.Inlet<T> inlet) { }
         protected virtual void AfterPostStop() { }
         protected virtual void BeforePreStart() { }
+        protected void Cancel<T>(Akka.Streams.Inlet<T> inlet, System.Exception cause) { }
         protected void Cancel<T>(Akka.Streams.Inlet<T> inlet) { }
+        public void CancelStage(System.Exception cause) { }
         protected void Complete<T>(Akka.Streams.Outlet<T> outlet) { }
         public void CompleteStage() { }
         public static Akka.Streams.Stage.InHandler ConditionalTerminateInput(System.Func<bool> predicate) { }
@@ -4735,6 +4766,8 @@ namespace Akka.Streams.Stage
         protected Akka.Streams.Stage.StageActor GetStageActor(Akka.Streams.Stage.StageActorRef.Receive receive) { }
         protected T Grab<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool HasBeenPulled<T>(Akka.Streams.Inlet<T> inlet) { }
+        [Akka.Annotations.InternalApiAttribute()]
+        public void InternalOnDownstreamFinish(System.Exception cause) { }
         protected bool IsAvailable<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool IsAvailable<T>(Akka.Streams.Outlet<T> outlet) { }
         protected bool IsClosed<T>(Akka.Streams.Inlet<T> inlet) { }
@@ -4750,7 +4783,7 @@ namespace Akka.Streams.Stage
         protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, Akka.Streams.Stage.IInHandler handler) { }
         protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, System.Action onPush, System.Action onUpstreamFinish = null, System.Action<System.Exception> onUpstreamFailure = null) { }
         protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, Akka.Streams.Stage.IOutHandler handler) { }
-        protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, System.Action onPull, System.Action onDownstreamFinish = null) { }
+        protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, System.Action onPull, System.Action<System.Exception> onDownstreamFinish = null) { }
         [System.ObsoleteAttribute("Use method `SetHandlers` instead. Will be removed in v1.5")]
         protected void SetHandler<TIn, TOut>(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Stage.InAndOutGraphStageLogic handler) { }
         protected void SetHandlers<TIn, TOut>(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Stage.InAndOutGraphStageLogic handler) { }
@@ -4765,8 +4798,8 @@ namespace Akka.Streams.Stage
         }
         protected sealed class LambdaOutHandler : Akka.Streams.Stage.OutHandler
         {
-            public LambdaOutHandler(System.Action onPull, System.Action onDownstreamFinish = null) { }
-            public override void OnDownstreamFinish() { }
+            public LambdaOutHandler(System.Action onPull, System.Action<System.Exception> onDownstreamFinish = null) { }
+            public override void OnDownstreamFinish(System.Exception cause) { }
             public override void OnPull() { }
         }
         [Akka.Annotations.InternalApiAttribute()]
@@ -4778,6 +4811,7 @@ namespace Akka.Streams.Stage
             public bool IsClosed { get; }
             public Akka.Streams.IGraph<Akka.Streams.SinkShape<T>, Akka.NotUsed> Sink { get; }
             public void Cancel() { }
+            public void Cancel(System.Exception cause) { }
             public T Grab() { }
             public void Pull() { }
             public void SetHandler(Akka.Streams.Stage.IInHandler handler) { }
@@ -4838,6 +4872,7 @@ namespace Akka.Streams.Stage
         Akka.Streams.Stage.ITerminationDirective AbsorbTermination();
         Akka.Streams.Stage.FreeDirective Fail(System.Exception cause);
         Akka.Streams.Stage.FreeDirective Finish();
+        Akka.Streams.Stage.FreeDirective Finish(System.Exception cause);
         Akka.Streams.Stage.IUpstreamDirective Pull();
         Akka.Streams.Stage.IDownstreamDirective Push(object element);
         Akka.Streams.Stage.IDownstreamDirective PushAndFinish(object element);
@@ -4888,7 +4923,7 @@ namespace Akka.Streams.Stage
     }
     public interface IOutHandler
     {
-        void OnDownstreamFinish();
+        void OnDownstreamFinish(System.Exception cause);
         void OnPull();
     }
     public interface IStageLogging
@@ -4909,14 +4944,14 @@ namespace Akka.Streams.Stage
     public sealed class IgnoreTerminateOutput : Akka.Streams.Stage.OutHandler
     {
         public static readonly Akka.Streams.Stage.IgnoreTerminateOutput Instance;
-        public override void OnDownstreamFinish() { }
+        public override void OnDownstreamFinish(System.Exception cause) { }
         public override void OnPull() { }
     }
     public abstract class InAndOutGraphStageLogic : Akka.Streams.Stage.GraphStageLogic, Akka.Streams.Stage.IInHandler, Akka.Streams.Stage.IOutHandler
     {
         protected InAndOutGraphStageLogic(int inCount, int outCount) { }
         protected InAndOutGraphStageLogic(Akka.Streams.Shape shape) { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
         public abstract void OnPush();
         public virtual void OnUpstreamFailure(System.Exception e) { }
@@ -4925,7 +4960,7 @@ namespace Akka.Streams.Stage
     public abstract class InAndOutHandler : Akka.Streams.Stage.IInHandler, Akka.Streams.Stage.IOutHandler
     {
         protected InAndOutHandler() { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
         public abstract void OnPush();
         public virtual void OnUpstreamFailure(System.Exception e) { }
@@ -4956,13 +4991,13 @@ namespace Akka.Streams.Stage
     {
         protected OutGraphStageLogic(int inCount, int outCount) { }
         protected OutGraphStageLogic(Akka.Streams.Shape shape) { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
     }
     public abstract class OutHandler : Akka.Streams.Stage.IOutHandler
     {
         protected OutHandler() { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
     }
     public class PushPullGraphStageWithMaterializedValue<TIn, TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.FlowShape<TIn, TOut>, TMat>

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
@@ -723,6 +723,10 @@ namespace Akka.Streams
     {
         Akka.Streams.Dsl.Source<TOut, Akka.NotUsed> Source { get; }
     }
+    public interface ISubscriptionWithCancelException : Reactive.Streams.ISubscription
+    {
+        void Cancel(System.Exception cause);
+    }
     public interface ITransformerLike<in TIn, out TOut>
     {
         bool IsComplete { get; }
@@ -919,6 +923,7 @@ namespace Akka.Streams
         public static readonly Akka.Streams.StreamDetachedException Instance;
         public StreamDetachedException() { }
         public StreamDetachedException(string message) { }
+        public StreamDetachedException(string message, System.Exception innerException) { }
     }
     public class StreamLimitReachedException : System.Exception
     {
@@ -996,6 +1001,23 @@ namespace Akka.Streams
         public StreamTcpException(string message) { }
         public StreamTcpException(string message, System.Exception innerException) { }
         protected StreamTcpException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class static SubscriptionWithCancelException
+    {
+        public sealed class NoMoreElementsNeeded : Akka.Streams.SubscriptionWithCancelException.NonFailureCancellation
+        {
+            public static readonly Akka.Streams.SubscriptionWithCancelException.NoMoreElementsNeeded Instance;
+        }
+        [Akka.Annotations.DoNotInheritAttribute()]
+        public abstract class NonFailureCancellation : System.Exception
+        {
+            protected NonFailureCancellation() { }
+            public virtual string StackTrace { get; }
+        }
+        public sealed class StageWasCompleted : Akka.Streams.SubscriptionWithCancelException.NonFailureCancellation
+        {
+            public static readonly Akka.Streams.SubscriptionWithCancelException.StageWasCompleted Instance;
+        }
     }
     public enum SubstreamCancelStrategy
     {
@@ -3461,7 +3483,7 @@ namespace Akka.Streams.Implementation
         public static void RequireNonNullException(System.Exception exception) { }
         public static void RequireNonNullSubscriber<T>(Reactive.Streams.ISubscriber<T> subscriber) { }
         public static void RequireNonNullSubscription(Reactive.Streams.ISubscription subscription) { }
-        public static void TryCancel(Reactive.Streams.ISubscription subscription) { }
+        public static void TryCancel(Reactive.Streams.ISubscription subscription, System.Exception cause) { }
         public static void TryOnComplete<T>(Reactive.Streams.ISubscriber<T> subscriber) { }
         public static void TryOnError<T>(Reactive.Streams.ISubscriber<T> subscriber, System.Exception cause) { }
         public static void TryOnNext<T>(Reactive.Streams.ISubscriber<T> subscriber, T element) { }
@@ -3837,7 +3859,7 @@ namespace Akka.Streams.Implementation.Fusing
         {
             public BatchingActorInputBoundary(int size, int id) { }
             public override Akka.Streams.Outlet Out { get; }
-            public void Cancel() { }
+            public void Cancel(System.Exception cause) { }
             public void OnComplete() { }
             public void OnError(System.Exception reason) { }
             public void OnInternalError(System.Exception reason) { }
@@ -3858,17 +3880,20 @@ namespace Akka.Streams.Implementation.Fusing
             public void OnNext(T element) { }
             public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
         }
-        public sealed class BoundarySubscription : Reactive.Streams.ISubscription
+        public sealed class BoundarySubscription : Akka.Streams.ISubscriptionWithCancelException, Reactive.Streams.ISubscription
         {
             public BoundarySubscription(Akka.Actor.IActorRef parent, Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
             public void Cancel() { }
+            public void Cancel(System.Exception cause) { }
             public void Request(long elements) { }
             public override string ToString() { }
         }
         public struct Cancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
-            public Cancel(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
+            public Cancel(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, System.Exception cause) { }
+            [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
+            public System.Exception Cause { get; }
             [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
@@ -4074,6 +4099,11 @@ namespace Akka.Streams.Implementation.Fusing
         public void SetHandler(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Stage.IInHandler handler) { }
         public void SetHandler(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Stage.IOutHandler handler) { }
         public override string ToString() { }
+        public sealed class Cancelled
+        {
+            public readonly System.Exception Cause;
+            public Cancelled(System.Exception cause) { }
+        }
         [Akka.Annotations.InternalApiAttribute()]
         public sealed class Connection
         {
@@ -4638,7 +4668,7 @@ namespace Akka.Streams.Stage
         protected AbstractStage() { }
         protected virtual bool IsDetached { get; }
         public virtual Akka.Streams.Supervision.Directive Decide(System.Exception cause) { }
-        public abstract Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context);
+        public abstract Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context, System.Exception cause);
         public abstract Akka.Streams.Stage.IDirective OnPull(Akka.Streams.Stage.IContext context);
         public abstract Akka.Streams.Stage.IDirective OnPush(TIn element, Akka.Streams.Stage.IContext context);
         public abstract Akka.Streams.Stage.ITerminationDirective OnUpstreamFailure(System.Exception cause, Akka.Streams.Stage.IContext context);
@@ -4655,8 +4685,8 @@ namespace Akka.Streams.Stage
     {
         protected TContext Context;
         protected AbstractStage() { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context) { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(TContext context) { }
+        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context, System.Exception cause) { }
+        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(TContext context, System.Exception cause) { }
         public abstract TPullDirective OnPull(TContext context);
         public override Akka.Streams.Stage.IDirective OnPull(Akka.Streams.Stage.IContext context) { }
         public abstract TPushDirective OnPush(TIn element, TContext context);
@@ -4677,7 +4707,7 @@ namespace Akka.Streams.Stage
     public class ConditionalTerminateOutput : Akka.Streams.Stage.OutHandler
     {
         public ConditionalTerminateOutput(System.Func<bool> predicate) { }
-        public override void OnDownstreamFinish() { }
+        public override void OnDownstreamFinish(System.Exception cause) { }
         public override void OnPull() { }
     }
     [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
@@ -4724,7 +4754,9 @@ namespace Akka.Streams.Stage
         protected void AbortReading<T>(Akka.Streams.Inlet<T> inlet) { }
         protected virtual void AfterPostStop() { }
         protected virtual void BeforePreStart() { }
+        protected void Cancel<T>(Akka.Streams.Inlet<T> inlet, System.Exception cause) { }
         protected void Cancel<T>(Akka.Streams.Inlet<T> inlet) { }
+        public void CancelStage(System.Exception cause) { }
         protected void Complete<T>(Akka.Streams.Outlet<T> outlet) { }
         public void CompleteStage() { }
         public static Akka.Streams.Stage.InHandler ConditionalTerminateInput(System.Func<bool> predicate) { }
@@ -4746,6 +4778,8 @@ namespace Akka.Streams.Stage
         protected Akka.Streams.Stage.StageActor GetStageActor(Akka.Streams.Stage.StageActorRef.Receive receive) { }
         protected T Grab<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool HasBeenPulled<T>(Akka.Streams.Inlet<T> inlet) { }
+        [Akka.Annotations.InternalApiAttribute()]
+        public void InternalOnDownstreamFinish(System.Exception cause) { }
         protected bool IsAvailable<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool IsAvailable<T>(Akka.Streams.Outlet<T> outlet) { }
         protected bool IsClosed<T>(Akka.Streams.Inlet<T> inlet) { }
@@ -4761,7 +4795,7 @@ namespace Akka.Streams.Stage
         protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, Akka.Streams.Stage.IInHandler handler) { }
         protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, System.Action onPush, System.Action onUpstreamFinish = null, System.Action<System.Exception> onUpstreamFailure = null) { }
         protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, Akka.Streams.Stage.IOutHandler handler) { }
-        protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, System.Action onPull, System.Action onDownstreamFinish = null) { }
+        protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, System.Action onPull, System.Action<System.Exception> onDownstreamFinish = null) { }
         [System.ObsoleteAttribute("Use method `SetHandlers` instead. Will be removed in v1.5")]
         protected void SetHandler<TIn, TOut>(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Stage.InAndOutGraphStageLogic handler) { }
         protected void SetHandlers<TIn, TOut>(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Stage.InAndOutGraphStageLogic handler) { }
@@ -4776,8 +4810,8 @@ namespace Akka.Streams.Stage
         }
         protected sealed class LambdaOutHandler : Akka.Streams.Stage.OutHandler
         {
-            public LambdaOutHandler(System.Action onPull, System.Action onDownstreamFinish = null) { }
-            public override void OnDownstreamFinish() { }
+            public LambdaOutHandler(System.Action onPull, System.Action<System.Exception> onDownstreamFinish = null) { }
+            public override void OnDownstreamFinish(System.Exception cause) { }
             public override void OnPull() { }
         }
         [Akka.Annotations.InternalApiAttribute()]
@@ -4789,6 +4823,7 @@ namespace Akka.Streams.Stage
             public bool IsClosed { get; }
             public Akka.Streams.IGraph<Akka.Streams.SinkShape<T>, Akka.NotUsed> Sink { get; }
             public void Cancel() { }
+            public void Cancel(System.Exception cause) { }
             public T Grab() { }
             public void Pull() { }
             public void SetHandler(Akka.Streams.Stage.IInHandler handler) { }
@@ -4849,6 +4884,7 @@ namespace Akka.Streams.Stage
         Akka.Streams.Stage.ITerminationDirective AbsorbTermination();
         Akka.Streams.Stage.FreeDirective Fail(System.Exception cause);
         Akka.Streams.Stage.FreeDirective Finish();
+        Akka.Streams.Stage.FreeDirective Finish(System.Exception cause);
         Akka.Streams.Stage.IUpstreamDirective Pull();
         Akka.Streams.Stage.IDownstreamDirective Push(object element);
         Akka.Streams.Stage.IDownstreamDirective PushAndFinish(object element);
@@ -4899,7 +4935,7 @@ namespace Akka.Streams.Stage
     }
     public interface IOutHandler
     {
-        void OnDownstreamFinish();
+        void OnDownstreamFinish(System.Exception cause);
         void OnPull();
     }
     public interface IStageLogging
@@ -4920,14 +4956,14 @@ namespace Akka.Streams.Stage
     public sealed class IgnoreTerminateOutput : Akka.Streams.Stage.OutHandler
     {
         public static readonly Akka.Streams.Stage.IgnoreTerminateOutput Instance;
-        public override void OnDownstreamFinish() { }
+        public override void OnDownstreamFinish(System.Exception cause) { }
         public override void OnPull() { }
     }
     public abstract class InAndOutGraphStageLogic : Akka.Streams.Stage.GraphStageLogic, Akka.Streams.Stage.IInHandler, Akka.Streams.Stage.IOutHandler
     {
         protected InAndOutGraphStageLogic(int inCount, int outCount) { }
         protected InAndOutGraphStageLogic(Akka.Streams.Shape shape) { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
         public abstract void OnPush();
         public virtual void OnUpstreamFailure(System.Exception e) { }
@@ -4936,7 +4972,7 @@ namespace Akka.Streams.Stage
     public abstract class InAndOutHandler : Akka.Streams.Stage.IInHandler, Akka.Streams.Stage.IOutHandler
     {
         protected InAndOutHandler() { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
         public abstract void OnPush();
         public virtual void OnUpstreamFailure(System.Exception e) { }
@@ -4969,13 +5005,13 @@ namespace Akka.Streams.Stage
     {
         protected OutGraphStageLogic(int inCount, int outCount) { }
         protected OutGraphStageLogic(Akka.Streams.Shape shape) { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
     }
     public abstract class OutHandler : Akka.Streams.Stage.IOutHandler
     {
         protected OutHandler() { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
     }
     public class PushPullGraphStageWithMaterializedValue<TIn, TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.FlowShape<TIn, TOut>, TMat>

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
@@ -723,6 +723,10 @@ namespace Akka.Streams
     {
         Akka.Streams.Dsl.Source<TOut, Akka.NotUsed> Source { get; }
     }
+    public interface ISubscriptionWithCancelException : Reactive.Streams.ISubscription
+    {
+        void Cancel(System.Exception cause);
+    }
     public interface ITransformerLike<in TIn, out TOut>
     {
         bool IsComplete { get; }
@@ -919,6 +923,7 @@ namespace Akka.Streams
         public static readonly Akka.Streams.StreamDetachedException Instance;
         public StreamDetachedException() { }
         public StreamDetachedException(string message) { }
+        public StreamDetachedException(string message, System.Exception innerException) { }
     }
     public class StreamLimitReachedException : System.Exception
     {
@@ -996,6 +1001,23 @@ namespace Akka.Streams
         public StreamTcpException(string message) { }
         public StreamTcpException(string message, System.Exception innerException) { }
         protected StreamTcpException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class static SubscriptionWithCancelException
+    {
+        public sealed class NoMoreElementsNeeded : Akka.Streams.SubscriptionWithCancelException.NonFailureCancellation
+        {
+            public static readonly Akka.Streams.SubscriptionWithCancelException.NoMoreElementsNeeded Instance;
+        }
+        [Akka.Annotations.DoNotInheritAttribute()]
+        public abstract class NonFailureCancellation : System.Exception
+        {
+            protected NonFailureCancellation() { }
+            public virtual string StackTrace { get; }
+        }
+        public sealed class StageWasCompleted : Akka.Streams.SubscriptionWithCancelException.NonFailureCancellation
+        {
+            public static readonly Akka.Streams.SubscriptionWithCancelException.StageWasCompleted Instance;
+        }
     }
     public enum SubstreamCancelStrategy
     {
@@ -3461,7 +3483,7 @@ namespace Akka.Streams.Implementation
         public static void RequireNonNullException(System.Exception exception) { }
         public static void RequireNonNullSubscriber<T>(Reactive.Streams.ISubscriber<T> subscriber) { }
         public static void RequireNonNullSubscription(Reactive.Streams.ISubscription subscription) { }
-        public static void TryCancel(Reactive.Streams.ISubscription subscription) { }
+        public static void TryCancel(Reactive.Streams.ISubscription subscription, System.Exception cause) { }
         public static void TryOnComplete<T>(Reactive.Streams.ISubscriber<T> subscriber) { }
         public static void TryOnError<T>(Reactive.Streams.ISubscriber<T> subscriber, System.Exception cause) { }
         public static void TryOnNext<T>(Reactive.Streams.ISubscriber<T> subscriber, T element) { }
@@ -3835,7 +3857,7 @@ namespace Akka.Streams.Implementation.Fusing
         {
             public BatchingActorInputBoundary(int size, int id) { }
             public override Akka.Streams.Outlet Out { get; }
-            public void Cancel() { }
+            public void Cancel(System.Exception cause) { }
             public void OnComplete() { }
             public void OnError(System.Exception reason) { }
             public void OnInternalError(System.Exception reason) { }
@@ -3856,17 +3878,19 @@ namespace Akka.Streams.Implementation.Fusing
             public void OnNext(T element) { }
             public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
         }
-        public sealed class BoundarySubscription : Reactive.Streams.ISubscription
+        public sealed class BoundarySubscription : Akka.Streams.ISubscriptionWithCancelException, Reactive.Streams.ISubscription
         {
             public BoundarySubscription(Akka.Actor.IActorRef parent, Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
             public void Cancel() { }
+            public void Cancel(System.Exception cause) { }
             public void Request(long elements) { }
             public override string ToString() { }
         }
         public struct Cancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
-            public Cancel(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
+            public Cancel(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, System.Exception cause) { }
+            public System.Exception Cause { get; }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
         public struct ExposedPublisher : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
@@ -4063,6 +4087,11 @@ namespace Akka.Streams.Implementation.Fusing
         public void SetHandler(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Stage.IInHandler handler) { }
         public void SetHandler(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Stage.IOutHandler handler) { }
         public override string ToString() { }
+        public sealed class Cancelled
+        {
+            public readonly System.Exception Cause;
+            public Cancelled(System.Exception cause) { }
+        }
         [Akka.Annotations.InternalApiAttribute()]
         public sealed class Connection
         {
@@ -4627,7 +4656,7 @@ namespace Akka.Streams.Stage
         protected AbstractStage() { }
         protected virtual bool IsDetached { get; }
         public virtual Akka.Streams.Supervision.Directive Decide(System.Exception cause) { }
-        public abstract Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context);
+        public abstract Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context, System.Exception cause);
         public abstract Akka.Streams.Stage.IDirective OnPull(Akka.Streams.Stage.IContext context);
         public abstract Akka.Streams.Stage.IDirective OnPush(TIn element, Akka.Streams.Stage.IContext context);
         public abstract Akka.Streams.Stage.ITerminationDirective OnUpstreamFailure(System.Exception cause, Akka.Streams.Stage.IContext context);
@@ -4644,8 +4673,8 @@ namespace Akka.Streams.Stage
     {
         protected TContext Context;
         protected AbstractStage() { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context) { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(TContext context) { }
+        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context, System.Exception cause) { }
+        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(TContext context, System.Exception cause) { }
         public abstract TPullDirective OnPull(TContext context);
         public override Akka.Streams.Stage.IDirective OnPull(Akka.Streams.Stage.IContext context) { }
         public abstract TPushDirective OnPush(TIn element, TContext context);
@@ -4666,7 +4695,7 @@ namespace Akka.Streams.Stage
     public class ConditionalTerminateOutput : Akka.Streams.Stage.OutHandler
     {
         public ConditionalTerminateOutput(System.Func<bool> predicate) { }
-        public override void OnDownstreamFinish() { }
+        public override void OnDownstreamFinish(System.Exception cause) { }
         public override void OnPull() { }
     }
     [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
@@ -4713,7 +4742,9 @@ namespace Akka.Streams.Stage
         protected void AbortReading<T>(Akka.Streams.Inlet<T> inlet) { }
         protected virtual void AfterPostStop() { }
         protected virtual void BeforePreStart() { }
+        protected void Cancel<T>(Akka.Streams.Inlet<T> inlet, System.Exception cause) { }
         protected void Cancel<T>(Akka.Streams.Inlet<T> inlet) { }
+        public void CancelStage(System.Exception cause) { }
         protected void Complete<T>(Akka.Streams.Outlet<T> outlet) { }
         public void CompleteStage() { }
         public static Akka.Streams.Stage.InHandler ConditionalTerminateInput(System.Func<bool> predicate) { }
@@ -4735,6 +4766,8 @@ namespace Akka.Streams.Stage
         protected Akka.Streams.Stage.StageActor GetStageActor(Akka.Streams.Stage.StageActorRef.Receive receive) { }
         protected T Grab<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool HasBeenPulled<T>(Akka.Streams.Inlet<T> inlet) { }
+        [Akka.Annotations.InternalApiAttribute()]
+        public void InternalOnDownstreamFinish(System.Exception cause) { }
         protected bool IsAvailable<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool IsAvailable<T>(Akka.Streams.Outlet<T> outlet) { }
         protected bool IsClosed<T>(Akka.Streams.Inlet<T> inlet) { }
@@ -4750,7 +4783,7 @@ namespace Akka.Streams.Stage
         protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, Akka.Streams.Stage.IInHandler handler) { }
         protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, System.Action onPush, System.Action onUpstreamFinish = null, System.Action<System.Exception> onUpstreamFailure = null) { }
         protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, Akka.Streams.Stage.IOutHandler handler) { }
-        protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, System.Action onPull, System.Action onDownstreamFinish = null) { }
+        protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, System.Action onPull, System.Action<System.Exception> onDownstreamFinish = null) { }
         [System.ObsoleteAttribute("Use method `SetHandlers` instead. Will be removed in v1.5")]
         protected void SetHandler<TIn, TOut>(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Stage.InAndOutGraphStageLogic handler) { }
         protected void SetHandlers<TIn, TOut>(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Stage.InAndOutGraphStageLogic handler) { }
@@ -4765,8 +4798,8 @@ namespace Akka.Streams.Stage
         }
         protected sealed class LambdaOutHandler : Akka.Streams.Stage.OutHandler
         {
-            public LambdaOutHandler(System.Action onPull, System.Action onDownstreamFinish = null) { }
-            public override void OnDownstreamFinish() { }
+            public LambdaOutHandler(System.Action onPull, System.Action<System.Exception> onDownstreamFinish = null) { }
+            public override void OnDownstreamFinish(System.Exception cause) { }
             public override void OnPull() { }
         }
         [Akka.Annotations.InternalApiAttribute()]
@@ -4778,6 +4811,7 @@ namespace Akka.Streams.Stage
             public bool IsClosed { get; }
             public Akka.Streams.IGraph<Akka.Streams.SinkShape<T>, Akka.NotUsed> Sink { get; }
             public void Cancel() { }
+            public void Cancel(System.Exception cause) { }
             public T Grab() { }
             public void Pull() { }
             public void SetHandler(Akka.Streams.Stage.IInHandler handler) { }
@@ -4838,6 +4872,7 @@ namespace Akka.Streams.Stage
         Akka.Streams.Stage.ITerminationDirective AbsorbTermination();
         Akka.Streams.Stage.FreeDirective Fail(System.Exception cause);
         Akka.Streams.Stage.FreeDirective Finish();
+        Akka.Streams.Stage.FreeDirective Finish(System.Exception cause);
         Akka.Streams.Stage.IUpstreamDirective Pull();
         Akka.Streams.Stage.IDownstreamDirective Push(object element);
         Akka.Streams.Stage.IDownstreamDirective PushAndFinish(object element);
@@ -4888,7 +4923,7 @@ namespace Akka.Streams.Stage
     }
     public interface IOutHandler
     {
-        void OnDownstreamFinish();
+        void OnDownstreamFinish(System.Exception cause);
         void OnPull();
     }
     public interface IStageLogging
@@ -4909,14 +4944,14 @@ namespace Akka.Streams.Stage
     public sealed class IgnoreTerminateOutput : Akka.Streams.Stage.OutHandler
     {
         public static readonly Akka.Streams.Stage.IgnoreTerminateOutput Instance;
-        public override void OnDownstreamFinish() { }
+        public override void OnDownstreamFinish(System.Exception cause) { }
         public override void OnPull() { }
     }
     public abstract class InAndOutGraphStageLogic : Akka.Streams.Stage.GraphStageLogic, Akka.Streams.Stage.IInHandler, Akka.Streams.Stage.IOutHandler
     {
         protected InAndOutGraphStageLogic(int inCount, int outCount) { }
         protected InAndOutGraphStageLogic(Akka.Streams.Shape shape) { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
         public abstract void OnPush();
         public virtual void OnUpstreamFailure(System.Exception e) { }
@@ -4925,7 +4960,7 @@ namespace Akka.Streams.Stage
     public abstract class InAndOutHandler : Akka.Streams.Stage.IInHandler, Akka.Streams.Stage.IOutHandler
     {
         protected InAndOutHandler() { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
         public abstract void OnPush();
         public virtual void OnUpstreamFailure(System.Exception e) { }
@@ -4956,13 +4991,13 @@ namespace Akka.Streams.Stage
     {
         protected OutGraphStageLogic(int inCount, int outCount) { }
         protected OutGraphStageLogic(Akka.Streams.Shape shape) { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
     }
     public abstract class OutHandler : Akka.Streams.Stage.IOutHandler
     {
         protected OutHandler() { }
-        public virtual void OnDownstreamFinish() { }
+        public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
     }
     public class PushPullGraphStageWithMaterializedValue<TIn, TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.FlowShape<TIn, TOut>, TMat>

--- a/src/core/Akka.Streams.TestKit/TestGraphStage.cs
+++ b/src/core/Akka.Streams.TestKit/TestGraphStage.cs
@@ -126,10 +126,10 @@ namespace Akka.Streams.TestKit
             {
                 _probe.Ref.Tell(GraphStageMessages.Pull.Instance);
                 outHandler.OnPull();
-            }, onDownstreamFinish: () =>
+            }, onDownstreamFinish: cause =>
             {
                 _probe.Ref.Tell(GraphStageMessages.DownstreamFinish.Instance);
-                outHandler.OnDownstreamFinish();
+                outHandler.OnDownstreamFinish(cause);
             });
 
             return logicAndMaterialized;

--- a/src/core/Akka.Streams.Tests.Performance/InterpreterBenchmark.cs
+++ b/src/core/Akka.Streams.Tests.Performance/InterpreterBenchmark.cs
@@ -94,7 +94,7 @@ namespace Akka.Streams.Tests.Performance
                     }
                     else
                         CompleteStage();
-                }, onDownstreamFinish: CompleteStage);
+                }, onDownstreamFinish: InternalOnDownstreamFinish);
                 Console.WriteLine("Handler Set");
             }
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
@@ -305,7 +305,7 @@ namespace Akka.Streams.Tests.Dsl
                         onUpstreamFailure: FailStage);
 
 
-                    SetHandler(stage.Outlet, onPull: DoNothing, onDownstreamFinish: CompleteStage);
+                    SetHandler(stage.Outlet, onPull: DoNothing, onDownstreamFinish: cause => CompleteStage());
                 }
 
                 public override void PreStart() => ScheduleRepeatedly(TimerKey, TimeSpan.FromMilliseconds(100));

--- a/src/core/Akka.Streams.Tests/Dsl/GraphUnzipWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphUnzipWithSpec.cs
@@ -8,6 +8,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.TestKit.Tests;
@@ -173,6 +175,57 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
+        [Fact]
+        public void UnzipWith_must_propagate_last_downstream_cancellation_cause_once_all_downstream_have_cancelled()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var probe = CreateTestProbe();
+                RunnableGraph.FromGraph(GraphDsl.Create(b =>
+                {
+                    var source = Source
+                        .Maybe<int>()
+                        .WatchTermination(Keep.Right)
+                        .MapMaterializedValue(t =>
+                        {
+                            // side effecting our way out of this
+                            probe.Ref.Tell(t, Nobody.Instance);
+                            return NotUsed.Instance;
+                        });
+
+                    var unzip = b.Add(new UnzipWith<int, int, string>(i => (1 / i, $"1 / {i}")));
+
+                    b.From(source).To(unzip.In);
+                
+                    Flow<T, T, NotUsed> KillSwitchFlow<T>()
+                        => Flow.Create<T, NotUsed>()
+                            .ViaMaterialized(KillSwitches.Single<T>(), Keep.Right)
+                            .MapMaterializedValue(killSwitch =>
+                            {
+                                probe.Ref.Tell(killSwitch);
+                                return NotUsed.Instance;
+                            });
+
+                    b.From(unzip.Out0).Via(KillSwitchFlow<int>()).To(Sink.Ignore<int>());
+                    b.From(unzip.Out1).Via(KillSwitchFlow<string>()).To(Sink.Ignore<string>());
+
+                    return ClosedShape.Instance;
+                })).Run(Materializer);
+
+                var termination = probe.ExpectMsg<Task<Done>>();
+                var killSwitch1 = probe.ExpectMsg<UniqueKillSwitch>();
+                var killSwitch2 = probe.ExpectMsg<UniqueKillSwitch>();
+                var boom = new TestException("Boom");
+                killSwitch1.Abort(boom);
+                killSwitch2.Abort(boom);
+                termination.ContinueWith(t =>
+                {
+                    t.Exception.Should().NotBeNull();
+                    t.Exception.InnerException.Should().Be(boom);
+                });
+            }, Materializer);
+        }
+        
         [Fact]
         public void UnzipWith_must_unzipWith_expanded_Person_unapply_3_outputs()
         {

--- a/src/core/Akka.Streams.Tests/Dsl/LazySourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LazySourceSpec.cs
@@ -8,6 +8,8 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.Stage;
 using Akka.Streams.TestKit;
@@ -111,6 +113,40 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
+        [Fact]
+        public void A_lazy_source_must_propagate_downstream_cancellation_cause_when_inner_source_has_been_materialized()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var probe = CreateTestProbe();
+                var (doneF, killSwitch) = Source.Lazily(() =>
+                    {
+                        return Source
+                            .Maybe<int>()
+                            .WatchTermination(Keep.Right)
+                            .MapMaterializedValue(done =>
+                            {
+                                probe.Ref.Tell(Done.Instance, Nobody.Instance);
+                                return done;
+                            });
+                    })
+                    .MapMaterializedValue(t => t.Unwrap())
+                    .ViaMaterialized(KillSwitches.Single<int>(), Keep.Both)
+                    .To(Sink.Ignore<int>())
+                    .Run(Materializer);
+
+                var boom = new TestException("boom");
+                probe.ExpectMsg<Done>();
+                killSwitch.Abort(boom);
+                doneF.ContinueWith(t =>
+                {
+                    t.Exception.Should().NotBeNull();
+                    t.Exception.InnerException.Should().NotBeNull();
+                    t.Exception.InnerException.Should().Be(boom);
+                });
+            }, Materializer);
+        }
+        
         [Fact]
         public void A_lazy_source_must_fail_stage_when_upstream_fails()
         {

--- a/src/core/Akka.Streams.Tests/Dsl/MaybeSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/MaybeSourceSpec.cs
@@ -1,0 +1,183 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="MaybeSourceSpec.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Streams.Dsl;
+using Akka.Streams.Implementation;
+using Akka.Streams.Implementation.Fusing;
+using Akka.Streams.TestKit;
+using Akka.Streams.TestKit.Tests;
+using Akka.TestKit;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+using static FluentAssertions.FluentActions;
+
+namespace Akka.Streams.Tests.Dsl
+{
+    public class MaybeSourceSpec : AkkaSpec
+    {
+        private readonly ActorMaterializer _materializer;
+        public MaybeSourceSpec(ITestOutputHelper output) : base(output)
+        {
+            _materializer = Sys.Materializer();
+        }
+
+        [Fact(DisplayName = "The Maybe Source must complete materialized promise with None when stream cancels")]
+        public void CompleteMaterializedPromiseWithNoneWhenCancelled()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var neverSource = Source.Maybe<int>();
+                var pubSink = Sink.AsPublisher<int>(false);
+
+                var (tcs, neverPub) = neverSource
+                    .ToMaterialized(pubSink, Keep.Both)
+                    .Run(_materializer);
+
+                var c = this.CreateManualSubscriberProbe<int>();
+                neverPub.Subscribe(c);
+                var subs = c.ExpectSubscription();
+
+                subs.Request(1000);
+                c.ExpectNoMsg(100.Milliseconds());
+                
+                subs.Cancel();
+
+                tcs.Task.Wait(3.Seconds()).Should().BeTrue();
+                tcs.Task.Result.Should().Be(0);
+            }, _materializer);
+        }
+
+        [Fact(DisplayName = "The Maybe Source must complete materialized promise with 0 when stream cancels with a failure cause")]
+        public void CompleteMaterializedTaskWithNoneWhenStreamCancelsWithFailure()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var (tcs, killSwitch) = Source.Maybe<int>()
+                    .ViaMaterialized(KillSwitches.Single<int>(), Keep.Both)
+                    .To(Sink.Ignore<int>())
+                    .Run(_materializer);
+
+                var boom = new TestException("Boom");
+                killSwitch.Abort(boom);
+                // Could make sense to fail it with the propagated exception instead but that breaks
+                // the assumptions in the CoupledTerminationFlowSpec
+                tcs.Task.Wait(3.Seconds()).Should().BeTrue();
+                tcs.Task.Result.Should().Be(0);
+            }, _materializer);
+        }
+
+        [Fact(DisplayName = "The Maybe Source must allow external triggering of empty completion")]
+        public void AllowExternalTriggeringOfEmptyCompletion()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var neverSource = Source.Maybe<int>().Where(_ => false);
+                var counterSink = Sink.Aggregate<int, int>(0, (acc, _) => acc + 1);
+                var (neverPromise, counterFuture) = neverSource
+                    .ToMaterialized(counterSink, Keep.Both)
+                    .Run(_materializer);
+            
+                // external cancellation
+                neverPromise.TrySetResult(0).Should().BeTrue();
+                counterFuture.Wait(3.Seconds()).Should().BeTrue();
+                counterFuture.Result.Should().Be(0);
+            }, _materializer);
+        }
+
+        // MaybeSource code is different compared to JVM, maybe that's why? -- Greg
+        // TODO: Why isn't the probe receive an OnComplete?
+        [Fact(
+            DisplayName = "The Maybe Source must allow external triggering of empty completion when there was no demand",
+            Skip = "Not working, check Maybe<T> source.")]
+        public void AllowExternalTriggerOfEmptyCompletionWhenNoDemand()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var probe = this.CreateSubscriberProbe<int>();
+                var promise = Source
+                    .Maybe<int>()
+                    .To(Sink.FromSubscriber(probe))
+                    .Run(_materializer);
+            
+                // external cancellation
+                probe.EnsureSubscription();
+                promise.TrySetResult(0).Should().BeTrue();
+                probe.ExpectComplete();
+            }, _materializer);
+        }
+
+        [Fact(DisplayName = "The Maybe Source must allow external triggering of non-empty completion")]
+        public void AllowExternalTriggerNonEmptyCompletion()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var neverSource = Source.Maybe<int>();
+                var counterSink = Sink.First<int>();
+
+                var (neverPromise, counterFuture) = neverSource
+                    .ToMaterialized(counterSink, Keep.Both)
+                    .Run(_materializer);
+            
+                // external cancellation
+                neverPromise.TrySetResult(6).Should().BeTrue();
+                counterFuture.Wait(3.Seconds()).Should().BeTrue();
+                counterFuture.Result.Should().Be(6);
+            }, _materializer);
+        }
+
+        [Fact(DisplayName = "The Maybe Source must allow external triggering of onError")]
+        public void AllowExternalTriggerOnError()
+        {
+            this.AssertAllStagesStopped(() =>
+            {
+                var neverSource = Source.Maybe<int>();
+                var counterSink = Sink.Aggregate<int, int>(0, (acc, _) => acc + 1);
+
+                var (neverPromise, counterFuture) = neverSource
+                    .ToMaterialized(counterSink, Keep.Both)
+                    .Run(_materializer);
+            
+                // external cancellation
+                neverPromise.TrySetException(new TestException("Boom")).Should().BeTrue();
+
+                Invoking(() => counterFuture.Wait(3.Seconds()))
+                    .Should().Throw<AggregateException>()
+                    .WithInnerException<AggregateException>()
+                    .WithInnerException<TestException>()
+                    .WithMessage("Boom");
+            }, _materializer);
+        }
+
+        // MaybeSource code is different compared to JVM, maybe that's why? -- Greg
+        // TODO: Why isn't Maybe<T> throws AbruptStageTerminationException?
+        [Fact(
+            DisplayName = "The Maybe Source must complete materialized future when materializer is shutdown",
+            Skip = "Not working, no exception is thrown. Check Maybe<T> source.")]
+        public void CompleteMaterializedTaskWhenShutDown()
+        {
+            var mat = ActorMaterializer.Create(Sys);
+            var neverSource = Source.Maybe<int>();
+            var pubSink = Sink.AsPublisher<int>(false);
+
+            var (f, neverPub) = neverSource
+                .ToMaterialized(pubSink, Keep.Both)
+                .Run(mat);
+
+            var c = this.CreateManualSubscriberProbe<int>();
+            neverPub.Subscribe(c);
+            c.ExpectSubscription();
+            
+            mat.Shutdown();
+            Invoking(() => f.Task.Wait(3.Seconds())).Should()
+                .Throw<AbruptStageTerminationException>();
+        }
+    }
+}

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
@@ -346,11 +346,11 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
                     SetHandler(shape.Outlet1,
                         onPull: () => Pull(shape.Inlet1),
-                        onDownstreamFinish: () => Cancel(shape.Inlet1));
+                        onDownstreamFinish: cause => Cancel(shape.Inlet1, cause));
 
                     SetHandler(shape.Outlet2,
                         onPull: () => Pull(shape.Inlet2),
-                        onDownstreamFinish: () => Cancel(shape.Inlet2));
+                        onDownstreamFinish: cause => Cancel(shape.Inlet2, cause));
                 }
             }
 
@@ -395,11 +395,11 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
                     SetHandler(shape.Outlet1,
                         onPull: () => Pull(shape.Inlet2),
-                        onDownstreamFinish: () => Cancel(shape.Inlet2));
+                        onDownstreamFinish: cause => Cancel(shape.Inlet2, cause));
 
                     SetHandler(shape.Outlet2,
                         onPull: () => Pull(shape.Inlet1),
-                        onDownstreamFinish: () => Cancel(shape.Inlet1));
+                        onDownstreamFinish: cause => Cancel(shape.Inlet1, cause));
                 }
             }
 

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterFailureModesSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterFailureModesSpec.cs
@@ -57,7 +57,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
             lastEvents()
                 .Should()
-                .BeEquivalentTo(new Cancel(upstream), new OnError(downstream, testException()), new PostStop(stage.Value));
+                .BeEquivalentTo(new Cancel(upstream, testException()), new OnError(downstream, testException()), new PostStop(stage.Value));
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
             lastEvents()
                 .Should()
-                .BeEquivalentTo(new Cancel(upstream), new OnError(downstream, testException()), new PostStop(stage.Value));
+                .BeEquivalentTo(new Cancel(upstream, testException()), new OnError(downstream, testException()), new PostStop(stage.Value));
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
             lastEvents()
                 .Should()
-                .BeEquivalentTo(new Cancel(upstream), new PostStop(stage.Value));
+                .BeEquivalentTo(new Cancel(upstream, testException()), new PostStop(stage.Value));
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
             lastEvents()
                 .Should()
-                .BeEquivalentTo(new Cancel(upstream), new PostStop(stage.Value));
+                .BeEquivalentTo(new Cancel(upstream, testException()), new PostStop(stage.Value));
         }
 
         [Fact]
@@ -161,8 +161,8 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
             setup.LastEvents()
                 .Should()
-                .BeEquivalentTo(new Cancel(setup.Upstream), new OnError(setup.Downstream, setup.TestException()),
-                    new PostStop(setup.Stage.Value));
+                .BeEquivalentTo(new Cancel(setup.Upstream, setup.TestException()), 
+                    new OnError(setup.Downstream, setup.TestException()), new PostStop(setup.Stage.Value));
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterPortsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterPortsSpec.cs
@@ -514,7 +514,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
             stepAll();
 
-            lastEvents().Should().BeEquivalentTo(new Cancel(outlet));
+            lastEvents().Should().BeEquivalentTo(new Cancel(outlet, SubscriptionWithCancelException.NoMoreElementsNeeded.Instance));
             outlet.IsAvailable().Should().Be(false);
             outlet.IsClosed().Should().Be(true);
             inlet.IsAvailable().Should().Be(false);
@@ -581,7 +581,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
             stepAll();
 
-            lastEvents().Should().BeEquivalentTo(new Cancel(outlet));
+            lastEvents().Should().BeEquivalentTo(new Cancel(outlet, SubscriptionWithCancelException.NoMoreElementsNeeded.Instance));
             outlet.IsAvailable().Should().Be(false);
             outlet.IsClosed().Should().Be(true);
             inlet.IsAvailable().Should().Be(false);
@@ -647,7 +647,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
             stepAll();
 
-            lastEvents().Should().BeEquivalentTo(new Cancel(outlet));
+            lastEvents().Should().BeEquivalentTo(new Cancel(outlet, SubscriptionWithCancelException.NoMoreElementsNeeded.Instance));
             outlet.IsAvailable().Should().Be(false);
             outlet.IsClosed().Should().Be(true);
             inlet.IsAvailable().Should().Be(false);
@@ -716,7 +716,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
             stepAll();
 
-            lastEvents().Should().BeEquivalentTo(new Cancel(outlet));
+            lastEvents().Should().BeEquivalentTo(new Cancel(outlet, SubscriptionWithCancelException.NoMoreElementsNeeded.Instance));
             outlet.IsAvailable().Should().Be(false);
             outlet.IsClosed().Should().Be(true);
             inlet.IsAvailable().Should().Be(false);
@@ -771,7 +771,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
             stepAll();
 
-            lastEvents().Should().BeEquivalentTo(new Cancel(outlet));
+            lastEvents().Should().BeEquivalentTo(new Cancel(outlet, SubscriptionWithCancelException.NoMoreElementsNeeded.Instance));
             outlet.IsAvailable().Should().Be(false);
             outlet.IsClosed().Should().Be(true);
             inlet.IsAvailable().Should().Be(false);
@@ -809,7 +809,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             inlet.Invoking(x => x.Grab()).Should().Throw<ArgumentException>();
 
             stepAll();
-            lastEvents().Should().BeEquivalentTo(new Cancel(outlet));
+            lastEvents().Should().BeEquivalentTo(new Cancel(outlet, SubscriptionWithCancelException.NoMoreElementsNeeded.Instance));
             outlet.IsAvailable().Should().Be(false);
             outlet.IsClosed().Should().Be(true);
             inlet.IsAvailable().Should().Be(false);

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterPortsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterPortsSpec.cs
@@ -29,7 +29,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         private Action step;
         private Action clearEvents;
 
-        public GraphInterpreterPortsSpec(ITestOutputHelper output = null) : base(output)
+        public GraphInterpreterPortsSpec(ITestOutputHelper output) : base(output)
         {
         }
 

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterSpecKit.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterSpecKit.cs
@@ -205,10 +205,18 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             public class Cancel : ITestEvent
             {
                 public GraphStageLogic Source { get; }
+                public Exception Cause { get; }
 
-                public Cancel(GraphStageLogic source) => Source = source;
+                public Cancel(GraphStageLogic source, Exception cause)
+                {
+                    Source = source;
+                    Cause = cause;
+                }
 
-                protected bool Equals(Cancel other) => Equals(Source, other.Source);
+                protected bool Equals(Cancel other) => 
+                    Equals(Source, other.Source)
+                    && Cause.GetType() == other.Cause.GetType()
+                    && Cause.Message == other.Cause.Message;
 
                 public override bool Equals(object obj)
                 {
@@ -387,7 +395,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     Outlet = new Outlet<T>("out") {Id = 0};
 
                     var probe = this;
-                    SetHandler(Outlet, () => setup.LastEvent.Add(new RequestOne(probe)), cause => setup.LastEvent.Add(new Cancel(probe)));
+                    SetHandler(Outlet, () => setup.LastEvent.Add(new RequestOne(probe)), cause => setup.LastEvent.Add(new Cancel(probe, cause)));
                 }
 
                 public sealed override Outlet Out => Outlet;
@@ -728,7 +736,16 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
             public class Cancel : ITestEvent
             {
-                protected bool Equals(Cancel other) => true;
+                public Cancel(Exception cause)
+                {
+                    Cause = cause;
+                }
+
+                public Exception Cause { get; }
+
+                protected bool Equals(Cancel other) =>
+                    Cause.GetType() == other.Cause.GetType()
+                    && Cause.Message == other.Cause.Message;
 
                 public override bool Equals(object obj)
                 {
@@ -846,7 +863,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                             setup.LastEvent.Add(new RequestAnother());
                         else
                             setup.LastEvent.Add(new RequestOne());
-                    }, cause => setup.LastEvent.Add(new Cancel()));
+                    }, cause => setup.LastEvent.Add(new Cancel(cause)));
                 }
 
                 public override Outlet Out => _outlet;
@@ -902,7 +919,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
                 public void Cancel()
                 {
-                    Cancel(_inlet);
+                    Cancel(_inlet, SubscriptionWithCancelException.NoMoreElementsNeeded.Instance);
                     _setup.Run();
                 }
             }

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterSpecKit.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterSpecKit.cs
@@ -387,7 +387,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     Outlet = new Outlet<T>("out") {Id = 0};
 
                     var probe = this;
-                    SetHandler(Outlet, () => setup.LastEvent.Add(new RequestOne(probe)), () => setup.LastEvent.Add(new Cancel(probe)));
+                    SetHandler(Outlet, () => setup.LastEvent.Add(new RequestOne(probe)), cause => setup.LastEvent.Add(new Cancel(probe)));
                 }
 
                 public sealed override Outlet Out => Outlet;
@@ -513,7 +513,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
                     public void OnPull() => Pull(_stage.In);
 
-                    public void OnDownstreamFinish() => Cancel(_stage.In);
+                    public void OnDownstreamFinish(Exception cause) => Cancel(_stage.In, cause);
                 }
 
                 public EventPropagateStage() => Shape  = new FlowShape<int, int>(In, Out);
@@ -640,7 +640,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
 
                     SetHandler(setup._stageOut,
                         () => MayFail(() => Pull(setup._stageIn)),
-                        () => MayFail(CompleteStage));
+                        cause => MayFail(CompleteStage));
                 }
 
                 private void MayFail(Action task)
@@ -846,7 +846,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                             setup.LastEvent.Add(new RequestAnother());
                         else
                             setup.LastEvent.Add(new RequestOne());
-                    }, () => setup.LastEvent.Add(new Cancel()));
+                    }, cause => setup.LastEvent.Add(new Cancel()));
                 }
 
                 public override Outlet Out => _outlet;

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
@@ -835,7 +835,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                 return context.Pull();
             }
 
-            public override ITerminationDirective OnDownstreamFinish(IContext<T> context)
+            public override ITerminationDirective OnDownstreamFinish(IContext<T> context, Exception cause)
             {
                 return context.AbsorbTermination();
             }

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
@@ -172,7 +172,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     lastEvents().Should().BeEquivalentTo(new RequestOne());
 
                     downstream.Cancel();
-                    lastEvents().Should().BeEquivalentTo(new Cancel());
+                    lastEvents().Should().BeEquivalentTo(new Cancel(SubscriptionWithCancelException.NoMoreElementsNeeded.Instance));
                 });
         }
 
@@ -194,7 +194,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     lastEvents().Should().BeEquivalentTo(new RequestOne());
 
                     upstream.OnNext(1);
-                    lastEvents().Should().BeEquivalentTo(new OnNext(1), new Cancel(), new OnComplete());
+                    lastEvents().Should().BeEquivalentTo(new OnNext(1), new Cancel(SubscriptionWithCancelException.StageWasCompleted.Instance), new OnComplete());
                 });
         }
 
@@ -224,7 +224,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     lastEvents().Should().BeEquivalentTo(new RequestOne());
 
                     upstream.OnNext(2);
-                    lastEvents().Should().BeEquivalentTo(new OnNext(3), new Cancel(), new OnComplete());
+                    lastEvents().Should().BeEquivalentTo(new OnNext(3), new Cancel(SubscriptionWithCancelException.StageWasCompleted.Instance), new OnComplete());
                 });
         }
 
@@ -274,7 +274,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     lastEvents().Should().BeEquivalentTo(new RequestOne());
 
                     downstream.Cancel();
-                    lastEvents().Should().BeEquivalentTo(new Cancel());
+                    lastEvents().Should().BeEquivalentTo(new Cancel(SubscriptionWithCancelException.NoMoreElementsNeeded.Instance));
                 });
         }
 
@@ -355,7 +355,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     lastEvents().Should().BeEquivalentTo(new OnNext(4), new RequestOne());
 
                     downstream.Cancel();
-                    lastEvents().Should().BeEquivalentTo(new Cancel());
+                    lastEvents().Should().BeEquivalentTo(new Cancel(SubscriptionWithCancelException.NoMoreElementsNeeded.Instance));
                 });
         }
 
@@ -424,7 +424,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     lastEvents().Should().BeEquivalentTo(new RequestOne(), new OnNext(4));
 
                     downstream.Cancel();
-                    lastEvents().Should().BeEquivalentTo(new Cancel());
+                    lastEvents().Should().BeEquivalentTo(new Cancel(SubscriptionWithCancelException.NoMoreElementsNeeded.Instance));
                 });
         }
 
@@ -502,7 +502,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     lastEvents().Should().BeEquivalentTo(new OnNext(2));
 
                     downstream.Cancel();
-                    lastEvents().Should().BeEquivalentTo(new Cancel());
+                    lastEvents().Should().BeEquivalentTo(new Cancel(SubscriptionWithCancelException.NoMoreElementsNeeded.Instance));
                 });
         }
 
@@ -662,7 +662,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     lastEvents().Should().BeEquivalentTo(new RequestOne());
 
                     upstream.OnNext(1);
-                    lastEvents().Should().BeEquivalentTo(new Cancel(), new OnNext(1), new OnComplete());
+                    lastEvents().Should().BeEquivalentTo(new Cancel(SubscriptionWithCancelException.StageWasCompleted.Instance), new OnNext(1), new OnComplete());
                 });
         }
 
@@ -700,7 +700,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                         .ExpectOne(() =>
                         {
                             downstream.Cancel();
-                            lastEvents().Should().BeEquivalentTo(new Cancel());
+                            lastEvents().Should().BeEquivalentTo(new Cancel(new NotSupportedException("It is not allowed to call AbsorbTermination() from OnDownstreamFinish.")));
                         });
                 });
         }

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterStressSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterStressSpec.cs
@@ -103,7 +103,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                 lastEvents().Should().BeEquivalentTo(new RequestOne());
 
                 upstream.OnNext(0);
-                lastEvents().Should().BeEquivalentTo(new OnNext(0 + ChainLength), new Cancel(), new OnComplete());
+                lastEvents().Should().BeEquivalentTo(new OnNext(0 + ChainLength), new Cancel(SubscriptionWithCancelException.StageWasCompleted.Instance), new OnComplete());
 
                 tstamp.Stop();
                 var time = tstamp.Elapsed.TotalSeconds;
@@ -125,7 +125,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                 lastEvents().Should().BeEquivalentTo(new RequestOne());
 
                 upstream.OnNext(0);
-                lastEvents().Should().BeEquivalentTo(new OnNext(0), new Cancel(), new OnComplete());
+                lastEvents().Should().BeEquivalentTo(new OnNext(0), new Cancel(SubscriptionWithCancelException.StageWasCompleted.Instance), new OnComplete());
             });
         }
 

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSupervisionSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSupervisionSpec.cs
@@ -119,7 +119,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     downstream.RequestOne();
                     lastEvents().Should().BeEquivalentTo(new RequestOne());
                     upstream.OnNext(0); // boom
-                    lastEvents().Should().BeEquivalentTo(new Cancel(), new OnError(TE()));
+                    lastEvents().Should().BeEquivalentTo(new Cancel(TE()), new OnError(TE()));
                 });
         }
 
@@ -141,7 +141,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     downstream.RequestOne();
                     lastEvents().Should().BeEquivalentTo(new RequestOne());
                     upstream.OnNext(-1); // boom
-                    lastEvents().Should().BeEquivalentTo(new Cancel(), new OnError(TE()));
+                    lastEvents().Should().BeEquivalentTo(new Cancel(TE()), new OnError(TE()));
                 });
         }
 
@@ -244,7 +244,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     lastEvents().Should().BeEquivalentTo(new OnNext(-1));
 
                     upstream.OnNext(2); // boom
-                    lastEvents().Should().BeEquivalentTo(new OnError(TE()), new Cancel());
+                    lastEvents().Should().BeEquivalentTo(new OnError(TE()), new Cancel(TE()));
                 });
         }
 
@@ -271,7 +271,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     downstream.RequestOne();
                     var events = lastEvents();
                     events.OfType<OnError>().Select(x => x.Cause.InnerException).Should().BeEquivalentTo(TE());
-                    events.OfType<Cancel>().Should().BeEquivalentTo(new Cancel());
+                    events.OfType<Cancel>().Should().BeEquivalentTo(new Cancel(new AggregateException(TE())));
                 });
         }
 

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/LifecycleInterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/LifecycleInterpreterSpec.cs
@@ -284,7 +284,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             WithOneBoundedSetup(op, (lastEvents, upstream, downstream) =>
             {
                 var events = lastEvents().ToArray();
-                events[0].Should().Be(new Cancel());
+                events[0].Should().Be(new Cancel(new TestException("Boom!")));
                 events[1].Should().BeOfType<OnError>();
                 ((OnError) events[1]).Cause.Should().BeOfType<TestException>();
                 ((OnError) events[1]).Cause.Message.Should().Be("Boom!");
@@ -322,7 +322,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             WithOneBoundedSetup(ops, (lastEvents, upstream, downstream) =>
             {
                 var events = lastEvents().ToArray();
-                events[0].Should().Be(new Cancel());
+                events[0].Should().Be(new Cancel(new TestException("Boom!")));
                 events[1].Should().BeOfType<OnError>();
                 ((OnError)events[1]).Cause.Should().BeOfType<TestException>();
                 ((OnError)events[1]).Cause.Message.Should().Be("Boom!");

--- a/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
@@ -494,7 +494,7 @@ namespace Akka.Streams.Tests.Implementation
                 interpreter =>
                 {
                     interpreter.Complete(interpreter.Connections[0]);
-                    interpreter.Cancel(interpreter.Connections[1]);
+                    interpreter.Cancel(interpreter.Connections[1], SubscriptionWithCancelException.NoMoreElementsNeeded.Instance);
                     interpreter.Execute(2);
 
                     ExpectMsg("postStop2");

--- a/src/core/Akka.Streams/Akka.Streams.csproj
+++ b/src/core/Akka.Streams/Akka.Streams.csproj
@@ -1,19 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <Import Project="..\..\common.props"/>
+    <Import Project="..\..\common.props" />
     <PropertyGroup>
         <AssemblyTitle>Akka.Streams</AssemblyTitle>
         <Description>Reactive stream support for Akka.NET</Description>
         <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
         <PackageTags>$(AkkaPackageTags);reactive;stream</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <EmbeddedResource Include="reference.conf"/>
-        <ProjectReference Include="..\Akka\Akka.csproj"/>
+        <EmbeddedResource Include="reference.conf" />
+        <ProjectReference Include="..\Akka\Akka.csproj" />
     </ItemGroup>
     <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
-        <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0"/>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0"/>
+        <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="CodeGen\Dsl\GraphApply.tt">
@@ -63,8 +64,8 @@
         </Compile>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)"/>
-        <PackageReference Include="Reactive.Streams" Version="1.0.2"/>
+        <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
+        <PackageReference Include="Reactive.Streams" Version="1.0.2" />
     </ItemGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/core/Akka.Streams/CodeGen/Dsl/UnzipWith.cs
+++ b/src/core/Akka.Streams/CodeGen/Dsl/UnzipWith.cs
@@ -1,10 +1,10 @@
-﻿//-----------------------------------------------------------------------
+﻿// --- auto generated: 5/18/2022 2:05:03 AM --- //
+//-----------------------------------------------------------------------
 // <copyright file="UnzipWith.cs" company="Akka.NET Project">
-//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//     Copyright (C) 2015-2016 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2016 Akka.NET project <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
 using System;
 using Akka.Streams.Stage;
 
@@ -277,9 +277,9 @@ namespace Akka.Streams.Dsl
                     _pending0 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending0) _pendingCount--;
@@ -292,9 +292,9 @@ namespace Akka.Streams.Dsl
                     _pending1 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending1) _pendingCount--;
@@ -401,9 +401,9 @@ namespace Akka.Streams.Dsl
                     _pending0 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending0) _pendingCount--;
@@ -416,9 +416,9 @@ namespace Akka.Streams.Dsl
                     _pending1 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending1) _pendingCount--;
@@ -431,9 +431,9 @@ namespace Akka.Streams.Dsl
                     _pending2 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending2) _pendingCount--;
@@ -552,9 +552,9 @@ namespace Akka.Streams.Dsl
                     _pending0 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending0) _pendingCount--;
@@ -567,9 +567,9 @@ namespace Akka.Streams.Dsl
                     _pending1 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending1) _pendingCount--;
@@ -582,9 +582,9 @@ namespace Akka.Streams.Dsl
                     _pending2 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending2) _pendingCount--;
@@ -597,9 +597,9 @@ namespace Akka.Streams.Dsl
                     _pending3 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending3) _pendingCount--;
@@ -730,9 +730,9 @@ namespace Akka.Streams.Dsl
                     _pending0 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending0) _pendingCount--;
@@ -745,9 +745,9 @@ namespace Akka.Streams.Dsl
                     _pending1 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending1) _pendingCount--;
@@ -760,9 +760,9 @@ namespace Akka.Streams.Dsl
                     _pending2 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending2) _pendingCount--;
@@ -775,9 +775,9 @@ namespace Akka.Streams.Dsl
                     _pending3 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending3) _pendingCount--;
@@ -790,9 +790,9 @@ namespace Akka.Streams.Dsl
                     _pending4 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending4) _pendingCount--;
@@ -935,9 +935,9 @@ namespace Akka.Streams.Dsl
                     _pending0 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending0) _pendingCount--;
@@ -950,9 +950,9 @@ namespace Akka.Streams.Dsl
                     _pending1 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending1) _pendingCount--;
@@ -965,9 +965,9 @@ namespace Akka.Streams.Dsl
                     _pending2 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending2) _pendingCount--;
@@ -980,9 +980,9 @@ namespace Akka.Streams.Dsl
                     _pending3 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending3) _pendingCount--;
@@ -995,9 +995,9 @@ namespace Akka.Streams.Dsl
                     _pending4 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending4) _pendingCount--;
@@ -1010,9 +1010,9 @@ namespace Akka.Streams.Dsl
                     _pending5 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending5) _pendingCount--;
@@ -1167,9 +1167,9 @@ namespace Akka.Streams.Dsl
                     _pending0 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending0) _pendingCount--;
@@ -1182,9 +1182,9 @@ namespace Akka.Streams.Dsl
                     _pending1 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending1) _pendingCount--;
@@ -1197,9 +1197,9 @@ namespace Akka.Streams.Dsl
                     _pending2 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending2) _pendingCount--;
@@ -1212,9 +1212,9 @@ namespace Akka.Streams.Dsl
                     _pending3 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending3) _pendingCount--;
@@ -1227,9 +1227,9 @@ namespace Akka.Streams.Dsl
                     _pending4 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending4) _pendingCount--;
@@ -1242,9 +1242,9 @@ namespace Akka.Streams.Dsl
                     _pending5 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending5) _pendingCount--;
@@ -1257,9 +1257,9 @@ namespace Akka.Streams.Dsl
                     _pending6 = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending6) _pendingCount--;

--- a/src/core/Akka.Streams/CodeGen/Dsl/UnzipWith.tt
+++ b/src/core/Akka.Streams/CodeGen/Dsl/UnzipWith.tt
@@ -115,9 +115,9 @@ namespace Akka.Streams.Dsl
                     _pending<#=t#> = false;
                     if (_pendingCount == 0) Pull(stage.In);
                 },
-                onDownstreamFinish: () => {
+                onDownstreamFinish: cause => {
                     _downstreamRunning--;
-                    if (_downstreamRunning == 0) CompleteStage();
+                    if (_downstreamRunning == 0) CancelStage(cause);
                     else 
                     {
                         if (_pending<#=t#>) _pendingCount--;

--- a/src/core/Akka.Streams/Dsl/DelayFlow.cs
+++ b/src/core/Akka.Streams/Dsl/DelayFlow.cs
@@ -149,7 +149,7 @@ namespace Akka.Streams.Dsl
                 Pull(_delayFlow.Inlet);
             }
 
-            public void OnDownstreamFinish() => CompleteStage();
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
 
             protected internal override void OnTimer(object timerKey)
             {

--- a/src/core/Akka.Streams/Dsl/Graph.cs
+++ b/src/core/Akka.Streams/Dsl/Graph.cs
@@ -939,13 +939,13 @@ namespace Akka.Streams.Dsl
                         _pendingCount--;
                         TryPull();
                     },
-                    onDownstreamFinish: () =>
+                    onDownstreamFinish: cause =>
                     {
-                        if (stage._eagerCancel) CompleteStage();
+                        if (stage._eagerCancel) CancelStage(cause);
                         else
                         {
                             _downstreamsRunning--;
-                            if (_downstreamsRunning == 0) CompleteStage();
+                            if (_downstreamsRunning == 0) CancelStage(cause);
                             else if (_pending[i])
                             {
                                 _pending[i] = false;
@@ -1099,19 +1099,18 @@ namespace Akka.Streams.Dsl
                         }
                         else if (!HasBeenPulled(stage.In))
                             Pull(stage.In);
-                    }, onDownstreamFinish: () =>
+                    }, onDownstreamFinish: cause =>
                     {
                         downstreamRunning--;
                         if(downstreamRunning == 0)
-                            CompleteStage();
-                        else if (_outPendingElement != null)
+                            CancelStage(cause);
+                        else if (_outPendingElement != null && index == _outPendingIndex)
                         {
-                            if (index == _outPendingIndex)
-                            {
-                                _outPendingElement = null;
-                                if(!HasBeenPulled(stage.In))
-                                    Pull(stage.In);
-                            }
+                            _outPendingElement = null;
+                            if(IsClosed(stage.In))
+                                CancelStage(cause);
+                            else if(!HasBeenPulled(stage.In))
+                                Pull(stage.In);
                         }
                     });
                 }
@@ -1282,10 +1281,10 @@ namespace Akka.Streams.Dsl
                         }
                         else _pendingQueue.Enqueue(outlet);
                     },
-                    onDownstreamFinish: () =>
+                    onDownstreamFinish: cause =>
                     {
                         downstreamsRunning--;
-                        if (downstreamsRunning == 0) CompleteStage();
+                        if (downstreamsRunning == 0) CancelStage(cause);
                         else if (!hasPulled && needDownstreamPulls > 0)
                         {
                             needDownstreamPulls--;
@@ -1977,7 +1976,7 @@ namespace Akka.Streams.Dsl
                         _pendingTap = elem;
                 });
                 
-                SetHandler(stage.OutMain, () => Pull(stage.In), CompleteStage);
+                SetHandler(stage.OutMain, () => Pull(stage.In), CancelStage);
                 
                 // The 'tap' output can neither backpressure, nor cancel, the stage.
                 SetHandler(stage.OutTap, 
@@ -1992,7 +1991,7 @@ namespace Akka.Streams.Dsl
                         Push(stage.OutTap, _pendingTap.Value);
                         _pendingTap = Option<T>.None;
                     },
-                    () =>
+                    cause =>
                     {
                         SetHandler(stage.In, () => Push(stage.OutMain, Grab(stage.In)));
                         // Allow any outstanding element to be garbage-collected

--- a/src/core/Akka.Streams/Dsl/KeepAliveConcat.cs
+++ b/src/core/Akka.Streams/Dsl/KeepAliveConcat.cs
@@ -95,7 +95,7 @@ namespace Akka.Streams.Dsl
                     Pull(_keepAliveConcat.In);
             }
 
-            public void OnDownstreamFinish() => CompleteStage();
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
 
             protected internal override void OnTimer(object timerKey)
             {

--- a/src/core/Akka.Streams/Dsl/One2OneBidiFlow.cs
+++ b/src/core/Akka.Streams/Dsl/One2OneBidiFlow.cs
@@ -119,7 +119,7 @@ namespace Akka.Streams.Dsl
                     else
                         _pullSuppressed = true;
                 },
-                    onDownstreamFinish: () => Cancel(_inInlet));
+                    onDownstreamFinish: cause => Cancel(_inInlet, cause));
             }
 
             private void SetOutInletHandler()
@@ -152,7 +152,7 @@ namespace Akka.Streams.Dsl
 
             private void SetOutOutletHandler()
             {
-                SetHandler(_outOutlet, onPull: () => Pull(_outInlet), onDownstreamFinish: () => Cancel(_outInlet));
+                SetHandler(_outOutlet, onPull: () => Pull(_outInlet), onDownstreamFinish: cause => Cancel(_outInlet, cause));
             }
         }
 

--- a/src/core/Akka.Streams/Dsl/Pulse.cs
+++ b/src/core/Akka.Streams/Dsl/Pulse.cs
@@ -57,7 +57,7 @@ namespace Akka.Streams.Dsl
                 }
             }
 
-            public void OnDownstreamFinish() => CompleteStage();
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
 
             protected internal override void OnTimer(object timerKey)
             {

--- a/src/core/Akka.Streams/Dsl/RestartFlow.cs
+++ b/src/core/Akka.Streams/Dsl/RestartFlow.cs
@@ -9,6 +9,7 @@ using System;
 using Akka.Pattern;
 using Akka.Streams.Implementation.Fusing;
 using Akka.Streams.Stage;
+using Akka.Util;
 
 namespace Akka.Streams.Dsl
 {
@@ -326,10 +327,10 @@ namespace Akka.Streams.Dsl
 
             SetHandler(Out,
                 onPull: () => sinkIn.Pull(),
-                onDownstreamFinish: () =>
+                onDownstreamFinish: cause =>
                 {
                     _finishing = true;
-                    sinkIn.Cancel();
+                    sinkIn.Cancel(cause);
                 });
 
             return sinkIn;
@@ -349,10 +350,10 @@ namespace Akka.Streams.Dsl
                             Pull(In);
                     }
                 },
-                onDownstreamFinish: () =>
+                onDownstreamFinish: cause =>
                 {
                     if (_finishing || MaxRestartsReached() || _onlyOnFailures)
-                        Cancel(In);
+                        Cancel(In, cause);
                     else
                     {
                         ScheduleRestartTimer();
@@ -471,7 +472,8 @@ namespace Akka.Streams.Dsl
         private sealed class Logic : TimerGraphStageLogic
         {
             private readonly DelayCancellationStage<T> _stage;
-            
+            private Option<Exception> _cause = Option<Exception>.None;
+
             public Logic(DelayCancellationStage<T> stage, Attributes inheritedAttributes) : base(stage.Shape)
             {
                 _stage = stage;
@@ -484,9 +486,9 @@ namespace Akka.Streams.Dsl
             /// <summary>
             /// We should really. port the Cause parameter functionality for the OnDownStreamFinished delegate
             /// </summary>
-            private void OnDownStreamFinished()
+            private void OnDownStreamFinished(Exception cause)
             {
-                //_cause = new Option<Exception>(/*cause*/);
+                _cause = cause;
                 ScheduleOnce("CompleteState", _stage._delay);
                 SetHandler(_stage.Inlet, onPush:DoNothing);
             }
@@ -494,15 +496,10 @@ namespace Akka.Streams.Dsl
             protected internal override void OnTimer(object timerKey)
             {
                 Log.Debug($"Stage was cancelled after delay of {_stage._delay}");
-                CompleteStage();
-                
-                // this code will replace the CompleteStage() call once we port the Exception Cause parameter for the OnDownStreamFinished delegate
-                /*if(_cause != null)
-                    FailStage(_cause.Value); //<-- is this the same as cancelStage ?
+                if(_cause.HasValue)
+                    CancelStage(_cause.Value);
                 else
-                {
                     throw new IllegalStateException("Timer hitting without first getting a cancel cannot happen");
-                }*/
             }
         }
     }

--- a/src/core/Akka.Streams/Dsl/Retry.cs
+++ b/src/core/Akka.Streams/Dsl/Retry.cs
@@ -176,7 +176,7 @@ namespace Akka.Streams.Dsl
                             else if (!HasBeenPulled(retry.In1))
                                 Pull(retry.In1);
                         }
-                    }, onDownstreamFinish: () =>
+                    }, onDownstreamFinish: cause =>
                     {
                         //Do Nothing, intercept completion as downstream
                     });
@@ -327,7 +327,7 @@ namespace Akka.Streams.Dsl
                                     Pull(_retry.In2);
                             }
                         }
-                    }, onDownstreamFinish: () =>
+                    }, onDownstreamFinish: cause =>
                     {
                         //Do Nothing, intercept completion as downstream
                     });

--- a/src/core/Akka.Streams/Dsl/UnfoldFlow.cs
+++ b/src/core/Akka.Streams/Dsl/UnfoldFlow.cs
@@ -57,7 +57,8 @@ namespace Akka.Streams.Dsl
             }
         }
 
-        public void OnDownstreamFinish()
+        // TODO: Is this correct? check JVM please
+        public void OnDownstreamFinish(Exception cause)
         {
             // Do Nothing until `timeout` to try and intercept completion as downstream,
             // but cancel stream after timeout if inlet is not closed to prevent deadlock.

--- a/src/core/Akka.Streams/Dsl/Valve.cs
+++ b/src/core/Akka.Streams/Dsl/Valve.cs
@@ -147,7 +147,7 @@ namespace Akka.Streams.Dsl
                     Pull(_valve.In);
             }
 
-            public void OnDownstreamFinish() => CompleteStage();
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
         }
 
         #endregion

--- a/src/core/Akka.Streams/Implementation/Fusing/EnumeratorInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/EnumeratorInterpreter.cs
@@ -55,7 +55,7 @@ namespace Akka.Streams.Implementation.Fusing
                         else Push(_outlet, element);
                     }
                 },
-                onDownstreamFinish: CompleteStage);
+                onDownstreamFinish: InternalOnDownstreamFinish);
             }
 
             /// <summary>

--- a/src/core/Akka.Streams/Implementation/Fusing/GraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphInterpreter.cs
@@ -125,7 +125,7 @@ namespace Akka.Streams.Implementation.Fusing
 
 
         /// <summary>
-        /// TBD
+        /// Marker class that indicates that a port was failed with a given cause and a potential outstanding element
         /// </summary>
         public sealed class Failed
         {
@@ -147,6 +147,19 @@ namespace Akka.Streams.Implementation.Fusing
             {
                 Reason = reason;
                 PreviousElement = previousElement;
+            }
+        }
+        
+        /// <summary>
+        /// Marker class that indicates that a port was cancelled with a given cause
+        /// </summary>
+        public sealed class Cancelled
+        {
+            public readonly Exception Cause;
+
+            public Cancelled(Exception cause)
+            {
+                Cause = cause;
             }
         }
 
@@ -253,12 +266,15 @@ namespace Akka.Streams.Implementation.Fusing
             public IOutHandler OutHandler { get; set; }
 
             /// <summary>
-            /// TBD
+            /// See <see cref="GraphInterpreter"/> about possible states
             /// </summary>
             public int PortState { get; set; } = InReady;
 
             /// <summary>
-            /// TBD
+            /// Can either be:
+            /// * An in-flight element
+            /// * A failure (with an optional in-flight element), if elem is an instance of <see cref="Failed"/>
+            /// * A cancellation cause, is elem is an instance of <see cref="Cancelled"/>
             /// </summary>
             public object Slot { get; set; } = Empty.Instance;
 
@@ -845,7 +861,9 @@ namespace Akka.Streams.Implementation.Fusing
                 if (IsDebug) Console.WriteLine($"{Name} CANCEL {InOwnerName(connection)} -> {OutOwnerName(connection)} ({connection.OutHandler}) [{OutLogicName(connection)}]");
                 connection.PortState |= OutClosed;
                 CompleteConnection(connection.OutOwnerId);
-                connection.OutHandler.OnDownstreamFinish();
+                var cause = ((Cancelled)connection.Slot).Cause;
+                connection.Slot = Empty.Instance;
+                connection.OutHandler.OnDownstreamFinish(cause);
             }
             else if ((code & (OutClosed | InClosed)) == OutClosed)
             {
@@ -1067,14 +1085,15 @@ namespace Akka.Streams.Implementation.Fusing
         /// TBD
         /// </summary>
         /// <param name="connection">TBD</param>
-        internal void Cancel(Connection connection)
+        /// <param name="cause"></param>
+        internal void Cancel(Connection connection, Exception cause)
         {
             var currentState = connection.PortState;
-            if (IsDebug) Console.WriteLine($"{Name}   Cancel({connection}) [{currentState}]");
+            if (IsDebug) Console.WriteLine($"{Name}   Cancel({connection}) [{currentState}] [{cause.Message}]");
             connection.PortState = currentState | InClosed;
             if ((currentState & OutClosed) == 0)
             {
-                connection.Slot = Empty.Instance;
+                connection.Slot = new Cancelled(cause);
                 if ((currentState & (Pulling | Pushing | InClosed)) == 0)
                     Enqueue(connection);
                 else if (_chasedPull == connection)

--- a/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
@@ -309,7 +309,8 @@ namespace Akka.Streams.Implementation.Fusing
                 _stage = stage;
                 _finishPromise = finishPromise;
 
-                SetHandler(stage._inlet, stage._outlet, this);
+                SetHandler(stage._inlet, this);
+                SetHandler(stage._outlet, this);
             }
 
             public override void OnPush() => Push(_stage._outlet, Grab(_stage._inlet));
@@ -330,11 +331,15 @@ namespace Akka.Streams.Implementation.Fusing
 
             public override void OnPull() => Pull(_stage._inlet);
 
-            public override void OnDownstreamFinish()
+            public override void OnDownstreamFinish(Exception cause)
             {
-                _finishPromise.TrySetResult(Done.Instance);
+                if (cause is SubscriptionWithCancelException.NonFailureCancellation)
+                    _finishPromise.TrySetResult(Done.Instance);
+                else
+                    _finishPromise.TrySetException(cause);
+                
                 _completedSignalled = true;
-                CompleteStage();
+                CancelStage(cause);
             }
 
             public override void PostStop()
@@ -457,9 +462,9 @@ namespace Akka.Streams.Implementation.Fusing
 
             public override void OnPull() => Pull(_stage.In);
 
-            public override void OnDownstreamFinish()
+            public override void OnDownstreamFinish(Exception cause)
             {
-                CompleteStage();
+                InternalOnDownstreamFinish(cause);
                 _monitor.Value = FlowMonitor.Finished.Instance;
             }
 
@@ -843,16 +848,16 @@ namespace Akka.Streams.Implementation.Fusing
                 // initial handler (until task completes)
                 SetHandler(stage.Outlet, new LambdaOutHandler(
                     onPull: () => { },
-                    onDownstreamFinish: () =>
+                    onDownstreamFinish: cause =>
                     {
                         if (!_materialized.Task.IsCompleted)
                         {
                             // we used to try to materialize the "inner" source here just to get
                             // the materialized value, but that is not safe and may cause the graph shell
                             // to leak/stay alive after the stage completes
-                            _materialized.TrySetException(new StreamDetachedException("Stream cancelled before Source Task completed"));
+                            _materialized.TrySetException(new StreamDetachedException("Stream cancelled before Source Task completed", cause));
                         }
-                        OnDownstreamFinish();
+                        InternalOnDownstreamFinish(cause);
                     }));
             }
 

--- a/src/core/Akka.Streams/Implementation/Fusing/StreamOfStreams.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/StreamOfStreams.cs
@@ -303,10 +303,10 @@ namespace Akka.Streams.Implementation.Fusing
                     FailStage(ex);
             }
 
-            public void OnDownstreamFinish()
+            public void OnDownstreamFinish(Exception cause)
             {
                 if (!IsPrefixComplete)
-                    CompleteStage();
+                    CancelStage(cause);
                 // Otherwise substream is open, ignore
             }
         }
@@ -461,9 +461,9 @@ namespace Akka.Streams.Implementation.Fusing
 
             public void OnUpstreamFailure(Exception ex) => Fail(ex);
 
-            public void OnDownstreamFinish()
+            public void OnDownstreamFinish(Exception cause)
             {
-                if (!TryCancel()) 
+                if (!TryCancel(cause)) 
                     SetKeepGoing(true);
             }
 
@@ -490,12 +490,12 @@ namespace Akka.Streams.Implementation.Fusing
                 return false;
             }
 
-            private bool TryCancel()
+            private bool TryCancel(Exception cause)
             {
                 // if there's no active substreams or there's only one but it's not been pushed yet
                 if (_activeSubstreams.Count == 0 || (_activeSubstreams.Count == 1 && _substreamWaitingToBePushed.HasValue))
                 {
-                    CompleteStage();
+                    CancelStage(cause);
                     return true;
                 }
 
@@ -610,12 +610,12 @@ namespace Akka.Streams.Implementation.Fusing
                     TryCompleteHandler();
                 }
 
-                public void OnDownstreamFinish()
+                public void OnDownstreamFinish(Exception cause)
                 {
                     if(_logic.HasNextElement && _logic._nextElementKey.Equals(Key)) _logic.ClearNextElement();
                     if (FirstPush) _logic._firstPushCounter--;
                     CompleteSubStream();
-                    if (_logic.IsClosed(_logic._stage.Out)) _logic.TryCancel();
+                    if (_logic.IsClosed(_logic._stage.Out)) _logic.TryCancel(cause);
                     if (_logic.IsClosed(_logic._stage.In)) _logic.TryCompleteAll(); 
                     else if (_logic.NeedToPull) _logic.Pull(_logic._stage.In);
                 }
@@ -781,15 +781,21 @@ namespace Akka.Streams.Implementation.Fusing
                         _logic.Pull(_inlet);
                 }
 
-                public override void OnDownstreamFinish()
+                public override void OnDownstreamFinish(Exception cause)
                 {
                     _logic._substreamCancelled = true;
                     if (_logic.IsClosed(_inlet) || _logic._stage._propagateSubstreamCancel)
-                        _logic.CompleteStage();
+                    {
+                        _logic.CancelStage(cause);
+                    }
                     else
+                    {
                         // Start draining
                         if (!_logic.HasBeenPulled(_inlet))
-                        _logic.Pull(_inlet);
+                        {
+                            _logic.Pull(_inlet);
+                        }
+                    }
                 }
 
                 public override void OnPush()
@@ -891,11 +897,11 @@ namespace Akka.Streams.Implementation.Fusing
                     PushSubstreamSource();
             }
 
-            public void OnDownstreamFinish()
+            public void OnDownstreamFinish(Exception cause)
             {
                 // If the substream is already cancelled or it has not been handed out, we can go away
                 if (_substreamSource == null || _substreamWaitingToBePushed || _substreamCancelled)
-                    CompleteStage();
+                    CancelStage(cause);
             }
 
             public override void PreStart()
@@ -1032,9 +1038,7 @@ namespace Akka.Streams.Implementation.Fusing
         /// </summary>
         internal sealed class CancelScheduledBeforeMaterialization : CommandScheduledBeforeMaterialization
         {
-            public static readonly CancelScheduledBeforeMaterialization Instance = new CancelScheduledBeforeMaterialization(Cancel.Instance);
-
-            private CancelScheduledBeforeMaterialization(ICommand command) : base(command)
+            public CancelScheduledBeforeMaterialization(Exception cause) : base(new Cancel(cause))
             {
             }
         }
@@ -1058,13 +1062,14 @@ namespace Akka.Streams.Implementation.Fusing
             }
         }
 
-        internal class Cancel : ICommand
+        internal sealed class Cancel : ICommand
         {
-            public static readonly Cancel Instance = new Cancel();
-
-            private Cancel()
+            public Cancel(Exception cause)
             {
+                Cause = cause;
             }
+
+            public Exception Cause { get; }
         }
     }
 
@@ -1168,7 +1173,7 @@ namespace Akka.Streams.Implementation.Fusing
         /// <summary>
         /// TBD
         /// </summary>
-        public void CancelSubstream() => DispatchCommand(SubSink.CancelScheduledBeforeMaterialization.Instance);
+        public void CancelSubstream(Exception cause) => DispatchCommand(new SubSink.CancelScheduledBeforeMaterialization(cause));
 
         private void DispatchCommand(SubSink.CommandScheduledBeforeMaterialization newState)
         {
@@ -1179,7 +1184,7 @@ namespace Akka.Streams.Implementation.Fusing
                     if(!_status.CompareAndSet(SubSink.Uninitialized.Instance, newState))
                         DispatchCommand(newState); // changed to materialized in the meantime
                     break;
-                case SubSink.RequestOneScheduledBeforeMaterialization _ when newState == SubSink.CancelScheduledBeforeMaterialization.Instance:
+                case SubSink.RequestOneScheduledBeforeMaterialization _ when newState is SubSink.CancelScheduledBeforeMaterialization:
                     // cancellation is allowed to replace pull
                     if(!_status.CompareAndSet(SubSink.RequestOneScheduledBeforeMaterialization.Instance, newState))
                         DispatchCommand(SubSink.RequestOneScheduledBeforeMaterialization.Instance);
@@ -1206,47 +1211,6 @@ namespace Akka.Streams.Implementation.Fusing
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal static class SubSource
-    {
-        /// <summary>
-        /// INTERNAL API
-        /// 
-        /// HERE ACTUALLY ARE DRAGONS, YOU HAVE BEEN WARNED!
-        /// 
-        /// FIXME #19240 (jvm)
-        /// </summary>
-        /// <typeparam name="T">TBD</typeparam>
-        /// <typeparam name="TMat">TBD</typeparam>
-        /// <param name="s">TBD</param>
-        /// <exception cref="NotSupportedException">TBD</exception>
-        [InternalApi]
-        public static void Kill<T, TMat>(Source<T, TMat> s)
-        {
-            var module = s.Module as GraphStageModule;
-            if (module?.Stage is SubSource<T>)
-            {
-                ((SubSource<T>) module.Stage).ExternalCallback(SubSink.Cancel.Instance);
-                return;
-            }
-
-            var pub = s.Module as PublisherSource<T>;
-            if (pub != null)
-            {
-                NotUsed _;
-                pub.Create(default(MaterializationContext), out _).Subscribe(CancelingSubscriber<T>.Instance);
-                return;
-            }
-
-            var intp = GraphInterpreter.CurrentInterpreterOrNull;
-            if (intp == null)
-                throw new NotSupportedException($"cannot drop Source of type {s.Module.GetType().Name}");
-            s.RunWith(Sink.Ignore<T>(), intp.SubFusingMaterializer);
-        }
-    }
-
-    /// <summary>
-    /// INTERNAL API
-    /// </summary>
     /// <typeparam name="T">TBD</typeparam>
     internal sealed class SubSource<T> : GraphStage<SourceShape<T>>
     {
@@ -1265,7 +1229,7 @@ namespace Akka.Streams.Implementation.Fusing
 
             public override void OnPull() => _stage.ExternalCallback(SubSink.RequestOne.Instance);
 
-            public override void OnDownstreamFinish() => _stage.ExternalCallback(SubSink.Cancel.Instance);
+            public override void OnDownstreamFinish(Exception cause) => _stage.ExternalCallback(new SubSink.Cancel(cause));
 
             private void SetCallback(Action<IActorSubscriberMessage> callback)
             {

--- a/src/core/Akka.Streams/Implementation/ReactiveStreamsCompliance.cs
+++ b/src/core/Akka.Streams/Implementation/ReactiveStreamsCompliance.cs
@@ -362,14 +362,25 @@ namespace Akka.Streams.Implementation
         /// TBD
         /// </summary>
         /// <param name="subscription">TBD</param>
+        /// <param name="cause">TBD</param>
         /// <exception cref="SignalThrewException">
         /// This exception is thrown when an exception occurs while canceling the specified <paramref name="subscription"/>.
         /// </exception>
-        public static void TryCancel(ISubscription subscription)
+        public static void TryCancel(ISubscription subscription, Exception cause)
         {
+            if (subscription == null)
+                throw new IllegalStateException("Subscription must be not null on cancel() call, rule 1.3");
+            
             try
             {
-                subscription.Cancel();
+                if (subscription is ISubscriptionWithCancelException s)
+                {
+                    s.Cancel(cause);
+                }
+                else
+                {
+                    subscription.Cancel();
+                }
             }
             catch (Exception e)
             {

--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -988,7 +988,7 @@ namespace Akka.Streams.Implementation
                     }));
 
                 subOutlet.SetHandler(new LambdaOutHandler(
-                    () =>
+                    onPull: () =>
                     {
                         if (firstElementPushed)
                             Pull(_stage.In);
@@ -1006,9 +1006,9 @@ namespace Akka.Streams.Implementation
                             }
                         }
                     },
-                    () =>
+                    onDownstreamFinish: cause =>
                     {
-                        if (!IsClosed(_stage.In)) Cancel(_stage.In);
+                        if (!IsClosed(_stage.In)) Cancel(_stage.In, cause);
                         MaybeCompleteStage();
                     }));
 

--- a/src/core/Akka.Streams/Implementation/Sources.cs
+++ b/src/core/Akka.Streams/Implementation/Sources.cs
@@ -786,8 +786,8 @@ namespace Akka.Streams.Implementation
 
             public override void OnDownstreamFinish(Exception cause)
             {
-                _completion.SetException(new Exception("Downstream canceled without triggering lazy source materialization"));
-                InternalOnDownstreamFinish(cause);
+                _completion.SetException(new Exception("Downstream canceled without triggering lazy source materialization", cause));
+                CompleteStage();
             }
 
 

--- a/src/core/Akka.Streams/Implementation/StreamRef/SourceRefImpl.cs
+++ b/src/core/Akka.Streams/Implementation/StreamRef/SourceRefImpl.cs
@@ -149,10 +149,7 @@ namespace Akka.Streams.Implementation.StreamRef
                 TriggerCumulativeDemand();
             }
 
-            public void OnDownstreamFinish()
-            {
-                CompleteStage();
-            }
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
 
             private void TriggerCumulativeDemand()
             {

--- a/src/core/Akka.Streams/Implementation/Throttle.cs
+++ b/src/core/Akka.Streams/Implementation/Throttle.cs
@@ -73,7 +73,7 @@ namespace Akka.Streams.Implementation
 
             public void OnPull() => Pull(_stage.Inlet);
 
-            public void OnDownstreamFinish() => CompleteStage();
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
 
             protected internal override void OnTimer(object timerKey)
             {

--- a/src/core/Akka.Streams/Implementation/Timers.cs
+++ b/src/core/Akka.Streams/Implementation/Timers.cs
@@ -75,7 +75,7 @@ namespace Akka.Streams.Implementation
 
             public void OnPull() => Pull(_stage.Inlet);
 
-            public void OnDownstreamFinish() => CompleteStage();
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
 
             protected internal override void OnTimer(object timerKey)
             {
@@ -149,7 +149,7 @@ namespace Akka.Streams.Implementation
 
             public void OnPull() => Pull(_stage.Inlet);
 
-            public void OnDownstreamFinish() => CompleteStage();
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
 
             protected internal override void OnTimer(object timerKey)
                 => FailStage(new TimeoutException($"The stream has not been completed in {_stage.Timeout}."));
@@ -227,7 +227,7 @@ namespace Akka.Streams.Implementation
 
             public void OnPull() => Pull(_stage.Inlet);
 
-            public void OnDownstreamFinish() => CompleteStage();
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
 
             protected internal override void OnTimer(object timerKey)
             {
@@ -315,7 +315,7 @@ namespace Akka.Streams.Implementation
                 Pull(_stage.Inlet);
             }
 
-            public void OnDownstreamFinish() => CompleteStage();
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
 
             protected internal override void OnTimer(object timerKey)
             {
@@ -394,7 +394,7 @@ namespace Akka.Streams.Implementation
 
                 SetHandler(_stage.Out2,
                     onPull: () => Pull(_stage.In2),
-                    onDownstreamFinish: () => Cancel(_stage.In2));
+                    onDownstreamFinish: cause => Cancel(_stage.In2, cause));
             }
 
             public void OnPush()
@@ -409,7 +409,7 @@ namespace Akka.Streams.Implementation
 
             public void OnPull() => Pull(_stage.In1);
 
-            public void OnDownstreamFinish() => Cancel(_stage.In1);
+            public void OnDownstreamFinish(Exception cause) => Cancel(_stage.In1, cause);
 
             protected internal override void OnTimer(object timerKey)
             {
@@ -514,7 +514,7 @@ namespace Akka.Streams.Implementation
                     Pull(_stage.Inlet);
             }
 
-            public void OnDownstreamFinish() => CompleteStage();
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
 
             protected internal override void OnTimer(object timerKey)
             {
@@ -634,7 +634,7 @@ namespace Akka.Streams.Implementation
                 }
             }
 
-            public void OnDownstreamFinish() => CompleteStage();
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
 
             protected internal override void OnTimer(object timerKey)
             {

--- a/src/core/Akka.Streams/KillSwitch.cs
+++ b/src/core/Akka.Streams/KillSwitch.cs
@@ -254,7 +254,7 @@ namespace Akka.Streams
 
                     SetHandler(killSwitch.Out2,
                         onPull: () => Pull(killSwitch.In2),
-                        onDownstreamFinish: () => Cancel(killSwitch.In2));
+                        onDownstreamFinish: cause => Cancel(killSwitch.In2, cause));
                 }
 
                 public override void OnPush() => Push(_killSwitch.Out1, Grab(_killSwitch.In1));
@@ -265,7 +265,7 @@ namespace Akka.Streams
 
                 public override void OnPull() => Pull(_killSwitch.In1);
 
-                public override void OnDownstreamFinish() => Cancel(_killSwitch.In1);
+                public override void OnDownstreamFinish(Exception cause) => Cancel(_killSwitch.In1, cause);
             }
 
             #endregion

--- a/src/core/Akka.Streams/Stage/AbstractStage.cs
+++ b/src/core/Akka.Streams/Stage/AbstractStage.cs
@@ -52,7 +52,7 @@ namespace Akka.Streams.Stage
 
             SetHandler(_shape.Outlet, 
                 onPull: () => _currentStage.OnPull(Context),
-                onDownstreamFinish: () => _currentStage.OnDownstreamFinish(Context));
+                onDownstreamFinish: cause => _currentStage.OnDownstreamFinish(Context, cause));
         }
 
         /// <summary>
@@ -116,7 +116,12 @@ namespace Akka.Streams.Stage
         /// <returns>TBD</returns>
         public FreeDirective Finish()
         {
-            CompleteStage();
+            return Finish(SubscriptionWithCancelException.NoMoreElementsNeeded.Instance);
+        }
+
+        public FreeDirective Finish(Exception cause)
+        {
+            CancelStage(cause);
             return null;
         }
 
@@ -452,7 +457,7 @@ namespace Akka.Streams.Stage
         /// </summary>
         /// <param name="context">TBD</param>
         /// <returns>TBD</returns>
-        public abstract ITerminationDirective OnDownstreamFinish(IContext context);
+        public abstract ITerminationDirective OnDownstreamFinish(IContext context, Exception cause);
 
         /// <summary>
         /// <para>
@@ -625,16 +630,18 @@ namespace Akka.Streams.Stage
         /// By default the cancel signal is immediately propagated with <see cref="IContext.Finish"/>.
         /// </summary>
         /// <param name="context">TBD</param>
+        /// <param name="cause"></param>
         /// <returns>TBD</returns>
-        public sealed override ITerminationDirective OnDownstreamFinish(IContext context) => OnDownstreamFinish((TContext) context);
+        public sealed override ITerminationDirective OnDownstreamFinish(IContext context, Exception cause) => OnDownstreamFinish((TContext) context, cause);
 
         /// <summary>
         /// This method is called when downstream has cancelled. 
         /// By default the cancel signal is immediately propagated with <see cref="IContext.Finish"/>.
         /// </summary>
         /// <param name="context">TBD</param>
+        /// <param name="cause"></param>
         /// <returns>TBD</returns>
-        public virtual ITerminationDirective OnDownstreamFinish(TContext context) => context.Finish();
+        public virtual ITerminationDirective OnDownstreamFinish(TContext context, Exception cause) => context.Finish(cause);
 
         /// <summary>
         /// <para>

--- a/src/core/Akka.Streams/Stage/Context.cs
+++ b/src/core/Akka.Streams/Stage/Context.cs
@@ -106,6 +106,8 @@ namespace Akka.Streams.Stage
         /// <returns>TBD</returns>
         FreeDirective Finish();
         
+        FreeDirective Finish(Exception cause);
+
         /// <summary>
         /// Cancel upstreams and complete downstreams with failure.
         /// </summary>

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -565,7 +565,7 @@ namespace Akka.Streams.Stage
                 return result;
             }
 
-            public override void OnDownstreamFinish() => Previous.OnDownstreamFinish();
+            public override void OnDownstreamFinish(Exception cause) => Previous.OnDownstreamFinish(cause);
         }
 
         private sealed class EmittingSingle<T> : Emitting
@@ -699,14 +699,14 @@ namespace Akka.Streams.Stage
         protected sealed class LambdaOutHandler : OutHandler
         {
             private readonly Action _onPull;
-            private readonly Action _onDownstreamFinish;
+            private readonly Action<Exception> _onDownstreamFinish;
 
             /// <summary>
             /// TBD
             /// </summary>
             /// <param name="onPull">TBD</param>
             /// <param name="onDownstreamFinish">TBD</param>
-            public LambdaOutHandler(Action onPull, Action onDownstreamFinish = null)
+            public LambdaOutHandler(Action onPull, Action<Exception> onDownstreamFinish = null)
             {
                 _onPull = onPull;
                 _onDownstreamFinish = onDownstreamFinish;
@@ -720,12 +720,12 @@ namespace Akka.Streams.Stage
             /// <summary>
             /// TBD
             /// </summary>
-            public override void OnDownstreamFinish()
+            public override void OnDownstreamFinish(Exception cause)
             {
                 if (_onDownstreamFinish != null)
-                    _onDownstreamFinish();
+                    _onDownstreamFinish(cause);
                 else
-                    base.OnDownstreamFinish();
+                    base.OnDownstreamFinish(cause);
             }
         }
 
@@ -962,7 +962,7 @@ namespace Akka.Streams.Stage
         /// <exception cref="ArgumentNullException">
         /// This exception is thrown when the specified <paramref name="onPull"/> is undefined.
         /// </exception>
-        protected internal void SetHandler<T>(Outlet<T> outlet, Action onPull, Action onDownstreamFinish = null)
+        protected internal void SetHandler<T>(Outlet<T> outlet, Action onPull, Action<Exception> onDownstreamFinish = null)
         {
             if (onPull == null)
                 throw new ArgumentNullException(nameof(onPull), "GraphStageLogic onPull handler must be provided");
@@ -1069,7 +1069,9 @@ namespace Akka.Streams.Stage
         /// Requests to stop receiving events from a given input port. Cancelling clears any ungrabbed elements from the port.
         /// </summary>
         /// <param name="inlet">TBD</param>
-        protected void Cancel<T>(Inlet<T> inlet) => Interpreter.Cancel(GetConnection(inlet));
+        /// <param name="cause"></param>
+        protected void Cancel<T>(Inlet<T> inlet, Exception cause) => Interpreter.Cancel(GetConnection(inlet), cause);
+        protected void Cancel<T>(Inlet<T> inlet) => Interpreter.Cancel(GetConnection(inlet), SubscriptionWithCancelException.NoMoreElementsNeeded.Instance);
 
         /// <summary>
         /// Once the callback <see cref="InHandler.OnPush"/> for an input port has been invoked, the element that has been pushed
@@ -1089,23 +1091,29 @@ namespace Akka.Streams.Stage
             var connection = GetConnection(inlet);
             var element = connection.Slot;
 
-            if ((connection.PortState & (InReady | InFailed)) ==
-                InReady && !ReferenceEquals(element, Empty.Instance))
+            if ((connection.PortState & (InReady | InFailed | InClosed)) == InReady && !ReferenceEquals(element, Empty.Instance))
             {
                 // fast path
                 connection.Slot = Empty.Instance;
+                return (T)element;
             }
-            else
-            {
-                // slow path
-                if (!IsAvailable(inlet))
-                    throw new ArgumentException("Cannot get element from already empty input port");
-                var failed = (GraphInterpreter.Failed)element;
-                element = failed.PreviousElement;
-                connection.Slot = new GraphInterpreter.Failed(failed.Reason, Empty.Instance);
-            }
+            
+            // Slow path for grabbing element from already failed or completed connections
+            if (!IsAvailable(inlet))
+                throw new ArgumentException($"Cannot get element from already empty input port ({inlet})");
 
-            return (T)element;
+            if ((connection.PortState & (InReady | InFailed)) == (InReady | InFailed))
+            {
+                // failed
+                var failed = (GraphInterpreter.Failed)element;
+                connection.Slot = new GraphInterpreter.Failed(failed.Reason, Empty.Instance);
+                return (T)failed.PreviousElement;
+            }
+            
+            // Completed
+            var elem = (T) connection.Slot;
+            connection.Slot = Empty.Instance;
+            return elem;
         }
 
         /// <summary>
@@ -1148,7 +1156,7 @@ namespace Akka.Streams.Stage
         private bool IsAvailable(Inlet inlet)
         {
             var connection = GetConnection(inlet);
-            var normalArrived = (connection.PortState & (InReady | InFailed)) == InReady;
+            var normalArrived = (connection.PortState & (InReady | InFailed | InClosed)) == InReady;
 
             if (normalArrived)
             {
@@ -1157,11 +1165,23 @@ namespace Akka.Streams.Stage
             }
 
             // slow path on failure
+            if ((connection.PortState & (InReady | InClosed | InFailed)) == (InReady | InClosed))
+            {
+                return connection.Slot switch
+                {
+                    Empty _ => false, // cancelled (element is discarded when cancelled)
+                    Cancelled _ => false, // cancelled (element is discarded when cancelled)
+                    _ => true // completed but element still there to grab
+                };
+            }
+            
             if ((connection.PortState & (InReady | InFailed)) == (InReady | InFailed))
             {
-                // This can only be Empty actually (if a cancel was concurrent with a failure)
-                return connection.Slot is GraphInterpreter.Failed failed &&
-                       !ReferenceEquals(failed.PreviousElement, Empty.Instance);
+                return connection.Slot switch
+                {
+                    GraphInterpreter.Failed failed => !ReferenceEquals(failed.PreviousElement, Empty.Instance), // failed but element still there to grab
+                    _ => false
+                };
             }
 
             return false;
@@ -1264,26 +1284,51 @@ namespace Akka.Streams.Stage
         protected void Fail<T>(Outlet<T> outlet, Exception reason) => Interpreter.Fail(GetConnection(outlet), reason);
 
         /// <summary>
+        /// INTERNAL API
+        ///
+        /// Variable used from `OutHandler.onDownstreamFinish` to carry over cancellation cause in cases where
+        /// `OutHandler` implementations call `InternalOnDownstreamFinish()`.
+        /// </summary>
+        [InternalApi] private Exception _lastCancellationCause = null;
+
+        [InternalApi] 
+        public void InternalOnDownstreamFinish(Exception cause)
+        {
+            try
+            {
+                if (cause == null)
+                    throw new ArgumentException("Cancellation cause must not be null", nameof(cause));
+                if (_lastCancellationCause != null)
+                    throw new ArgumentException("OnDownstreamFinish must not be called recursively", nameof(cause));
+                _lastCancellationCause = cause;
+                CancelStage(_lastCancellationCause);
+            }
+            finally
+            {
+                _lastCancellationCause = null;
+            }
+        }
+        
+        public void CancelStage(Exception cause)
+        {
+            
+            switch (cause)
+            {
+                case SubscriptionWithCancelException.NonFailureCancellation _:
+                    InternalCompleteStage(cause, Option<Exception>.None);
+                    break;
+                default:
+                    InternalCompleteStage(cause, cause);
+                    break;
+            }
+        }
+        
+        /// <summary>
         /// Automatically invokes <see cref="Cancel"/> or <see cref="Complete"/> on all the input or output ports that have been called,
         /// then marks the stage as stopped.
         /// </summary>
-        public void CompleteStage()
-        {
-            for (var i = 0; i < PortToConn.Length; i++)
-            {
-                if (i < InCount)
-                    Interpreter.Cancel(PortToConn[i]);
-                else
-                {
-                    if (Handlers[i] is Emitting e)
-                        e.AddFollowUp(new EmittingCompletion(e.Out, e.Previous, this));
-                    else
-                        Interpreter.Complete(PortToConn[i]);
-                }
-            }
-
-            SetKeepGoing(false);
-        }
+        public void CompleteStage() 
+            => InternalCompleteStage(SubscriptionWithCancelException.StageWasCompleted.Instance, Option<Exception>.None);
 
         /// <summary>
         /// Automatically invokes <see cref="Cancel"/> or <see cref="Fail{T}"/> on all the input or output ports that have been called,
@@ -1291,13 +1336,27 @@ namespace Akka.Streams.Stage
         /// </summary>
         /// <param name="reason">TBD</param>
         public void FailStage(Exception reason)
+            => InternalCompleteStage(reason, reason);
+
+        private void InternalCompleteStage(Exception cancelCause, Option<Exception> optionalFailureCause)
         {
             for (var i = 0; i < PortToConn.Length; i++)
             {
                 if (i < InCount)
-                    Interpreter.Cancel(PortToConn[i]);
+                {
+                    Interpreter.Cancel(PortToConn[i], cancelCause);
+                }
+                else if (optionalFailureCause.HasValue)
+                {
+                    Interpreter.Fail(PortToConn[i], optionalFailureCause.Value);
+                }
                 else
-                    Interpreter.Fail(PortToConn[i], reason);
+                {
+                    if (Handlers[i] is Emitting e)
+                        e.AddFollowUp(new EmittingCompletion(e.Out, e.Previous, this));
+                    else
+                        Interpreter.Complete(PortToConn[i]);
+                }
             }
 
             SetKeepGoing(false);
@@ -1798,10 +1857,15 @@ namespace Akka.Streams.Stage
             /// <summary>
             /// TBD
             /// </summary>
-            public void Cancel()
+            public void Cancel() => Cancel(SubscriptionWithCancelException.NoMoreElementsNeeded.Instance);
+            
+            /// <summary>
+            /// TBD
+            /// </summary>
+            public void Cancel(Exception cause)
             {
                 _closed = true;
-                _sink.CancelSubstream();
+                _sink.CancelSubstream(cause);
             }
 
             /// <inheritdoc/>
@@ -1856,13 +1920,13 @@ namespace Akka.Streams.Stage
                             _handler.OnPull();
                         }
                     }
-                    else if (command is SubSink.Cancel)
+                    else if (command is SubSink.Cancel cancel)
                     {
                         if (!_closed)
                         {
                             _available = false;
                             _closed = true;
-                            _handler.OnDownstreamFinish();
+                            _handler.OnDownstreamFinish(SubscriptionWithCancelException.StageWasCompleted.Instance);
                         }
                     }
                 }));
@@ -1997,7 +2061,7 @@ namespace Akka.Streams.Stage
         /// <summary>
         /// Called when the output port will no longer accept any new elements. After this callback no other callbacks will be called for this port.
         /// </summary>
-        void OnDownstreamFinish();
+        void OnDownstreamFinish(Exception cause);
     }
 
     /// <summary>
@@ -2014,7 +2078,8 @@ namespace Akka.Streams.Stage
         /// <summary>
         /// Called when the output port will no longer accept any new elements. After this callback no other callbacks will be called for this port.
         /// </summary>
-        public virtual void OnDownstreamFinish() => Current.ActiveStage.CompleteStage();
+        public virtual void OnDownstreamFinish(Exception cause) =>
+            Current.ActiveStage.InternalOnDownstreamFinish(cause);
     }
 
     /// <summary>
@@ -2049,7 +2114,8 @@ namespace Akka.Streams.Stage
         /// <summary>
         /// Called when the output port will no longer accept any new elements. After this callback no other callbacks will be called for this port.
         /// </summary>
-        public virtual void OnDownstreamFinish() => Current.ActiveStage.CompleteStage();
+        public virtual void OnDownstreamFinish(Exception cause) =>
+            Current.ActiveStage.InternalOnDownstreamFinish(cause);
     }
 
     /// <summary>
@@ -2128,7 +2194,7 @@ namespace Akka.Streams.Stage
         /// <summary>
         /// Called when the output port will no longer accept any new elements. After this callback no other callbacks will be called for this port.
         /// </summary>
-        public virtual void OnDownstreamFinish() => CompleteStage();
+        public virtual void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
     }
 
     /// <summary>
@@ -2184,7 +2250,7 @@ namespace Akka.Streams.Stage
         /// <summary>
         /// Called when the output port will no longer accept any new elements. After this callback no other callbacks will be called for this port.
         /// </summary>
-        public virtual void OnDownstreamFinish() => CompleteStage();
+        public virtual void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
     }
 
     /// <summary>
@@ -2338,7 +2404,7 @@ namespace Akka.Streams.Stage
         /// <summary>
         /// TBD
         /// </summary>
-        public override void OnDownstreamFinish() { }
+        public override void OnDownstreamFinish(Exception cause) { }
     }
 
     /// <summary>
@@ -2362,10 +2428,10 @@ namespace Akka.Streams.Stage
         /// <summary>
         /// TBD
         /// </summary>
-        public override void OnDownstreamFinish()
+        public override void OnDownstreamFinish(Exception cause)
         {
             if (_predicate())
-                Current.ActiveStage.CompleteStage();
+                Current.ActiveStage.CancelStage(cause);
         }
     }
 

--- a/src/core/Akka.Streams/StreamTcpException.cs
+++ b/src/core/Akka.Streams/StreamTcpException.cs
@@ -62,6 +62,12 @@ namespace Akka.Streams
             : base(message)
         {
         }
+        
+        public StreamDetachedException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+        
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/SubscriptionWithCancelException.cs
+++ b/src/core/Akka.Streams/SubscriptionWithCancelException.cs
@@ -1,0 +1,39 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="SubscriptionWithCancelException.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using Akka.Annotations;
+using Reactive.Streams;
+
+namespace Akka.Streams
+{
+    public static class SubscriptionWithCancelException
+    {
+        [DoNotInherit]
+        public abstract class NonFailureCancellation : Exception
+        {
+            public sealed override string StackTrace => "";
+        }
+        
+        public sealed class NoMoreElementsNeeded : NonFailureCancellation
+        {
+            public static readonly NoMoreElementsNeeded Instance = new NoMoreElementsNeeded();
+            private NoMoreElementsNeeded() { }
+        }
+    
+        public sealed class StageWasCompleted : NonFailureCancellation
+        {
+            public static readonly StageWasCompleted Instance = new StageWasCompleted();
+            private StageWasCompleted() { }
+        }
+    }
+    
+    public interface ISubscriptionWithCancelException: ISubscription
+    {
+        void Cancel(Exception cause);
+    }    
+}


### PR DESCRIPTION
Port of https://github.com/akka/akka/pull/27266 and https://github.com/akka/akka/pull/27547

From the original PR:
>This PR is focussed on adding APIs and machinery to provide cancellation causes across stages and reactive streams interfaces. The new APIs are (so far) completely optional:
> * A reactive streams subscription can implement SubscriptionWithCancelException if it wants to support that feature
> * There's a new GraphStage.cancel(cause) method that can be used to provide a cause (otherwise, SubscriptionWithCancelException.NoMoreElementsNeeded is used)
> * There's a new OutHandler.onDownstreamFinished(cause) method to override if you want access to (or to propagate) the cancellation cause. If not overridden it calls the old method.
> * Similar APIs (SubSink etc.) have already also been adapted.
>
> These changes should be completely transparent and only noticeable to those parties that implement the APIs.