### PR TITLE
[BACKPORT #6281] Add ReceiveAsync to TestActorRef

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/ExceptionHandling.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/ExceptionHandling.cs
@@ -1,0 +1,61 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ExceptionHandling.cs" company="Akka.NET Project">
+//      Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+using static FluentAssertions.FluentActions;
+
+namespace Akka.TestKit.Tests.TestActorRefTests
+{
+    public class ExceptionHandling: TestKit.Xunit2.TestKit
+    {
+        private class GiveError
+        { }
+
+        private class GiveErrorAsync
+        { }
+        
+        private class ExceptionActor : ReceiveActor
+        {
+            public ExceptionActor()
+            {
+                Receive<GiveError>((b) => throw new Exception("WAT"));
+
+                ReceiveAsync<GiveErrorAsync>(async (b) =>
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(0.1));
+                    throw new Exception("WATASYNC");
+                });
+            }
+        }
+
+        public ExceptionHandling(ITestOutputHelper helper) : base("akka.loglevel = debug", helper)
+        {
+        }
+        
+        [Fact]
+        public void GetException()
+        {
+            var props = Props.Create<ExceptionActor>();
+            var subject = new TestActorRef<ExceptionActor>(Sys, props, null, "testA");
+            Invoking(() => subject.Receive(new GiveError()))
+                .Should().Throw<Exception>().WithMessage("WAT");
+        }
+        
+        [Fact]
+        public async Task GetExceptionAsync()
+        {
+            var props = Props.Create<ExceptionActor>();
+            var subject = new TestActorRef<ExceptionActor>(Sys, props, null, "testB");
+            await Awaiting(() => subject.ReceiveAsync(new GiveErrorAsync()))
+                .Should().ThrowAsync<Exception>().WithMessage("WATASYNC");
+        }
+    }
+}

--- a/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
+++ b/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
@@ -298,7 +298,7 @@ namespace Akka.TestKit.Internal
             {
                 if (!_testActorTasks.TryGetValue(message, out var tcs)) 
                     return;
-                if (exception is { })
+                if (!(exception is null))
                     tcs.TrySetException(exception);
                 else
                     tcs.TrySetResult(Done.Instance);

--- a/src/core/Akka.TestKit/TestActorRefBase.cs
+++ b/src/core/Akka.TestKit/TestActorRefBase.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
@@ -51,6 +52,22 @@ namespace Akka.TestKit
             _internalRef.Receive(message, sender);
         }
 
+        /// <summary>
+        /// Directly inject messages into actor ReceiveAsync behavior. Any exceptions
+        /// thrown will be available to you, while still being able to use
+        /// become/unbecome.
+        /// Note: This method violates the actor model and could cause unpredictable 
+        /// behavior. For example, a Receive call to an actor could run simultaneously 
+        /// (2 simultaneous threads running inside the actor) with the actor's handling 
+        /// of a previous Tell call. 
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="sender">The sender.</param>
+        public Task ReceiveAsync(object message, IActorRef sender = null)
+        {
+            return _internalRef.ReceiveAsync(message, sender);
+        }
+        
         /// <summary>
         /// TBD
         /// </summary>


### PR DESCRIPTION
Backport of #6281

Fixes #6265

## Changes

- Add ReceiveAsync feature to Akka.TestKit TestActorRef
- Add IAsyncResultInterceptor interface to tap directly into ReceiveAsync execution result

(cherry-picked from 5605d8303f3e901b297d9dface7efce51e90d27b)