### PR TITLE
Cluster singleton should consider Member AppVersion during hand over.

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
@@ -31,6 +31,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
               akka.cluster.app-version = ""1.0.0""
               akka.cluster.auto-down-unreachable-after = 2s
               akka.cluster.singleton.min-number-of-hand-over-retries = 5
+              akka.cluster.singleton.consider-app-version = true
               akka.remote {
                 dot-netty.tcp {
                   hostname = ""127.0.0.1""

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
@@ -1,0 +1,134 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ClusterSingletonRestart2Spec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2021 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2021 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Cluster.Tools.Tests.Singleton
+{
+    public class ClusterSingletonRestart3Spec : AkkaSpec
+    {
+        private readonly ActorSystem _sys1;
+        private readonly ActorSystem _sys2;
+        private readonly ActorSystem _sys3;
+
+        public ClusterSingletonRestart3Spec(ITestOutputHelper output) : base(@"
+              akka.loglevel = DEBUG
+              akka.actor.provider = ""cluster""
+              akka.cluster.app-version = ""1.0.0""
+              akka.cluster.auto-down-unreachable-after = 2s
+              akka.cluster.singleton.min-number-of-hand-over-retries = 5
+              akka.remote {
+                dot-netty.tcp {
+                  hostname = ""127.0.0.1""
+                  port = 0
+                }
+              }", output)
+        {
+            _sys1 = Sys;
+            _sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+            InitializeLogger(_sys2);
+            _sys3 = ActorSystem.Create(Sys.Name, ConfigurationFactory.ParseString("akka.cluster.app-version = \"1.0.2\"")
+                .WithFallback(Sys.Settings.Config));
+            InitializeLogger(_sys3);
+        }
+
+        public void Join(ActorSystem from, ActorSystem to)
+        {
+            from.ActorOf(ClusterSingletonManager.Props(Props.Create(() => new Singleton()),
+                PoisonPill.Instance,
+                ClusterSingletonManagerSettings.Create(from)), "echo");
+
+
+            Within(TimeSpan.FromSeconds(45), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(from).Join(Cluster.Get(to).SelfAddress);
+                    Cluster.Get(from).State.Members.Select(x => x.UniqueAddress).Should().Contain(Cluster.Get(from).SelfUniqueAddress);
+                    Cluster.Get(from)
+                        .State.Members.Select(x => x.Status)
+                        .ToImmutableHashSet()
+                        .Should()
+                        .Equal(ImmutableHashSet<MemberStatus>.Empty.Add(MemberStatus.Up));
+                });
+            });
+        }
+
+        [Fact]
+        public void Singleton_should_consider_AppVersion_when_handing_over()
+        {
+            Join(_sys1, _sys1);
+            Join(_sys2, _sys1);
+
+            var proxy2 = _sys2.ActorOf(
+                ClusterSingletonProxy.Props("user/echo", ClusterSingletonProxySettings.Create(_sys2)), "proxy2");
+
+            Within(TimeSpan.FromSeconds(5), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    var probe = CreateTestProbe(_sys2);
+                    proxy2.Tell("poke", probe.Ref);
+                    var singleton = probe.ExpectMsg<Member>(TimeSpan.FromSeconds(1));
+                    singleton.Should().Be(Cluster.Get(_sys1).SelfMember);
+                    singleton.AppVersion.Version.Should().Be("1.0.0");
+                });
+            });
+            
+            // A new node with higher AppVersion joins the cluster
+            Join(_sys3, _sys1);
+
+            // Old node with the singleton instance left the cluster
+            Cluster.Get(_sys1).Leave(Cluster.Get(_sys1).SelfAddress);
+
+            // let it stabilize
+            Task.Delay(TimeSpan.FromSeconds(5)).Wait();
+
+            Within(TimeSpan.FromSeconds(10), () =>
+            {
+                AwaitAssert(() =>
+                {
+                    var probe = CreateTestProbe(_sys2);
+                    proxy2.Tell("poke", probe.Ref);
+
+                    // note that _sys3 has a higher app-version, so the singleton should start there
+                    var singleton = probe.ExpectMsg<Member>(TimeSpan.FromSeconds(1));
+                    singleton.Should().Be(Cluster.Get(_sys3).SelfMember);
+                    singleton.AppVersion.Version.Should().Be("1.0.2");
+                });
+            });
+        }
+
+        protected override async Task AfterAllAsync()
+        {
+            await base.AfterAllAsync();
+            await ShutdownAsync(_sys2);
+            await ShutdownAsync(_sys3);
+        }
+
+        public class Singleton : ReceiveActor
+        {
+            public Singleton()
+            {
+                ReceiveAny(o =>
+                {
+                    Sender.Tell(Cluster.Get(Context.System).SelfMember);
+                });
+            }
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/MemberAgeOrderingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/MemberAgeOrderingSpec.cs
@@ -59,10 +59,10 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             {
                 Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 3, appVersion: AppVersion.Create("1.0.0")),
                 Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1, appVersion: AppVersion.Create("1.0.0")),
