### PR TITLE
Added GroupedWeightedWithin operator

### DIFF
--- a/docs/articles/streams/builtinstages.md
+++ b/docs/articles/streams/builtinstages.md
@@ -843,12 +843,23 @@ Skip elements until a timeout has fired
 
 ### GroupedWithin
 
-Chunk up the stream into groups of elements received within a time window, or limited by the given number of elements,
-whichever happens first.
+Chunk up this stream into groups of elements received within a time window, or limited by the number of the elements, whatever happens first. Empty groups will not be emitted if no elements are received from upstream. The last group before end-of-stream will contain the buffered elements since the previously emitted group.
 
-**emits** when the configured time elapses since the last group has been emitted
+**emits** when the configured time elapses since the last group has been emitted, but not if no elements has been grouped (i.e: no empty groups), or when limit has been reached.
 
-**backpressures** when the group has been assembled (the duration elapsed) and downstream backpressures
+**backpressures** when downstream backpressures, and there are n+1 buffered elements
+
+**completes** when upstream completes
+
+### GroupedWeightedWithin
+
+Chunk up this stream into groups of elements received within a time window, or limited by the weight of the elements, whatever happens first. Empty groups will not be emitted if no elements are received from upstream.
+The last group before end-of-stream will contain the buffered elements since the previously emitted group.
+
+**emits** when the configured time elapses since the last group has been emitted,
+but not if no elements has been grouped (i.e: no empty groups), or when weight limit has been reached.
+
+**backpressures** downstream backpressures, and buffered group (+ pending element) weighs more than `maxWeight`
 
 **completes** when upstream completes
 

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Core.verified.txt
@@ -1371,6 +1371,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc, bool allowClosedSubstreamRecreation) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> Grouped<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n) { }
+        public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> IdleTimeout<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> InitialDelay<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan delay) { }
@@ -2047,6 +2048,8 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Expand<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, System.Collections.Generic.IEnumerator<TOut2>> extrapolate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> GroupBy<TOut, TMat, TKey>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> Grouped<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int n) { }
+        public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long maxWeight, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
+        public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int n, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> IdleTimeout<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> InitialDelay<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan delay) { }
@@ -2233,6 +2236,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat3, TClosed> DivertToMaterialized<TOut, TMat, TMat2, TMat3, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TOut, bool> when, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Expand<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, System.Collections.Generic.IEnumerator<TOut2>> extrapolate) { }
         public static Akka.Streams.Dsl.SubFlow<System.Collections.Generic.IEnumerable<TOut>, TMat, TClosed> Grouped<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int n) { }
+        public static Akka.Streams.Dsl.SubFlow<System.Collections.Generic.IEnumerable<TOut>, TMat, TClosed> GroupedWeightedWithin<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.SubFlow<System.Collections.Generic.IEnumerable<TOut>, TMat, TClosed> GroupedWithin<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int n, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> IdleTimeout<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> InitialDelay<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan delay) { }
@@ -4179,9 +4183,9 @@ namespace Akka.Streams.Implementation.Fusing
         public static Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T> Identity<T>() { }
     }
     [Akka.Annotations.InternalApiAttribute()]
-    public sealed class GroupedWithin<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
+    public sealed class GroupedWeightedWithin<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
-        public GroupedWithin(int count, System.TimeSpan timeout) { }
+        public GroupedWeightedWithin(long maxWeight, int maxNumber, System.Func<T, long> costFn, System.TimeSpan interval) { }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public override Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
@@ -4543,6 +4547,8 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Akka.Streams.Attributes Fused;
         public static readonly Akka.Streams.Attributes GroupBy;
         public static readonly Akka.Streams.Attributes Grouped;
