### PR TITLE
Harden `Option<T>` by disallowing null value

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -965,7 +965,7 @@ namespace Akka.Cluster.Sharding
                     {
                         var entityRef = await Context.ActorSelection(entityPath).ResolveOne(getEntityLocation.Timeout);
                         sender.Tell(new EntityLocation(getEntityLocation.EntityId, shardId, destinationAddress,
-                            new Option<IActorRef>(entityRef)));
+                            Option<IActorRef>.Create(entityRef)));
                     }
                     catch (ActorNotFoundException ex)
                     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
@@ -5114,10 +5114,12 @@ namespace Akka.Util
     public struct Option<T>
     {
         public static readonly Akka.Util.Option<T> None;
+        [System.ObsoleteAttribute("Use Option<T>.Create() instead")]
         public Option(T value) { }
         public bool HasValue { get; }
         public bool IsEmpty { get; }
         public T Value { get; }
+        public static Akka.Util.Option<T> Create(T value) { }
         public bool Equals(Akka.Util.Option<T> other) { }
         public override bool Equals(object obj) { }
         public Akka.Util.Option<TNew> FlatSelect<TNew>(System.Func<T, Akka.Util.Option<TNew>> mapper) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -5122,10 +5122,12 @@ namespace Akka.Util
     public struct Option<T>
     {
         public static readonly Akka.Util.Option<T> None;
+        [System.ObsoleteAttribute("Use Option<T>.Create() instead")]
         public Option(T value) { }
         public bool HasValue { get; }
         public bool IsEmpty { get; }
         public T Value { get; }
+        public static Akka.Util.Option<T> Create(T value) { }
         public bool Equals(Akka.Util.Option<T> other) { }
         public override bool Equals(object obj) { }
         public Akka.Util.Option<TNew> FlatSelect<TNew>(System.Func<T, Akka.Util.Option<TNew>> mapper) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -5114,10 +5114,12 @@ namespace Akka.Util
     public struct Option<T>
     {
         public static readonly Akka.Util.Option<T> None;
+        [System.ObsoleteAttribute("Use Option<T>.Create() instead")]
         public Option(T value) { }
         public bool HasValue { get; }
         public bool IsEmpty { get; }
         public T Value { get; }
+        public static Akka.Util.Option<T> Create(T value) { }
         public bool Equals(Akka.Util.Option<T> other) { }
         public override bool Equals(object obj) { }
         public Akka.Util.Option<TNew> FlatSelect<TNew>(System.Func<T, Akka.Util.Option<TNew>> mapper) { }

--- a/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/StressSpec.cs
@@ -813,7 +813,7 @@ akka.remote.default-remote-dispatcher {
         {
             Sys.ActorSelection(new RootActorPath(GetAddress(Roles.First())) / "user" / ("result" + Step))
                 .Tell(new Identify(Step), IdentifyProbe.Ref);
-            return new Option<IActorRef>(IdentifyProbe.ExpectMsg<ActorIdentity>().Subject);
+            return Option<IActorRef>.Create(IdentifyProbe.ExpectMsg<ActorIdentity>().Subject);
         }
 
         public void CreateResultAggregator(string title, int expectedResults, bool includeInHistory)
@@ -826,7 +826,7 @@ akka.remote.default-remote-dispatcher {
 
                     if (includeInHistory && Settings.Infolog)
                     {
-                        aggregator.Tell(new ReportTo(new Option<IActorRef>(ClusterResultHistory.Value)));
+                        aggregator.Tell(new ReportTo(Option<IActorRef>.Create(ClusterResultHistory.Value)));
                     }
                     else
                     {
@@ -1180,7 +1180,7 @@ akka.remote.default-remote-dispatcher {
                             var sys = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
                             MuteLog(sys);
                             Akka.Cluster.Cluster.Get(sys).JoinSeedNodes(SeedNodes.Select(x => GetAddress(x)));
-                            nextAs = new Option<ActorSystem>(sys);
+                            nextAs = Option<ActorSystem>.Create(sys);
                         }
                         else
                         {

--- a/src/core/Akka.Cluster/ClusterHeartbeat.cs
+++ b/src/core/Akka.Cluster/ClusterHeartbeat.cs
@@ -634,7 +634,7 @@ namespace Akka.Cluster
             {
                 if (_myReceivers.IsEmpty)
                 {
-                    _myReceivers = new Option<IImmutableSet<UniqueAddress>>(Receivers(SelfAddress));
+                    _myReceivers = Option<IImmutableSet<UniqueAddress>>.Create(Receivers(SelfAddress));
                 }
 
                 return _myReceivers;

--- a/src/core/Akka.Streams.Tests/Dsl/FlowRecoverSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowRecoverSpec.cs
@@ -40,7 +40,7 @@ namespace Akka.Streams.Tests.Dsl
                         throw Ex;
                     return x;
                 })
-                    .Recover(_ => new Option<int>(0))
+                    .Recover(_ => Option<int>.Create(0))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .RequestNext(1)
                     .RequestNext(2)
@@ -77,7 +77,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 Source.From(Enumerable.Range(1, 3))
                     .Select(x => x)
-                    .Recover(_ => new Option<int>(0))
+                    .Recover(_ => Option<int>.Create(0))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
                     .ExpectNext(1, 2, 3)
@@ -92,7 +92,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 Source.Empty<int>()
                     .Select(x => x)
-                    .Recover(_ => new Option<int>(0))
+                    .Recover(_ => Option<int>.Create(0))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(1)
                     .ExpectComplete();

--- a/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
@@ -33,7 +33,7 @@ namespace Akka.Streams.Tests.Dsl
                 .ExpectNext(1, 2, 3)
                 .ExpectComplete();
 
-            lastElement.AwaitResult(TimeSpan.FromSeconds(1)).Should().Be(new Option<int>(3));
+            lastElement.AwaitResult(TimeSpan.FromSeconds(1)).Should().Be(Option<int>.Create(3));
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             var t = Source.UnfoldInfinite(1, n => n >= 3 ? throw new Exception() : (n + 1, n + 1))
                 .ViaMaterialized(new LastElement<int>(), Keep.Right)
-                .ToMaterialized(Sink.Aggregate<int, Option<int>>(Option<int>.None, (_, o) => new Option<int>(o)), Keep.Both)
+                .ToMaterialized(Sink.Aggregate<int, Option<int>>(Option<int>.None, (_, o) => Option<int>.Create(o)), Keep.Both)
                 .Run(Sys.Materializer());
 
             var lastElement = t.Item1;

--- a/src/core/Akka.Streams.Tests/Dsl/PagedSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/PagedSourceSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Streams.Tests.Dsl
                     var indices = Enumerable.Range(key * _itemsPerPage, _itemsPerPage);
                     var filteredIndices = _size.HasValue ? indices.Where(x => x < _size.Value) : indices;
 
-                    return Task.FromResult(new PagedSource.Page<int, int>(filteredIndices.Select(x => x * 2), new Option<int>(key + 1)));
+                    return Task.FromResult(new PagedSource.Page<int, int>(filteredIndices.Select(x => x * 2), Option<int>.Create(key + 1)));
                 }
             }
 
@@ -65,7 +65,7 @@ namespace Akka.Streams.Tests.Dsl
             private readonly Source<string, NotUsed> _source = PagedSource.Create
             (
                 1,
-                i => Task.FromResult(new PagedSource.Page<string, int>(Page(i), new Option<int>(i + 1)))
+                i => Task.FromResult(new PagedSource.Page<string, int>(Page(i), Option<int>.Create(i + 1)))
             );
 
             private static IEnumerable<string> Page(int key)
@@ -107,7 +107,7 @@ namespace Akka.Streams.Tests.Dsl
                     var items = t.Item1;
                     var next = t.Item2;
 
-                    return Task.FromResult(new PagedSource.Page<int, string>(items, next == "" ? Option<string>.None : new Option<string>(next)));
+                    return Task.FromResult(new PagedSource.Page<int, string>(items, next == "" ? Option<string>.None : Option<string>.Create(next)));
                 }
             );
 

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
@@ -44,10 +44,10 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var expected = new List<Option<int>>
                 {
-                    new Option<int>(1),
-                    new Option<int>(2),
-                    new Option<int>(3),
-                    new Option<int>()
+                    Option<int>.Create(1),
+                    Option<int>.Create(2),
+                    Option<int>.Create(3),
+                    Option<int>.None
                 };
                 var queue = Source.From(expected.Where(o => o.HasValue).Select(o => o.Value))
                     .RunWith(Sink.Queue<int>(), _materializer);
@@ -74,7 +74,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 sub.SendNext(1);
                 future.PipeTo(TestActor);
-                ExpectMsg(new Option<int>(1));
+                ExpectMsg(Option<int>.Create(1));
 
                 sub.SendComplete();
                 queue.PullAsync();
@@ -94,7 +94,7 @@ namespace Akka.Streams.Tests.Dsl
                 ExpectNoMsg(_pause);
 
                 sub.SendNext(1);
-                ExpectMsg(new Option<int>(1));
+                ExpectMsg(Option<int>.Create(1));
                 sub.SendComplete();
                 queue.PullAsync();
             }, _materializer);
