### PR TITLE
Fix sharding tolerant reader

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -109,15 +109,12 @@ namespace Akka.Cluster.Sharding
             }
 
             /// <summary>
-            /// Feed an event into the ShardCoordinator state.
+            /// TBD
             /// </summary>
-            /// <param name="e">The event to process.</param>
-            /// <param name="isRecovering">A flag to indicate if we're trying to recover state previously stored in the database.
-            /// We need to be more tolerant when this happens in the name of trying to accelerate recovery, so the system doesn't compromise
-            /// itself and go offline.</param>
-            /// <exception cref="ArgumentException">Thrown if an event is illegal in the current state.</exception>
-            /// <returns>An update copy of this state.</returns>
-            public State Updated(IDomainEvent e, bool isRecovering = false)
+            /// <param name="e">TBD</param>
+            /// <exception cref="ArgumentException">TBD</exception>
+            /// <returns>TBD</returns>
+            public State Updated(IDomainEvent e)
             {
                 switch (e)
                 {
@@ -156,27 +153,7 @@ namespace Akka.Cluster.Sharding
                             if (!Regions.TryGetValue(message.Region, out var shardRegions))
                                 throw new ArgumentException($"Region {message.Region} not registered", nameof(e));
                             if (Shards.ContainsKey(message.Shard))
-                            {
-                                if (!isRecovering)
-                                    throw new ArgumentException($"Shard {message.Shard} is already allocated",
-                                        nameof(e));
-                                
-                                // per https://github.com/akkadotnet/akka.net/issues/5604
-                                // we're going to allow new value to overwrite previous
-                                var newRegions = Regions;
-                                var previousRegion = Shards[message.Shard];
-                                if (Regions.TryGetValue(previousRegion, out var previousShards))
-                                {
-                                    newRegions = newRegions.SetItem(previousRegion,
-                                        previousShards.Remove(message.Shard));
-                                }
-                                var newUnallocatedShardsRecovery = RememberEntities ? UnallocatedShards.Remove(message.Shard) : UnallocatedShards;
-                                return Copy(
-                                    shards: Shards.SetItem(message.Shard, message.Region),
-                                    regions: newRegions.SetItem(message.Region, shardRegions.Add(message.Shard)),
-                                    unallocatedShards: newUnallocatedShardsRecovery);
-                            }
-                                
+                                throw new ArgumentException($"Shard {message.Shard} is already allocated", nameof(e));
 
                             var newUnallocatedShards = RememberEntities ? UnallocatedShards.Remove(message.Shard) : UnallocatedShards;
                             return Copy(
@@ -1369,26 +1346,26 @@ namespace Akka.Cluster.Sharding
                     switch (evt)
                     {
                         case ShardRegionRegistered _:
-                            CurrentState = CurrentState.Updated(evt, true);
+                            CurrentState = CurrentState.Updated(evt);
                             return true;
                         case ShardRegionProxyRegistered _:
-                            CurrentState = CurrentState.Updated(evt, true);
+                            CurrentState = CurrentState.Updated(evt);
                             return true;
                         case ShardRegionTerminated regionTerminated:
                             if (CurrentState.Regions.ContainsKey(regionTerminated.Region))
-                                CurrentState = CurrentState.Updated(evt, true);
+                                CurrentState = CurrentState.Updated(evt);
                             else
                                 Log.Debug("ShardRegionTerminated but region {0} was not registered", regionTerminated.Region);
                             return true;
                         case ShardRegionProxyTerminated proxyTerminated:
                             if (CurrentState.RegionProxies.Contains(proxyTerminated.RegionProxy))
-                                CurrentState = CurrentState.Updated(evt, true);
+                                CurrentState = CurrentState.Updated(evt);
                             return true;
                         case ShardHomeAllocated _:
-                            CurrentState = CurrentState.Updated(evt, true);
+                            CurrentState = CurrentState.Updated(evt);
                             return true;
                         case ShardHomeDeallocated _:
-                            CurrentState = CurrentState.Updated(evt, true);
+                            CurrentState = CurrentState.Updated(evt);
                             return true;
                     }
                     return false;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/PersistentShardCoordinator.cs
@@ -1364,9 +1364,10 @@ namespace Akka.Cluster.Sharding
                         case ShardHomeAllocated homeAllocated:
                             // if we already have identical ShardHomeAllocated data, skip processing it
                             // addresses https://github.com/akkadotnet/akka.net/issues/5604
-                            if(!(CurrentState.Shards.TryGetValue(homeAllocated.Shard, out var currentShardRegion) 
-                               && Equals(homeAllocated.Region, currentShardRegion)))
-                                CurrentState = CurrentState.Updated(evt);
+                            if (CurrentState.Shards.TryGetValue(homeAllocated.Shard, out var currentShardRegion)
+                                && Equals(homeAllocated.Region, currentShardRegion))
+                                return true;
+                            CurrentState = CurrentState.Updated(evt);
                             return true;
                         case ShardHomeDeallocated _:
                             CurrentState = CurrentState.Updated(evt);


### PR DESCRIPTION
Fixes #5604 
Reverts https://github.com/akkadotnet/akka.net/pull/5967

## Changes

De-duplicate only exact `ShardHomeAllocated` duplicate data, makes the changes to the `PersistentShardCoordinator` safer and more narrow in scope than https://github.com/akkadotnet/akka.net/pull/5967

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #5970 