+        public static readonly Akka.Streams.Attributes GroupedWeightedWithin;
+        public static readonly Akka.Streams.Attributes GroupedWithin;
         public static readonly Akka.Streams.Attributes IODispatcher;
         public static readonly Akka.Streams.Attributes IdentityOp;
         public static readonly Akka.Streams.Attributes Idle;

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
@@ -1371,6 +1371,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc, bool allowClosedSubstreamRecreation) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> Grouped<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n) { }
+        public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> IdleTimeout<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> InitialDelay<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan delay) { }
@@ -2047,6 +2048,8 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Expand<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, System.Collections.Generic.IEnumerator<TOut2>> extrapolate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> GroupBy<TOut, TMat, TKey>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> Grouped<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int n) { }
+        public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long maxWeight, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
+        public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int n, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> IdleTimeout<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> InitialDelay<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan delay) { }
@@ -2233,6 +2236,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat3, TClosed> DivertToMaterialized<TOut, TMat, TMat2, TMat3, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TOut, bool> when, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Expand<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, System.Collections.Generic.IEnumerator<TOut2>> extrapolate) { }
         public static Akka.Streams.Dsl.SubFlow<System.Collections.Generic.IEnumerable<TOut>, TMat, TClosed> Grouped<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int n) { }
+        public static Akka.Streams.Dsl.SubFlow<System.Collections.Generic.IEnumerable<TOut>, TMat, TClosed> GroupedWeightedWithin<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.SubFlow<System.Collections.Generic.IEnumerable<TOut>, TMat, TClosed> GroupedWithin<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int n, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> IdleTimeout<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> InitialDelay<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan delay) { }
@@ -4191,9 +4195,9 @@ namespace Akka.Streams.Implementation.Fusing
         public static Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T> Identity<T>() { }
     }
     [Akka.Annotations.InternalApiAttribute()]
-    public sealed class GroupedWithin<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
+    public sealed class GroupedWeightedWithin<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
-        public GroupedWithin(int count, System.TimeSpan timeout) { }
+        public GroupedWeightedWithin(long maxWeight, int maxNumber, System.Func<T, long> costFn, System.TimeSpan interval) { }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public override Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
@@ -4555,6 +4559,8 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Akka.Streams.Attributes Fused;
         public static readonly Akka.Streams.Attributes GroupBy;
         public static readonly Akka.Streams.Attributes Grouped;
+        public static readonly Akka.Streams.Attributes GroupedWeightedWithin;
+        public static readonly Akka.Streams.Attributes GroupedWithin;
         public static readonly Akka.Streams.Attributes IODispatcher;
         public static readonly Akka.Streams.Attributes IdentityOp;
         public static readonly Akka.Streams.Attributes Idle;

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
@@ -1371,6 +1371,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc, bool allowClosedSubstreamRecreation) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> Grouped<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n) { }
+        public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> IdleTimeout<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> InitialDelay<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan delay) { }
@@ -2047,6 +2048,8 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Expand<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, System.Collections.Generic.IEnumerator<TOut2>> extrapolate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> GroupBy<TOut, TMat, TKey>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> Grouped<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int n) { }
+        public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long maxWeight, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
+        public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int n, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> IdleTimeout<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> InitialDelay<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan delay) { }
@@ -2233,6 +2236,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat3, TClosed> DivertToMaterialized<TOut, TMat, TMat2, TMat3, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TOut, bool> when, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Expand<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, System.Collections.Generic.IEnumerator<TOut2>> extrapolate) { }
         public static Akka.Streams.Dsl.SubFlow<System.Collections.Generic.IEnumerable<TOut>, TMat, TClosed> Grouped<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int n) { }
+        public static Akka.Streams.Dsl.SubFlow<System.Collections.Generic.IEnumerable<TOut>, TMat, TClosed> GroupedWeightedWithin<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.SubFlow<System.Collections.Generic.IEnumerable<TOut>, TMat, TClosed> GroupedWithin<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int n, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> IdleTimeout<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> InitialDelay<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan delay) { }
@@ -4179,9 +4183,9 @@ namespace Akka.Streams.Implementation.Fusing
         public static Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T> Identity<T>() { }
     }
     [Akka.Annotations.InternalApiAttribute()]