-                Create(Address.Parse("akka://sys@darkstar:1116"), upNumber: 6, appVersion: AppVersion.Create("1.0.2")),
                 Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 2, appVersion: AppVersion.Create("1.0.0")),
                 Create(Address.Parse("akka://sys@darkstar:1114"), upNumber: 7, appVersion: AppVersion.Create("1.0.2")),
                 Create(Address.Parse("akka://sys@darkstar:1115"), upNumber: 8, appVersion: AppVersion.Create("1.0.2")),
+                Create(Address.Parse("akka://sys@darkstar:1116"), upNumber: 6, appVersion: AppVersion.Create("1.0.2")),
             };
 
             var seq = members.ToList();

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/MemberAgeOrderingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/MemberAgeOrderingSpec.cs
@@ -1,0 +1,89 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MemberAgeOrderingSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Actor;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Cluster.Tools.Tests.Singleton
+{
+    public class MemberAgeOrderingSpec
+    {
+        [Fact(DisplayName = "MemberAgeOrdering should sort based on UpNumber")]
+        public void SortByUpNumberTest()
+        {
+            var members = new SortedSet<Member>(MemberAgeOrdering.DescendingWithAppVersion)
+            {
+                Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 3),
+                Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1),
+                Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 9),
+            };
+
+            var seq = members.ToList();
+            seq.Count.Should().Be(3);
+            seq[0].Should().Be(Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1));
+            seq[1].Should().Be(Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 3));
+            seq[2].Should().Be(Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 9));
+        }
+        
+        [Fact(DisplayName = "MemberAgeOrdering should sort based on Address if UpNumber is the same")]
+        public void SortByAddressTest()
+        {
+            var members = new SortedSet<Member>(MemberAgeOrdering.DescendingWithAppVersion)
+            {
+                Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 1),
+                Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1),
+                Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 1),
+            };
+
+            var seq = members.ToList();
+            seq.Count.Should().Be(3);
+            seq[0].Should().Be(Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 1));
+            seq[1].Should().Be(Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 1));
+            seq[2].Should().Be(Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1));
+        }
+        
+        [Fact(DisplayName = "MemberAgeOrdering should prefer AppVersion over UpNumber")]
+        public void SortByAppVersionTest()
+        {
+            var members = new SortedSet<Member>(MemberAgeOrdering.DescendingWithAppVersion)
+            {
+                Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 3, appVersion: AppVersion.Create("1.0.0")),
+                Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1, appVersion: AppVersion.Create("1.0.0")),
+                Create(Address.Parse("akka://sys@darkstar:1116"), upNumber: 6, appVersion: AppVersion.Create("1.0.2")),
+                Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 2, appVersion: AppVersion.Create("1.0.0")),
+                Create(Address.Parse("akka://sys@darkstar:1114"), upNumber: 7, appVersion: AppVersion.Create("1.0.2")),
+                Create(Address.Parse("akka://sys@darkstar:1115"), upNumber: 8, appVersion: AppVersion.Create("1.0.2")),
+            };
+
+            var seq = members.ToList();
+            seq.Count.Should().Be(6);
+            seq[0].Should().Be(Create(Address.Parse("akka://sys@darkstar:1116"), upNumber: 6, appVersion: AppVersion.Create("1.0.2")));
+            seq[1].Should().Be(Create(Address.Parse("akka://sys@darkstar:1114"), upNumber: 7, appVersion: AppVersion.Create("1.0.2")));
+            seq[2].Should().Be(Create(Address.Parse("akka://sys@darkstar:1115"), upNumber: 8, appVersion: AppVersion.Create("1.0.2")));
+            seq[3].Should().Be(Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1, appVersion: AppVersion.Create("1.0.0")));
+            seq[4].Should().Be(Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 2, appVersion: AppVersion.Create("1.0.0")));
+            seq[5].Should().Be(Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 3, appVersion: AppVersion.Create("1.0.0")));
+        }
+        
+        public static Member Create(
+            Address address,
+            MemberStatus status = MemberStatus.Up,
+            ImmutableHashSet<string> roles = null,
+            int uid = 0,
+            int upNumber = 0,
+            AppVersion appVersion = null)
+        {
+            return Member.Create(new UniqueAddress(address, uid), upNumber, status, roles ?? ImmutableHashSet<string>.Empty, appVersion ?? AppVersion.Zero);
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
@@ -880,7 +880,9 @@ namespace Akka.Cluster.Tools.Singleton
                 {
                     case StartOldestChangedBuffer _:
                         {
-                            _oldestChangedBuffer = Context.ActorOf(Actor.Props.Create<OldestChangedBuffer>(_settings.Role).WithDispatcher(Context.Props.Dispatcher));
+                            _oldestChangedBuffer = Context.ActorOf(
+                                Actor.Props.Create(() => new OldestChangedBuffer(_settings.Role, _settings.ConsiderAppVersion))
+                                .WithDispatcher(Context.Props.Dispatcher));
                             GetNextOldestChanged();
                             return Stay();
                         }

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxy.cs
@@ -76,6 +76,7 @@ namespace Akka.Cluster.Tools.Singleton
                 .WithDeploy(Deploy.Local);
         }
 
+        private readonly MemberAgeOrdering _memberAgeComparer;
         private readonly ClusterSingletonProxySettings _settings;
         private readonly Cluster _cluster = Cluster.Get(Context.System);
         private readonly Queue<KeyValuePair<object, IActorRef>> _buffer = new Queue<KeyValuePair<object, IActorRef>>(); // queue seems to fit better
@@ -84,7 +85,7 @@ namespace Akka.Cluster.Tools.Singleton
         private string _identityId;
         private IActorRef _singleton = null;
         private ICancelable _identityTimer = null;
-        private ImmutableSortedSet<Member> _membersByAge = ImmutableSortedSet<Member>.Empty.WithComparer(MemberAgeOrdering.Descending);
+        private ImmutableSortedSet<Member> _membersByAge;
         private ILoggingAdapter _log;
 
         /// <summary>
@@ -97,6 +98,11 @@ namespace Akka.Cluster.Tools.Singleton
             _settings = settings;
             _singletonPath = (singletonManagerPath + "/" + settings.SingletonName).Split('/');
             _identityId = CreateIdentifyId(_identityCounter);
+
+            _memberAgeComparer = settings.ConsiderAppVersion
+                ? MemberAgeOrdering.DescendingWithAppVersion
+                : MemberAgeOrdering.Descending;
+            _membersByAge = ImmutableSortedSet<Member>.Empty.WithComparer(_memberAgeComparer);
 
             Receive<ClusterEvent.CurrentClusterState>(s => HandleInitial(s));
             Receive<ClusterEvent.MemberUp>(m => Add(m.Member));
@@ -197,7 +203,7 @@ namespace Akka.Cluster.Tools.Singleton
             TrackChanges(() =>
                 _membersByAge = state.Members
                     .Where(m => m.Status == MemberStatus.Up && MatchingRole(m))
-                    .ToImmutableSortedSet(MemberAgeOrdering.Descending));
+                    .ToImmutableSortedSet(_memberAgeComparer));
         }
 
         // Discard old singleton ActorRef and send a periodic message to self to identify the singleton.

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxySettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxySettings.cs
@@ -32,7 +32,9 @@ namespace Akka.Cluster.Tools.Singleton
             if (config.IsNullOrEmpty())
                 throw ConfigurationException.NullOrEmptyConfig<ClusterSingletonProxySettings>("akka.cluster.singleton-proxy");
 
