### PR TITLE
remove `Deadline` allocations from Akka.Remote

### DIFF
--- a/src/benchmark/RemotePingPong/Program.cs
+++ b/src/benchmark/RemotePingPong/Program.cs
@@ -116,9 +116,11 @@ namespace RemotePingPong
                 var bestThroughput = 0L;
                 foreach (var throughput in GetClientSettings())
                 {
+                    GC.Collect();
                     var result1 = await Benchmark(throughput, repeat, bestThroughput, redCount);
                     bestThroughput = result1.Item2;
                     redCount = result1.Item3;
+                    GC.Collect(); // for good measure
                 }
             }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
@@ -66,7 +66,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// <summary>
         /// TBD
         /// </summary>
-        protected Deadline PruneDeadline = null;
+        protected Deadline PruneDeadline = Deadline.Never;
 
         /// <summary>
         /// Used to toggle what we do during publication when there are no subscribers
@@ -109,7 +109,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
                 case Subscribe subscribe:
                     Context.Watch(subscribe.Ref);
                     Subscribers.Add(subscribe.Ref);
-                    PruneDeadline = null;
+                    PruneDeadline = Deadline.Never;
                     Context.Parent.Tell(new Subscribed(new SubscribeAck(subscribe), Sender));
                     return true;
 
@@ -124,9 +124,9 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
                     return true;
 
                 case Prune _:
-                    if (PruneDeadline != null && PruneDeadline.IsOverdue)
+                    if (PruneDeadline != Deadline.Never && PruneDeadline.IsOverdue)
                     {
-                        PruneDeadline = null;
+                        PruneDeadline = Deadline.Never;
                         Context.Parent.Tell(NoMoreSubscribers.Instance);
                     }
 
@@ -224,7 +224,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
                             NewGroupActor(encodedGroup).Forward(message);
                         }
                     });
-                    PruneDeadline = null;
+                    PruneDeadline = Deadline.Never;
                     return true;
 
                 case Unsubscribe unsubscribe when unsubscribe.Group != null:

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.verified.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveRemote.verified.txt
@@ -64,8 +64,9 @@ namespace Akka.Remote
         public override string ToString() { }
     }
     public delegate long Clock();
-    public class Deadline
+    public struct Deadline
     {
+        public static readonly Akka.Remote.Deadline Never;
         public Deadline(System.DateTime when) { }
         public bool HasTimeLeft { get; }
         public bool IsOverdue { get; }
@@ -76,6 +77,8 @@ namespace Akka.Remote
         public override int GetHashCode() { }
         public static Akka.Remote.Deadline +(Akka.Remote.Deadline deadline, System.TimeSpan duration) { }
         public static Akka.Remote.Deadline +(Akka.Remote.Deadline deadline, System.Nullable<System.TimeSpan> duration) { }
+        public static bool ==(Akka.Remote.Deadline left, Akka.Remote.Deadline right) { }
+        public static bool !=(Akka.Remote.Deadline left, Akka.Remote.Deadline right) { }
     }
     public class DeadlineFailureDetector : Akka.Remote.FailureDetector
     {

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -1310,7 +1310,7 @@ namespace Akka.Cluster
         {
             _joinSeedNodesDeadline = _cluster.Settings.ShutdownAfterUnsuccessfulJoinSeedNodes != null
                 ? Deadline.Now + _cluster.Settings.ShutdownAfterUnsuccessfulJoinSeedNodes
-                : null;
+                : Deadline.Never;
         }
 
         private void JoinSeedNodesWasUnsuccessful()
@@ -1318,7 +1318,7 @@ namespace Akka.Cluster
             _log.Warning("Joining of seed-nodes [{0}] was unsuccessful after configured shutdown-after-unsuccessful-join-seed-nodes [{1}]. Running CoordinatedShutdown.",
                 string.Join(", ", _seedNodes), _cluster.Settings.ShutdownAfterUnsuccessfulJoinSeedNodes);
 
-            _joinSeedNodesDeadline = null;
+            _joinSeedNodesDeadline = Deadline.Never;
             _coordShutdown.Run(CoordinatedShutdown.ClusterJoinUnsuccessfulReason.Instance);
         }
 
