### PR TITLE
[PORT #6366] set default PoolRouter SupervisorStrategy to Restart

### DIFF
--- a/src/core/Akka.Tests/Actor/ActorTelemetrySpecs.cs
+++ b/src/core/Akka.Tests/Actor/ActorTelemetrySpecs.cs
@@ -283,8 +283,7 @@ namespace Akka.Tests.Actor
                 // assert that actor start count is still 10
                 Assert.Equal(12, telemetry.ActorCreated);
                 
-                // bug due to https://github.com/akkadotnet/akka.net/issues/6295 - all routees and the router start each time
-                Assert.Equal(110, telemetry.ActorRestarted);
+                Assert.Equal(10, telemetry.ActorRestarted);
                 // assert no stops recorded
                 Assert.Equal(0, telemetry.ActorStopped);
             }, RemainingOrDefault);
@@ -296,7 +295,7 @@ namespace Akka.Tests.Actor
                 var telemetry = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance);
                 // assert that actor start count is still 10
                 Assert.Equal(12, telemetry.ActorCreated);
-                Assert.Equal(110, telemetry.ActorRestarted);
+                Assert.Equal(10, telemetry.ActorRestarted);
                 Assert.Equal(11, telemetry.ActorStopped);
             }, RemainingOrDefault);
         }

--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -354,15 +354,9 @@ namespace Akka.Routing
         /// <summary>
         /// TBD
         /// </summary>
-        public static SupervisorStrategy DefaultSupervisorStrategy
-        {
-            get
-            {
-                return new OneForOneStrategy(Decider.From(Directive.Escalate));
-            }
-        }
+        public static SupervisorStrategy DefaultSupervisorStrategy => SupervisorStrategy.DefaultStrategy;
 
-        
+
         public bool Equals(Pool other)
         {
             if (ReferenceEquals(null, other)) return false;


### PR DESCRIPTION
Port of #6366

* close #6295 - set default PoolRouter SupervisorStrategy to Restart
* use the `SupervisionStrategy.DefaultStrategy`
* Fix unit test
* Change unit test to use RoundRobinPool router

(cherry-picked from ffd9a9e15e2841cabb7ac9e71db937c7ea320cbd)