### PR TITLE
cleaned up `IAsyncEnumerable` Source to use local functions

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
@@ -218,7 +218,7 @@ namespace Akka.Streams.Tests.Dsl
             IAsyncEnumerable<int> Range() => ProbeableRangeAsync(0, 100, latch);
             var subscriber = this.CreateManualSubscriberProbe<int>();
 
-            var probe = Source.From(Range)
+            Source.From(Range)
                 .RunWith(Sink.FromSubscriber(subscriber), Materializer);
 
             var subscription = await subscriber.ExpectSubscriptionAsync();
@@ -226,8 +226,8 @@ namespace Akka.Streams.Tests.Dsl
             await subscriber.ExpectNextNAsync(Enumerable.Range(0, 50));
             subscription.Cancel();
 
+            // The cancellation token inside the IAsyncEnumerable should be cancelled
             await WithinAsync(3.Seconds(), async () => latch.Value);
-            latch.Value.Should().BeTrue();
         }
 
         private static async IAsyncEnumerable<int> RangeAsync(int start, int count, 

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -3871,8 +3871,20 @@ namespace Akka.Streams.Implementation.Fusing
             {
                 _completionCts.Cancel();
                 _completionCts.Dispose();
-                CompleteStage();
-                base.OnDownstreamFinish(cause);
+
+                try
+                {
+                    _enumerator.DisposeAsync().GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Failed to dispose IAsyncEnumerator asynchronously");
+                }
+                finally
+                {
+                    CompleteStage();
+                    base.OnDownstreamFinish(cause);
+                }
             }
 
         }


### PR DESCRIPTION
## Changes

Better to use `await` around `ValueTask` rather than converting to `Task` and doing `ContinueWith`

Cleanup from #6044

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).