### PR TITLE
harden `ClusterLogSpec`

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
@@ -68,7 +68,7 @@ namespace Akka.Cluster.Tests
             {
                 await EventFilter
                     .Info(contains: expected)
-                    .ExpectOneAsync(async () => _cluster.Join(_selfAddress));
+                    .ExpectOneAsync(async () => await _cluster.JoinAsync(_selfAddress));
             });
         }
 

--- a/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
@@ -90,7 +90,7 @@ namespace Akka.Cluster.Tests
                         tcs.TrySetResult(true);
                     });
                     _cluster.Down(_selfAddress);
-                    await tcs.Task.ShouldCompleteWithin(RemainingOrDefault);
+                    await tcs.Task.ShouldCompleteWithin(Remaining);
                 });
             });
         }

--- a/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
@@ -68,7 +68,15 @@ namespace Akka.Cluster.Tests
             {
                 await EventFilter
                     .Info(contains: expected)
-                    .ExpectOneAsync(async () => await _cluster.JoinAsync(_selfAddress).ShouldCompleteWithin(Remaining));
+                    .ExpectOneAsync(async () => {
+                        var tcs = new TaskCompletionSource<bool>();
+                         _cluster.RegisterOnMemberUp(() =>
+                            {
+                                tcs.TrySetResult(true);
+                            });
+                        _cluster.Join(_selfAddress);
+                        await tcs.Task.ShouldCompleteWithin(Remaining);   
+                    });
             });
         }
 


### PR DESCRIPTION
## Changes

The `JoinAsync` method wasn't written correctly - need to force `JoinAsync` to run to completion for assertion to make any kind of sense.
