### PR TITLE
Added support for `UnrestrictedStash`

### DIFF
--- a/docs/articles/actors/receive-actor-api.md
+++ b/docs/articles/actors/receive-actor-api.md
@@ -790,12 +790,15 @@ static void Main(string[] args)
 
 ## Stash
 
-The `IWithUnboundedStash` interface enables an actor to temporarily stash away messages that can not or should not be handled using the actor's current behavior. Upon changing the actor's message handler, i.e., right before invoking `Context.BecomeStacked()` or `Context.UnbecomeStacked()`;, all stashed messages can be "un-stashed", thereby prepending them to the actor's mailbox. This way, the stashed messages can be processed in the same order as they have been received originally. An actor that implements `IWithUnboundedStash` will automatically get a dequeue-based mailbox.
+The `IWithStash` interface enables an actor to temporarily stash away messages that can not or should not be handled using the actor's current behavior. Upon changing the actor's message handler, i.e., right before invoking `Context.Become()` or `Context.Unbecome()`, all stashed messages can be "un-stashed", thereby prepending them to the actor's mailbox. This way, the stashed messages can be processed in the same order as they have been received originally.
 
-Here is an example of the `IWithUnboundedStash` interface in action:
+> [!NOTE]
+> The interface `IWithStash` implements the marker interface `IRequiresMessageQueue<IDequeBasedMessageQueueSemantics>` which requests the system to automatically choose a deque-based mailbox implementation for the actor (defaults to an unbounded deque mailbox). If you want more control over the mailbox, see the documentation on mailboxes: [Mailboxes](xref:mailboxes).
+
+Here is an example of the `IWithStash` interface in action:
 
 ```csharp
-public class ActorWithProtocol : ReceiveActor, IWithUnboundedStash
+public class ActorWithProtocol : ReceiveActor, IWithStash
 {
     public IStash Stash { get; set; }
 
@@ -827,11 +830,18 @@ public class ActorWithProtocol : ReceiveActor, IWithUnboundedStash
 }
 ```
 
-Invoking `Stash()` adds the current message (the message that the actor received last) to the actor's stash. It is typically invoked when handling the default case in the actor's message handler to stash messages that aren't handled by the other cases. It is illegal to stash the same message twice; to do so results in an `IllegalStateException` being thrown. The stash may also be bounded in which case invoking `Stash()` may lead to a capacity violation, which results in a `StashOverflowException`. The capacity of the stash can be configured using the stash-capacity setting (an `Int`) of the mailbox's configuration.
+Invoking `Stash()` adds the current message (the message that the actor received last) to the actor's stash. It is typically invoked when handling the default case in the actor's message handler to stash messages that aren't handled by the other cases. It is illegal to stash the same message twice; to do so results in an `IllegalStateException` being thrown. The stash may also be bounded in which case invoking `Stash()` may lead to a capacity violation, which results in a `StashOverflowException`. The capacity of the stash can be configured using the stash-capacity setting (an `int`) of the mailbox's configuration.
 
 Invoking `UnstashAll()` enqueues messages from the stash to the actor's mailbox until the capacity of the mailbox (if any) has been reached (note that messages from the stash are prepended to the mailbox). In case a bounded mailbox overflows, a `MessageQueueAppendFailedException` is thrown. The stash is guaranteed to be empty after calling `UnstashAll()`.
 
-Note that the `stash` is part of the ephemeral actor state, unlike the mailbox. Therefore, it should be managed like other parts of the actor's state which have the same property. The `IWithUnboundedStash` interface implementation of `PreRestart` will call `UnstashAll()`, which is usually the desired behavior.
+Note that the stash is part of the ephemeral actor state, unlike the mailbox. Therefore, it should be managed like other parts of the actor's state which have the same property.
+
+However, the `IWithStash` interface implementation of `PreRestart` will call `UnstashAll()`. This means that before the actor restarts, it will transfer all stashed messages back to the actor’s mailbox.
+
+The result of this is that when an actor is restarted, any stashed messages will be delivered to the new incarnation of the actor. This is usually the desired behavior.
+
+> [!NOTE]
+> If you want to enforce that your actor can only work with an unbounded stash, then you should use the `IWithUnboundedStash` interface instead.
 
 ## Killing an Actor
 