-    public sealed class GroupedWithin<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
+    public sealed class GroupedWeightedWithin<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
-        public GroupedWithin(int count, System.TimeSpan timeout) { }
+        public GroupedWeightedWithin(long maxWeight, int maxNumber, System.Func<T, long> costFn, System.TimeSpan interval) { }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public override Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
@@ -4543,6 +4547,8 @@ namespace Akka.Streams.Implementation.Stages
         public static readonly Akka.Streams.Attributes Fused;
         public static readonly Akka.Streams.Attributes GroupBy;
         public static readonly Akka.Streams.Attributes Grouped;
+        public static readonly Akka.Streams.Attributes GroupedWeightedWithin;
+        public static readonly Akka.Streams.Attributes GroupedWithin;
         public static readonly Akka.Streams.Attributes IODispatcher;
         public static readonly Akka.Streams.Attributes IdentityOp;
         public static readonly Akka.Streams.Attributes Idle;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowGroupedWithinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowGroupedWithinSpec.cs
@@ -143,7 +143,7 @@ namespace Akka.Streams.Tests.Dsl
                 .GroupedWithin(1000, TimeSpan.FromMilliseconds(500))
                 .To(Sink.FromSubscriber(c))
                 .Run(Materializer);
-            
+
             var pSub = p.ExpectSubscription();
             var cSub = c.ExpectSubscription();
 
@@ -153,7 +153,7 @@ namespace Akka.Streams.Tests.Dsl
 
             pSub.SendNext(1);
             pSub.SendNext(2);
-            c.ExpectNext().Should().BeEquivalentTo(new [] {1,2});
+            c.ExpectNext().Should().BeEquivalentTo(new[] { 1, 2 });
             // nothing more requested
             c.ExpectNoMsg(TimeSpan.FromMilliseconds(1100));
             cSub.Request(3);
@@ -182,7 +182,7 @@ namespace Akka.Streams.Tests.Dsl
             pSub.SendComplete();
             c.ExpectComplete();
         }
-        
+
         [Fact(Skip = "Skipped for async_testkit conversion build")]
         public void A_GroupedWithin_must_reset_time_window_when_max_elements_reached()
         {
@@ -198,10 +198,10 @@ namespace Akka.Streams.Tests.Dsl
             downstream.Request(2);
             downstream.ExpectNoMsg(TimeSpan.FromMilliseconds(1000));
 
-            Enumerable.Range(1,4).ForEach(_=>upstream.SendNext(input.Next()));
+            Enumerable.Range(1, 4).ForEach(_ => upstream.SendNext(input.Next()));
             downstream.Within(TimeSpan.FromMilliseconds(1000), () =>
             {
-                downstream.ExpectNext().Should().BeEquivalentTo(new[] {1, 2, 3});
+                downstream.ExpectNext().Should().BeEquivalentTo(new[] { 1, 2, 3 });
                 return NotUsed.Instance;
             });
 
@@ -209,7 +209,7 @@ namespace Akka.Streams.Tests.Dsl
 
             downstream.Within(TimeSpan.FromMilliseconds(1000), () =>
             {
-                downstream.ExpectNext().Should().BeEquivalentTo(new[] {4});
+                downstream.ExpectNext().Should().BeEquivalentTo(new[] { 4 });
                 return NotUsed.Instance;
             });
 
@@ -228,7 +228,7 @@ namespace Akka.Streams.Tests.Dsl
                     var y = random.Next();
                     var z = random.Next();
 
-                    return ((ICollection<int>)new[] {x, y, z}, (ICollection<IEnumerable<int>>)new[] {new[] {x, y, z}});
+                    return ((ICollection<int>)new[] { x, y, z }, (ICollection<IEnumerable<int>>)new[] { new[] { x, y, z } });
                 }).ToArray());
 
             RandomTestRange(Sys)
