### PR TITLE
[BACKPORT  #6045] cleaned up `IAsyncEnumerable` Source to use local functions

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
@@ -10,12 +10,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Pattern;
-using Akka.Routing;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
-using Nito.AsyncEx.Synchronous;
 using Xunit;
 using Xunit.Abstractions;
 using System.Collections.Generic;
@@ -24,6 +22,9 @@ using Akka.Streams.Actors;
 using Akka.Streams.TestKit.Tests;
 using Akka.Streams.Tests.Actor;
 using Reactive.Streams;
+using System.Runtime.CompilerServices;
+using Akka.Util;
+using FluentAssertions.Extensions;
 
 namespace Akka.Streams.Tests.Dsl
 {
@@ -33,8 +34,8 @@ namespace Akka.Streams.Tests.Dsl
         private ActorMaterializer Materializer { get; }
         private ITestOutputHelper _helper;
         public AsyncEnumerableSpec(ITestOutputHelper helper) : base(
-                AkkaSpecConfig.WithFallback(StreamTestDefaultMailbox.DefaultConfig),
-                helper)
+            AkkaSpecConfig.WithFallback(StreamTestDefaultMailbox.DefaultConfig),
+            helper)
         {
             _helper = helper;
             var settings = ActorMaterializerSettings.Create(Sys).WithInputBuffer(2, 16);
@@ -42,7 +43,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
 
-        [Fact] 
+        [Fact]
         public async Task RunAsAsyncEnumerable_Uses_CancellationToken()
         {
             var input = Enumerable.Range(1, 6).ToList();
@@ -67,7 +68,7 @@ namespace Akka.Streams.Tests.Dsl
             
             caught.ShouldBeTrue();
         }
-        
+
         [Fact]
         public async Task RunAsAsyncEnumerable_must_return_an_IAsyncEnumerableT_from_a_Source()
         {
@@ -79,7 +80,7 @@ namespace Akka.Streams.Tests.Dsl
                 (output[0] == a).ShouldBeTrue("Did not get elements in order!");
                 output = output.Skip(1).ToArray();
             }
-            output.Length.ShouldBe(0,"Did not receive all elements!");
+            output.Length.ShouldBe(0, "Did not receive all elements!");
         }
 
         [Fact]
@@ -93,7 +94,7 @@ namespace Akka.Streams.Tests.Dsl
                 (output[0] == a).ShouldBeTrue("Did not get elements in order!");
                 output = output.Skip(1).ToArray();
             }
-            output.Length.ShouldBe(0,"Did not receive all elements!");
+            output.Length.ShouldBe(0, "Did not receive all elements!");
             
             output = input.ToArray();
             await foreach (var a in asyncEnumerable)
@@ -101,7 +102,7 @@ namespace Akka.Streams.Tests.Dsl
                 (output[0] == a).ShouldBeTrue("Did not get elements in order!");
                 output = output.Skip(1).ToArray();
             }
-            output.Length.ShouldBe(0,"Did not receive all elements in second enumeration!!");
+            output.Length.ShouldBe(0, "Did not receive all elements in second enumeration!!");
         }
 
 
@@ -112,7 +113,7 @@ namespace Akka.Streams.Tests.Dsl
             var probe = this.CreatePublisherProbe<int>();
             var task = Source.FromPublisher(probe).RunAsAsyncEnumerable(materializer);
             