--- a/docs/cSpell.json
+++ b/docs/cSpell.json
@@ -26,6 +26,7 @@
         "CRDT",
         "datacenter",
         "denormalization",
+        "deque",
         "deserialization",
         "downstream",
         "downstreams",

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
@@ -1178,14 +1178,15 @@ namespace Akka.Actor
         void Become(Akka.Actor.UntypedReceive receive);
         void BecomeStacked(Akka.Actor.UntypedReceive receive);
     }
-    [System.ObsoleteAttribute("Bounded stashing is not yet implemented. Unbounded stashing will be used instead " +
-        "[0.7.0]")]
-    public interface IWithBoundedStash : Akka.Actor.IActorStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics> { }
+    [System.ObsoleteAttribute("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
+    public interface IWithBoundedStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics> { }
+    public interface IWithStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IDequeBasedMessageQueueSemantics> { }
     public interface IWithTimers
     {
         Akka.Actor.ITimerScheduler Timers { get; set; }
     }
-    public interface IWithUnboundedStash : Akka.Actor.IActorStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics> { }
+    public interface IWithUnboundedStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics> { }
+    public interface IWithUnrestrictedStash : Akka.Actor.IActorStash { }
     public interface IWrappedMessage
     {
         object Message { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -1180,14 +1180,15 @@ namespace Akka.Actor
         void Become(Akka.Actor.UntypedReceive receive);
         void BecomeStacked(Akka.Actor.UntypedReceive receive);
     }
-    [System.ObsoleteAttribute("Bounded stashing is not yet implemented. Unbounded stashing will be used instead " +
-        "[0.7.0]")]
-    public interface IWithBoundedStash : Akka.Actor.IActorStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics> { }
+    [System.ObsoleteAttribute("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
+    public interface IWithBoundedStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics> { }
+    public interface IWithStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IDequeBasedMessageQueueSemantics> { }
     public interface IWithTimers
     {
         Akka.Actor.ITimerScheduler Timers { get; set; }
     }
-    public interface IWithUnboundedStash : Akka.Actor.IActorStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics> { }
+    public interface IWithUnboundedStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics> { }
+    public interface IWithUnrestrictedStash : Akka.Actor.IActorStash { }
     public interface IWrappedMessage
     {
         object Message { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -1178,14 +1178,15 @@ namespace Akka.Actor
         void Become(Akka.Actor.UntypedReceive receive);
         void BecomeStacked(Akka.Actor.UntypedReceive receive);
     }
-    [System.ObsoleteAttribute("Bounded stashing is not yet implemented. Unbounded stashing will be used instead " +
-        "[0.7.0]")]
-    public interface IWithBoundedStash : Akka.Actor.IActorStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics> { }
+    [System.ObsoleteAttribute("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
+    public interface IWithBoundedStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics> { }
+    public interface IWithStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IDequeBasedMessageQueueSemantics> { }
     public interface IWithTimers
     {
         Akka.Actor.ITimerScheduler Timers { get; set; }
     }
-    public interface IWithUnboundedStash : Akka.Actor.IActorStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics> { }
+    public interface IWithUnboundedStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics> { }
+    public interface IWithUnrestrictedStash : Akka.Actor.IActorStash { }
     public interface IWrappedMessage
     {
         object Message { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Core.verified.txt
@@ -209,7 +209,7 @@ namespace Akka.Persistence
     {
         public static Akka.Persistence.DiscardToDeadLetterStrategy Instance { get; }
     }
-    public abstract class Eventsourced : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>, Akka.Persistence.IPersistenceRecovery, Akka.Persistence.IPersistenceStash, Akka.Persistence.IPersistentIdentity
+    public abstract class Eventsourced : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>, Akka.Persistence.IPersistenceRecovery, Akka.Persistence.IPersistenceStash, Akka.Persistence.IPersistentIdentity
     {
         public static readonly System.Func<Akka.Actor.Envelope, bool> UnstashFilterPredicate;
         protected Eventsourced() { }
@@ -270,7 +270,7 @@ namespace Akka.Persistence
     {
         Akka.Persistence.Recovery Recovery { get; }
     }
-    public interface IPersistenceStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public interface IPersistenceStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         Akka.Persistence.IStashOverflowStrategy InternalStashOverflowStrategy { get; }
     }
@@ -844,7 +844,7 @@ namespace Akka.Persistence.Journal
         protected System.Exception TryUnwrapException(System.Exception e) { }
         protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages);
     }
-    public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected AsyncWriteProxy() { }
         public Akka.Actor.IStash Stash { get; set; }
@@ -980,7 +980,7 @@ namespace Akka.Persistence.Journal
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Update(string pid, long seqNr, System.Func<Akka.Persistence.IPersistentRepresentation, Akka.Persistence.IPersistentRepresentation> updater) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
     }
-    public class PersistencePluginProxy : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public class PersistencePluginProxy : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         public PersistencePluginProxy(Akka.Configuration.Config config) { }
         public Akka.Actor.IStash Stash { get; set; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -209,7 +209,7 @@ namespace Akka.Persistence
     {
         public static Akka.Persistence.DiscardToDeadLetterStrategy Instance { get; }
     }
-    public abstract class Eventsourced : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>, Akka.Persistence.IPersistenceRecovery, Akka.Persistence.IPersistenceStash, Akka.Persistence.IPersistentIdentity
+    public abstract class Eventsourced : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>, Akka.Persistence.IPersistenceRecovery, Akka.Persistence.IPersistenceStash, Akka.Persistence.IPersistentIdentity
     {
         public static readonly System.Func<Akka.Actor.Envelope, bool> UnstashFilterPredicate;
         protected Eventsourced() { }
@@ -270,7 +270,7 @@ namespace Akka.Persistence
     {
         Akka.Persistence.Recovery Recovery { get; }
     }
-    public interface IPersistenceStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public interface IPersistenceStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         Akka.Persistence.IStashOverflowStrategy InternalStashOverflowStrategy { get; }
     }
@@ -844,7 +844,7 @@ namespace Akka.Persistence.Journal
         protected System.Exception TryUnwrapException(System.Exception e) { }
         protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages);
     }
-    public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected AsyncWriteProxy() { }
         public Akka.Actor.IStash Stash { get; set; }
@@ -980,7 +980,7 @@ namespace Akka.Persistence.Journal
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Update(string pid, long seqNr, System.Func<Akka.Persistence.IPersistentRepresentation, Akka.Persistence.IPersistentRepresentation> updater) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
     }
-    public class PersistencePluginProxy : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public class PersistencePluginProxy : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         public PersistencePluginProxy(Akka.Configuration.Config config) { }
         public Akka.Actor.IStash Stash { get; set; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -209,7 +209,7 @@ namespace Akka.Persistence
     {
         public static Akka.Persistence.DiscardToDeadLetterStrategy Instance { get; }
     }
-    public abstract class Eventsourced : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>, Akka.Persistence.IPersistenceRecovery, Akka.Persistence.IPersistenceStash, Akka.Persistence.IPersistentIdentity
+    public abstract class Eventsourced : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>, Akka.Persistence.IPersistenceRecovery, Akka.Persistence.IPersistenceStash, Akka.Persistence.IPersistentIdentity
     {
         public static readonly System.Func<Akka.Actor.Envelope, bool> UnstashFilterPredicate;
         protected Eventsourced() { }
@@ -270,7 +270,7 @@ namespace Akka.Persistence
     {
         Akka.Persistence.Recovery Recovery { get; }
     }
-    public interface IPersistenceStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public interface IPersistenceStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         Akka.Persistence.IStashOverflowStrategy InternalStashOverflowStrategy { get; }
     }
@@ -844,7 +844,7 @@ namespace Akka.Persistence.Journal
         protected System.Exception TryUnwrapException(System.Exception e) { }
         protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages);
     }
-    public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected AsyncWriteProxy() { }
         public Akka.Actor.IStash Stash { get; set; }
@@ -980,7 +980,7 @@ namespace Akka.Persistence.Journal
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Update(string pid, long seqNr, System.Func<Akka.Persistence.IPersistentRepresentation, Akka.Persistence.IPersistentRepresentation> updater) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
     }
-    public class PersistencePluginProxy : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public class PersistencePluginProxy : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         public PersistencePluginProxy(Akka.Configuration.Config config) { }
         public Akka.Actor.IStash Stash { get; set; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Core.verified.txt
@@ -272,7 +272,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         public long Offset { get; }
         public Akka.Actor.IActorRef ReplyTo { get; }
     }
-    public abstract class SqlJournal : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public abstract class SqlJournal : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected SqlJournal(Akka.Configuration.Config journalConfig) { }
         protected bool HasNewEventSubscribers { get; }
@@ -424,7 +424,7 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         public readonly System.DateTime Timestamp;
         public SnapshotEntry(string persistenceId, long sequenceNr, System.DateTime timestamp, string manifest, object payload) { }
     }
-    public abstract class SqlSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public abstract class SqlSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected SqlSnapshotStore(Akka.Configuration.Config config) { }
         protected Akka.Event.ILoggingAdapter Log { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.DotNet.verified.txt
@@ -272,7 +272,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         public long Offset { get; }
         public Akka.Actor.IActorRef ReplyTo { get; }
     }
-    public abstract class SqlJournal : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public abstract class SqlJournal : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected SqlJournal(Akka.Configuration.Config journalConfig) { }
         protected bool HasNewEventSubscribers { get; }
@@ -424,7 +424,7 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         public readonly System.DateTime Timestamp;
         public SnapshotEntry(string persistenceId, long sequenceNr, System.DateTime timestamp, string manifest, object payload) { }
     }
-    public abstract class SqlSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public abstract class SqlSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected SqlSnapshotStore(Akka.Configuration.Config config) { }
         protected Akka.Event.ILoggingAdapter Log { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Net.verified.txt
@@ -272,7 +272,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         public long Offset { get; }
         public Akka.Actor.IActorRef ReplyTo { get; }
     }
-    public abstract class SqlJournal : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public abstract class SqlJournal : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected SqlJournal(Akka.Configuration.Config journalConfig) { }
         protected bool HasNewEventSubscribers { get; }
@@ -424,7 +424,7 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         public readonly System.DateTime Timestamp;
         public SnapshotEntry(string persistenceId, long sequenceNr, System.DateTime timestamp, string manifest, object payload) { }
     }
