### PR TITLE
make `DedicatedThreadPool.QueueUserWorkItem<T>` generic

### DIFF
--- a/src/core/Akka/Helios.Concurrency.DedicatedThreadPool.cs
+++ b/src/core/Akka/Helios.Concurrency.DedicatedThreadPool.cs
@@ -226,7 +226,7 @@ namespace Helios.Concurrency
             }
         }
 
-        private struct RequestWorkerTask : IRunnable
+        private readonly struct RequestWorkerTask : IRunnable
         {
             private readonly DedicatedThreadPoolTaskScheduler _scheduler;
 
@@ -312,7 +312,7 @@ namespace Helios.Concurrency
         /// This exception is thrown if the given <paramref name="work"/> item is undefined.
         /// </exception>
         /// <returns>TBD</returns>
-        public bool QueueUserWorkItem(IRunnable work)
+        public bool QueueUserWorkItem<T>(T work) where T:IRunnable
         {
             if (work == null)
                 throw new ArgumentNullException(nameof(work), "Work item cannot be null.");


### PR DESCRIPTION
## Changes

Done to avoid boxing allocations - however, the tasks this effects are few and far between so there's not much in the way of measurable impact. Still, may not be a bad idea.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue https://github.com/akkadotnet/akka.net/pull/6143#discussion_r988468548
* [x] Changes in public API reviewed, if any.

### Latest `v1.4` Benchmarks 

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.2006 (21H2)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.201
  [Host]     : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  DefaultJob : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT


```
|        Method | TaskCount |      Configurator |       Mean |    Error |    StdDev |     Median |       Gen 0 | Allocated |
|-------------- |---------- |------------------ |-----------:|---------:|----------:|-----------:|------------:|----------:|
| **RunDispatcher** |   **1000000** |          **ChannelD** | **2,484.7 ms** | **22.17 ms** |  **19.65 ms** | **2,482.8 ms** | **161000.0000** |    **641 MB** |
| **RunDispatcher** |   **1000000** | **DefaultThreadPool** | **1,123.4 ms** | **59.06 ms** | **174.15 ms** | **1,172.5 ms** |  **15000.0000** |     **61 MB** |
| **RunDispatcher** |   **1000000** |  **ForkJoin(remote)** |   **606.5 ms** | **12.10 ms** |  **34.90 ms** |   **612.9 ms** |   **7000.0000** |     **31 MB** |
| **RunDispatcher** |   **1000000** |     **ForkJoin(sys)** |   **625.1 ms** | **12.12 ms** |  **15.76 ms** |   **625.3 ms** |   **7000.0000** |     **31 MB** |
| **RunDispatcher** |   **1000000** |             **TaskD** | **1,129.0 ms** | **31.68 ms** |  **93.41 ms** | **1,149.7 ms** |  **23000.0000** |     **92 MB** |


### This PR's Benchmarks

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19044.2006 (21H2)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=6.0.201
  [Host]     : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT
  DefaultJob : .NET 6.0.3 (6.0.322.12309), X64 RyuJIT


```
|        Method | TaskCount |      Configurator |       Mean |    Error |    StdDev |     Median |       Gen 0 | Allocated |
|-------------- |---------- |------------------ |-----------:|---------:|----------:|-----------:|------------:|----------:|
| **RunDispatcher** |   **1000000** |          **ChannelD** | **2,484.7 ms** | **22.17 ms** |  **19.65 ms** | **2,482.8 ms** | **161000.0000** |    **641 MB** |
| **RunDispatcher** |   **1000000** | **DefaultThreadPool** | **1,123.4 ms** | **59.06 ms** | **174.15 ms** | **1,172.5 ms** |  **15000.0000** |     **61 MB** |
| **RunDispatcher** |   **1000000** |  **ForkJoin(remote)** |   **606.5 ms** | **12.10 ms** |  **34.90 ms** |   **612.9 ms** |   **7000.0000** |     **31 MB** |
| **RunDispatcher** |   **1000000** |     **ForkJoin(sys)** |   **625.1 ms** | **12.12 ms** |  **15.76 ms** |   **625.3 ms** |   **7000.0000** |     **31 MB** |
| **RunDispatcher** |   **1000000** |             **TaskD** | **1,129.0 ms** | **31.68 ms** |  **93.41 ms** | **1,149.7 ms** |  **23000.0000** |     **92 MB** |

