### PR TITLE
Delete unnecessary / bad Sql.Common.Journal subscriptions

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/Akka.Persistence.Query.Sql.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/Akka.Persistence.Query.Sql.csproj
@@ -7,6 +7,7 @@
         <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
         <PackageTags>$(AkkaPackageTags);persistence;eventsource;sql;reactive;streams</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/AllEventsPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/AllEventsPublisher.cs
@@ -47,7 +47,7 @@ namespace Akka.Persistence.Query.Sql
             JournalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
         }
 
-        protected ILoggingAdapter Log => _log ?? (_log = Context.GetLogger());
+        protected ILoggingAdapter Log => _log ??= Context.GetLogger();
         protected IActorRef JournalRef { get; }
         protected DeliveryBuffer<EventEnvelope> Buffer { get; }
         protected long FromOffset { get; }
@@ -81,7 +81,6 @@ namespace Akka.Persistence.Query.Sql
             switch (message)
             {
                 case AllEventsPublisher.Continue _:
-                case NewEventAppended _:
                     if (IsTimeForReplay) Replay();
                     return true;
                 case Request _:
@@ -138,7 +137,6 @@ namespace Akka.Persistence.Query.Sql
                     Context.Stop(Self);
                     return true;
                 case AllEventsPublisher.Continue _:
-                case NewEventAppended _:
                     return true;
                 default:
                     return false;
@@ -166,7 +164,6 @@ namespace Akka.Persistence.Query.Sql
 
         protected override void ReceiveInitialRequest()
         {
-            JournalRef.Tell(SubscribeNewEvents.Instance);
             Replay();
         }
 

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByTagPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByTagPublisher.cs
@@ -50,7 +50,7 @@ namespace Akka.Persistence.Query.Sql
             JournalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
         }
 
-        protected ILoggingAdapter Log => _log ?? (_log = Context.GetLogger());
+        protected ILoggingAdapter Log => _log ??= Context.GetLogger();
         protected string Tag { get; }
         protected long FromOffset { get; }
         protected abstract long ToOffset { get; }