-            var a = Task.Run( async () =>
+            var a = Task.Run(async () =>
             {
                 await foreach (var notused in task)
                 {
@@ -123,19 +124,20 @@ namespace Akka.Streams.Tests.Dsl
             //we want to send messages so we aren't just waiting forever.
             probe.SendNext(1);
             probe.SendNext(2);
-            bool thrown = false;
+            var thrown = false;
             try
             {
                 await a;
             }
-            catch (StreamDetachedException e) 
-            { 
-                thrown = true; 
-            } 
+            catch (StreamDetachedException e)
+            {
+                thrown = true;
+            }
             catch (AbruptTerminationException e)
             {
                 thrown = true;
             }
+
             thrown.ShouldBeTrue();
         }
         
@@ -151,47 +153,128 @@ namespace Akka.Streams.Tests.Dsl
             {
                 await foreach (var a in task)
                 {
-                    
                 }
             }
             
             await Assert.ThrowsAsync<IllegalStateException>(ShouldThrow);
         }
 
-    [Fact]
-        public void AsyncEnumerableSource_Must_Complete_Immediately_With_No_elements_When_An_Empty_IAsyncEnumerable_Is_Passed_In()
+        [Fact]
+        public void
+            AsyncEnumerableSource_Must_Complete_Immediately_With_No_elements_When_An_Empty_IAsyncEnumerable_Is_Passed_In()
         {
-            Func<IAsyncEnumerable<int>> range = () =>
-            {
-                return RangeAsync(1, 100);
-            };
+            IAsyncEnumerable<int> Range() => RangeAsync(0, 0);
             var subscriber = this.CreateManualSubscriberProbe<int>();
 
-            Source.From(range)
+            Source.From(Range)
                 .RunWith(Sink.FromSubscriber(subscriber), Materializer);
 
             var subscription = subscriber.ExpectSubscription();
             subscription.Request(100);
-            for (int i = 1; i <= 20; i++)
-            {
-                var next = subscriber.ExpectNext(i);
-                _helper.WriteLine(i.ToString());
-            }
-
-            //subscriber.ExpectComplete();
+            subscriber.ExpectComplete();
         }
 
-        static async IAsyncEnumerable<int> RangeAsync(int start, int count)
+        [Fact]
+        public void AsyncEnumerableSource_Must_Process_All_Elements()
         {
-            for (var i = 0; i < count; i++)
+            IAsyncEnumerable<int> Range() => RangeAsync(0, 100);
+            var subscriber = this.CreateManualSubscriberProbe<int>();
+
+            Source.From(Range)
+                .RunWith(Sink.FromSubscriber(subscriber), Materializer);
+
+            var subscription = subscriber.ExpectSubscription();
+            subscription.Request(101);
+
+            subscriber.ExpectNextN(Enumerable.Range(0, 100));
+            
+            subscriber.ExpectComplete();
+        }
+
+        [Fact]
+        public void AsyncEnumerableSource_Must_Process_Source_That_Immediately_Throws()
+        {
+            IAsyncEnumerable<int> Range() => ThrowingRangeAsync(0, 100, 50);
+            var subscriber = this.CreateManualSubscriberProbe<int>();
+
+            Source.From(Range)
+                .RunWith(Sink.FromSubscriber(subscriber), Materializer);
+
+            var subscription = subscriber.ExpectSubscription();
+            subscription.Request(101);
+
+            subscriber.ExpectNextN(Enumerable.Range(0, 50));
+
+            var exception = subscriber.ExpectError();
+            
+            // Exception should be automatically unrolled, this SHOULD NOT be AggregateException
+            exception.Should().BeOfType<TestException>();
+            exception.Message.Should().Be("BOOM!");
+        }
+
+        [Fact]
+        public async Task AsyncEnumerableSource_Must_Cancel_Running_Source_If_Downstream_Completes()
+        {
+            var latch = new AtomicBoolean();
+            IAsyncEnumerable<int> Range() => ProbeableRangeAsync(0, 100, latch);
+            var subscriber = this.CreateManualSubscriberProbe<int>();
+
+            Source.From(Range)
+                .RunWith(Sink.FromSubscriber(subscriber), Materializer);
+
+            var subscription = subscriber.ExpectSubscription();
+            subscription.Request(50);
+            subscriber.ExpectNextN(Enumerable.Range(0, 50));
+            subscription.Cancel();
+
+            // The cancellation token inside the IAsyncEnumerable should be cancelled
+            await WithinAsync(3.Seconds(), async () => latch.Value);
+        }
+
+        private static async IAsyncEnumerable<int> RangeAsync(int start, int count, 
+            [EnumeratorCancellation] CancellationToken token = default)
+        {
+            foreach (var i in Enumerable.Range(start, count))
             {
-                await Task.Delay(i);
-                yield return start + i;
+                await Task.Delay(10, token);
+                if(token.IsCancellationRequested)
+                    yield break;
+                yield return i;
+            }
+        }
+
+        private static async IAsyncEnumerable<int> ThrowingRangeAsync(int start, int count, int throwAt,
+            [EnumeratorCancellation] CancellationToken token = default)
+        {
+            foreach (var i in Enumerable.Range(start, count))
+            {
+                if(token.IsCancellationRequested)
+                    yield break;
+
+                if (i == throwAt)
+                    throw new TestException("BOOM!");
+                
+                yield return i;
+            }
+        }
+
+        private static async IAsyncEnumerable<int> ProbeableRangeAsync(int start, int count, AtomicBoolean latch,
+            [EnumeratorCancellation] CancellationToken token = default)
+        {
+            token.Register(() =>
+            {
+                latch.GetAndSet(true);
+            });
+            foreach (var i in Enumerable.Range(start, count))
+            {
+                if(token.IsCancellationRequested)
+                    yield break;
+
+                yield return i;
             }
         }
         
     }
 #else
 #endif
-
 }

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Annotations;
 using Akka.Event;
