### PR TITLE
[Backports #6290] Akka:Streams Resolve `IAsyncEnumerator.DisposeAsync` bug

### DIFF
--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>Akka.Streams.Tests</AssemblyName>
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Streams/Akka.Streams.csproj
+++ b/src/core/Akka.Streams/Akka.Streams.csproj
@@ -7,7 +7,7 @@
         <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
         <PackageTags>$(AkkaPackageTags);reactive;stream</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <LangVersion>8.0</LangVersion>
+        <LangVersion>9</LangVersion>
     </PropertyGroup>
     <ItemGroup>
         <EmbeddedResource Include="reference.conf" />

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -3871,20 +3871,8 @@ namespace Akka.Streams.Implementation.Fusing
             {
                 _completionCts.Cancel();
                 _completionCts.Dispose();
-
-                try
-                {
-                    _enumerator.DisposeAsync().GetAwaiter().GetResult();
-                }
-                catch (Exception ex)
-                {
-                    Log.Warning(ex, "Failed to dispose IAsyncEnumerator asynchronously");
-                }
-                finally
-                {
-                    CompleteStage();
-                    base.OnDownstreamFinish(cause);
-                }
+                CompleteStage();
+                base.OnDownstreamFinish();
             }
 
         }

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -3872,7 +3872,7 @@ namespace Akka.Streams.Implementation.Fusing
                 _completionCts.Cancel();
                 _completionCts.Dispose();
                 CompleteStage();
-                base.OnDownstreamFinish();
+                base.OnDownstreamFinish(cause);
             }
 
         }


### PR DESCRIPTION
Backports #6290
Fixes #6280

We no longer attempt to dispose IAsyncEnumerators inside Source stages due to the reasons outlined here: #6280 (comment)

This prevents the log from being filled with NotSupportedException warnings from failed DisposeAsync operations.

(cherry-picked from 3156272a480db1ee0faa80555695757c702a2dcd)