### PR TITLE
Backport #5971 - Trap all exception thrown while trying to dispatch messages in Akka.Remote.EndpointReader

### DIFF
--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -1953,21 +1953,9 @@ namespace Akka.Remote
                                     ackAndMessage.MessageOption.SerializedMessage,
                                     ackAndMessage.MessageOption.SenderOptional);
                             }
-                            catch (SerializationException e)
-                            {
-                                LogTransientSerializationError(ackAndMessage.MessageOption, e);
-                            }
-                            catch (ArgumentException e)
-                            {
-                                LogTransientSerializationError(ackAndMessage.MessageOption, e);
-                            }
-                            catch (InvalidCastException e)
-                            {
-                                LogTransientSerializationError(ackAndMessage.MessageOption, e);
-                            }
                             catch (Exception e)
                             {
-                                throw;
+                                LogTransientSerializationError(ackAndMessage.MessageOption, e);
                             }
                         }
                     }


### PR DESCRIPTION
Backport of #5971 from `1.4` branch into `dev` branch