### PR TITLE
Update version numbers in spellcheck pipeline

### DIFF
--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -26,11 +26,11 @@ jobs:
         submodules: recursive # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
       - task: NodeTool@0
         inputs:
-          versionSpec: "12.x"
+          versionSpec: "16.x"
       - task: Npm@1
         inputs:
           command: "custom"
-          customCommand: "install -g cspell@5.17.0"
+          customCommand: "install -g cspell@6.12.0"
       - task: CmdLine@2
         inputs:
           script: 'cspell --config ./docs/cSpell.json "docs/**/*.md"'

--- a/docs/cSpell.json
+++ b/docs/cSpell.json
@@ -16,6 +16,7 @@
         "blackhole",
         "Bootcamp",
         "buncher",
+        "concat",
         "combinator",
         "combinators",
         "composability",

--- a/docs/community/contributing/documentation-guidelines.md
+++ b/docs/community/contributing/documentation-guidelines.md
@@ -235,7 +235,7 @@ build.sh docfx
 
 This will generate all of the static HTML / CSS / JS files needed to render the website into the `~/docs/_site` folder in your local repository.
 
-In order for all of the JavaScript components to work correctly in your browser, you'll need to serve the documents via a local webserver rather than the file system. You can launch DocFx's build in server via the following script in the root of this repository:
+In order for all of the JavaScript components to work correctly in your browser, you'll need to serve the documents via a local web server rather than the file system. You can launch DocFx's build in server via the following script in the root of this repository:
 
 ```console
 serve-docs.cmd


### PR DESCRIPTION
Just a quick drive-by. I've been doing some other similar PR work and figured I'd bump the versions since I know they work.

## Changes

* Updates node version of spellcheck task from 12.x --> 16.x
* Updates cSpell version to the latest 6.12.0