### PR TITLE
[BACKPORT #6374] Fix PersistenceIdsPublisher hung on failure messages

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/AllPersistenceIdsPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/AllPersistenceIdsPublisher.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Persistence.Sql.Common.Journal;
 using Akka.Streams.Actors;
 
@@ -22,6 +23,7 @@ namespace Akka.Persistence.Query.Sql
         private readonly IActorRef _journalRef;
 
         private readonly DeliveryBuffer<string> _buffer;
+        private readonly ILoggingAdapter _log;
 
         public IStash Stash { get; set; }
 
@@ -29,6 +31,7 @@ namespace Akka.Persistence.Query.Sql
         {
             _buffer = new DeliveryBuffer<string>(OnNext);
             _journalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
+            _log = Context.GetLogger();
         }
 
         protected override bool Receive(object message)
@@ -36,12 +39,16 @@ namespace Akka.Persistence.Query.Sql
             switch (message)
             {
                 case Request _:
-                    _journalRef.Tell(new SelectCurrentPersistenceIds(0, Self));
                     Become(Initializing);
+                    _journalRef
+                        .Ask<CurrentPersistenceIds>(new SelectCurrentPersistenceIds(0, Self))
+                        .PipeTo(Self);
                     return true;
+                
                 case Cancel _:
                     Context.Stop(Self);
                     return true;
+                
                 default:
                     return false;
             }
@@ -64,9 +71,26 @@ namespace Akka.Persistence.Query.Sql
                     Become(Active);
                     Stash.UnstashAll();
                     return true;
+                
                 case Cancel _:
                     Context.Stop(Self);
                     return true;
+                
+                case Status.Failure msg:
+                    if (msg.Cause is AskTimeoutException e)
+                    {
+                        _log.Info(e, "Current persistence id query timed out, retrying");
+                    }
+                    else
+                    {
+                        _log.Info(msg.Cause, "Current persistence id query failed, retrying");
+                    }
+                    
+                    _journalRef
+                        .Ask<CurrentPersistenceIds>(new SelectCurrentPersistenceIds(0, Self))
+                        .PipeTo(Self);
+                    return true;
+                    
                 default:
                     Stash.Stash();
                     return true;
@@ -77,14 +101,20 @@ namespace Akka.Persistence.Query.Sql
         {
             switch (message)
             {
+                case CurrentPersistenceIds _:
+                    // Ignore duplicate CurrentPersistenceIds response
+                    return true;
+                
                 case Request _:
                     _buffer.DeliverBuffer(TotalDemand);
                     if (_buffer.IsEmpty)
                         OnCompleteThenStop();
                     return true;
+                
                 case Cancel _:
                     Context.Stop(Self);
                     return true;
+                
                 default:
                     return false;
             }
@@ -93,7 +123,7 @@ namespace Akka.Persistence.Query.Sql
 
     internal sealed class LivePersistenceIdsPublisher : ActorPublisher<string>, IWithUnboundedStash
     {
-        private class Continue
+        private sealed class Continue
         {
             public static readonly Continue Instance = new Continue();
 
@@ -109,11 +139,13 @@ namespace Akka.Persistence.Query.Sql
         private readonly ICancelable _tickCancelable;
         private readonly IActorRef _journalRef;
         private readonly DeliveryBuffer<string> _buffer;
+        private readonly ILoggingAdapter _log;
 
         public IStash Stash { get; set; }
 
         public LivePersistenceIdsPublisher(TimeSpan refreshInterval, string writeJournalPluginId)
         {
+            _log = Context.GetLogger();
             _tickCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(
                 refreshInterval, 
                 refreshInterval, 
@@ -135,14 +167,19 @@ namespace Akka.Persistence.Query.Sql
             switch (message)
             {
                 case Request _:
-                    _journalRef.Tell(new SelectCurrentPersistenceIds(0, Self));
                     Become(Waiting);
+                    _journalRef
+                        .Ask<CurrentPersistenceIds>(new SelectCurrentPersistenceIds(_lastOrderingOffset, Self))
+                        .PipeTo(Self);
                     return true;
+                
                 case Continue _:
                     return true;
+                
                 case Cancel _:
                     Context.Stop(Self);
                     return true;
+                
                 default:
                     return false;
             }
@@ -160,11 +197,28 @@ namespace Akka.Persistence.Query.Sql
                     Become(Active);
                     Stash.UnstashAll();
                     return true;
+                
                 case Continue _:
                     return true;
+                
                 case Cancel _:
                     Context.Stop(Self);
                     return true;
+                
+                case Status.Failure msg:
+                    if (msg.Cause is AskTimeoutException e)
+                    {
+                        _log.Info(e, $"Current persistence id query timed out, retrying. Offset: {_lastOrderingOffset}");
+                    }
+                    else
+                    {
+                        _log.Info(msg.Cause, $"Current persistence id query failed, retrying. Offset: {_lastOrderingOffset}");
+                    }
+                    
+                    Become(Active);
+                    Stash.UnstashAll();
+                    return true;
+                    
                 default:
                     Stash.Stash();
                     return true;
@@ -175,16 +229,29 @@ namespace Akka.Persistence.Query.Sql
         {
             switch (message)
             {
+                case CurrentPersistenceIds _:
+                    // Ignore duplicate CurrentPersistenceIds response
+                    return true;
+                
                 case Request _:
                     _buffer.DeliverBuffer(TotalDemand);
                     return true;
+                
                 case Continue _:
-                    _journalRef.Tell(new SelectCurrentPersistenceIds(_lastOrderingOffset, Self));
                     Become(Waiting);
+                    _journalRef
+                        .Ask<CurrentPersistenceIds>(new SelectCurrentPersistenceIds(_lastOrderingOffset, Self))
+                        .PipeTo(Self);
                     return true;
+                
                 case Cancel _:
                     Context.Stop(Self);
                     return true;
+                
+                case Status.Failure msg:
+                    _log.Info(msg.Cause, "Unexpected failure received");
+                    return true;
+                
                 default:
                     return false;
             }

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/SqlReadJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/SqlReadJournal.cs
@@ -6,7 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Threading;
 using Reactive.Streams;
 using Akka.Actor;
 using Akka.Configuration;
@@ -26,7 +25,7 @@ namespace Akka.Persistence.Query.Sql
         IAllEventsQuery,
         ICurrentAllEventsQuery
     {
-        public static string Identifier = "akka.persistence.query.journal.sql";
+        public const string Identifier = "akka.persistence.query.journal.sql";
 
         /// <summary>
         /// Returns a default query configuration for akka persistence SQLite-based journals and snapshot stores.
@@ -52,7 +51,6 @@ namespace Akka.Persistence.Query.Sql
             _maxBufferSize = config.GetInt("max-buffer-size", 0);
             _system = system;
 
-            _lock = new ReaderWriterLockSlim();
             _persistenceIdsPublisher = null;
         }
 

--- a/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistenceSqlCommonQuery.verified.txt
+++ b/src/core/Akka.API.Tests/CoreAPISpec.ApprovePersistenceSqlCommonQuery.verified.txt
@@ -6,7 +6,7 @@ namespace Akka.Persistence.Query.Sql
 {
     public class SqlReadJournal : Akka.Persistence.Query.IAllEventsQuery, Akka.Persistence.Query.ICurrentAllEventsQuery, Akka.Persistence.Query.ICurrentEventsByPersistenceIdQuery, Akka.Persistence.Query.ICurrentEventsByTagQuery, Akka.Persistence.Query.ICurrentPersistenceIdsQuery, Akka.Persistence.Query.IEventsByPersistenceIdQuery, Akka.Persistence.Query.IEventsByTagQuery, Akka.Persistence.Query.IPersistenceIdsQuery, Akka.Persistence.Query.IReadJournal
     {
-        public static string Identifier;
+        public const string Identifier = "akka.persistence.query.journal.sql";
         public SqlReadJournal(Akka.Actor.ExtendedActorSystem system, Akka.Configuration.Config config) { }
         public Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> AllEvents(Akka.Persistence.Query.Offset offset = null) { }
         public Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> CurrentAllEvents(Akka.Persistence.Query.Offset offset) { }


### PR DESCRIPTION
Fixes #6365
Backport of #6374

## Changes
* Fix PersistenceIdsPublisher hung on failure messages
* Downgrade failure messages from Warning to Info
* Update API Verify list

(Cherry-picked from d3b89da6faaf06b394382aad78e475982cded23f)