### PR TITLE
feat: info about serilog context properties

### DIFF
--- a/docs/articles/utilities/serilog.md
+++ b/docs/articles/utilities/serilog.md
@@ -89,13 +89,13 @@ There are few properties that one can use in their `OutputTemplate` for logger c
 
 * `ActorPath` - contains the current actor's path.
 * `LogSource` - also contains `ActorPath`, however it can also have other values such as:
-    - `<TypeName> (<ActorSystemName>)`
-    - `<string> (<ActorSystemName>)`
+  * `<TypeName> (<ActorSystemName>)`
+  * `<string> (<ActorSystemName>)`
 * `Thread` - thread id on which given log action was executed.
 
 ### Example OutputTemplate
 
-```
+```console
 [{Timestamp:yyyy-MM-dd HH:mm:ss.fff} {Level:u3}] [{ActorPath}] [{SourceContext}] {Message}{NewLine}{Exception}
 ```
 

--- a/docs/articles/utilities/serilog.md
+++ b/docs/articles/utilities/serilog.md
@@ -83,6 +83,25 @@ var logger = new LoggerConfiguration()
     .CreateLogger();
 ```
 
+## Formatting OutputTemplate
+
+There are few properties that one can use in their `OutputTemplate` for logger configuration:
+
+- `ActorPath`
+  - Contains actor's path
+- `LogSource`
+  - Should contain `ActorPath`, however it can also have other values such as:
+    - `<TypeName> (<ActorSystemName>)`
+    - `<string> (<ActorSystemName>)`
+- `Thread`
+  - Contains thread id on which given log action was executed.
+
+### Example OutputTemplate
+
+```
+[{Timestamp:yyyy-MM-dd HH:mm:ss.fff} {Level:u3}] [{ActorPath}] [{SourceContext}] {Message}{NewLine}{Exception}
+```
+
 ## HOCON Configuration
 
 In order to be able to change log level without the need to recompile, we need to employ some sort of application configuration.  To use Serilog via HOCON configuration, add the following to the __App.config__ of the project.

--- a/docs/articles/utilities/serilog.md
+++ b/docs/articles/utilities/serilog.md
@@ -87,14 +87,11 @@ var logger = new LoggerConfiguration()
 
 There are few properties that one can use in their `OutputTemplate` for logger configuration:
 
-- `ActorPath`
-  - Contains actor's path
-- `LogSource`
-  - Should contain `ActorPath`, however it can also have other values such as:
+* `ActorPath` - contains the current actor's path.
+* `LogSource` - also contains `ActorPath`, however it can also have other values such as:
     - `<TypeName> (<ActorSystemName>)`
     - `<string> (<ActorSystemName>)`
-- `Thread`
-  - Contains thread id on which given log action was executed.
+* `Thread` - thread id on which given log action was executed.
 
 ### Example OutputTemplate
 


### PR DESCRIPTION
## Changes

Add list of properties one can use to customize serilog output template for akka logging adapter.

This information is missing from documentation and it took me 1 hour to find that information. It is going to be helpful to people that would also like to see actor path in logs.
