### PR TITLE
[BACKPORT #6044] Add IAsyncEnumerable as Akka.Streams Source

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.verified.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveStreams.verified.txt
@@ -1966,6 +1966,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> Empty<T>() { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> Failed<T>(System.Exception cause) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> From<T>(System.Collections.Generic.IEnumerable<T> enumerable) { }
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> From<T>(System.Func<System.Collections.Generic.IAsyncEnumerable<T>> asyncEnumerable) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEnumerator<T>(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEvent<TDelegate, T>(System.Func<System.Action<T>, TDelegate> conversion, System.Action<TDelegate> addHandler, System.Action<TDelegate> removeHandler, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEvent<T>(System.Action<System.EventHandler<T>> addHandler, System.Action<System.EventHandler<T>> removeHandler, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
@@ -3954,6 +3955,15 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
+        protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override string ToString() { }
+    }
+    [Akka.Annotations.InternalApiAttribute()]
+    public sealed class AsyncEnumerable<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<T>>
+    {
+        public AsyncEnumerable(System.Func<System.Collections.Generic.IAsyncEnumerable<T>> factory) { }
+        protected override Akka.Streams.Attributes InitialAttributes { get; }
+        public override Akka.Streams.SourceShape<T> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }

--- a/src/core/Akka.Streams.TestKit.Tests/StreamTestDefaultMailbox.cs
+++ b/src/core/Akka.Streams.TestKit.Tests/StreamTestDefaultMailbox.cs
@@ -24,6 +24,8 @@ namespace Akka.Streams.TestKit.Tests
     [InternalApi]
     public sealed class StreamTestDefaultMailbox : MailboxType, IProducesMessageQueue<UnboundedMessageQueue>
     {
+        public static Config DefaultConfig =>
+            ConfigurationFactory.FromResource<StreamTestDefaultMailbox>("Akka.Streams.TestKit.Tests.reference.conf");
 
         public override IMessageQueue Create(IActorRef owner, ActorSystem system)
         {

--- a/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
@@ -32,7 +32,7 @@ namespace Akka.Streams.Tests.Dsl
         private ActorMaterializer Materializer { get; }
         private ITestOutputHelper _helper;
         public AsyncEnumerableSpec(ITestOutputHelper helper) : base(
-                AkkaSpecConfig.WithFallback(StreamTestDefaultMailbox.DefaultConfig),
+                AkkaSpecConfig.WithFallback(DefaultConfig),
                 helper)
         {
             _helper = helper;

--- a/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
@@ -21,6 +21,7 @@ using Xunit.Abstractions;
 using System.Collections.Generic;
 using Akka.Actor;
 using Akka.Streams.Actors;
+using Akka.Streams.TestKit.Tests;
 using Akka.Streams.Tests.Actor;
 using Reactive.Streams;
 
@@ -32,7 +33,7 @@ namespace Akka.Streams.Tests.Dsl
         private ActorMaterializer Materializer { get; }
         private ITestOutputHelper _helper;
         public AsyncEnumerableSpec(ITestOutputHelper helper) : base(
-                AkkaSpecConfig.WithFallback(DefaultConfig),
+                AkkaSpecConfig.WithFallback(StreamTestDefaultMailbox.DefaultConfig),
                 helper)
         {
             _helper = helper;

--- a/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
@@ -18,6 +18,11 @@ using FluentAssertions;
 using Nito.AsyncEx.Synchronous;
 using Xunit;
 using Xunit.Abstractions;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Streams.Actors;
+using Akka.Streams.Tests.Actor;
+using Reactive.Streams;
 
 namespace Akka.Streams.Tests.Dsl
 {
@@ -25,14 +30,19 @@ namespace Akka.Streams.Tests.Dsl
     public class AsyncEnumerableSpec : AkkaSpec
     {
         private ActorMaterializer Materializer { get; }
-
-        public AsyncEnumerableSpec(ITestOutputHelper helper) : base(helper)
+        private ITestOutputHelper _helper;
+        public AsyncEnumerableSpec(ITestOutputHelper helper) : base(
+                AkkaSpecConfig.WithFallback(StreamTestDefaultMailbox.DefaultConfig),
+                helper)
         {
+            _helper = helper;
             var settings = ActorMaterializerSettings.Create(Sys).WithInputBuffer(2, 16);
             Materializer = ActorMaterializer.Create(Sys, settings);
         }
 
-        [Fact] public async Task RunAsAsyncEnumerable_Uses_CancellationToken()
+
+        [Fact] 
+        public async Task RunAsAsyncEnumerable_Uses_CancellationToken()
         {
             var input = Enumerable.Range(1, 6).ToList();
 
@@ -146,10 +156,41 @@ namespace Akka.Streams.Tests.Dsl
             
             await Assert.ThrowsAsync<IllegalStateException>(ShouldThrow);
         }
-        
+
+    [Fact]
+        public void AsyncEnumerableSource_Must_Complete_Immediately_With_No_elements_When_An_Empty_IAsyncEnumerable_Is_Passed_In()
+        {
+            Func<IAsyncEnumerable<int>> range = () =>
+            {
+                return RangeAsync(1, 100);
+            };
+            var subscriber = this.CreateManualSubscriberProbe<int>();
+
+            Source.From(range)
+                .RunWith(Sink.FromSubscriber(subscriber), Materializer);
+
+            var subscription = subscriber.ExpectSubscription();
+            subscription.Request(100);
+            for (int i = 1; i <= 20; i++)
+            {
+                var next = subscriber.ExpectNext(i);
+                _helper.WriteLine(i.ToString());
+            }
+
+            //subscriber.ExpectComplete();
+        }
+
+        static async IAsyncEnumerable<int> RangeAsync(int start, int count)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                await Task.Delay(i);
+                yield return start + i;
+            }
+        }
         
     }
-
 #else
 #endif
+
 }

--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -525,6 +525,22 @@ namespace Akka.Streams.Dsl
         public static Source<T, NotUsed> From<T>(IEnumerable<T> enumerable)
             => Single(enumerable).SelectMany(x => x).WithAttributes(DefaultAttributes.EnumerableSource);
 
+
+        /// <summary>
+        /// Helper to create <see cref="Source{TOut,TMat}"/> from <see cref="IAsyncEnumerable{T}"/>.
+        /// Example usage: Source.From(Enumerable.Range(1, 10))
+        /// 
+        /// Starts a new <see cref="Source{TOut,TMat}"/> from the given <see cref="IAsyncEnumerable{T}"/>. This is like starting from an
+        /// Enumerator, but every Subscriber directly attached to the Publisher of this
+        /// stream will see an individual flow of elements (always starting from the
+        /// beginning) regardless of when they subscribed.
+        /// </summary>
+        /// <typeparam name="T">TBD</typeparam>
+        /// <param name=" asyncEnumerable">TBD</param>
+        /// <returns>TBD</returns>
+        public static Source<T, NotUsed> From<T>(Func<IAsyncEnumerable<T>> asyncEnumerable)
+            => FromGraph(new AsyncEnumerable<T>(asyncEnumerable)).WithAttributes(DefaultAttributes.EnumerableSource);
+
         /// <summary>
         /// Create a <see cref="Source{TOut,TMat}"/> with one element.
         /// Every connected <see cref="Sink{TIn,TMat}"/> of this stream will see an individual stream consisting of one element.


### PR DESCRIPTION
Cherry-picked from https://github.com/akkadotnet/akka.net/commit/af513b05c2128bc916bfe2ef9598e4c5b4d78960

Backport of #6044

## Changes
- Adapted the API verify list
- Change the `OnDownstreamFinish` override signature, 1.4 does not support downstream failure propagation.
- Added missing StreamTestDefaultMailbox.DefaultConfig