### PR TITLE
Model-based tests for `PersistentShardCoordinator.State`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
@@ -37,4 +37,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\..\core\Akka.Cluster.Tests\ClusterGenerators.cs">
+      <Link>ClusterGenerators.cs</Link>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardCoordinatorStateModelTests.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardCoordinatorStateModelTests.cs
@@ -134,7 +134,7 @@ namespace Akka.Cluster.Sharding.Tests
     {
         public StateModel()
         {
-            var gen0 = Gen.Choose(0, 100); // shardCount
+            var gen0 = Gen.Choose(10, 100); // shardCount
             var gen1 = ClusterShardingGenerator.ShardRegionRefGenerator().Generator.ArrayOf(100); //shardRegions
             var gen2 = ClusterShardingGenerator.ShardRegionRefGenerator(true).Generator
                 .ArrayOf(100); // shardRegionProxies
@@ -223,15 +223,15 @@ namespace Akka.Cluster.Sharding.Tests
 
                 return actual.State.Regions.Keys.ToImmutableHashSet().SetEquals(model.Regions.Keys)
                     .Label(
-                        $"Both ShardRegions should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptRegions)}]")
+                        $"Both ShardRegions should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptRegions)}]. Model: [{string.Join(",", model.Regions.Select(c => (c.Key, string.Join(",", c.Value))))}], Actual: [{string.Join(",", actual.State.Regions.Select(c => (c.Key, string.Join(",", c.Value))))}]")
                     .And(actual.State.Shards.Keys.ToImmutableHashSet().SetEquals(model.Shards.Keys)
                         .Label(
-                            $"Both Shards should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptShards)}]"))
+                            $"Both Shards should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptShards)}]. Model: [{string.Join(",", model.Shards)}], Actual: [{string.Join(",", actual.State.Shards)}]"))
                     .And(actual.State.RegionProxies.SetEquals(model.RegionProxies).Label(
-                        $"Both ShardProxies should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptProxies)}]"))
+                        $"Both ShardProxies should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptProxies)}]. Model: [{string.Join(",", model.RegionProxies)}], Actual: [{string.Join(",", actual.State.RegionProxies)}]"))
                     .And(actual.State.UnallocatedShards.SetEquals(model.UnallocatedShards)
                         .Label(
-                            $"Both UnallocatedShards should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptUnallocatedShards)}]"));
+                            $"Both UnallocatedShards should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptUnallocatedShards)}]. Model: [{string.Join(",", model.UnallocatedShards)}], Actual: [{string.Join(",", actual.State.UnallocatedShards)}]"));
             }
 
             public Property CheckShardRegionSpecificStates(StateHolder actual, TestState model, IActorRef shardRegion)
