### PR TITLE
Logging Benchmarks

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
@@ -1,0 +1,170 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="LoggingBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Event;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class LoggingBenchmarks
+    {
+        private sealed class BenchmarkLogAdapter : LoggingAdapterBase
+        {
+            public int CurrentLogs { get; private set; }
+            public LogEvent[] AllLogs { get; private set; }
+
+            private readonly string _logSource;
+            private readonly Type _logClass;
+
+            public BenchmarkLogAdapter(int capacity) : base(new DefaultLogMessageFormatter())
+            {
+                AllLogs = new LogEvent[capacity];
+                _logSource = LogSource.Create(this).Source;
+                _logClass = typeof(BenchmarkLogAdapter);
+            }
+
+            public override bool IsDebugEnabled { get; } = true;
+            public override bool IsInfoEnabled { get; } = true;
+            public override bool IsWarningEnabled { get; } = true;
+            public override bool IsErrorEnabled { get; } = true;
+
+            private void AddLogMessage(LogEvent m)
+            {
+                AllLogs[CurrentLogs++] = m;
+            }
+
+            protected override void NotifyError(object message)
+            {
+               AddLogMessage(new Error(null, _logSource, _logClass, message));
+            }
+
+            /// <summary>
+            /// Publishes the error message and exception onto the LoggingBus.
+            /// </summary>
+            /// <param name="cause">The exception that caused this error.</param>
+            /// <param name="message">The error message.</param>
+            protected override void NotifyError(Exception cause, object message)
+            {
+                AddLogMessage((new Error(cause, _logSource, _logClass, message);
+            }
+
+            /// <summary>
+            /// Publishes the warning message onto the LoggingBus.
+            /// </summary>
+            /// <param name="message">The warning message.</param>
+            protected override void NotifyWarning(object message)
+            {
+                AddLogMessage((new Warning(_logSource, _logClass, message);
+            }
+
+            protected override void NotifyWarning(Exception cause, object message)
+            {
+                AddLogMessage(new Warning(cause, _logSource, _logClass, message));
+            }
+
+            /// <summary>
+            /// Publishes the info message onto the LoggingBus.
+            /// </summary>
+            /// <param name="message">The info message.</param>
+            protected override void NotifyInfo(object message)
+            {
+                AddLogMessage(new Info(_logSource, _logClass, message));
+            }
+
+            protected override void NotifyInfo(Exception cause, object message)
+            {
+                AddLogMessage(new Info(cause, _logSource, _logClass, message));
+            }
+
+            /// <summary>
+            /// Publishes the debug message onto the LoggingBus.
+            /// </summary>
+            /// <param name="message">The debug message.</param>
+            protected override void NotifyDebug(object message)
+            {
+                AddLogMessage(new Debug(_logSource, _logClass, message));
+            }
+
+            protected override void NotifyDebug(Exception cause, object message)
+            {
+                AddLogMessage(new Debug(cause, _logSource, _logClass, message));
+            }
+        }
+
+        public const int NumOperations = 1_000_000;
+
+        private BenchmarkLogAdapter _log;
+
+        [IterationSetup]
+        public void InitLogger()
+        {
+            _log = new BenchmarkLogAdapter(NumOperations);
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfoNoParams()
+        {
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info("foo");
+
+            return _log.AllLogs;
+        }
+        
+        [Benchmark( OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfo1Params()
+        {
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info("foo {0}", i);
+
+            return _log.AllLogs;
+        }
+        
+        [Benchmark(OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfo2Params()
+        {
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info("foo {0} and {1}", i, i-1);
+
+            return _log.AllLogs;
+        }
+        
+        [Benchmark(OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfoWithException()
+        {
+            var ex = new ApplicationException();
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info(ex, "foo");
+
+            return _log.AllLogs;
+        }
+        
+        [Benchmark(OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfoWithException1Params()
+        {
+            var ex = new ApplicationException();
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info(ex, "foo {0}", i);
+
+            return _log.AllLogs;
+        }
+        
+        [Benchmark(OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfoWithException2Params()
+        {
+            var ex = new ApplicationException();
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info(ex, "foo {0} and {1}", i, i-1);
+
+            return _log.AllLogs;
+        }
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
@@ -54,7 +54,7 @@ namespace Akka.Benchmarks
             /// <param name="message">The error message.</param>
             protected override void NotifyError(Exception cause, object message)
             {
-                AddLogMessage((new Error(cause, _logSource, _logClass, message);
+                AddLogMessage(new Error(cause, _logSource, _logClass, message));
             }
 
             /// <summary>
@@ -63,7 +63,7 @@ namespace Akka.Benchmarks
             /// <param name="message">The warning message.</param>
             protected override void NotifyWarning(object message)
             {
-                AddLogMessage((new Warning(_logSource, _logClass, message);
+                AddLogMessage(new Warning(_logSource, _logClass, message));
             }
 
             protected override void NotifyWarning(Exception cause, object message)


### PR DESCRIPTION
## Changes

The Akka.NET logging system fundamentals haven't really changed much since 2014 or so, and I suspect we are doing some _extremely ugly_ things in that code. Adding some benchmarks using a custom `ILoggingAdapter` implementation so I can measure the overhead.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

``` ini

BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19043.2006/21H1/May2021Update)
Intel Core i7-8850H CPU 2.60GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 6.0.9 (6.0.922.41905), X64 RyuJIT AVX2
  Job-JJNOTA : .NET 6.0.9 (6.0.922.41905), X64 RyuJIT AVX2

InvocationCount=1  UnrollFactor=1  

```
|                      Method |     Mean |    Error |   StdDev | Ratio | RatioSD |   Gen0 |   Gen1 |   Gen2 | Allocated | Alloc Ratio |
|---------------------------- |---------:|---------:|---------:|------:|--------:|-------:|-------:|-------:|----------:|------------:|
|             LogInfoNoParams | 159.0 ns |  3.18 ns |  6.42 ns |  1.00 |    0.00 | 0.0110 | 0.0040 | 0.0010 |      64 B |        1.00 |
|              LogInfo1Params | 663.5 ns | 11.04 ns |  9.79 ns |  4.15 |    0.20 | 0.0280 | 0.0110 | 0.0030 |     160 B |        2.50 |
|              LogInfo2Params | 849.3 ns | 14.42 ns | 12.78 ns |  5.31 |    0.29 | 0.0340 | 0.0140 | 0.0040 |     192 B |        3.00 |
|        LogInfoWithException | 162.7 ns |  3.11 ns |  5.99 ns |  1.03 |    0.05 | 0.0110 | 0.0040 | 0.0010 |      64 B |        1.00 |
| LogInfoWithException1Params | 669.4 ns | 13.36 ns | 12.50 ns |  4.20 |    0.21 | 0.0280 | 0.0110 | 0.0030 |     160 B |        2.50 |
| LogInfoWithException2Params | 850.4 ns | 11.39 ns | 10.10 ns |  5.32 |    0.25 | 0.0340 | 0.0140 | 0.0040 |     192 B |        3.00 |


Bear in mind - these results are scaled down _per operation_. This means writing a single log event in Akka.NET is roughly 10x more expensive than processing a message by default.
