### PR TITLE
Added Dispatcher Benchmarks

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Dispatch/DispatcherBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Dispatch/DispatcherBenchmarks.cs
@@ -1,0 +1,121 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="DispatcherBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Configuration;
+using Akka.Dispatch;
+using BenchmarkDotNet.Attributes;
+using IRunnable = Akka.Dispatch.IRunnable;
+
+namespace Akka.Benchmarks.Dispatch
+{
+    /// <summary>
+    /// Used to test the performance of various dispatchers
+    /// </summary>
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class DispatcherBenchmarks
+    {
+        private ActorSystem _sys;
+        private DefaultDispatcherPrerequisites _prereqs;
+
+        private MessageDispatcher _dispatcher;
+
+        [Params(1_000_000)] // higher values will cause the CallingThreadDispatcher to stack overflow
+        public int TaskCount { get; set; }
+
+        [ParamsSource(nameof(AllConfigurators))]
+        public DispatcherConfig Configurator { get; set; }
+
+        public class DispatcherConfig
+        {
+            public DispatcherConfig(Config config, string name)
+            {
+                Config = config;
+                Name = name;
+            }
+
+            public Config Config { get; }
+
+            public string Name { get; }
+
+            public override string ToString()
+            {
+                return Name;
+            }
+        }
+
+        private static readonly Config DefaultConfig = Akka.Remote.Configuration.RemoteConfigFactory.Default()
+            .WithFallback(Akka.Configuration.ConfigurationFactory.Default());
+
+        public IEnumerable<DispatcherConfig> AllConfigurators()
+        {
+            yield return new DispatcherConfig(DefaultConfig.GetConfig("akka.actor.default-dispatcher"), "DefaultThreadPool");
+            yield return new DispatcherConfig(DefaultConfig.GetConfig("akka.actor.internal-dispatcher"), "ForkJoinDispatcher(Default /system)");
+            yield return new DispatcherConfig(DefaultConfig.GetConfig("akka.remote.default-remote-dispatcher"), "ForkJoinDispatcher(Default /remoting)");
+            yield return new DispatcherConfig(@" executor = channel-executor
+                throughput=30", "ChannelDispatcher(default priority)");
+            yield return new DispatcherConfig(@" executor = task-executor
+                throughput=30", "TaskDispatcher");
+        }
+
+        private TaskCompletionSource<int> _tcs;
+
+        public sealed class RunnableTarget : IRunnable
+        {
+            private readonly TaskCompletionSource<int> _tcs;
+            private readonly int _target;
+            private int _counter = 0;
+
+            public RunnableTarget(TaskCompletionSource<int> tcs, int target)
+            {
+                _tcs = tcs;
+                _target = target;
+            }
+
+            public void Run()
+            {
+                if (Interlocked.Increment(ref _counter) >= _target)
+                {
+                    _tcs.TrySetResult(_counter);
+                }
+            }
+        }
+
+        private RunnableTarget _runnable;
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _sys = ActorSystem.Create("Bench");
+            _prereqs = new DefaultDispatcherPrerequisites(_sys.EventStream, _sys.Scheduler, _sys.Settings,
+                _sys.Mailboxes);
+            var configurator = new DispatcherConfigurator(Configurator.Config, _prereqs);
+            _dispatcher = configurator.Dispatcher();
+            _tcs = new TaskCompletionSource<int>();
+            _runnable = new RunnableTarget(_tcs, TaskCount);
+        }
+
+        [GlobalCleanup]
+        public void CleanUp()
+        {
+            _sys.Terminate().Wait();
+        }
+
+        [Benchmark]
+        public async Task RunDispatcher()
+        {
+            for (var i = 0; i < TaskCount; i++)
+                _dispatcher.Schedule(_runnable);
+            await _tcs.Task;
+        }
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/Dispatch/DispatcherBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Dispatch/DispatcherBenchmarks.cs
@@ -58,12 +58,12 @@ namespace Akka.Benchmarks.Dispatch
         public IEnumerable<DispatcherConfig> AllConfigurators()
         {
             yield return new DispatcherConfig(DefaultConfig.GetConfig("akka.actor.default-dispatcher"), "DefaultThreadPool");
-            yield return new DispatcherConfig(DefaultConfig.GetConfig("akka.actor.internal-dispatcher"), "ForkJoinDispatcher(Default /system)");
-            yield return new DispatcherConfig(DefaultConfig.GetConfig("akka.remote.default-remote-dispatcher"), "ForkJoinDispatcher(Default /remoting)");
+            yield return new DispatcherConfig(DefaultConfig.GetConfig("akka.actor.internal-dispatcher"), "ForkJoin(sys)");
+            yield return new DispatcherConfig(DefaultConfig.GetConfig("akka.remote.default-remote-dispatcher"), "ForkJoin(remote)");
             yield return new DispatcherConfig(@" executor = channel-executor
-                throughput=30", "ChannelDispatcher(default priority)");
+                throughput=30", "ChannelD");
             yield return new DispatcherConfig(@" executor = task-executor
-                throughput=30", "TaskDispatcher");
+                throughput=30", "TaskD");
         }
 
         private TaskCompletionSource<int> _tcs;

--- a/src/benchmark/Akka.Benchmarks/Dispatch/MailboxThroughputBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Dispatch/MailboxThroughputBenchmarks.cs
@@ -69,6 +69,12 @@ namespace Akka.Benchmarks.Dispatch
             _msg = new Envelope("hit", ActorRefs.NoSender);
         }
 
+        [GlobalCleanup]
+        public void CleanUp()
+        {
+            _system.Terminate().Wait();
+        }
+
         [IterationSetup]
         public void IterationSetup()
         {


### PR DESCRIPTION
## Changes

Added Benchmark.NET ports of our old NBench benchmarks in order to measure memory allocation and throughput for various benchmark configurations.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `v1.4` Benchmarks 

#### .NET 6

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.2006 (21H2)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.201
  [Host]     : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  DefaultJob : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT


```
|        Method | TaskCount |      Configurator |       Mean |    Error |    StdDev |       Gen 0 | Allocated |
|-------------- |---------- |------------------ |-----------:|---------:|----------:|------------:|----------:|
| **RunDispatcher** |   **1000000** |          **ChannelD** | **2,422.2 ms** | **17.45 ms** |  **16.32 ms** | **161000.0000** |    **641 MB** |
| **RunDispatcher** |   **1000000** | **DefaultThreadPool** | **1,156.6 ms** | **43.33 ms** | **127.75 ms** |  **15000.0000** |     **61 MB** |
| **RunDispatcher** |   **1000000** |  **ForkJoin(remote)** |   **658.4 ms** | **10.47 ms** |   **9.79 ms** |  **23000.0000** |     **92 MB** |
| **RunDispatcher** |   **1000000** |     **ForkJoin(sys)** |   **649.2 ms** |  **6.33 ms** |   **5.29 ms** |  **23000.0000** |     **92 MB** |
| **RunDispatcher** |   **1000000** |             **TaskD** | **1,204.3 ms** |  **8.15 ms** |   **7.62 ms** |  **23000.0000** |     **92 MB** |


#### .NET Core 3.1

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.2006 (21H2)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.201
  [Host]     : .NET Core 3.1.23 (CoreCLR 4.700.22.11601, CoreFX 4.700.22.12208), X64 RyuJIT
  DefaultJob : .NET Core 3.1.23 (CoreCLR 4.700.22.11601, CoreFX 4.700.22.12208), X64 RyuJIT


```
|        Method | TaskCount |      Configurator |       Mean |    Error |   StdDev |     Median |       Gen 0 | Allocated |
|-------------- |---------- |------------------ |-----------:|---------:|---------:|-----------:|------------:|----------:|
| **RunDispatcher** |   **1000000** |          **ChannelD** | **2,792.1 ms** | **10.40 ms** |  **8.12 ms** | **2,790.2 ms** | **161000.0000** |    **641 MB** |
| **RunDispatcher** |   **1000000** | **DefaultThreadPool** | **1,266.9 ms** | **25.25 ms** | **71.63 ms** | **1,290.7 ms** |  **15000.0000** |     **61 MB** |
| **RunDispatcher** |   **1000000** |  **ForkJoin(remote)** |   **699.4 ms** |  **6.21 ms** |  **5.81 ms** |   **700.3 ms** |  **23000.0000** |     **92 MB** |
| **RunDispatcher** |   **1000000** |     **ForkJoin(sys)** |   **696.7 ms** |  **7.25 ms** |  **6.78 ms** |   **696.9 ms** |  **23000.0000** |     **92 MB** |
| **RunDispatcher** |   **1000000** |             **TaskD** | **1,346.5 ms** |  **3.24 ms** |  **3.03 ms** | **1,346.3 ms** |  **23000.0000** |     **92 MB** |

