### PR TITLE
[BACKPORT #6175] Fix DbCommand.CommandTimeout

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
@@ -974,7 +974,7 @@ namespace Akka.Persistence.Sql.Common.Journal
                 using (var tx = connection.BeginTransaction(Setup.IsolationLevel))
                 using (var command = (TCommand)connection.CreateCommand())
                 {
-                    command.CommandTimeout = (int)Setup.ConnectionTimeout.TotalMilliseconds;
+                    command.CommandTimeout = (int)Setup.ConnectionTimeout.TotalSeconds;
                     command.Transaction = tx;
                     try
                     {


### PR DESCRIPTION
(cherry picked from commit 695fada8f3abebc94d096bcd3945c9ab0a051e00)