@@ -146,7 +146,7 @@ namespace Akka.Streams.Tests.Dsl
                 ExpectNoMsg(_pause);
 
                 sub.SendNext(1);
-                ExpectMsg(new Option<int>(1));
+                ExpectMsg(Option<int>.Create(1));
                 sub.SendComplete();
                 queue.PullAsync();
             }, _materializer);
@@ -163,7 +163,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 queue.PullAsync().PipeTo(TestActor);
                 sub.SendNext(1);
-                ExpectMsg(new Option<int>(1));
+                ExpectMsg(Option<int>.Create(1));
 
                 sub.SendComplete();
                 var result = queue.PullAsync().Result;
@@ -195,7 +195,7 @@ namespace Akka.Streams.Tests.Dsl
                 for (var i = 1; i <= streamElementCount; i++)
                 {
                     queue.PullAsync().PipeTo(TestActor);
-                    ExpectMsg(new Option<int>(i));
+                    ExpectMsg(Option<int>.Create(i));
                 }
                 queue.PullAsync().PipeTo(TestActor);
                 ExpectMsg(Option<int>.None);
@@ -214,12 +214,12 @@ namespace Akka.Streams.Tests.Dsl
 
                 queue.PullAsync().PipeTo(TestActor);
                 sub.SendNext(1); // should pull next element