-            return Create(config);
+            var considerAppVersion =
+                system.Settings.Config.GetBoolean("akka.cluster.singleton.consider-app-version", false);
+            return Create(config, considerAppVersion);
         }
 
         /// <summary>
@@ -40,8 +42,9 @@ namespace Akka.Cluster.Tools.Singleton
         /// the default configuration `akka.cluster.singleton-proxy`.
         /// </summary>
         /// <param name="config">TBD</param>
+        /// <param name="considerAppVersion">TBD</param>
         /// <returns>TBD</returns>
-        public static ClusterSingletonProxySettings Create(Config config)
+        public static ClusterSingletonProxySettings Create(Config config, bool considerAppVersion)
         {
             if (config.IsNullOrEmpty())
                 throw ConfigurationException.NullOrEmptyConfig<ClusterSingletonProxySettings>();
@@ -53,7 +56,8 @@ namespace Akka.Cluster.Tools.Singleton
                 singletonName: config.GetString("singleton-name"),
                 role: role,
                 singletonIdentificationInterval: config.GetTimeSpan("singleton-identification-interval"),
-                bufferSize: config.GetInt("buffer-size", 0));
+                bufferSize: config.GetInt("buffer-size", 0),
+                considerAppVersion: considerAppVersion);
         }
 
         /// <summary>
