### PR TITLE
Add compression option for NewtonSoftJsonSerializer

### DIFF
--- a/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApproveCore.verified.txt
@@ -4789,6 +4789,7 @@ namespace Akka.Serialization
         public NewtonSoftJsonSerializer(Akka.Actor.ExtendedActorSystem system) { }
         public NewtonSoftJsonSerializer(Akka.Actor.ExtendedActorSystem system, Akka.Configuration.Config config) { }
         public NewtonSoftJsonSerializer(Akka.Actor.ExtendedActorSystem system, Akka.Serialization.NewtonSoftJsonSerializerSettings settings) { }
+        public bool Compressed { get; }
         public override bool IncludeManifest { get; }
         public object Serializer { get; }
         public Newtonsoft.Json.JsonSerializerSettings Settings { get; }
@@ -4799,6 +4800,8 @@ namespace Akka.Serialization
     {
         public static readonly Akka.Serialization.NewtonSoftJsonSerializerSettings Default;
         public NewtonSoftJsonSerializerSettings(bool encodeTypeNames, bool preserveObjectReferences, System.Collections.Generic.IEnumerable<System.Type> converters, bool usePooledStringBuilder, int stringBuilderMinSize, int stringBuilderMaxSize) { }
+        public NewtonSoftJsonSerializerSettings(bool encodeTypeNames, bool preserveObjectReferences, System.Collections.Generic.IEnumerable<System.Type> converters, bool usePooledStringBuilder, int stringBuilderMinSize, int stringBuilderMaxSize, bool compressed) { }
+        public bool Compressed { get; }
         public System.Collections.Generic.IEnumerable<System.Type> Converters { get; }
         public bool EncodeTypeNames { get; }
         public bool PreserveObjectReferences { get; }

--- a/src/core/Akka.Tests/Serialization/NewtonsoftJsonConfigSpec.cs
+++ b/src/core/Akka.Tests/Serialization/NewtonsoftJsonConfigSpec.cs
@@ -29,6 +29,7 @@ namespace Akka.Tests.Serialization
                 Assert.Equal(2, serializer.Settings.Converters.Count);
                 Assert.Contains(serializer.Settings.Converters, x => x is DiscriminatedUnionConverter);
                 Assert.Contains(serializer.Settings.Converters, x => x is NewtonSoftJsonSerializer.SurrogateConverter);
+                Assert.False(serializer.Compressed);
             }
         }
 
@@ -40,6 +41,7 @@ namespace Akka.Tests.Serialization
                     serialization-settings.json {
                         preserve-object-references = false
                         encode-type-names = false
+                        use-compression = true
                     }
                 }
             ");
@@ -51,6 +53,7 @@ namespace Akka.Tests.Serialization
                 Assert.Equal(2, serializer.Settings.Converters.Count);
                 Assert.Contains(serializer.Settings.Converters, x => x is DiscriminatedUnionConverter);
                 Assert.Contains(serializer.Settings.Converters, x => x is NewtonSoftJsonSerializer.SurrogateConverter);
