### PR TITLE
[BACKPORT #6230] Upgrade to Newtonsoft.Json 13.0.1 as minimum version 

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -14,7 +14,7 @@
     <XunitRunnerVersion>2.4.3</XunitRunnerVersion>
     <TestSdkVersion>17.0.0</TestSdkVersion>
     <HyperionVersion>0.12.2</HyperionVersion>
-    <NewtonsoftJsonVersion>[12.0.3,)</NewtonsoftJsonVersion>
+    <NewtonsoftJsonVersion>[13.0.1,)</NewtonsoftJsonVersion>
     <NBenchVersion>2.0.1</NBenchVersion>
     <ProtobufVersion>3.19.4</ProtobufVersion>
     <BenchmarkDotNetVersion>0.13.1</BenchmarkDotNetVersion>


### PR DESCRIPTION
Backport of #6230
(cherry picked from commit 5e66bf004d2286940d252ef82d6a08c32360899b)

