### PR TITLE
added performance benchmarks for FSM

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Actor/FsmBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/FsmBenchmarks.cs
@@ -1,0 +1,162 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="FsmBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Actor
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class FsmBenchmarks
+    {
+        #region Classes
+        
+        public enum States
+        {
+            Initial,
+            Running
+        }
+
+        public sealed class FsmData
+        {
+            public FsmData(string d)
+            {
+                D = d;
+            }
+
+            public string D { get; }
+        }
+
+        public class BenchmarkFsmActor : FSM<States, FsmData>
+        {
+            public BenchmarkFsmActor(string init)
+            {
+                StartWith(States.Initial, new FsmData(init));
+                
+                When(States.Initial, @e =>
+                {
+                    switch (e.FsmEvent)
+                    {
+                        case string str1 when e.StateData.D.Equals("transition"):
+                            Sender.Tell(str1);
+                            return GoTo(States.Running);
+                        case string str2:
+                            Sender.Tell(str2);
+                            return Stay().Using(new FsmData(str2));
+                        default:
+                            Sender.Tell(e.FsmEvent);
+                            return Stay();
+                    }
+                });
+                
+                When(States.Running, @e =>
+                {
+                    switch (e.FsmEvent)
+                    {
+                        case string str1 when e.StateData.D.Equals("transition"):
+                            Sender.Tell(str1);
+                            return GoTo(States.Initial);
+                        case string str2:
+                            Sender.Tell(str2);
+                            return Stay().Using(new FsmData(str2));
+                        default:
+                            Sender.Tell(e.FsmEvent);
+                            return Stay();
+                    }
+                });
+            }
+        }
+
+        public class UntypedActorBaseline : UntypedActor
+        {
+            private FsmData _data;
+
+            public UntypedActorBaseline(string d)
+            {
+                _data = new FsmData(d);
+            }
+
+            protected override void OnReceive(object message)
+            {
+                switch (message)
+                {
+                    case string str1 when _data.D.Equals("transition"):
+                        Sender.Tell(str1);
+                        break;
+                    case string str2:
+                        Sender.Tell(str2);
+                        _data = new FsmData(str2);
+                        break;
+                    default:
+                        Sender.Tell(message);
+                        break;
+                }
+            }
+        }
+        
+        #endregion
+        
+        private ActorSystem _sys;
+        private IActorRef _fsmActor;
+        private IActorRef _untypedActor;
+        
+        [Params(1_000_000)]
+        public int MsgCount { get; set; }
+        
+        [GlobalSetup]
+        public void Setup()
+        {
+            _sys = ActorSystem.Create("Bench", @"akka.log-dead-letters = off");
+            _fsmActor = _sys.ActorOf(Props.Create(() => new BenchmarkFsmActor("start")));
+            _untypedActor = _sys.ActorOf(Props.Create(() => new UntypedActorBaseline("start")));
+        }
+
+        [GlobalCleanup]
+        public void CleanUp()
+        {
+            _sys.Terminate().Wait();
+        }
+
+        [Benchmark]
+        public async Task BenchmarkFsm()
+        {
+            for (var i = 0; i < MsgCount; i++)
+            {
+                if (i % 4 == 0)
+                {
+                    _fsmActor.Tell("transition");
+                }
+                else
+                {
+                    _fsmActor.Tell(i);
+                }
+            }
+
+            await _fsmActor.Ask<string>("stop");
+        }
+        
+        [Benchmark(Baseline = true)]
+        public async Task BenchmarkUntyped()
+        {
+            for (var i = 0; i < MsgCount; i++)
+            {
+                if (i % 4 == 0)
+                {
+                    _untypedActor.Tell("transition");
+                }
+                else
+                {
+                    _untypedActor.Tell(i);
+                }
+            }
+
+            await _untypedActor.Ask<string>("stop");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2560

## Changes

added performance benchmarks for FSM

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #2560 

### This PR's Benchmarks

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.2006 (21H2)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.201
  [Host]     : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  DefaultJob : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT


```
|           Method | MsgCount |     Mean |    Error |   StdDev | Ratio | RatioSD |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|----------------- |--------- |---------:|---------:|---------:|------:|--------:|-----------:|----------:|----------:|----------:|
|     BenchmarkFsm |  1000000 | 758.8 ms | 10.92 ms | 10.21 ms |  1.67 |    0.03 | 69000.0000 | 4000.0000 | 1000.0000 |    287 MB |
| BenchmarkUntyped |  1000000 | 456.2 ms |  8.86 ms | 10.21 ms |  1.00 |    0.00 | 11000.0000 | 3000.0000 | 1000.0000 |     56 MB |

LOTS of memory allocations for FSMs, and a 67% perf penalty.