+                Assert.True(serializer.Compressed);
             }
         }
 

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -26,7 +26,7 @@ using Xunit;
 namespace Akka.Tests.Serialization
 {
     
-    public class SerializationSpec : AkkaSpec
+    public abstract class SerializationSpecBase : AkkaSpec
     {
         public class UntypedContainerMessage : IEquatable<UntypedContainerMessage>
         {
@@ -608,26 +608,9 @@ namespace Akka.Tests.Serialization
                 .Where(ex => ex.Message.Contains("Serializer Id [101] is not one of the internal Akka.NET serializer."));
         }
 
-        public SerializationSpec():base(GetConfig())
+        public SerializationSpecBase(string config):base(config)
         {
         }
-
-        private static string GetConfig() => @"
-            akka.actor {
-                serializers {
-                    dummy = """ + typeof(DummySerializer).AssemblyQualifiedName + @"""
-                    dummy2 = """ + typeof(DummyConfigurableSerializer).AssemblyQualifiedName + @"""
-                }
-
-                serialization-bindings {
-                  ""System.String"" = dummy
-                }
-                serialization-settings {
-                    dummy2 {
-                        test-key = ""test value""
-                    }
-                }
-            }";
 
         public class DummySerializer : Serializer
         {
@@ -707,6 +690,81 @@ namespace Akka.Tests.Serialization
             {
                 public string Value { get; set; }
             }
+        }
+    }
+
+    public class SerializationSpec: SerializationSpecBase
+    {
+        private static string GetConfig() => @"
+akka.actor {
+    serializers {
+        dummy = """ + typeof(DummySerializer).AssemblyQualifiedName + @"""
+        dummy2 = """ + typeof(DummyConfigurableSerializer).AssemblyQualifiedName + @"""
+    }
+
+    serialization-bindings {
+        ""System.String"" = dummy
+    }
+    serialization-settings {
+        dummy2 {
+            test-key = ""test value""
+        }
+    }
+}";
+
+        public SerializationSpec() : base(GetConfig())
+        {
+        }
+
+        [Fact(DisplayName = "Compression must be turned off")]
+        public void SettingTest()
+        {
+            var serializer = (NewtonSoftJsonSerializer) Sys.Serialization.FindSerializerFor(123);
+            serializer.Compressed.Should().BeFalse();
+        }
+    }
+
+    
+    public class CompressedSerializationSpec: SerializationSpecBase
+    {
+        private static string GetConfig() => @"
+akka.actor {
+    serializers {
+        dummy = """ + typeof(DummySerializer).AssemblyQualifiedName + @"""
+        dummy2 = """ + typeof(DummyConfigurableSerializer).AssemblyQualifiedName + @"""
+    }
+
+    serialization-bindings {
+        ""System.String"" = dummy
+    }
+    serialization-settings {
+        dummy2 {
+            test-key = ""test value""
+        }
+        json {
+            use-compression = true
+        }
+    }
+}";
+
+        public CompressedSerializationSpec() : base(GetConfig())
+        {
+        }
+
+        [Fact(DisplayName = "Compression must be turned on")]
+        public void SettingTest()
+        {
+            var serializer = (NewtonSoftJsonSerializer) Sys.Serialization.FindSerializerFor(123);
+            serializer.Compressed.Should().BeTrue();
+            var bytes = serializer.ToBinary(new BigData());
+            bytes.Length.Should().BeLessThan(10 * 1024); // compressed size should be less than 10Kb
+            var deserialized = serializer.FromBinary<BigData>(bytes);
+            deserialized.Message.Should().Be(new string('x', 5 * 1024 * 1024));
+        }
+        
+        private class BigData
+        {
+            public string Message { get; } = new string('x', 5 * 1024 * 1024); // 5 megabyte worth of chars
         }
     }
 }

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -554,6 +554,12 @@ akka {
         # So after ~42k characters you might wind up
         # on the Large Object Heap (which may not be a bad thing...)
         pooled-string-builder-maxsize = 32768
+        
+        # When set true, this will compress the serialized 
+        # JSON string using GZip.
+        # Useful to avoid network congestion when your serialized 
+        # data starts to grow to the megabyte size
+        use-compression = false
       }
     }
   }

--- a/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
+++ b/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
@@ -408,7 +408,7 @@ namespace Akka.Serialization
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte[] Compress(byte[] data)
+        private static byte[] Compress(byte[] data)
         {
             using var compressedStream = new MemoryStream();
             using var compressor = new GZipStream(compressedStream, CompressionMode.Compress);
@@ -418,7 +418,7 @@ namespace Akka.Serialization
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static byte[] Decompress(byte[] raw)
+        private static byte[] Decompress(byte[] raw)
         {
             using var compressedStream = new MemoryStream(raw);
             using var compressor = new GZipStream(compressedStream, CompressionMode.Decompress);

--- a/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
+++ b/src/core/Akka/Serialization/NewtonSoftJsonSerializer.cs
@@ -9,8 +9,10 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Akka.Actor;
 using Akka.Configuration;
@@ -37,7 +39,8 @@ namespace Akka.Serialization
             converters: Enumerable.Empty<Type>(),
             usePooledStringBuilder:true,
             stringBuilderMinSize:2048,
-            stringBuilderMaxSize:32768);
+            stringBuilderMaxSize:32768, 
+            compressed: false);
 
         /// <summary>
         /// Creates a new instance of the <see cref="NewtonSoftJsonSerializerSettings"/> based on a provided <paramref name="config"/>.
@@ -64,7 +67,8 @@ namespace Akka.Serialization
                 stringBuilderMinSize:config.GetInt("pooled-string-builder-minsize", 2048),
                 stringBuilderMaxSize:
                     config.GetInt("pooled-string-builder-maxsize",
-                        32768)
+                        32768),
+                compressed: config.GetBoolean("use-compression")
             );
         }
 
@@ -116,6 +120,11 @@ namespace Akka.Serialization
         public bool UsePooledStringBuilder { get; }
 
         /// <summary>
+        /// If <c>true</c>, serialized data are compressed using GZip to reduce size
+        /// </summary>
+        public bool Compressed { get; }
+
+        /// <summary>
         /// Creates a new instance of the <see cref="NewtonSoftJsonSerializerSettings"/>.
         /// </summary>
         /// <param name="encodeTypeNames">Determines if a special `$type` field should be emitted into serialized JSON. Must be true if corresponding serializer is used as default.</param>
@@ -124,7 +133,31 @@ namespace Akka.Serialization
         /// <param name="usePooledStringBuilder">Determines if string builders will be used from a pool to lower memory usage</param>
         /// <param name="stringBuilderMinSize">Starting size used for pooled string builders if enabled</param>
         /// <param name="stringBuilderMaxSize">Max retained size used for pooled string builders if enabled</param>
