### PR TITLE
Eliminate `DefaultLogMessageFormatter` allocations

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
@@ -25,7 +25,7 @@ namespace Akka.Benchmarks
             private readonly string _logSource;
             private readonly Type _logClass;
 
-            public BenchmarkLogAdapter(int capacity) : base(new DefaultLogMessageFormatter())
+            public BenchmarkLogAdapter(int capacity) : base(DefaultLogMessageFormatter.Instance)
             {
                 AllLogs = new LogEvent[capacity];
                 _logSource = LogSource.Create(this).Source;

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
@@ -2986,7 +2986,7 @@ namespace Akka.Event
     }
     public class DefaultLogMessageFormatter : Akka.Event.ILogMessageFormatter
     {
-        public DefaultLogMessageFormatter() { }
+        public static readonly Akka.Event.DefaultLogMessageFormatter Instance;
         public string Format(string format, params object[] args) { }
     }
     public class DefaultLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -2991,7 +2991,7 @@ namespace Akka.Event
     }
     public class DefaultLogMessageFormatter : Akka.Event.ILogMessageFormatter
     {
-        public DefaultLogMessageFormatter() { }
+        public static readonly Akka.Event.DefaultLogMessageFormatter Instance;
         public string Format(string format, params object[] args) { }
     }
     public class DefaultLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -2986,7 +2986,7 @@ namespace Akka.Event
     }
     public class DefaultLogMessageFormatter : Akka.Event.ILogMessageFormatter
     {
-        public DefaultLogMessageFormatter() { }
+        public static readonly Akka.Event.DefaultLogMessageFormatter Instance;
         public string Format(string format, params object[] args) { }
     }
     public class DefaultLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>

--- a/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
@@ -107,7 +107,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Log_on_source_must_allow_passing_in_custom_LoggingAdapter()
         {
-            var log = new BusLogging(Sys.EventStream, "com.example.ImportantLogger", LogType, new DefaultLogMessageFormatter());
+            var log = new BusLogging(Sys.EventStream, "com.example.ImportantLogger", LogType, DefaultLogMessageFormatter.Instance);
 
             Source.Single(42)
                 .Log("flow-5", log: log)

--- a/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
@@ -422,7 +422,7 @@ namespace Akka.Streams.Implementation.Fusing
 
         private BusLogging GetLogger()
         {
-            return new BusLogging(Materializer.System.EventStream, Self.ToString(), typeof(GraphInterpreterShell), new DefaultLogMessageFormatter());
+            return new BusLogging(Materializer.System.EventStream, Self.ToString(), typeof(GraphInterpreterShell), DefaultLogMessageFormatter.Instance);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -2948,7 +2948,7 @@ namespace Akka.Streams.Implementation.Fusing
                     try
                     {
                         var materializer = ActorMaterializerHelper.Downcast(Materializer);
-                        _log = new BusLogging(materializer.System.EventStream, _stage._name, GetType(), new DefaultLogMessageFormatter());
+                        _log = new BusLogging(materializer.System.EventStream, _stage._name, GetType(), DefaultLogMessageFormatter.Instance);
                     }
                     catch (Exception ex)
                     {

--- a/src/core/Akka.Tests/Loggers/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/LoggerSpec.cs
@@ -136,7 +136,7 @@ akka.stdout-loglevel = DEBUG");
             var logSource = LogSource.Create(nameof(LoggerSpec));
             var ls = logSource.Source;
             var lc = logSource.Type;
-            var formatter = new DefaultLogMessageFormatter();
+            var formatter =  DefaultLogMessageFormatter.Instance;
 
             yield return new object[] { new Error(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p)) }; 
 

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -464,7 +464,7 @@ namespace Akka.Actor.Internal
 
         private void ConfigureLoggers()
         {
-            _log = new BusLogging(_eventStream, "ActorSystem(" + _name + ")", GetType(), new DefaultLogMessageFormatter());
+            _log = new BusLogging(_eventStream, "ActorSystem(" + _name + ")", GetType(), DefaultLogMessageFormatter.Instance);
         }
 
         private void ConfigureDispatchers()

--- a/src/core/Akka/Event/DefaultLogMessageFormatter.cs
+++ b/src/core/Akka/Event/DefaultLogMessageFormatter.cs
@@ -12,6 +12,9 @@ namespace Akka.Event
     /// </summary>
     public class DefaultLogMessageFormatter : ILogMessageFormatter
     {
+        public static readonly DefaultLogMessageFormatter Instance = new DefaultLogMessageFormatter();
+        private DefaultLogMessageFormatter(){}
+        
         /// <summary>
         /// Formats a specified composite string using an optional list of item substitutions.
         /// </summary>

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -213,7 +213,7 @@ namespace Akka.Event
             catch // had a failure, don't want to propagate it. Just start the logger without remote context
             {
                 var logSource = LogSource.Create(context);
-                return new BusLogging(context.System.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? new DefaultLogMessageFormatter());
+                return new BusLogging(context.System.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? DefaultLogMessageFormatter.Instance);
             }
         }
 
@@ -226,7 +226,7 @@ namespace Akka.Event
         public static ILoggingAdapter GetLogger(this IActorContext context, ILogMessageFormatter logMessageFormatter = null)
         {
             var logSource = LogSource.Create(context, context.System);
-            return new BusLogging(context.System.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? new DefaultLogMessageFormatter());
+            return new BusLogging(context.System.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? DefaultLogMessageFormatter.Instance);
         }
 
         /// <summary>
@@ -239,7 +239,7 @@ namespace Akka.Event
         public static ILoggingAdapter GetLogger(ActorSystem system, object logSourceObj, ILogMessageFormatter logMessageFormatter = null)
         {
             var logSource = LogSource.Create(logSourceObj, system);
-            return new BusLogging(system.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? new DefaultLogMessageFormatter());
+            return new BusLogging(system.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? DefaultLogMessageFormatter.Instance);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace Akka.Event
         public static ILoggingAdapter GetLogger(LoggingBus loggingBus, object logSourceObj, ILogMessageFormatter logMessageFormatter = null)
         {
             var logSource = LogSource.Create(logSourceObj);
-            return new BusLogging(loggingBus, logSource.Source, logSource.Type, logMessageFormatter ?? new DefaultLogMessageFormatter());
+            return new BusLogging(loggingBus, logSource.Source, logSource.Type, logMessageFormatter ?? DefaultLogMessageFormatter.Instance);
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

`DefaultLogMessageFormatter` is essentially a `static` class - removed its constructor and made it a singleton. This won't help with actor performance at all, but will reduce the total actor memory footprint especially in larger `ActorSystem`s.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.