-                ExpectMsg(new Option<int>(1));
+                ExpectMsg(Option<int>.Create(1));
 
                 queue.PullAsync().PipeTo(TestActor);
                 ExpectNoMsg(); // element requested but buffer empty
                 sub.SendNext(2);
-                ExpectMsg(new Option<int>(2));
+                ExpectMsg(Option<int>.Create(2));
 
                 sub.SendComplete();
                 var future = queue.PullAsync();

--- a/src/core/Akka.Streams.Tests/Dsl/UnfoldFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnfoldFlowSpec.cs
@@ -59,7 +59,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Recover(ex =>
                     {
                         if (ex == _done)
-                            return new Option<(int, int)>((1, 1));
+                            return Option<(int, int)>.Create((1, 1));
 
                         return Option<(int, int)>.None;
                     }), 
@@ -100,7 +100,7 @@ namespace Akka.Streams.Tests.Dsl
                             .Recover(ex =>
                             {
                                 if (ex == _done)
-                                    return new Option<(int, int)>((1, 1));
+                                    return Option<(int, int)>.Create((1, 1));
 
                                 return Option<(int, int)>.None;
                             }), _timeout)
@@ -287,7 +287,7 @@ namespace Akka.Streams.Tests.Dsl
             public WithFunction()
             {
                 var controlledFlow = Flow.FromSinkAndSource(this.SinkProbe<int>(), this.SourceProbe<int>(), Keep.Both);
-                _source = SourceGen.UnfoldFlowWith(1, controlledFlow, n => new Option<(int, int)>((n + 1, n)), _timeout);
+                _source = SourceGen.UnfoldFlowWith(1, controlledFlow, n => Option<(int, int)>.Create((n + 1, n)), _timeout);
             }
 
             [Fact]
