### PR TITLE
Fix persistence allocations #5505.

### DIFF
--- a/src/benchmark/Akka.Cluster.Benchmarks/Persistence/AtomicWriteBenchmark.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Persistence/AtomicWriteBenchmark.cs
@@ -1,0 +1,38 @@
+// //-----------------------------------------------------------------------
+// // <copyright file="AtomicWriteBenchmark.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Collections.Immutable;
+using Akka.Benchmarks.Configurations;
+using Akka.Persistence;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Cluster.Benchmarks.Persistence
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class AtomicWriteBenchmark
+    {
+        private IImmutableList<IPersistentRepresentation> _immutableList;
+        
+        [Params(100000)] public int WriteMsgCount;
+
+        [IterationSetup]
+        public void Setup()
+        {
+            _immutableList = ImmutableList.Create<IPersistentRepresentation>(new Persistent(new object()));
+        }
+
+        [Benchmark]
+        public void Constructor()
+        {
+            for (var i = 0; i < WriteMsgCount; i++)
+            {
+                _ = new AtomicWrite(_immutableList);
+            }
+        }
+    }    
+}
+

--- a/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Program.cs
@@ -23,7 +23,6 @@ namespace Akka.Cluster.Benchmarks
 #else
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 #endif
-
         }
     }
 }

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -357,7 +357,7 @@ namespace Akka.Persistence.Journal
         {
             try
             {
-                var prepared = PreparePersistentBatch(message.Messages);
+                var prepared = PreparePersistentBatch(message.Messages).ToArray();
                 // try in case AsyncWriteMessages throws
                 try
                 {

--- a/src/core/Akka.Persistence/Persistent.cs
+++ b/src/core/Akka.Persistence/Persistent.cs
@@ -122,8 +122,11 @@ namespace Akka.Persistence
                 throw new ArgumentException("Payload of AtomicWrite must not be empty.", nameof(payload));
 
             var firstMessage = payload[0];
-            if (payload.Count > 1 && !payload.Skip(1).All(m => m.PersistenceId.Equals(firstMessage.PersistenceId)))
-                throw new ArgumentException($"AtomicWrite must contain messages for the same persistenceId, yet difference persistenceIds found: {payload.Select(m => m.PersistenceId).Distinct()}.", nameof(payload));
+            for (var i = 1; i < payload.Count; i++)
+            {
+                if (!payload[i].PersistenceId.Equals(firstMessage.PersistenceId))
+                    throw new ArgumentException($"AtomicWrite must contain messages for the same persistenceId, yet difference persistenceIds found: {payload.Select(m => m.PersistenceId).Distinct()}.", nameof(payload));
+            }
 
             Payload = payload;
             Sender = ActorRefs.NoSender;


### PR DESCRIPTION
Fixes #

## Changes

As discussed in #5505 closure object creation for `WithCircuitBreaker<TResult>` was fixed. Also all local functions like `ProcessResults`, `ExecuteBatch`, `Resequence` was moved into class method because every call ends with closure object creation. 
For `AtomicWrite` linq methods was removed usage because it ends in memory allocation.
It shows good consumed memory performance for write journal critical path:
`JournalWriteBenchmarks`  - 4% lower.
`AtomicWriteBenchmark` - 25% lower

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

BenchmarkDotNet=v0.13.2, OS=macOS Monterey 12.5.1 (21G83) [Darwin 21.6.0]
Apple M1 2.40GHz, 1 CPU, 8 logical and 8 physical cores
.NET SDK=7.0.101
  [Host] : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT SSE4.2 DEBUG

JournalWriteBenchmarks

|             Method | PersistentActors | WriteMsgCount |        Mean |     Error |   StdDev |      Gen0 |      Gen1 |   Allocated |
|------------------- |----------------- |-------------- |------------:|----------:|---------:|----------:|----------:|------------:|
| WriteToPersistence |                1 |           100 |    789.1 us |  47.17 us | 133.8 us |         - |         - |   163.88 KB |
| WriteToPersistence |               10 |           100 |  1,868.0 us |  50.21 us | 145.7 us |         - |         - |  1582.23 KB |
| WriteToPersistence |              100 |           100 | 24,981.2 us | 492.14 us | 657.0 us | 2000.0000 | 1000.0000 | 15686.82 KB |

AtomicWriteBenchmark

|      Method | WriteMsgCount |     Mean |     Error |    StdDev |      Gen0 | Allocated |
|------------ |-------------- |---------:|----------:|----------:|----------:|----------:|
| Constructor |        100000 | 9.324 ms | 0.1661 ms | 0.2434 ms | 1000.0000 |   8.39 MB |

### This PR's Benchmarks

InJournalWriteBenchmarks

|             Method | PersistentActors | WriteMsgCount |        Mean |     Error |   StdDev |      Median |      Gen0 |      Gen1 |   Allocated |
|------------------- |----------------- |-------------- |------------:|----------:|---------:|------------:|----------:|----------:|------------:|
| WriteToPersistence |                1 |           100 |    785.2 us |  50.09 us | 143.7 us |    756.2 us |         - |         - |   156.91 KB |
| WriteToPersistence |               10 |           100 |  1,811.6 us |  54.72 us | 157.9 us |  1,765.2 us |         - |         - |  1518.79 KB |
| WriteToPersistence |              100 |           100 | 23,806.4 us | 463.65 us | 694.0 us | 23,761.8 us | 2000.0000 | 1000.0000 | 14953.15 KB |

AtomicWriteBenchmark

|      Method | WriteMsgCount |     Mean |     Error |    StdDev |      Gen0 | Allocated |
|------------ |-------------- |---------:|----------:|----------:|----------:|----------:|
| Constructor |        100000 | 8.652 ms | 0.1305 ms | 0.2031 ms | 1000.0000 |    6.1 MB |