@@ -1534,7 +1534,7 @@ namespace Akka.Cluster
                 else
                 {
                     var joinDeadline = _cluster.Settings.RetryUnsuccessfulJoinAfter == null
-                        ? null
+                        ? Deadline.Never
                         : Deadline.Now + _cluster.Settings.RetryUnsuccessfulJoinAfter;
 
                     Context.Become(m => TryingToJoin(m, address, joinDeadline));

--- a/src/core/Akka.Cluster/Gossip.cs
+++ b/src/core/Akka.Cluster/Gossip.cs
@@ -455,7 +455,7 @@ namespace Akka.Cluster
         /// <param name="gossip">TBD</param>
         /// <param name="deadline">TBD</param>
         /// <returns>TBD</returns>
-        public GossipEnvelope(UniqueAddress from, UniqueAddress to, Gossip gossip, Deadline deadline = null)
+        public GossipEnvelope(UniqueAddress from, UniqueAddress to, Gossip gossip, Deadline? deadline = null)
         {
             _from = from;
             _to = to;
@@ -478,7 +478,7 @@ namespace Akka.Cluster
         /// <summary>
         /// TBD
         /// </summary>
-        public Deadline Deadline { get; set; }
+        public Deadline? Deadline { get; set; }
     }
 
     /// <summary>

--- a/src/core/Akka.Remote.TestKit.Tests/BarrierSpec.cs
+++ b/src/core/Akka.Remote.TestKit.Tests/BarrierSpec.cs
@@ -94,7 +94,7 @@ namespace Akka.Remote.TestKit.Tests
             b.Tell(new BarrierCoordinator.RemoveClient(A));
             ExpectMsg(new Failed(b,
                 new BarrierCoordinator.BarrierEmptyException(
-                    new BarrierCoordinator.Data(ImmutableHashSet.Create<Controller.NodeInfo>(), "", null, null),
+                    new BarrierCoordinator.Data(ImmutableHashSet.Create<Controller.NodeInfo>(), "", null, Deadline.Never),
                     "cannot remove RoleName(a): no client to remove")));
         }
 

--- a/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
+++ b/src/core/Akka.Remote.TestKit/BarrierCoordinator.cs
@@ -75,12 +75,12 @@ namespace Akka.Remote.TestKit
             public Deadline Deadline { get; private set; }
 
             public Data Copy(ImmutableHashSet<Controller.NodeInfo> clients = null, string barrier = null,
-                ImmutableHashSet<IActorRef> arrived = null, Deadline deadline = null)
+                ImmutableHashSet<IActorRef> arrived = null, Deadline deadline = default)
             {
                 return new Data(clients ?? Clients,
                     barrier ?? Barrier,
                     arrived ?? Arrived,
-                    deadline ?? Deadline);
+                    deadline == default ? Deadline : deadline);
             }
 
             private bool Equals(Data other)
@@ -494,7 +494,7 @@ namespace Akka.Remote.TestKit
 
         protected void InitFSM()
         {
-            StartWith(State.Idle, new Data(ImmutableHashSet.Create<Controller.NodeInfo>(), "", ImmutableHashSet.Create<IActorRef>(), null));
+            StartWith(State.Idle, new Data(ImmutableHashSet.Create<Controller.NodeInfo>(), "", ImmutableHashSet.Create<IActorRef>(), Deadline.Never));
 
             WhenUnhandled(@event =>
             {

--- a/src/core/Akka.Remote/Deadline.cs
+++ b/src/core/Akka.Remote/Deadline.cs
@@ -12,7 +12,7 @@ namespace Akka.Remote
     /// <summary>
     /// This class represents the latest date or time by which an operation should be completed.
     /// </summary>
-    public class Deadline
+    public readonly struct Deadline
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Deadline"/> class.
@@ -42,7 +42,7 @@ namespace Akka.Remote
         /// <summary>
         /// The <see cref="DateTime"/> that the deadline is due.
         /// </summary>
-        public DateTime When { get; private set; }
+        public DateTime When { get; }
 
         /// <summary>
         /// <para>
@@ -91,6 +91,11 @@ namespace Akka.Remote
         }
 
         /// <summary>
+        /// A <see cref="Deadline"/> that will never expire.
+        /// </summary>
+        public static readonly Deadline Never = new Deadline(DateTime.MaxValue);
+
+        /// <summary>
         /// Adds a given <see cref="TimeSpan"/> to the due time of this <see cref="Deadline"/>
         /// </summary>
         /// <param name="deadline">The deadline whose time is being extended</param>
@@ -113,6 +118,16 @@ namespace Akka.Remote
                 return new Deadline(deadline.When.Add(duration.Value));
             else
                 return deadline;
+        }
+
+        public static bool operator ==(Deadline left, Deadline right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Deadline left, Deadline right)
+        {
+            return !(left == right);
         }
 
         #endregion


### PR DESCRIPTION
## Changes

Made `Deadline` into a `readonly struct` - it's a minor source of allocations but relatively easy to remove.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

Benchmark throughput data emerging from this change is negligible - showed up in Rider's dynamic profiling report as a source of 200mb of allocation over the course of running RemotePingPong.