-        public NewtonSoftJsonSerializerSettings(bool encodeTypeNames, bool preserveObjectReferences, IEnumerable<Type> converters, bool usePooledStringBuilder, int stringBuilderMinSize, int stringBuilderMaxSize)
+        public NewtonSoftJsonSerializerSettings(
+            bool encodeTypeNames,
+            bool preserveObjectReferences,
+            IEnumerable<Type> converters,
+            bool usePooledStringBuilder,
+            int stringBuilderMinSize,
+            int stringBuilderMaxSize)
+            : this(
+                encodeTypeNames: encodeTypeNames,
+                preserveObjectReferences: preserveObjectReferences,
+                converters: converters,
+                usePooledStringBuilder: usePooledStringBuilder,
+                stringBuilderMinSize: stringBuilderMinSize,
+                stringBuilderMaxSize: stringBuilderMaxSize, 
+                compressed: false)
+        { }
+        
+        public NewtonSoftJsonSerializerSettings(
+            bool encodeTypeNames, 
+            bool preserveObjectReferences,
+            IEnumerable<Type> converters,
+            bool usePooledStringBuilder,
+            int stringBuilderMinSize,
+            int stringBuilderMaxSize,
+            bool compressed)
         {
             if (converters == null)
                 throw new ArgumentNullException(nameof(converters), $"{nameof(NewtonSoftJsonSerializerSettings)} requires a sequence of converters.");
@@ -135,6 +168,7 @@ namespace Akka.Serialization
             UsePooledStringBuilder = usePooledStringBuilder;
             StringBuilderMinSize = stringBuilderMinSize;
             StringBuilderMaxSize = stringBuilderMaxSize;
+            Compressed = compressed;
         }
     }
 
@@ -157,6 +191,8 @@ namespace Akka.Serialization
         /// </summary>
         public object Serializer { get { return _serializer; } }
 
+        public bool Compressed { get; }
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="NewtonSoftJsonSerializer" /> class.
         /// </summary>
@@ -217,6 +253,8 @@ namespace Akka.Serialization
             Settings.ContractResolver = new AkkaContractResolver();
 
             _serializer = JsonSerializer.Create(Settings);
+
+            Compressed = settings.Compressed;
         }
 
 
@@ -280,9 +318,9 @@ namespace Akka.Serialization
 
         private byte[] toBinary_NewBuilder(object obj)
         {
-            string data = JsonConvert.SerializeObject(obj, Formatting.None, Settings);
-            byte[] bytes = Encoding.UTF8.GetBytes(data);
-            return bytes;
+            var data = JsonConvert.SerializeObject(obj, Formatting.None, Settings);
+            var bytes = Encoding.UTF8.GetBytes(data);
+            return Compressed ? Compress(bytes) : bytes;
         }
 
         private byte[] toBinary_PooledBuilder(object obj)
@@ -304,7 +342,8 @@ namespace Akka.Serialization
                     {
                         ser.Serialize(jw, obj);
                     }
-                    return Encoding.UTF8.GetBytes(tw.ToString());
+                    var bytes = Encoding.UTF8.GetBytes(tw.ToString());
+                    return Compressed ? Compress(bytes) : bytes;
                 }
             }
             finally
@@ -324,8 +363,8 @@ namespace Akka.Serialization
         /// <returns>The object contained in the array</returns>
         public override object FromBinary(byte[] bytes, Type type)
         {
-            string data = Encoding.UTF8.GetString(bytes);
-            object res = JsonConvert.DeserializeObject(data, Settings);
+            var data = Encoding.UTF8.GetString(Compressed ? Decompress(bytes) : bytes);
+            var res = JsonConvert.DeserializeObject(data, Settings);
             return TranslateSurrogate(res, this, type);
         }
 
@@ -366,6 +405,26 @@ namespace Akka.Serialization
                 return decimal.Parse(v, NumberFormatInfo.InvariantInfo);
 
             throw new NotSupportedException();
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte[] Compress(byte[] data)
+        {
+            using var compressedStream = new MemoryStream();
+            using var compressor = new GZipStream(compressedStream, CompressionMode.Compress);
+            compressor.Write(data, 0, data.Length);
+            compressor.Flush(); // It is critical to flush here
+            return compressedStream.ToArray();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte[] Decompress(byte[] raw)
+        {
+            using var compressedStream = new MemoryStream(raw);
+            using var compressor = new GZipStream(compressedStream, CompressionMode.Decompress);
+            using var uncompressedStream = new MemoryStream();
+            compressor.CopyTo(uncompressedStream);
+            return uncompressedStream.ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes
- Adds `use-compression` to NewtonSoftJsonSerializer
- When enabled, serialized data are compressed using `System.IO.Compression.GZip`