### PR TITLE
add simple actor telemetry

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
@@ -314,6 +314,13 @@ namespace Akka.Actor
         public static readonly Akka.Actor.IActorRef NoSender;
         public static readonly Akka.Actor.Nobody Nobody;
     }
+    public struct ActorRestarted : Akka.Actor.IActorTelemetryEvent, Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.INotInfluenceReceiveTimeout
+    {
+        public ActorRestarted(Akka.Actor.IActorRef subject, System.Type actorType, Akka.Actor.Reason reason) { }
+        public System.Type ActorType { get; }
+        public Akka.Actor.Reason Reason { get; }
+        public Akka.Actor.IActorRef Subject { get; }
+    }
     public class ActorSelection : Akka.Actor.ICanTell
     {
         public ActorSelection() { }
@@ -340,12 +347,24 @@ namespace Akka.Actor
         public Akka.Actor.ActorSelectionMessage Copy(object message = null, Akka.Actor.SelectionPathElement[] elements = null, System.Nullable<bool> wildCardFanOut = null) { }
         public override string ToString() { }
     }
+    public struct ActorStarted : Akka.Actor.IActorTelemetryEvent, Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.INotInfluenceReceiveTimeout
+    {
+        public ActorStarted(Akka.Actor.IActorRef subject, System.Type actorType) { }
+        public System.Type ActorType { get; }
+        public Akka.Actor.IActorRef Subject { get; }
+    }
     public class ActorStashPlugin : Akka.Actor.ActorProducerPluginBase
     {
         public ActorStashPlugin() { }
         public override void AfterIncarnated(Akka.Actor.ActorBase actor, Akka.Actor.IActorContext context) { }
         public override void BeforeIncarnated(Akka.Actor.ActorBase actor, Akka.Actor.IActorContext context) { }
         public override bool CanBeAppliedTo(System.Type actorType) { }
+    }
+    public struct ActorStopped : Akka.Actor.IActorTelemetryEvent, Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.INotInfluenceReceiveTimeout
+    {
+        public ActorStopped(Akka.Actor.IActorRef subject, System.Type actorType) { }
+        public System.Type ActorType { get; }
+        public Akka.Actor.IActorRef Subject { get; }
     }
     public abstract class ActorSystem : Akka.Actor.IActorRefFactory, System.IDisposable
     {
@@ -988,6 +1007,11 @@ namespace Akka.Actor
     {
         Akka.Actor.IStash Stash { get; set; }
     }
+    public interface IActorTelemetryEvent : Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.INotInfluenceReceiveTimeout
+    {
+        System.Type ActorType { get; }
+        Akka.Actor.IActorRef Subject { get; }
+    }
     public interface IAdvancedScheduler : Akka.Actor.IActionScheduler, Akka.Actor.IRunnableScheduler { }
     public interface IAutoReceivedMessage { }
     public interface ICanTell
@@ -1486,6 +1510,16 @@ namespace Akka.Actor
             public static readonly Akka.Actor.ProviderSelection.Remote Instance;
         }
     }
+    public sealed class Reason
+    {
+        public Reason(string type, string message = null) { }
+        public string Message { get; }
+        public string Type { get; }
+    }
+    public class static ReasonExtensions
+    {
+        public static Akka.Actor.Reason ToReason(this System.Exception ex) { }
+    }
     public delegate bool Receive(object message);
     public abstract class ReceiveActor : Akka.Actor.UntypedActor, Akka.Actor.Internal.IInitializableActor
     {
@@ -1682,6 +1716,7 @@ namespace Akka.Actor
         public bool DebugRouterMisconfiguration { get; }
         public bool DebugUnhandledMessage { get; }
         public int DefaultVirtualNodesFactor { get; }
+        public bool EmitActorTelemetry { get; }
         public bool FsmDebugEvent { get; }
         public bool HasCluster { get; }
         public string Home { get; }

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -449,6 +449,8 @@ namespace Akka.Actor
                 CheckReceiveTimeout();
                 if (System.Settings.DebugLifecycle)
                     Publish(new Debug(Self.Path.ToString(), created.GetType(), "Started (" + created + ")"));
+                if(System.Settings.EmitActorTelemetry)
+                    System.EventStream.Publish(new ActorStarted(Self, Props.Type));
             }
             catch (Exception e)
             {

--- a/src/core/Akka/Actor/ActorCell.FaultHandling.cs
+++ b/src/core/Akka/Actor/ActorCell.FaultHandling.cs
@@ -291,6 +291,9 @@ namespace Akka.Actor
                     var pipeline = _systemImpl.ActorPipelineResolver.ResolvePipeline(a.GetType());
                     pipeline.BeforeActorIncarnated(a, this);
                 }