-    public abstract class SqlSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    public abstract class SqlSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected SqlSnapshotStore(Akka.Configuration.Config config) { }
         protected Akka.Event.ILoggingAdapter Log { get; }

--- a/src/core/Akka/Actor/Stash/IWithBoundedStash.cs
+++ b/src/core/Akka/Actor/Stash/IWithBoundedStash.cs
@@ -17,8 +17,8 @@ namespace Akka.Actor
     /// <code>public IStash Stash { get; set; }</code>
     /// </summary>
     // ReSharper disable once InconsistentNaming
-    [Obsolete("Bounded stashing is not yet implemented. Unbounded stashing will be used instead [0.7.0]")]
-    public interface IWithBoundedStash : IActorStash, IRequiresMessageQueue<IBoundedDequeBasedMessageQueueSemantics>
+    [Obsolete("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
+    public interface IWithBoundedStash : IWithUnrestrictedStash, IRequiresMessageQueue<IBoundedDequeBasedMessageQueueSemantics>
     { }
 }
 

--- a/src/core/Akka/Actor/Stash/IWithStash.cs
+++ b/src/core/Akka/Actor/Stash/IWithStash.cs
@@ -1,0 +1,37 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IWithUnboundedStash.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Dispatch;
+
+namespace Akka.Actor
+{
+    /// <summary>
+    /// The `IWithStash` interface enables an actor to temporarily stash away messages that can not or
+    /// should not be handled using the actor's current behavior. 
+    /// <para>
+    /// Note that the `IWithStash` interface can only be used together with actors that have a deque-based
+    /// mailbox. By default Stash based actors request a Deque based mailbox since the stash
+    /// interface extends <see cref="IRequiresMessageQueue{T}"/>.
+    /// </para>
+    /// You can override the default mailbox provided when `IDequeBasedMessageQueueSemantics` are requested via config:
+    /// <code>
+    /// akka.actor.mailbox.requirements {
+    ///     "Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics" = your-custom-mailbox
+    /// }
+    /// </code>
+    /// Alternatively, you can add your own requirement marker to the actor and configure a mailbox type to be used
+    /// for your marker.
+    /// <para>
+    /// For a `Stash` that also enforces unboundedness of the deque see <see cref="IWithUnboundedStash"/>. For a `Stash`
+    /// that does not enforce any mailbox type see <see cref="IWithUnrestrictedStash"/>.
+    /// </para>
+    /// </summary>
+    public interface IWithStash : IWithUnrestrictedStash, IRequiresMessageQueue<IDequeBasedMessageQueueSemantics>
+    {
+    }
+}
+

--- a/src/core/Akka/Actor/Stash/IWithUnrestrictedStash.cs
+++ b/src/core/Akka/Actor/Stash/IWithUnrestrictedStash.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="IWithUnboundedStash.cs" company="Akka.NET Project">
+// <copyright file="IWithUnrestrictedStash.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -10,11 +10,10 @@ using Akka.Dispatch;
 namespace Akka.Actor
 {
     /// <summary>
-    /// The `IWithUnboundedStash` interface is a version of <see cref="IActorStash"/> that enforces an unbounded stash for you actor.
+    /// A version of <see cref="IActorStash"/> that does not enforce any mailbox type. The proper mailbox has to be configured
+    /// manually, and the mailbox should extend the <see cref="IDequeBasedMessageQueueSemantics"/> marker interface.
     /// </summary>
-    // ReSharper disable once InconsistentNaming
-    public interface IWithUnboundedStash : IWithUnrestrictedStash, IRequiresMessageQueue<IUnboundedDequeBasedMessageQueueSemantics>
-    {
+    public interface IWithUnrestrictedStash : IActorStash
+    { 
     }
 }
-

--- a/src/core/Akka/Actor/Stash/Internal/AbstractStash.cs
+++ b/src/core/Akka/Actor/Stash/Internal/AbstractStash.cs
@@ -19,7 +19,7 @@ namespace Akka.Actor.Internal
     /// INTERNAL API
     /// <para>
     /// Support class for implementing a stash for an actor instance. A default stash per actor (= user stash)
-    /// is maintained by [[UnrestrictedStash]] by extending this trait. Actors that explicitly need other stashes
+    /// is maintained by this class. Actors that explicitly need other stashes
     /// (optionally in addition to and isolated from the user stash) can create new stashes via <see cref="StashFactory"/>.
     /// </para>
     /// </summary>

--- a/src/core/Akka/Actor/Stash/Internal/UnrestrictedStashImpl.cs
+++ b/src/core/Akka/Actor/Stash/Internal/UnrestrictedStashImpl.cs
@@ -1,0 +1,16 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="UnrestrictedStashImpl.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Akka.Actor.Internal
+{
+    internal class UnrestrictedStashImpl : AbstractStash
+    {
+        public UnrestrictedStashImpl(IActorContext context)
+            : base(context)
+        { }
+    }
+}

--- a/src/core/Akka/Actor/Stash/StashFactory.cs
+++ b/src/core/Akka/Actor/Stash/StashFactory.cs
@@ -22,7 +22,7 @@ namespace Akka.Actor
         /// <typeparam name="T">TBD</typeparam>
         /// <param name="context">TBD</param>
         /// <returns>TBD</returns>
-        public static IStash CreateStash<T>(this IActorContext context) where T:ActorBase
+        public static IStash CreateStash<T>(this IActorContext context) where T : ActorBase
         {
             var actorType = typeof(T);
             return CreateStash(context, actorType);
@@ -34,10 +34,8 @@ namespace Akka.Actor
         /// <param name="context">TBD</param>
         /// <param name="actorInstance">TBD</param>
         /// <returns>TBD</returns>
-        public static IStash CreateStash(this IActorContext context, IActorStash actorInstance)
-        {
-            return CreateStash(context, actorInstance.GetType());
-        }
+        public static IStash CreateStash(this IActorContext context, IActorStash actorInstance) =>
+            CreateStash(context, actorInstance.GetType());
 
         /// <summary>
         /// TBD
@@ -50,15 +48,14 @@ namespace Akka.Actor
         /// <returns>TBD</returns>
         public static IStash CreateStash(this IActorContext context, Type actorType)
         {
-            if(actorType.Implements<IWithBoundedStash>())
-            {
+            if (actorType.Implements<IWithBoundedStash>())
                 return new BoundedStashImpl(context);
-            }
 
-            if(actorType.Implements<IWithUnboundedStash>())
-            {
+            if (actorType.Implements<IWithUnboundedStash>())
                 return new UnboundedStashImpl(context);
-            }
+
+            if (actorType.Implements<IWithUnrestrictedStash>())
+                return new UnrestrictedStashImpl(context);
 
             throw new ArgumentException($"Actor {actorType} implements an unrecognized subclass of {typeof(IActorStash)} - cannot instantiate", nameof(actorType));
         }

--- a/src/core/Akka/Dispatch/IRequiresMessageQueue.cs
+++ b/src/core/Akka/Dispatch/IRequiresMessageQueue.cs
@@ -5,17 +5,22 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using Akka.Actor;
-using Akka.Dispatch.MessageQueues;
-
 namespace Akka.Dispatch
 {
     /// <summary>
-    /// Used to help give hints to the <see cref="ActorSystem"/> as to what types of <see cref="IMessageQueue"/> this
-    /// actor requires. Used mostly for system actors.
+    /// Interface to signal that an Actor requires a certain type of message queue semantics.
+    /// <para>
+    /// The mailbox type will be looked up by mapping the type T via <c>akka.actor.mailbox.requirements</c> in the config,
+    /// to a mailbox configuration. If no mailbox is assigned on Props or in deployment config then this one will be used.
+    /// </para>
+    /// <para>
+    /// The queue type of the created mailbox will be checked against the type T and actor creation will fail if it doesn't
+    /// fulfill the requirements.
+    /// </para>
     /// </summary>
     /// <typeparam name="T">The type of <see cref="ISemantics"/> required</typeparam>
-    public interface IRequiresMessageQueue<T> where T:ISemantics
+    public interface IRequiresMessageQueue<T> 
+        where T : ISemantics
     {
     }
 }


### PR DESCRIPTION
Currently, once you've marked your actor with any of the Stash interfaces (`IWithUnboundedStash` or `IWithBoundedStash`) there's no way to change it afterward via configuration (it is a design-time operation that requires recompiling).

But there are two traits that allow users to do that in the JVM:

- A default `Stash` trait (`IWithStash` in this PR) which allows using any Deque-based mailbox (i.e., bounded or unbounded) via configuration. By default, it uses an UnboundedDeque mailbox, so it is akin to the current `IWithUnboundedStash` if you don't specify a custom mailbox type.

- `UnrestrictedStash` trait, which does not enforce any mailbox type. The proper mailbox *must* be configured
manually.

## Checklist

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [X] Changes in public API reviewed, if any.
* [X] I have added website documentation for this feature.