### PR TITLE
Fix InterceptAsync and TestKit.RemainingOrDilated

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterSpec.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterSpec.cs
@@ -1,0 +1,62 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="EventFilterSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.TestKit.Extensions;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+using static FluentAssertions.FluentActions;
+
+namespace Akka.TestKit.Tests.TestEventListenerTests
+{
+    public class EventFilterSpec: TestKit.Xunit2.TestKit
+    {
+        // A very short EventFilter leeway value
+        public EventFilterSpec(ITestOutputHelper helper): base("akka.test.filter-leeway = 50ms", helper)
+        {}
+        
+        [Fact(DisplayName = "ExpectOneAsync should respect WithinAsync block Remaining value and overrides the default filter-leeway settings")]
+        public async Task ExpectOneRemainingTest()
+        {
+            await Awaiting(async () =>
+            {
+                await WithinAsync(3.Seconds(), async () =>
+                {
+                    var task = EventFilter.Info(start: "test message")
+                        .ExpectOneAsync(() => Task.CompletedTask);
+
+                    // This should NOT throw, the 100ms EventFilter leeway SHOULD be replaced with WithinAsync Remaining
+                    await Task.Delay(200.Milliseconds());
+                    Sys.Log.Info("test message");
+                    await task.ShouldCompleteWithin(3.Seconds());
+                });
+            }).Should().NotThrowAsync();
+        }
+        
+        [Fact(DisplayName = "ExpectAsync should respect WithinAsync block Remaining value and overrides the default filter-leeway settings")]
+        public async Task ExpectRemainingTest()
+        {
+            await Awaiting(async () =>
+            {
+                await WithinAsync(3.Seconds(), async () =>
+                {
+                    var task = EventFilter.Info(start: "test message")
+                        .ExpectAsync(2, () => Task.CompletedTask);
+
+                    // This should NOT throw, the 100ms EventFilter leeway SHOULD be replaced with WithinAsync Remaining
+                    await Task.Delay(200.Milliseconds());
+                    Sys.Log.Info("test message");
+                    Sys.Log.Info("test message");
+                    await task.ShouldCompleteWithin(3.Seconds());
+                });
+            }).Should().NotThrowAsync();
+        }
+        
+    }
+}

--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -442,7 +442,7 @@ namespace Akka.TestKit.Internal
                 ? TestKitExtension.For(system).TestEventFilterLeeway
                 : _testkit.TestKitSettings.TestEventFilterLeeway;
 
-            var timeoutValue = timeout.HasValue ? _testkit.Dilated(timeout.Value) : leeway;
+            var timeoutValue = timeout.HasValue ? _testkit.Dilated(timeout.Value) : _testkit.RemainingOrDilated(leeway);
             matchedEventHandler ??= new MatchedEventHandler();
             system.EventStream.Publish(new Mute(_filters));
             try

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -455,9 +455,9 @@ namespace Akka.TestKit
         /// <exception cref="ArgumentException">Thrown if <paramref name="duration"/> is infinite</exception>
         public TimeSpan RemainingOrDilated(TimeSpan? duration)
         {
-            if(!duration.HasValue) return RemainingOrDefault;
-            if(duration < TimeSpan.Zero) throw new ArgumentException("Must be positive TimeSpan", nameof(duration));
-            return Dilated(duration.Value);
+            if(duration == null) return RemainingOrDefault;
+            if(duration <= TimeSpan.Zero) throw new ArgumentException("Must be positive TimeSpan", nameof(duration));
+            return RemainingOr(Dilated(duration.Value));
         }
 
 

--- a/src/core/Akka.TestKit/TestKitBase_Within.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Within.cs
@@ -283,7 +283,7 @@ namespace Akka.TestKit
 
                     if (resultTask == executionTask)
                     {
-                        ret = executionTask.Result;
+                        ret = executionTask.GetAwaiter().GetResult();
                     }
                     else
                     {


### PR DESCRIPTION
Superceeds #6039

## Changes
- Change `RemainingOrDilated` behavior so it is consistent with `RemainingOrDefault`.
- Fix WithinAsync to use `GetAwaiter().GetResult()` instead of `Result` to automatically unroll `AggregatedException`.
- Fix `EventFilterApplier.InterceptAsync` to consider `WithinAsync` `Remaining` value as its timeout value.
- Add unit tests