@@ -242,7 +242,7 @@ namespace Akka.Streams.Tests.Dsl
             Func<Script<int, IEnumerable<int>>> script = () =>
             {
                 var i = random.Next();
-                var rest = (new[] {i}, new[] {new[] {i}});
+                var rest = (new[] { i }, new[] { new[] { i } });
 
                 return Script.Create(RandomTestRange(Sys).Select(_ =>
                 {
@@ -250,7 +250,7 @@ namespace Akka.Streams.Tests.Dsl
                     var y = random.Next();
                     var z = random.Next();
 
-                    return ((ICollection<int>)new[] { x, y, z }, (ICollection<IEnumerable<int>>)new[] { new[] { x, y, z }});
+                    return ((ICollection<int>)new[] { x, y, z }, (ICollection<IEnumerable<int>>)new[] { new[] { x, y, z } });
                 }).Concat(rest).ToArray());
             };
 
@@ -266,7 +266,172 @@ namespace Akka.Streams.Tests.Dsl
                 .Throttle(1, TimeSpan.FromMilliseconds(110), 0, ThrottleMode.Shaping)
                 .RunWith(Sink.Seq<IEnumerable<int>>(), Materializer);
             t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-            t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 10).Select(i => new List<int> {i}));
+            t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 10).Select(i => new List<int> { i }));
+        }
+    }
+
+    public class FlowGroupedWeightedWithinSpec : ScriptedTest
+    {
+        private ActorMaterializerSettings Settings { get; }
+        private ActorMaterializer Materializer { get; }
+
+        public FlowGroupedWeightedWithinSpec(ITestOutputHelper helper) : base(helper)
+        {
+            Settings = ActorMaterializerSettings.Create(Sys);
+            Materializer = ActorMaterializer.Create(Sys, Settings);
+        }
+
+        [Fact]
+        public void A_GroupedWeightedWithin_must_handle_handle_elements_larger_than_the_limit()
+        {
+            var downstream = this.CreateSubscriberProbe<IEnumerable<int>>();
+
+            Source.From(new List<int> { 1, 2, 3, 101, 4, 5, 6 })
+                .GroupedWeightedWithin(100, TimeSpan.FromMilliseconds(100), t => t)
+                .To(Sink.FromSubscriber(downstream))
+                .Run(Materializer);
+
+            downstream.Request(1);
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<int> { 1, 2, 3 });
+            downstream.Request(1);
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<int> { 101 });
+            downstream.Request(1);
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<int> { 4, 5, 6 });
+            downstream.ExpectComplete();
+        }
+
+        [Fact]
+        public void A_GroupedWeightedWithin_must_not_drop_a_pending_last_element_on_upstream_finish()
+        {
+            var upstream = this.CreatePublisherProbe<long>();
+            var downstream = this.CreateSubscriberProbe<IEnumerable<long>>();
+
+            Source.FromPublisher(upstream)
+                .GroupedWeightedWithin(5, TimeSpan.FromMilliseconds(50), t => t)
+                .To(Sink.FromSubscriber(downstream))
+                .Run(Materializer);
+
+            downstream.EnsureSubscription();
+            downstream.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+            upstream.SendNext(1);
+            upstream.SendNext(2);
+            upstream.SendNext(3);
+            upstream.SendComplete();
+            downstream.Request(1);
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<long> { 1, 2 });
+            downstream.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+            downstream.Request(1);
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<long> { 3 });
+            downstream.ExpectComplete();
+        }
+
+        [Fact]
+        public void A_GroupedWeightedWithin_must_append_zero_weighted_elements_to_a_full_group_before_timeout_received_if_downstream_hasnt_pulled_yet()
+        {
+            var upstream = this.CreatePublisherProbe<string>();
+            var downstream = this.CreateSubscriberProbe<IEnumerable<string>>();
+
+            Source.FromPublisher(upstream)
+                .GroupedWeightedWithin(5, TimeSpan.FromMilliseconds(50), t => t.Length)
+                .To(Sink.FromSubscriber(downstream))
+                .Run(Materializer);
+
+            downstream.EnsureSubscription();
+            upstream.SendNext("333");
+            upstream.SendNext("22");
+            upstream.SendNext("");
+            upstream.SendNext("");
+            upstream.SendNext("");
+            downstream.Request(1);
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<string> { "333", "22", "", "", "" });
+            upstream.SendNext("");
+            upstream.SendNext("");
+            upstream.SendComplete();
+            downstream.Request(1);
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<string> { "", "" });
+            downstream.ExpectComplete();
+        }
+
+        [Fact]
+        public void A_GroupedWeightedWithin_must_not_emit_an_empty_group_if_first_element_is_heavier_than_maxWeight()
+        {
+            var upstream = this.CreatePublisherProbe<long>();
+            var downstream = this.CreateSubscriberProbe<IEnumerable<long>>();
+
+            Source.FromPublisher(upstream)
+                .GroupedWeightedWithin(10, TimeSpan.FromMilliseconds(50), t => t)
+                .To(Sink.FromSubscriber(downstream))
+                .Run(Materializer);
+
+            downstream.EnsureSubscription();
+            downstream.Request(1);
+            upstream.SendNext(11);
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<long> { 11 });
+            upstream.SendComplete();
+            downstream.ExpectComplete();
+        }
+
+        [Fact]
+        public void A_GroupedWeightedWithin_must_handle_zero_cost_function_to_get_only_timed_based_grouping_without_limit()
+        {
+            var upstream = this.CreatePublisherProbe<string>();
+            var downstream = this.CreateSubscriberProbe<IEnumerable<string>>();
+
+            Source.FromPublisher(upstream)
+                .GroupedWeightedWithin(1L, TimeSpan.FromMilliseconds(100), _ => 0L)
+                .To(Sink.FromSubscriber(downstream))
+                .Run(Materializer);
+
+            downstream.EnsureSubscription();
+            downstream.Request(1);
+            upstream.SendNext("333");
+            upstream.SendNext("22");
+            upstream.SendNext("333");
+            upstream.SendNext("22");
+            downstream.ExpectNoMsg(TimeSpan.FromMilliseconds(50));
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<string> { "333", "22", "333", "22" });
+            upstream.SendComplete();
+            downstream.ExpectComplete();
+        }
+
+        [Fact]
+        public void A_GroupedWeightedWithin_must_group_by_max_weight_and_max_number_of_elements_reached()
+        {
+            var upstream = this.CreatePublisherProbe<long>();
+            var downstream = this.CreateSubscriberProbe<IEnumerable<long>>();
+
+            Source.FromPublisher(upstream)
+                .GroupedWeightedWithin(10, 3, TimeSpan.FromSeconds(30), t => t)
+                .To(Sink.FromSubscriber(downstream))
+                .Run(Materializer);
+
+            downstream.EnsureSubscription();
+            upstream.SendNext(1);
+            upstream.SendNext(2);
+            upstream.SendNext(3);
+            upstream.SendNext(4);
+            upstream.SendNext(5);
+            upstream.SendNext(6);
+            upstream.SendNext(11);
+            upstream.SendNext(7);
+            upstream.SendNext(2);
+            upstream.SendComplete();
+            downstream.Request(1);
+            // split because of maxNumber: 3 element
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<long> { 1, 2, 3 });
+            downstream.Request(1);
+            // split because of maxWeight: 9=4+5, one more element did not fit
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<long> { 4, 5 });
+            downstream.Request(1);
+            // split because of maxWeight: 6, one more element did not fit
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<long> { 6 });
+            downstream.Request(1);
+            // split because of maxWeight: 11
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<long> { 11 });
+            downstream.Request(1);
+            // no split
+            downstream.ExpectNext().Should().BeEquivalentTo(new List<long> { 7, 2 });
+            downstream.ExpectComplete();
         }
     }
 }

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -840,6 +840,58 @@ namespace Akka.Streams.Dsl
         }
 
         /// <summary>
