### PR TITLE
enabled `Directive.Resume` to log the full `Exception`

### DIFF
--- a/src/core/Akka/Actor/SupervisorStrategy.cs
+++ b/src/core/Akka/Actor/SupervisorStrategy.cs
@@ -142,9 +142,8 @@ namespace Akka.Actor
         {
             if (LoggingEnabled)
             {
-                var actorInitializationException = cause as ActorInitializationException;
                 string message;
-                if (actorInitializationException != null && actorInitializationException.InnerException != null)
+                if (cause is ActorInitializationException actorInitializationException && actorInitializationException.InnerException != null)
                     message = actorInitializationException.InnerException.Message;
                 else
                     message = cause.Message;
@@ -152,7 +151,7 @@ namespace Akka.Actor
                 switch (directive)
                 {
                     case Directive.Resume:
-                        Publish(context, new Warning(child.Path.ToString(), GetType(), message));
+                        Publish(context, new Warning(cause, child.Path.ToString(), GetType(), message));
                         break;
                     case Directive.Escalate:
                         //Don't log here
@@ -171,7 +170,7 @@ namespace Akka.Actor
         /// </summary>
         protected bool LoggingEnabled { get; set; }
 
-        private void Publish(IActorContext context, LogEvent logEvent)
+        private static void Publish(IActorContext context, LogEvent logEvent)
         {
             try
             {


### PR DESCRIPTION
## Changes

Modified the default `SupervisorStrategy` to record the full `Exception` when a `Warning` is issued when a `Directive.Resume` is returned by the `Decider` when handling child actor failures. The only material impact of this is improved visibility into the stack trace and error details.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.
