### PR TITLE
Singleton class and settings based on current Akka Typed implementation

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonApiSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonApiSpec.cs
@@ -1,0 +1,133 @@
+//-----------------------------------------------------------------------
+// <copyright file="ClusterSingletonConfigSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.TestKit;
+using Akka.TestKit.Configs;
+using Akka.TestKit.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Cluster.Tools.Tests.Singleton
+{
+    public class ClusterSingletonApiSpec : AkkaSpec
+    {
+        #region Internal
+
+        public sealed class Pong
+        {
+            public static Pong Instance => new Pong();
+            private Pong() { }
+        }
+
+        public sealed class Ping
+        {
+            public IActorRef RespondTo { get; }
+            public Ping(IActorRef respondTo) => RespondTo = respondTo;
+        }
+
+        public sealed class Perish
+        {
+            public static Perish Instance => new Perish();
+            private Perish() { }
+        }
+
+        public class PingPong : UntypedActor
+        {
+            protected override void OnReceive(object message)
+            {
+                switch (message)
+                {
+                    case Ping ping:
+                        ping.RespondTo.Tell(Pong.Instance);
+                        break;
+                    case Perish _:
+                        Context.Stop(Self);
+                        break;
+                }
+            }
+        }
+
+        #endregion
+
+        private readonly Cluster _clusterNode1;
+        private readonly Cluster _clusterNode2;
+        private readonly ActorSystem _system2;
+
+        public static Config GetConfig() => ConfigurationFactory.ParseString(@"
+            akka.loglevel = DEBUG
+            akka.actor.provider = ""cluster""
+            akka.cluster.roles = [""singleton""]
+            akka.remote {
+                dot-netty.tcp {
+                    hostname = ""127.0.0.1""
+                    port = 0
+                }
+            }").WithFallback(TestConfigs.DefaultConfig);
+
+        public ClusterSingletonApiSpec(ITestOutputHelper testOutput)
+            : base(GetConfig(), testOutput)
+        {
+            _clusterNode1 = Cluster.Get(Sys);
+
+            _system2 = ActorSystem.Create(
+                Sys.Name,
+                ConfigurationFactory.ParseString("akka.cluster.roles = [\"singleton\"]").WithFallback(Sys.Settings.Config));
+
+            _clusterNode2 = Cluster.Get(_system2);
+        }
+
+        [Fact]
+        public void A_cluster_singleton_must_be_accessible_from_two_nodes_in_a_cluster()
+        {
+            var node1UpProbe = CreateTestProbe(Sys);
+            var node2UpProbe = CreateTestProbe(Sys);
+
+            _clusterNode1.Join(_clusterNode1.SelfAddress);
+            node1UpProbe.AwaitAssert(() => _clusterNode1.SelfMember.Status.ShouldBe(MemberStatus.Up), TimeSpan.FromSeconds(3));
+
+            _clusterNode2.Join(_clusterNode2.SelfAddress);
+            node2UpProbe.AwaitAssert(() => _clusterNode2.SelfMember.Status.ShouldBe(MemberStatus.Up), TimeSpan.FromSeconds(3));
+
+            var cs1 = ClusterSingleton.Get(Sys);
+            var cs2 = ClusterSingleton.Get(_system2);
+
+            var settings = ClusterSingletonSettings.Create(Sys).WithRole("singleton");
+            var node1ref = cs1.Init(SingletonActor.Create(Props.Create<PingPong>(), "ping-pong").WithStopMessage(Perish.Instance).WithSettings(settings));
+            var node2ref = cs2.Init(SingletonActor.Create(Props.Create<PingPong>(), "ping-pong").WithStopMessage(Perish.Instance).WithSettings(settings));
+
+            // subsequent spawning returns the same refs
+            cs1.Init(SingletonActor.Create(Props.Create<PingPong>(), "ping-pong").WithStopMessage(Perish.Instance).WithSettings(settings)).ShouldBe(node1ref);
+            cs2.Init(SingletonActor.Create(Props.Create<PingPong>(), "ping-pong").WithStopMessage(Perish.Instance).WithSettings(settings)).ShouldBe(node2ref);
+
+            var node1PongProbe = CreateTestProbe(Sys);
+            var node2PongProbe = CreateTestProbe(_system2);
+
+            node1PongProbe.AwaitAssert(() =>
+            {
+                node1ref.Tell(new Ping(node1PongProbe.Ref));
+                node1PongProbe.ExpectMsg<Pong>();
+            }, TimeSpan.FromSeconds(3));
+
+            node2PongProbe.AwaitAssert(() =>
+            {
+                node2ref.Tell(new Ping(node2PongProbe.Ref));
+                node2PongProbe.ExpectMsg<Pong>();
+            }, TimeSpan.FromSeconds(3));
+        }
+
+        protected override async Task AfterAllAsync()
+        {
+            await base.AfterAllAsync();
+            await _system2.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(3));
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingleton.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingleton.cs
@@ -1,0 +1,131 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterSingletonManager.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using Akka.Actor;
+using Akka.Annotations;
+using Akka.Util;
+
+namespace Akka.Cluster.Tools.Singleton
+{
+    /// <summary>
+    /// This class is not intended for user extension other than for test purposes (e.g. stub implementation). 
+    /// More methods may be added in the future and that may break such implementations.
+    /// </summary>
+    [DoNotInherit]
+    public class ClusterSingleton : IExtension
+    {
+        private readonly ActorSystem _system;
+        private readonly Lazy<Cluster> _cluster;
+        private readonly ConcurrentDictionary<string, IActorRef> _proxies = new ConcurrentDictionary<string, IActorRef>();
+
+        public static ClusterSingleton Get(ActorSystem system) =>
+            system.WithExtension<ClusterSingleton, ClusterSingletonProvider>();
+
+        public ClusterSingleton(ExtendedActorSystem system)
+        {
+            _system = system;
+            _cluster = new Lazy<Cluster>(() => Cluster.Get(system));
+        }
+
+        /// <summary>
+        /// Start if needed and provide a proxy to a named singleton.
+        /// 
+        /// <para>If there already is a manager running for the given `singletonName` on this node, no additional manager is started.</para>
+        /// <para>If there already is a proxy running for the given `singletonName` on this node, an <see cref="IActorRef"/> to that is returned.</para>
+        /// </summary>
+        /// <returns>A proxy actor that can be used to communicate with the singleton in the cluster</returns>
+        public IActorRef Init(SingletonActor singleton)
+        {
+            var settings = singleton.Settings.GetOrElse(ClusterSingletonSettings.Create(_system));
+            if (settings.ShouldRunManager(_cluster.Value))
+            {
+                var managerName = ManagerNameFor(singleton.Name);
+                try
+                {
+                    _system.ActorOf(ClusterSingletonManager.Props(
+                        singletonProps: singleton.Props,
+                        terminationMessage: singleton.StopMessage.GetOrElse(PoisonPill.Instance),
+                        settings: settings.ToManagerSettings(singleton.Name)),
+                        managerName);
+                }
+                catch (InvalidActorNameException ex) when (ex.Message.EndsWith("is not unique!"))
+                {
+                    // This is fine. We just wanted to make sure it is running and it already is
+                }
+            }
+
+            return GetProxy(singleton.Name, settings);
+        }
+
+        private IActorRef GetProxy(string name, ClusterSingletonSettings settings)
+        {
+            IActorRef ProxyCreator()
+            {
+                var proxyName = $"singletonProxy{name}";
+                return _system.ActorOf(ClusterSingletonProxy.Props(
+                    singletonManagerPath: $"/user/{ManagerNameFor(name)}",
+                    settings: settings.ToProxySettings(name)),
+                    proxyName);
+            }
+
+            return _proxies.GetOrAdd(name, _ => ProxyCreator());
+        }
+
+
+        private string ManagerNameFor(string singletonName) => $"singletonManager{singletonName}";
+    }
+
+    public class ClusterSingletonProvider : ExtensionIdProvider<ClusterSingleton>
+    {
+        public override ClusterSingleton CreateExtension(ExtendedActorSystem system) => new ClusterSingleton(system);
+    }
+
+    public class SingletonActor
+    {
+        public string Name { get; }
+
+        public Props Props { get; }
+
+        public Option<object> StopMessage { get; }
+
+        public Option<ClusterSingletonSettings> Settings { get; }
+
+        public static SingletonActor Create(Props props, string name) =>
+            new SingletonActor(name, props, Option<object>.None, Option<ClusterSingletonSettings>.None);
+
+        private SingletonActor(string name, Props props, Option<object> stopMessage, Option<ClusterSingletonSettings> settings)
+        {
+            Name = name;
+            Props = props;
+            StopMessage = stopMessage;
+            Settings = settings;
+        }
+
+        /// <summary>
+        /// <see cref="Props"/> of the singleton actor, such as dispatcher settings.
+        /// </summary>
+        public SingletonActor WithProps(Props props) => Copy(props: props);
+
+        /// <summary>
+        /// Message sent to the singleton to tell it to stop, e.g. when being migrated. 
+        /// If this is not defined, a <see cref="PoisonPill"/> will be used instead. 
+        /// It can be useful to define a custom stop message if the singleton needs to 
+        /// perform some asynchronous cleanup or interactions before stopping.
+        /// </summary>
+        public SingletonActor WithStopMessage(object stopMessage) => Copy(stopMessage: stopMessage);
+
+        /// <summary>
+        /// Additional settings, typically loaded from configuration.
+        /// </summary>
+        public SingletonActor WithSettings(ClusterSingletonSettings settings) => Copy(settings: settings);
+
+        private SingletonActor Copy(string name = null, Props props = null, Option<object> stopMessage = default, Option<ClusterSingletonSettings> settings = default) =>
+            new SingletonActor(name ?? Name, props ?? Props, stopMessage.HasValue ? stopMessage : StopMessage, settings.HasValue ? settings : Settings);
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonSettings.cs
@@ -1,0 +1,141 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterSingletonManager.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Annotations;
+using Akka.Configuration;
+using Akka.Coordination;
+using Akka.Util;
+
+namespace Akka.Cluster.Tools.Singleton
+{
+    /// <summary>
+    /// The settings used for the <see cref="ClusterSingleton"/>
+    /// </summary>
+    [Serializable]
+    public class ClusterSingletonSettings : INoSerializationVerificationNeeded
+    {
+        /// <summary>
+        /// Singleton among the nodes tagged with specified role. If the role is not specified it's a singleton among all nodes in the cluster.
+        /// </summary>
+        public string Role { get; }
+
+        /// <summary>
+        /// Interval at which the proxy will try to resolve the singleton instance.
+        /// </summary>
+        public TimeSpan SingletonIdentificationInterval { get; }
+
+        /// <summary>
+        /// Margin until the singleton instance that belonged to a downed/removed partition is created in surviving partition. 
+        /// The purpose of this margin is that in case of a network partition the singleton actors in the non-surviving 
+        /// partitions must be stopped before corresponding actors are started somewhere else. This is especially important 
+        /// for persistent actors.
+        /// </summary>
+        public TimeSpan RemovalMargin { get; }
+
+        /// <summary>
+        /// When a node is becoming oldest it sends hand-over request to previous oldest, that might be leaving the cluster.
+        /// This is retried with this interval until the previous oldest confirms that the hand over has started or the 
+        /// previous oldest member is removed from the cluster (+ `removalMargin`).
+        /// </summary>
+        public TimeSpan HandOverRetryInterval { get; }
+
+        /// <summary>
+        /// If the location of the singleton is unknown the proxy will buffer this number of messages and deliver them when the singleton 
+        /// is identified. When the buffer is full old messages will be dropped when new messages are sent viea the proxy. Use `0` to 
+        /// disable buffering, i.e. messages will be dropped immediately if the location of the singleton is unknown.
+        /// </summary>
+        public int BufferSize { get; }
+
+        /// <summary>
+        /// LeaseSettings for acquiring before creating the singleton actor.
+        /// </summary>
+        public LeaseUsageSettings LeaseSettings { get; }
+
+        /// <summary>
+        /// Create settings from the default configuration `akka.cluster`.
+        /// </summary>
+        public static ClusterSingletonSettings Create(ActorSystem system)
+        {
+            system.Settings.InjectTopLevelFallback(ClusterSingletonManager.DefaultConfig());
+            return Create(system.Settings.Config.GetConfig("akka.cluster"));
+        }
+
+        /// <summary>
+        /// Create settings from a configuration with the same layout as the default configuration `akka.cluster.singleton` and `akka.cluster.singleton-proxy`.
+        /// </summary>
+        public static ClusterSingletonSettings Create(Config config)
+        {
+            var mgrSettings = ClusterSingletonManagerSettings.Create(config.GetConfig("singleton"));
+            var proxySettings = ClusterSingletonProxySettings.Create(config.GetConfig("singleton-proxy"));
+
+            return new ClusterSingletonSettings(
+                mgrSettings.Role,
+                proxySettings.SingletonIdentificationInterval,
+                mgrSettings.RemovalMargin,
+                mgrSettings.HandOverRetryInterval,
+                proxySettings.BufferSize,
+                mgrSettings.LeaseSettings);
+        }
+
+        private ClusterSingletonSettings(string role, TimeSpan singletonIdentificationInterval, TimeSpan removalMargin, TimeSpan handOverRetryInterval, int bufferSize, LeaseUsageSettings leaseSettings)
+        {
+            if (singletonIdentificationInterval == TimeSpan.Zero)
+                throw new ArgumentException("singletonIdentificationInterval must be positive", nameof(singletonIdentificationInterval));
+
+            if (removalMargin < TimeSpan.Zero)
+                throw new ArgumentException("ClusterSingletonManagerSettings.RemovalMargin must be positive", nameof(removalMargin));
+
+            if (handOverRetryInterval <= TimeSpan.Zero)
+                throw new ArgumentException("ClusterSingletonManagerSettings.HandOverRetryInterval must be positive", nameof(handOverRetryInterval));
+
+            if (bufferSize < 0 || bufferSize > 10000)
+                throw new ArgumentException("bufferSize must be >= 0 and <= 10000", nameof(bufferSize));
+
+            Role = role;
+            SingletonIdentificationInterval = singletonIdentificationInterval;
+            RemovalMargin = removalMargin;
+            HandOverRetryInterval = handOverRetryInterval;
+            BufferSize = bufferSize;
+            LeaseSettings = leaseSettings;
+        }
+
+        public ClusterSingletonSettings WithRole(string role) => Copy(role: role);
+
+        public ClusterSingletonSettings WithRemovalMargin(TimeSpan removalMargin) => Copy(removalMargin: removalMargin);
+
+        public ClusterSingletonSettings WithHandOverRetryInterval(TimeSpan handOverRetryInterval) => Copy(handOverRetryInterval: handOverRetryInterval);
+
+        public ClusterSingletonSettings WithLeaseSettings(LeaseUsageSettings leaseSettings) => Copy(leaseSettings: leaseSettings);
+
+        private ClusterSingletonSettings Copy(Option<string> role = default, TimeSpan? singletonIdentificationInterval = null, TimeSpan? removalMargin = null, TimeSpan? handOverRetryInterval = null, int? bufferSize = null, Option<LeaseUsageSettings> leaseSettings = default)
+        {
+            return new ClusterSingletonSettings(
+                role: role.HasValue ? role.Value : Role,
+                singletonIdentificationInterval: singletonIdentificationInterval ?? SingletonIdentificationInterval,
+                removalMargin: removalMargin ?? RemovalMargin,
+                handOverRetryInterval: handOverRetryInterval ?? HandOverRetryInterval,
+                bufferSize: bufferSize ?? BufferSize,
+                leaseSettings: leaseSettings.HasValue ? leaseSettings.Value : LeaseSettings);
+        }
+
+        [InternalApi]
+        internal ClusterSingletonManagerSettings ToManagerSettings(string singletonName) =>
+            new ClusterSingletonManagerSettings(singletonName, Role, RemovalMargin, HandOverRetryInterval, LeaseSettings);
+
+        [InternalApi]
+        internal ClusterSingletonProxySettings ToProxySettings(string singletonName) =>
+            new ClusterSingletonProxySettings(singletonName, Role, SingletonIdentificationInterval, BufferSize);
+
+        [InternalApi]
+        internal bool ShouldRunManager(Cluster cluster) => string.IsNullOrEmpty(Role) || cluster.SelfMember.Roles.Contains(Role);
+
+        public override string ToString() =>
+            $"ClusterSingletonSettings({Role}, {SingletonIdentificationInterval}, {RemovalMargin}, {HandOverRetryInterval}, {BufferSize}, {LeaseSettings})";
+    }
+}

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Core.verified.txt
@@ -333,6 +333,13 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
 }
 namespace Akka.Cluster.Tools.Singleton
 {
+    [Akka.Annotations.DoNotInheritAttribute()]
+    public class ClusterSingleton : Akka.Actor.IExtension
+    {
+        public ClusterSingleton(Akka.Actor.ExtendedActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingleton Get(Akka.Actor.ActorSystem system) { }
+        public Akka.Actor.IActorRef Init(Akka.Cluster.Tools.Singleton.SingletonActor singleton) { }
+    }
     public sealed class ClusterSingletonManager : Akka.Actor.FSM<Akka.Cluster.Tools.Singleton.ClusterSingletonState, Akka.Cluster.Tools.Singleton.IClusterSingletonData>
     {
         public ClusterSingletonManager(Akka.Actor.Props singletonProps, object terminationMessage, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
@@ -364,6 +371,11 @@ namespace Akka.Cluster.Tools.Singleton
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithRole(string role) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithSingletonName(string singletonName) { }
     }
+    public class ClusterSingletonProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Tools.Singleton.ClusterSingleton>
+    {
+        public ClusterSingletonProvider() { }
+        public override Akka.Cluster.Tools.Singleton.ClusterSingleton CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
+    }
     public sealed class ClusterSingletonProxy : Akka.Actor.ReceiveActor
     {
         public ClusterSingletonProxy(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
@@ -388,6 +400,22 @@ namespace Akka.Cluster.Tools.Singleton
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonIdentificationInterval(System.TimeSpan singletonIdentificationInterval) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonName(string singletonName) { }
     }
+    public class ClusterSingletonSettings : Akka.Actor.INoSerializationVerificationNeeded
+    {
+        public int BufferSize { get; }
+        public System.TimeSpan HandOverRetryInterval { get; }
+        public Akka.Coordination.LeaseUsageSettings LeaseSettings { get; }
+        public System.TimeSpan RemovalMargin { get; }
+        public string Role { get; }
+        public System.TimeSpan SingletonIdentificationInterval { get; }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Configuration.Config config) { }
+        public override string ToString() { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithHandOverRetryInterval(System.TimeSpan handOverRetryInterval) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithLeaseSettings(Akka.Coordination.LeaseUsageSettings leaseSettings) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithRemovalMargin(System.TimeSpan removalMargin) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithRole(string role) { }
+    }
     public enum ClusterSingletonState
     {
         Start = 0,
@@ -403,6 +431,17 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public interface IClusterSingletonData { }
     public interface IClusterSingletonMessage { }
+    public class SingletonActor
+    {
+        public string Name { get; }
+        public Akka.Actor.Props Props { get; }
+        public Akka.Util.Option<Akka.Cluster.Tools.Singleton.ClusterSingletonSettings> Settings { get; }
+        public Akka.Util.Option<object> StopMessage { get; }
+        public static Akka.Cluster.Tools.Singleton.SingletonActor Create(Akka.Actor.Props props, string name) { }
+        public Akka.Cluster.Tools.Singleton.SingletonActor WithProps(Akka.Actor.Props props) { }
+        public Akka.Cluster.Tools.Singleton.SingletonActor WithSettings(Akka.Cluster.Tools.Singleton.ClusterSingletonSettings settings) { }
+        public Akka.Cluster.Tools.Singleton.SingletonActor WithStopMessage(object stopMessage) { }
+    }
 }
 namespace Akka.Cluster.Tools.Singleton.Serialization
 {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -333,6 +333,13 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
 }
 namespace Akka.Cluster.Tools.Singleton
 {
+    [Akka.Annotations.DoNotInheritAttribute()]
+    public class ClusterSingleton : Akka.Actor.IExtension
+    {
+        public ClusterSingleton(Akka.Actor.ExtendedActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingleton Get(Akka.Actor.ActorSystem system) { }
+        public Akka.Actor.IActorRef Init(Akka.Cluster.Tools.Singleton.SingletonActor singleton) { }
+    }
     public sealed class ClusterSingletonManager : Akka.Actor.FSM<Akka.Cluster.Tools.Singleton.ClusterSingletonState, Akka.Cluster.Tools.Singleton.IClusterSingletonData>
     {
         public ClusterSingletonManager(Akka.Actor.Props singletonProps, object terminationMessage, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
@@ -364,6 +371,11 @@ namespace Akka.Cluster.Tools.Singleton
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithRole(string role) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithSingletonName(string singletonName) { }
     }
+    public class ClusterSingletonProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Tools.Singleton.ClusterSingleton>
+    {
+        public ClusterSingletonProvider() { }
+        public override Akka.Cluster.Tools.Singleton.ClusterSingleton CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
+    }
     public sealed class ClusterSingletonProxy : Akka.Actor.ReceiveActor
     {
         public ClusterSingletonProxy(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
@@ -388,6 +400,22 @@ namespace Akka.Cluster.Tools.Singleton
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonIdentificationInterval(System.TimeSpan singletonIdentificationInterval) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonName(string singletonName) { }
     }
+    public class ClusterSingletonSettings : Akka.Actor.INoSerializationVerificationNeeded
+    {
+        public int BufferSize { get; }
+        public System.TimeSpan HandOverRetryInterval { get; }
+        public Akka.Coordination.LeaseUsageSettings LeaseSettings { get; }
+        public System.TimeSpan RemovalMargin { get; }
+        public string Role { get; }
+        public System.TimeSpan SingletonIdentificationInterval { get; }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Configuration.Config config) { }
+        public override string ToString() { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithHandOverRetryInterval(System.TimeSpan handOverRetryInterval) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithLeaseSettings(Akka.Coordination.LeaseUsageSettings leaseSettings) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithRemovalMargin(System.TimeSpan removalMargin) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithRole(string role) { }
+    }
     public enum ClusterSingletonState
     {
         Start = 0,
@@ -403,6 +431,17 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public interface IClusterSingletonData { }
     public interface IClusterSingletonMessage { }
+    public class SingletonActor
+    {
+        public string Name { get; }
+        public Akka.Actor.Props Props { get; }
+        public Akka.Util.Option<Akka.Cluster.Tools.Singleton.ClusterSingletonSettings> Settings { get; }
+        public Akka.Util.Option<object> StopMessage { get; }
+        public static Akka.Cluster.Tools.Singleton.SingletonActor Create(Akka.Actor.Props props, string name) { }
+        public Akka.Cluster.Tools.Singleton.SingletonActor WithProps(Akka.Actor.Props props) { }
+        public Akka.Cluster.Tools.Singleton.SingletonActor WithSettings(Akka.Cluster.Tools.Singleton.ClusterSingletonSettings settings) { }
+        public Akka.Cluster.Tools.Singleton.SingletonActor WithStopMessage(object stopMessage) { }
+    }
 }
 namespace Akka.Cluster.Tools.Singleton.Serialization
 {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -333,6 +333,13 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
 }
 namespace Akka.Cluster.Tools.Singleton
 {
+    [Akka.Annotations.DoNotInheritAttribute()]
+    public class ClusterSingleton : Akka.Actor.IExtension
+    {
+        public ClusterSingleton(Akka.Actor.ExtendedActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingleton Get(Akka.Actor.ActorSystem system) { }
+        public Akka.Actor.IActorRef Init(Akka.Cluster.Tools.Singleton.SingletonActor singleton) { }
+    }
     public sealed class ClusterSingletonManager : Akka.Actor.FSM<Akka.Cluster.Tools.Singleton.ClusterSingletonState, Akka.Cluster.Tools.Singleton.IClusterSingletonData>
     {
         public ClusterSingletonManager(Akka.Actor.Props singletonProps, object terminationMessage, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
@@ -364,6 +371,11 @@ namespace Akka.Cluster.Tools.Singleton
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithRole(string role) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithSingletonName(string singletonName) { }
     }
+    public class ClusterSingletonProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Tools.Singleton.ClusterSingleton>
+    {
+        public ClusterSingletonProvider() { }
+        public override Akka.Cluster.Tools.Singleton.ClusterSingleton CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
+    }
     public sealed class ClusterSingletonProxy : Akka.Actor.ReceiveActor
     {
         public ClusterSingletonProxy(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
@@ -388,6 +400,22 @@ namespace Akka.Cluster.Tools.Singleton
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonIdentificationInterval(System.TimeSpan singletonIdentificationInterval) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonName(string singletonName) { }
     }
+    public class ClusterSingletonSettings : Akka.Actor.INoSerializationVerificationNeeded
+    {
+        public int BufferSize { get; }
+        public System.TimeSpan HandOverRetryInterval { get; }
+        public Akka.Coordination.LeaseUsageSettings LeaseSettings { get; }
+        public System.TimeSpan RemovalMargin { get; }
+        public string Role { get; }
+        public System.TimeSpan SingletonIdentificationInterval { get; }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Configuration.Config config) { }
+        public override string ToString() { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithHandOverRetryInterval(System.TimeSpan handOverRetryInterval) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithLeaseSettings(Akka.Coordination.LeaseUsageSettings leaseSettings) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithRemovalMargin(System.TimeSpan removalMargin) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithRole(string role) { }
+    }
     public enum ClusterSingletonState
     {
         Start = 0,
@@ -403,6 +431,17 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public interface IClusterSingletonData { }
     public interface IClusterSingletonMessage { }
+    public class SingletonActor
+    {
+        public string Name { get; }
+        public Akka.Actor.Props Props { get; }
+        public Akka.Util.Option<Akka.Cluster.Tools.Singleton.ClusterSingletonSettings> Settings { get; }
+        public Akka.Util.Option<object> StopMessage { get; }
+        public static Akka.Cluster.Tools.Singleton.SingletonActor Create(Akka.Actor.Props props, string name) { }
+        public Akka.Cluster.Tools.Singleton.SingletonActor WithProps(Akka.Actor.Props props) { }
+        public Akka.Cluster.Tools.Singleton.SingletonActor WithSettings(Akka.Cluster.Tools.Singleton.ClusterSingletonSettings settings) { }
+        public Akka.Cluster.Tools.Singleton.SingletonActor WithStopMessage(object stopMessage) { }
+    }
 }
 namespace Akka.Cluster.Tools.Singleton.Serialization
 {


### PR DESCRIPTION
Fixes #6036

## Changes

Since this already exists in Akka Typed and it isn't built on top of anything Akka-Typed specific, I put together a quick port with this functionality:

- If there already is a manager running for the given `singletonName` on this node, no additional manager is started.
- If there already is a proxy running for the given `singletonName` on this node, an IActorRef to that is returned.

### Usage

```
var singleton = ClusterSingleton.Get(system);
var settings = ClusterSingletonSettings.Create(system).WithRole("singleton");

var proxy = singleton.Init(SingletonActor.Create(Props.Create<GlobalCounter>(), "GlobalCounter").WithSettings(settings));
proxy.Tell(Counter.Increment);
```

This will required a complete cluster restart though, since the names for both the `ClusterSingletonManager` and `ClusterSingletonManagerProxy` are now automatically constructed (i.e., based on the code above, the new manager will be named `singletonManagerGlobalCounter` and the proxy `singletonProxyGlobalCounter`).

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [X] Design discussion issue #6036
* [X] Changes in public API reviewed, if any.
* [X] I have added website documentation for this feature.