### PR TITLE
Make JoinAsync and JoinSeedNodesAsync more robust by using an async state

### DIFF
--- a/src/core/Akka.Cluster/AsyncJoinState.cs
+++ b/src/core/Akka.Cluster/AsyncJoinState.cs
@@ -1,0 +1,71 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="AsyncJoinState.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Akka.Cluster
+{
+    internal sealed class AsyncJoinState: IDisposable
+    {
+        private readonly TaskCompletionSource<NotUsed> _completion;
+        private CancellationTokenSource _timeoutCts;
+        private bool _isDisposed;
+
+        public Task Task => _completion.Task;
+        public bool IsCompleted => _completion.Task.IsCompleted; // IsCompleted covers Faulted, Canceled, and RanToCompletion
+        
+        public AsyncJoinState(
+            Cluster cluster, 
+            Exception failException,
+            Action onComplete, 
+            CancellationToken token = default)
+        {
+            Debug.Assert(cluster != null, $"{nameof(cluster)} != null");
+            Debug.Assert(failException != null, $"{nameof(failException)} != null");
+            Debug.Assert(onComplete != null, $"{nameof(onComplete)} != null");
+            
+            _completion = new TaskCompletionSource<NotUsed>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            _timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            _timeoutCts.CancelAfter(cluster.Settings.SeedNodeTimeout);
+            _timeoutCts.Token.Register(() =>
+            {
+                if (IsCompleted)
+                    return;
+                
+                _completion.TrySetException(failException);
+                onComplete();
+                Dispose();
+            });
+            
+            cluster.RegisterOnMemberUp(() =>
+            {
+                if (IsCompleted)
+                    return;
+                
+                _completion.TrySetResult(NotUsed.Instance);
+                onComplete();
+                Dispose();
+            });
+        }
+
+        public void Dispose()
+        {
+            if(!_isDisposed)
+            {
+                //Clean up managed resources
+                _timeoutCts?.Dispose();
+                //Clean up unmanaged resources
+                _timeoutCts = null;
+            }
+            _isDisposed = true;
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- JoinAsync and JoinSeedNodesAsync is now idempotent, always returning the same Task instance when called multiple times.
- More robust memory claen-up

## Still a problem
- There is still no way to remove the cluster message listener actors, these listeners will persist until the Cluster is shut down.
- It is possible that variables inside these listener delegates went out of scope or are nullified, causing NRE to be thrown, filling the log with confusing error messages.