### PR TITLE
Block Xunit2 TestKit until unit test logger is ready

### DIFF
--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
@@ -35,6 +35,7 @@ namespace Akka.TestKit.Xunit2.Internals
             Receive<InitializeLogger>(e =>
             {
                 e.LoggingBus.Subscribe(Self, typeof (LogEvent));
+                Sender.Tell(new LoggerInitialized());
             });
         }
 

--- a/src/contrib/testkits/Akka.TestKit.Xunit2/TestKit.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/TestKit.cs
@@ -145,7 +145,8 @@ namespace Akka.TestKit.Xunit2
             {
                 var extSystem = (ExtendedActorSystem)system;
                 var logger = extSystem.SystemActorOf(Props.Create(() => new TestOutputLogger(Output)), "log-test");
-                logger.Tell(new InitializeLogger(system.EventStream));
+                logger.Ask<LoggerInitialized>(new InitializeLogger(system.EventStream), TimeSpan.FromSeconds(3))
+                    .ConfigureAwait(false).GetAwaiter().GetResult();
             }
         }
 
@@ -156,7 +157,8 @@ namespace Akka.TestKit.Xunit2
                 var extSystem = (ExtendedActorSystem)system;
                 var logger = extSystem.SystemActorOf(Props.Create(() => new TestOutputLogger(
                     string.IsNullOrEmpty(prefix) ? Output : new PrefixedOutput(Output, prefix))), "log-test");
-                logger.Tell(new InitializeLogger(system.EventStream));
+                logger.Ask<LoggerInitialized>(new InitializeLogger(system.EventStream), TimeSpan.FromSeconds(3))
+                    .ConfigureAwait(false).GetAwaiter().GetResult();
             }
         }
         public virtual Task InitializeAsync()


### PR DESCRIPTION
Fixes #6125

Note that since we're blocking during test start, there are a chance that some tests that timed to system startup might start to racily fail.