### PR TITLE
removed boxing allocations inside `FSM.State.Equals`

### DIFF
--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -1262,12 +1262,14 @@ namespace Akka.Actor
                 {
                     Sender.Tell(nextState.Replies[i]);
                 }
-                if (!_currentState.StateName.Equals(nextState.StateName) || nextState.Notifies)
+                
+                // avoid boxing
+                if (!EqualityComparer<TState>.Default.Equals(_currentState.StateName, nextState.StateName) || nextState.Notifies)
                 {
                     _nextState = nextState;
                     HandleTransition(_currentState.StateName, nextState.StateName);
                     Listeners.Gossip(new Transition<TState>(Self, _currentState.StateName, nextState.StateName));
-                    _nextState = default(State<TState, TData>);
+                    _nextState = default;
                 }
                 _currentState = nextState;
 


### PR DESCRIPTION
## Changes

The `object.Equals` call here generated hundreds of mb in boxing allocations inside RemotePingPong - using the `EqualityComparer<TState>.Default.Equals` eliminates them.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

Used Rider's Dynamic Program Analysis to verify that the allocations were removed.
