### PR TITLE
Fix `ConfigureAwait` issues inside `Ask<T>` and `ReceiveAsync`

### DIFF
--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -10,19 +10,22 @@ using Xunit;
 using Akka.Actor;
 using Akka.Actor.Dsl;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Nito.AsyncEx;
 using Akka.Dispatch.SysMsg;
+using Akka.TestKit.TestActors;
+using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor
 {
     public class AskSpec : AkkaSpec
     {
-        public AskSpec()
-            : base(@"akka.actor.ask-timeout = 3000ms")
+        public AskSpec(ITestOutputHelper outputHelper)
+            : base(@"akka.actor.ask-timeout = 3000ms", outputHelper)
         { }
 
         public class SomeActor : UntypedActor
@@ -109,6 +112,27 @@ namespace Akka.Tests.Actor
 
         public sealed class DummySystemMessage : ISystemMessage
         {
+        }
+
+        public sealed class AsyncAwaitActor : ReceiveActor
+        {
+            private readonly IActorRef _replyActor;
+            private readonly bool _configureAwait;
+
+            public AsyncAwaitActor(IActorRef replyActor, bool configureAwait)
+            {
+                _replyActor = replyActor;
+                _configureAwait = configureAwait;
+
+                ReceiveAsync<int>(async max =>
+                {
+                    foreach (var i in Enumerable.Range(0, max))
+                    {
+                        var count = await _replyActor.Ask<int>(i, TimeSpan.FromSeconds(1)).ConfigureAwait(configureAwait);
+                        Sender.Tell(count);
+                    }
+                });
+            }
         }
 
         [Fact]
@@ -320,6 +344,23 @@ namespace Akka.Tests.Actor
             var waitActor = Sys.ActorOf(Props.Create(() => new WaitActor(replyActor, TestActor)));
             waitActor.Tell("ask");
             ExpectMsg("bar");
+        }
+        
+        /// <summary>
+        /// Reproduction spec for https://github.com/akkadotnet/akka.net/issues/6279
+        /// </summary>
+        /// <param name="configureAwait">Input for actor's ConfigureAwait(bool)</param>
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Actor_should_Await_on_Ask_inside_receive_loop(bool configureAwait)
+        {
+            var count = 3;
+            var replyActor = Sys.ActorOf(act => { act.ReceiveAny((o, context) => context.Sender.Tell(o)); });
+            // create AsyncAwaitActor
+            var asyncAwaitActor = Sys.ActorOf(Props.Create(() => new AsyncAwaitActor(replyActor, configureAwait)));
+            asyncAwaitActor.Tell(count);
+            ReceiveN(count);
         }
     }
 }


### PR DESCRIPTION
## Changes

Added reproduction for https://github.com/akkadotnet/akka.net/issues/6279

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).