@@ -3715,29 +3716,22 @@ namespace Akka.Streams.Implementation.Fusing
 
         private sealed class Logic : OutGraphStageLogic
         {
-            private readonly IAsyncEnumerator<T> _enumerator;
+            private readonly IAsyncEnumerable<T> _enumerable;
             private readonly Outlet<T> _outlet;
             private readonly Action<T> _onSuccess;
             private readonly Action<Exception> _onFailure;
             private readonly Action _onComplete;
-            private readonly Action<Task<bool>> _handleContinuation;
 
-            public Logic(SourceShape<T> shape, IAsyncEnumerator<T> enumerator) : base(shape)
+            private CancellationTokenSource _completionCts;
+            private IAsyncEnumerator<T> _enumerator;
+
+            public Logic(SourceShape<T> shape, IAsyncEnumerable<T> enumerable) : base(shape)
             {
-                _enumerator = enumerator;
+                _enumerable = enumerable;
                 _outlet = shape.Outlet;
                 _onSuccess = GetAsyncCallback<T>(OnSuccess);
                 _onFailure = GetAsyncCallback<Exception>(OnFailure);
                 _onComplete = GetAsyncCallback(OnComplete);
-                _handleContinuation = task =>
-                {
-                    // Since this Action is used as task continuation, we cannot safely call corresponding
-                    // OnSuccess/OnFailure/OnComplete methods directly. We need to do that via async callbacks.
-                    if (task.IsFaulted) _onFailure(task.Exception);
-                    else if (task.IsCanceled) _onFailure(new TaskCanceledException(task));
-                    else if (task.Result) _onSuccess(enumerator.Current);
-                    else _onComplete();
-                };
 
                 SetHandler(_outlet, this);
             }
@@ -3750,12 +3744,19 @@ namespace Akka.Streams.Implementation.Fusing
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private void OnSuccess(T element) => Push(_outlet, element);
 
+            public override void PreStart()
+            {
+                base.PreStart();
+                _completionCts = new CancellationTokenSource();
+                _enumerator = _enumerable.GetAsyncEnumerator(_completionCts.Token);
+            }
+
             public override void OnPull()
             {
                 var vtask = _enumerator.MoveNextAsync();
                 if (vtask.IsCompletedSuccessfully)
                 {
-                    // When MoveNextAsync returned immediatelly, we don't need to await.
+                    // When MoveNextAsync returned immediately, we don't need to await.
                     // We can use fast path instead.
                     if (vtask.Result)
                     {
@@ -3767,24 +3768,67 @@ namespace Akka.Streams.Implementation.Fusing
                         // if result is false, it means enumerator was closed. Complete stage in that case.
                         CompleteStage();
                     }
+                } 
+                else if (vtask.IsCompleted) // IsCompleted covers Faulted, Cancelled, and RanToCompletion async state
+                {
+                    // vtask will always contains an exception because we know we're not successful and always throws
+                    try
+                    {
+                        // This does not block because we know that the task already completed
+                        // Using GetAwaiter().GetResult() to automatically unwraps AggregateException inner exception
+                        vtask.GetAwaiter().GetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        FailStage(ex);
+                        return;
+                    }
+
+                    throw new InvalidOperationException("Should never reach this code");
                 }
                 else
                 {
-                    vtask.AsTask().ContinueWith(_handleContinuation);
+                    async Task ProcessTask()
+                    {
+                        // Since this Action is used as task continuation, we cannot safely call corresponding
+                        // OnSuccess/OnFailure/OnComplete methods directly. We need to do that via async callbacks.
+                        try
+                        {
+                            var completed = await vtask.ConfigureAwait(false);
+                            if (completed)
+                                _onSuccess(_enumerator.Current);
+                            else
+                                _onComplete();
+                        }
+                        catch (Exception ex)
+                        {
+                            _onFailure(ex);
+                        }
+                    }
+
+#pragma warning disable CS4014
+                    ProcessTask();
+#pragma warning restore CS4014
                 }
             }
 
             public override void OnDownstreamFinish()
             {
-                var vtask = _enumerator.DisposeAsync();
-                if (vtask.IsCompletedSuccessfully)
+                _completionCts.Cancel();
+                _completionCts.Dispose();
+
+                try
                 {
-                    CompleteStage(); // if dispose completed immediately, complete stage directly
+                    _enumerator.DisposeAsync().GetAwaiter().GetResult();
                 }
-                else
+                catch (Exception ex)
                 {
-                    // for async disposals use async callback
-                    vtask.GetAwaiter().OnCompleted(_onComplete);
+                    Log.Warning(ex, "Failed to dispose IAsyncEnumerator asynchronously");
+                }
+                finally
+                {
+                    CompleteStage();
+                    base.OnDownstreamFinish();
                 }
                 base.OnDownstreamFinish();
             }
@@ -3802,7 +3846,7 @@ namespace Akka.Streams.Implementation.Fusing
         }
 
         public override SourceShape<T> Shape { get; }
-        protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(Shape, _factory().GetAsyncEnumerator());
+        protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(Shape, _factory());
 
         protected override Attributes InitialAttributes { get; } = DefaultAttributes.EnumerableSource;
 


### PR DESCRIPTION
Cherry-picked from https://github.com/akkadotnet/akka.net/commit/0c92aac98c9421a4112692155ec33b28dbc4940d