@@ -75,6 +79,13 @@ namespace Akka.Cluster.Tools.Singleton
         /// If the location of the singleton is unknown the proxy will buffer this number of messages and deliver them when the singleton is identified.
         /// </summary>
         public int BufferSize { get; }
+        
+        /// <summary>
+        /// Should <see cref="Member.AppVersion"/> be considered when the cluster singleton instance is being moved to another node.
+        /// When set to false, singleton instance will always be created on oldest member.
+        /// When set to true, singleton instance will be created on the oldest member with the highest <see cref="Member.AppVersion"/> number.
+        /// </summary>
+        public bool ConsiderAppVersion { get; }
 
         /// <summary>
         /// Creates new instance of the <see cref="ClusterSingletonProxySettings"/>.
@@ -88,12 +99,22 @@ namespace Akka.Cluster.Tools.Singleton
         /// are sent via the proxy. Use 0 to disable buffering, i.e.messages will be dropped immediately if the location
         /// of the singleton is unknown.
         /// </param>
+        /// <param name="considerAppVersion">
+        /// Should <see cref="Member.AppVersion"/> be considered when the cluster singleton instance is being moved to another node.
+        /// When set to false, singleton instance will always be created on oldest member.
+        /// When set to true, singleton instance will be created on the oldest member with the highest <see cref="Member.AppVersion"/> number.
+        /// </param>
         /// <exception cref="ArgumentException">
         /// This exception is thrown when either the specified <paramref name="singletonIdentificationInterval"/>
         /// or <paramref name="bufferSize"/> is less than or equal to zero.
         /// </exception>
         /// <exception cref="ArgumentNullException"></exception>
-        public ClusterSingletonProxySettings(string singletonName, string role, TimeSpan singletonIdentificationInterval, int bufferSize)
+        public ClusterSingletonProxySettings(
+            string singletonName,
+            string role,
+            TimeSpan singletonIdentificationInterval, 
+            int bufferSize, 
+            bool considerAppVersion)
         {
             if (string.IsNullOrEmpty(singletonName))
                 throw new ArgumentNullException(nameof(singletonName));
@@ -106,6 +127,7 @@ namespace Akka.Cluster.Tools.Singleton
             Role = role;
             SingletonIdentificationInterval = singletonIdentificationInterval;
             BufferSize = bufferSize;
+            ConsiderAppVersion = considerAppVersion;
         }
 
         /// <summary>
@@ -176,14 +198,19 @@ namespace Akka.Cluster.Tools.Singleton
             return Copy(bufferSize: bufferSize);
         }
 
