### PR TITLE
harden timing on racy Akka.Streams specs

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
@@ -106,6 +106,7 @@ namespace Akka.Streams.Tests.Dsl
                         materializer.Shutdown();
                 }
             });
+            
             //since we are collapsing the stream inside the read
             //we want to send messages so we aren't just waiting forever.
             await probe.SendNextAsync(1);
@@ -113,7 +114,7 @@ namespace Akka.Streams.Tests.Dsl
             var thrown = false;
             try
             {
-                await a.ShouldCompleteWithin(3.Seconds());
+                await a.ShouldCompleteWithin(10.Seconds());
             }
             catch (StreamDetachedException)
             {


### PR DESCRIPTION
## Changes

harden timing on racy Akka.Streams specs

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