@@ -299,9 +299,9 @@ namespace Akka.Streams.Tests.Dsl
                         return Option<(int, int)>.None;
 
                     if (x % 2 == 0)
-                        return new Option<(int, int)>((x / 2, x));
+                        return Option<(int, int)>.Create((x / 2, x));
 
-                    return new Option<(int, int)>((x * 3 + 1, x));
+                    return Option<(int, int)>.Create((x * 3 + 1, x));
                 }
 
                 var source = SourceGen.UnfoldFlowWith(27, Flow.FromFunction<int, int>(x => x), Map, _timeout);

--- a/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceAsyncSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceAsyncSourceSpec.cs
@@ -240,7 +240,7 @@ namespace Akka.Streams.Tests.Dsl
                                 switch (next)
                                 {
                                     case int n:
-                                        return Task.FromResult(new Option<int>(n));
+                                        return Task.FromResult(Option<int>.Create(n));
                                     case TestException e:
                                         throw e;
                                     default:
@@ -274,7 +274,7 @@ namespace Akka.Streams.Tests.Dsl
                                 switch (next)
                                 {
                                     case int n:
-                                        return Task.FromResult(new Option<int>(n));
+                                        return Task.FromResult(Option<int>.Create(n));
                                     case TestException e:
                                         return Task.FromException<Option<int>>(e);
                                     default:
@@ -316,7 +316,7 @@ namespace Akka.Streams.Tests.Dsl
                             }
 
                             return reader.MoveNext() && reader.Current != null
-                                ? Task.FromResult(new Option<int>((int)reader.Current))
+                                ? Task.FromResult(Option<int>.Create((int)reader.Current))
                                 : Task.FromResult(Option<int>.None);
                         },
                         _ => Task.FromResult(Done.Instance))
@@ -352,7 +352,7 @@ namespace Akka.Streams.Tests.Dsl
                             }
 
                             return reader.MoveNext() && reader.Current != null
-                                ? Task.FromResult(new Option<int>((int)reader.Current))
+                                ? Task.FromResult(Option<int>.Create((int)reader.Current))
                                 : Task.FromResult(Option<int>.None);
                         },
                         _ => Task.FromResult(Done.Instance))
