### PR TITLE
v1.5 logging (version 2)

### DIFF
--- a/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
+++ b/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
@@ -160,3 +160,29 @@ akka.cluster.sharding {
 ```
 
 If you run into any trouble upgrading, [please file an issue with Akka.NET](https://github.com/akkadotnet/akka.net/issues/new/choose).
+
+
+### Breaking Logging Changes
+
+In v1.5, we've re-engineering the `ILoggingAdapter` construct to be more extensible and performant. Unfortunately this necessistate some breaking changes that will affect end-user code - but the remedy for those changes is trivial.
+
+After installing the v1.5 NuGet packages into your applications or libraries, you will need to add the following to all of your source files where you previously made calls to the `ILoggingAdapter`:
+
+```csharp
+using Akka.Event;
+```
+
+That `using` statement will pull in the extension methods that match all of the v1.4 API `ILoggingAdapter` signatures in v1.5.
+
+_Even better_ - if you can take advantage of [`global using` statements in C#10](https://blog.jetbrains.com/dotnet/2021/11/18/global-usings-in-csharp-10/), then this is a one-liner as either the MSBuild or project level:
+
+In `Directory.Build.props`:
+
+```xml
+<Project>
+    <ItemGroup>
+        <PackageReference Include="Akka" />
+        <Using Include="Akka.Event" />
+    </ItemGroup>
+</Project>
+```

--- a/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
+++ b/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
@@ -161,10 +161,9 @@ akka.cluster.sharding {
 
 If you run into any trouble upgrading, [please file an issue with Akka.NET](https://github.com/akkadotnet/akka.net/issues/new/choose).
 
-
 ### Breaking Logging Changes
 
-In v1.5, we've re-engineering the `ILoggingAdapter` construct to be more extensible and performant. Unfortunately this necessistate some breaking changes that will affect end-user code - but the remedy for those changes is trivial.
+In v1.5, we've re-engineering the `ILoggingAdapter` construct to be more extensible and performant. Unfortunately this necessitate some breaking changes that will affect end-user code - but the remedy for those changes is trivial.
 
 After installing the v1.5 NuGet packages into your applications or libraries, you will need to add the following to all of your source files where you previously made calls to the `ILoggingAdapter`:
 

--- a/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
@@ -35,9 +35,21 @@ namespace Akka.Benchmarks
             public override bool IsDebugEnabled { get; } = true;
             public override bool IsInfoEnabled { get; } = true;
             public override bool IsWarningEnabled { get; } = true;
+            
+            private LogEvent CreateLogEvent(LogLevel logLevel, object message, Exception cause = null)
+            {
+                return logLevel switch
+                {
+                    LogLevel.DebugLevel => new Debug(cause, _logSource, _logClass, message),
+                    LogLevel.InfoLevel => new Info(cause, _logSource, _logClass, message),
+                    LogLevel.WarningLevel => new Warning(cause, _logSource, _logClass, message),
+                    LogLevel.ErrorLevel => new Error(cause, _logSource, _logClass, message),
+                    _ => throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null)
+                };
+            }
             protected override void NotifyLog(LogLevel logLevel, object message, Exception cause = null)
             {
-                throw new NotImplementedException();
+                AddLogMessage(CreateLogEvent(logLevel, message, cause));
             }
 
             public override bool IsErrorEnabled { get; } = true;

--- a/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
@@ -35,68 +35,16 @@ namespace Akka.Benchmarks
             public override bool IsDebugEnabled { get; } = true;
             public override bool IsInfoEnabled { get; } = true;
             public override bool IsWarningEnabled { get; } = true;
+            protected override void NotifyLog(LogLevel logLevel, object message, Exception cause = null)
+            {
+                throw new NotImplementedException();
+            }
+
             public override bool IsErrorEnabled { get; } = true;
 
             private void AddLogMessage(LogEvent m)
             {
                 AllLogs[CurrentLogs++] = m;
-            }
-
-            protected override void NotifyError(object message)
-            {
-               AddLogMessage(new Error(null, _logSource, _logClass, message));
-            }
-
-            /// <summary>
-            /// Publishes the error message and exception onto the LoggingBus.
-            /// </summary>
-            /// <param name="cause">The exception that caused this error.</param>
-            /// <param name="message">The error message.</param>
-            protected override void NotifyError(Exception cause, object message)
-            {
-                AddLogMessage(new Error(cause, _logSource, _logClass, message));
-            }
-
-            /// <summary>
-            /// Publishes the warning message onto the LoggingBus.
-            /// </summary>
-            /// <param name="message">The warning message.</param>
-            protected override void NotifyWarning(object message)
-            {
-                AddLogMessage(new Warning(_logSource, _logClass, message));
-            }
-
-            protected override void NotifyWarning(Exception cause, object message)
-            {
-                AddLogMessage(new Warning(cause, _logSource, _logClass, message));
-            }
-
-            /// <summary>
-            /// Publishes the info message onto the LoggingBus.
-            /// </summary>
-            /// <param name="message">The info message.</param>
-            protected override void NotifyInfo(object message)
-            {
-                AddLogMessage(new Info(_logSource, _logClass, message));
-            }
-
-            protected override void NotifyInfo(Exception cause, object message)
-            {
-                AddLogMessage(new Info(cause, _logSource, _logClass, message));
-            }
-
-            /// <summary>
-            /// Publishes the debug message onto the LoggingBus.
-            /// </summary>
-            /// <param name="message">The debug message.</param>
-            protected override void NotifyDebug(object message)
-            {
-                AddLogMessage(new Debug(_logSource, _logClass, message));
-            }
-
-            protected override void NotifyDebug(Exception cause, object message)
-            {
-                AddLogMessage(new Debug(cause, _logSource, _logClass, message));
             }
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Metrics/ClusterMetrics.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/ClusterMetrics.cs
@@ -13,6 +13,7 @@ using Akka.Cluster.Metrics.Events;
 using Akka.Cluster.Metrics.Helpers;
 using Akka.Cluster.Metrics.Serialization;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.Util;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;
 
@@ -88,7 +89,7 @@ namespace Akka.Cluster.Metrics
                     {
                         _system.Log.Error(
                             $"Configured strategy provider {Settings.SupervisorStrategyProvider} failed to load, " +
-                            $"using default {typeof(ClusterMetricsStrategy).Name}.");
+                            $"using default {nameof(ClusterMetricsStrategy)}.");
                         return new ClusterMetricsStrategy(Settings.SupervisorStrategyConfiguration);
                     })
                     .Get();

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowning2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowning2Spec.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Akka.Actor;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.Util;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowningSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowningSpec.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Akka.Actor;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.Util;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.Util;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.Util;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategyRandomizedSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategyRandomizedSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using FluentAssertions.Execution;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentStartEntitySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentStartEntitySpec.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessSpec.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.TestKit;
 using Xunit;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/StorageHelpers.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/StorageHelpers.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -174,7 +174,7 @@ namespace Akka.Cluster.Sharding
     /// <para>
     /// Typical usage of this extension:
     ///   1. At system startup on each cluster node by registering the supported entity types with
-    /// the <see cref="ClusterShardingGuardian.Start"/> method
+    /// the <see cref="ClusterSharding.Start"/> method
     ///   1. Retrieve the <see cref="Sharding.ShardRegion"/> actor for a named entity type with <see cref="ClusterSharding.ShardRegion"/>
     /// Settings can be configured as described in the `akka.cluster.sharding` section of the `reference.conf`.
     /// </para>
@@ -275,19 +275,19 @@ namespace Akka.Cluster.Sharding
         private readonly Cluster _cluster;
 
         /// <summary>
-        /// TBD
+        /// Retrieves or creates the <see cref="ClusterSharding"/> extension for the given <see cref="ActorSystem"/>.
         /// </summary>
-        /// <param name="system">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="system">The ActorSystem.</param>
+        /// <returns>The singleton instances of the ClusterSharding extension associated with this ActorSystem.</returns>
         public static ClusterSharding Get(ActorSystem system)
         {
             return system.WithExtension<ClusterSharding, ClusterShardingExtensionProvider>();
         }
 
         /// <summary>
-        /// TBD
+        /// Instantiates the Akka.Cluster.Sharding extension for this system.
         /// </summary>
-        /// <param name="system">TBD</param>
+        /// <param name="system">The ActorSystem.</param>
         public ClusterSharding(ExtendedActorSystem system)
         {
             _system = system;
@@ -1358,7 +1358,7 @@ namespace Akka.Cluster.Sharding
 #pragma warning disable CS0419 // Ambiguous reference in cref attribute
         /// <summary>
         /// Retrieve the actor reference of the <see cref="Sharding.ShardRegion"/> actor responsible for the named entity type.
-        /// The entity type must be registered with the <see cref="ClusterShardingGuardian.Start"/> or <see cref="ClusterShardingGuardian.StartProxy"/> method before it
+        /// The entity type must be registered with the <see cref="ClusterSharding.Start"/> or <see cref="ClusterSharding.StartProxy"/> method before it
         /// can be used here. Messages to the entity is always sent via the <see cref="Sharding.ShardRegion"/>.
         /// </summary>
         /// <param name="typeName">TBD</param>
@@ -1384,7 +1384,7 @@ namespace Akka.Cluster.Sharding
         /// Retrieve the actor reference of the <see cref="Sharding.ShardRegion"/> actor that will act as a proxy to the
         /// named entity type running in another data center. A proxy within the same data center can be accessed
         /// with <see cref="Sharding.ShardRegion"/> instead of this method. The entity type must be registered with the
-        /// <see cref="ClusterShardingGuardian.StartProxy"/> method before it can be used here. Messages to the entity is always sent
+        /// <see cref="ClusterSharding.StartProxy"/> method before it can be used here. Messages to the entity is always sent
         /// via the <see cref="Sharding.ShardRegion"/>.
         /// </summary>
         /// <param name="typeName"></param>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -17,6 +17,7 @@ using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
 using Akka.Dispatch;
+using Akka.Event;
 using Akka.Pattern;
 using Akka.Util;
 
@@ -173,7 +174,7 @@ namespace Akka.Cluster.Sharding
     /// <para>
     /// Typical usage of this extension:
     ///   1. At system startup on each cluster node by registering the supported entity types with
-    /// the <see cref="ClusterSharding.Start"/> method
+    /// the <see cref="ClusterShardingGuardian.Start"/> method
     ///   1. Retrieve the <see cref="Sharding.ShardRegion"/> actor for a named entity type with <see cref="ClusterSharding.ShardRegion"/>
     /// Settings can be configured as described in the `akka.cluster.sharding` section of the `reference.conf`.
     /// </para>
@@ -1357,7 +1358,7 @@ namespace Akka.Cluster.Sharding
 #pragma warning disable CS0419 // Ambiguous reference in cref attribute
         /// <summary>
         /// Retrieve the actor reference of the <see cref="Sharding.ShardRegion"/> actor responsible for the named entity type.
-        /// The entity type must be registered with the <see cref="Start"/> or <see cref="StartProxy"/> method before it
+        /// The entity type must be registered with the <see cref="ClusterShardingGuardian.Start"/> or <see cref="ClusterShardingGuardian.StartProxy"/> method before it
         /// can be used here. Messages to the entity is always sent via the <see cref="Sharding.ShardRegion"/>.
         /// </summary>
         /// <param name="typeName">TBD</param>
@@ -1383,7 +1384,7 @@ namespace Akka.Cluster.Sharding
         /// Retrieve the actor reference of the <see cref="Sharding.ShardRegion"/> actor that will act as a proxy to the
         /// named entity type running in another data center. A proxy within the same data center can be accessed
         /// with <see cref="Sharding.ShardRegion"/> instead of this method. The entity type must be registered with the
-        /// <see cref="StartProxy"/> method before it can be used here. Messages to the entity is always sent
+        /// <see cref="ClusterShardingGuardian.StartProxy"/> method before it can be used here. Messages to the entity is always sent
         /// via the <see cref="Sharding.ShardRegion"/>.
         /// </summary>
         /// <param name="typeName"></param>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Internal/EventSourcedRememberEntitiesCoordinatorStore.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Internal/EventSourcedRememberEntitiesCoordinatorStore.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Persistence;
 
 namespace Akka.Cluster.Sharding.Internal

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Internal/EventSourcedRememberEntitiesShardStore.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Internal/EventSourcedRememberEntitiesShardStore.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Persistence;
 
 namespace Akka.Cluster.Sharding.Internal

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardedDaemonProcess.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardedDaemonProcess.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using Akka.Actor;
 using Akka.Annotations;
+using Akka.Event;
 using Akka.Util.Internal;
 
 namespace Akka.Cluster.Sharding

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
@@ -17,6 +17,7 @@ using Akka.Cluster.Tools.Client;
 using Akka.Cluster.Tools.PublishSubscribe;
 using Akka.Cluster.Tools.PublishSubscribe.Internal;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.Remote.Transport;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerChaosSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerChaosSpec.cs
@@ -11,6 +11,7 @@ using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.TestKit;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonLeavingSpeedSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonLeavingSpeedSpec.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.TestKit;
 using Akka.TestKit.TestActors;
 using FluentAssertions;

--- a/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/DurableDataPocoSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/DurableDataPocoSpec.cs
@@ -13,6 +13,7 @@ using Akka.Cluster;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.DistributedData.Durable;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.TestKit;

--- a/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/DurableDataSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/DurableDataSpec.cs
@@ -13,6 +13,7 @@ using Akka.Cluster;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.DistributedData.Durable;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.TestKit;

--- a/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/ReplicatorSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/ReplicatorSpec.cs
@@ -14,6 +14,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Akka.Cluster;
 using Akka.Cluster.TestKit;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.Transport;
 using Akka.TestKit;

--- a/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorResiliencySpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorResiliencySpec.cs
@@ -15,6 +15,7 @@ using Akka.Configuration;
 using Akka.Dispatch.SysMsg;
 using Akka.DistributedData.Durable;
 using Akka.DistributedData.LightningDB;
+using Akka.Event;
 using Akka.Pattern;
 using Akka.TestKit;
 using FluentAssertions;

--- a/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorSpecs.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorSpecs.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using FluentAssertions.Extensions;

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection/DependencyResolverSetup.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection/DependencyResolverSetup.cs
@@ -8,7 +8,6 @@
 using System;
 using Akka.Actor;
 using Akka.Actor.Setup;
-using Akka.Dispatch.SysMsg;
 
 namespace Akka.DependencyInjection
 {
@@ -47,7 +46,7 @@ namespace Akka.DependencyInjection
     /// The <see cref="IDependencyResolver"/> will be used to access previously registered services
     /// in the creation of actors and other pieces of infrastructure inside Akka.NET.
     ///
-    /// The constructor is internal. Please use <see cref="Dispatch.SysMsg.Create"/> to create a new instance.
+    /// The constructor is internal. Please use <see cref="DependencyResolverSetup.Create"/> to create a new instance.
     /// </summary>
     public class DependencyResolverSetup : Setup
     {

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection/DependencyResolverSetup.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection/DependencyResolverSetup.cs
@@ -8,6 +8,7 @@
 using System;
 using Akka.Actor;
 using Akka.Actor.Setup;
+using Akka.Dispatch.SysMsg;
 
 namespace Akka.DependencyInjection
 {
@@ -46,7 +47,7 @@ namespace Akka.DependencyInjection
     /// The <see cref="IDependencyResolver"/> will be used to access previously registered services
     /// in the creation of actors and other pieces of infrastructure inside Akka.NET.
     ///
-    /// The constructor is internal. Please use <see cref="Create"/> to create a new instance.
+    /// The constructor is internal. Please use <see cref="Dispatch.SysMsg.Create"/> to create a new instance.
     /// </summary>
     public class DependencyResolverSetup : Setup
     {

--- a/src/contrib/testkits/Akka.TestKit.Xunit/Internals/Loggers.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/Internals/Loggers.cs
@@ -48,7 +48,7 @@ namespace Akka.TestKit.Xunit.Internals
                 if (e.Message is LogMessage msg)
                 {
                     var message =
-                        $"Received a malformed formatted message. Log level: [{e.LogLevel()}], Template: [{msg.Format}], args: [{string.Join(",", msg.Args)}]";
+                        $"Received a malformed formatted message. Log level: [{e.LogLevel()}], Template: [{msg.Format}], args: [{string.Join(",", msg.Unformatted())}]";
                     if(e.Cause != null)
                         throw new AggregateException(message, ex, e.Cause);
                     throw new FormatException(message, ex);

--- a/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/Internals/Loggers.cs
@@ -50,7 +50,7 @@ namespace Akka.TestKit.Xunit2.Internals
                 if (e.Message is LogMessage msg)
                 {
                     var message =
-                        $"Received a malformed formatted message. Log level: [{e.LogLevel()}], Template: [{msg.Format}], args: [{string.Join(",", msg.Args)}]";
+                        $"Received a malformed formatted message. Log level: [{e.LogLevel()}], Template: [{msg.Format}], args: [{string.Join(",", msg.Unformatted())}]";
                     if (e.Cause != null)
                         throw new AggregateException(message, ex, e.Cause);
                     throw new FormatException(message, ex);

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
@@ -3007,14 +3007,7 @@ namespace Akka.Event
         public override bool IsErrorEnabled { get; }
         public override bool IsInfoEnabled { get; }
         public override bool IsWarningEnabled { get; }
-        protected override void NotifyDebug(object message) { }
-        protected override void NotifyDebug(System.Exception cause, object message) { }
-        protected override void NotifyError(object message) { }
-        protected override void NotifyError(System.Exception cause, object message) { }
-        protected override void NotifyInfo(object message) { }
-        protected override void NotifyInfo(System.Exception cause, object message) { }
-        protected override void NotifyWarning(object message) { }
-        protected override void NotifyWarning(System.Exception cause, object message) { }
+        protected override void NotifyLog(Akka.Event.LogLevel logLevel, object message, System.Exception cause = null) { }
     }
     public sealed class DeadLetter : Akka.Event.AllDeadLetters
     {
@@ -3039,6 +3032,7 @@ namespace Akka.Event
     {
         public static readonly Akka.Event.DefaultLogMessageFormatter Instance;
         public string Format(string format, params object[] args) { }
+        public string Format(string format, System.Collections.Generic.IEnumerable<object> args) { }
     }
     public class DefaultLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>
     {
@@ -3094,25 +3088,19 @@ namespace Akka.Event
     public interface ILogMessageFormatter
     {
         string Format(string format, params object[] args);
+        string Format(string format, System.Collections.Generic.IEnumerable<object> args);
     }
     public interface ILoggerMessageQueueSemantics : Akka.Dispatch.ISemantics { }
     public interface ILoggingAdapter
     {
+        Akka.Event.ILogMessageFormatter Formatter { get; }
         bool IsDebugEnabled { get; }
         bool IsErrorEnabled { get; }
         bool IsInfoEnabled { get; }
         bool IsWarningEnabled { get; }
-        void Debug(string format, params object[] args);
-        void Debug(System.Exception cause, string format, params object[] args);
-        void Error(string format, params object[] args);
-        void Error(System.Exception cause, string format, params object[] args);
-        void Info(string format, params object[] args);
-        void Info(System.Exception cause, string format, params object[] args);
         bool IsEnabled(Akka.Event.LogLevel logLevel);
-        void Log(Akka.Event.LogLevel logLevel, string format, params object[] args);
-        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args);
-        void Warning(string format, params object[] args);
-        void Warning(System.Exception cause, string format, params object[] args);
+        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format);
+        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message);
     }
     public class Info : Akka.Event.LogEvent
     {
@@ -3144,13 +3132,15 @@ namespace Akka.Event
         WarningLevel = 2,
         ErrorLevel = 3,
     }
-    public class LogMessage
+    public abstract class LogMessage
     {
-        public LogMessage(Akka.Event.ILogMessageFormatter formatter, string format, params object[] args) { }
-        public object[] Args { get; }
+        protected readonly Akka.Event.ILogMessageFormatter Formatter;
+        public LogMessage(Akka.Event.ILogMessageFormatter formatter, string format) { }
         public string Format { get; }
-        public override string ToString() { }
+        [Akka.Annotations.InternalApiAttribute()]
+        public abstract string Unformatted();
     }
+    public class static LogMessageExtensions { }
     public struct LogSource
     {
         public string Source { get; }
@@ -3187,32 +3177,15 @@ namespace Akka.Event
     public abstract class LoggingAdapterBase : Akka.Event.ILoggingAdapter
     {
         protected LoggingAdapterBase(Akka.Event.ILogMessageFormatter logMessageFormatter) { }
+        public Akka.Event.ILogMessageFormatter Formatter { get; }
         public abstract bool IsDebugEnabled { get; }
         public abstract bool IsErrorEnabled { get; }
         public abstract bool IsInfoEnabled { get; }
         public abstract bool IsWarningEnabled { get; }
-        public virtual void Debug(string format, params object[] args) { }
-        public virtual void Debug(System.Exception cause, string format, params object[] args) { }
-        public virtual void Error(System.Exception cause, string format, params object[] args) { }
-        public virtual void Error(string format, params object[] args) { }
-        public virtual void Info(System.Exception cause, string format, params object[] args) { }
-        public virtual void Info(string format, params object[] args) { }
         public bool IsEnabled(Akka.Event.LogLevel logLevel) { }
-        public virtual void Log(Akka.Event.LogLevel logLevel, string format, params object[] args) { }
-        public virtual void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args) { }
-        protected abstract void NotifyDebug(object message);
-        protected abstract void NotifyDebug(System.Exception cause, object message);
-        protected abstract void NotifyError(object message);
-        protected abstract void NotifyError(System.Exception cause, object message);
-        protected abstract void NotifyInfo(object message);
-        protected abstract void NotifyInfo(System.Exception cause, object message);
-        protected void NotifyLog(Akka.Event.LogLevel logLevel, object message) { }
-        protected void NotifyLog(Akka.Event.LogLevel logLevel, System.Exception cause, object message) { }
-        protected abstract void NotifyWarning(object message);
-        protected abstract void NotifyWarning(System.Exception cause, object message);
-        public virtual void Warn(string format, params object[] args) { }
-        public virtual void Warning(string format, params object[] args) { }
-        public virtual void Warning(System.Exception cause, string format, params object[] args) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format) { }
+        protected abstract void NotifyLog(Akka.Event.LogLevel logLevel, object message, System.Exception cause = null);
     }
     public class LoggingBus : Akka.Event.ActorEventBus<object, System.Type>
     {
@@ -3225,6 +3198,82 @@ namespace Akka.Event
         public void SetLogLevel(Akka.Event.LogLevel logLevel) { }
         public void StartStdoutLogger(Akka.Actor.Settings config) { }
     }
+    public class static LoggingExtensions
+    {
+        public static void Debug(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Debug<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Debug<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Debug<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Debug<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Debug<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Debug<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Debug<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Debug<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Debug<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Debug<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Debug<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Debug<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Error<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Error<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Error<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Error<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Error<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Error<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Error<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Error<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Error<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Error<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Error<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Error<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Info<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Info<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Info<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Info<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Info<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Info<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Info<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Info<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Info<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Info<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Info<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Info<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, string format) { }
+        public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, string format, object[] args) { }
+        public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, System.Exception cause, string format, object[] args) { }
+        public static void Log<T1>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1) { }
+        public static void Log<T1, T2>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Log<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Log<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Log<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Log<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Warning<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Warning<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Warning<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Warning<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Warning<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Warning<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Warning<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Warning<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Warning<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Warning<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Warning<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Warning<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+    }
     public abstract class MinimalLogger : Akka.Actor.MinimalActorRef
     {
         protected MinimalLogger() { }
@@ -3236,22 +3285,14 @@ namespace Akka.Event
     public sealed class NoLogger : Akka.Event.ILoggingAdapter
     {
         public static readonly Akka.Event.ILoggingAdapter Instance;
+        public Akka.Event.ILogMessageFormatter Formatter { get; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsWarningEnabled { get; }
-        public void Debug(string format, params object[] args) { }
-        public void Debug(System.Exception cause, string format, params object[] args) { }
-        public void Error(string format, params object[] args) { }
-        public void Error(System.Exception cause, string format, params object[] args) { }
-        public void Info(string format, params object[] args) { }
-        public void Info(System.Exception cause, string format, params object[] args) { }
         public bool IsEnabled(Akka.Event.LogLevel logLevel) { }
-        public void Log(Akka.Event.LogLevel logLevel, string format, params object[] args) { }
-        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args) { }
-        public void Warn(string format, params object[] args) { }
-        public void Warning(string format, params object[] args) { }
-        public void Warning(System.Exception cause, string format, params object[] args) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message) { }
     }
     public class StandardOutLogger : Akka.Event.MinimalLogger
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3012,14 +3012,7 @@ namespace Akka.Event
         public override bool IsErrorEnabled { get; }
         public override bool IsInfoEnabled { get; }
         public override bool IsWarningEnabled { get; }
-        protected override void NotifyDebug(object message) { }
-        protected override void NotifyDebug(System.Exception cause, object message) { }
-        protected override void NotifyError(object message) { }
-        protected override void NotifyError(System.Exception cause, object message) { }
-        protected override void NotifyInfo(object message) { }
-        protected override void NotifyInfo(System.Exception cause, object message) { }
-        protected override void NotifyWarning(object message) { }
-        protected override void NotifyWarning(System.Exception cause, object message) { }
+        protected override void NotifyLog(Akka.Event.LogLevel logLevel, object message, System.Exception cause = null) { }
     }
     public sealed class DeadLetter : Akka.Event.AllDeadLetters
     {
@@ -3044,6 +3037,7 @@ namespace Akka.Event
     {
         public static readonly Akka.Event.DefaultLogMessageFormatter Instance;
         public string Format(string format, params object[] args) { }
+        public string Format(string format, System.Collections.Generic.IEnumerable<object> args) { }
     }
     public class DefaultLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>
     {
@@ -3099,25 +3093,19 @@ namespace Akka.Event
     public interface ILogMessageFormatter
     {
         string Format(string format, params object[] args);
+        string Format(string format, System.Collections.Generic.IEnumerable<object> args);
     }
     public interface ILoggerMessageQueueSemantics : Akka.Dispatch.ISemantics { }
     public interface ILoggingAdapter
     {
+        Akka.Event.ILogMessageFormatter Formatter { get; }
         bool IsDebugEnabled { get; }
         bool IsErrorEnabled { get; }
         bool IsInfoEnabled { get; }
         bool IsWarningEnabled { get; }
-        void Debug(string format, params object[] args);
-        void Debug(System.Exception cause, string format, params object[] args);
-        void Error(string format, params object[] args);
-        void Error(System.Exception cause, string format, params object[] args);
-        void Info(string format, params object[] args);
-        void Info(System.Exception cause, string format, params object[] args);
         bool IsEnabled(Akka.Event.LogLevel logLevel);
-        void Log(Akka.Event.LogLevel logLevel, string format, params object[] args);
-        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args);
-        void Warning(string format, params object[] args);
-        void Warning(System.Exception cause, string format, params object[] args);
+        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format);
+        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message);
     }
     public class Info : Akka.Event.LogEvent
     {
@@ -3149,13 +3137,15 @@ namespace Akka.Event
         WarningLevel = 2,
         ErrorLevel = 3,
     }
-    public class LogMessage
+    public abstract class LogMessage
     {
-        public LogMessage(Akka.Event.ILogMessageFormatter formatter, string format, params object[] args) { }
-        public object[] Args { get; }
+        protected readonly Akka.Event.ILogMessageFormatter Formatter;
+        public LogMessage(Akka.Event.ILogMessageFormatter formatter, string format) { }
         public string Format { get; }
-        public override string ToString() { }
+        [Akka.Annotations.InternalApiAttribute()]
+        public abstract string Unformatted();
     }
+    public class static LogMessageExtensions { }
     public struct LogSource
     {
         [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
@@ -3194,32 +3184,15 @@ namespace Akka.Event
     public abstract class LoggingAdapterBase : Akka.Event.ILoggingAdapter
     {
         protected LoggingAdapterBase(Akka.Event.ILogMessageFormatter logMessageFormatter) { }
+        public Akka.Event.ILogMessageFormatter Formatter { get; }
         public abstract bool IsDebugEnabled { get; }
         public abstract bool IsErrorEnabled { get; }
         public abstract bool IsInfoEnabled { get; }
         public abstract bool IsWarningEnabled { get; }
-        public virtual void Debug(string format, params object[] args) { }
-        public virtual void Debug(System.Exception cause, string format, params object[] args) { }
-        public virtual void Error(System.Exception cause, string format, params object[] args) { }
-        public virtual void Error(string format, params object[] args) { }
-        public virtual void Info(System.Exception cause, string format, params object[] args) { }
-        public virtual void Info(string format, params object[] args) { }
         public bool IsEnabled(Akka.Event.LogLevel logLevel) { }
-        public virtual void Log(Akka.Event.LogLevel logLevel, string format, params object[] args) { }
-        public virtual void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args) { }
-        protected abstract void NotifyDebug(object message);
-        protected abstract void NotifyDebug(System.Exception cause, object message);
-        protected abstract void NotifyError(object message);
-        protected abstract void NotifyError(System.Exception cause, object message);
-        protected abstract void NotifyInfo(object message);
-        protected abstract void NotifyInfo(System.Exception cause, object message);
-        protected void NotifyLog(Akka.Event.LogLevel logLevel, object message) { }
-        protected void NotifyLog(Akka.Event.LogLevel logLevel, System.Exception cause, object message) { }
-        protected abstract void NotifyWarning(object message);
-        protected abstract void NotifyWarning(System.Exception cause, object message);
-        public virtual void Warn(string format, params object[] args) { }
-        public virtual void Warning(string format, params object[] args) { }
-        public virtual void Warning(System.Exception cause, string format, params object[] args) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format) { }
+        protected abstract void NotifyLog(Akka.Event.LogLevel logLevel, object message, System.Exception cause = null);
     }
     public class LoggingBus : Akka.Event.ActorEventBus<object, System.Type>
     {
@@ -3232,6 +3205,82 @@ namespace Akka.Event
         public void SetLogLevel(Akka.Event.LogLevel logLevel) { }
         public void StartStdoutLogger(Akka.Actor.Settings config) { }
     }
+    public class static LoggingExtensions
+    {
+        public static void Debug(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Debug<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Debug<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Debug<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Debug<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Debug<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Debug<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Debug<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Debug<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Debug<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Debug<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Debug<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Debug<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Error<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Error<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Error<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Error<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Error<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Error<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Error<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Error<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Error<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Error<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Error<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Error<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Info<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Info<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Info<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Info<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Info<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Info<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Info<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Info<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Info<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Info<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Info<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Info<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, string format) { }
+        public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, string format, object[] args) { }
+        public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, System.Exception cause, string format, object[] args) { }
+        public static void Log<T1>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1) { }
+        public static void Log<T1, T2>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Log<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Log<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Log<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Log<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Warning<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Warning<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Warning<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Warning<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Warning<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Warning<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Warning<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Warning<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Warning<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Warning<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Warning<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Warning<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+    }
     public abstract class MinimalLogger : Akka.Actor.MinimalActorRef
     {
         protected MinimalLogger() { }
@@ -3243,22 +3292,14 @@ namespace Akka.Event
     public sealed class NoLogger : Akka.Event.ILoggingAdapter
     {
         public static readonly Akka.Event.ILoggingAdapter Instance;
+        public Akka.Event.ILogMessageFormatter Formatter { get; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsWarningEnabled { get; }
-        public void Debug(string format, params object[] args) { }
-        public void Debug(System.Exception cause, string format, params object[] args) { }
-        public void Error(string format, params object[] args) { }
-        public void Error(System.Exception cause, string format, params object[] args) { }
-        public void Info(string format, params object[] args) { }
-        public void Info(System.Exception cause, string format, params object[] args) { }
         public bool IsEnabled(Akka.Event.LogLevel logLevel) { }
-        public void Log(Akka.Event.LogLevel logLevel, string format, params object[] args) { }
-        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args) { }
-        public void Warn(string format, params object[] args) { }
-        public void Warning(string format, params object[] args) { }
-        public void Warning(System.Exception cause, string format, params object[] args) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message) { }
     }
     public class StandardOutLogger : Akka.Event.MinimalLogger
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3007,14 +3007,7 @@ namespace Akka.Event
         public override bool IsErrorEnabled { get; }
         public override bool IsInfoEnabled { get; }
         public override bool IsWarningEnabled { get; }
-        protected override void NotifyDebug(object message) { }
-        protected override void NotifyDebug(System.Exception cause, object message) { }
-        protected override void NotifyError(object message) { }
-        protected override void NotifyError(System.Exception cause, object message) { }
-        protected override void NotifyInfo(object message) { }
-        protected override void NotifyInfo(System.Exception cause, object message) { }
-        protected override void NotifyWarning(object message) { }
-        protected override void NotifyWarning(System.Exception cause, object message) { }
+        protected override void NotifyLog(Akka.Event.LogLevel logLevel, object message, System.Exception cause = null) { }
     }
     public sealed class DeadLetter : Akka.Event.AllDeadLetters
     {
@@ -3039,6 +3032,7 @@ namespace Akka.Event
     {
         public static readonly Akka.Event.DefaultLogMessageFormatter Instance;
         public string Format(string format, params object[] args) { }
+        public string Format(string format, System.Collections.Generic.IEnumerable<object> args) { }
     }
     public class DefaultLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>
     {
@@ -3094,25 +3088,19 @@ namespace Akka.Event
     public interface ILogMessageFormatter
     {
         string Format(string format, params object[] args);
+        string Format(string format, System.Collections.Generic.IEnumerable<object> args);
     }
     public interface ILoggerMessageQueueSemantics : Akka.Dispatch.ISemantics { }
     public interface ILoggingAdapter
     {
+        Akka.Event.ILogMessageFormatter Formatter { get; }
         bool IsDebugEnabled { get; }
         bool IsErrorEnabled { get; }
         bool IsInfoEnabled { get; }
         bool IsWarningEnabled { get; }
-        void Debug(string format, params object[] args);
-        void Debug(System.Exception cause, string format, params object[] args);
-        void Error(string format, params object[] args);
-        void Error(System.Exception cause, string format, params object[] args);
-        void Info(string format, params object[] args);
-        void Info(System.Exception cause, string format, params object[] args);
         bool IsEnabled(Akka.Event.LogLevel logLevel);
-        void Log(Akka.Event.LogLevel logLevel, string format, params object[] args);
-        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args);
-        void Warning(string format, params object[] args);
-        void Warning(System.Exception cause, string format, params object[] args);
+        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format);
+        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message);
     }
     public class Info : Akka.Event.LogEvent
     {
@@ -3144,13 +3132,15 @@ namespace Akka.Event
         WarningLevel = 2,
         ErrorLevel = 3,
     }
-    public class LogMessage
+    public abstract class LogMessage
     {
-        public LogMessage(Akka.Event.ILogMessageFormatter formatter, string format, params object[] args) { }
-        public object[] Args { get; }
+        protected readonly Akka.Event.ILogMessageFormatter Formatter;
+        public LogMessage(Akka.Event.ILogMessageFormatter formatter, string format) { }
         public string Format { get; }
-        public override string ToString() { }
+        [Akka.Annotations.InternalApiAttribute()]
+        public abstract string Unformatted();
     }
+    public class static LogMessageExtensions { }
     public struct LogSource
     {
         public string Source { get; }
@@ -3187,32 +3177,15 @@ namespace Akka.Event
     public abstract class LoggingAdapterBase : Akka.Event.ILoggingAdapter
     {
         protected LoggingAdapterBase(Akka.Event.ILogMessageFormatter logMessageFormatter) { }
+        public Akka.Event.ILogMessageFormatter Formatter { get; }
         public abstract bool IsDebugEnabled { get; }
         public abstract bool IsErrorEnabled { get; }
         public abstract bool IsInfoEnabled { get; }
         public abstract bool IsWarningEnabled { get; }
-        public virtual void Debug(string format, params object[] args) { }
-        public virtual void Debug(System.Exception cause, string format, params object[] args) { }
-        public virtual void Error(System.Exception cause, string format, params object[] args) { }
-        public virtual void Error(string format, params object[] args) { }
-        public virtual void Info(System.Exception cause, string format, params object[] args) { }
-        public virtual void Info(string format, params object[] args) { }
         public bool IsEnabled(Akka.Event.LogLevel logLevel) { }
-        public virtual void Log(Akka.Event.LogLevel logLevel, string format, params object[] args) { }
-        public virtual void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args) { }
-        protected abstract void NotifyDebug(object message);
-        protected abstract void NotifyDebug(System.Exception cause, object message);
-        protected abstract void NotifyError(object message);
-        protected abstract void NotifyError(System.Exception cause, object message);
-        protected abstract void NotifyInfo(object message);
-        protected abstract void NotifyInfo(System.Exception cause, object message);
-        protected void NotifyLog(Akka.Event.LogLevel logLevel, object message) { }
-        protected void NotifyLog(Akka.Event.LogLevel logLevel, System.Exception cause, object message) { }
-        protected abstract void NotifyWarning(object message);
-        protected abstract void NotifyWarning(System.Exception cause, object message);
-        public virtual void Warn(string format, params object[] args) { }
-        public virtual void Warning(string format, params object[] args) { }
-        public virtual void Warning(System.Exception cause, string format, params object[] args) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format) { }
+        protected abstract void NotifyLog(Akka.Event.LogLevel logLevel, object message, System.Exception cause = null);
     }
     public class LoggingBus : Akka.Event.ActorEventBus<object, System.Type>
     {
@@ -3225,6 +3198,82 @@ namespace Akka.Event
         public void SetLogLevel(Akka.Event.LogLevel logLevel) { }
         public void StartStdoutLogger(Akka.Actor.Settings config) { }
     }
+    public class static LoggingExtensions
+    {
+        public static void Debug(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Debug<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Debug<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Debug<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Debug<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Debug<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Debug<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Debug<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Debug<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Debug<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Debug<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Debug<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Debug<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Error<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Error<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Error<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Error<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Error<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Error<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Error<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Error<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Error<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Error<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Error<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Error<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Info<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Info<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Info<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Info<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Info<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Info<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Info<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Info<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Info<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Info<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Info<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Info<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, string format) { }
+        public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, string format, object[] args) { }
+        public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, System.Exception cause, string format, object[] args) { }
+        public static void Log<T1>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1) { }
+        public static void Log<T1, T2>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Log<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Log<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Log<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Log<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, string format) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Warning<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
+        public static void Warning<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
+        public static void Warning<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
+        public static void Warning<T1, T2>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2) { }
+        public static void Warning<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Warning<T1, T2, T3>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3) { }
+        public static void Warning<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Warning<T1, T2, T3, T4>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4) { }
+        public static void Warning<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Warning<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
+        public static void Warning<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Warning<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+    }
     public abstract class MinimalLogger : Akka.Actor.MinimalActorRef
     {
         protected MinimalLogger() { }
@@ -3236,22 +3285,14 @@ namespace Akka.Event
     public sealed class NoLogger : Akka.Event.ILoggingAdapter
     {
         public static readonly Akka.Event.ILoggingAdapter Instance;
+        public Akka.Event.ILogMessageFormatter Formatter { get; }
         public bool IsDebugEnabled { get; }
         public bool IsErrorEnabled { get; }
         public bool IsInfoEnabled { get; }
         public bool IsWarningEnabled { get; }
-        public void Debug(string format, params object[] args) { }
-        public void Debug(System.Exception cause, string format, params object[] args) { }
-        public void Error(string format, params object[] args) { }
-        public void Error(System.Exception cause, string format, params object[] args) { }
-        public void Info(string format, params object[] args) { }
-        public void Info(System.Exception cause, string format, params object[] args) { }
         public bool IsEnabled(Akka.Event.LogLevel logLevel) { }
-        public void Log(Akka.Event.LogLevel logLevel, string format, params object[] args) { }
-        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format, params object[] args) { }
-        public void Warn(string format, params object[] args) { }
-        public void Warning(string format, params object[] args) { }
-        public void Warning(System.Exception cause, string format, params object[] args) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message) { }
     }
     public class StandardOutLogger : Akka.Event.MinimalLogger
     {

--- a/src/core/Akka.Cluster.Tests.MultiNode/QuickRestartSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/QuickRestartSpec.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.TestKit;

--- a/src/core/Akka.Cluster.Tests.MultiNode/Routing/ClusterBroadcastRouter2266BugfixSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/Routing/ClusterBroadcastRouter2266BugfixSpec.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.Routing;

--- a/src/core/Akka.Cluster.Tests.MultiNode/SunnyWeatherSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SunnyWeatherSpec.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.Util;

--- a/src/core/Akka.Cluster.Tests.MultiNode/TransitionSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/TransitionSpec.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using FluentAssertions;

--- a/src/core/Akka.Cluster/ClusterRemoteWatcher.cs
+++ b/src/core/Akka.Cluster/ClusterRemoteWatcher.cs
@@ -10,6 +10,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
 using Akka.Dispatch;
+using Akka.Event;
 using Akka.Remote;
 
 namespace Akka.Cluster

--- a/src/core/Akka.FSharp.Tests/RemoteSpecs.fs
+++ b/src/core/Akka.FSharp.Tests/RemoteSpecs.fs
@@ -9,9 +9,7 @@ module Akka.FSharp.Tests.RemoteSpecs
 
 open System
 open Akka.Actor
-open Akka.Configuration
-open Akka.Serialization
-open Newtonsoft.Json.Converters
+open Akka.Event
 open Xunit
 open Xunit.Abstractions
 open Akka.FSharp

--- a/src/core/Akka.Persistence.TCK/Query/TestActor.cs
+++ b/src/core/Akka.Persistence.TCK/Query/TestActor.cs
@@ -8,6 +8,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Persistence.Journal;
 
 namespace Akka.Persistence.TCK.Query

--- a/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Akka.Actor;
+using Akka.Event;
 
 namespace Akka.Persistence
 {

--- a/src/core/Akka.Persistence/Fsm/PersistentFSM.cs
+++ b/src/core/Akka.Persistence/Fsm/PersistentFSM.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.Persistence.Serialization;
 using static Akka.Persistence.Fsm.PersistentFSM;
 

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteDeliverySpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteDeliverySpec.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using Akka.Actor;
 using Akka.Remote.TestKit;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 
 namespace Akka.Remote.Tests.MultiNode

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeDeathWatchSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteNodeDeathWatchSpec.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
 using Akka.Remote.Transport;

--- a/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.Remote.Transport;
 using Akka.TestKit;
 using Akka.TestKit.Extensions;

--- a/src/core/Akka.Remote/Transport/DotNetty/AkkaLoggingHandler.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/AkkaLoggingHandler.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Akka.Event;
 using Akka.Util;
 using DotNetty.Buffers;
 using DotNetty.Common.Concurrency;

--- a/src/core/Akka.Streams.TestKit/TestSubscriber_Shared.cs
+++ b/src/core/Akka.Streams.TestKit/TestSubscriber_Shared.cs
@@ -13,6 +13,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Akka.Event;
 using Akka.TestKit;
 using Reactive.Streams;
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowDelaySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowDelaySpec.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;

--- a/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Akka.Event;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using FluentAssertions;

--- a/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.Pattern;
 using Akka.Streams.Dsl;
 using Akka.Streams.Stage;

--- a/src/core/Akka.Streams/Dsl/FlowWithContextOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowWithContextOperations.cs
@@ -37,7 +37,7 @@ namespace Akka.Streams.Dsl
         }
 
         /// <summary>
-        /// Context-preserving variant of <see cref="FlowOperations.Collect{TIn,T,TOut,TMat}"/>
+        /// Context-preserving variant of <see cref="Collect{TIn,TOut}"/>
         /// </summary>
         public static FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(
             this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, Func<TOut, TOut2> fn) where TOut2 : class
@@ -179,7 +179,7 @@ namespace Akka.Streams.Dsl
         }
 
         /// <summary>
-        /// Context-preserving variant of <see cref="SourceOperations.Collect{T,TOut,TMat}"/>
+        /// Context-preserving variant of <see cref="Collect{TIn,TOut}"/>
         /// </summary>
         public static SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(
             this SourceWithContext<TOut, TCtx, TMat> flow, Func<TOut, TOut2> fn) where TOut2 : class

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -2568,7 +2568,7 @@ namespace Akka.Streams.Dsl.Internal
         /// elements that would've been sent to it will be dropped instead.
         /// </para>
         /// <para>It is similar to <seealso cref="AlsoToMaterialized{TOut,TMat,TMat2,TMat3}"/> which does backpressure instead of dropping elements.</para>
-        /// <para>@see <seealso cref="WireTap{TOut,TMat}"/></para>
+        /// <para>@see <seealso cref="WireTap"/></para>
         /// <para>
         /// It is recommended to use the internally optimized <seealso cref="Keep.Left{TLeft,TRight}"/> and <seealso cref="Keep.Right{TLeft,TRight}"/> combiners
         /// where appropriate instead of manually writing functions that pass through one of the values.

--- a/src/core/Akka.Streams/Dsl/RestartFlow.cs
+++ b/src/core/Akka.Streams/Dsl/RestartFlow.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using Akka.Event;
 using Akka.Pattern;
 using Akka.Streams.Implementation.Fusing;
 using Akka.Streams.Stage;

--- a/src/core/Akka.Streams/Implementation/ActorRefSinkStage.cs
+++ b/src/core/Akka.Streams/Implementation/ActorRefSinkStage.cs
@@ -8,6 +8,7 @@
 using System;
 using Akka.Actor;
 using Akka.Annotations;
+using Akka.Event;
 using Akka.Streams.Implementation.Stages;
 using Akka.Streams.Stage;
 

--- a/src/core/Akka.Streams/Implementation/FanoutProcessorImpl.cs
+++ b/src/core/Akka.Streams/Implementation/FanoutProcessorImpl.cs
@@ -7,6 +7,7 @@
 
 using System;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Pattern;
 using Akka.Util.Internal;
 using Reactive.Streams;

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -2930,6 +2930,7 @@ namespace Akka.Streams.Implementation.Fusing
                 if (IsEnabled(_logLevels.OnFinish))
                     _log.Log(
                         _logLevels.OnFinish,
+                        null,
                         "[{0}] Downstream finished. cause: {1}: {2}.",
                         _stage._name,
                         Logging.SimpleName(cause.GetType()),

--- a/src/core/Akka.Streams/Implementation/Fusing/StreamOfStreams.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/StreamOfStreams.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Akka.Annotations;
+using Akka.Event;
 using Akka.Pattern;
 using Akka.Streams.Actors;
 using Akka.Streams.Dsl;

--- a/src/core/Akka.Streams/Implementation/IO/TcpStages.cs
+++ b/src/core/Akka.Streams/Implementation/IO/TcpStages.cs
@@ -11,6 +11,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Annotations;
+using Akka.Event;
 using Akka.IO;
 using Akka.Pattern;
 using Akka.Streams.Dsl;

--- a/src/core/Akka.Streams/Implementation/StreamRef/SinkRefImpl.cs
+++ b/src/core/Akka.Streams/Implementation/StreamRef/SinkRefImpl.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Annotations;
+using Akka.Event;
 using Akka.Streams.Dsl;
 using Akka.Streams.Serialization;
 using Akka.Streams.Stage;

--- a/src/core/Akka.Streams/Implementation/StreamRef/SourceRefImpl.cs
+++ b/src/core/Akka.Streams/Implementation/StreamRef/SourceRefImpl.cs
@@ -9,6 +9,7 @@ using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Annotations;
+using Akka.Event;
 using Akka.Pattern;
 using Akka.Streams.Actors;
 using Akka.Streams.Dsl;

--- a/src/core/Akka.Streams/Stage/AbstractStage.cs
+++ b/src/core/Akka.Streams/Stage/AbstractStage.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using Akka.Event;
 using Directive = Akka.Streams.Supervision.Directive;
 
 namespace Akka.Streams.Stage
@@ -440,7 +441,7 @@ namespace Akka.Streams.Stage
         /// with <see cref="IContext.IsFinishing"/>.
         /// </para>
         /// <para>
-        /// By default the finish signal is immediately propagated with <see cref="IContext.Finish"/>.
+        /// By default the finish signal is immediately propagated with <see cref="StatefulStage.Finish"/>.
         /// </para>
         /// <para>
         /// IMPORTANT NOTICE: this signal is not back-pressured, it might arrive from upstream even though
@@ -453,7 +454,7 @@ namespace Akka.Streams.Stage
 
         /// <summary>
         /// This method is called when downstream has cancelled. 
-        /// By default the cancel signal is immediately propagated with <see cref="IContext.Finish"/>.
+        /// By default the cancel signal is immediately propagated with <see cref="StatefulStage.Finish"/>.
         /// </summary>
         /// <param name="context">TBD</param>
         /// <returns>TBD</returns>
@@ -594,7 +595,7 @@ namespace Akka.Streams.Stage
         /// with <see cref="IContext.IsFinishing"/>.
         /// </para>
         /// <para>
-        /// By default the finish signal is immediately propagated with <see cref="IContext.Finish"/>.
+        /// By default the finish signal is immediately propagated with <see cref="StatefulStage.Finish"/>.
         /// </para>
         /// <para>
         /// IMPORTANT NOTICE: this signal is not back-pressured, it might arrive from upstream even though
@@ -614,7 +615,7 @@ namespace Akka.Streams.Stage
         /// with <see cref="IContext.IsFinishing"/>.
         /// </para>
         /// <para>
-        /// By default the finish signal is immediately propagated with <see cref="IContext.Finish"/>.
+        /// By default the finish signal is immediately propagated with <see cref="StatefulStage.Finish"/>.
         /// </para>
         /// <para>
         /// IMPORTANT NOTICE: this signal is not back-pressured, it might arrive from upstream even though
@@ -627,7 +628,7 @@ namespace Akka.Streams.Stage
 
         /// <summary>
         /// This method is called when downstream has cancelled. 
-        /// By default the cancel signal is immediately propagated with <see cref="IContext.Finish"/>.
+        /// By default the cancel signal is immediately propagated with <see cref="StatefulStage.Finish"/>.
         /// </summary>
         /// <param name="context">TBD</param>
         /// <param name="cause"></param>
@@ -636,7 +637,7 @@ namespace Akka.Streams.Stage
 
         /// <summary>
         /// This method is called when downstream has cancelled. 
-        /// By default the cancel signal is immediately propagated with <see cref="IContext.Finish"/>.
+        /// By default the cancel signal is immediately propagated with <see cref="StatefulStage.Finish"/>.
         /// </summary>
         /// <param name="context">TBD</param>
         /// <param name="cause"></param>

--- a/src/core/Akka.Streams/Stage/Stage.cs
+++ b/src/core/Akka.Streams/Stage/Stage.cs
@@ -56,7 +56,7 @@ namespace Akka.Streams.Stage
     /// <see cref="PushStage{TIn,TOut}"/> instead of <see cref="PushPullStage{TIn,TOut}"/>.
     /// </para>
     /// <para>
-    /// Stages are allowed to do early completion of downstream and cancel of upstream. This is done with <see cref="IContext.Finish"/>,
+    /// Stages are allowed to do early completion of downstream and cancel of upstream. This is done with <see cref="StatefulStage.Finish"/>,
     /// which is a combination of cancel/complete.
     /// </para>
     /// <para>
@@ -72,7 +72,7 @@ namespace Akka.Streams.Stage
     /// <see cref="IContext.AbsorbTermination"/> which stops the propagation of the termination signal, and puts the stage in a
     /// <see cref="IContext.IsFinishing"/> state. Depending on whether the stage has a pending pull signal it
     /// has not yet "consumed" by a push its <see cref="AbstractStage{TIn,TOut}.OnPull"/> handler might be called immediately or later. From
-    /// <see cref="AbstractStage{TIn,TOut}.OnPull"/> final elements can be pushed before completing downstream with <see cref="IContext.Finish"/> or
+    /// <see cref="AbstractStage{TIn,TOut}.OnPull"/> final elements can be pushed before completing downstream with <see cref="StatefulStage.Finish"/> or
     /// <see cref="IContext.PushAndFinish"/>.
     /// </para>
     /// <para>

--- a/src/core/Akka.TestKit/Internal/InternalTestActor.cs
+++ b/src/core/Akka.TestKit/Internal/InternalTestActor.cs
@@ -45,9 +45,9 @@ namespace Akka.TestKit.Internal
             }
             catch (FormatException)
             {
-                if (message is LogEvent evt && evt.Message is LogMessage msg)
+                if (message is LogEvent { Message: LogMessage msg })
                     global::System.Diagnostics.Debug.WriteLine(
-                        $"TestActor received a malformed formatted message. Template:[{msg.Format}], args:[{string.Join(",", msg.Args)}]");
+                        $"TestActor received a malformed formatted message. Template:[{msg.Format}], args:[{string.Join(",", msg.Unformatted())}]");
                 else
                     throw;
             }

--- a/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
+++ b/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.Dispatch;
+using Akka.Event;
 using Akka.Pattern;
 using Akka.Util;
 using Akka.Util.Internal;

--- a/src/core/Akka.TestKit/TestKitBase_Expect.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Expect.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Event;
 using Akka.TestKit.Internal;
 using Akka.Util;
 

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Akka.Event;
 using Akka.TestKit.Internal;
 
 namespace Akka.TestKit

--- a/src/core/Akka.Tests/Loggers/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/LoggerSpec.cs
@@ -138,13 +138,13 @@ akka.stdout-loglevel = DEBUG");
             var lc = logSource.Type;
             var formatter =  DefaultLogMessageFormatter.Instance;
 
-            yield return new object[] { new Error(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p)) }; 
+            yield return new object[] { new Error(ex, ls, lc, new DefaultLogMessage(formatter, Case.t, Case.p)) }; 
 
-            yield return new object[] {new Warning(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p))};
+            yield return new object[] {new Warning(ex, ls, lc, new DefaultLogMessage(formatter, Case.t, Case.p))};
 
-            yield return new object[] {new Info(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p))};
+            yield return new object[] {new Info(ex, ls, lc, new DefaultLogMessage(formatter, Case.t, Case.p))};
 
-            yield return new object[] {new Debug(ex, ls, lc, new LogMessage(formatter, Case.t, Case.p))};
+            yield return new object[] {new Debug(ex, ls, lc, new DefaultLogMessage(formatter, Case.t, Case.p))};
         }
 
         private class FakeException : Exception

--- a/src/core/Akka/Event/BusLogging.cs
+++ b/src/core/Akka/Event/BusLogging.cs
@@ -57,66 +57,23 @@ namespace Akka.Event
         /// Check to determine whether the <see cref="LogLevel.WarningLevel" /> is enabled.
         /// </summary>
         public override bool IsWarningEnabled { get; }
-
-        /// <summary>
-        /// Publishes the error message onto the LoggingBus.
-        /// </summary>
-        /// <param name="message">The error message.</param>
-        protected override void NotifyError(object message)
+        
+        private LogEvent CreateLogEvent(LogLevel logLevel, object message, Exception cause = null)
         {
-            _bus.Publish(new Error(null, _logSource, _logClass, message));
+            return logLevel switch
+            {
+                LogLevel.DebugLevel => new Debug(cause, _logSource, _logClass, message),
+                LogLevel.InfoLevel => new Info(cause, _logSource, _logClass, message),
+                LogLevel.WarningLevel => new Warning(cause, _logSource, _logClass, message),
+                LogLevel.ErrorLevel => new Error(cause, _logSource, _logClass, message),
+                _ => throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null)
+            };
         }
 
-        /// <summary>
-        /// Publishes the error message and exception onto the LoggingBus.
-        /// </summary>
-        /// <param name="cause">The exception that caused this error.</param>
-        /// <param name="message">The error message.</param>
-        protected override void NotifyError(Exception cause, object message)
+        protected override void NotifyLog(LogLevel logLevel, object message, Exception cause = null)
         {
-            _bus.Publish(new Error(cause, _logSource, _logClass, message));
-        }
-
-        /// <summary>
-        /// Publishes the warning message onto the LoggingBus.
-        /// </summary>
-        /// <param name="message">The warning message.</param>
-        protected override void NotifyWarning(object message)
-        {
-            _bus.Publish(new Warning(_logSource, _logClass, message));
-        }
-
-        protected override void NotifyWarning(Exception cause, object message)
-        {
-            _bus.Publish(new Warning(cause, _logSource, _logClass, message));
-        }
-
-        /// <summary>
-        /// Publishes the info message onto the LoggingBus.
-        /// </summary>
-        /// <param name="message">The info message.</param>
-        protected override void NotifyInfo(object message)
-        {
-            _bus.Publish(new Info(_logSource, _logClass, message));
-        }
-
-        protected override void NotifyInfo(Exception cause, object message)
-        {
-            _bus.Publish(new Info(cause, _logSource, _logClass, message));
-        }
-
-        /// <summary>
-        /// Publishes the debug message onto the LoggingBus.
-        /// </summary>
-        /// <param name="message">The debug message.</param>
-        protected override void NotifyDebug(object message)
-        {
-            _bus.Publish(new Debug(_logSource, _logClass, message));
-        }
-
-        protected override void NotifyDebug(Exception cause, object message)
-        {
-            _bus.Publish(new Debug(cause, _logSource, _logClass, message));
+            var logEvent = CreateLogEvent(logLevel, message, cause);
+            _bus.Publish(logEvent);
         }
     }
 }

--- a/src/core/Akka/Event/BusLogging.cs
+++ b/src/core/Akka/Event/BusLogging.cs
@@ -32,35 +32,31 @@ namespace Akka.Event
             _logSource = logSource;
             _logClass = logClass;
 
-            _isErrorEnabled = bus.LogLevel <= LogLevel.ErrorLevel;
-            _isWarningEnabled = bus.LogLevel <= LogLevel.WarningLevel;
-            _isInfoEnabled = bus.LogLevel <= LogLevel.InfoLevel;
-            _isDebugEnabled = bus.LogLevel <= LogLevel.DebugLevel;
+            IsErrorEnabled = bus.LogLevel <= LogLevel.ErrorLevel;
+            IsWarningEnabled = bus.LogLevel <= LogLevel.WarningLevel;
+            IsInfoEnabled = bus.LogLevel <= LogLevel.InfoLevel;
+            IsDebugEnabled = bus.LogLevel <= LogLevel.DebugLevel;
         }
 
-        private readonly bool _isDebugEnabled;
         /// <summary>
         /// Check to determine whether the <see cref="LogLevel.DebugLevel" /> is enabled.
         /// </summary>
-        public override bool IsDebugEnabled { get { return _isDebugEnabled; } }
+        public override bool IsDebugEnabled { get; }
 
-        private readonly bool _isErrorEnabled;
         /// <summary>
         /// Check to determine whether the <see cref="LogLevel.ErrorLevel" /> is enabled.
         /// </summary>
-        public override bool IsErrorEnabled { get { return _isErrorEnabled; } }
+        public override bool IsErrorEnabled { get; }
 
-        private readonly bool _isInfoEnabled;
         /// <summary>
         /// Check to determine whether the <see cref="LogLevel.InfoLevel" /> is enabled.
         /// </summary>
-        public override bool IsInfoEnabled { get { return _isInfoEnabled; } }
+        public override bool IsInfoEnabled { get; }
 
-        private readonly bool _isWarningEnabled;
         /// <summary>
         /// Check to determine whether the <see cref="LogLevel.WarningLevel" /> is enabled.
         /// </summary>
-        public override bool IsWarningEnabled { get { return _isWarningEnabled; } }
+        public override bool IsWarningEnabled { get; }
 
         /// <summary>
         /// Publishes the error message onto the LoggingBus.

--- a/src/core/Akka/Event/DefaultLogMessageFormatter.cs
+++ b/src/core/Akka/Event/DefaultLogMessageFormatter.cs
@@ -5,6 +5,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Akka.Event
 {
     /// <summary>
@@ -15,15 +18,14 @@ namespace Akka.Event
         public static readonly DefaultLogMessageFormatter Instance = new DefaultLogMessageFormatter();
         private DefaultLogMessageFormatter(){}
         
-        /// <summary>
-        /// Formats a specified composite string using an optional list of item substitutions.
-        /// </summary>
-        /// <param name="format">The string that is being formatted.</param>
-        /// <param name="args">An optional list of items used to format the string.</param>
-        /// <returns>The given string that has been correctly formatted.</returns>
         public string Format(string format, params object[] args)
         {
             return string.Format(format, args);
+        }
+
+        public string Format(string format, IEnumerable<object> args)
+        {
+            return string.Format(format, args.ToArray());
         }
     }
 }

--- a/src/core/Akka/Event/EventBus.cs
+++ b/src/core/Akka/Event/EventBus.cs
@@ -20,11 +20,9 @@ namespace Akka.Event
     /// <typeparam name="TSubscriber">The type of the subscriber that listens for events.</typeparam>
     public abstract class EventBus<TEvent, TClassifier, TSubscriber>
     {
-        private readonly Dictionary<TClassifier, List<Subscription<TSubscriber, TClassifier>>> _classifiers =
-            new Dictionary<TClassifier, List<Subscription<TSubscriber, TClassifier>>>();
+        private readonly Dictionary<TClassifier, List<Subscription<TSubscriber, TClassifier>>> _classifiers = new();
 
-        private volatile ConcurrentDictionary<TClassifier, List<TSubscriber>> _cache =
-            new ConcurrentDictionary<TClassifier, List<TSubscriber>>();
+        private volatile ConcurrentDictionary<TClassifier, List<TSubscriber>> _cache = new();
 
         /// <summary>
         /// Retrieves the simplified type name (the class name without the namespace) of a given object.

--- a/src/core/Akka/Event/ILogMessageFormatter.cs
+++ b/src/core/Akka/Event/ILogMessageFormatter.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Collections.Generic;
+
 namespace Akka.Event
 {
     /// <summary>
@@ -19,5 +21,16 @@ namespace Akka.Event
         /// <param name="args">An optional list of items used to format the string.</param>
         /// <returns>The given string that has been correctly formatted.</returns>
         string Format(string format, params object[] args);
+        
+        /// <summary>
+        /// Formats a string without explicit array allocation.
+        /// </summary>
+        /// <param name="format">The string that is being formatted.</param>
+        /// <param name="args">An optional list of items used to format the string.</param>
+        /// <returns>The given string that has been correctly formatted.</returns>
+        /// <remarks>
+        /// Delays array allocation until formatting time.
+        /// </remarks>
+        string Format(string format, IEnumerable<object> args);
     }
 }

--- a/src/core/Akka/Event/ILoggingAdapter.cs
+++ b/src/core/Akka/Event/ILoggingAdapter.cs
@@ -9,6 +9,117 @@ using System;
 
 namespace Akka.Event
 {
+    public static class LoggingExtensions
+    {
+        /// <summary>
+        /// Logs a <see cref="LogLevel.DebugLevel"/> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public static void Debug(this ILoggingAdapter log, string format, params object[] args)
+        {
+            if (!log.IsDebugEnabled)
+                return;
+
+            log.Log(LogLevel.DebugLevel, format, args);
+        }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.DebugLevel"/> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public static void Debug(this ILoggingAdapter log, Exception cause, string format, params object[] args)
+        {
+            if (!log.IsDebugEnabled)
+                return;
+
+            log.Log(LogLevel.DebugLevel, cause, format, args);
+        }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.InfoLevel"/> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public static void Info(this ILoggingAdapter log, string format, params object[] args)
+        {
+            if (!log.IsInfoEnabled)
+                return;
+
+            log.Log(LogLevel.InfoLevel, format, args);
+        }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.InfoLevel"/> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public static void Info(this ILoggingAdapter log, Exception cause, string format, params object[] args)
+        {
+            if (!log.IsInfoEnabled)
+                return;
+
+            log.Log(LogLevel.InfoLevel, cause, format, args);
+        }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.WarningLevel"/> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public static void Warning(this ILoggingAdapter log, string format, params object[] args)
+        {
+            if (!log.IsWarningEnabled)
+                return;
+
+            log.Log(LogLevel.WarningLevel, format, args);
+        }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.WarningLevel"/> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public static void Warning(this ILoggingAdapter log, Exception cause, string format, params object[] args)
+        {
+            if (!log.IsWarningEnabled)
+                return;
+
+            log.Log(LogLevel.WarningLevel, cause, format, args);
+        }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.ErrorLevel"/> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public static void Error(this ILoggingAdapter log, string format, params object[] args)
+        {
+            if (!log.IsErrorEnabled)
+                return;
+
+            log.Log(LogLevel.ErrorLevel, format, args);
+        }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.ErrorLevel"/> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public static void Error(this ILoggingAdapter log, Exception cause, string format, params object[] args)
+        {
+            if (!log.IsErrorEnabled)
+                return;
+
+            log.Log(LogLevel.ErrorLevel, cause, format, args);
+        }
+    }
+
     /// <summary>
     /// This interface describes the methods used to log events within the system.
     /// </summary>
@@ -42,66 +153,6 @@ namespace Akka.Event
         bool IsEnabled(LogLevel logLevel);
 
         /// <summary>
-        /// Logs a <see cref="LogLevel.DebugLevel"/> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        void Debug(string format, params object[] args);
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.DebugLevel"/> message and associated exception.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        void Debug(Exception cause, string format, params object[] args);
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.InfoLevel"/> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        void Info(string format, params object[] args);
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.InfoLevel"/> message and associated exception.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        void Info(Exception cause, string format, params object[] args);
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.WarningLevel"/> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        void Warning(string format, params object[] args);
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.WarningLevel"/> message and associated exception.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        void Warning(Exception cause, string format, params object[] args);
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.ErrorLevel"/> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        void Error(string format, params object[] args);
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.ErrorLevel"/> message and associated exception.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        void Error(Exception cause, string format, params object[] args);
-
-        /// <summary>
         /// Logs a message with a specified level.
         /// </summary>
         /// <param name="logLevel">The level used to log the message.</param>
@@ -117,6 +168,22 @@ namespace Akka.Event
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
         void Log(LogLevel logLevel, Exception cause, string format, params object[] args);
+
+        void Log(LogLevel logLevel, string format, Exception cause = null);
+
+        void Log<T1>(LogLevel logLevel, string format, T1 arg1, Exception cause = null);
+        void Log<T1, T2>(LogLevel logLevel, string format, T1 arg1, T2 arg2, Exception cause = null);
+
+        void Log<T1, T2, T3>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, Exception cause = null);
+
+        void Log<T1, T2, T3, T4>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+            Exception cause = null);
+
+        void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
+            Exception cause = null);
+
+        void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
+            T6 arg6, Exception cause = null);
     }
 
     /// <summary>
@@ -128,27 +195,42 @@ namespace Akka.Event
         /// Retrieves a singleton instance of the <see cref="NoLogger"/> class.
         /// </summary>
         public static readonly ILoggingAdapter Instance = new NoLogger();
-        private NoLogger() { }
+
+        private NoLogger()
+        {
+        }
 
         /// <summary>
         /// Check to determine whether the <see cref="LogLevel.DebugLevel" /> is enabled.
         /// </summary>
-        public bool IsDebugEnabled { get { return false; } }
+        public bool IsDebugEnabled
+        {
+            get { return false; }
+        }
 
         /// <summary>
         /// Check to determine whether the <see cref="LogLevel.InfoLevel" /> is enabled.
         /// </summary>
-        public bool IsInfoEnabled { get { return false; } }
+        public bool IsInfoEnabled
+        {
+            get { return false; }
+        }
 
         /// <summary>
         /// Check to determine whether the <see cref="LogLevel.WarningLevel" /> is enabled.
         /// </summary>
-        public bool IsWarningEnabled { get { return false; } }
+        public bool IsWarningEnabled
+        {
+            get { return false; }
+        }
 
         /// <summary>
         /// Check to determine whether the <see cref="LogLevel.ErrorLevel" /> is enabled.
         /// </summary>
-        public bool IsErrorEnabled { get { return false; } }
+        public bool IsErrorEnabled
+        {
+            get { return false; }
+        }
 
         /// <summary>
         /// Determines whether a specific log level is enabled.
@@ -163,79 +245,14 @@ namespace Akka.Event
         }
 
         /// <summary>
-        /// Logs a <see cref="LogLevel.DebugLevel" /> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public void Debug(string format, params object[] args) { }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.ErrorLevel" /> message and associated exception.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public void Debug(Exception cause, string format, params object[] args){ }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.InfoLevel" /> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public void Info(string format, params object[] args) { }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.InfoLevel" /> message and associated exception.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public void Info(Exception cause, string format, params object[] args){ }
-
-        /// <summary>
-        /// Obsolete. Use <see cref="Warning(string, object[])" /> instead!
-        /// </summary>
-        /// <param name="format">N/A</param>
-        /// <param name="args">N/A</param>
-        public void Warn(string format, params object[] args) { }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.WarningLevel" /> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public void Warning(string format, params object[] args) { }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.WarningLevel" /> message and associated exception.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public void Warning(Exception cause, string format, params object[] args){ }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.ErrorLevel" /> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public void Error(string format, params object[] args) { }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.ErrorLevel" /> message and associated exception.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public void Error(Exception cause, string format, params object[] args) { }
-
-        /// <summary>
         /// Logs a message with a specified level.
         /// </summary>
         /// <param name="logLevel">The level used to log the message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public void Log(LogLevel logLevel, string format, params object[] args) { }
+        public void Log(LogLevel logLevel, string format, params object[] args)
+        {
+        }
 
         /// <summary>
         /// Logs a message with a specified level.
@@ -245,6 +262,39 @@ namespace Akka.Event
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
         public void Log(LogLevel logLevel, Exception cause, string format, params object[] args)
+        {
+        }
+
+        public void Log(LogLevel logLevel, string format, Exception cause = null)
+        {
+        }
+
+        public void Log<T1>(LogLevel logLevel, string format, T1 arg1, Exception cause = null)
+        {
+        }
+
+        public void Log<T1, T2>(LogLevel logLevel, string format, T1 arg1, T2 arg2, Exception cause = null)
+        {
+        }
+
+        public void Log<T1, T2, T3>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, Exception cause = null)
+        {
+        }
+
+        public void Log<T1, T2, T3, T4>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+            Exception cause = null)
+        {
+        }
+
+        public void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+            T5 arg5,
+            Exception cause = null)
+        {
+        }
+
+        public void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+            T5 arg5, T6 arg6,
+            Exception cause = null)
         {
         }
     }

--- a/src/core/Akka/Event/ILoggingAdapter.cs
+++ b/src/core/Akka/Event/ILoggingAdapter.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 
 namespace Akka.Event
 {
@@ -15,13 +16,75 @@ namespace Akka.Event
         {
             log.Log(level, null, format);
         }
-        
+
+        public static void Log(this ILoggingAdapter log, LogLevel level, string format, object[] args)
+        {
+            log.Log(level, null, new DefaultLogMessage(log.Formatter, format, args));
+        }
+
+        public static void Log(this ILoggingAdapter log, LogLevel level, Exception cause, string format, object[] args)
+        {
+            log.Log(level, cause, new DefaultLogMessage(log.Formatter, format, args));
+        }
+
+        public static void Log<T1>(this ILoggingAdapter log, LogLevel logLevel, Exception cause, string format, T1 arg1)
+        {
+            log.Log(logLevel, cause, new LogMessage<LogValues<T1>>(log.Formatter, format, new LogValues<T1>(arg1)));
+        }
+
+        public static void Log<T1, T2>(this ILoggingAdapter log, LogLevel logLevel, Exception cause, string format,
+            T1 arg1, T2 arg2)
+        {
+            log.Log(logLevel, cause,
+                new LogMessage<LogValues<T1, T2>>(log.Formatter, format, new LogValues<T1, T2>(arg1, arg2)));
+        }
+
+        public static void Log<T1, T2, T3>(this ILoggingAdapter log, LogLevel logLevel, Exception cause, string format,
+            T1 arg1, T2 arg2, T3 arg3)
+        {
+            log.Log(logLevel, cause,
+                new LogMessage<LogValues<T1, T2, T3>>(log.Formatter, format,
+                    new LogValues<T1, T2, T3>(arg1, arg2, arg3)));
+        }
+
+        public static void Log<T1, T2, T3, T4>(this ILoggingAdapter log, LogLevel logLevel, Exception cause,
+            string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            log.Log(logLevel, cause,
+                new LogMessage<LogValues<T1, T2, T3, T4>>(log.Formatter, format,
+                    new LogValues<T1, T2, T3, T4>(arg1, arg2, arg3, arg4)));
+        }
+
+        public static void Log<T1, T2, T3, T4, T5>(this ILoggingAdapter log, LogLevel logLevel, Exception cause,
+            string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            log.Log(logLevel, cause,
+                new LogMessage<LogValues<T1, T2, T3, T4, T5>>(log.Formatter, format,
+                    new LogValues<T1, T2, T3, T4, T5>(arg1, arg2, arg3, arg4, arg5)));
+        }
+
+        public static void Log<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, LogLevel logLevel, Exception cause,
+            string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            log.Log(logLevel, cause,
+                new LogMessage<LogValues<T1, T2, T3, T4, T5, T6>>(log.Formatter, format,
+                    new LogValues<T1, T2, T3, T4, T5, T6>(arg1, arg2, arg3, arg4, arg5, arg6)));
+        }
+
         public static void Debug(this ILoggingAdapter log, string format)
         {
             if (!log.IsDebugEnabled)
                 return;
 
             log.Log(LogLevel.DebugLevel, null, format);
+        }
+
+        public static void Debug(this ILoggingAdapter log, Exception cause, string format)
+        {
+            if (!log.IsDebugEnabled)
+                return;
+
+            log.Log(LogLevel.DebugLevel, cause, format);
         }
 
         /// <summary>
@@ -38,7 +101,7 @@ namespace Akka.Event
             if (!log.IsDebugEnabled)
                 return;
 
-            log.Log(LogLevel.DebugLevel, cause, format, arg1);
+            log.Log<T1>(LogLevel.DebugLevel, cause, format, arg1);
         }
 
         public static void Debug<T1, T2>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2)
@@ -51,7 +114,7 @@ namespace Akka.Event
             if (!log.IsDebugEnabled)
                 return;
 
-            log.Log(LogLevel.DebugLevel, cause, format, arg1, arg2);
+            log.Log<T1, T2>(LogLevel.DebugLevel, cause, format, arg1, arg2);
         }
 
         public static void Debug<T1, T2, T3>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3)
@@ -65,7 +128,7 @@ namespace Akka.Event
             if (!log.IsDebugEnabled)
                 return;
 
-            log.Log(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3);
+            log.Log<T1, T2, T3>(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3);
         }
 
         public static void Debug<T1, T2, T3, T4>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
@@ -80,7 +143,7 @@ namespace Akka.Event
             if (!log.IsDebugEnabled)
                 return;
 
-            log.Log(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3, arg4);
+            log.Log<T1, T2, T3, T4>(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3, arg4);
         }
 
         public static void Debug<T1, T2, T3, T4, T5>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
@@ -95,7 +158,7 @@ namespace Akka.Event
             if (!log.IsDebugEnabled)
                 return;
 
-            log.Log(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
+            log.Log<T1, T2, T3, T4, T5>(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
         }
 
         public static void Debug<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2,
@@ -110,7 +173,7 @@ namespace Akka.Event
             if (!log.IsDebugEnabled)
                 return;
 
-            log.Log(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
+            log.Log<T1, T2, T3, T4, T5, T6>(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
         /// <summary>
@@ -119,12 +182,20 @@ namespace Akka.Event
         /// <param name="cause">The exception associated with this message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public static void Debug(this ILoggingAdapter log, Exception cause, string format, params object[] args)
+        public static void Debug(this ILoggingAdapter log, Exception cause, string format, object[] args)
         {
             if (!log.IsDebugEnabled)
                 return;
 
             log.Log(LogLevel.DebugLevel, cause, format, args);
+        }
+
+        public static void Debug(this ILoggingAdapter log, string format, object[] args)
+        {
+            if (!log.IsDebugEnabled)
+                return;
+
+            log.Log(LogLevel.DebugLevel, null, format, args);
         }
 
         /* END DEBUG */
@@ -141,6 +212,19 @@ namespace Akka.Event
             log.Log(LogLevel.InfoLevel, null, format);
         }
 
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.InfoLevel"/> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        public static void Info(this ILoggingAdapter log, Exception cause, string format)
+        {
+            if (!log.IsInfoEnabled)
+                return;
+
+            log.Log(LogLevel.InfoLevel, cause, format);
+        }
+
         /// <summary>
         /// Logs a <see cref="LogLevel.InfoLevel"/> message.
         /// </summary>
@@ -155,7 +239,7 @@ namespace Akka.Event
             if (!log.IsInfoEnabled)
                 return;
 
-            log.Log(LogLevel.InfoLevel, cause, format, arg1);
+            log.Log<T1>(LogLevel.InfoLevel, cause, format, arg1);
         }
 
         public static void Info<T1, T2>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2)
@@ -168,7 +252,7 @@ namespace Akka.Event
             if (!log.IsInfoEnabled)
                 return;
 
-            log.Log(LogLevel.InfoLevel, cause, format, arg1, arg2);
+            log.Log<T1, T2>(LogLevel.InfoLevel, cause, format, arg1, arg2);
         }
 
         public static void Info<T1, T2, T3>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3)
@@ -182,7 +266,7 @@ namespace Akka.Event
             if (!log.IsInfoEnabled)
                 return;
 
-            log.Log(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3);
+            log.Log<T1, T2, T3>(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3);
         }
 
         public static void Info<T1, T2, T3, T4>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
@@ -197,7 +281,7 @@ namespace Akka.Event
             if (!log.IsInfoEnabled)
                 return;
 
-            log.Log(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3, arg4);
+            log.Log<T1, T2, T3, T4>(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3, arg4);
         }
 
         public static void Info<T1, T2, T3, T4, T5>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
@@ -212,7 +296,7 @@ namespace Akka.Event
             if (!log.IsInfoEnabled)
                 return;
 
-            log.Log(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
+            log.Log<T1, T2, T3, T4, T5>(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
         }
 
         public static void Info<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2,
@@ -227,7 +311,7 @@ namespace Akka.Event
             if (!log.IsInfoEnabled)
                 return;
 
-            log.Log(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
+            log.Log<T1, T2, T3, T4, T5, T6>(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
         /// <summary>
@@ -236,14 +320,22 @@ namespace Akka.Event
         /// <param name="cause">The exception associated with this message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public static void Info(this ILoggingAdapter log, Exception cause, string format, params object[] args)
+        public static void Info(this ILoggingAdapter log, Exception cause, string format, object[] args)
         {
             if (!log.IsInfoEnabled)
                 return;
 
             log.Log(LogLevel.InfoLevel, cause, format, args);
         }
-        
+
+        public static void Info(this ILoggingAdapter log, string format, object[] args)
+        {
+            if (!log.IsInfoEnabled)
+                return;
+
+            log.Log(LogLevel.InfoLevel, null, format, args);
+        }
+
         /* BEGIN WARNING */
 
         /// <summary>
@@ -260,6 +352,19 @@ namespace Akka.Event
         }
 
         /// <summary>
+        /// Logs a <see cref="LogLevel.WarningLevel"/> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public static void Warning(this ILoggingAdapter log, Exception cause, string format)
+        {
+            if (!log.IsWarningEnabled)
+                return;
+
+            log.Log(LogLevel.WarningLevel, cause, format);
+        }
+
+        /// <summary>
         /// Logs a <see cref="LogLevel.InfoLevel"/> message.
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
@@ -273,7 +378,7 @@ namespace Akka.Event
             if (!log.IsWarningEnabled)
                 return;
 
-            log.Log(LogLevel.WarningLevel, cause, format, arg1);
+            log.Log<T1>(LogLevel.WarningLevel, cause, format, arg1);
         }
 
         public static void Warning<T1, T2>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2)
@@ -286,7 +391,7 @@ namespace Akka.Event
             if (!log.IsWarningEnabled)
                 return;
 
-            log.Log(LogLevel.WarningLevel, cause, format, arg1, arg2);
+            log.Log<T1, T2>(LogLevel.WarningLevel, cause, format, arg1, arg2);
         }
 
         public static void Warning<T1, T2, T3>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3)
@@ -294,13 +399,14 @@ namespace Akka.Event
             log.Warning<T1, T2, T3>(null, format, arg1, arg2, arg3);
         }
 
-        public static void Warning<T1, T2, T3>(this ILoggingAdapter log, Exception cause, string format, T1 arg1, T2 arg2,
+        public static void Warning<T1, T2, T3>(this ILoggingAdapter log, Exception cause, string format, T1 arg1,
+            T2 arg2,
             T3 arg3)
         {
             if (!log.IsWarningEnabled)
                 return;
 
-            log.Log(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3);
+            log.Log<T1, T2, T3>(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3);
         }
 
         public static void Warning<T1, T2, T3, T4>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
@@ -315,22 +421,24 @@ namespace Akka.Event
             if (!log.IsWarningEnabled)
                 return;
 
-            log.Log(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3, arg4);
+            log.Log<T1, T2, T3, T4>(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3, arg4);
         }
 
-        public static void Warning<T1, T2, T3, T4, T5>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
+        public static void Warning<T1, T2, T3, T4, T5>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2,
+            T3 arg3,
             T4 arg4, T5 arg5)
         {
             log.Warning<T1, T2, T3, T4, T5>(null, format, arg1, arg2, arg3, arg4, arg5);
         }
 
-        public static void Warning<T1, T2, T3, T4, T5>(this ILoggingAdapter log, Exception cause, string format, T1 arg1,
+        public static void Warning<T1, T2, T3, T4, T5>(this ILoggingAdapter log, Exception cause, string format,
+            T1 arg1,
             T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             if (!log.IsWarningEnabled)
                 return;
 
-            log.Log(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
+            log.Log<T1, T2, T3, T4, T5>(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
         }
 
         public static void Warning<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2,
@@ -345,7 +453,7 @@ namespace Akka.Event
             if (!log.IsWarningEnabled)
                 return;
 
-            log.Log(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
+            log.Log<T1, T2, T3, T4, T5, T6>(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
         /// <summary>
@@ -361,7 +469,7 @@ namespace Akka.Event
 
             log.Log(LogLevel.WarningLevel, cause, format, args);
         }
-        
+
         /* BEGIN ERROR */
 
         /// <summary>
@@ -378,6 +486,19 @@ namespace Akka.Event
         }
 
         /// <summary>
+        /// Logs a <see cref="LogLevel.ErrorLevel"/> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public static void Error(this ILoggingAdapter log, Exception cause, string format)
+        {
+            if (!log.IsErrorEnabled)
+                return;
+
+            log.Log(LogLevel.ErrorLevel, cause, format);
+        }
+
+        /// <summary>
         /// Logs a <see cref="LogLevel.InfoLevel"/> message.
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
@@ -391,7 +512,7 @@ namespace Akka.Event
             if (!log.IsErrorEnabled)
                 return;
 
-            log.Log(LogLevel.ErrorLevel, cause, format, arg1);
+            log.Log<T1>(LogLevel.ErrorLevel, cause, format, arg1);
         }
 
         public static void Error<T1, T2>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2)
@@ -404,7 +525,7 @@ namespace Akka.Event
             if (!log.IsErrorEnabled)
                 return;
 
-            log.Log(LogLevel.ErrorLevel, cause, format, arg1, arg2);
+            log.Log<T1, T2>(LogLevel.ErrorLevel, cause, format, arg1, arg2);
         }
 
         public static void Error<T1, T2, T3>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3)
@@ -418,7 +539,7 @@ namespace Akka.Event
             if (!log.IsErrorEnabled)
                 return;
 
-            log.Log(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3);
+            log.Log<T1, T2, T3>(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3);
         }
 
         public static void Error<T1, T2, T3, T4>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
@@ -433,7 +554,7 @@ namespace Akka.Event
             if (!log.IsInfoEnabled)
                 return;
 
-            log.Log(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3, arg4);
+            log.Log<T1, T2, T3, T4>(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3, arg4);
         }
 
         public static void Error<T1, T2, T3, T4, T5>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
@@ -448,7 +569,7 @@ namespace Akka.Event
             if (!log.IsErrorEnabled)
                 return;
 
-            log.Log(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
+            log.Log<T1, T2, T3, T4, T5>(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
         }
 
         public static void Error<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2,
@@ -463,7 +584,7 @@ namespace Akka.Event
             if (!log.IsErrorEnabled)
                 return;
 
-            log.Log(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
+            log.Log<T1, T2, T3, T4, T5, T6>(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
 
@@ -473,12 +594,20 @@ namespace Akka.Event
         /// <param name="cause">The exception associated with this message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public static void Error(this ILoggingAdapter log, Exception cause, string format, params object[] args)
+        public static void Error(this ILoggingAdapter log, Exception cause, string format, object[] args)
         {
             if (!log.IsErrorEnabled)
                 return;
 
             log.Log(LogLevel.ErrorLevel, cause, format, args);
+        }
+
+        public static void Error(this ILoggingAdapter log, string format, object[] args)
+        {
+            if (!log.IsErrorEnabled)
+                return;
+
+            log.Log(LogLevel.ErrorLevel, null, format, args);
         }
     }
 
@@ -487,6 +616,11 @@ namespace Akka.Event
     /// </summary>
     public interface ILoggingAdapter
     {
+        /// <summary>
+        /// The <see cref="ILogMessageFormatter"/> used to format log messages.
+        /// </summary>
+        public ILogMessageFormatter Formatter { get; }
+
         /// <summary>
         /// Check to determine whether the <see cref="LogLevel.DebugLevel"/> is enabled.
         /// </summary>
@@ -530,37 +664,8 @@ namespace Akka.Event
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
         void Log(LogLevel logLevel, Exception cause, string format);
-        
-        /// <summary>
-        /// For backwards compatibility.
-        /// </summary>
-        /// <param name="logLevel"></param>
-        /// <param name="cause"></param>
-        /// <param name="format"></param>
-        /// <param name="args"></param>
-        void Log(LogLevel logLevel, Exception cause, string format, params object[] args);
-        
-        /// <summary>
-        /// For backwards compatibility.
-        /// </summary>
-        /// <param name="logLevel"></param>
-        /// <param name="format"></param>
-        /// <param name="args"></param>
-        void Log(LogLevel logLevel, string format, params object[] args);
 
-        void Log<T1>(LogLevel logLevel, Exception cause, string format, T1 arg1);
-        void Log<T1, T2>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2);
-
-        void Log<T1, T2, T3>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3);
-
-        void Log<T1, T2, T3, T4>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4);
-
-        void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3,
-            T4 arg4, T5 arg5);
-
-        void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3,
-            T4 arg4, T5 arg5,
-            T6 arg6);
+        void Log(LogLevel logLevel, Exception cause, LogMessage message);
     }
 
     /// <summary>
@@ -576,6 +681,8 @@ namespace Akka.Event
         private NoLogger()
         {
         }
+
+        public ILogMessageFormatter Formatter => DefaultLogMessageFormatter.Instance;
 
         /// <summary>
         /// Check to determine whether the <see cref="LogLevel.DebugLevel" /> is enabled.
@@ -625,42 +732,7 @@ namespace Akka.Event
         {
         }
 
-        public void Log(LogLevel logLevel, Exception cause, string format, params object[] args)
-        {
-            
-        }
-
-        public void Log(LogLevel logLevel, string format, params object[] args)
-        {
-            
-        }
-
-        public void Log<T1>(LogLevel logLevel, Exception cause, string format, T1 arg1)
-        {
-        }
-
-        public void Log<T1, T2>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2)
-        {
-        }
-
-        public void Log<T1, T2, T3>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3)
-        {
-        }
-
-        public void Log<T1, T2, T3, T4>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3,
-            T4 arg4)
-        {
-        }
-
-        public void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2,
-            T3 arg3, T4 arg4,
-            T5 arg5)
-        {
-        }
-
-        public void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2,
-            T3 arg3, T4 arg4,
-            T5 arg5, T6 arg6)
+        public void Log(LogLevel logLevel, Exception cause, LogMessage message)
         {
         }
     }

--- a/src/core/Akka/Event/ILoggingAdapter.cs
+++ b/src/core/Akka/Event/ILoggingAdapter.cs
@@ -462,12 +462,26 @@ namespace Akka.Event
         /// <param name="cause">The exception associated with this message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public static void Warning(this ILoggingAdapter log, Exception cause, string format, params object[] args)
+        public static void Warning(this ILoggingAdapter log, Exception cause, string format, object[] args)
         {
             if (!log.IsWarningEnabled)
                 return;
 
             log.Log(LogLevel.WarningLevel, cause, format, args);
+        }
+        
+        /// <summary>
+        /// Logs a <see cref="LogLevel.WarningLevel"/> message and associated exception.
+        /// </summary>
+        /// <param name="cause">The exception associated with this message.</param>
+        /// <param name="format">The message that is being logged.</param>
+        /// <param name="args">An optional list of items used to format the message.</param>
+        public static void Warning(this ILoggingAdapter log, string format, object[] args)
+        {
+            if (!log.IsWarningEnabled)
+                return;
+
+            log.Log(LogLevel.WarningLevel, null, format, args);
         }
 
         /* BEGIN ERROR */

--- a/src/core/Akka/Event/ILoggingAdapter.cs
+++ b/src/core/Akka/Event/ILoggingAdapter.cs
@@ -11,17 +11,106 @@ namespace Akka.Event
 {
     public static class LoggingExtensions
     {
-        /// <summary>
-        /// Logs a <see cref="LogLevel.DebugLevel"/> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public static void Debug(this ILoggingAdapter log, string format, params object[] args)
+        public static void Log(this ILoggingAdapter log, LogLevel level, string format)
+        {
+            log.Log(level, null, format);
+        }
+        
+        public static void Debug(this ILoggingAdapter log, string format)
         {
             if (!log.IsDebugEnabled)
                 return;
 
-            log.Log(LogLevel.DebugLevel, format, args);
+            log.Log(LogLevel.DebugLevel, null, format);
+        }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.DebugLevel"/> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        public static void Debug<T1>(this ILoggingAdapter log, string format, T1 arg1)
+        {
+            log.Debug<T1>(null, format, arg1);
+        }
+
+        public static void Debug<T1>(this ILoggingAdapter log, Exception cause, string format, T1 arg1)
+        {
+            if (!log.IsDebugEnabled)
+                return;
+
+            log.Log(LogLevel.DebugLevel, cause, format, arg1);
+        }
+
+        public static void Debug<T1, T2>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2)
+        {
+            log.Debug<T1, T2>(null, format, arg1, arg2);
+        }
+
+        public static void Debug<T1, T2>(this ILoggingAdapter log, Exception cause, string format, T1 arg1, T2 arg2)
+        {
+            if (!log.IsDebugEnabled)
+                return;
+
+            log.Log(LogLevel.DebugLevel, cause, format, arg1, arg2);
+        }
+
+        public static void Debug<T1, T2, T3>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3)
+        {
+            log.Debug<T1, T2, T3>(null, format, arg1, arg2, arg3);
+        }
+
+        public static void Debug<T1, T2, T3>(this ILoggingAdapter log, Exception cause, string format, T1 arg1, T2 arg2,
+            T3 arg3)
+        {
+            if (!log.IsDebugEnabled)
+                return;
+
+            log.Log(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3);
+        }
+
+        public static void Debug<T1, T2, T3, T4>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4)
+        {
+            log.Debug<T1, T2, T3, T4>(null, format, arg1, arg2, arg3, arg4);
+        }
+
+        public static void Debug<T1, T2, T3, T4>(this ILoggingAdapter log, Exception cause, string format, T1 arg1,
+            T2 arg2, T3 arg3, T4 arg4)
+        {
+            if (!log.IsDebugEnabled)
+                return;
+
+            log.Log(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3, arg4);
+        }
+
+        public static void Debug<T1, T2, T3, T4, T5>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4, T5 arg5)
+        {
+            log.Debug<T1, T2, T3, T4, T5>(null, format, arg1, arg2, arg3, arg4, arg5);
+        }
+
+        public static void Debug<T1, T2, T3, T4, T5>(this ILoggingAdapter log, Exception cause, string format, T1 arg1,
+            T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            if (!log.IsDebugEnabled)
+                return;
+
+            log.Log(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
+        }
+
+        public static void Debug<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2,
+            T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            log.Debug<T1, T2, T3, T4, T5, T6>(null, format, arg1, arg2, arg3, arg4, arg5, arg6);
+        }
+
+        public static void Debug<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, Exception cause, string format,
+            T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            if (!log.IsDebugEnabled)
+                return;
+
+            log.Log(LogLevel.DebugLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
         /// <summary>
@@ -38,17 +127,107 @@ namespace Akka.Event
             log.Log(LogLevel.DebugLevel, cause, format, args);
         }
 
+        /* END DEBUG */
+
         /// <summary>
         /// Logs a <see cref="LogLevel.InfoLevel"/> message.
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public static void Info(this ILoggingAdapter log, string format, params object[] args)
+        public static void Info(this ILoggingAdapter log, string format)
         {
             if (!log.IsInfoEnabled)
                 return;
 
-            log.Log(LogLevel.InfoLevel, format, args);
+            log.Log(LogLevel.InfoLevel, null, format);
+        }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.InfoLevel"/> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        public static void Info<T1>(this ILoggingAdapter log, string format, T1 arg1)
+        {
+            log.Info<T1>(null, format, arg1);
+        }
+
+        public static void Info<T1>(this ILoggingAdapter log, Exception cause, string format, T1 arg1)
+        {
+            if (!log.IsInfoEnabled)
+                return;
+
+            log.Log(LogLevel.InfoLevel, cause, format, arg1);
+        }
+
+        public static void Info<T1, T2>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2)
+        {
+            log.Info<T1, T2>(null, format, arg1, arg2);
+        }
+
+        public static void Info<T1, T2>(this ILoggingAdapter log, Exception cause, string format, T1 arg1, T2 arg2)
+        {
+            if (!log.IsInfoEnabled)
+                return;
+
+            log.Log(LogLevel.InfoLevel, cause, format, arg1, arg2);
+        }
+
+        public static void Info<T1, T2, T3>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3)
+        {
+            log.Info<T1, T2, T3>(null, format, arg1, arg2, arg3);
+        }
+
+        public static void Info<T1, T2, T3>(this ILoggingAdapter log, Exception cause, string format, T1 arg1, T2 arg2,
+            T3 arg3)
+        {
+            if (!log.IsInfoEnabled)
+                return;
+
+            log.Log(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3);
+        }
+
+        public static void Info<T1, T2, T3, T4>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4)
+        {
+            log.Info<T1, T2, T3, T4>(null, format, arg1, arg2, arg3, arg4);
+        }
+
+        public static void Info<T1, T2, T3, T4>(this ILoggingAdapter log, Exception cause, string format, T1 arg1,
+            T2 arg2, T3 arg3, T4 arg4)
+        {
+            if (!log.IsInfoEnabled)
+                return;
+
+            log.Log(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3, arg4);
+        }
+
+        public static void Info<T1, T2, T3, T4, T5>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4, T5 arg5)
+        {
+            log.Info<T1, T2, T3, T4, T5>(null, format, arg1, arg2, arg3, arg4, arg5);
+        }
+
+        public static void Info<T1, T2, T3, T4, T5>(this ILoggingAdapter log, Exception cause, string format, T1 arg1,
+            T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            if (!log.IsInfoEnabled)
+                return;
+
+            log.Log(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
+        }
+
+        public static void Info<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2,
+            T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            log.Info<T1, T2, T3, T4, T5, T6>(null, format, arg1, arg2, arg3, arg4, arg5, arg6);
+        }
+
+        public static void Info<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, Exception cause, string format,
+            T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            if (!log.IsInfoEnabled)
+                return;
+
+            log.Log(LogLevel.InfoLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
         /// <summary>
@@ -64,18 +243,109 @@ namespace Akka.Event
 
             log.Log(LogLevel.InfoLevel, cause, format, args);
         }
+        
+        /* BEGIN WARNING */
 
         /// <summary>
         /// Logs a <see cref="LogLevel.WarningLevel"/> message.
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public static void Warning(this ILoggingAdapter log, string format, params object[] args)
+        public static void Warning(this ILoggingAdapter log, string format)
         {
             if (!log.IsWarningEnabled)
                 return;
 
-            log.Log(LogLevel.WarningLevel, format, args);
+            log.Log(LogLevel.WarningLevel, null, format);
+        }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.InfoLevel"/> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        public static void Warning<T1>(this ILoggingAdapter log, string format, T1 arg1)
+        {
+            log.Warning<T1>(null, format, arg1);
+        }
+
+        public static void Warning<T1>(this ILoggingAdapter log, Exception cause, string format, T1 arg1)
+        {
+            if (!log.IsWarningEnabled)
+                return;
+
+            log.Log(LogLevel.WarningLevel, cause, format, arg1);
+        }
+
+        public static void Warning<T1, T2>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2)
+        {
+            log.Warning<T1, T2>(null, format, arg1, arg2);
+        }
+
+        public static void Warning<T1, T2>(this ILoggingAdapter log, Exception cause, string format, T1 arg1, T2 arg2)
+        {
+            if (!log.IsWarningEnabled)
+                return;
+
+            log.Log(LogLevel.WarningLevel, cause, format, arg1, arg2);
+        }
+
+        public static void Warning<T1, T2, T3>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3)
+        {
+            log.Warning<T1, T2, T3>(null, format, arg1, arg2, arg3);
+        }
+
+        public static void Warning<T1, T2, T3>(this ILoggingAdapter log, Exception cause, string format, T1 arg1, T2 arg2,
+            T3 arg3)
+        {
+            if (!log.IsWarningEnabled)
+                return;
+
+            log.Log(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3);
+        }
+
+        public static void Warning<T1, T2, T3, T4>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4)
+        {
+            log.Warning<T1, T2, T3, T4>(null, format, arg1, arg2, arg3, arg4);
+        }
+
+        public static void Warning<T1, T2, T3, T4>(this ILoggingAdapter log, Exception cause, string format, T1 arg1,
+            T2 arg2, T3 arg3, T4 arg4)
+        {
+            if (!log.IsWarningEnabled)
+                return;
+
+            log.Log(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3, arg4);
+        }
+
+        public static void Warning<T1, T2, T3, T4, T5>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4, T5 arg5)
+        {
+            log.Warning<T1, T2, T3, T4, T5>(null, format, arg1, arg2, arg3, arg4, arg5);
+        }
+
+        public static void Warning<T1, T2, T3, T4, T5>(this ILoggingAdapter log, Exception cause, string format, T1 arg1,
+            T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            if (!log.IsWarningEnabled)
+                return;
+
+            log.Log(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
+        }
+
+        public static void Warning<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2,
+            T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            log.Warning<T1, T2, T3, T4, T5, T6>(null, format, arg1, arg2, arg3, arg4, arg5, arg6);
+        }
+
+        public static void Warning<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, Exception cause, string format,
+            T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            if (!log.IsWarningEnabled)
+                return;
+
+            log.Log(LogLevel.WarningLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
         }
 
         /// <summary>
@@ -91,19 +361,111 @@ namespace Akka.Event
 
             log.Log(LogLevel.WarningLevel, cause, format, args);
         }
+        
+        /* BEGIN ERROR */
 
         /// <summary>
         /// Logs a <see cref="LogLevel.ErrorLevel"/> message.
         /// </summary>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public static void Error(this ILoggingAdapter log, string format, params object[] args)
+        public static void Error(this ILoggingAdapter log, string format)
         {
             if (!log.IsErrorEnabled)
                 return;
 
-            log.Log(LogLevel.ErrorLevel, format, args);
+            log.Log(LogLevel.ErrorLevel, null, format);
         }
+
+        /// <summary>
+        /// Logs a <see cref="LogLevel.InfoLevel"/> message.
+        /// </summary>
+        /// <param name="format">The message that is being logged.</param>
+        public static void Error<T1>(this ILoggingAdapter log, string format, T1 arg1)
+        {
+            log.Error<T1>(null, format, arg1);
+        }
+
+        public static void Error<T1>(this ILoggingAdapter log, Exception cause, string format, T1 arg1)
+        {
+            if (!log.IsErrorEnabled)
+                return;
+
+            log.Log(LogLevel.ErrorLevel, cause, format, arg1);
+        }
+
+        public static void Error<T1, T2>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2)
+        {
+            log.Error<T1, T2>(null, format, arg1, arg2);
+        }
+
+        public static void Error<T1, T2>(this ILoggingAdapter log, Exception cause, string format, T1 arg1, T2 arg2)
+        {
+            if (!log.IsErrorEnabled)
+                return;
+
+            log.Log(LogLevel.ErrorLevel, cause, format, arg1, arg2);
+        }
+
+        public static void Error<T1, T2, T3>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3)
+        {
+            log.Error<T1, T2, T3>(null, format, arg1, arg2, arg3);
+        }
+
+        public static void Error<T1, T2, T3>(this ILoggingAdapter log, Exception cause, string format, T1 arg1, T2 arg2,
+            T3 arg3)
+        {
+            if (!log.IsErrorEnabled)
+                return;
+
+            log.Log(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3);
+        }
+
+        public static void Error<T1, T2, T3, T4>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4)
+        {
+            log.Error<T1, T2, T3, T4>(null, format, arg1, arg2, arg3, arg4);
+        }
+
+        public static void Error<T1, T2, T3, T4>(this ILoggingAdapter log, Exception cause, string format, T1 arg1,
+            T2 arg2, T3 arg3, T4 arg4)
+        {
+            if (!log.IsInfoEnabled)
+                return;
+
+            log.Log(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3, arg4);
+        }
+
+        public static void Error<T1, T2, T3, T4, T5>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4, T5 arg5)
+        {
+            log.Error<T1, T2, T3, T4, T5>(null, format, arg1, arg2, arg3, arg4, arg5);
+        }
+
+        public static void Error<T1, T2, T3, T4, T5>(this ILoggingAdapter log, Exception cause, string format, T1 arg1,
+            T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            if (!log.IsErrorEnabled)
+                return;
+
+            log.Log(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3, arg4, arg5);
+        }
+
+        public static void Error<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, string format, T1 arg1, T2 arg2,
+            T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            log.Error<T1, T2, T3, T4, T5, T6>(null, format, arg1, arg2, arg3, arg4, arg5, arg6);
+        }
+
+        public static void Error<T1, T2, T3, T4, T5, T6>(this ILoggingAdapter log, Exception cause, string format,
+            T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            if (!log.IsErrorEnabled)
+                return;
+
+            log.Log(LogLevel.ErrorLevel, cause, format, arg1, arg2, arg3, arg4, arg5, arg6);
+        }
+
 
         /// <summary>
         /// Logs a <see cref="LogLevel.ErrorLevel"/> message and associated exception.
@@ -152,13 +514,13 @@ namespace Akka.Event
         /// <returns><c>true</c> if the specified level is enabled; otherwise <c>false</c>.</returns>
         bool IsEnabled(LogLevel logLevel);
 
-        /// <summary>
-        /// Logs a message with a specified level.
-        /// </summary>
-        /// <param name="logLevel">The level used to log the message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        void Log(LogLevel logLevel, string format, params object[] args);
+        // /// <summary>
+        // /// Logs a message with a specified level.
+        // /// </summary>
+        // /// <param name="logLevel">The level used to log the message.</param>
+        // /// <param name="format">The message that is being logged.</param>
+        // /// <param name="args">An optional list of items used to format the message.</param>
+        // void Log(LogLevel logLevel, string format, params object[] args);
 
         /// <summary>
         /// Logs a message with a specified level.
@@ -167,23 +529,38 @@ namespace Akka.Event
         /// <param name="cause">The exception that caused this log message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
+        void Log(LogLevel logLevel, Exception cause, string format);
+        
+        /// <summary>
+        /// For backwards compatibility.
+        /// </summary>
+        /// <param name="logLevel"></param>
+        /// <param name="cause"></param>
+        /// <param name="format"></param>
+        /// <param name="args"></param>
         void Log(LogLevel logLevel, Exception cause, string format, params object[] args);
+        
+        /// <summary>
+        /// For backwards compatibility.
+        /// </summary>
+        /// <param name="logLevel"></param>
+        /// <param name="format"></param>
+        /// <param name="args"></param>
+        void Log(LogLevel logLevel, string format, params object[] args);
 
-        void Log(LogLevel logLevel, string format, Exception cause = null);
+        void Log<T1>(LogLevel logLevel, Exception cause, string format, T1 arg1);
+        void Log<T1, T2>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2);
 
-        void Log<T1>(LogLevel logLevel, string format, T1 arg1, Exception cause = null);
-        void Log<T1, T2>(LogLevel logLevel, string format, T1 arg1, T2 arg2, Exception cause = null);
+        void Log<T1, T2, T3>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3);
 
-        void Log<T1, T2, T3>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, Exception cause = null);
+        void Log<T1, T2, T3, T4>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4);
 
-        void Log<T1, T2, T3, T4>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
-            Exception cause = null);
+        void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4, T5 arg5);
 
-        void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
-            Exception cause = null);
-
-        void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
-            T6 arg6, Exception cause = null);
+        void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4, T5 arg5,
+            T6 arg6);
     }
 
     /// <summary>
@@ -244,57 +621,46 @@ namespace Akka.Event
             return false;
         }
 
-        /// <summary>
-        /// Logs a message with a specified level.
-        /// </summary>
-        /// <param name="logLevel">The level used to log the message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public void Log(LogLevel logLevel, string format, params object[] args)
+        public void Log(LogLevel logLevel, Exception cause, string format)
         {
         }
 
-        /// <summary>
-        /// Logs a message with a specified level.
-        /// </summary>
-        /// <param name="logLevel">The level used to log the message.</param>
-        /// <param name="cause">The exception that caused this log message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
         public void Log(LogLevel logLevel, Exception cause, string format, params object[] args)
         {
+            
         }
 
-        public void Log(LogLevel logLevel, string format, Exception cause = null)
+        public void Log(LogLevel logLevel, string format, params object[] args)
+        {
+            
+        }
+
+        public void Log<T1>(LogLevel logLevel, Exception cause, string format, T1 arg1)
         {
         }
 
-        public void Log<T1>(LogLevel logLevel, string format, T1 arg1, Exception cause = null)
+        public void Log<T1, T2>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2)
         {
         }
 
-        public void Log<T1, T2>(LogLevel logLevel, string format, T1 arg1, T2 arg2, Exception cause = null)
+        public void Log<T1, T2, T3>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3)
         {
         }
 
-        public void Log<T1, T2, T3>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, Exception cause = null)
+        public void Log<T1, T2, T3, T4>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4)
         {
         }
 
-        public void Log<T1, T2, T3, T4>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
-            Exception cause = null)
+        public void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2,
+            T3 arg3, T4 arg4,
+            T5 arg5)
         {
         }
 
-        public void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
-            T5 arg5,
-            Exception cause = null)
-        {
-        }
-
-        public void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4,
-            T5 arg5, T6 arg6,
-            Exception cause = null)
+        public void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2,
+            T3 arg3, T4 arg4,
+            T5 arg5, T6 arg6)
         {
         }
     }

--- a/src/core/Akka/Event/LogMessage.cs
+++ b/src/core/Akka/Event/LogMessage.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Akka.Annotations;
 
 namespace Akka.Event
 {
@@ -49,7 +50,8 @@ namespace Akka.Event
         /// INTERNAL API
         /// </summary>
         /// <returns>An unformatted copy of the state string - used for debugging bad logging templates</returns>
-        internal abstract string Unformatted();
+        [InternalApi]
+        public abstract string Unformatted();
     }
 
     /// <summary>
@@ -70,7 +72,7 @@ namespace Akka.Event
             return Formatter.Format(Format, Arg);
         }
 
-        internal override string Unformatted()
+        public override string Unformatted()
         {
             return Arg.ToString();
         }
@@ -93,7 +95,7 @@ namespace Akka.Event
             return Formatter.Format(Format, Args);
         }
 
-        internal override string Unformatted()
+        public override string Unformatted()
         {
             return string.Join(",", Args);
         }

--- a/src/core/Akka/Event/LogMessage.cs
+++ b/src/core/Akka/Event/LogMessage.cs
@@ -5,14 +5,28 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
 namespace Akka.Event
 {
     /// <summary>
+    /// Extension methods for creating <see cref="LogMessage"/> instances.
+    /// </summary>
+    public static class LogMessageExtensions{
+        
+    }
+    
+    /// <summary>
     /// Represents a log message which is composed of a format string and format args.
     /// </summary>
-    public class LogMessage
+    /// <remarks>
+    /// Call ToString to get the formatted output.
+    /// </remarks>
+    public abstract class LogMessage
     {
-        private readonly ILogMessageFormatter _formatter;
+        protected readonly ILogMessageFormatter Formatter;
 
         /// <summary>
         /// Gets the format string of this log message.
@@ -20,30 +34,330 @@ namespace Akka.Event
         public string Format { get; private set; }
 
         /// <summary>
-        /// Gets the format args of this log message.
-        /// </summary>
-        public object[] Args { get; private set; }
-
-        /// <summary>
         /// Initializes an instance of the LogMessage with the specified formatter, format and args.
         /// </summary>
         /// <param name="formatter">The formatter for the LogMessage.</param>
         /// <param name="format">The string format of the LogMessage.</param>
         /// <param name="args">The format args of the LogMessage.</param>
-        public LogMessage(ILogMessageFormatter formatter, string format, params object[] args)
+        public LogMessage(ILogMessageFormatter formatter, string format)
         {
-            _formatter = formatter;
+            Formatter = formatter;
             Format = format;
-            Args = args;
         }
 
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>An unformatted copy of the state string - used for debugging bad logging templates</returns>
+        internal abstract string Unformatted();
+    }
+
+    /// <summary>
+    /// Generic version of the argument.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal sealed class LogMessage<T> : LogMessage where T:IEnumerable<object>
+    {
+        public LogMessage(ILogMessageFormatter formatter, string format, T arg) : base(formatter, format)
+        {
+            Arg = arg;
+        }
+        
+        public T Arg { get; }
+
         public override string ToString()
         {
-            return _formatter.Format(Format, Args);
+            return Formatter.Format(Format, Arg);
+        }
+
+        internal override string Unformatted()
+        {
+            return Arg.ToString();
+        }
+    }
+
+    /// <summary>
+    /// Works akin to the original <see cref="LogMessage"/> class with an array of objects as the format args.
+    /// </summary>
+    internal sealed class DefaultLogMessage : LogMessage
+    {
+        public DefaultLogMessage(ILogMessageFormatter formatter, string format, params object[] args) : base(formatter, format)
+        {
+            Args = args;
+        }
+        
+        public object[] Args { get; }
+
+        public override string ToString()
+        {
+            return Formatter.Format(Format, Args);
+        }
+
+        internal override string Unformatted()
+        {
+            return string.Join(",", Args);
+        }
+    }
+
+    internal readonly struct LogValues<T1> : IReadOnlyList<object>
+    {
+        private readonly T1 _value1;
+
+        public LogValues(T1 value1)
+        {
+            _value1 = value1;
+        }
+
+        public IEnumerator<object> GetEnumerator()
+        {
+            yield return this[0];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public int Count => 1;
+
+        public object this[int index]
+        {
+            get
+            {
+                if(index == 0)
+                    return _value1;
+                throw new IndexOutOfRangeException(nameof(index));
+            }
+        }
+    }
+    
+    internal readonly struct LogValues<T1, T2> : IReadOnlyList<object>
+    {
+        private readonly T1 _value1;
+        private readonly T2 _value2;
+
+        public LogValues(T1 value1, T2 value2)
+        {
+            _value1 = value1;
+            _value2 = value2;
+        }
+
+        public IEnumerator<object> GetEnumerator()
+        {
+            yield return this[0];
+            yield return this[1];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public int Count => 2;
+
+        public object this[int index]
+        {
+            get
+            {
+                return index switch
+                {
+                    0 => _value1,
+                    1 => _value2,
+                    _ => throw new IndexOutOfRangeException(nameof(index))
+                };
+            }
+        }
+    }
+    
+    internal readonly struct LogValues<T1, T2, T3> : IReadOnlyList<object>
+    {
+        private readonly T1 _value1;
+        private readonly T2 _value2;
+        private readonly T3 _value3;
+
+        public LogValues(T1 value1, T2 value2, T3 value3)
+        {
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+        }
+
+        public IEnumerator<object> GetEnumerator()
+        {
+            yield return this[0];
+            yield return this[1];
+            yield return this[2];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public int Count => 3;
+
+        public object this[int index]
+        {
+            get
+            {
+                return index switch
+                {
+                    0 => _value1,
+                    1 => _value2,
+                    2 => _value3,
+                    _ => throw new IndexOutOfRangeException(nameof(index))
+                };
+            }
+        }
+    }
+    
+    internal readonly struct LogValues<T1, T2, T3, T4> : IReadOnlyList<object>
+    {
+        private readonly T1 _value1;
+        private readonly T2 _value2;
+        private readonly T3 _value3;
+        private readonly T4 _value4;
+
+        public LogValues(T1 value1, T2 value2, T3 value3, T4 value4)
+        {
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
+        }
+
+        public IEnumerator<object> GetEnumerator()
+        {
+            yield return this[0];
+            yield return this[1];
+            yield return this[2];
+            yield return this[3];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public int Count => 4;
+
+        public object this[int index]
+        {
+            get
+            {
+                return index switch
+                {
+                    0 => _value1,
+                    1 => _value2,
+                    2 => _value3,
+                    3 => _value4,
+                    _ => throw new IndexOutOfRangeException(nameof(index))
+                };
+            }
+        }
+    }
+    
+    internal readonly struct LogValues<T1, T2, T3, T4, T5> : IReadOnlyList<object>
+    {
+        private readonly T1 _value1;
+        private readonly T2 _value2;
+        private readonly T3 _value3;
+        private readonly T4 _value4;
+        private readonly T5 _value5;
+
+        public LogValues(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
+        {
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
+            _value5 = value5;
+        }
+
+        public IEnumerator<object> GetEnumerator()
+        {
+            yield return this[0];
+            yield return this[1];
+            yield return this[2];
+            yield return this[3];
+            yield return this[4];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public int Count => 5;
+
+        public object this[int index]
+        {
+            get
+            {
+                return index switch
+                {
+                    0 => _value1,
+                    1 => _value2,
+                    2 => _value3,
+                    3 => _value4,
+                    4 => _value5,
+                    _ => throw new IndexOutOfRangeException(nameof(index))
+                };
+            }
+        }
+    }
+    
+    internal readonly struct LogValues<T1, T2, T3, T4, T5, T6> : IReadOnlyList<object>
+    {
+        private readonly T1 _value1;
+        private readonly T2 _value2;
+        private readonly T3 _value3;
+        private readonly T4 _value4;
+        private readonly T5 _value5;
+        private readonly T6 _value6;
+
+        public LogValues(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
+        {
+            _value1 = value1;
+            _value2 = value2;
+            _value3 = value3;
+            _value4 = value4;
+            _value5 = value5;
+            _value6 = value6;
+        }
+
+        public IEnumerator<object> GetEnumerator()
+        {
+            yield return this[0];
+            yield return this[1];
+            yield return this[2];
+            yield return this[3];
+            yield return this[4];
+            yield return this[5];
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public int Count => 6;
+
+        public object this[int index]
+        {
+            get
+            {
+                return index switch
+                {
+                    0 => _value1,
+                    1 => _value2,
+                    2 => _value3,
+                    3 => _value4,
+                    4 => _value5,
+                    5 => _value6,
+                    _ => throw new IndexOutOfRangeException(nameof(index))
+                };
+            }
         }
     }
 }

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -14,7 +14,7 @@ namespace Akka.Event
     /// </summary>
     public abstract class LoggingAdapterBase : ILoggingAdapter
     {
-        private readonly ILogMessageFormatter _logMessageFormatter;
+        public ILogMessageFormatter Formatter { get; }
 
         /// <summary>
         /// Check to determine whether the <see cref="LogLevel.DebugLevel" /> is enabled.
@@ -44,7 +44,7 @@ namespace Akka.Event
         /// <exception cref="ArgumentNullException">This exception is thrown when the given <paramref name="logMessageFormatter"/> is undefined.</exception>
         protected LoggingAdapterBase(ILogMessageFormatter logMessageFormatter)
         {
-            _logMessageFormatter = logMessageFormatter ?? throw new ArgumentNullException(nameof(logMessageFormatter), "The message formatter must not be null.");
+            Formatter = logMessageFormatter ?? throw new ArgumentNullException(nameof(logMessageFormatter), "The message formatter must not be null.");
         }
 
         /// <summary>
@@ -79,76 +79,14 @@ namespace Akka.Event
         /// <exception cref="NotSupportedException">This exception is thrown when the given <paramref name="logLevel"/> is unknown.</exception>
         protected abstract void NotifyLog(LogLevel logLevel, object message, Exception cause = null);
 
-        /// <summary>
-        /// Logs a message with a specified level.
-        /// </summary>
-        /// <param name="logLevel">The level used to log the message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public void Log(LogLevel logLevel, string format, params object[] args)
+        public void Log(LogLevel logLevel, Exception cause, LogMessage message)
         {
-            if (args == null || args.Length == 0)
-            {
-                NotifyLog(logLevel, format);
-            }
-            else
-            {
-                NotifyLog(logLevel, new DefaultLogMessage(_logMessageFormatter, format, args));
-            }
-        }
-
-        /// <summary>
-        /// Logs a message with a specified level.
-        /// </summary>
-        /// <param name="logLevel">The level used to log the message.</param>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public void Log(LogLevel logLevel, Exception cause, string format, params object[] args)
-        {
-            if (args == null || args.Length == 0)
-            {
-                NotifyLog(logLevel, format, cause);
-            }
-            else
-            {
-                NotifyLog(logLevel, new DefaultLogMessage(_logMessageFormatter, format, args), cause);
-            }
+            NotifyLog(logLevel, message, cause);
         }
 
         public void Log(LogLevel logLevel, Exception cause, string format)
         {
             NotifyLog(logLevel, format, cause);
-        }
-
-        public void Log<T1>(LogLevel logLevel, Exception cause, string format, T1 arg1)
-        {
-            NotifyLog(logLevel, new LogMessage<LogValues<T1>>(_logMessageFormatter, format, new LogValues<T1>(arg1)), cause);
-        }
-
-        public void Log<T1, T2>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2)
-        {
-            NotifyLog(logLevel, new LogMessage<LogValues<T1, T2>>(_logMessageFormatter, format, new LogValues<T1, T2>(arg1, arg2)), cause);
-        }
-
-        public void Log<T1, T2, T3>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3)
-        {
-            NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3>>(_logMessageFormatter, format, new LogValues<T1, T2, T3>(arg1, arg2, arg3)), cause);
-        }
-
-        public void Log<T1, T2, T3, T4>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
-        {
-            NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3, T4>>(_logMessageFormatter, format, new LogValues<T1, T2, T3, T4>(arg1, arg2, arg3, arg4)), cause);
-        }
-
-        public void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
-        {
-            NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3, T4, T5>>(_logMessageFormatter, format, new LogValues<T1, T2, T3, T4, T5>(arg1, arg2, arg3, arg4, arg5)), cause);
-        }
-
-        public void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
-        {
-            NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3, T4, T5, T6>>(_logMessageFormatter, format, new LogValues<T1, T2, T3, T4, T5, T6>(arg1, arg2, arg3, arg4, arg5, arg6)), cause);
         }
     }
 }

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -85,7 +85,7 @@ namespace Akka.Event
         /// <param name="logLevel">The level used to log the message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public virtual void Log(LogLevel logLevel, string format, params object[] args)
+        public void Log(LogLevel logLevel, string format, params object[] args)
         {
             if (args == null || args.Length == 0)
             {
@@ -104,7 +104,7 @@ namespace Akka.Event
         /// <param name="cause">The exception associated with this message.</param>
         /// <param name="format">The message that is being logged.</param>
         /// <param name="args">An optional list of items used to format the message.</param>
-        public virtual void Log(LogLevel logLevel, Exception cause, string format, params object[] args)
+        public void Log(LogLevel logLevel, Exception cause, string format, params object[] args)
         {
             if (args == null || args.Length == 0)
             {
@@ -116,39 +116,37 @@ namespace Akka.Event
             }
         }
 
-        public void Log(LogLevel logLevel, string format, Exception cause = null)
+        public void Log(LogLevel logLevel, Exception cause, string format)
         {
             NotifyLog(logLevel, format, cause);
         }
 
-        public void Log<T1>(LogLevel logLevel, string format, T1 arg1, Exception cause = null)
+        public void Log<T1>(LogLevel logLevel, Exception cause, string format, T1 arg1)
         {
             NotifyLog(logLevel, new LogMessage<LogValues<T1>>(_logMessageFormatter, format, new LogValues<T1>(arg1)), cause);
         }
 
-        public void Log<T1, T2>(LogLevel logLevel, string format, T1 arg1, T2 arg2, Exception cause = null)
+        public void Log<T1, T2>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2)
         {
             NotifyLog(logLevel, new LogMessage<LogValues<T1, T2>>(_logMessageFormatter, format, new LogValues<T1, T2>(arg1, arg2)), cause);
         }
 
-        public void Log<T1, T2, T3>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, Exception cause = null)
+        public void Log<T1, T2, T3>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3)
         {
             NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3>>(_logMessageFormatter, format, new LogValues<T1, T2, T3>(arg1, arg2, arg3)), cause);
         }
 
-        public void Log<T1, T2, T3, T4>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, Exception cause = null)
+        public void Log<T1, T2, T3, T4>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3, T4>>(_logMessageFormatter, format, new LogValues<T1, T2, T3, T4>(arg1, arg2, arg3, arg4)), cause);
         }
 
-        public void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
-            Exception cause = null)
+        public void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
             NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3, T4, T5>>(_logMessageFormatter, format, new LogValues<T1, T2, T3, T4, T5>(arg1, arg2, arg3, arg4, arg5)), cause);
         }
 
-        public void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6,
-            Exception cause = null)
+        public void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3, T4, T5, T6>>(_logMessageFormatter, format, new LogValues<T1, T2, T3, T4, T5, T6>(arg1, arg2, arg3, arg4, arg5, arg6)), cause);
         }

--- a/src/core/Akka/Event/LoggingAdapterBase.cs
+++ b/src/core/Akka/Event/LoggingAdapterBase.cs
@@ -36,57 +36,6 @@ namespace Akka.Event
         /// </summary>
         public abstract bool IsWarningEnabled { get; }
 
-        /// <summary>
-        /// Notifies all subscribers that an <see cref="LogLevel.ErrorLevel" /> log event occurred.
-        /// </summary>
-        /// <param name="message">The message related to the log event.</param>
-        protected abstract void NotifyError(object message);
-
-        /// <summary>
-        /// Notifies all subscribers that an <see cref="LogLevel.ErrorLevel" /> log event occurred.
-        /// </summary>
-        /// <param name="cause">The exception that caused the log event.</param>
-        /// <param name="message">The message related to the log event.</param>
-        protected abstract void NotifyError(Exception cause, object message);
-
-        /// <summary>
-        /// Notifies all subscribers that an <see cref="LogLevel.WarningLevel" /> log event occurred.
-        /// </summary>
-        /// <param name="message">The message related to the log event.</param>
-        protected abstract void NotifyWarning(object message);
-
-        /// <summary>
-        /// Notifies all subscribers that an <see cref="LogLevel.WarningLevel" /> log event occurred.
-        /// </summary>
-        /// <param name="cause">The exception that caused the log event.</param>
-        /// <param name="message">The message related to the log event.</param>
-        protected abstract void NotifyWarning(Exception cause, object message);
-
-        /// <summary>
-        /// Notifies all subscribers that an <see cref="LogLevel.InfoLevel" /> log event occurred.
-        /// </summary>
-        /// <param name="message">The message related to the log event.</param>
-        protected abstract void NotifyInfo(object message);
-
-        /// <summary>
-        /// Notifies all subscribers that an <see cref="LogLevel.InfoLevel" /> log event occurred.
-        /// </summary>
-        /// <param name="cause">The exception that caused the log event.</param>
-        /// <param name="message">The message related to the log event.</param>
-        protected abstract void NotifyInfo(Exception cause, object message);
-
-        /// <summary>
-        /// Notifies all subscribers that an <see cref="LogLevel.DebugLevel" /> log event occurred.
-        /// </summary>
-        /// <param name="message">The message related to the log event.</param>
-        protected abstract void NotifyDebug(object message);
-
-        /// <summary>
-        /// Notifies all subscribers that an <see cref="LogLevel.DebugLevel" /> log event occurred.
-        /// </summary>
-        /// <param name="cause">The exception that caused the log event.</param>
-        /// <param name="message">The message related to the log event.</param>
-        protected abstract void NotifyDebug(Exception cause, object message);
 
         /// <summary>
         /// Creates an instance of the LoggingAdapterBase.
@@ -126,230 +75,9 @@ namespace Akka.Event
         /// </summary>
         /// <param name="logLevel">The log level associated with the log event.</param>
         /// <param name="message">The message related to the log event.</param>
-        /// <exception cref="NotSupportedException">This exception is thrown when the given <paramref name="logLevel"/> is unknown.</exception>
-        protected void NotifyLog(LogLevel logLevel, object message)
-        {
-            switch(logLevel)
-            {
-                case LogLevel.DebugLevel:
-                    if(IsDebugEnabled) NotifyDebug(message);
-                    break;
-                case LogLevel.InfoLevel:
-                    if(IsInfoEnabled) NotifyInfo(message);
-                    break;
-                case LogLevel.WarningLevel:
-                    if(IsWarningEnabled) NotifyWarning(message);
-                    break;
-                case LogLevel.ErrorLevel:
-                    if(IsErrorEnabled) NotifyError(message);
-                    break;
-                default:
-                    throw new NotSupportedException($"Unknown LogLevel {logLevel}");
-            }
-        }
-
-        /// <summary>
-        /// Notifies all subscribers that a log event occurred for a particular level.
-        /// </summary>
-        /// <param name="logLevel">The log level associated with the log event.</param>
         /// <param name="cause">The exception that caused the log event.</param>
-        /// <param name="message">The message related to the log event.</param>
         /// <exception cref="NotSupportedException">This exception is thrown when the given <paramref name="logLevel"/> is unknown.</exception>
-        protected void NotifyLog(LogLevel logLevel, Exception cause, object message)
-        {
-            switch (logLevel)
-            {
-                case LogLevel.DebugLevel:
-                    if (IsDebugEnabled) NotifyDebug(cause, message);
-                    break;
-                case LogLevel.InfoLevel:
-                    if (IsInfoEnabled) NotifyInfo(cause, message);
-                    break;
-                case LogLevel.WarningLevel:
-                    if (IsWarningEnabled) NotifyWarning(cause, message);
-                    break;
-                case LogLevel.ErrorLevel:
-                    if (IsErrorEnabled) NotifyError(cause, message);
-                    break;
-                default:
-                    throw new NotSupportedException($"Unknown LogLevel {logLevel}");
-            }
-        }
-
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.DebugLevel" /> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public virtual void Debug(string format, params object[] args)
-        {
-            if (!IsDebugEnabled) 
-                return;
-
-            if (args == null || args.Length == 0)
-            {
-                NotifyDebug(format);
-            }
-            else
-            {
-                NotifyDebug(new LogMessage(_logMessageFormatter, format, args));
-            }
-        }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.DebugLevel" /> message.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public virtual void Debug(Exception cause, string format, params object[] args)
-        {
-            if (!IsDebugEnabled)
-                return;
-
-            if (args == null || args.Length == 0)
-            {
-                NotifyDebug(cause, format);
-            }
-            else
-            {
-                NotifyDebug(cause, new LogMessage(_logMessageFormatter, format, args));
-            }
-        }
-
-        /// <summary>
-        /// Obsolete. Use <see cref="Warning(string, object[])" /> instead!
-        /// </summary>
-        /// <param name="format">N/A</param>
-        /// <param name="args">N/A</param>
-        public virtual void Warn(string format, params object[] args)
-        {
-            Warning(format, args);
-        }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.InfoLevel" /> message.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public virtual void Info(Exception cause, string format, params object[] args)
-        {
-            if (!IsInfoEnabled)
-                return;
-
-            if (args == null || args.Length == 0)
-            {
-                NotifyInfo(cause, format);
-            }
-            else
-            {
-                NotifyInfo(cause, new LogMessage(_logMessageFormatter, format, args));
-            }
-        }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.WarningLevel" /> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public virtual void Warning(string format, params object[] args)
-        {
-            if (!IsWarningEnabled) 
-                return;
-
-            if (args == null || args.Length == 0)
-            {
-                NotifyWarning(format);
-            }
-            else
-            {
-                NotifyWarning(new LogMessage(_logMessageFormatter, format, args));
-            }
-        }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.WarningLevel" /> message.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public virtual void Warning(Exception cause, string format, params object[] args)
-        {
-            if (!IsWarningEnabled)
-                return;
-
-            if (args == null || args.Length == 0)
-            {
-                NotifyWarning(cause, format);
-            }
-            else
-            {
-                NotifyWarning(cause, new LogMessage(_logMessageFormatter, format, args));
-            }
-        }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.ErrorLevel" /> message and associated exception.
-        /// </summary>
-        /// <param name="cause">The exception associated with this message.</param>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public virtual void Error(Exception cause, string format, params object[] args)
-        {
-            if (!IsErrorEnabled) 
-                return;
-
-            if (args == null || args.Length == 0)
-            {
-                NotifyError(cause, format);
-            }
-            else
-            {
-                NotifyError(cause, new LogMessage(_logMessageFormatter, format, args));
-            }
-        }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.ErrorLevel" /> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public virtual void Error(string format, params object[] args)
-        {
-            if (!IsErrorEnabled) 
-                return;
-
-            if (args == null || args.Length == 0)
-            {
-                NotifyError(format);
-            }
-            else
-            {
-                NotifyError(new LogMessage(_logMessageFormatter, format, args));
-            }
-        }
-
-        /// <summary>
-        /// Logs a <see cref="LogLevel.InfoLevel" /> message.
-        /// </summary>
-        /// <param name="format">The message that is being logged.</param>
-        /// <param name="args">An optional list of items used to format the message.</param>
-        public virtual void Info(string format, params object[] args)
-        {
-            if (!IsInfoEnabled) 
-                return;
-
-            if (args == null || args.Length == 0)
-            {
-                NotifyInfo(format);
-            }
-            else
-            {
-                NotifyInfo(new LogMessage(_logMessageFormatter, format, args)); 
-            }
-        }
+        protected abstract void NotifyLog(LogLevel logLevel, object message, Exception cause = null);
 
         /// <summary>
         /// Logs a message with a specified level.
@@ -365,7 +93,7 @@ namespace Akka.Event
             }
             else
             {
-                NotifyLog(logLevel, new LogMessage(_logMessageFormatter, format, args));
+                NotifyLog(logLevel, new DefaultLogMessage(_logMessageFormatter, format, args));
             }
         }
 
@@ -380,12 +108,49 @@ namespace Akka.Event
         {
             if (args == null || args.Length == 0)
             {
-                NotifyLog(logLevel, cause, format);
+                NotifyLog(logLevel, format, cause);
             }
             else
             {
-                NotifyLog(logLevel, cause, new LogMessage(_logMessageFormatter, format, args));
+                NotifyLog(logLevel, new DefaultLogMessage(_logMessageFormatter, format, args), cause);
             }
+        }
+
+        public void Log(LogLevel logLevel, string format, Exception cause = null)
+        {
+            NotifyLog(logLevel, format, cause);
+        }
+
+        public void Log<T1>(LogLevel logLevel, string format, T1 arg1, Exception cause = null)
+        {
+            NotifyLog(logLevel, new LogMessage<LogValues<T1>>(_logMessageFormatter, format, new LogValues<T1>(arg1)), cause);
+        }
+
+        public void Log<T1, T2>(LogLevel logLevel, string format, T1 arg1, T2 arg2, Exception cause = null)
+        {
+            NotifyLog(logLevel, new LogMessage<LogValues<T1, T2>>(_logMessageFormatter, format, new LogValues<T1, T2>(arg1, arg2)), cause);
+        }
+
+        public void Log<T1, T2, T3>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, Exception cause = null)
+        {
+            NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3>>(_logMessageFormatter, format, new LogValues<T1, T2, T3>(arg1, arg2, arg3)), cause);
+        }
+
+        public void Log<T1, T2, T3, T4>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, Exception cause = null)
+        {
+            NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3, T4>>(_logMessageFormatter, format, new LogValues<T1, T2, T3, T4>(arg1, arg2, arg3, arg4)), cause);
+        }
+
+        public void Log<T1, T2, T3, T4, T5>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5,
+            Exception cause = null)
+        {
+            NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3, T4, T5>>(_logMessageFormatter, format, new LogValues<T1, T2, T3, T4, T5>(arg1, arg2, arg3, arg4, arg5)), cause);
+        }
+
+        public void Log<T1, T2, T3, T4, T5, T6>(LogLevel logLevel, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6,
+            Exception cause = null)
+        {
+            NotifyLog(logLevel, new LogMessage<LogValues<T1, T2, T3, T4, T5, T6>>(_logMessageFormatter, format, new LogValues<T1, T2, T3, T4, T5, T6>(arg1, arg2, arg3, arg4, arg5, arg6)), cause);
         }
     }
 }

--- a/src/core/Akka/Event/StandardOutLogger.cs
+++ b/src/core/Akka/Event/StandardOutLogger.cs
@@ -166,7 +166,7 @@ namespace Akka.Event
                 switch (logEvent.Message)
                 {
                     case LogMessage formatted: // a parameterized log
-                        msg = " str=[" + formatted.Format + "], args=["+ string.Join(",", formatted.Args) +"]";
+                        msg = " str=[" + formatted.Format + "], args=["+ formatted.Unformatted() +"]";
                         break;
                     case string unformatted: // pre-formatted or non-parameterized log
                         msg = unformatted;

--- a/src/core/Akka/IO/TcpOutgoingConnection.cs
+++ b/src/core/Akka/IO/TcpOutgoingConnection.cs
@@ -13,6 +13,7 @@ using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using Akka.Actor;
 using Akka.Annotations;
+using Akka.Event;
 using Akka.Util;
 
 namespace Akka.IO

--- a/src/core/Akka/Pattern/BackoffOptions.cs
+++ b/src/core/Akka/Pattern/BackoffOptions.cs
@@ -11,7 +11,7 @@ using Akka.Actor;
 namespace Akka.Pattern
 {
     /// <summary>
-    /// Builds back-off options for creating a back-off supervisor. You can pass <see cref="BackoffOptions"/> to <see cref="BackoffSupervisor.Props"/>.
+    /// Builds back-off options for creating a back-off supervisor. You can pass <see cref="BackoffOptions"/> to <see cref="Props"/>.
     /// </summary>
     public static class Backoff
     {

--- a/src/core/Akka/Util/Reflection/ExpressionExtensions.cs
+++ b/src/core/Akka/Util/Reflection/ExpressionExtensions.cs
@@ -110,12 +110,11 @@ namespace Akka.Util.Reflection
                         }
                     }
                 }
-                catch (Exception exception)
+                catch (Exception)
                 {
                     //Fallback. Do the worst way and compile.
                     try
                     {
-                        object fallbackVal;
                         {
                             _jobArgs[i] = Expression.Lambda(
                                     Expression.Convert(theArg, _objectType)


### PR DESCRIPTION
## Changes

Fixes https://github.com/akkadotnet/akka.net/pull/6394

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue https://github.com/akkadotnet/akka.net/pull/6394#issuecomment-1424987909
* [x] Changes in public API reviewed, if any.
* [x] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

``` ini

BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19044.2486/21H2/November2021Update)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK=7.0.100
  [Host]     : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2
  Job-WCODYP : .NET 7.0.0 (7.0.22.51805), X64 RyuJIT AVX2