@@ -86,9 +86,6 @@ namespace Akka.Persistence.Query.Sql
             switch (message)
             {
                 case EventsByTagPublisher.Continue _:
-                    if (IsTimeForReplay) Replay();
-                    return true;
-                case TaggedEventAppended _:
                     if (IsTimeForReplay) Replay();
                     return true;
                 case Request _:
@@ -146,11 +143,6 @@ namespace Akka.Persistence.Query.Sql
                     case EventsByTagPublisher.Continue _:
                         // no-op
                         return true;
-                    
-                    case  TaggedEventAppended _:
-                        // no-op
-                        return true;
-                    
                     case Cancel _:
                         Context.Stop(Self);
                         return true;
@@ -182,7 +174,6 @@ namespace Akka.Persistence.Query.Sql
 
         protected override void ReceiveInitialRequest()
         {
-            JournalRef.Tell(new SubscribeTag(Tag));
             Replay();
         }
 

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -7,6 +7,7 @@
         <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
         <PackageTags>$(AkkaPackageTags);persistence;eventsource;sql</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj.DotSettings
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp80</s:String></wpf:ResourceDictionary>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
@@ -515,21 +515,6 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected BatchingSqlJournalSetup Setup { get; }
 
         /// <summary>
-        /// Flag determining if current journal has any subscribers for <see cref="EventAppended"/> events.
-        /// </summary>
-        protected bool HasPersistenceIdSubscribers => _persistenceIdSubscribers.Count != 0;
-
-        /// <summary>
-        /// Flag determining if current journal has any subscribers for <see cref="TaggedEventAppended"/> events.
-        /// </summary>
-        protected bool HasTagSubscribers => _tagSubscribers.Count != 0;
-
-        /// <summary>
-        /// Flag determining if current journal has any subscribers for <see cref="NewEventAppended"/> and 
-        /// </summary>
-        protected bool HasNewEventsSubscribers => _newEventSubscriber.Count != 0;
-
-        /// <summary>
         /// Flag determining if incoming journal requests should be published in current actor system event stream.
         /// Useful mostly for tests.
         /// </summary>
@@ -559,10 +544,6 @@ namespace Akka.Persistence.Sql.Common.Journal
 
         private readonly AtomicCounterLong _bufferIdCounter;
 
-        private readonly Dictionary<string, HashSet<IActorRef>> _persistenceIdSubscribers;
-        private readonly Dictionary<string, HashSet<IActorRef>> _tagSubscribers;
-        private readonly HashSet<IActorRef> _newEventSubscriber;
-
         private readonly Akka.Serialization.Serialization _serialization;
         private readonly CircuitBreaker _circuitBreaker;
         private int _remainingOperations;
@@ -575,11 +556,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         {
             Setup = setup;
             CanPublish = Persistence.Instance.Apply(Context.System).Settings.Internal.PublishPluginCommands;      
-            TimestampProvider = TimestampProviderProvider.GetTimestampProvider(setup.TimestampProviderTypeName, Context);      
-
-            _persistenceIdSubscribers = new Dictionary<string, HashSet<IActorRef>>();
-            _tagSubscribers = new Dictionary<string, HashSet<IActorRef>>();
-            _newEventSubscriber = new HashSet<IActorRef>();
+            TimestampProvider = TimestampProviderProvider.GetTimestampProvider(setup.TimestampProviderTypeName, Context);
 
             _remainingOperations = Setup.MaxConcurrentOperations;
             _buffers = new[]
@@ -739,18 +716,6 @@ namespace Akka.Persistence.Sql.Common.Journal
                 case BatchComplete msg:
                     CompleteBatch(msg);
                     return true;
-                case SubscribePersistenceId msg:
-                    AddPersistenceIdSubscriber(msg);
-                    return true;
-                case SubscribeTag msg:
-                    AddTagSubscriber(msg);
-                    return true;
-                case SubscribeNewEvents msg:
-                    AddNewEventsSubscriber(msg);
-                    return true;
-                case Terminated msg:
-                    RemoveSubscriber(msg.ActorRef);
-                    return true;
                 case ChunkExecutionFailure msg:
                     FailChunkExecution(msg);
                     return true;
@@ -833,68 +798,6 @@ namespace Akka.Persistence.Sql.Common.Journal
 
             TryProcess();
         }
-
-        #region subscriptions
-        private void RemoveSubscriber(IActorRef subscriberRef)
-        {
-            _persistenceIdSubscribers.RemoveItem(subscriberRef);
-            _tagSubscribers.RemoveItem(subscriberRef);
-            _newEventSubscriber.Remove(subscriberRef);
-        }
-
-        private void AddNewEventsSubscriber(SubscribeNewEvents message)
-        {
-            var subscriber = Sender;
-            _newEventSubscriber.Add(subscriber);
-            Context.Watch(subscriber);
-        }
-
-        private void AddTagSubscriber(SubscribeTag message)
-        {
-            var subscriber = Sender;
-            _tagSubscribers.AddItem(message.Tag, subscriber);
-            Context.Watch(subscriber);
-        }
-
-        private void AddPersistenceIdSubscriber(SubscribePersistenceId message)
-        {
-            var subscriber = Sender;
-            _persistenceIdSubscribers.AddItem(message.PersistenceId, subscriber);
-            Context.Watch(subscriber);
-        }
-
-        private void NotifyNewEventAppended()
-        {
-            if (HasNewEventsSubscribers)
-            {
-                foreach (var subscriber in _newEventSubscriber)
-                {
-                    subscriber.Tell(NewEventAppended.Instance);
-                }
-            }
-        }
-
-        private void NotifyTagChanged(string tag)
-        {
-            if (_tagSubscribers.TryGetValue(tag, out var bucket))
-            {
-                var changed = new TaggedEventAppended(tag);
-                foreach (var subscriber in bucket)
-                    subscriber.Tell(changed);
-            }
-        }
-
-        private void NotifyPersistenceIdChanged(string persistenceId)
-        {
-            if (_persistenceIdSubscribers.TryGetValue(persistenceId, out var bucket))
-            {
-                var changed = new EventAppended(persistenceId);
-                foreach (var subscriber in bucket)
-                    subscriber.Tell(changed);
-            }
-        }
-
-        #endregion
 
         /// <summary>
         /// Tries to add incoming <paramref name="message"/> to <see cref="Buffer"/>.
@@ -1505,28 +1408,6 @@ namespace Akka.Persistence.Sql.Common.Journal
                         aRef.Tell(new WriteMessageSuccess(unadapted, actorInstanceId), unadapted.Sender);
                     }
                 }
