### PR TITLE
Reduce `FSM<TState, TData>` allocations

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Actor/FsmBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/FsmBenchmarks.cs
@@ -1,0 +1,162 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="FsmBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Actor
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class FsmBenchmarks
+    {
+        #region Classes
+        
+        public enum States
+        {
+            Initial,
+            Running
+        }
+
+        public sealed class FsmData
+        {
+            public FsmData(string d)
+            {
+                D = d;
+            }
+
+            public string D { get; }
+        }
+
+        public class BenchmarkFsmActor : FSM<States, FsmData>
+        {
+            public BenchmarkFsmActor(string init)
+            {
+                StartWith(States.Initial, new FsmData(init));
+                
+                When(States.Initial, @e =>
+                {
+                    switch (e.FsmEvent)
+                    {
+                        case string str1 when e.StateData.D.Equals("transition"):
+                            Sender.Tell(str1);
+                            return GoTo(States.Running);
+                        case string str2:
+                            Sender.Tell(str2);
+                            return Stay().Using(new FsmData(str2));
+                        default:
+                            Sender.Tell(e.FsmEvent);
+                            return Stay();
+                    }
+                });
+                
+                When(States.Running, @e =>
+                {
+                    switch (e.FsmEvent)
+                    {
+                        case string str1 when e.StateData.D.Equals("transition"):
+                            Sender.Tell(str1);
+                            return GoTo(States.Initial);
+                        case string str2:
+                            Sender.Tell(str2);
+                            return Stay().Using(new FsmData(str2));
+                        default:
+                            Sender.Tell(e.FsmEvent);
+                            return Stay();
+                    }
+                });
+            }
+        }
+
+        public class UntypedActorBaseline : UntypedActor
+        {
+            private FsmData _data;
+
+            public UntypedActorBaseline(string d)
+            {
+                _data = new FsmData(d);
+            }
+
+            protected override void OnReceive(object message)
+            {
+                switch (message)
+                {
+                    case string str1 when _data.D.Equals("transition"):
+                        Sender.Tell(str1);
+                        break;
+                    case string str2:
+                        Sender.Tell(str2);
+                        _data = new FsmData(str2);
+                        break;
+                    default:
+                        Sender.Tell(message);
+                        break;
+                }
+            }
+        }
+        
+        #endregion
+        
+        private ActorSystem _sys;
+        private IActorRef _fsmActor;
+        private IActorRef _untypedActor;
+        
+        [Params(1_000_000)]
+        public int MsgCount { get; set; }
+        
+        [GlobalSetup]
+        public void Setup()
+        {
+            _sys = ActorSystem.Create("Bench", @"akka.log-dead-letters = off");
+            _fsmActor = _sys.ActorOf(Props.Create(() => new BenchmarkFsmActor("start")));
+            _untypedActor = _sys.ActorOf(Props.Create(() => new UntypedActorBaseline("start")));
+        }
+
+        [GlobalCleanup]
+        public void CleanUp()
+        {
+            _sys.Terminate().Wait();
+        }
+
+        [Benchmark]
+        public async Task BenchmarkFsm()
+        {
+            for (var i = 0; i < MsgCount; i++)
+            {
+                if (i % 4 == 0)
+                {
+                    _fsmActor.Tell("transition");
+                }
+                else
+                {
+                    _fsmActor.Tell(i);
+                }
+            }
+
+            await _fsmActor.Ask<string>("stop");
+        }
+        
+        [Benchmark(Baseline = true)]
+        public async Task BenchmarkUntyped()
+        {
+            for (var i = 0; i < MsgCount; i++)
+            {
+                if (i % 4 == 0)
+                {
+                    _untypedActor.Tell("transition");
+                }
+                else
+                {
+                    _untypedActor.Tell(i);
+                }
+            }
+
+            await _untypedActor.Ask<string>("stop");
+        }
+    }
+}

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
@@ -736,7 +736,7 @@ namespace Akka.Actor
             public override int GetHashCode() { }
             public override string ToString() { }
         }