InvocationCount=1  UnrollFactor=1  

```
|                      Method |     Mean |    Error |   StdDev |   Median | Ratio | RatioSD |   Gen0 |   Gen1 |   Gen2 | Allocated | Alloc Ratio |
|---------------------------- |---------:|---------:|---------:|---------:|------:|--------:|-------:|-------:|-------:|----------:|------------:|
|             LogInfoNoParams | 163.2 ns |  3.25 ns |  8.22 ns | 160.3 ns |  1.00 |    0.00 | 0.0110 | 0.0060 | 0.0010 |      64 B |        1.00 |
|              LogInfo1Params | 383.5 ns | 19.88 ns | 58.61 ns | 401.0 ns |  2.36 |    0.39 | 0.0250 | 0.0120 |      - |     160 B |        2.50 |
|              LogInfo2Params | 401.8 ns |  9.62 ns | 28.21 ns | 410.3 ns |  2.47 |    0.22 | 0.0300 | 0.0150 |      - |     192 B |        3.00 |
|        LogInfoWithException | 164.6 ns |  3.26 ns |  7.62 ns | 160.9 ns |  1.01 |    0.07 | 0.0100 | 0.0050 |      - |      64 B |        1.00 |
| LogInfoWithException1Params | 383.3 ns | 20.53 ns | 60.52 ns | 398.9 ns |  2.36 |    0.38 | 0.0260 | 0.0130 | 0.0010 |     160 B |        2.50 |
| LogInfoWithException2Params | 408.3 ns |  9.78 ns | 28.82 ns | 416.9 ns |  2.51 |    0.22 | 0.0300 | 0.0150 |      - |     192 B |        3.00 |

### This PR's Benchmarks

Include data from after this change here.
