### PR TITLE
harden racy `ActorCellSpec`s

### DIFF
--- a/src/core/Akka.Tests/Actor/ActorCellSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorCellSpec.cs
@@ -22,54 +22,55 @@ namespace Akka.Tests.Actor
     {
         public class DummyActor : ReceiveActor
         {
-            public DummyActor(AutoResetEvent autoResetEvent)
+            public DummyActor()
             {
-                ReceiveAny(m => autoResetEvent.Set());
+                ReceiveAny(m => Sender.Tell(m));
             }
         }
 
         public class DummyAsyncActor : ReceiveActor
         {
-            public DummyAsyncActor(AutoResetEvent autoResetEvent)
+            public DummyAsyncActor()
             {
                 ReceiveAsync<string>(async m =>
                 {
-                    await Task.Delay(500);
-                    autoResetEvent.Set();
+                    await Task.Delay(5);
+                    Sender.Tell(m);
                 });
             }
         }
 
         [Fact]
-        public void Cell_should_clear_current_message_after_receive()
+        public async Task Cell_should_clear_current_message_after_receive()
         {
-            AutoResetEvent autoResetEvent = new AutoResetEvent(false);
-            var actor = Sys.ActorOf(Props.Create(() => new DummyActor(autoResetEvent)));
-            actor.Tell("hello");
-            //ensure the message was received
-            autoResetEvent.WaitOne();
-            var refCell = actor as ActorRefWithCell;
-            var cell = refCell.Underlying as ActorCell;
+            // arrange
+            var actor = Sys.ActorOf(Props.Create(() => new DummyActor()));
+            
+            // act
+            await actor.Ask<string>("hello", RemainingOrDefault);
+            
+            // assert
+            var refCell = (ActorRefWithCell)actor;
             //wait while current message is not null (that is, receive is not yet completed/exited)
-            SpinWait.SpinUntil(() => cell.CurrentMessage == null, TimeSpan.FromSeconds(2));
 
-            cell.CurrentMessage.ShouldBe(null);
+            AwaitCondition(() => refCell.Underlying is ActorCell { CurrentMessage: null });
         }
 
         [Fact]
-        public void Cell_should_clear_current_message_after_async_receive()
+        public async Task Cell_should_clear_current_message_after_async_receive()
         {
-            AutoResetEvent autoResetEvent = new AutoResetEvent(false);
-            var actor = Sys.ActorOf(Props.Create(() => new DummyAsyncActor(autoResetEvent)));
-            actor.Tell("hello");
-            //ensure the message was received
-            Assert.True(autoResetEvent.WaitOne(TimeSpan.FromSeconds(3)), "Timed out while waiting for autoreset event");
-            var refCell = actor as ActorRefWithCell;
-            var cell = refCell.Underlying as ActorCell;
-            //wait while current message is not null (that is, receive is not yet completed/exited)
-            SpinWait.SpinUntil(() => cell.CurrentMessage == null, TimeSpan.FromSeconds(2));
+            // arrange
+            var actor = Sys.ActorOf(Props.Create(() => new DummyAsyncActor()));
+            
+            // act
+            await actor.Ask<string>("hello", RemainingOrDefault);
 
-            cell.CurrentMessage.ShouldBe(null);
+            // assert
+            
+            var refCell = (ActorRefWithCell)actor;
+            //wait while current message is not null (that is, receive is not yet completed/exited)
+
+            AwaitCondition(() => refCell.Underlying is ActorCell { CurrentMessage: null });
         }
     }
 }


### PR DESCRIPTION
## Changes

harden racy `ActorCellSpec`s - also modernized these specs to use built-in `TestKit` methods and `async Task` unit tests.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
