### PR TITLE
[PORT #6183] removed boxing allocations inside `FSM` 

### DIFF
--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -1262,12 +1262,14 @@ namespace Akka.Actor
                 {
                     Sender.Tell(nextState.Replies[i]);
                 }
-                if (!_currentState.StateName.Equals(nextState.StateName) || nextState.Notifies)
+                
+                // avoid boxing
+                if (!EqualityComparer<TState>.Default.Equals(_currentState.StateName, nextState.StateName) || nextState.Notifies)
                 {
                     _nextState = nextState;
                     HandleTransition(_currentState.StateName, nextState.StateName);
                     Listeners.Gossip(new Transition<TState>(Self, _currentState.StateName, nextState.StateName));
-                    _nextState = default(State<TState, TData>);
+                    _nextState = default;
                 }
                 _currentState = nextState;
 


### PR DESCRIPTION
The `object.Equals` call here generated hundreds of mb in boxing allocations inside RemotePingPong - using the `EqualityComparer<TState>.Default.Equals` eliminates them.

(cherry picked from commit 183ec5ae1229b2948e1b18c2e90aa75eb52f8955)