-
-                if (journal.HasTagSubscribers && _tags.Count != 0)
-                {
-                    foreach (var tag in _tags)
-                    {
-                        journal.NotifyTagChanged(tag);
-                    }
-                }
-
-                if (journal.HasPersistenceIdSubscribers)
-                {
-                    foreach (var persistenceId in _persistenceIds)
-                    {
-                        journal.NotifyPersistenceIdChanged(persistenceId);
-                    }
-                }
-
-                if (journal.HasNewEventsSubscribers)
-                {
-                    journal.NotifyNewEventAppended();
-                }
-
             }
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryApi.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryApi.cs
@@ -15,9 +15,7 @@ using Akka.Persistence.Journal;
 
 namespace Akka.Persistence.Sql.Common.Journal
 {
-    /// <summary>
-    /// TBD
-    /// </summary>
+    [Obsolete("Query is not implemented.")]
     public interface ISubscriptionCommand { }
 
     /// <summary>
@@ -26,6 +24,7 @@ namespace Akka.Persistence.Sql.Common.Journal
     /// the subscriber when <see cref="AsyncWriteJournal.WriteMessagesAsync"/> has been called.
     /// </summary>
     [Serializable]
+    [Obsolete("Query is not implemented.", true)]
     public sealed class SubscribePersistenceId : ISubscriptionCommand
     {
         /// <summary>
@@ -47,6 +46,7 @@ namespace Akka.Persistence.Sql.Common.Journal
     /// TBD
     /// </summary>
     [Serializable]
+    [Obsolete("Query is not implemented.", true)]
     public sealed class EventAppended : IDeadLetterSuppression
     {
         /// <summary>
@@ -108,6 +108,7 @@ namespace Akka.Persistence.Sql.Common.Journal
     /// the subscriber when `asyncWriteMessages` has been called.
     /// </summary>
     [Serializable]
+    [Obsolete("Query is not implemented.", true)]
     public sealed class SubscribeNewEvents : ISubscriptionCommand
     {
         public static SubscribeNewEvents Instance = new SubscribeNewEvents();
@@ -116,6 +117,7 @@ namespace Akka.Persistence.Sql.Common.Journal
     }
 
     [Serializable]
+    [Obsolete("Query is not implemented.", true)]
     public sealed class NewEventAppended : IDeadLetterSuppression
     {
         public static NewEventAppended Instance = new NewEventAppended();
@@ -131,6 +133,7 @@ namespace Akka.Persistence.Sql.Common.Journal
     /// via an <see cref="IEventAdapter"/>.
     /// </summary>
     [Serializable]
+    [Obsolete("Query is not implemented.", true)]
     public sealed class SubscribeTag : ISubscriptionCommand
     {
         /// <summary>
@@ -152,6 +155,7 @@ namespace Akka.Persistence.Sql.Common.Journal
     /// TBD
     /// </summary>
     [Serializable]
+    [Obsolete("Query is not implemented.", true)]
     public sealed class TaggedEventAppended : IDeadLetterSuppression
     {
         /// <summary>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -25,9 +25,6 @@ namespace Akka.Persistence.Sql.Common.Journal
     /// </summary>
     public abstract class SqlJournal : AsyncWriteJournal, IWithUnboundedStash
     {
-        private ImmutableDictionary<string, IImmutableSet<IActorRef>> _persistenceIdSubscribers = ImmutableDictionary.Create<string, IImmutableSet<IActorRef>>();
-        private ImmutableDictionary<string, IImmutableSet<IActorRef>> _tagSubscribers = ImmutableDictionary.Create<string, IImmutableSet<IActorRef>>();
-        private readonly HashSet<IActorRef> _newEventsSubscriber = new HashSet<IActorRef>();
         private IImmutableDictionary<string, long> _tagSequenceNr = ImmutableDictionary<string, long>.Empty;
 
         private readonly CancellationTokenSource _pendingRequestsCancellation;
@@ -48,19 +45,6 @@ namespace Akka.Persistence.Sql.Common.Journal
         public IStash Stash { get; set; }
 
         /// <summary>
-        /// TBD
-        /// </summary>
-        protected bool HasPersistenceIdSubscribers => _persistenceIdSubscribers.Count != 0;
-        /// <summary>
-        /// TBD
-        /// </summary>
-        protected bool HasTagSubscribers => _tagSubscribers.Count != 0;
-        /// <summary>
-        /// TBD
-        /// </summary>
-        protected bool HasNewEventSubscribers => _newEventsSubscriber.Count != 0;
-
-        /// <summary>
         /// Returns a HOCON config path to associated journal.
         /// </summary>
         protected abstract string JournalConfigPath { get; }
@@ -68,7 +52,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <summary>
         /// System logger.
         /// </summary>
-        protected ILoggingAdapter Log => _log ?? (_log = Context.GetLogger());
+        protected ILoggingAdapter Log => _log ??= Context.GetLogger();
 
         /// <summary>
         /// Initializes a database connection.
@@ -91,6 +75,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         {
             switch (message)
             {
+                // todo: SelectCurrentPersistenceIds
                 case ReplayTaggedMessages replay:
                     ReplayTaggedMessagesAsync(replay)
                         .PipeTo(replay.ReplyTo, success: h => new RecoverySuccess(h), failure: e => new ReplayMessagesFailure(e));
@@ -99,25 +84,6 @@ namespace Akka.Persistence.Sql.Common.Journal
                     ReplayAllEventsAsync(replay)
                         .PipeTo(replay.ReplyTo, success: h => new EventReplaySuccess(h),
                             failure: e => new EventReplayFailure(e));
-                    return true;
-                case SubscribePersistenceId subscribe:
-                    AddPersistenceIdSubscriber(Sender, subscribe.PersistenceId);
-                    Context.Watch(Sender);
-                    return true;
-                case SelectCurrentPersistenceIds request:
-                    SelectAllPersistenceIdsAsync(request.Offset)
-                        .PipeTo(request.ReplyTo, success: result => new CurrentPersistenceIds(result.Ids, result.LastOrdering));
-                    return true;
-                case SubscribeTag subscribe:
-                    AddTagSubscriber(Sender, subscribe.Tag);
-                    Context.Watch(Sender);
-                    return true;
-                case SubscribeNewEvents _:
-                    AddNewEventsSubscriber(Sender);
-                    Context.Watch(Sender);
-                    return true;
-                case Terminated terminated:
-                    RemoveSubscriber(terminated.ActorRef);
                     return true;
                 default:
                     return false;
@@ -135,9 +101,6 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <returns>TBD</returns>
         protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
         {
-            var persistenceIds = new HashSet<string>();
-            var allTags = new HashSet<string>();
-
             var writeTasks = messages.Select(async message =>
             {
                 using (var connection = CreateDbConnection())
@@ -146,18 +109,13 @@ namespace Akka.Persistence.Sql.Common.Journal
 
                     var eventToTags = new Dictionary<IPersistentRepresentation, IImmutableSet<string>>();
                     var persistentMessages = ((IImmutableList<IPersistentRepresentation>)message.Payload).ToArray();
-                    for (int i = 0; i < persistentMessages.Length; i++)
+                    for (var i = 0; i < persistentMessages.Length; i++)
                     {
                         var p = persistentMessages[i];
                         if (p.Payload is Tagged tagged)
                         {
                             persistentMessages[i] = p = p.WithPayload(tagged.Payload);
-                            if (tagged.Tags.Count != 0)
-                            {
-                                allTags.UnionWith(tagged.Tags);
-                                eventToTags.Add(p, tagged.Tags);
-                            }
-                            else eventToTags.Add(p, ImmutableHashSet<string>.Empty);
+                            eventToTags.Add(p, tagged.Tags.Count != 0 ? tagged.Tags : ImmutableHashSet<string>.Empty);
                         }
                         else eventToTags.Add(p, ImmutableHashSet<string>.Empty);
 
@@ -175,25 +133,6 @@ namespace Akka.Persistence.Sql.Common.Journal
                 .Factory
                 .ContinueWhenAll(writeTasks,
                     tasks => tasks.Select(t => t.IsFaulted ? TryUnwrapException(t.Exception) : null).ToImmutableList());
-
-            if (HasPersistenceIdSubscribers)
-            {
-                foreach (var persistenceId in persistenceIds)
-                {
-                    NotifyPersistenceIdChange(persistenceId);
-                }
-            }
-
-            if (HasTagSubscribers && allTags.Count != 0)
-            {
-                foreach (var tag in allTags)
-                {
-                    NotifyTagChange(tag);
-                }
-            }
-
-            if (HasNewEventSubscribers)
-                NotifyNewEventAppended();
 
             return result;
         }
@@ -357,65 +296,9 @@ namespace Akka.Persistence.Sql.Common.Journal
             return CreateDbConnection(connectionString);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="subscriber">TBD</param>
-        public void RemoveSubscriber(IActorRef subscriber)
-        {
-            _persistenceIdSubscribers = _persistenceIdSubscribers.SetItems(_persistenceIdSubscribers
-                .Where(kv => kv.Value.Contains(subscriber))
-                .Select(kv => new KeyValuePair<string, IImmutableSet<IActorRef>>(kv.Key, kv.Value.Remove(subscriber))));
-
-            _tagSubscribers = _tagSubscribers.SetItems(_tagSubscribers
-                .Where(kv => kv.Value.Contains(subscriber))
-                .Select(kv => new KeyValuePair<string, IImmutableSet<IActorRef>>(kv.Key, kv.Value.Remove(subscriber))));
-
-            _newEventsSubscriber.Remove(subscriber);
-        }
-
-        public void AddNewEventsSubscriber(IActorRef subscriber)
-        {
-            _newEventsSubscriber.Add(subscriber);
-        }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="subscriber">TBD</param>
-        /// <param name="tag">TBD</param>
-        public void AddTagSubscriber(IActorRef subscriber, string tag)
-        {
-            if (!_tagSubscribers.TryGetValue(tag, out var subscriptions))
-            {
-                _tagSubscribers = _tagSubscribers.Add(tag, ImmutableHashSet.Create(subscriber));
-            }
-            else
-            {
-                _tagSubscribers = _tagSubscribers.SetItem(tag, subscriptions.Add(subscriber));
-            }
-        }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="subscriber">TBD</param>
-        /// <param name="persistenceId">TBD</param>
-        public void AddPersistenceIdSubscriber(IActorRef subscriber, string persistenceId)
-        {
-            if (!_persistenceIdSubscribers.TryGetValue(persistenceId, out var subscriptions))
-            {
-                _persistenceIdSubscribers = _persistenceIdSubscribers.Add(persistenceId, ImmutableHashSet.Create(subscriber));
-            }
-            else
-            {
-                _persistenceIdSubscribers = _persistenceIdSubscribers.SetItem(persistenceId, subscriptions.Add(subscriber));
-            }
-        }
-
         private async Task<long> NextTagSequenceNr(string tag)
         {
-            if (!_tagSequenceNr.TryGetValue(tag, out long value))
+            if (!_tagSequenceNr.TryGetValue(tag, out var value))
                 value = await ReadHighestSequenceNrAsync(TagId(tag), 0L);
 
             value++;
@@ -428,37 +311,6 @@ namespace Akka.Persistence.Sql.Common.Journal
         private bool IsTagId(string persistenceId)
         {
             return persistenceId.StartsWith(QueryExecutor.Configuration.TagsColumnName);
-        }
-
-        private void NotifyPersistenceIdChange(string persistenceId)
-        {
-            if (_persistenceIdSubscribers.TryGetValue(persistenceId, out var subscribers))
-            {
-                var changed = new EventAppended(persistenceId);
-                foreach (var subscriber in subscribers)
-                    subscriber.Tell(changed);
-            }
-        }
-
-        private void NotifyTagChange(string tag)
-        {
-            if (_tagSubscribers.TryGetValue(tag, out var subscribers))
-            {
-                var changed = new TaggedEventAppended(tag);
-                foreach (var subscriber in subscribers)
-                    subscriber.Tell(changed);
-            }
-        }
-
-        private void NotifyNewEventAppended()
-        {
-            if (HasNewEventSubscribers)
-            {
-                foreach (var subscriber in _newEventsSubscriber)
-                {
-                    subscriber.Tell(NewEventAppended.Instance);
-                }
-            }
         }
 
         /// <summary>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Data.Common;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -74,7 +74,10 @@ namespace Akka.Persistence.Sql.Common.Journal
         {
             switch (message)
             {
-                // todo: SelectCurrentPersistenceIds
+                case SelectCurrentPersistenceIds msg:
+                    SelectAllPersistenceIdsAsync(msg.Offset)
+                        .PipeTo(msg.ReplyTo, success: h => new CurrentPersistenceIds(h.Ids, h.LastOrdering), failure: e => new Status.Failure(e));
+                    return true;
                 case ReplayTaggedMessages replay:
                     ReplayTaggedMessagesAsync(replay)
                         .PipeTo(replay.ReplyTo, success: h => new RecoverySuccess(h), failure: e => new ReplayMessagesFailure(e));

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Core.verified.txt
@@ -91,9 +91,6 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected virtual string ByPersistenceIdSql { get; }
         protected virtual string ByTagSql { get; }
         protected virtual string DeleteBatchSql { get; }
-        protected bool HasNewEventsSubscribers { get; }
-        protected bool HasPersistenceIdSubscribers { get; }
-        protected bool HasTagSubscribers { get; }
         protected virtual string HighestOrderingSql { get; }
         protected virtual string HighestSequenceNrSql { get; }
         protected abstract System.Collections.Immutable.ImmutableDictionary<string, string> Initializers { get; }
@@ -137,6 +134,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         public DefaultTimestampProvider() { }
         public long GenerateTimestamp(Akka.Persistence.IPersistentRepresentation message) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class EventAppended : Akka.Event.IDeadLetterSuppression
     {
         public readonly string PersistenceId;
@@ -180,6 +178,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         System.Threading.Tasks.Task<long> SelectHighestSequenceNrAsync(System.Data.Common.DbConnection connection, System.Threading.CancellationToken cancellationToken, string persistenceId);
         System.Threading.Tasks.Task<long> SelectHighestSequenceNrAsync(System.Data.Common.DbConnection connection, System.Threading.CancellationToken cancellationToken);
     }
+    [System.ObsoleteAttribute("Query is not implemented.")]
     public interface ISubscriptionCommand { }
     public interface ITimestampProvider
     {
@@ -201,6 +200,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         public readonly System.DateTime Timestamp;
         public JournalEntry(string persistenceId, long sequenceNr, bool isDeleted, string manifest, System.DateTime timestamp, object payload) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class NewEventAppended : Akka.Event.IDeadLetterSuppression
     {
         public static Akka.Persistence.Sql.Common.Journal.NewEventAppended Instance;
@@ -275,16 +275,10 @@ namespace Akka.Persistence.Sql.Common.Journal
     public abstract class SqlJournal : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected SqlJournal(Akka.Configuration.Config journalConfig) { }
-        protected bool HasNewEventSubscribers { get; }
-        protected bool HasPersistenceIdSubscribers { get; }
-        protected bool HasTagSubscribers { get; }
         protected abstract string JournalConfigPath { get; }
         protected Akka.Event.ILoggingAdapter Log { get; }
         public abstract Akka.Persistence.Sql.Common.Journal.IJournalQueryExecutor QueryExecutor { get; }
         public Akka.Actor.IStash Stash { get; set; }
-        public void AddNewEventsSubscriber(Akka.Actor.IActorRef subscriber) { }
-        public void AddPersistenceIdSubscriber(Akka.Actor.IActorRef subscriber, string persistenceId) { }
-        public void AddTagSubscriber(Akka.Actor.IActorRef subscriber, string tag) { }
         protected abstract System.Data.Common.DbConnection CreateDbConnection(string connectionString);
         public System.Data.Common.DbConnection CreateDbConnection() { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
@@ -294,7 +288,6 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected override void PreStart() { }
         public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
         protected override bool ReceivePluginInternal(object message) { }
-        public void RemoveSubscriber(Akka.Actor.IActorRef subscriber) { }
         protected virtual System.Threading.Tasks.Task<long> ReplayAllEventsAsync(Akka.Persistence.Sql.Common.Journal.ReplayAllEvents replay) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         protected virtual System.Threading.Tasks.Task<long> ReplayTaggedMessagesAsync(Akka.Persistence.Sql.Common.Journal.ReplayTaggedMessages replay) { }
@@ -305,20 +298,24 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected bool WaitingForInitialization(object message) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class SubscribeNewEvents : Akka.Persistence.Sql.Common.Journal.ISubscriptionCommand
     {
         public static Akka.Persistence.Sql.Common.Journal.SubscribeNewEvents Instance;
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class SubscribePersistenceId : Akka.Persistence.Sql.Common.Journal.ISubscriptionCommand
     {
         public readonly string PersistenceId;
         public SubscribePersistenceId(string persistenceId) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class SubscribeTag : Akka.Persistence.Sql.Common.Journal.ISubscriptionCommand
     {
         public readonly string Tag;
         public SubscribeTag(string tag) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class TaggedEventAppended : Akka.Event.IDeadLetterSuppression
     {
         public readonly string Tag;

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.DotNet.verified.txt
@@ -91,9 +91,6 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected virtual string ByPersistenceIdSql { get; }
         protected virtual string ByTagSql { get; }
         protected virtual string DeleteBatchSql { get; }
-        protected bool HasNewEventsSubscribers { get; }
-        protected bool HasPersistenceIdSubscribers { get; }
-        protected bool HasTagSubscribers { get; }
         protected virtual string HighestOrderingSql { get; }
         protected virtual string HighestSequenceNrSql { get; }
         protected abstract System.Collections.Immutable.ImmutableDictionary<string, string> Initializers { get; }
@@ -137,6 +134,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         public DefaultTimestampProvider() { }
         public long GenerateTimestamp(Akka.Persistence.IPersistentRepresentation message) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class EventAppended : Akka.Event.IDeadLetterSuppression
     {
         public readonly string PersistenceId;
@@ -180,6 +178,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         System.Threading.Tasks.Task<long> SelectHighestSequenceNrAsync(System.Data.Common.DbConnection connection, System.Threading.CancellationToken cancellationToken, string persistenceId);
         System.Threading.Tasks.Task<long> SelectHighestSequenceNrAsync(System.Data.Common.DbConnection connection, System.Threading.CancellationToken cancellationToken);
     }
+    [System.ObsoleteAttribute("Query is not implemented.")]
     public interface ISubscriptionCommand { }
     public interface ITimestampProvider
     {
@@ -201,6 +200,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         public readonly System.DateTime Timestamp;
         public JournalEntry(string persistenceId, long sequenceNr, bool isDeleted, string manifest, System.DateTime timestamp, object payload) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class NewEventAppended : Akka.Event.IDeadLetterSuppression
     {
         public static Akka.Persistence.Sql.Common.Journal.NewEventAppended Instance;
@@ -275,16 +275,10 @@ namespace Akka.Persistence.Sql.Common.Journal
     public abstract class SqlJournal : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected SqlJournal(Akka.Configuration.Config journalConfig) { }
-        protected bool HasNewEventSubscribers { get; }
-        protected bool HasPersistenceIdSubscribers { get; }
-        protected bool HasTagSubscribers { get; }
         protected abstract string JournalConfigPath { get; }
         protected Akka.Event.ILoggingAdapter Log { get; }
         public abstract Akka.Persistence.Sql.Common.Journal.IJournalQueryExecutor QueryExecutor { get; }
         public Akka.Actor.IStash Stash { get; set; }
-        public void AddNewEventsSubscriber(Akka.Actor.IActorRef subscriber) { }
-        public void AddPersistenceIdSubscriber(Akka.Actor.IActorRef subscriber, string persistenceId) { }
-        public void AddTagSubscriber(Akka.Actor.IActorRef subscriber, string tag) { }
         protected abstract System.Data.Common.DbConnection CreateDbConnection(string connectionString);
         public System.Data.Common.DbConnection CreateDbConnection() { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
@@ -294,7 +288,6 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected override void PreStart() { }
         public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
         protected override bool ReceivePluginInternal(object message) { }
-        public void RemoveSubscriber(Akka.Actor.IActorRef subscriber) { }
         protected virtual System.Threading.Tasks.Task<long> ReplayAllEventsAsync(Akka.Persistence.Sql.Common.Journal.ReplayAllEvents replay) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         protected virtual System.Threading.Tasks.Task<long> ReplayTaggedMessagesAsync(Akka.Persistence.Sql.Common.Journal.ReplayTaggedMessages replay) { }
@@ -305,20 +298,24 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected bool WaitingForInitialization(object message) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class SubscribeNewEvents : Akka.Persistence.Sql.Common.Journal.ISubscriptionCommand
     {
         public static Akka.Persistence.Sql.Common.Journal.SubscribeNewEvents Instance;
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class SubscribePersistenceId : Akka.Persistence.Sql.Common.Journal.ISubscriptionCommand
     {
         public readonly string PersistenceId;
         public SubscribePersistenceId(string persistenceId) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class SubscribeTag : Akka.Persistence.Sql.Common.Journal.ISubscriptionCommand
     {
         public readonly string Tag;
         public SubscribeTag(string tag) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class TaggedEventAppended : Akka.Event.IDeadLetterSuppression
     {
         public readonly string Tag;

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Net.verified.txt
@@ -91,9 +91,6 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected virtual string ByPersistenceIdSql { get; }
         protected virtual string ByTagSql { get; }
         protected virtual string DeleteBatchSql { get; }
-        protected bool HasNewEventsSubscribers { get; }
-        protected bool HasPersistenceIdSubscribers { get; }
-        protected bool HasTagSubscribers { get; }
         protected virtual string HighestOrderingSql { get; }
         protected virtual string HighestSequenceNrSql { get; }
         protected abstract System.Collections.Immutable.ImmutableDictionary<string, string> Initializers { get; }
@@ -137,6 +134,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         public DefaultTimestampProvider() { }
         public long GenerateTimestamp(Akka.Persistence.IPersistentRepresentation message) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class EventAppended : Akka.Event.IDeadLetterSuppression
     {
         public readonly string PersistenceId;
@@ -180,6 +178,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         System.Threading.Tasks.Task<long> SelectHighestSequenceNrAsync(System.Data.Common.DbConnection connection, System.Threading.CancellationToken cancellationToken, string persistenceId);
         System.Threading.Tasks.Task<long> SelectHighestSequenceNrAsync(System.Data.Common.DbConnection connection, System.Threading.CancellationToken cancellationToken);
     }
+    [System.ObsoleteAttribute("Query is not implemented.")]
     public interface ISubscriptionCommand { }
     public interface ITimestampProvider
     {
@@ -201,6 +200,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         public readonly System.DateTime Timestamp;
         public JournalEntry(string persistenceId, long sequenceNr, bool isDeleted, string manifest, System.DateTime timestamp, object payload) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class NewEventAppended : Akka.Event.IDeadLetterSuppression
     {
         public static Akka.Persistence.Sql.Common.Journal.NewEventAppended Instance;
@@ -275,16 +275,10 @@ namespace Akka.Persistence.Sql.Common.Journal
     public abstract class SqlJournal : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         protected SqlJournal(Akka.Configuration.Config journalConfig) { }
-        protected bool HasNewEventSubscribers { get; }
-        protected bool HasPersistenceIdSubscribers { get; }
-        protected bool HasTagSubscribers { get; }
         protected abstract string JournalConfigPath { get; }
         protected Akka.Event.ILoggingAdapter Log { get; }
         public abstract Akka.Persistence.Sql.Common.Journal.IJournalQueryExecutor QueryExecutor { get; }
         public Akka.Actor.IStash Stash { get; set; }
-        public void AddNewEventsSubscriber(Akka.Actor.IActorRef subscriber) { }
-        public void AddPersistenceIdSubscriber(Akka.Actor.IActorRef subscriber, string persistenceId) { }
-        public void AddTagSubscriber(Akka.Actor.IActorRef subscriber, string tag) { }
         protected abstract System.Data.Common.DbConnection CreateDbConnection(string connectionString);
         public System.Data.Common.DbConnection CreateDbConnection() { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
@@ -294,7 +288,6 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected override void PreStart() { }
         public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
         protected override bool ReceivePluginInternal(object message) { }
-        public void RemoveSubscriber(Akka.Actor.IActorRef subscriber) { }
         protected virtual System.Threading.Tasks.Task<long> ReplayAllEventsAsync(Akka.Persistence.Sql.Common.Journal.ReplayAllEvents replay) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         protected virtual System.Threading.Tasks.Task<long> ReplayTaggedMessagesAsync(Akka.Persistence.Sql.Common.Journal.ReplayTaggedMessages replay) { }
@@ -305,20 +298,24 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected bool WaitingForInitialization(object message) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class SubscribeNewEvents : Akka.Persistence.Sql.Common.Journal.ISubscriptionCommand
     {
         public static Akka.Persistence.Sql.Common.Journal.SubscribeNewEvents Instance;
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class SubscribePersistenceId : Akka.Persistence.Sql.Common.Journal.ISubscriptionCommand
     {
         public readonly string PersistenceId;
         public SubscribePersistenceId(string persistenceId) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class SubscribeTag : Akka.Persistence.Sql.Common.Journal.ISubscriptionCommand
     {
         public readonly string Tag;
         public SubscribeTag(string tag) { }
     }
+    [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class TaggedEventAppended : Akka.Event.IDeadLetterSuppression
     {
         public readonly string Tag;


### PR DESCRIPTION
## Changes

All of the old SubscribeTo___ methods from the Akka.Persistence.Sql.Common journal implement some bad practices, i.e. not able to detect events published in other instances of the Akka.NET processes targeting the same journal. This method deletes them and marks the old queries in Sql.Common as `Obsolete`. Rewrote existing queries to poll the database rather than rely on in-memory events, which is the correct way to implement these.

Also: significantly reduces allocations and overheads for writes for all Akka.Persistence.Sql.Common implementations.

Related: https://github.com/akkadotnet/akka.net/issues/5522

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #5522
* [x] Changes in public API reviewed, if any.