-        private ClusterSingletonProxySettings Copy(string singletonName = null, Option<string> role = default,
-            TimeSpan? singletonIdentificationInterval = null, int? bufferSize = null)
+        private ClusterSingletonProxySettings Copy(
+            string singletonName = null,
+            Option<string> role = default,
+            TimeSpan? singletonIdentificationInterval = null,
+            int? bufferSize = null,
+            bool? considerAppVersion = null)
         {
             return new ClusterSingletonProxySettings(
                 singletonName: singletonName ?? SingletonName,
                 role: role.HasValue ? role.Value : Role,
                 singletonIdentificationInterval: singletonIdentificationInterval ?? SingletonIdentificationInterval,
-                bufferSize: bufferSize ?? BufferSize);
+                bufferSize: bufferSize ?? BufferSize,
+                considerAppVersion: considerAppVersion ?? ConsiderAppVersion);
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/MemberAgeOrdering.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/MemberAgeOrdering.cs
@@ -15,28 +15,24 @@ namespace Akka.Cluster.Tools.Singleton
     internal sealed class MemberAgeOrdering : IComparer<Member>
     {
         private readonly bool _ascending;
+        private readonly bool _considerAppVersion;
 
-        private MemberAgeOrdering(bool ascending)
+        private MemberAgeOrdering(bool ascending, bool considerAppVersion)
         {
             _ascending = ascending;
+            _considerAppVersion = considerAppVersion;
         }
 
         /// <inheritdoc/>
         public int Compare(Member x, Member y)
         {
-            if (x is null && y is null)
-                return 0;
-
-            if (y is null)
-                return _ascending ? 1 : -1;
-
-            if (x is null)
-                return _ascending ? -1 : 1;
-
-            // prefer nodes with the highest app version, even if they're younger
-            var appVersionDiff = x.AppVersion.CompareTo(y.AppVersion);
-            if (appVersionDiff != 0)
-                return _ascending ? appVersionDiff : appVersionDiff * -1;
+            if (_considerAppVersion)
+            {
+                // prefer nodes with the highest app version, even if they're younger
+                var appVersionDiff = x.AppVersion.CompareTo(y.AppVersion);
+                if (appVersionDiff != 0)
+                    return _ascending ? appVersionDiff : appVersionDiff * -1;
+            }
             
             if (x.Equals(y)) return 0;
             return x.IsOlderThan(y)
@@ -47,11 +43,15 @@ namespace Akka.Cluster.Tools.Singleton
         /// <summary>
         /// TBD
         /// </summary>
-        public static readonly MemberAgeOrdering Ascending = new MemberAgeOrdering(true);
+        public static readonly MemberAgeOrdering Ascending = new MemberAgeOrdering(true, false);
+
+        public static readonly MemberAgeOrdering AscendingWithAppVersion = new MemberAgeOrdering(true, true);
 
         /// <summary>
         /// TBD
         /// </summary>
-        public static readonly MemberAgeOrdering Descending = new MemberAgeOrdering(false);
+        public static readonly MemberAgeOrdering Descending = new MemberAgeOrdering(false, false);
+        
+        public static readonly MemberAgeOrdering DescendingWithAppVersion = new MemberAgeOrdering(false, true);
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/MemberAgeOrdering.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/MemberAgeOrdering.cs
@@ -24,6 +24,20 @@ namespace Akka.Cluster.Tools.Singleton
         /// <inheritdoc/>
         public int Compare(Member x, Member y)
         {
+            if (x is null && y is null)
+                return 0;
+
+            if (y is null)
+                return _ascending ? 1 : -1;
+
+            if (x is null)
+                return _ascending ? -1 : 1;
+
+            // prefer nodes with the highest app version, even if they're younger
+            var appVersionDiff = x.AppVersion.CompareTo(y.AppVersion);
+            if (appVersionDiff != 0)
+                return _ascending ? appVersionDiff : appVersionDiff * -1;
+            
             if (x.Equals(y)) return 0;
             return x.IsOlderThan(y)
                 ? (_ascending ? 1 : -1)

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
@@ -92,15 +92,22 @@ namespace Akka.Cluster.Tools.Singleton
 
         #endregion
 
+        private readonly MemberAgeOrdering _memberAgeComparer;
         private readonly CoordinatedShutdown _coordShutdown = CoordinatedShutdown.Get(Context.System);
 
         /// <summary>
         /// Creates a new instance of the <see cref="OldestChangedBuffer"/>.
         /// </summary>
         /// <param name="role">The role for which we're watching for membership changes.</param>
-        public OldestChangedBuffer(string role)
+        /// <param name="considerAppVersion">Should cluster AppVersion be considered when sorting member age</param>
+        public OldestChangedBuffer(string role, bool considerAppVersion)
         {
             _role = role;
+            _memberAgeComparer = considerAppVersion
+                ? MemberAgeOrdering.DescendingWithAppVersion
+                : MemberAgeOrdering.Descending;
+            _membersByAge = ImmutableSortedSet<Member>.Empty.WithComparer(_memberAgeComparer);
+            
             SetupCoordinatedShutdown();
         }
 
@@ -130,7 +137,7 @@ namespace Akka.Cluster.Tools.Singleton
         }
 
         private readonly string _role;
-        private ImmutableSortedSet<Member> _membersByAge = ImmutableSortedSet<Member>.Empty.WithComparer(MemberAgeOrdering.Descending);
+        private ImmutableSortedSet<Member> _membersByAge;
         private ImmutableQueue<object> _changes = ImmutableQueue<object>.Empty;
 
         private readonly Cluster _cluster = Cluster.Get(Context.System);
@@ -156,7 +163,7 @@ namespace Akka.Cluster.Tools.Singleton
             // all members except Joining and WeaklyUp
             _membersByAge = state.Members
                 .Where(m => m.UpNumber != int.MaxValue && MatchingRole(m))
-                .ToImmutableSortedSet(MemberAgeOrdering.Descending);
+                .ToImmutableSortedSet(_memberAgeComparer);
 
             // If there is some removal in progress of an older node it's not safe to immediately become oldest,
             // removal of younger nodes doesn't matter. Note that it can also be started via restart after

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/reference.conf
@@ -42,6 +42,11 @@ akka.cluster.singleton {
 
   # The interval between retries for acquiring the lease
   lease-retry-interval = 5s
+  
+  # Should akka.cluster.app-version be considered when the cluster singleton instance is being moved to another node
+  # When set to false, singleton instance will always be created on oldest member
+  # When set to true, singleton instance will be created on the oldest node with the highest member app-version number
+  consider-app-version = false
 }
 # //#singleton-config
 

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Core.verified.txt
@@ -9,6 +9,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.MultiNode")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.Performance")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests.MultiNode")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Management.Cluster.Http")]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
@@ -9,6 +9,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.MultiNode")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.Performance")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests.MultiNode")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Management.Cluster.Http")]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
@@ -9,6 +9,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.MultiNode")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.Performance")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests.MultiNode")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Management.Cluster.Http")]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Core.verified.txt
@@ -356,8 +356,9 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public sealed class ClusterSingletonManagerSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval) { }
-        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
+        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, bool considerAppVersion) { }
+        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, Akka.Coordination.LeaseUsageSettings leaseSettings, bool considerAppVersion) { }
+        public bool ConsiderAppVersion { get; }
         public System.TimeSpan HandOverRetryInterval { get; }
         public Akka.Coordination.LeaseUsageSettings LeaseSettings { get; }
         public System.TimeSpan RemovalMargin { get; }
