### PR TITLE
cleaned up duplicate System.Collections.Immutable package reference

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -28,6 +28,7 @@
     <HoconVersion>2.0.3</HoconVersion>
     <ConfigurationManagerVersion>6.0.1</ConfigurationManagerVersion>
     <MultiNodeAdapterVersion>1.1.1</MultiNodeAdapterVersion>
+    <MicrosoftLibVersion>5.0.0</MicrosoftLibVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -17,10 +17,9 @@
   <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.5" />
       <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-      <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-      <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
+      <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+      <PackageReference Include="System.Collections.Immutable" Version="$(MicrosoftLibVersion)" />
+      <PackageReference Include="System.Threading.Channels" Version="$(MicrosoftLibVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardLibVersion)'">


### PR DESCRIPTION
## Changes

Cleaned up duplicate System.Collections.Immutable package reference and also standardized all System.* packages on a common version.

N.B. - have not actually changed any of the versions being used, just sync'd them;.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).