+        /// Chunk up this stream into groups of elements received within a time window,
+        /// or limited by the weight of the elements, whatever happens first.
+        /// Empty groups will not be emitted if no elements are received from upstream.
+        /// The last group before end-of-stream will contain the buffered elements
+        /// since the previously emitted group.
+        /// <para>
+        /// <paramref name="maxWeight" /> must be positive, and <paramref name="interval"/> must be greater than 0 seconds, 
+        /// otherwise ArgumentException is thrown.
+        /// </para>
+        /// <para>Emits when the configured time elapses since the last group has been emitted or weight limit reached</para>
+        /// <para>Backpressures when downstream backpressures, and buffered group(+ pending element) weighs more than `maxWeight`</para>
+        /// <para>Completes when upstream completes(emits last group)</para>
+        /// <para>Cancels when downstream completes</para>
+        /// </summary>
+        /// <typeparam name="TOut">TBD</typeparam>
+        /// <typeparam name="TMat">TBD</typeparam>
+        /// <param name="flow">TBD</param>
+        /// <param name="maxWeight">TBD</param>
+        /// <param name="interval">TBD</param>
+        /// <param name="costFn">TBD</param>
+        /// <returns>TBD</returns>
+        public static Source<IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Source<TOut, TMat> flow, long maxWeight, TimeSpan interval, Func<TOut, long> costFn) =>
+            (Source<IEnumerable<TOut>, TMat>)InternalFlowOperations.GroupedWeightedWithin(flow, maxWeight, int.MaxValue, interval, costFn);
+
+        /// <summary>
+        /// Chunk up this stream into groups of elements received within a time window,
+        /// or limited by the weight and number of the elements, whatever happens first.
+        /// Empty groups will not be emitted if no elements are received from upstream.
+        /// The last group before end-of-stream will contain the buffered elements
+        /// since the previously emitted group.
+        /// <para>
+        /// <paramref name="maxWeight"/> must be positive, <paramref name="maxNumber"/> must be positive, and <paramref name="interval"/> must be greater than 0 seconds, 
+        /// otherwise <see cref="ArgumentException"/>  is thrown.
+        /// </para>
+        /// <para>Emits when the configured time elapses since the last group has been emitted or weight limit reached</para>
+        /// <para>Backpressures when downstream backpressures, and buffered group(+ pending element) weighs more than `maxWeight` or has more than `maxNumber` elements</para>
+        /// <para>Completes when upstream completes(emits last group)</para>
+        /// <para>Cancels when downstream completes</para>
+        /// </summary>
+        /// <typeparam name="TIn">TBD</typeparam>
+        /// <typeparam name="TOut">TBD</typeparam>
+        /// <typeparam name="TMat">TBD</typeparam>
+        /// <param name="flow">TBD</param>
+        /// <param name="maxWeight">TBD</param>
+        /// <param name="maxNumber">TBD</param>
+        /// <param name="costFn">TBD</param>
+        /// <param name="interval">TBD</param>
+        /// <returns>TBD</returns>
+        public static Source<IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Source<TOut, TMat> flow, long maxWeight, int maxNumber, TimeSpan interval, Func<TOut, long> costFn) =>
+            (Source<IEnumerable<TOut>, TMat>)InternalFlowOperations.GroupedWeightedWithin(flow, maxWeight, maxNumber, interval, costFn);
+
+        /// <summary>
         /// Shifts elements emission in time by a specified amount. It allows to store elements
         /// in internal buffer while waiting for next element to be emitted. Depending on the defined
         /// <see cref="DelayOverflowStrategy"/> it might drop elements or backpressure the upstream if

