### PR TITLE
close #6295 - set default PoolRouter SupervisorStrategy to Restart

### DIFF
--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -358,7 +358,7 @@ namespace Akka.Routing
         {
             get
             {
-                return new OneForOneStrategy(Decider.From(Directive.Escalate));
+                return new OneForOneStrategy(Decider.From(Directive.Restart));
             }
         }
 

--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -354,15 +354,9 @@ namespace Akka.Routing
         /// <summary>
         /// TBD
         /// </summary>
-        public static SupervisorStrategy DefaultSupervisorStrategy
-        {
-            get
-            {
-                return new OneForOneStrategy(Decider.From(Directive.Restart));
-            }
-        }
+        public static SupervisorStrategy DefaultSupervisorStrategy => SupervisorStrategy.DefaultStrategy;
 
-        
+
         public bool Equals(Pool other)
         {
             if (ReferenceEquals(null, other)) return false;


### PR DESCRIPTION
## Changes

Fixes #6295 - this fixes a _very_ old bug in Akka.NET where any time a routee on a `Pool` router restarted, the default supervision directive on the router was set to `Escalate` which would cause _the router itself_ to restart and _kill all of the routees in the process_. I believe this was done as a result of misunderstanding what Escalate does and how it works. We now know better and this sets the supervision directive to `Restart`, which is the safe default we use for everything else.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #6295