@@ -386,13 +387,14 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public sealed class ClusterSingletonProxySettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize) { }
+        public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize, bool considerAppVersion) { }
         public int BufferSize { get; }
+        public bool ConsiderAppVersion { get; }
         public string Role { get; }
         public System.TimeSpan SingletonIdentificationInterval { get; }
         public string SingletonName { get; }
         public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config, bool considerAppVersion) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithBufferSize(int bufferSize) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithRole(string role) { }
         [System.ObsoleteAttribute("For compatibility reasons only. Use method with TimeSpan parameter instead")]
@@ -403,6 +405,7 @@ namespace Akka.Cluster.Tools.Singleton
     public class ClusterSingletonSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
         public int BufferSize { get; }
+        public bool ConsiderAppVersion { get; }
         public System.TimeSpan HandOverRetryInterval { get; }
         public Akka.Coordination.LeaseUsageSettings LeaseSettings { get; }
         public System.TimeSpan RemovalMargin { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -356,8 +356,9 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public sealed class ClusterSingletonManagerSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval) { }
-        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
+        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, bool considerAppVersion) { }
+        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, Akka.Coordination.LeaseUsageSettings leaseSettings, bool considerAppVersion) { }
+        public bool ConsiderAppVersion { get; }
         public System.TimeSpan HandOverRetryInterval { get; }
         public Akka.Coordination.LeaseUsageSettings LeaseSettings { get; }
         public System.TimeSpan RemovalMargin { get; }