--- a/src/core/Akka.Streams/Dsl/SubFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SubFlowOperations.cs
@@ -844,9 +844,9 @@ namespace Akka.Streams.Dsl
         /// <paramref name="n"/> must be positive, and <paramref name="timeout"/> must be greater than 0 seconds, otherwise
         /// <see cref="ArgumentException"/> is thrown.
         /// <para>
-        /// Emits when the configured time elapses since the last group has been emitted
+        /// Emits when the configured time elapses since the last group has been emitted or `n` elements is buffered
         /// </para>
-        /// Backpressures when the configured time elapses since the last group has been emitted
+        /// Backpressures when downstream backpressures, and there are `n+1` buffered elements
         /// <para>
         /// Completes when upstream completes (emits last group)
         /// </para>
@@ -864,6 +864,33 @@ namespace Akka.Streams.Dsl
         {
             return (SubFlow<IEnumerable<TOut>, TMat, TClosed>)InternalFlowOperations.GroupedWithin(flow, n, timeout);
         }
+
+        /// <summary>
+        /// Chunk up this stream into groups of elements received within a time window,
+        /// or limited by the weight of the elements, whatever happens first.
+        /// Empty groups will not be emitted if no elements are received from upstream.
+        /// The last group before end-of-stream will contain the buffered elements
+        /// since the previously emitted group.
+        /// <para>
+        /// <paramref name="maxWeight" /> must be positive, and <paramref name="interval"/> must be greater than 0 seconds, 
+        /// otherwise ArgumentException is thrown.
+        /// </para>
+        /// <para>Emits when the configured time elapses since the last group has been emitted or weight limit reached</para>
+        /// <para>Backpressures when downstream backpressures, and buffered group(+ pending element) weighs more than `maxWeight`</para>
+        /// <para>Completes when upstream completes(emits last group)</para>
+        /// <para>Cancels when downstream completes</para>
+        /// </summary>
+        /// <typeparam name="TOut">TBD</typeparam>
+        /// <typeparam name="TMat">TBD</typeparam>
+        /// <typeparam name="TClosed">TBD</typeparam>
+        /// <param name="flow">TBD</param>
+        /// <param name="maxWeight">TBD</param>
+        /// <param name="maxNumber">TBD</param>
+        /// <param name="interval">TBD</param>
+        /// <param name="costFn">TBD</param>
+        /// <returns>TBD</returns>
+        public static SubFlow<IEnumerable<TOut>, TMat, TClosed> GroupedWeightedWithin<TOut, TMat, TClosed>(this SubFlow<TOut, TMat, TClosed> flow, long maxWeight, int maxNumber, TimeSpan interval, Func<TOut, long> costFn) => 
+            (SubFlow<IEnumerable<TOut>, TMat, TClosed>)InternalFlowOperations.GroupedWeightedWithin(flow, maxWeight, maxNumber, interval, costFn);
 
         /// <summary>
         /// Shifts elements emission in time by a specified amount. It allows to store elements

--- a/src/core/Akka.Streams/Implementation/Stages/Stages.cs
+++ b/src/core/Akka.Streams/Implementation/Stages/Stages.cs
@@ -70,6 +70,14 @@ namespace Akka.Streams.Implementation.Stages
         /// <summary>
         /// TBD
         /// </summary>
+        public static readonly Attributes GroupedWithin = Attributes.CreateName("groupedWithin");
+        /// <summary>
+        /// TBD
+        /// </summary>
+        public static readonly Attributes GroupedWeightedWithin = Attributes.CreateName("groupedWeightedWithin");
+        /// <summary>
+        /// TBD
+        /// </summary>
         public static readonly Attributes Limit = Attributes.CreateName("limit");
         /// <summary>
         /// TBD


### PR DESCRIPTION
## Changes

Adds `GroupedWeightedWithin` operator and `GroupedWeightedWithin{T}` stage. `GroupedWithin` operator is now based on this stage too.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [X] Changes in public API reviewed, if any.
* [X] I have added website documentation for this feature.