### PR TITLE
[BACKPORT #6166] Eliminate `DefaultLogMessageFormatter` allocations

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
@@ -1,0 +1,170 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="LoggingBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Event;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class LoggingBenchmarks
+    {
+        private sealed class BenchmarkLogAdapter : LoggingAdapterBase
+        {
+            public int CurrentLogs { get; private set; }
+            public LogEvent[] AllLogs { get; private set; }
+
+            private readonly string _logSource;
+            private readonly Type _logClass;
+
+            public BenchmarkLogAdapter(int capacity) : base(DefaultLogMessageFormatter.Instance)
+            {
+                AllLogs = new LogEvent[capacity];
+                _logSource = LogSource.Create(this).Source;
+                _logClass = typeof(BenchmarkLogAdapter);
+            }
+
+            public override bool IsDebugEnabled { get; } = true;
+            public override bool IsInfoEnabled { get; } = true;
+            public override bool IsWarningEnabled { get; } = true;
+            public override bool IsErrorEnabled { get; } = true;
+
+            private void AddLogMessage(LogEvent m)
+            {
+                AllLogs[CurrentLogs++] = m;
+            }
+
+            protected override void NotifyError(object message)
+            {
+               AddLogMessage(new Error(null, _logSource, _logClass, message));
+            }
+
+            /// <summary>
+            /// Publishes the error message and exception onto the LoggingBus.
+            /// </summary>
+            /// <param name="cause">The exception that caused this error.</param>
+            /// <param name="message">The error message.</param>
+            protected override void NotifyError(Exception cause, object message)
+            {
+                AddLogMessage(new Error(cause, _logSource, _logClass, message));
+            }
+
+            /// <summary>
+            /// Publishes the warning message onto the LoggingBus.
+            /// </summary>
+            /// <param name="message">The warning message.</param>
+            protected override void NotifyWarning(object message)
+            {
+                AddLogMessage(new Warning(_logSource, _logClass, message));
+            }
+
+            protected override void NotifyWarning(Exception cause, object message)
+            {
+                AddLogMessage(new Warning(cause, _logSource, _logClass, message));
+            }
+
+            /// <summary>
+            /// Publishes the info message onto the LoggingBus.
+            /// </summary>
+            /// <param name="message">The info message.</param>
+            protected override void NotifyInfo(object message)
+            {
+                AddLogMessage(new Info(_logSource, _logClass, message));
+            }
+
+            protected override void NotifyInfo(Exception cause, object message)
+            {
+                AddLogMessage(new Info(cause, _logSource, _logClass, message));
+            }
+
+            /// <summary>
+            /// Publishes the debug message onto the LoggingBus.
+            /// </summary>
+            /// <param name="message">The debug message.</param>
+            protected override void NotifyDebug(object message)
+            {
+                AddLogMessage(new Debug(_logSource, _logClass, message));
+            }
+
+            protected override void NotifyDebug(Exception cause, object message)
+            {
+                AddLogMessage(new Debug(cause, _logSource, _logClass, message));
+            }
+        }
+
+        public const int NumOperations = 1_000_000;
+
+        private BenchmarkLogAdapter _log;
+
+        [IterationSetup]
+        public void InitLogger()
+        {
+            _log = new BenchmarkLogAdapter(NumOperations);
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfoNoParams()
+        {
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info("foo");
+
+            return _log.AllLogs;
+        }
+        
+        [Benchmark( OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfo1Params()
+        {
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info("foo {0}", i);
+
+            return _log.AllLogs;
+        }
+        
+        [Benchmark(OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfo2Params()
+        {
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info("foo {0} and {1}", i, i-1);
+
+            return _log.AllLogs;
+        }
+        
+        [Benchmark(OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfoWithException()
+        {
+            var ex = new ApplicationException();
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info(ex, "foo");
+
+            return _log.AllLogs;
+        }
+        
+        [Benchmark(OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfoWithException1Params()
+        {
+            var ex = new ApplicationException();
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info(ex, "foo {0}", i);
+
+            return _log.AllLogs;
+        }
+        
+        [Benchmark(OperationsPerInvoke = NumOperations)]
+        public LogEvent[] LogInfoWithException2Params()
+        {
+            var ex = new ApplicationException();
+            for(var i = 0; i < NumOperations; i++)
+                _log.Info(ex, "foo {0} and {1}", i, i-1);
+
+            return _log.AllLogs;
+        }
+    }
+}

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
@@ -3003,7 +3003,7 @@ namespace Akka.Event
     }
     public class DefaultLogMessageFormatter : Akka.Event.ILogMessageFormatter
     {
-        public DefaultLogMessageFormatter() { }
+        public static readonly Akka.Event.DefaultLogMessageFormatter Instance;
         public string Format(string format, params object[] args) { }
     }
     public class DefaultLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>

--- a/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
@@ -107,7 +107,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public void A_Log_on_source_must_allow_passing_in_custom_LoggingAdapter()
         {
-            var log = new BusLogging(Sys.EventStream, "com.example.ImportantLogger", LogType, new DefaultLogMessageFormatter());
+            var log = new BusLogging(Sys.EventStream, "com.example.ImportantLogger", LogType, DefaultLogMessageFormatter.Instance);
 
             Source.Single(42)
                 .Log("flow-5", log: log)

--- a/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
@@ -422,7 +422,7 @@ namespace Akka.Streams.Implementation.Fusing
 
         private BusLogging GetLogger()
         {
-            return new BusLogging(Materializer.System.EventStream, Self.ToString(), typeof(GraphInterpreterShell), new DefaultLogMessageFormatter());
+            return new BusLogging(Materializer.System.EventStream, Self.ToString(), typeof(GraphInterpreterShell), DefaultLogMessageFormatter.Instance);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -2943,7 +2943,7 @@ namespace Akka.Streams.Implementation.Fusing
                     try
                     {
                         var materializer = ActorMaterializerHelper.Downcast(Materializer);
-                        _log = new BusLogging(materializer.System.EventStream, _stage._name, GetType(), new DefaultLogMessageFormatter());
+                        _log = new BusLogging(materializer.System.EventStream, _stage._name, GetType(), DefaultLogMessageFormatter.Instance);
                     }
                     catch (Exception ex)
                     {

--- a/src/core/Akka.Tests/Loggers/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/LoggerSpec.cs
@@ -129,7 +129,7 @@ akka.stdout-loglevel = DEBUG");
             var logSource = LogSource.Create(nameof(LoggerSpec));
             var ls = logSource.Source;
             var lc = logSource.Type;
-            var formatter = new DefaultLogMessageFormatter();
+            var formatter =  DefaultLogMessageFormatter.Instance;
 
             yield return new object[] { new Error(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p)) }; 
 

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -462,7 +462,7 @@ namespace Akka.Actor.Internal
 
         private void ConfigureLoggers()
         {
-            _log = new BusLogging(_eventStream, "ActorSystem(" + _name + ")", GetType(), new DefaultLogMessageFormatter());
+            _log = new BusLogging(_eventStream, "ActorSystem(" + _name + ")", GetType(), DefaultLogMessageFormatter.Instance);
         }
 
         private void ConfigureDispatchers()

--- a/src/core/Akka/Event/DefaultLogMessageFormatter.cs
+++ b/src/core/Akka/Event/DefaultLogMessageFormatter.cs
@@ -12,6 +12,9 @@ namespace Akka.Event
     /// </summary>
     public class DefaultLogMessageFormatter : ILogMessageFormatter
     {
+        public static readonly DefaultLogMessageFormatter Instance = new DefaultLogMessageFormatter();
+        private DefaultLogMessageFormatter(){}
+        
         /// <summary>
         /// Formats a specified composite string using an optional list of item substitutions.
         /// </summary>

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -213,7 +213,7 @@ namespace Akka.Event
             catch // had a failure, don't want to propagate it. Just start the logger without remote context
             {
                 var logSource = LogSource.Create(context);
-                return new BusLogging(context.System.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? new DefaultLogMessageFormatter());
+                return new BusLogging(context.System.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? DefaultLogMessageFormatter.Instance);
             }
         }
 
@@ -226,7 +226,7 @@ namespace Akka.Event
         public static ILoggingAdapter GetLogger(this IActorContext context, ILogMessageFormatter logMessageFormatter = null)
         {
             var logSource = LogSource.Create(context, context.System);
-            return new BusLogging(context.System.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? new DefaultLogMessageFormatter());
+            return new BusLogging(context.System.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? DefaultLogMessageFormatter.Instance);
         }
 
         /// <summary>
@@ -239,7 +239,7 @@ namespace Akka.Event
         public static ILoggingAdapter GetLogger(ActorSystem system, object logSourceObj, ILogMessageFormatter logMessageFormatter = null)
         {
             var logSource = LogSource.Create(logSourceObj, system);
-            return new BusLogging(system.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? new DefaultLogMessageFormatter());
+            return new BusLogging(system.EventStream, logSource.Source, logSource.Type, logMessageFormatter ?? DefaultLogMessageFormatter.Instance);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace Akka.Event
         public static ILoggingAdapter GetLogger(LoggingBus loggingBus, object logSourceObj, ILogMessageFormatter logMessageFormatter = null)
         {
             var logSource = LogSource.Create(logSourceObj);
-            return new BusLogging(loggingBus, logSource.Source, logSource.Type, logMessageFormatter ?? new DefaultLogMessageFormatter());
+            return new BusLogging(loggingBus, logSource.Source, logSource.Type, logMessageFormatter ?? DefaultLogMessageFormatter.Instance);
         }
 
         /// <summary>


### PR DESCRIPTION
Backport #6166
