### PR TITLE
Fix for issue #6377

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
@@ -1721,6 +1721,7 @@ namespace Akka.Actor
         public bool LogDeadLettersDuringShutdown { get; }
         public System.TimeSpan LogDeadLettersSuspendDuration { get; }
         public string LogLevel { get; }
+        public bool LogSerializerOverrideOnStart { get; }
         public bool LoggerAsyncStart { get; }
         public System.TimeSpan LoggerStartTimeout { get; }
         public System.Collections.Generic.IList<string> Loggers { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -1723,6 +1723,7 @@ namespace Akka.Actor
         public bool LogDeadLettersDuringShutdown { get; }
         public System.TimeSpan LogDeadLettersSuspendDuration { get; }
         public string LogLevel { get; }
+        public bool LogSerializerOverrideOnStart { get; }
         public bool LoggerAsyncStart { get; }
         public System.TimeSpan LoggerStartTimeout { get; }
         public System.Collections.Generic.IList<string> Loggers { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -1721,6 +1721,7 @@ namespace Akka.Actor
         public bool LogDeadLettersDuringShutdown { get; }
         public System.TimeSpan LogDeadLettersSuspendDuration { get; }
         public string LogLevel { get; }
+        public bool LogSerializerOverrideOnStart { get; }
         public bool LoggerAsyncStart { get; }
         public System.TimeSpan LoggerStartTimeout { get; }
         public System.Collections.Generic.IList<string> Loggers { get; }

--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -46,6 +46,7 @@ namespace Akka.Tests.Configuration
             settings.StdoutLogger.Should().NotBeNull();
             settings.StdoutLogger.Should().BeOfType<StandardOutLogger>();
             settings.LogConfigOnStart.ShouldBeFalse();
+            settings.LogSerializerOverrideOnStart.ShouldBeTrue();
             settings.LogDeadLetters.ShouldBe(10);
             settings.LogDeadLettersDuringShutdown.ShouldBeFalse();
             settings.LogDeadLettersSuspendDuration.ShouldBe(TimeSpan.FromMinutes(5));

--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -143,6 +143,7 @@ namespace Akka.Actor
 
             //handled
             LogConfigOnStart = Config.GetBoolean("akka.log-config-on-start", false);
+            LogSerializerOverrideOnStart = Config.GetBoolean("akka.log-serializer-override-on-start", true);
             LogDeadLetters = 0;
             switch (Config.GetString("akka.log-dead-letters", null))
             {
@@ -319,6 +320,13 @@ namespace Akka.Actor
         /// </summary>
         /// <value><c>true</c> if [log configuration on start]; otherwise, <c>false</c>.</value>
         public bool LogConfigOnStart { get; private set; }
+
+
+        /// <summary>
+        ///     Gets a value indicating whether [log serializer override on start].
+        /// </summary>
+        /// <value><c>true</c> if [log serializer override on start]; otherwise, <c>false</c>.</value>
+        public bool LogSerializerOverrideOnStart { get; private set; }
 
         /// <summary>
         ///     Gets the log dead letters.

--- a/src/core/Akka/Configuration/Pigeon.conf
+++ b/src/core/Akka/Configuration/Pigeon.conf
@@ -51,6 +51,11 @@ akka {
   # This is useful when you are uncertain of what configuration is used.
   log-config-on-start = off
 
+  # Log the serializer override notification at WARNING level when the actor system is started.
+  # This is useful if want to make a change of the default serializer(s) and suppress the warning
+  # that is created if the configuration is changed.
+  log-serializer-override-on-start = on
+
   # Log at info level when messages are sent to dead letters, or published to
   # eventStream as `DeadLetter`, `Dropped` or `UnhandledMessage`.
   # Possible values:

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -150,6 +150,8 @@ namespace Akka.Serialization
         private readonly ImmutableHashSet<SerializerDetails> _serializerDetails;
         private readonly MinimalLogger _initializationLogger;
 
+        private readonly bool _logSerializerOverrideOnStart;
+
         /// <summary>
         /// Serialization module. Contains methods for serialization and deserialization as well as
         /// locating a Serializer for a particular class as defined in the mapping in the configuration.
@@ -164,6 +166,9 @@ namespace Akka.Serialization
             System = system;
             _nullSerializer = new NullSerializer(system);
             AddSerializer("null", _nullSerializer);
+
+
+            _logSerializerOverrideOnStart = system.Settings.LogSerializerOverrideOnStart;
 
             var serializersConfig = system.Settings.Config.GetConfig("akka.actor.serializers").AsEnumerable().ToList();
             var serializerBindingConfig = system.Settings.Config.GetConfig("akka.actor.serialization-bindings").AsEnumerable().ToList();
@@ -333,7 +338,7 @@ namespace Akka.Serialization
         public void AddSerializer(Serializer serializer)
         {
             var id = serializer.Identifier;
-            if(_serializersById.ContainsKey(id) && _serializersById[id].GetType() != serializer.GetType())
+            if(_logSerializerOverrideOnStart && _serializersById.ContainsKey(id) && _serializersById[id].GetType() != serializer.GetType())
             {
                 LogWarning(
                     $"Serializer with identifier [{id}] are being overriden  " +
@@ -352,7 +357,7 @@ namespace Akka.Serialization
         public void AddSerializer(string name, Serializer serializer)
         {
             var id = serializer.Identifier;
-            if(_serializersById.ContainsKey(id) && _serializersById[id].GetType() != serializer.GetType())
+            if(_logSerializerOverrideOnStart && _serializersById.ContainsKey(id) && _serializersById[id].GetType() != serializer.GetType())
             {
                 LogWarning(
                     $"Serializer with identifier [{id}] are being overriden  " +
@@ -360,7 +365,7 @@ namespace Akka.Serialization
                     "Did you mean to do this?");
             }
             
-            if(_serializersByName.ContainsKey(name) && _serializersByName[name].GetType() != serializer.GetType())
+            if(_logSerializerOverrideOnStart && _serializersByName.ContainsKey(name) && _serializersByName[name].GetType() != serializer.GetType())
                 LogWarning(
                     $"Serializer with name [{serializer.Identifier}] are being overriden  " +
                     $"from [{_serializersByName[name].GetType()}] to [{serializer.GetType()}]. " +
@@ -379,7 +384,7 @@ namespace Akka.Serialization
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AddSerializationMap(Type type, Serializer serializer)
         {
-            if(_serializerMap.ContainsKey(type) && _serializerMap[type].GetType() != serializer.GetType())
+            if(_logSerializerOverrideOnStart && _serializerMap.ContainsKey(type) && _serializerMap[type].GetType() != serializer.GetType())
                 LogWarning(
                     $"Serializer for type [{type}] are being overriden  " +
                     $"from [{_serializerMap[type].GetType()}] to [{serializer.GetType()}]. " +


### PR DESCRIPTION
* created a setting property LogSerializerOverrideOnStart to reflect if warning should be logged or not
* updated default config to enable logging for this issue by default
* added property to the configuration specification

Fixes #6377

## Changes

Allows to suppress the WARNING message about changes in the serializer settings.

Set the value in the config
`log-serializer-override-on-start = off`
to disable the logging of the message.
The default value is `on` to get notified at the first time and check if the change was by intention.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #
It is worth to mention that the solution has the shortcomming of a global enable/disable behavior. It would be nice to just mark the intended change (for example by having a white list of checked changes configured in a mapping table (type <-> serializer)) but this seems to be an overkill for the rare cases to me.
* [x] Changes in public API reviewed, if any.
* [x] I have added website documentation for this feature.
I only added the change to the default config and documented the code (according the other configuration properties documentation). However, I wrote no Markdown files or so. Please ask, if required.

The changes do not affect the performance, so I added no benchmarks.
