### PR TITLE
Added TimeBasedUuid offset

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Core.verified.txt
@@ -67,6 +67,7 @@ namespace Akka.Persistence.Query
         public abstract int CompareTo(Akka.Persistence.Query.Offset other);
         public static Akka.Persistence.Query.Offset NoOffset() { }
         public static Akka.Persistence.Query.Offset Sequence(long value) { }
+        public static Akka.Persistence.Query.Offset TimeBasedUuid(System.Guid value) { }
     }
     public sealed class PersistenceQuery : Akka.Actor.IExtension
     {
@@ -92,6 +93,15 @@ namespace Akka.Persistence.Query
         public Sequence(long value) { }
         public long Value { get; }
         public int CompareTo(Akka.Persistence.Query.Sequence other) { }
+        public override int CompareTo(Akka.Persistence.Query.Offset other) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+    }
+    public sealed class TimeBasedUuid : Akka.Persistence.Query.Offset, System.IComparable<Akka.Persistence.Query.TimeBasedUuid>
+    {
+        public TimeBasedUuid(System.Guid value) { }
+        public System.Guid Value { get; }
+        public int CompareTo(Akka.Persistence.Query.TimeBasedUuid other) { }
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
@@ -67,6 +67,7 @@ namespace Akka.Persistence.Query
         public abstract int CompareTo(Akka.Persistence.Query.Offset other);
         public static Akka.Persistence.Query.Offset NoOffset() { }
         public static Akka.Persistence.Query.Offset Sequence(long value) { }
+        public static Akka.Persistence.Query.Offset TimeBasedUuid(System.Guid value) { }
     }
     public sealed class PersistenceQuery : Akka.Actor.IExtension
     {
@@ -92,6 +93,15 @@ namespace Akka.Persistence.Query
         public Sequence(long value) { }
         public long Value { get; }
         public int CompareTo(Akka.Persistence.Query.Sequence other) { }
+        public override int CompareTo(Akka.Persistence.Query.Offset other) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+    }
+    public sealed class TimeBasedUuid : Akka.Persistence.Query.Offset, System.IComparable<Akka.Persistence.Query.TimeBasedUuid>
+    {
+        public TimeBasedUuid(System.Guid value) { }
+        public System.Guid Value { get; }
+        public int CompareTo(Akka.Persistence.Query.TimeBasedUuid other) { }
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
@@ -67,6 +67,7 @@ namespace Akka.Persistence.Query
         public abstract int CompareTo(Akka.Persistence.Query.Offset other);
         public static Akka.Persistence.Query.Offset NoOffset() { }
         public static Akka.Persistence.Query.Offset Sequence(long value) { }
+        public static Akka.Persistence.Query.Offset TimeBasedUuid(System.Guid value) { }
     }
     public sealed class PersistenceQuery : Akka.Actor.IExtension
     {
@@ -92,6 +93,15 @@ namespace Akka.Persistence.Query
         public Sequence(long value) { }
         public long Value { get; }
         public int CompareTo(Akka.Persistence.Query.Sequence other) { }
+        public override int CompareTo(Akka.Persistence.Query.Offset other) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+    }
+    public sealed class TimeBasedUuid : Akka.Persistence.Query.Offset, System.IComparable<Akka.Persistence.Query.TimeBasedUuid>
+    {
+        public TimeBasedUuid(System.Guid value) { }
+        public System.Guid Value { get; }
+        public int CompareTo(Akka.Persistence.Query.TimeBasedUuid other) { }
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/core/Akka.Persistence.Query.Tests/OffsetSpec.cs
+++ b/src/core/Akka.Persistence.Query.Tests/OffsetSpec.cs
@@ -1,0 +1,42 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="OffsetSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Persistence.Query.Tests
+{
+    public class OffsetSpec
+    {
+        [Fact]
+        public void TimeBasedUuid_offset_must_be_ordered_correctly()
+        {
+            var uuid1 = new TimeBasedUuid(TimeUuid.Parse("49225740-2019-11ea-a6f0-a0a60c2ef4ff")); //2019-12-16T15:32:36.148Z[UTC]            
+            var uuid2 = new TimeBasedUuid(TimeUuid.Parse("91be23d0-2019-11ea-a752-ffae2393b6e4")); //2019-12-16T15:34:37.965Z[UTC]
+            var uuid3 = new TimeBasedUuid(TimeUuid.Parse("91f95810-2019-11ea-a752-ffae2393b6e4")); //2019-12-16T15:34:38.353Z[UTC]
+
+            ((TimeUuid)uuid1.Value).GetDate().Should().BeBefore(((TimeUuid)uuid2.Value).GetDate());
+            ((TimeUuid)uuid2.Value).GetDate().Should().BeBefore(((TimeUuid)uuid3.Value).GetDate());
+
+            new List<TimeBasedUuid>() { uuid2, uuid1, uuid3 }.OrderBy(_ => Guid.NewGuid())
+                .Should().BeEquivalentTo(new List<TimeBasedUuid>() { uuid1, uuid2, uuid3 });
+            new List<TimeBasedUuid>() { uuid3, uuid2, uuid1 }.OrderBy(_ => Guid.NewGuid())
+                .Should().BeEquivalentTo(new List<TimeBasedUuid>() { uuid1, uuid2, uuid3 });
+        }
+
+        [Fact]
+        public void Sequence_offset_must_be_ordered_correctly()
+        {
+            var sequenceBasedList = new List<long> { 1L, 2L, 3L }.Select(l => new Sequence(l));
+            var shuffledSequenceBasedList = sequenceBasedList.OrderBy(_ => Guid.NewGuid());
+            shuffledSequenceBasedList.Should().BeEquivalentTo(sequenceBasedList);
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Query.Tests/Utils/TimeUuid.cs
+++ b/src/core/Akka.Persistence.Query.Tests/Utils/TimeUuid.cs
@@ -1,0 +1,270 @@
+﻿//
+//      Copyright (C) DataStax Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+//
+
+using System;
+
+namespace Akka.Persistence.Query
+{
+    /// <summary>
+    /// Represents a v1 uuid 
+    /// </summary>
+    internal struct TimeUuid : IEquatable<TimeUuid>, IComparable<TimeUuid>
+    {
+        private static readonly DateTimeOffset GregorianCalendarTime = new DateTimeOffset(1582, 10, 15, 0, 0, 0, TimeSpan.Zero);
+        //Reuse the random generator to avoid collisions
+        private static readonly Random RandomGenerator = new Random();
+        private static readonly object RandomLock = new object();
+        private static readonly byte[] MinNodeId = { 0x80, 0x80, 0x80, 0x80, 0x80, 0x80 };
+        private static readonly byte[] MinClockId = { 0x80, 0x80 };
+        private static readonly byte[] MaxNodeId = { 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f };
+        private static readonly byte[] MaxClockId = { 0x7f, 0x7f };
+
+        private readonly Guid _value;
+
+        private TimeUuid(Guid value)
+        {
+            _value = value;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="TimeUuid"/>.
+        /// </summary>
+        /// <param name="nodeId">6-byte node identifier</param>
+        /// <param name="clockId">2-byte clock identifier</param>
+        /// <param name="time">The timestamp</param>
+        /// <exception cref="ArgumentException"></exception>
+        private TimeUuid(byte[] nodeId, byte[] clockId, DateTimeOffset time)
+        {
+            if (nodeId == null || nodeId.Length != 6)
+            {
+                throw new ArgumentException("node Id should contain 6 bytes", nameof(nodeId));
+            }
+            if (clockId == null || clockId.Length != 2)
+            {
+                throw new ArgumentException("clock Id should contain 2 bytes", nameof(clockId));
+            }
+            var timeBytes = BitConverter.GetBytes((time - GregorianCalendarTime).Ticks);
+            if (!BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(timeBytes);
+            }
+            var buffer = new byte[16];
+            //Positions 0-7 Timestamp
+            Buffer.BlockCopy(timeBytes, 0, buffer, 0, 8);
+            //Position 8-9 Clock
+            Buffer.BlockCopy(clockId, 0, buffer, 8, 2);
+            //Positions 10-15 Node
+            Buffer.BlockCopy(nodeId, 0, buffer, 10, 6);
+
+            //Version Byte: Time based
+            //0001xxxx
+            //turn off first 4 bits
+            buffer[7] &= 0x0f; //00001111
+            //turn on fifth bit
+            buffer[7] |= 0x10; //00010000
+
+            //Variant Byte: 1.0.x
+            //10xxxxxx
+            //turn off first 2 bits
+            buffer[8] &= 0x3f; //00111111
+            //turn on first bit
+            buffer[8] |= 0x80; //10000000
+
+            _value = new Guid(buffer);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance and a specified TimeUuid object represent the same value.
+        /// </summary>
+        public bool Equals(TimeUuid other)
+        {
+            return _value.Equals(other._value);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance and a specified TimeUuid object represent the same value.
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            var otherTimeUuid = obj as TimeUuid?;
+            return otherTimeUuid != null && Equals(otherTimeUuid.Value);
+        }
+
+        /// <summary>
+        /// Gets the DateTimeOffset representation of this instance
+        /// </summary>
+        public DateTimeOffset GetDate()
+        {
+            var bytes = _value.ToByteArray();
+            //Remove version bit
+            bytes[7] &= 0x0f; //00001111
+            //Remove variant
+            bytes[8] &= 0x3f; //00111111
+            if (!BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(bytes);
+            }
+            var timestamp = BitConverter.ToInt64(bytes, 0);
+            var ticks = timestamp + GregorianCalendarTime.Ticks;
+
+            return new DateTimeOffset(ticks, TimeSpan.Zero);
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Returns a 16-element byte array that contains the value of this instance.
+        /// </summary>
+        public byte[] ToByteArray()
+        {
+            return _value.ToByteArray();
+        }
+
+        /// <summary>
+        /// Gets the Guid representation of the Id
+        /// </summary>
+        public Guid ToGuid()
+        {
+            return _value;
+        }
+
+        /// <summary>
+        /// Compares the current TimeUuid with another TimeUuid based on the time representation of this instance.
+        /// </summary>
+        public int CompareTo(TimeUuid other)
+        {
+            return GetDate().CompareTo(other.GetDate());
+        }
+
+        /// <summary>
+        /// Returns a string representation of the value of this instance in registry format.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return _value.ToString();
+        }
+
+        /// <summary>
+        /// Returns a string representation
+        /// </summary>
+        public string ToString(string format, IFormatProvider provider)
+        {
+            return _value.ToString(format, provider);
+        }
+
+        /// <summary>
+        /// Returns a string representation
+        /// </summary>
+        public string ToString(string format)
+        {
+            return _value.ToString(format);
+        }
+
+        /// <summary>
+        /// Returns the smaller possible type 1 uuid with the provided date.
+        /// </summary>
+        public static TimeUuid Min(DateTimeOffset date)
+        {
+            return new TimeUuid(MinNodeId, MinClockId, date);
+        }
+
+        /// <summary>
+        /// Returns the biggest possible type 1 uuid with the provided Date.
+        /// </summary>
+        public static TimeUuid Max(DateTimeOffset date)
+        {
+            return new TimeUuid(MaxNodeId, MaxClockId, date);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the TimeUuid structure, using a random node id and clock sequence and the current date time
+        /// </summary>
+        public static TimeUuid NewId()
+        {
+            return NewId(DateTimeOffset.Now);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the TimeUuid structure, using a random node id and clock sequence
+        /// </summary>
+        public static TimeUuid NewId(DateTimeOffset date)
+        {
+            byte[] nodeId;
+            byte[] clockId;
+            lock (RandomLock)
+            {
+                //oh yeah, thread safety
+                nodeId = new byte[6];
+                clockId = new byte[2];
+                RandomGenerator.NextBytes(nodeId);
+                RandomGenerator.NextBytes(clockId);
+            }
+            return new TimeUuid(nodeId, clockId, date);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the TimeUuid structure
+        /// </summary>
+        public static TimeUuid NewId(byte[] nodeId, byte[] clockId, DateTimeOffset date)
+        {
+            return new TimeUuid(nodeId, clockId, date);
+        }
+
+        /// <summary>
+        /// Converts the string representation of a time-based uuid (v1) to the equivalent 
+        /// <see cref="TimeUuid"/> structure.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <returns></returns>
+        public static TimeUuid Parse(string input)
+        {
+            return new TimeUuid(Guid.Parse(input));
+        }
+
+        /// <summary>
+        /// From TimeUuid to Guid
+        /// </summary>
+        public static implicit operator Guid(TimeUuid value)
+        {
+            return value.ToGuid();
+        }
+
+        /// <summary>
+        /// From Guid to TimeUuid
+        /// </summary>
+        public static implicit operator TimeUuid(Guid value)
+        {
+            return new TimeUuid(value);
+        }
+
+        public static bool operator ==(TimeUuid id1, TimeUuid id2)
+        {
+            return id1.ToGuid() == id2.ToGuid();
+        }
+
+        public static bool operator !=(TimeUuid id1, TimeUuid id2)
+        {
+            return id1.ToGuid() != id2.ToGuid();
+        }
+    }
+}

--- a/src/core/Akka.Persistence.Query/Offset.cs
+++ b/src/core/Akka.Persistence.Query/Offset.cs
@@ -23,14 +23,14 @@ namespace Akka.Persistence.Query
         public static Offset NoOffset() => Query.NoOffset.Instance;
 
         /// <summary>
-        /// Corresponds to an ordered sequence number for the events.Note that the corresponding
-        /// offset of each event is provided in the <see cref="EventEnvelope"/>,
-        /// which makes it possible to resume the stream at a later point from a given offset.
-        /// The `offset` is exclusive, i.e.the event with the exact same sequence number will not be included
-        /// in the returned stream. This means that you can use the offset that is returned in <see cref="EventEnvelope"/>
-        /// as the `offset` parameter in a subsequent query.
+        /// Factory to create an offset of type <see cref="Query.Sequence"/>
         /// </summary>
         public static Offset Sequence(long value) => new Sequence(value);
+
+        /// <summary>
+        /// Factory to create an offset of type <see cref="TimeBasedUuid"/>
+        /// </summary>
+        public static Offset TimeBasedUuid(Guid value) => new TimeBasedUuid(value);
 
         /// <summary>
         /// Used to compare to other <see cref="Offset"/> implementations.
@@ -43,9 +43,11 @@ namespace Akka.Persistence.Query
     /// Corresponds to an ordered sequence number for the events.Note that the corresponding
     /// offset of each event is provided in the <see cref="EventEnvelope"/>,
     /// which makes it possible to resume the stream at a later point from a given offset.
+    /// <para>
     /// The `offset` is exclusive, i.e.the event with the exact same sequence number will not be included
     /// in the returned stream. This means that you can use the offset that is returned in <see cref="EventEnvelope"/>
     /// as the `offset` parameter in a subsequent query.
+    /// </para>
     /// </summary>
     public sealed class Sequence : Offset, IComparable<Sequence>
     {
@@ -80,6 +82,46 @@ namespace Akka.Persistence.Query
             }
 
             throw new InvalidOperationException($"Can't compare offset of type {GetType()} to offset of type {other.GetType()}");
+        }
+    }
+
+    /// <summary>
+    /// Corresponds to an ordered unique identifier of the events. Note that the corresponding
+    /// offset of each event is provided in the <see cref="EventEnvelope"/>, which makes it 
+    /// possible to resume the stream at a later point from a given offset.
+    /// <para>
+    /// The `offset` is exclusive, i.e. the event with the exact same sequence number will not be included
+    /// in the returned stream. This means that you can use the offset that is returned in `EventEnvelope`
+    /// as the `offset` parameter in a subsequent query.
+    /// </para>
+    /// </summary>
+    public sealed class TimeBasedUuid : Offset, IComparable<TimeBasedUuid>
+    {
+        public Guid Value { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeBasedUuid"/> class.
+        /// </summary>
+        public TimeBasedUuid(Guid value) => Value = value;
+
+        public int CompareTo(TimeBasedUuid other) => Value.CompareTo(other.Value);
+
+        private bool Equals(TimeBasedUuid other) => Value == other.Value;
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is TimeBasedUuid uUID && Equals(uUID);
+        }
+
+        public override int GetHashCode() => Value.GetHashCode();
+
+        public override int CompareTo(Offset other)
+        {
+            return other is TimeBasedUuid seq
+                ? CompareTo(seq)
+                : throw new InvalidOperationException($"Can't compare offset of type {GetType()} to offset of type {other.GetType()}");
         }
     }
 


### PR DESCRIPTION
## Changes

Adds TimeBasedUuid offset used in Cassandra.

Sadly, there's no built-in support for time-based guids in .NET. The CSharp cassandra driver has a struct (`TimeUuid`) compatible with `v1` of `java.utils.uuid`. And since we can't have a reference to the cassandra driver in the Core, this implementation of the `TimeBasedUuid` takes a `Guid` instead. But then there's no way to check whether the `Guid` passed to `TimeBasedUuid` is actually a `TimeUuid`.

`TimeUuid` code has been pulled into the Tests to enable proper testing.

Feedback?

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [X] Changes in public API reviewed, if any.