### PR TITLE
Akka.NET v1.5.0-beta1 Release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,10 +15,42 @@ All of the changes made here are _source compatible_, but not _binary compatible
 In addition to improving the performance of the `ILoggingAdapter` system, we've also made it more extensible - for instance, you can now globally configure the `ILogMessageFormatter` via the following HOCON:
 
 ```
-
+akka { 
+    loglevel=INFO,
+    loggers=["Akka.Logger.Serilog.SerilogLogger, Akka.Logger.Serilog"]
+    logger-formatter="Akka.Logger.Serilog.SerilogLogMessageFormatter, Akka.Logger.Serilog"
+}
 ```
 
-#### 1.5.0-alpha4 February 1st 2022 ####
+That will allow users to use the `SerilogLogMessageFormatter` globally throughout their applications - no more annoying calls like this inside individual actors that want to use semantic logging:
+
+```csharp
+private readonly ILoggingAdapter _logger = Context.GetLogger<SerilogLoggingAdapter>();
+```
+
+**Breaking Changes: Akka.Persistence.Sql.Common**
+
+This is a breaking change that should effect almost no users, but [we deleted some old, bad ideas from the API surface](https://github.com/akkadotnet/akka.net/pull/6412) and it might require all Akka.Persistence.Sql* plugins to be recompiled.
+
+For what it's worth, [Akka.Persistence.Sql.Common's performance has been improved significantly](https://github.com/akkadotnet/akka.net/pull/6384) and we'll continue working on that with some additional API changes this week.
+
+**Other Changes and Additions**
+
+* [Akka.Actor: New API - `IActorRef.WatchAsync`](https://github.com/akkadotnet/akka.net/pull/6102) - adds a new extension method to `IActorRef` which allows users to subscribe to actor lifecycle notifications outside of the `ActorSystem`.
+* [Akka.Actor: Suppress `System.Object` warning for serializer configuration changes](https://github.com/akkadotnet/akka.net/issues/6377)
+
+If you want to see the [full set of changes made in Akka.NET v1.5.0 so far, click here](https://github.com/akkadotnet/akka.net/milestone/7?closed=1).
+
+                                        
+| COMMITS | LOC+ | LOC- | AUTHOR |      
+| --- | --- | --- | --- |               
+| 12 | 15 | 15 | dependabot[bot] |      
+| 11 | 1930 | 1278 | Aaron Stannard |   
+| 2 | 143 | 73 | Sergey Popov |         
+| 1 | 26 | 4 | Thomas Stegemann |       
+| 1 | 1 | 1 | Michel van Os |           
+
+#### 1.5.0-alpha4 February 1st 2023 ####
 Version 1.5.0-alpha3 contains several bug fixes and new features to Akka.NET
 
 * [Akka.TestKit: Remove Akka.Tests.Shared.Internal dependency](https://github.com/akkadotnet/akka.net/pull/6258)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,22 @@
 #### 1.5.0-beta1 February 20th 2023 ####
-Version 1.5.0-beta1 contains breaking API changes for Akka.NET:
+Version 1.5.0-beta1 contains **breaking API changes** and new API changes for Akka.NET.
 
-* []()
+**Breaking Changes: Logging**
+
+In [https://github.com/akkadotnet/akka.net/pull/6408](https://github.com/akkadotnet/akka.net/pull/6408) the entire `ILoggingAdapter` interface was rewritten in order to improve extensibility and performance (logging is now 30-40% faster in all cases and allocates ~50% fewer objects for large format strings).
+
+All of the changes made here are _source compatible_, but not _binary compatible_ - meaning that users and package authors will need to do the following:
+
+* Add `using Akka.Event` in all files that used the `ILoggingAdapter` and
+* Recompile.
+
+> NOTE: you can use a [`global using Akka.Event` directive](https://devblogs.microsoft.com/dotnet/welcome-to-csharp-10/#global-using-directives) to do this solution / project-wide if your project supports C# 10 and / or .NET 6.
+
+In addition to improving the performance of the `ILoggingAdapter` system, we've also made it more extensible - for instance, you can now globally configure the `ILogMessageFormatter` via the following HOCON:
+
+```
+
+```
 
 #### 1.5.0-alpha4 February 1st 2022 ####
 Version 1.5.0-alpha3 contains several bug fixes and new features to Akka.NET

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+#### 1.5.0-beta1 February 20th 2023 ####
+Version 1.5.0-beta1 contains breaking API changes for Akka.NET:
+
+* []()
+
 #### 1.5.0-alpha4 February 1st 2022 ####
 Version 1.5.0-alpha3 contains several bug fixes and new features to Akka.NET
 

--- a/src/common.props
+++ b/src/common.props
@@ -36,22 +36,39 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Akka.NET v1.5.0-alpha2 is a maintenance release for Akka.NET v1.5 that contains numerous performance improvements in critical areas, including core actor message processing and Akka.Remote.
-Performance Fixes**
-[remove delegate allocation from `ForkJoinDispatcher` and `DedicatedThreadPool`](https://github.com/akkadotnet/akka.net/pull/6162)
-[eliminate `Mailbox` delegate allocations](https://github.com/akkadotnet/akka.net/pull/6162)
-[Reduce `FSM&lt;TState, TData&gt;` allocations](https://github.com/akkadotnet/akka.net/pull/6162)
-[removed boxing allocations inside `FSM.State.Equals`](https://github.com/akkadotnet/akka.net/pull/6196)
-[Eliminate `DefaultLogMessageFormatter` allocations](https://github.com/akkadotnet/akka.net/pull/6166)
-In sum you should expect to see total memory consumption, garbage collection, and throughput improve when you upgrade to Akka.NET v1.5.0-alpha2.
-Other Features and Improvements**
-[DData: Suppress gossip message from showing up in debug log unless verbose debug logging is turned on](https://github.com/akkadotnet/akka.net/pull/6089)
-[TestKit: TestKit automatically injects the default TestKit default configuration if an ActorSystem is passed into its constructor](https://github.com/akkadotnet/akka.net/pull/6092)
-[Sharding: Added a new `GetEntityLocation` query message to retrieve an entity address location in the shard region](https://github.com/akkadotnet/akka.net/pull/6107)
-[Sharding: Fixed `GetEntityLocation` uses wrong actor path](https://github.com/akkadotnet/akka.net/pull/6121)
-[Akka.Cluster and Akka.Cluster.Sharding: should throw human-friendly exception when accessing cluster / sharding plugins when clustering is not running](https://github.com/akkadotnet/akka.net/pull/6169)
-[Akka.Cluster.Sharding: Add `HashCodeMessageExtractor` factory](https://github.com/akkadotnet/akka.net/pull/6173)
-[Akka.Persistence.Sql.Common: Fix `DbCommand.CommandTimeout` in `BatchingSqlJournal`](https://github.com/akkadotnet/akka.net/pull/6175)</PackageReleaseNotes>
+    <PackageReleaseNotes>Version 1.5.0-beta1 contains **breaking API changes** and new API changes for Akka.NET.
+Breaking Changes: Logging**
+In [https://github.com/akkadotnet/akka.net/pull/6408](https://github.com/akkadotnet/akka.net/pull/6408) the entire `ILoggingAdapter` interface was rewritten in order to improve extensibility and performance (logging is now 30-40% faster in all cases and allocates ~50% fewer objects for large format strings).
+All of the changes made here are _source compatible_, but not _binary compatible_ - meaning that users and package authors will need to do the following:
+Add `using Akka.Event` in all files that used the `ILoggingAdapter` and
+Recompile.
+&gt; NOTE: you can use a [`global using Akka.Event` directive](https://devblogs.microsoft.com/dotnet/welcome-to-csharp-10/#global-using-directives) to do this solution / project-wide if your project supports C# 10 and / or .NET 6.
+In addition to improving the performance of the `ILoggingAdapter` system, we've also made it more extensible - for instance, you can now globally configure the `ILogMessageFormatter` via the following HOCON:
+```
+akka {
+loglevel=INFO,
+loggers=["Akka.Logger.Serilog.SerilogLogger, Akka.Logger.Serilog"]
+logger-formatter="Akka.Logger.Serilog.SerilogLogMessageFormatter, Akka.Logger.Serilog"
+}
+```
+That will allow users to use the `SerilogLogMessageFormatter` globally throughout their applications - no more annoying calls like this inside individual actors that want to use semantic logging:
+```csharp
+private readonly ILoggingAdapter _logger = Context.GetLogger&lt;SerilogLoggingAdapter&gt;();
+```
+Breaking Changes: Akka.Persistence.Sql.Common**
+This is a breaking change that should effect almost no users, but [we deleted some old, bad ideas from the API surface](https://github.com/akkadotnet/akka.net/pull/6412) and it might require all Akka.Persistence.Sql* plugins to be recompiled.
+For what it's worth, [Akka.Persistence.Sql.Common's performance has been improved significantly](https://github.com/akkadotnet/akka.net/pull/6384) and we'll continue working on that with some additional API changes this week.
+Other Changes and Additions**
+[Akka.Actor: New API - `IActorRef.WatchAsync`](https://github.com/akkadotnet/akka.net/pull/6102) - adds a new extension method to `IActorRef` which allows users to subscribe to actor lifecycle notifications outside of the `ActorSystem`.
+[Akka.Actor: Suppress `System.Object` warning for serializer configuration changes](https://github.com/akkadotnet/akka.net/issues/6377)
+If you want to see the [full set of changes made in Akka.NET v1.5.0 so far, click here](https://github.com/akkadotnet/akka.net/milestone/7?closed=1).
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 12 | 15 | 15 | dependabot[bot] |
+| 11 | 1930 | 1278 | Aaron Stannard |
+| 2 | 143 | 73 | Sergey Popov |
+| 1 | 26 | 4 | Thomas Stegemann |
+| 1 | 1 | 1 | Michel van Os |</PackageReleaseNotes>
   </PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>


### PR DESCRIPTION
#### 1.5.0-beta1 February 20th 2023 ####
Version 1.5.0-beta1 contains **breaking API changes** and new API changes for Akka.NET.

**Breaking Changes: Logging**

In [https://github.com/akkadotnet/akka.net/pull/6408](https://github.com/akkadotnet/akka.net/pull/6408) the entire `ILoggingAdapter` interface was rewritten in order to improve extensibility and performance (logging is now 30-40% faster in all cases and allocates ~50% fewer objects for large format strings).

All of the changes made here are _source compatible_, but not _binary compatible_ - meaning that users and package authors will need to do the following:

* Add `using Akka.Event` in all files that used the `ILoggingAdapter` and
* Recompile.

> NOTE: you can use a [`global using Akka.Event` directive](https://devblogs.microsoft.com/dotnet/welcome-to-csharp-10/#global-using-directives) to do this solution / project-wide if your project supports C# 10 and / or .NET 6.

In addition to improving the performance of the `ILoggingAdapter` system, we've also made it more extensible - for instance, you can now globally configure the `ILogMessageFormatter` via the following HOCON:

```
akka { 
    loglevel=INFO,
    loggers=["Akka.Logger.Serilog.SerilogLogger, Akka.Logger.Serilog"]
    logger-formatter="Akka.Logger.Serilog.SerilogLogMessageFormatter, Akka.Logger.Serilog"
}
```

That will allow users to use the `SerilogLogMessageFormatter` globally throughout their applications - no more annoying calls like this inside individual actors that want to use semantic logging:

```csharp
private readonly ILoggingAdapter _logger = Context.GetLogger<SerilogLoggingAdapter>();
```

**Breaking Changes: Akka.Persistence.Sql.Common**

This is a breaking change that should effect almost no users, but [we deleted some old, bad ideas from the API surface](https://github.com/akkadotnet/akka.net/pull/6412) and it might require all Akka.Persistence.Sql* plugins to be recompiled.

For what it's worth, [Akka.Persistence.Sql.Common's performance has been improved significantly](https://github.com/akkadotnet/akka.net/pull/6384) and we'll continue working on that with some additional API changes this week.

**Other Changes and Additions**

* [Akka.Actor: New API - `IActorRef.WatchAsync`](https://github.com/akkadotnet/akka.net/pull/6102) - adds a new extension method to `IActorRef` which allows users to subscribe to actor lifecycle notifications outside of the `ActorSystem`.
* [Akka.Actor: Suppress `System.Object` warning for serializer configuration changes](https://github.com/akkadotnet/akka.net/issues/6377)

If you want to see the [full set of changes made in Akka.NET v1.5.0 so far, click here](https://github.com/akkadotnet/akka.net/milestone/7?closed=1).

                                        
| COMMITS | LOC+ | LOC- | AUTHOR |      
| --- | --- | --- | --- |               
| 12 | 15 | 15 | dependabot[bot] |      
| 11 | 1930 | 1278 | Aaron Stannard |   
| 2 | 143 | 73 | Sergey Popov |         
| 1 | 26 | 4 | Thomas Stegemann |       
| 1 | 1 | 1 | Michel van Os |    