### PR TITLE
Add API for UntypedActorWithStash types

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
@@ -1865,6 +1865,21 @@ namespace Akka.Actor
         protected void RunTask(System.Action action) { }
         protected void RunTask(System.Func<System.Threading.Tasks.Task> action) { }
     }
+    public abstract class UntypedActorWithStash : Akka.Actor.UntypedActor, Akka.Actor.IActorStash, Akka.Actor.IWithStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IDequeBasedMessageQueueSemantics>
+    {
+        protected UntypedActorWithStash() { }
+        public Akka.Actor.IStash Stash { get; set; }
+    }
+    public abstract class UntypedActorWithUnboundedStash : Akka.Actor.UntypedActor, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    {
+        protected UntypedActorWithUnboundedStash() { }
+        public Akka.Actor.IStash Stash { get; set; }
+    }
+    public abstract class UntypedActorWithUnrestrictedStash : Akka.Actor.UntypedActor, Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash
+    {
+        protected UntypedActorWithUnrestrictedStash() { }
+        public Akka.Actor.IStash Stash { get; set; }
+    }
     public delegate void UntypedReceive(object message);
     public class static WrappedMessage
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -1867,6 +1867,21 @@ namespace Akka.Actor
         protected void RunTask(System.Action action) { }
         protected void RunTask(System.Func<System.Threading.Tasks.Task> action) { }
     }
+    public abstract class UntypedActorWithStash : Akka.Actor.UntypedActor, Akka.Actor.IActorStash, Akka.Actor.IWithStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IDequeBasedMessageQueueSemantics>
+    {
+        protected UntypedActorWithStash() { }
+        public Akka.Actor.IStash Stash { get; set; }
+    }
+    public abstract class UntypedActorWithUnboundedStash : Akka.Actor.UntypedActor, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    {
+        protected UntypedActorWithUnboundedStash() { }
+        public Akka.Actor.IStash Stash { get; set; }
+    }
+    public abstract class UntypedActorWithUnrestrictedStash : Akka.Actor.UntypedActor, Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash
+    {
+        protected UntypedActorWithUnrestrictedStash() { }
+        public Akka.Actor.IStash Stash { get; set; }
+    }
     public delegate void UntypedReceive(object message);
     public class static WrappedMessage
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -1865,6 +1865,21 @@ namespace Akka.Actor
         protected void RunTask(System.Action action) { }
         protected void RunTask(System.Func<System.Threading.Tasks.Task> action) { }
     }
+    public abstract class UntypedActorWithStash : Akka.Actor.UntypedActor, Akka.Actor.IActorStash, Akka.Actor.IWithStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IDequeBasedMessageQueueSemantics>
+    {
+        protected UntypedActorWithStash() { }
+        public Akka.Actor.IStash Stash { get; set; }
+    }
+    public abstract class UntypedActorWithUnboundedStash : Akka.Actor.UntypedActor, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
+    {
+        protected UntypedActorWithUnboundedStash() { }
+        public Akka.Actor.IStash Stash { get; set; }
+    }
+    public abstract class UntypedActorWithUnrestrictedStash : Akka.Actor.UntypedActor, Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash
+    {
+        protected UntypedActorWithUnrestrictedStash() { }
+        public Akka.Actor.IStash Stash { get; set; }
+    }
     public delegate void UntypedReceive(object message);
     public class static WrappedMessage
     {

--- a/src/core/Akka/Actor/UntypedActorWithStash.cs
+++ b/src/core/Akka/Actor/UntypedActorWithStash.cs
@@ -1,0 +1,59 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="UntypedActorWithStash.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2022 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Dispatch;
+
+namespace Akka.Actor
+{
+    /// <summary>
+    /// Actor base class that should be extended to create an actor with a stash.
+    /// <para>
+    /// The stash enables an actor to temporarily stash away messages that can not or
+    /// should not be handled using the actor's current behavior.
+    /// </para>
+    /// <para>
+    /// Note that the subclasses of `UntypedActorWithStash` by default request a Deque based mailbox since this class
+    /// implements the <see cref="IRequiresMessageQueue{T}"/> marker interface.
+    /// </para>
+    /// You can override the default mailbox provided when `IDequeBasedMessageQueueSemantics` are requested via config:
+    /// <code>
+    /// akka.actor.mailbox.requirements {
+    ///     "Akka.Dispatch.IDequeBasedMessageQueueSemantics" = your-custom-mailbox
+    /// }
+    /// </code>
+    /// Alternatively, you can add your own requirement marker to the actor and configure a mailbox type to be used
+    /// for your marker.
+    /// <para>
+    /// For a `Stash` based actor that enforces unbounded  deques see <see cref="UntypedActorWithUnboundedStash"/>.
+    /// There is also an unrestricted version <see cref="UntypedActorWithUnrestrictedStash"/> that does not
+    /// enforce the mailbox type.
+    /// </para>
+    /// </summary>
+    public abstract class UntypedActorWithStash : UntypedActor, IWithStash
+    {
+        public IStash Stash { get; set; }
+    }
+
+    /// <summary>
+    /// Actor base class with `Stash` that enforces an unbounded deque for the actor.
+    /// See <see cref="UntypedActorWithStash"/> for details on how `Stash` works.
+    /// </summary>
+    public abstract class UntypedActorWithUnboundedStash : UntypedActor, IWithUnboundedStash
+    {
+        public IStash Stash { get; set; }
+    }
+
+    /// <summary>
+    /// Actor base class with `Stash` that does not enforce any mailbox type. The proper mailbox has to be configured
+    /// manually, and the mailbox should extend the <see cref="IDequeBasedMessageQueueSemantics"/> marker interface.
+    /// See <see cref="UntypedActorWithStash"/> for details on how `Stash` works.
+    /// </summary>
+    public abstract class UntypedActorWithUnrestrictedStash : UntypedActor, IWithUnrestrictedStash
+    {
+        public IStash Stash { get; set; }
+    }
+}


### PR DESCRIPTION
Added utility abstract classes for `UntypedActor`s that support stashing: 

- `UntypedActorWithStash`
- `UntypedActorWithUnboundedStash` 
- `UntypedActorWithUnrestrictedStash`

Depends on #6325 

## Checklist

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [X] Changes in public API reviewed, if any.
* [X] I have added website documentation for this feature.