### PR TITLE
Harden ClusterSpec CoordinatedShutdown

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -512,7 +512,7 @@ namespace Akka.Cluster.Tests
                 await probe.ExpectMsgAsync<ClusterEvent.MemberLeft>();
                 // MemberExited might not be published before MemberRemoved
                 var removed = (ClusterEvent.MemberRemoved)await probe.FishForMessageAsync(m => m is ClusterEvent.MemberRemoved);
-                removed.PreviousStatus.Should().BeEquivalentTo(MemberStatus.Exiting);
+                new [] {MemberStatus.Exiting, MemberStatus.Leaving}.Should().Contain(removed.PreviousStatus);
             }
             finally
             {


### PR DESCRIPTION
The probable cause for failure is a bit convoluted, but it started here:
https://github.com/akkadotnet/akka.net/blob/0c9677f700b6115090d3a277d28f310046e0235f/src/core/Akka.Cluster/CoordinatedShutdownLeave.cs#L64-L67

The cluster shutdown watcher actor allows for MemberStatus.Leaving to signal a complete cluster shutdown, and if CoordinatedShutdown reaches its completion faster than the cluster exit flow, it will trigger the `Shutdown` method registered here:
https://github.com/akkadotnet/akka.net/blob/0c9677f700b6115090d3a277d28f310046e0235f/src/core/Akka.Cluster/Cluster.cs#L144

invoking a hard ClusterDaemon stop here:
https://github.com/akkadotnet/akka.net/blob/0c9677f700b6115090d3a277d28f310046e0235f/src/core/Akka.Cluster/Cluster.cs#L579

stopping the ClusterDomainEventPublisher, which publishes a hard coded membership state change here:
https://github.com/akkadotnet/akka.net/blob/0c9677f700b6115090d3a277d28f310046e0235f/src/core/Akka.Cluster/ClusterEvent.cs#L1029

This will publish a `MemberRemoved` with `MemberStatus.Leaving` as its previous state if the status is still at `MemberStatus.Leaving` at this point.

I'm not sure if this is the real intended behaviour, but this is what it is as of today.