@@ -611,7 +611,7 @@ namespace Akka.Cluster.Sharding.Tests
                     obj0.Regions.TryGetValue(region, out var regionShards))
                 {
                     var newUnallocatedShards = obj0.RememberEntities
-                        ? obj0.UnallocatedShards.Remove(ShardId)
+                        ? obj0.UnallocatedShards.Add(ShardId)
                         : obj0.UnallocatedShards;
 
                     return obj0 with

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardCoordinatorStateModelTests.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardCoordinatorStateModelTests.cs
@@ -594,7 +594,7 @@ namespace Akka.Cluster.Sharding.Tests
 
     public class ShardCoordinatorStateModelTests
     {
-        public static ShardCoordinatorStateModelTests()
+        static ShardCoordinatorStateModelTests()
         {
             // register the custom generators to make testing easier
             Arb.Register<ClusterGenerators>();

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardCoordinatorStateModelTests.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardCoordinatorStateModelTests.cs
@@ -1,0 +1,286 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ShardCoordinatorStateModelTests.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+#if NET5_0_OR_GREATER
+
+using System;
+using System.Collections.Immutable;
+using Akka.Actor;
+using Akka.Cluster.Tests;
+using Akka.Tests.Shared.Internals.Helpers;
+using FsCheck;
+using FsCheck.Experimental;
+
+
+namespace Akka.Cluster.Sharding.Tests
+{
+    using ShardId = System.String;
+
+    internal sealed class StateHolder
+    {
+        /// <summary>
+        /// Has to be part of a mutable class in order for mutations
+        /// to be remembered in-between FsCheck operations.
+        /// </summary>
+        public PersistentShardCoordinator.State State { get; set; }
+    }
+
+    /// <summary>
+    /// Immutable model mirroring the <see cref="PersistentShardCoordinator.State"/> object.
+    /// </summary>
+    internal sealed record TestState
+    {
+        public const string ShardRegionName = "myRegion";
+
+        /// <summary>
+        /// Stack of recently executed commands
+        /// </summary>
+        public ImmutableStack<PersistentShardCoordinator.IDomainEvent> Commands { get; init; }
+
+        /// <summary>
+        /// All shard regions participating in the test.
+        /// </summary>
+        public ImmutableHashSet<IActorRef> AvailableShardRegions { get; init; }
+        
+        /// <summary>
+        /// All shard region proxies participating in the test.
+        /// </summary>
+        public ImmutableHashSet<IActorRef> AvailableShardRegionProxies { get; init; }
+
+        /// <summary>
+        /// Region for each shard.
+        /// </summary>
+        public IImmutableDictionary<ShardId, IActorRef> Shards { get; init; }
+
+        /// <summary>
+        /// Shards for each region.
+        /// </summary>
+        public IImmutableDictionary<IActorRef, IImmutableList<ShardId>> Regions { get; init; }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public IImmutableSet<IActorRef> RegionProxies { get; init; }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public IImmutableSet<ShardId> UnallocatedShards { get; init; }
+
+        public bool RememberEntities { get; init; }
+
+        public static Arbitrary<IActorRef> ShardRegionRefGenerator(int shardCount)
+        {
+            var gen1 = ClusterGenerators.AddressGenerator().Generator; // node addresses
+            var gen2 = Gen.Choose(0, shardCount); // shardIds
+            var gen3 = Arb.Default.Int64().Generator; // IActorRef UIDs
+
+
+            Func<Address, int, long, IActorRef> combiner = (node, shardId, actorUid) =>
+            {
+                var path = (new RootActorPath(node) / "system" / "sharding" / ShardRegionName / shardId.ToString())
+                    .WithUid(actorUid);
+                return new EmptyLocalActorRef(null, path, null);
+            };
+            var producer = FsharpDelegateHelper.Create(combiner);
+
+            return Arb.From(Gen.Map3(producer, gen1, gen2, gen3));
+        }
+    }
+
+    internal class StateModel : Machine<StateHolder, TestState>
+    {
+        public override Gen<Operation<StateHolder, TestState>> Next(TestState obj0)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override Arbitrary<Setup<StateHolder, TestState>> Setup =>
+            // compiler ceremony
+            Arb.From(Gen.Choose(0, 100)
+                .Select(x => (Setup<StateHolder, TestState>)new ClusterStateSetup(x)));
+
+        #region Setup Classes
+
+        /// <summary>
+        /// Used to populate the test
+        /// </summary>
+        // ReSharper disable once ClassNeverInstantiated.Local
+        private class ClusterStateSetup : Setup<StateHolder, TestState>
+        {
+            public ClusterStateSetup(int shardCount)
+            {
+                ShardCount = shardCount;
+            }
+
+            public int ShardCount { get; }
+
+            public override StateHolder Actual()
+            {
+                return new StateHolder() { State = PersistentShardCoordinator.State.Empty };
+            }
+
+            public override TestState Model()
+            {
+                return new TestState();
+            }
+        }
+
+        #endregion
+        
+        #region Operation Classes
+
+        public abstract class ShardOperationBase : Operation<StateHolder, TestState>
+        {
+            public abstract PersistentShardCoordinator.IDomainEvent Event { get; }
+
+            /// <summary>
+            /// Checks keys only - does not check shard-specific values.
+            /// </summary>
+            /// <param name="actual">The actual data from the sharding implementation.</param>
+            /// <param name="model">Data from our FsCheck model.</param>
+            /// <returns>A set of falsifiable FsCheck properties.</returns>
+            public Property CheckCommonShardStates(StateHolder actual, TestState model)
+            {
+                var exceptRegions = actual.State.Regions.Keys.ToImmutableHashSet()
+                    .SymmetricExcept(model.Regions.Keys);
+                var exceptProxies = actual.State.RegionProxies.SymmetricExcept(model.RegionProxies);
+                var exceptShards = actual.State.Shards.Keys.ToImmutableHashSet().SymmetricExcept(model.Shards.Keys);
+                var exceptUnallocatedShards = actual.State.UnallocatedShards.SymmetricExcept(model.UnallocatedShards);
+
+                return actual.State.Regions.Keys.ToImmutableHashSet().SetEquals(model.Regions.Keys)
+                    .Label(
+                        $"Both ShardRegions should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptRegions)}]")
+                    .And(actual.State.Shards.Keys.ToImmutableHashSet().SetEquals(model.Shards.Keys)
+                        .Label(
+                            $"Both Shards should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptShards)}]"))
+                    .And(actual.State.RegionProxies.SetEquals(model.RegionProxies).Label(
+                        $"Both ShardProxies should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptProxies)}]"))
+                    .And(actual.State.UnallocatedShards.SetEquals(model.UnallocatedShards)
+                        .Label(
+                            $"Both UnallocatedShards should contain same set of members. Instead found members not included in both sequences: [{string.Join(",", exceptUnallocatedShards)}]"));
+            }
+
+            public Property CheckShardRegionSpecificStates(StateHolder actual, TestState model, IActorRef shardRegion)
+            {
+                var regionDiff = actual.State.Regions[shardRegion].ToImmutableHashSet()
+                    .SymmetricExcept(model.Regions[shardRegion]);
+
+                return actual.State.Regions[shardRegion].ToImmutableHashSet().SetEquals(model.Regions[shardRegion])
+                    .Label(
+                        $"Both ShardRegions should contain shards, but found members not included in both sequences: [{string.Join(",", regionDiff)}]");
+            }
+
+            public Property CheckShardSpecificStates(StateHolder actual, TestState model, ShardId shard, bool unallocated = false)
+            {
+                Property CheckContains()
+                {
+                    return ((actual.State.Shards.ContainsKey(shard) || model.Shards.ContainsKey(shard)) == !unallocated)
+                        .Label(
+                            $"Shard [{shard}] should not be present in Shards collection (because, unallocated), but found in state: {actual.State.Shards.ContainsKey(shard)} && model {model.Shards.ContainsKey(shard)}")
+                        .And(((actual.State.UnallocatedShards.Contains(shard) &&
+                               model.UnallocatedShards.Contains(shard)) == unallocated)
+                            .Label(
+                                $"Shard [{shard}] should be unallocated, but found in state: {model.UnallocatedShards.Contains(shard)} && model {model.UnallocatedShards.Contains(shard)}"));
+                }
+
+                if (unallocated)
+                    return CheckContains();
+
+                return CheckContains().And(actual.State.Shards[shard].Equals(model.Shards[shard])
+                    .Label(
+                        $"Expected Shard [{shard}] to have registered ShardRegion [{model.Shards[shard]}], but found [{actual.State.Shards[shard]}]"));
+            }
+
+            public Property ShouldThrowException(StateHolder actual, string errMsgContains)
+            {
+                Action throwable = () =>
+                {
+                    actual.State = actual.State.Updated(Event);
+                };
+
+                Exception trapped = null;
+
+                try
+                {
+                    throwable();
+                }
+                catch (Exception ex)
+                {
+                    trapped = ex;
+                }
+
+                return (trapped != null && trapped.Message.Contains(errMsgContains)).Label(
+                    $"Expected state to throw error containing message [{errMsgContains}] when processing {Event}. Instead found [{trapped}]");
+            }
+        }
+
+        public class RegisterShardRegion : ShardOperationBase
+        {
+            public RegisterShardRegion(IActorRef shardRegion)
+            {
+                ShardRegion = shardRegion;
+            }
+
+            public IActorRef ShardRegion { get; }
+
+            public override PersistentShardCoordinator.IDomainEvent Event =>  new PersistentShardCoordinator.ShardRegionRegistered(ShardRegion);
+
+            public override Property Check(StateHolder actual, TestState model)
+            {
+                // check for whether we should expect an exception
+                if (!actual.State.Regions.ContainsKey(ShardRegion))
+                {
+                    return ShouldThrowException(actual, "").And(CheckCommonShardStates(actual, model))
+                        .And(CheckShardRegionSpecificStates(actual, model, ShardRegion));
+                }
+
+                actual.State = actual.State.Updated(Event);
+                return CheckCommonShardStates(actual, model)
+                    .And(CheckShardRegionSpecificStates(actual, model, ShardRegion));
+            }
+
+            public override TestState Run(TestState obj0)
+            {
+                var ob1 = obj0 with
+                {
+                    Commands = obj0.Commands.Push(Event),
+                };
+
+                // don't want to wipe out our ShardRegion here if this event was unexpected
+                if (ob1.Regions.ContainsKey(ShardRegion))
+                    return ob1;
+                return ob1 with { Regions = ob1.Regions.Add(ShardRegion, ImmutableList<string>.Empty) };
+            }
+        }
+
+        public class ShardRegionProxyRegistered : ShardOperationBase
+        {
+            public override Property Check(StateHolder obj0, TestState obj1)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override TestState Run(TestState obj0)
+            {
+                throw new NotImplementedException();
+            }
+            
+            public IActorRef ShardRegionProxy { get; }
+
+            public override PersistentShardCoordinator.IDomainEvent Event { get; }
+        }
+
+        #endregion
+    }
+
+    public class ShardCoordinatorStateModelTests
+    {
+    }
+}
+
+#endif

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessSpec.cs
@@ -125,7 +125,7 @@ namespace Akka.Cluster.Sharding.Tests
 
             var probe = CreateTestProbe();
             var settings = ShardedDaemonProcessSettings.Create(Sys).WithRole("workers");
-            ShardedDaemonProcess.Get(Sys).Init("roles", 3, id => MyActor.Props(id, probe.Ref), settings);
+            ShardedDaemonProcess.Get(Sys).Init("roles", 3, id => MyActor.Props(id, probe.Ref), settings, PoisonPill.Instance);
 
             probe.ExpectNoMsg();
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -47,8 +47,9 @@ namespace Akka.Cluster.Sharding
             /// TBD
             /// </summary>
             public readonly IImmutableSet<IActorRef> RegionProxies;
+            
             /// <summary>
-            /// TBD
+            /// Only used when <see cref="RememberEntities"/> is enabled.
             /// </summary>
             public readonly IImmutableSet<ShardId> UnallocatedShards;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -109,15 +109,12 @@ namespace Akka.Cluster.Sharding
             }
 
             /// <summary>
-            /// Feed an event into the ShardCoordinator state.
+            /// TBD
             /// </summary>
-            /// <param name="e">The event to process.</param>
-            /// <param name="isRecovering">A flag to indicate if we're trying to recover state previously stored in the database.
-            /// We need to be more tolerant when this happens in the name of trying to accelerate recovery, so the system doesn't compromise
-            /// itself and go offline.</param>
-            /// <exception cref="ArgumentException">Thrown if an event is illegal in the current state.</exception>
-            /// <returns>An update copy of this state.</returns>
-            public State Updated(IDomainEvent e, bool isRecovering = false)
+            /// <param name="e">TBD</param>
+            /// <exception cref="ArgumentException">TBD</exception>
+            /// <returns>TBD</returns>
+            public State Updated(IDomainEvent e)
             {
                 switch (e)
                 {
@@ -156,27 +153,7 @@ namespace Akka.Cluster.Sharding
                             if (!Regions.TryGetValue(message.Region, out var shardRegions))
                                 throw new ArgumentException($"Region {message.Region} not registered", nameof(e));
                             if (Shards.ContainsKey(message.Shard))
-                            {
-                                if (!isRecovering)
-                                    throw new ArgumentException($"Shard {message.Shard} is already allocated",
-                                        nameof(e));
-                                
-                                // per https://github.com/akkadotnet/akka.net/issues/5604
-                                // we're going to allow new value to overwrite previous
-                                var newRegions = Regions;
-                                var previousRegion = Shards[message.Shard];
-                                if (Regions.TryGetValue(previousRegion, out var previousShards))
-                                {
-                                    newRegions = newRegions.SetItem(previousRegion,
-                                        previousShards.Remove(message.Shard));
-                                }
-                                var newUnallocatedShardsRecovery = RememberEntities ? UnallocatedShards.Remove(message.Shard) : UnallocatedShards;
-                                return Copy(
-                                    shards: Shards.SetItem(message.Shard, message.Region),
-                                    regions: newRegions.SetItem(message.Region, shardRegions.Add(message.Shard)),
-                                    unallocatedShards: newUnallocatedShardsRecovery);
-                            }
-                                
+                                throw new ArgumentException($"Shard {message.Shard} is already allocated", nameof(e));
 
                             var newUnallocatedShards = RememberEntities ? UnallocatedShards.Remove(message.Shard) : UnallocatedShards;
                             return Copy(
@@ -1369,26 +1346,26 @@ namespace Akka.Cluster.Sharding
                     switch (evt)
                     {
                         case ShardRegionRegistered _:
-                            CurrentState = CurrentState.Updated(evt, true);
+                            CurrentState = CurrentState.Updated(evt);
                             return true;
                         case ShardRegionProxyRegistered _:
-                            CurrentState = CurrentState.Updated(evt, true);
+                            CurrentState = CurrentState.Updated(evt);
                             return true;
                         case ShardRegionTerminated regionTerminated:
                             if (CurrentState.Regions.ContainsKey(regionTerminated.Region))
-                                CurrentState = CurrentState.Updated(evt, true);
+                                CurrentState = CurrentState.Updated(evt);
                             else
                                 Log.Debug("ShardRegionTerminated but region {0} was not registered", regionTerminated.Region);
                             return true;
                         case ShardRegionProxyTerminated proxyTerminated:
                             if (CurrentState.RegionProxies.Contains(proxyTerminated.RegionProxy))
-                                CurrentState = CurrentState.Updated(evt, true);
+                                CurrentState = CurrentState.Updated(evt);
                             return true;
                         case ShardHomeAllocated _:
-                            CurrentState = CurrentState.Updated(evt, true);
+                            CurrentState = CurrentState.Updated(evt);
                             return true;
                         case ShardHomeDeallocated _:
-                            CurrentState = CurrentState.Updated(evt, true);
+                            CurrentState = CurrentState.Updated(evt);
                             return true;
                     }
                     return false;

--- a/src/core/Akka.Tests.Shared.Internals/Helpers/FSharpDelegateHelper.cs
+++ b/src/core/Akka.Tests.Shared.Internals/Helpers/FSharpDelegateHelper.cs
@@ -35,5 +35,13 @@ namespace Akka.Tests.Shared.Internals.Helpers
                 value1 => { return Create<T2, T3, TResult>((value2, value3) => func(value1, value2, value3)); };
             return FSharpFunc<T1, FSharpFunc<T2, FSharpFunc<T3, TResult>>>.FromConverter(conv);
         }
+        
+        public static FSharpFunc<T1, FSharpFunc<T2, FSharpFunc<T3, FSharpFunc<T4, TResult>>>> Create<T1, T2, T3, T4, TResult>(
+            Func<T1, T2, T3, T4, TResult> func)
+        {
+            Converter<T1, FSharpFunc<T2, FSharpFunc<T3, FSharpFunc<T4, TResult>>>> conv =
+                value1 => { return Create<T2, T3, T4, TResult>((value2, value3, value4) => func(value1, value2, value3, value4)); };
+            return FSharpFunc<T1, FSharpFunc<T2, FSharpFunc<T3, FSharpFunc<T4, TResult>>>>.FromConverter(conv);
+        }
     }
 }


### PR DESCRIPTION
Fixes #5604

## Changes

Added model-based test with FsCheck to validate that `PersistentShardCoordinator.State` is designed correctly.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
