### PR TITLE
[Async TestKit] Modernize TcpStage and TcpListener

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
@@ -3640,12 +3640,11 @@ namespace Akka.IO
         }
         public class ResumeReading : Akka.IO.Tcp.Command
         {
-            public static Akka.IO.Tcp.ResumeReading Instance;
+            public static readonly Akka.IO.Tcp.ResumeReading Instance;
         }
         public class ResumeWriting : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.ResumeWriting Instance;
-            public ResumeWriting() { }
         }
         public abstract class SimpleWriteCommand : Akka.IO.Tcp.WriteCommand
         {
@@ -3656,7 +3655,7 @@ namespace Akka.IO
         }
         public class SuspendReading : Akka.IO.Tcp.Command
         {
-            public static Akka.IO.Tcp.SuspendReading Instance;
+            public static readonly Akka.IO.Tcp.SuspendReading Instance;
         }
         public class Unbind : Akka.IO.Tcp.Command
         {
@@ -3664,8 +3663,7 @@ namespace Akka.IO
         }
         public class Unbound : Akka.IO.Tcp.Event
         {
-            public static Akka.IO.Tcp.Unbound Instance;
-            public Unbound() { }
+            public static readonly Akka.IO.Tcp.Unbound Instance;
         }
         public class Write : Akka.IO.Tcp.SimpleWriteCommand
         {
@@ -3686,8 +3684,7 @@ namespace Akka.IO
         }
         public class WritingResumed : Akka.IO.Tcp.Event
         {
-            public static Akka.IO.Tcp.WritingResumed Instance;
-            public WritingResumed() { }
+            public static readonly Akka.IO.Tcp.WritingResumed Instance;
         }
     }
     public sealed class TcpExt : Akka.IO.IOExtension

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3647,12 +3647,11 @@ namespace Akka.IO
         }
         public class ResumeReading : Akka.IO.Tcp.Command
         {
-            public static Akka.IO.Tcp.ResumeReading Instance;
+            public static readonly Akka.IO.Tcp.ResumeReading Instance;
         }
         public class ResumeWriting : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.ResumeWriting Instance;
-            public ResumeWriting() { }
         }
         public abstract class SimpleWriteCommand : Akka.IO.Tcp.WriteCommand
         {
@@ -3663,7 +3662,7 @@ namespace Akka.IO
         }
         public class SuspendReading : Akka.IO.Tcp.Command
         {
-            public static Akka.IO.Tcp.SuspendReading Instance;
+            public static readonly Akka.IO.Tcp.SuspendReading Instance;
         }
         public class Unbind : Akka.IO.Tcp.Command
         {
@@ -3671,8 +3670,7 @@ namespace Akka.IO
         }
         public class Unbound : Akka.IO.Tcp.Event
         {
-            public static Akka.IO.Tcp.Unbound Instance;
-            public Unbound() { }
+            public static readonly Akka.IO.Tcp.Unbound Instance;
         }
         public class Write : Akka.IO.Tcp.SimpleWriteCommand
         {
@@ -3693,8 +3691,7 @@ namespace Akka.IO
         }
         public class WritingResumed : Akka.IO.Tcp.Event
         {
-            public static Akka.IO.Tcp.WritingResumed Instance;
-            public WritingResumed() { }
+            public static readonly Akka.IO.Tcp.WritingResumed Instance;
         }
     }
     public sealed class TcpExt : Akka.IO.IOExtension

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3640,12 +3640,11 @@ namespace Akka.IO
         }
         public class ResumeReading : Akka.IO.Tcp.Command
         {
-            public static Akka.IO.Tcp.ResumeReading Instance;
+            public static readonly Akka.IO.Tcp.ResumeReading Instance;
         }
         public class ResumeWriting : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.ResumeWriting Instance;
-            public ResumeWriting() { }
         }
         public abstract class SimpleWriteCommand : Akka.IO.Tcp.WriteCommand
         {
@@ -3656,7 +3655,7 @@ namespace Akka.IO
         }
         public class SuspendReading : Akka.IO.Tcp.Command
         {
-            public static Akka.IO.Tcp.SuspendReading Instance;
+            public static readonly Akka.IO.Tcp.SuspendReading Instance;
         }
         public class Unbind : Akka.IO.Tcp.Command
         {
@@ -3664,8 +3663,7 @@ namespace Akka.IO
         }
         public class Unbound : Akka.IO.Tcp.Event
         {
-            public static Akka.IO.Tcp.Unbound Instance;
-            public Unbound() { }
+            public static readonly Akka.IO.Tcp.Unbound Instance;
         }
         public class Write : Akka.IO.Tcp.SimpleWriteCommand
         {
@@ -3686,8 +3684,7 @@ namespace Akka.IO
         }
         public class WritingResumed : Akka.IO.Tcp.Event
         {
-            public static Akka.IO.Tcp.WritingResumed Instance;
-            public WritingResumed() { }
+            public static readonly Akka.IO.Tcp.WritingResumed Instance;
         }
     }
     public sealed class TcpExt : Akka.IO.IOExtension

--- a/src/core/Akka/IO/Tcp.cs
+++ b/src/core/Akka/IO/Tcp.cs
@@ -667,6 +667,10 @@ namespace Akka.IO
             /// TBD
             /// </summary>
             public static readonly ResumeWriting Instance = new ResumeWriting();
+
+            private ResumeWriting()
+            {
+            }
         }
 
         /// <summary>
@@ -679,7 +683,7 @@ namespace Akka.IO
             /// <summary>
             /// TBD
             /// </summary>
-            public static SuspendReading Instance = new SuspendReading();
+            public static readonly SuspendReading Instance = new SuspendReading();
 
             private SuspendReading()
             {
@@ -695,7 +699,7 @@ namespace Akka.IO
             /// <summary>
             /// TBD
             /// </summary>
-            public static ResumeReading Instance = new ResumeReading();
+            public static readonly ResumeReading Instance = new ResumeReading();
 
             private ResumeReading()
             {
@@ -830,7 +834,11 @@ namespace Akka.IO
             /// <summary>
             /// TBD
             /// </summary>
-            public static WritingResumed Instance = new WritingResumed();
+            public static readonly WritingResumed Instance = new WritingResumed();
+
+            private WritingResumed()
+            {
+            }
         }
 
         /// <summary>
@@ -867,7 +875,11 @@ namespace Akka.IO
             /// <summary>
             /// Singleton instance
             /// </summary>
-            public static Unbound Instance = new Unbound();
+            public static readonly Unbound Instance = new Unbound();
+
+            private Unbound()
+            {
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Changes:
Make TcpListener binding and unbinding code non-blocking by running them on another thread.