### PR TITLE
Ported CircuitBreakerStressSpec

### DIFF
--- a/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
@@ -1,0 +1,134 @@
+//-----------------------------------------------------------------------
+// <copyright file="CircuitBreakerStressSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Pattern;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Tests.Pattern
+{
+    public class CircuitBreakerStressSpec : AkkaSpec
+    {
+        internal class RequestJob
+        {
+            public static RequestJob Instance => new RequestJob();
+            private RequestJob() { }
+        }
+
+        internal class JobDone
+        {
+            public static JobDone Instance => new JobDone();
+            private JobDone() { }
+        }
+
+        internal class GetResult
+        {
+            public static GetResult Instance => new GetResult();
+            private GetResult() { }
+        }
+
+        internal class Result
+        {
+            public int DoneCount { get; }
+            public int TimeoutCount { get; }
+            public int FailCount { get; }
+            public int CircCount { get; }
+
+            public Result(int doneCount, int timeoutCount, int failCount, int circCount)
+            {
+                DoneCount = doneCount;
+                TimeoutCount = timeoutCount;
+                FailCount = failCount;
+                CircCount = circCount;
+            }
+        }
+
+        internal class StressActor : UntypedActor
+        {
+            private readonly CircuitBreaker _breaker;
+            private int _doneCount;
+            private int _timeoutCount;
+            private int _failCount;
+            private int _circCount;
+
+            public StressActor(CircuitBreaker breaker) => _breaker = breaker;
+
+            protected override void OnReceive(object message)
+            {
+                switch (message)
+                {
+                    case RequestJob _:
+                        _breaker.WithCircuitBreaker(Job).PipeTo(Self);
+                        break;
+                    case JobDone _:
+                        _doneCount++;
+                        break;
+                    case Status.Failure failure when failure.Cause is OpenCircuitException:
+                        _circCount++;
+                        _breaker.WithCircuitBreaker(Job).PipeTo(Self);
+                        break;
+                    case Status.Failure failure when failure.Cause is TimeoutException:
+                        _timeoutCount++;
+                        _breaker.WithCircuitBreaker(Job).PipeTo(Self);
+                        break;
+                    case Status.Failure _:
+                        _failCount++;
+                        _breaker.WithCircuitBreaker(Job).PipeTo(Self);
+                        break;
+                    case GetResult _:
+                        Sender.Tell(new Result(_doneCount, _timeoutCount, _failCount, _circCount));
+                        break;
+                    default:
+                        base.Unhandled(message);
+                        break;
+                }
+            }
+
+            private async Task<JobDone> Job()
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(300));
+                return JobDone.Instance;
+            }
+        }
+
+        public CircuitBreakerStressSpec(ITestOutputHelper output) 
+            : base(output)
+        { }
+
+        [Fact]
+        public void A_CircuitBreaker_stress_test()
+        {
+            var breaker = new CircuitBreaker(Sys.Scheduler, 5, TimeSpan.FromMilliseconds(200), TimeSpan.FromSeconds(200));
+            var stressActors = Enumerable.Range(0, 3).Select(i => Sys.ActorOf(Props.Create<StressActor>(breaker))).ToList();
+
+            for (var i = 0; i < 1000; i++)
+                foreach (var stressActor in stressActors)
+                {
+                    stressActor.Tell(RequestJob.Instance);
+                }
+
+            // let them work for a while
+            Thread.Sleep(3000);
+
+            foreach (var stressActor in stressActors)
+            {
+                stressActor.Tell(GetResult.Instance);
+                var result = ExpectMsg<Result>();
+                result.FailCount.ShouldBe(0);
+
+                Output.WriteLine("FailCount:{0}, DoneCount:{1}, CircCount:{2}, TimeoutCount:{3}",
+                    result.FailCount, result.DoneCount, result.CircCount, result.TimeoutCount);                
+            }
+        }
+    }
+}


### PR DESCRIPTION
Might be related to #6106

This PR is to confirm that the `CircuitBreaker`, in its current implementation, could give false positives (signal tasks as done when in reality they failed). 

I ported the `CircuitBreakerStressSpec` and slightly modified it to make all tasks take longer than the CB's `CallTimeout`, so that all of them fail. Instead, by running the test you can see that they are all "marked" as succeeded (`DoneCount`).

Upon further inspection:

- The tasks indeed all failed with a `TimeException`, but the exception is swallowed by the `CallFail` method. This makes impossible to capture the `TimeException` outside the CB --as demonstrated by the `StressActor`.

- Because we are awaiting the task first, and only after it finishes we check whether it took longer than the `CallTimeout`, we could potentially be awaiting indefinitely for the task to complete.

I'll send next another PR with an alternative implementation leveraging the new `Task.WaitAsync` in .NET6

**TEST OUTPUT**
```
FailCount:0, DoneCount:1000, CircCount:0, TimeoutCount:0
FailCount:0, DoneCount:1000, CircCount:0, TimeoutCount:0
FailCount:0, DoneCount:1000, CircCount:0, TimeoutCount:0
```