### PR TITLE
added `EventStreamBenchmark`

### DIFF
--- a/src/benchmark/Akka.Benchmarks/EventStream/EventStreamBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/EventStream/EventStreamBenchmarks.cs
@@ -1,0 +1,57 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="EventStreamBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.EventStream
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class EventStreamBenchmarks
+    {
+                
+        public const int NumOperations = 1_000_000;
+        
+        internal sealed class FakeActor : MinimalActorRef
+        {
+            public override ActorPath Path { get; } = new RootActorPath(new Address("akka", "test")) / "fake";
+            public override IActorRefProvider Provider => throw new System.NotImplementedException();
+            
+            public int LastMessage { get; private set; }
+
+            protected override void TellInternal(object message, IActorRef sender)
+            {
+                LastMessage++;
+            }
+        }
+        
+        private FakeActor _fakeActor;
+        private Akka.Event.EventStream _eventStream;
+
+        private const string _msg = "foo";
+
+        
+        [IterationSetup]
+        public void InitLogger()
+        {
+            _eventStream = new Event.EventStream(false);
+            _fakeActor = new FakeActor();
+            _eventStream.Subscribe(_fakeActor, typeof(string));
+        }
+        
+        [Benchmark(OperationsPerInvoke = NumOperations)]
+        public object Publish()
+        {
+            for (var i = 0; i < NumOperations; i++)
+            {
+                _eventStream.Publish(_msg);
+            }
+            return _fakeActor.LastMessage;
+        }
+    }
+}


### PR DESCRIPTION
## Changes

Added some benchmarks to clock the throughput of the `EventStream` before we consider making some changes to it.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

``` ini

BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19044.2486/21H2/November2021Update)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  Job-JPMJGS : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2

InvocationCount=1  UnrollFactor=1  

```
|  Method |     Mean |    Error |   StdDev | Allocated |
|-------- |---------:|---------:|---------:|----------:|
| Publish | 54.90 ns | 0.498 ns | 0.441 ns |         - |

