### PR TITLE
harden `ClusterLogVerboseSpec`

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
@@ -125,9 +125,9 @@ namespace Akka.Cluster.Tests
         public async Task A_cluster_must_not_log_verbose_cluster_events_by_default()
         {
             _cluster.Settings.LogInfoVerbose.ShouldBeFalse();
-            await JoinAsync(upLogMessage).ShouldThrowWithin<TrueException>(11.Seconds());
+            await JoinAsync(upLogMessage).ShouldThrowWithin<XunitException>(11.Seconds());
             await AwaitUpAsync();
-            await DownAsync(downLogMessage).ShouldThrowWithin<TrueException>(11.Seconds());
+            await DownAsync(downLogMessage).ShouldThrowWithin<XunitException>(11.Seconds());
         }
     }
 


### PR DESCRIPTION
Multiple xUnit types can be thrown here, so handle the base `xUnitException` and not `TrueException`.