-        public sealed class Event<TD> : Akka.Actor.INoSerializationVerificationNeeded
+        public struct Event<TD> : Akka.Actor.INoSerializationVerificationNeeded
         {
             public Event(object fsmEvent, TD stateData) { }
             public object FsmEvent { get; }
@@ -773,10 +773,10 @@ namespace Akka.Actor
         {
             public static Akka.Actor.FSMBase.StateTimeout Instance { get; }
         }
-        public class State<TS, TD> : System.IEquatable<Akka.Actor.FSMBase.State<TS, TD>>
+        public sealed class State<TS, TD> : System.IEquatable<Akka.Actor.FSMBase.State<TS, TD>>
         {
             public State(TS stateName, TD stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, bool notifies = True) { }
-            public System.Collections.Generic.IReadOnlyList<object> Replies { get; set; }
+            public System.Collections.Generic.IReadOnlyList<object> Replies { get; }
             public TD StateData { get; }
             public TS StateName { get; }
             public Akka.Actor.FSMBase.Reason StopReason { get; }

--- a/src/core/Akka.Tests/Actor/FSMActorSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMActorSpec.cs
@@ -495,20 +495,20 @@ namespace Akka.Tests.Actor
             var fsmRef = new TestFSMRef<StopTimersFSM, string, object>(Sys, Props.Create(
                 () => new StopTimersFSM(TestActor, timerNames)));
 
-            Action<bool> checkTimersActive = active =>
+            void CheckTimersActive(bool active)
             {
                 foreach (var timer in timerNames)
                 {
                     fsmRef.IsTimerActive(timer).Should().Be(active);
                     fsmRef.IsStateTimerActive().Should().Be(active);
                 }
-            };
+            }
 
-            checkTimersActive(false);
+            CheckTimersActive(false);
 
             fsmRef.Tell("start");
             ExpectMsg("starting", 1.Seconds());
-            checkTimersActive(true);
+            CheckTimersActive(true);
 
             fsmRef.Tell("stop");
             ExpectMsg("stopped", 1.Seconds());

--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -752,7 +752,7 @@ namespace Akka.Actor
         /// <returns>Descriptor for staying in the current state.</returns>
         public State<TState, TData> Stay()
         {
-            return GoTo(_currentState.StateName).WithNotification(false);
+            return _currentState.WithNotification(false);
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -258,7 +258,7 @@ namespace Akka.Actor
         /// </summary>
         public sealed class StateTimeout
         {
-            public StateTimeout() { }
+            private StateTimeout() { }
 
             /// <summary>
             /// Singleton instance of StateTimeout


### PR DESCRIPTION
## Changes

Reduced some unnecessary allocations inside the `FSM<TState, TData>` class.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.

### Latest `v1.4` Benchmarks 

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.2006 (21H2)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.201
  [Host]     : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  DefaultJob : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT


```
|           Method | MsgCount |     Mean |    Error |   StdDev | Ratio | RatioSD |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|----------------- |--------- |---------:|---------:|---------:|------:|--------:|-----------:|----------:|----------:|----------:|
|     BenchmarkFsm |  1000000 | 772.8 ms | 13.20 ms | 12.35 ms |  1.74 |    0.06 | 68000.0000 | 4000.0000 | 1000.0000 |    287 MB |
| BenchmarkUntyped |  1000000 | 444.3 ms |  8.88 ms |  9.50 ms |  1.00 |    0.00 | 12000.0000 | 4000.0000 | 1000.0000 |     56 MB |


### This PR's Benchmarks

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.2006 (21H2)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.201
  [Host]     : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  DefaultJob : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT


```
|           Method | MsgCount |     Mean |    Error |   StdDev | Ratio | RatioSD |      Gen 0 |     Gen 1 |     Gen 2 | Allocated |
|----------------- |--------- |---------:|---------:|---------:|------:|--------:|-----------:|----------:|----------:|----------:|
|     BenchmarkFsm |  1000000 | 662.5 ms | 12.99 ms | 13.34 ms |  1.47 |    0.05 | 35000.0000 | 4000.0000 | 1000.0000 |    150 MB |
| BenchmarkUntyped |  1000000 | 453.5 ms |  8.97 ms | 11.35 ms |  1.00 |    0.00 | 13000.0000 | 3000.0000 | 1000.0000 |     56 MB |


48% memory reduction, 14% throughput improvement
