### PR TITLE
Make `Envelope` a reference type again

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
@@ -686,7 +686,7 @@ namespace Akka.Actor
         protected virtual bool SpecialHandle(object message, Akka.Actor.IActorRef sender) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
-    public struct Envelope
+    public sealed class Envelope
     {
         public Envelope(object message, Akka.Actor.IActorRef sender, Akka.Actor.ActorSystem system) { }
         public Envelope(object message, Akka.Actor.IActorRef sender) { }

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
@@ -686,7 +686,7 @@ namespace Akka.Actor
         protected virtual bool SpecialHandle(object message, Akka.Actor.IActorRef sender) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
-    public sealed class Envelope
+    public struct Envelope
     {
         public Envelope(object message, Akka.Actor.IActorRef sender, Akka.Actor.ActorSystem system) { }
         public Envelope(object message, Akka.Actor.IActorRef sender) { }

--- a/src/core/Akka/Actor/Message.cs
+++ b/src/core/Akka/Actor/Message.cs
@@ -12,7 +12,7 @@ namespace Akka.Actor
     /// <summary>
     /// Envelope class, represents a message and the sender of the message.
     /// </summary>
-    public struct Envelope
+    public sealed class Envelope
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Envelope"/> struct.
@@ -44,13 +44,13 @@ namespace Akka.Actor
         /// Gets or sets the sender.
         /// </summary>
         /// <value>The sender.</value>
-        public IActorRef Sender { get; private set; }
+        public IActorRef Sender { get; }
 
         /// <summary>
         /// Gets or sets the message.
         /// </summary>
         /// <value>The message.</value>
-        public object Message { get; private set; }
+        public object Message { get; }
 
         /// <summary>
         /// Converts the <see cref="Envelope"/> to a string representation.

--- a/src/core/Akka/Actor/Message.cs
+++ b/src/core/Akka/Actor/Message.cs
@@ -12,7 +12,7 @@ namespace Akka.Actor
     /// <summary>
     /// Envelope class, represents a message and the sender of the message.
     /// </summary>
-    public sealed class Envelope
+    public readonly struct Envelope
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Envelope"/> struct.


### PR DESCRIPTION
## Changes

Converts `Envelope` back into a `sealed class` rather than a `struct` - believe it or not, this significantly reduces total memory allocation and mailbox write latency.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.
* [x] I have added website documentation for this feature.

### Latest `v1.4` Benchmarks 

All benchmarks are running on .NET 6.

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.2006 (21H2)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.201
  [Host]     : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  Job-AMVGCN : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|             Method | MsgCount |           Mean |        Error |       StdDev |         Median |     Gen 0 |  Allocated |
|------------------- |--------- |---------------:|-------------:|-------------:|---------------:|----------:|-----------:|
| **EnqueuePerformance** |    **10000** |       **215.7 μs** |      **4.10 μs** |      **5.75 μs** |       **214.2 μs** |         **-** |     **385 KB** |
|     RunPerformance |    10000 |     2,604.8 μs |    301.89 μs |    890.12 μs |     3,027.6 μs |         - |      12 KB |
| **EnqueuePerformance** |   **100000** |     **2,187.6 μs** |     **42.70 μs** |     **39.94 μs** |     **2,168.9 μs** |         **-** |   **3,074 KB** |
|     RunPerformance |   100000 |    12,313.3 μs |    319.67 μs |    937.54 μs |    12,185.6 μs |         - |     102 KB |
| **EnqueuePerformance** |  **1000000** |    **16,205.6 μs** |    **113.18 μs** |    **105.87 μs** |    **16,222.6 μs** |         **-** |  **24,579 KB** |
|     RunPerformance |  1000000 |   106,720.7 μs |  2,118.54 μs |  3,298.31 μs |   106,311.6 μs |         - |   1,009 KB |
| **EnqueuePerformance** | **10000000** |   **163,270.1 μs** |    **860.33 μs** |    **671.69 μs** |   **163,038.3 μs** |         **-** | **245,765 KB** |
|     RunPerformance | 10000000 | 1,063,885.3 μs | 12,432.78 μs | 11,629.63 μs | 1,063,643.1 μs | 2000.0000 |  10,082 KB |


### This PR's Benchmarks

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.2006 (21H2)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.201
  [Host]     : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  Job-ONWZPU : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|             Method | MsgCount |           Mean |        Error |       StdDev |         Median |     Gen 0 |  Allocated |
|------------------- |--------- |---------------:|-------------:|-------------:|---------------:|----------:|-----------:|
| **EnqueuePerformance** |    **10000** |       **133.2 μs** |      **2.48 μs** |      **3.05 μs** |       **132.8 μs** |         **-** |     **258 KB** |
|     RunPerformance |    10000 |     1,475.9 μs |    135.40 μs |    359.07 μs |     1,398.5 μs |         - |      11 KB |
| **EnqueuePerformance** |   **100000** |     **1,138.8 μs** |     **19.96 μs** |     **50.44 μs** |     **1,122.1 μs** |         **-** |   **2,051 KB** |
|     RunPerformance |   100000 |    11,379.5 μs |    329.55 μs |    971.69 μs |    11,166.7 μs |         - |     102 KB |
| **EnqueuePerformance** |  **1000000** |    **11,090.3 μs** |    **172.91 μs** |    **153.28 μs** |    **11,124.0 μs** |         **-** |  **16,387 KB** |
|     RunPerformance |  1000000 |   111,643.2 μs |  2,053.49 μs |  2,945.05 μs |   110,532.5 μs |         - |   1,009 KB |
| **EnqueuePerformance** | **10000000** |   **136,359.7 μs** |  **4,479.73 μs** | **13,208.58 μs** |   **138,767.1 μs** |         **-** | **163,846 KB** |
|     RunPerformance | 10000000 | 1,041,018.8 μs | 15,412.80 μs | 14,417.15 μs | 1,044,527.0 μs | 2000.0000 |  10,083 KB |

