### PR TITLE
Documentation for ActorRefExtensions.IsNobody was fixed #6313.

### DIFF
--- a/src/core/Akka/Actor/ActorRef.Extensions.cs
+++ b/src/core/Akka/Actor/ActorRef.Extensions.cs
@@ -15,12 +15,12 @@ namespace Akka.Actor
     public static class ActorRefExtensions
     {
         /// <summary>
-        /// Determines if the specified <paramref name="actorRef"/> is valid.
+        /// Determines if the specified <paramref name="actorRef"/> is invalid.
         /// An <paramref name="actorRef"/> is thought to be invalid if it's one of the following:
         ///    <see langword="null"/>, <see cref="Nobody"/>, and <see cref="DeadLetterActorRef"/>
         /// </summary>
         /// <param name="actorRef">The actor that is being tested.</param>
-        /// <returns><c>true</c> if the <paramref name="actorRef"/> is valid; otherwise <c>false</c>.</returns>
+        /// <returns><c>true</c> if the <paramref name="actorRef"/> is invalid; otherwise <c>false</c>.</returns>
         public static bool IsNobody(this IActorRef actorRef)
         {
             return actorRef is null || actorRef is Nobody || actorRef is DeadLetterActorRef 


### PR DESCRIPTION
## Changes

Fixes #6313 

Documentaation of ActorRefExtensions.IsNobody was fixed

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.