+                
+                if(System.Settings.EmitActorTelemetry)
+                    System.EventStream.Publish(new ActorStopped(Self, Props.Type));
             }
             catch (Exception x)
             {
@@ -348,7 +351,9 @@ namespace Akka.Actor
 
                 if (System.Settings.DebugLifecycle)
                     Publish(new Debug(_self.Path.ToString(), freshActor.GetType(), "Restarted (" + freshActor + ")"));
-
+                if(System.Settings.EmitActorTelemetry)
+                    System.EventStream.Publish(new ActorRestarted(Self, Props.Type, cause.ToReason()));
+                
                 // only after parent is up and running again do restart the children which were not stopped
                 foreach (var survivingChild in survivors)
                 {
@@ -382,8 +387,7 @@ namespace Akka.Actor
             //the UID protects against reception of a Failed from a child which was
             //killed in preRestart and re-created in postRestart
 
-            ChildRestartStats childStats;
-            if (TryGetChildStatsByRef(failedChild, out childStats))
+            if (TryGetChildStatsByRef(failedChild, out var childStats))
             {
                 var statsUid = childStats.Child.Path.Uid;
                 if (statsUid == f.Uid)
@@ -429,8 +433,7 @@ namespace Akka.Actor
 
             // if the removal changed the state of the (terminating) children container,
             // then we are continuing the previously suspended recreate/create/terminate action
-            var recreation = status as SuspendReason.Recreation;
-            if (recreation != null)
+            if (status is SuspendReason.Recreation recreation)
             {
                 FinishRecreate(recreation.Cause, _actor);
             }

--- a/src/core/Akka/Actor/ActorTelemetry.cs
+++ b/src/core/Akka/Actor/ActorTelemetry.cs
@@ -1,0 +1,104 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ActorTelemetry.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Event;
+
+namespace Akka.Actor
+{
+    /// <summary>
+    /// A set of events designed to provide some basic telemetry functions for monitoring actor lifecycles.
+    ///
+    /// We want to track actor starts, stops, and restarts. More detailed metrics, such as mailbox size or message
+    /// processing rates will require something like Phobos [https://phobos.petabridge.com/].
+    /// </summary>
+    /// <remarks>
+    /// Not intended to be sent across network boundaries - should only be processed locally via the <see cref="EventStream"/>.
+    /// </remarks>
+    public interface IActorTelemetryEvent : INoSerializationVerificationNeeded, INotInfluenceReceiveTimeout
+    {
+        /// <summary>
+        /// The actor who emitted this event.
+        /// </summary>
+        IActorRef Subject {get;}
+        
+        /// <summary>
+        /// The implementation type for this actor.
+        /// </summary>
+        Type ActorType { get; }
+    }
+    
+    // Create ActorTelemetryEvent messages for the following events: starting an actor, stopping an actor, restarting an actor
+    public readonly struct ActorStarted : IActorTelemetryEvent
+    {
+        public ActorStarted(IActorRef subject, Type actorType)
+        {
+            Subject = subject;
+            ActorType = actorType;
+        }
+
+        public IActorRef Subject { get; }
+        public Type ActorType { get; }
+    }
+    
+    /// <summary>
+    /// Reason for stopping or restarting.
+    /// </summary>
+    public sealed class Reason
+    {
+        public Reason(string type, string message = null)
+        {
+            Type = type;
+            Message = message ?? string.Empty;
+        }
+
+        public string Type { get; }
+
+        public string Message { get; }
+    }
+
+    public static class ReasonExtensions
+    {
+        public static Reason ToReason(this Exception ex)
+        {
+            return new Reason(ex.GetType().Name, ex.Message);
+        }
+    }
+    
+    /// <summary>
+    /// Event emitted when actor shuts down.
+    /// </summary>
+    public readonly struct ActorStopped : IActorTelemetryEvent
+    {
+        public ActorStopped(IActorRef subject, Type actorType)
+        {
+            Subject = subject;
+            ActorType = actorType;
+        }
+
+        public IActorRef Subject { get; }
+        public Type ActorType { get; }
+    }
+    
+    /// <summary>
+    /// Emitted when an actor restarts.
+    /// </summary>
+    public readonly struct ActorRestarted : IActorTelemetryEvent
+    {
+        public ActorRestarted(IActorRef subject, Type actorType, Reason reason)
+        {
+            Subject = subject;
+            ActorType = actorType;
+            Reason = reason;
+        }
+
+        public IActorRef Subject { get; }
+        public Type ActorType { get; }
+        
+        public Reason Reason { get; }
+    }
+}

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -107,6 +107,7 @@ namespace Akka.Actor
 
             SerializeAllMessages = Config.GetBoolean("akka.actor.serialize-messages", false);
             SerializeAllCreators = Config.GetBoolean("akka.actor.serialize-creators", false);
+            EmitActorTelemetry = Config.GetBoolean("akka.actor.telemetry.enabled", false);
 
             LogLevel = Config.GetString("akka.loglevel", null);
             StdoutLogLevel = Config.GetString("akka.stdout-loglevel", null);
@@ -242,6 +243,17 @@ namespace Akka.Actor
         /// </summary>
         /// <value><c>true</c> if [serialize all creators]; otherwise, <c>false</c>.</value>
         public bool SerializeAllCreators { get; private set; }
+        
+        /// <summary>
+        /// When set to <c>true</c>, all actors will emit <see cref="IActorTelemetryEvent"/>s when they are created, stopped, or restarted.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <c>false</c>.
+        /// </remarks>
+        /// <code>
+        /// akka.actor.telemetry.enabled = on
+        /// </code>
+        public bool EmitActorTelemetry { get; }
 
         /// <summary>
         ///     Gets the default timeout for <see cref="Futures.Ask(ICanTell, object, TimeSpan?)">Futures.Ask</see> calls.

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -118,6 +118,12 @@ akka {
     # Default timeout for IActorRef.Ask.
     ask-timeout = infinite
 
+    # Controls telemetry settings built into Akka.NET
+    telemetry{
+      # Enables telemetry emission from actors - actors will emit events
+      # whenever they are started, stopped, or restarted.
+      enabled = false
+    }
 
     # THIS DOES NOT APPLY TO .NET
     #


### PR DESCRIPTION
## Changes

Fixes #6293

This is an initial implementation designed to provide basic actor start / stop / restart telemetry for keeping track of the number of alive actor instances in a given Akka.NET process. We have plans to use this in both [Petabridge.Cmd](https://cmd.petabridge.com/) and [Phobos](https://phobos.petabridge.com/) to improve observability experiences for users.

This design relies on publishing simple, lightweight events via the `EventStream` to listeners that subscriber to those events in-process. These metrics are not enabled by default and must be explicitly enabled via the following HOCON setting:

```hocon
akka.actor.telemetry.enabled = true
```

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #6293 
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

__Need to run actor spawn benchmarks with this setting enabled and not enabled__

### This PR's Benchmarks

Include data from after this change here.
