### PR TITLE
Enable dynamic PGO for RemotePingPong and PingPong

### DIFF
--- a/src/benchmark/PingPong/PingPong.csproj
+++ b/src/benchmark/PingPong/PingPong.csproj
@@ -10,6 +10,11 @@
     <Content Include="App.config" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <TieredPGO>true</TieredPGO>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\core\Akka\Akka.csproj" />
   </ItemGroup>

--- a/src/benchmark/RemotePingPong/RemotePingPong.csproj
+++ b/src/benchmark/RemotePingPong/RemotePingPong.csproj
@@ -11,11 +11,8 @@
 </PropertyGroup>
 
 <PropertyGroup>
-  <PlatformTarget>x64</PlatformTarget>
-</PropertyGroup>
-
-<PropertyGroup>
   <ServerGarbageCollection>true</ServerGarbageCollection>
+  <TieredPGO>true</TieredPGO>
 </PropertyGroup>
 
 <ItemGroup>


### PR DESCRIPTION
## Changes

Enables dynamic PGO and server GC for both RemotePingPong and PingPong benchmarks.

I'm enabling these because I hope that it will be easier to measure small differences in performance when we're working on problems like https://github.com/akkadotnet/akka.net/pull/6195