### PR TITLE
Set `akka.persistence.query.journal.sql.max-concurrent-queries = 100` by default

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/reference.conf
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/reference.conf
@@ -1,4 +1,4 @@
-﻿akka.persistence.query.journal.sql {
+akka.persistence.query.journal.sql {
   # Implementation class of the SQL ReadJournalProvider
   class = "Akka.Persistence.Query.Sql.SqlReadJournalProvider, Akka.Persistence.Query.Sql"
   
@@ -18,5 +18,5 @@
   max-buffer-size = 100
   
   # Determines how many queries are allowed to run in parallel at any given time
-  max-concurrent-queries = 50
+  max-concurrent-queries = 100
 }


### PR DESCRIPTION
## Changes

Need to be able to run additional queries by default due to pagination being highly interleaved. `100` is a safe value according to our tests.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).