### PR TITLE
added actor messaging pressure benchmark

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Actor/ActorMessagingMemoryPressureBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorMessagingMemoryPressureBenchmark.cs
@@ -1,0 +1,91 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ActorMessagingMemoryPressureBenchmark.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Routing;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Actor
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class ActorMessagingMemoryPressureBenchmark
+    {
+        #region Classes
+        public sealed class StopActor
+        {
+            private StopActor(){}
+            public static readonly StopActor Instance = new StopActor();
+        }
+        
+        public sealed class MyActor : ReceiveActor
+        {
+            public MyActor()
+            {
+                Receive<StopActor>(str =>
+                {
+                    Context.Stop(Self);
+                    Sender.Tell(str);
+                });
+                
+                Receive<string>(str =>
+                {
+                    Sender.Tell(str);
+                });
+            }
+        }
+        #endregion
+        
+        private ActorSystem _sys;
+        private IActorRef _actorEntryPoint;
+
+        private const string Msg = "hit";
+        
+        [Params(100_000)]
+        public int MsgCount { get; set; }
+        
+        [Params(10, 100)]
+        public int ActorCount { get; set; }
+        
+        [GlobalSetup]
+        public void Setup()
+        {
+            _sys = ActorSystem.Create("Bench", @"akka.log-dead-letters = off");
+        }
+        
+        [GlobalCleanup]
+        public async Task CleanUp()
+        {
+            await _sys.Terminate();
+        }
+
+        [IterationCleanup]
+        public void PerInvokeCleanup()
+        {
+            _actorEntryPoint.GracefulStop(TimeSpan.FromSeconds(5)).Wait();
+        }
+
+        [IterationSetup]
+        public void PerInvokeSetup()
+        {
+            _actorEntryPoint = _sys.ActorOf(Props.Create<MyActor>().WithRouter(new BroadcastPool(ActorCount)));
+        }
+
+        [Benchmark]
+        public Task PushMsgs()
+        {
+            for (var i = 0; i < MsgCount; i++)
+            {
+               _actorEntryPoint.Tell(Msg);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/Actor/FsmBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/FsmBenchmarks.cs
@@ -118,9 +118,9 @@ namespace Akka.Benchmarks.Actor
         }
 
         [GlobalCleanup]
-        public void CleanUp()
+        public async Task CleanUp()
         {
-            _sys.Terminate().Wait();
+            await _sys.Terminate();
         }
 
         [Benchmark]


### PR DESCRIPTION
## Changes

purpose of this benchmark is not to measure processing time - it's meant to measure allocation pressure created by Akka.NET infrastructure:

* `Envelope`s
* `Mailbox` and `MessageDispatcher` overhead
* `ActorCell` and `ActorBase` invocation overhead

Ideally the memory pressure, given a `const string` as messaging input, should be close to zero - but between mailbox queue segment allocations, delegate + closure allocations, and probably some boxing we know that's not the case. Purpose of this benchmark is to measure that impact across threads.

> **N.B.** - this benchmark makes no attempt to measure processing time nor does it wait for actors to process all messages. _That is by design_.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `v1.4` Benchmarks 

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.2006 (21H2)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.201
  [Host]     : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  Job-WGPBOC : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT

InvocationCount=1  UnrollFactor=1  

```
|   Method | MsgCount | ActorCount |     Mean |    Error |   StdDev |       Gen 0 |     Gen 1 | Allocated |
|--------- |--------- |----------- |---------:|---------:|---------:|------------:|----------:|----------:|
| **PushMsgs** |   **100000** |         **10** |  **1.287 s** | **0.0067 s** | **0.0063 s** |  **18000.0000** | **1000.0000** |     **71 MB** |
| **PushMsgs** |   **100000** |        **100** | **12.818 s** | **0.1166 s** | **0.1091 s** | **176000.0000** | **1000.0000** |    **689 MB** |
