### PR TITLE
Fix of EventFilter.And from Akka.testKit when one parameter is string (#6316).

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/DeadLettersEventFilterTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/DeadLettersEventFilterTests.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -45,6 +46,26 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
             await eventFilter.DeadLetter().ExpectOneAsync(async () =>
             {
                 _deadActor.Tell("whatever");
+            });
+        }
+        
+        [Fact]
+        public async Task Should_check_properly_type_parameters()
+        {
+            await EventFilter.DeadLetter<int>().And.DeadLetter<double>().ExpectAsync(2, async () =>
+            {
+                _deadActor.Tell(5);
+                _deadActor.Tell(1.2);
+            });
+        }
+
+        [Fact]
+        public async Task Should_check_properly_type_parameters_when_one_of_them_string()
+        {
+            await EventFilter.DeadLetter<string>().And.DeadLetter<double>().ExpectAsync(2, async () =>
+            {
+                _deadActor.Tell("asd");
+                _deadActor.Tell(1.2);
             });
         }
     }

--- a/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
+++ b/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
@@ -108,10 +108,7 @@ namespace Akka.TestKit
                         ? "Received dead system message: " + msg
                         : "Received dead letter from " + snd + ": " + msg;
                     var warning2 = new Warning(recipientPath, recipientType, new DeadLetter(msgStr, snd, rcp));
-                    if (!ShouldFilter(warning2))
-                    {
-                        Print(warning2);
-                    }
+                    Print(warning2);
                 }
             }
         }


### PR DESCRIPTION
Fixes #6316 

## Changes

The problem was in TestEventListenerClass because it calls `ShouldFilter` for deadLetter twice - first time with real parameter type and the second one with string param. So, for tests with `DeadLetter<string>` it might became false positive.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).