@@ -386,13 +387,14 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public sealed class ClusterSingletonProxySettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize) { }
+        public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize, bool considerAppVersion) { }
         public int BufferSize { get; }
+        public bool ConsiderAppVersion { get; }
         public string Role { get; }
         public System.TimeSpan SingletonIdentificationInterval { get; }
         public string SingletonName { get; }
         public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config, bool considerAppVersion) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithBufferSize(int bufferSize) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithRole(string role) { }
         [System.ObsoleteAttribute("For compatibility reasons only. Use method with TimeSpan parameter instead")]
@@ -403,6 +405,7 @@ namespace Akka.Cluster.Tools.Singleton
     public class ClusterSingletonSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
         public int BufferSize { get; }
+        public bool ConsiderAppVersion { get; }
         public System.TimeSpan HandOverRetryInterval { get; }
         public Akka.Coordination.LeaseUsageSettings LeaseSettings { get; }
         public System.TimeSpan RemovalMargin { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -356,8 +356,9 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public sealed class ClusterSingletonManagerSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval) { }
-        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
+        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, bool considerAppVersion) { }
+        public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, Akka.Coordination.LeaseUsageSettings leaseSettings, bool considerAppVersion) { }
+        public bool ConsiderAppVersion { get; }
         public System.TimeSpan HandOverRetryInterval { get; }
         public Akka.Coordination.LeaseUsageSettings LeaseSettings { get; }
         public System.TimeSpan RemovalMargin { get; }
@@ -386,13 +387,14 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public sealed class ClusterSingletonProxySettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize) { }
+        public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize, bool considerAppVersion) { }
         public int BufferSize { get; }
+        public bool ConsiderAppVersion { get; }
         public string Role { get; }
         public System.TimeSpan SingletonIdentificationInterval { get; }
         public string SingletonName { get; }
         public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config, bool considerAppVersion) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithBufferSize(int bufferSize) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithRole(string role) { }
         [System.ObsoleteAttribute("For compatibility reasons only. Use method with TimeSpan parameter instead")]
@@ -403,6 +405,7 @@ namespace Akka.Cluster.Tools.Singleton
     public class ClusterSingletonSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
         public int BufferSize { get; }
+        public bool ConsiderAppVersion { get; }
         public System.TimeSpan HandOverRetryInterval { get; }
         public Akka.Coordination.LeaseUsageSettings LeaseSettings { get; }
         public System.TimeSpan RemovalMargin { get; }

--- a/src/core/Akka.Cluster/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Cluster/Properties/AssemblyInfo.cs
@@ -16,6 +16,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Akka.Cluster.Tests.Performance")]
 [assembly: InternalsVisibleTo("Akka.Cluster.TestKit")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Tools")]
+[assembly: InternalsVisibleTo("Akka.Cluster.Tools.Tests")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Tools.Tests.MultiNode")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]

--- a/src/core/Akka/Util/AppVersion.cs
+++ b/src/core/Akka/Util/AppVersion.cs
@@ -208,7 +208,7 @@ namespace Akka.Util
 
         public int CompareTo(AppVersion other)
         {
-            if (Version == other.Version) // String equals without requiring parse
+            if (string.Equals(Version, other.Version, StringComparison.Ordinal)) // String equals without requiring parse
                 return 0;
             else
             {
@@ -232,7 +232,7 @@ namespace Akka.Util
                                 if (other._rest == "" && _rest != "")
                                     diff = -1;
                                 else
-                                    diff = _rest.CompareTo(other._rest);
+                                    diff = string.Compare(_rest, other._rest, StringComparison.Ordinal);
                             }
                         }
                     }
@@ -243,12 +243,12 @@ namespace Akka.Util
 
         public bool Equals(AppVersion other)
         {
-            return other != null && Version == other.Version;
+            return other != null && string.Equals(Version, other.Version, StringComparison.Ordinal);
         }
 
         public override bool Equals(object obj)
         {
-            return base.Equals(obj as AppVersion);
+            return obj is AppVersion av && Equals(av);
         }
 
         public static bool operator ==(AppVersion first, AppVersion second)


### PR DESCRIPTION
Fixes #6035

## Changes

Changes the way oldest member sorting comparator works, taking Member.AppVersion into consideration. Members with higher AppVersion will always be bumped to the front of the list, regardless of Member age.