@@ -490,7 +490,7 @@ namespace Akka.Streams.Tests.Dsl
             var p = Source.UnfoldResourceAsync(
                     () => Task.FromResult(closePromise),
                     // a slow trickle of elements that never ends
-                    _ => FutureTimeoutSupport.After(TimeSpan.FromMilliseconds(100), Sys.Scheduler, () => Task.FromResult(new Option<string>("element"))),
+                    _ => FutureTimeoutSupport.After(TimeSpan.FromMilliseconds(100), Sys.Scheduler, () => Task.FromResult(Option<string>.Create("element"))),
                     tcs =>
                     {
                         tcs.SetResult("Closed");
@@ -517,7 +517,7 @@ namespace Akka.Streams.Tests.Dsl
                 var closePromise = new TaskCompletionSource<string>();
                 var probe = Source.UnfoldResourceAsync(
                         () => Task.FromResult(closePromise),
-                        _ => Task.FromResult(new Option<string>("whatever")),
+                        _ => Task.FromResult(Option<string>.Create("whatever")),
                         tcs =>
                         {
                             tcs.SetResult("Closed");

--- a/src/core/Akka.Streams/Dsl/AccumulateWhileUnchanged.cs
+++ b/src/core/Akka.Streams/Dsl/AccumulateWhileUnchanged.cs
@@ -37,7 +37,7 @@ namespace Akka.Streams.Dsl
                     var nextState = accumulateWhileUnchanged._propertyExtractor(nextElement);
 
                     if (!_currentState.HasValue)
-                        _currentState = new Option<TProperty>(nextState);
+                        _currentState = Option<TProperty>.Create(nextState);
 
                     if (EqualityComparer<TProperty>.Default.Equals(_currentState.Value, nextState))
                     {
@@ -50,7 +50,7 @@ namespace Akka.Streams.Dsl
                         _buffer.Clear();
                         _buffer.Add(nextElement);
                         Push(accumulateWhileUnchanged.Out, result);
-                        _currentState = new Option<TProperty>(nextState);
+                        _currentState = Option<TProperty>.Create(nextState);
                     }
                 }, onUpstreamFinish: () =>
                 {

--- a/src/core/Akka.Streams/Dsl/Internal/GraphImpl.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/GraphImpl.cs
@@ -91,7 +91,7 @@ namespace Akka.Streams.Dsl.Internal
         public static Option<IModule> Unapply<TShape, TMat>(IGraph<TShape, TMat> graph) where TShape : Shape
         {
             var module = graph as IModule;
-            return module != null ? new Option<IModule>(module) : Option<IModule>.None;
+            return module != null ? Option<IModule>.Create(module) : Option<IModule>.None;
         }
     }
 }

--- a/src/core/Akka.Streams/Dsl/LastElement.cs
+++ b/src/core/Akka.Streams/Dsl/LastElement.cs
@@ -30,7 +30,7 @@ namespace Akka.Streams.Dsl
                 SetHandler(lastElement.In, onPush: () =>
                 {
                     var element = Grab(lastElement.In);
-                    currentElement = new Option<T>(element);
+                    currentElement = Option<T>.Create(element);
                     Push(lastElement.Out, element);
                 }, onUpstreamFinish: () =>
                 {

--- a/src/core/Akka.Streams/Dsl/PagedSource.cs
+++ b/src/core/Akka.Streams/Dsl/PagedSource.cs
@@ -52,7 +52,7 @@ namespace Akka.Streams.Dsl
             var pageSource =
                 Source.UnfoldAsync
                 (
-                    new Option<TKey>(firstKey),
+                    Option<TKey>.Create(firstKey),
                     async key =>
                     {
                         var page = key.HasValue ? await pageFactory(key.Value) : new Page<T, TKey>(Enumerable.Empty<T>(), Option<TKey>.None);

--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -716,7 +716,7 @@ namespace Akka.Streams.Implementation
             {
                 _stage = stage;
                 _maxBuffer = maxBuffer;
-                _currentRequest = new Option<TaskCompletionSource<Option<T>>>();
+                _currentRequest = Option<TaskCompletionSource<Option<T>>>.None;
 
                 SetHandler(stage.In, this);
             }

--- a/src/core/Akka.Tests/Actor/Setup/ActorSystemSetupSpec.cs
+++ b/src/core/Akka.Tests/Actor/Setup/ActorSystemSetupSpec.cs
@@ -54,7 +54,7 @@ namespace Akka.Tests.Actor.Setup
             var setup = new DummySetup("Ardbeg");
             var setups = ActorSystemSetup.Create(setup);
 
-            setups.Get<DummySetup>().Should().Be(new Option<DummySetup>(setup));
+            setups.Get<DummySetup>().Should().Be(Option<DummySetup>.Create(setup));
             setups.Get<DummySetup2>().Should().Be(Option<DummySetup2>.None);
         }
 
@@ -65,7 +65,7 @@ namespace Akka.Tests.Actor.Setup
             var setup2 = new DummySetup("Ledaig");
             var setups = ActorSystemSetup.Empty.WithSetup(setup1).WithSetup(setup2);
 
-            setups.Get<DummySetup>().Should().Be(new Option<DummySetup>(setup2));
+            setups.Get<DummySetup>().Should().Be(Option<DummySetup>.Create(setup2));
         }
 
         [Fact]
@@ -76,8 +76,8 @@ namespace Akka.Tests.Actor.Setup
             var setup3 = new DummySetup2("Blantons");
             var setups = setup1.And(setup2).And(setup3);
 
-            setups.Get<DummySetup>().Should().Be(new Option<DummySetup>(setup2));
-            setups.Get<DummySetup2>().Should().Be(new Option<DummySetup2>(setup3));
+            setups.Get<DummySetup>().Should().Be(Option<DummySetup>.Create(setup2));
+            setups.Get<DummySetup2>().Should().Be(Option<DummySetup2>.Create(setup3));
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace Akka.Tests.Actor.Setup
                 var setup = new DummySetup("Eagle Rare");
                 system = ActorSystem.Create("name", ActorSystemSetup.Create(setup));
 
-                system.Settings.Setup.Get<DummySetup>().Should().Be(new Option<DummySetup>(setup));
+                system.Settings.Setup.Get<DummySetup>().Should().Be(Option<DummySetup>.Create(setup));
             }
             finally
             {

--- a/src/core/Akka/Actor/Setup/ActorSystemSetup.cs
+++ b/src/core/Akka/Actor/Setup/ActorSystemSetup.cs
@@ -61,7 +61,7 @@ namespace Akka.Actor.Setup
 
         public Option<T> Get<T>() where T:Setup
         {
-            return _setups.ContainsKey(typeof(T)) ? new Option<T>((T)_setups[typeof(T)]) : Option<T>.None;
+            return _setups.ContainsKey(typeof(T)) ? Option<T>.Create((T)_setups[typeof(T)]) : Option<T>.None;
         }
         
         /// <summary>

--- a/src/core/Akka/Util/Extensions/ObjectExtensions.cs
+++ b/src/core/Akka/Util/Extensions/ObjectExtensions.cs
@@ -12,6 +12,6 @@ namespace Akka.Util.Extensions
         /// <summary>
         /// Wraps object to the <see cref="Option{T}"/> monade
         /// </summary>
-        public static Option<T> AsOption<T>(this T obj) => new Option<T>(obj);
+        public static Option<T> AsOption<T>(this T obj) => Option<T>.Create(obj);
     }
 }

--- a/src/core/Akka/Util/Option.cs
+++ b/src/core/Akka/Util/Option.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Akka.Util
 {
@@ -18,6 +19,7 @@ namespace Akka.Util
     /// <typeparam name="T">TBD</typeparam>
     public readonly struct Option<T>
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Option<T> Create(T value)
 #pragma warning disable CS0618
             => value is null ? None : new Option<T>(value);

--- a/src/core/Akka/Util/Option.cs
+++ b/src/core/Akka/Util/Option.cs
@@ -18,19 +18,24 @@ namespace Akka.Util
     /// <typeparam name="T">TBD</typeparam>
     public readonly struct Option<T>
     {
+        public static Option<T> Create(T value)
+#pragma warning disable CS0618
+            => value is null ? None : new Option<T>(value);
+#pragma warning restore CS0618
+
         /// <summary>
         /// None.
         /// </summary>
         public static readonly Option<T> None = new Option<T>();
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="value">TBD</param>
+        [Obsolete("Use Option<T>.Create() instead")] 
         public Option(T value)
         {
+            if (value is null)
+                throw new ArgumentNullException(nameof(value), "You can not create an Option<T> with null value. Either use Option<T>.None or use Option<T>.Create(null).");
+            
             Value = value;
-            HasValue = value != null;
+            HasValue = true;
         }
 
         /// <summary>
@@ -50,7 +55,7 @@ namespace Akka.Util
         /// </summary>
         /// <param name="value">The object to convert</param>
         /// <returns>The result of the conversion.</returns>
-        public static implicit operator Option<T>(T value) => new Option<T>(value);
+        public static implicit operator Option<T>(T value) => Create(value);
 
         /// <summary>
         /// Gets option value, if any, otherwise returns default value provided

--- a/src/core/Akka/Util/Option.cs
+++ b/src/core/Akka/Util/Option.cs
@@ -28,6 +28,7 @@ namespace Akka.Util
         /// </summary>
         public static readonly Option<T> None = new Option<T>();
 
+        // TODO: Change this to private constructor in the future
         [Obsolete("Use Option<T>.Create() instead")] 
         public Option(T value)
         {


### PR DESCRIPTION
Fixes #4604

Hardens Option<T>

## Changes

* Make `Option<T>` constructor throw an `ArgumentNullException` when null value is passed in
* Add a `Create` static method that returns a `None` when null is passed in