### PR TITLE
Backport of #5965 - pass Akka.Cluster.Cluster into IDowningProvider directly

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Core.verified.txt
@@ -19,7 +19,7 @@ namespace Akka.Cluster
 {
     public sealed class AutoDowning : Akka.Cluster.IDowningProvider
     {
-        public AutoDowning(Akka.Actor.ActorSystem system) { }
+        public AutoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
     }
@@ -266,13 +266,13 @@ namespace Akka.Cluster
     }
     public sealed class NoDowning : Akka.Cluster.IDowningProvider
     {
-        public NoDowning(Akka.Actor.ActorSystem system) { }
+        public NoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
     }
     public sealed class SplitBrainResolver : Akka.Cluster.IDowningProvider
     {
-        public SplitBrainResolver(Akka.Actor.ActorSystem system) { }
+        public SplitBrainResolver(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
         public System.TimeSpan StableAfter { get; }
@@ -417,7 +417,7 @@ namespace Akka.Cluster.SBR
     }
     public class SplitBrainResolverProvider : Akka.Cluster.IDowningProvider
     {
-        public SplitBrainResolverProvider(Akka.Actor.ActorSystem system) { }
+        public SplitBrainResolverProvider(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
@@ -19,7 +19,7 @@ namespace Akka.Cluster
 {
     public sealed class AutoDowning : Akka.Cluster.IDowningProvider
     {
-        public AutoDowning(Akka.Actor.ActorSystem system) { }
+        public AutoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
     }
@@ -266,13 +266,13 @@ namespace Akka.Cluster
     }
     public sealed class NoDowning : Akka.Cluster.IDowningProvider
     {
-        public NoDowning(Akka.Actor.ActorSystem system) { }
+        public NoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
     }
     public sealed class SplitBrainResolver : Akka.Cluster.IDowningProvider
     {
-        public SplitBrainResolver(Akka.Actor.ActorSystem system) { }
+        public SplitBrainResolver(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
         public System.TimeSpan StableAfter { get; }
@@ -417,7 +417,7 @@ namespace Akka.Cluster.SBR
     }
     public class SplitBrainResolverProvider : Akka.Cluster.IDowningProvider
     {
-        public SplitBrainResolverProvider(Akka.Actor.ActorSystem system) { }
+        public SplitBrainResolverProvider(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
@@ -19,7 +19,7 @@ namespace Akka.Cluster
 {
     public sealed class AutoDowning : Akka.Cluster.IDowningProvider
     {
-        public AutoDowning(Akka.Actor.ActorSystem system) { }
+        public AutoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
     }
@@ -266,13 +266,13 @@ namespace Akka.Cluster
     }
     public sealed class NoDowning : Akka.Cluster.IDowningProvider
     {
-        public NoDowning(Akka.Actor.ActorSystem system) { }
+        public NoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
     }
     public sealed class SplitBrainResolver : Akka.Cluster.IDowningProvider
     {
-        public SplitBrainResolver(Akka.Actor.ActorSystem system) { }
+        public SplitBrainResolver(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
         public System.TimeSpan StableAfter { get; }
@@ -417,7 +417,7 @@ namespace Akka.Cluster.SBR
     }
     public class SplitBrainResolverProvider : Akka.Cluster.IDowningProvider
     {
-        public SplitBrainResolverProvider(Akka.Actor.ActorSystem system) { }
+        public SplitBrainResolverProvider(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
         public System.TimeSpan DownRemovalMargin { get; }
         public Akka.Actor.Props DowningActorProps { get; }
     }

--- a/src/core/Akka.Cluster.Tests/Bugfix5962Spec.cs
+++ b/src/core/Akka.Cluster.Tests/Bugfix5962Spec.cs
@@ -1,0 +1,88 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="Bugfix5962Spec.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Configuration;
+using Akka.TestKit;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+using static FluentAssertions.FluentActions;
+
+
+namespace Akka.Cluster.Tests
+{
+     public class Bugfix5962Spec : TestKit.Xunit2.TestKit
+    {
+        private static readonly Config Config = ConfigurationFactory.ParseString(@"
+akka {
+    loglevel = INFO
+    actor {
+        provider = cluster
+        default-dispatcher = {
+            executor = channel-executor
+            channel-executor.priority = normal
+        }
+        # Adding this part in combination with the SplitBrainResolverProvider causes the error
+        internal-dispatcher = {
+            executor = channel-executor
+            channel-executor.priority = high
+        }
+    }
+    remote {
+        dot-netty.tcp {
+            port = 15508
+            hostname = ""127.0.0.1""
+        }
+        default-remote-dispatcher {
+            executor = channel-executor
+            channel-executor.priority = high
+        }
+        backoff-remote-dispatcher {
+            executor = channel-executor
+            channel-executor.priority = low
+        }
+    }
+    cluster {
+        seed-nodes = [""akka.tcp://Bugfix5962Spec@127.0.0.1:15508""]
+        downing-provider-class = ""Akka.Cluster.SBR.SplitBrainResolverProvider, Akka.Cluster""
+    }
+}");
+
+        private readonly Type _timerMsgType;
+        
+        public Bugfix5962Spec(ITestOutputHelper output): base(Config, nameof(Bugfix5962Spec), output)
+        {
+            _timerMsgType = Type.GetType("Akka.Actor.Scheduler.TimerScheduler+TimerMsg, Akka");
+        }
+
+        [Fact]
+        public async Task SBR_Should_work_with_channel_executor()
+        {
+            var latch = new TestLatch(1);
+            var cluster = Cluster.Get(Sys);
+            cluster.RegisterOnMemberUp(() =>
+            {
+                latch.CountDown();
+            });
+
+            var selection = Sys.ActorSelection("akka://Bugfix5962Spec/system/cluster/core/daemon/downingProvider");
+            
+            await Awaiting(() => selection.ResolveOne(1.Seconds()))
+                .Should().NotThrowAsync("Downing provider should be alive. ActorSelection will throw an ActorNotFoundException if this fails");
+            
+            // There should be no TimerMsg being sent to dead letter, this signals that the downing provider is dead
+            await EventFilter.DeadLetter(_timerMsgType).ExpectAsync(0, async () =>
+            {
+                latch.Ready(1.Seconds());
+                await Task.Delay(2.Seconds());
+            });
+        }
+    }
+}

--- a/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
+++ b/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
@@ -16,9 +16,9 @@ using Xunit;
 
 namespace Akka.Cluster.Tests
 {
-    class FailingDowningProvider : IDowningProvider
+    internal class FailingDowningProvider : IDowningProvider
     {
-        public FailingDowningProvider(ActorSystem system)
+        public FailingDowningProvider(ActorSystem system, Cluster cluster)
         {
         }
 
@@ -36,7 +36,7 @@ namespace Akka.Cluster.Tests
     class DummyDowningProvider : IDowningProvider
     {
         public readonly AtomicBoolean ActorPropsAccessed = new AtomicBoolean(false);
-        public DummyDowningProvider(ActorSystem system)
+        public DummyDowningProvider(ActorSystem system, Cluster cluster)
         {
         }
 

--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -132,7 +132,7 @@ namespace Akka.Cluster
             Scheduler = CreateScheduler(system);
 
             // it has to be lazy - otherwise if downing provider will init a cluster itself, it will deadlock
-            _downingProvider = new Lazy<IDowningProvider>(() => Akka.Cluster.DowningProvider.Load(Settings.DowningProviderType, system), LazyThreadSafetyMode.ExecutionAndPublication);
+            _downingProvider = new Lazy<IDowningProvider>(() => Akka.Cluster.DowningProvider.Load(Settings.DowningProviderType, system, this), LazyThreadSafetyMode.ExecutionAndPublication);
 
             //create supervisor for daemons under path "/system/cluster"
             _clusterDaemons = system.SystemActorOf(Props.Create(() => new ClusterDaemon(Settings)).WithDeploy(Deploy.Local), "cluster");

--- a/src/core/Akka.Cluster/Configuration/Cluster.conf
+++ b/src/core/Akka.Cluster/Configuration/Cluster.conf
@@ -59,8 +59,10 @@ akka {
     # * if it is 'off' the `NoDowning` provider is used and no automatic downing will be performed
     # * if it is set to a duration the `AutoDowning` provider is with the configured downing duration
     #
-    # If specified the value must be the fully qualified class name of a subclass of
-    # `akka.cluster.DowningProvider` having a public one argument constructor accepting an `ActorSystem`
+    # If specified the value must be the fully qualified class name of an implementation of
+    # `Akka.Cluster.IDowningProvider` having two argument constructor:
+    #   - argument 1: accepting an `ActorSystem`
+    #   - argument 2: accepting an `Akka.Cluster.Cluster`
     downing-provider-class = ""
 
     # If this is set to "off", the leader will not move 'Joining' members to 'Up' during a network

--- a/src/core/Akka.Cluster/DowningProvider.cs
+++ b/src/core/Akka.Cluster/DowningProvider.cs
@@ -45,20 +45,18 @@ namespace Akka.Cluster
     public sealed class NoDowning : IDowningProvider
     {
         private readonly ActorSystem _system;
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="system">TBD</param>
-        public NoDowning(ActorSystem system)
+        private readonly Cluster _cluster;
+        
+        public NoDowning(ActorSystem system, Cluster cluster)
         {
             _system = system;
+            _cluster = cluster;
         }
 
         /// <summary>
         /// TBD
         /// </summary>
-        public TimeSpan DownRemovalMargin => Cluster.Get(_system).Settings.DownRemovalMargin;
+        public TimeSpan DownRemovalMargin => _cluster.Settings.DownRemovalMargin;
 
         /// <summary>
         /// TBD
@@ -72,20 +70,25 @@ namespace Akka.Cluster
     internal static class DowningProvider
     {
         /// <summary>
-        /// TBD
+        /// Loads the <see cref="IDowningProvider"/> from configuration and instantiates it via reflection.
         /// </summary>
         /// <param name="downingProviderType">TBD</param>
         /// <param name="system">TBD</param>
+        /// <param name="cluster">The current cluster object.</param>
         /// <exception cref="ConfigurationException">
         /// This exception is thrown when the specified <paramref name="downingProviderType"/> does not implement <see cref="IDowningProvider"/>.
         /// </exception>
-        /// <returns>TBD</returns>
-        public static IDowningProvider Load(Type downingProviderType, ActorSystem system)
+        /// <returns>The activated <see cref="IDowningProvider"/></returns>
+        /// <remarks>
+        /// Required to pass in <see cref="Akka.Cluster.Cluster"/> manually here since https://github.com/akkadotnet/akka.net/issues/5962
+        /// can cause the SBR startup to fail when running with the `channel-executor`.
+        /// </remarks>
+        public static IDowningProvider Load(Type downingProviderType, ActorSystem system, Cluster cluster)
         {
             var extendedSystem = system as ExtendedActorSystem;
             try
             {
-                return (IDowningProvider)Activator.CreateInstance(downingProviderType, extendedSystem);
+                return (IDowningProvider)Activator.CreateInstance(downingProviderType, extendedSystem, cluster);
             }
             catch (Exception e)
             {

--- a/src/core/Akka.Cluster/SBR/SplitBrainResolver.cs
+++ b/src/core/Akka.Cluster/SBR/SplitBrainResolver.cs
@@ -27,22 +27,22 @@ namespace Akka.Cluster.SBR
     {
         private Cluster _cluster;
 
-        public SplitBrainResolver(TimeSpan stableAfter, DowningStrategy strategy)
+        public SplitBrainResolver(TimeSpan stableAfter, DowningStrategy strategy, Cluster cluster)
             : base(stableAfter, strategy)
         {
+            _cluster = cluster;
         }
 
         public override UniqueAddress SelfUniqueAddress => _cluster.SelfUniqueAddress;
 
-        public static Props Props2(TimeSpan stableAfter, DowningStrategy strategy)
+        public static Props Props2(TimeSpan stableAfter, DowningStrategy strategy, Cluster cluster)
         {
-            return Props.Create(() => new SplitBrainResolver(stableAfter, strategy));
+            return Props.Create(() => new SplitBrainResolver(stableAfter, strategy, cluster));
         }
 
         // re-subscribe when restart
         protected override void PreStart()
         {
-            _cluster = Cluster.Get(Context.System);
             _cluster.Subscribe(Self, InitialStateAsEvents, typeof(IClusterDomainEvent));
 
             base.PreStart();

--- a/src/core/Akka.Cluster/SBR/SplitBrainResolverProvider.cs
+++ b/src/core/Akka.Cluster/SBR/SplitBrainResolverProvider.cs
@@ -21,11 +21,13 @@ namespace Akka.Cluster.SBR
     {
         private readonly SplitBrainResolverSettings _settings;
         private readonly ActorSystem _system;
+        private readonly Cluster _cluster;
 
-        public SplitBrainResolverProvider(ActorSystem system)
+        public SplitBrainResolverProvider(ActorSystem system, Cluster cluster)
         {
             _system = system;
             _settings = new SplitBrainResolverSettings(system.Settings.Config);
+            _cluster = cluster;
         }
 
         public TimeSpan DownRemovalMargin
@@ -77,7 +79,7 @@ namespace Akka.Cluster.SBR
                         throw new InvalidOperationException();
                 }
 
-                return SplitBrainResolver.Props2(_settings.DowningStableAfter, strategy);
+                return SplitBrainResolver.Props2(_settings.DowningStableAfter, strategy, _cluster);
             }
         }
     }

--- a/src/core/Akka.Cluster/SplitBrainResolver.cs
+++ b/src/core/Akka.Cluster/SplitBrainResolver.cs
@@ -18,8 +18,9 @@ namespace Akka.Cluster
     public sealed class SplitBrainResolver : IDowningProvider
     {
         private readonly ActorSystem _system;
+        private readonly Cluster _cluster;
 
-        public SplitBrainResolver(ActorSystem system)
+        public SplitBrainResolver(ActorSystem system, Cluster cluster)
         {
             _system = system;
             var config = system.Settings.Config.GetConfig("akka.cluster.split-brain-resolver");
@@ -28,11 +29,12 @@ namespace Akka.Cluster
 
             StableAfter = config.GetTimeSpan("stable-after", null);
             Strategy = ResolveSplitBrainStrategy(config);
+            _cluster = cluster;
         }
 
         public TimeSpan DownRemovalMargin => Cluster.Get(_system).Settings.DownRemovalMargin;
         public TimeSpan StableAfter { get; }
-        public Props DowningActorProps => SplitBrainDecider.Props(StableAfter, Strategy);
+        public Props DowningActorProps => SplitBrainDecider.Props(StableAfter, Strategy, _cluster);
 
         internal ISplitBrainStrategy Strategy { get; }
 
@@ -176,7 +178,7 @@ namespace Akka.Cluster
 
             if (remaining.IsEmpty && unreachable.IsEmpty) // prevent exception due to both lists being empty
             {
-                return new Member[0];
+                return Array.Empty<Member>();
             }
 
             var oldest = remaining.Union(unreachable).ToImmutableSortedSet(Member.AgeOrdering).First();
@@ -241,8 +243,8 @@ namespace Akka.Cluster
 
         #endregion
 
-        public static Actor.Props Props(TimeSpan stableAfter, ISplitBrainStrategy strategy) =>
-            Actor.Props.Create(() => new SplitBrainDecider(stableAfter, strategy)).WithDeploy(Deploy.Local);
+        public static Actor.Props Props(TimeSpan stableAfter, ISplitBrainStrategy strategy, Cluster cluster) =>
+            Actor.Props.Create(() => new SplitBrainDecider(stableAfter, strategy, cluster)).WithDeploy(Deploy.Local);
 
         private readonly Cluster _cluster;
         private readonly TimeSpan _stabilityTimeout;
@@ -253,13 +255,13 @@ namespace Akka.Cluster
         private ICancelable _stabilityTask;
         private ILoggingAdapter _log;
 
-        public SplitBrainDecider(TimeSpan stableAfter, ISplitBrainStrategy strategy)
+        public SplitBrainDecider(TimeSpan stableAfter, ISplitBrainStrategy strategy, Cluster cluster)
         {
             if (strategy == null) throw new ArgumentNullException(nameof(strategy));
 
             _stabilityTimeout = stableAfter;
             _strategy = strategy;
-            _cluster = Cluster.Get(Context.System);
+            _cluster = cluster;
         }
 
         public ILoggingAdapter Log => _log ?? (_log = Context.GetLogger());


### PR DESCRIPTION
Backport of #5965 

> Passes a Cluster instance directly into the SBR constructor in order to avoid same-thread issues with Lazy<Cluster>.