### PR TITLE
Use `ActorSystem` for `Materializer`

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Core.verified.txt
@@ -1619,6 +1619,7 @@ namespace Akka.Streams.Dsl
         Akka.Streams.Dsl.IRunnableGraph<TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> func);
         Akka.Streams.Dsl.IRunnableGraph<TMat> Named(string name);
         TMat Run(Akka.Streams.IMaterializer materializer);
+        TMat Run(Akka.Actor.ActorSystem actorSystem);
         Akka.Streams.Dsl.IRunnableGraph<TMat> WithAttributes(Akka.Streams.Attributes attributes);
     }
     public interface IUnzipWithCreator<out TIn, in TOut, out T>
@@ -1924,6 +1925,7 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.IRunnableGraph<TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> func) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> Named(string name) { }
         public TMat Run(Akka.Streams.IMaterializer materializer) { }
+        public TMat Run(Akka.Actor.ActorSystem actorSystem) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
     public class Sample<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, T>>
@@ -2190,13 +2192,21 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.Source<TOut, TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> mapFunc) { }
         public Akka.Streams.Dsl.Source<TOut, TMat> Named(string name) { }
         public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Streams.IMaterializer materializer) { }
+        public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Actor.ActorSystem actorSystem) { }
         public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Actor.ActorSystem materializer) { }
         public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Actor.ActorSystem materializer) { }
         public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Streams.IMaterializer materializer) { }
+        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Actor.ActorSystem materializer) { }
         public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Streams.IMaterializer materializer, int minBuffer = 4, int maxBuffer = 16) { }
+        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Actor.ActorSystem materializer, int minBuffer = 4, int maxBuffer = 16) { }
         public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Actor.ActorSystem materializer) { }
         public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Actor.ActorSystem materializer) { }
         public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Streams.IMaterializer materializer) { }
+        public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Actor.ActorSystem materializer) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> To<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat3> ToMaterialized<TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, System.Func<TMat, TMat2, TMat3> combine) { }
         public override string ToString() { }
@@ -3637,7 +3647,7 @@ namespace Akka.Streams.Implementation
     }
     public class static StreamLayout
     {
-        public static readonly bool IsDebug;
+        public const bool IsDebug = false;
         public static void Validate(Akka.Streams.Implementation.IModule module, int level = 0, bool shouldPrint = False, System.Collections.Generic.IDictionary<object, int> idMap = null) { }
         public sealed class Atomic : Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode
         {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
@@ -1619,6 +1619,7 @@ namespace Akka.Streams.Dsl
         Akka.Streams.Dsl.IRunnableGraph<TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> func);
         Akka.Streams.Dsl.IRunnableGraph<TMat> Named(string name);
         TMat Run(Akka.Streams.IMaterializer materializer);
+        TMat Run(Akka.Actor.ActorSystem actorSystem);
         Akka.Streams.Dsl.IRunnableGraph<TMat> WithAttributes(Akka.Streams.Attributes attributes);
     }
     public interface IUnzipWithCreator<out TIn, in TOut, out T>
@@ -1924,6 +1925,7 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.IRunnableGraph<TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> func) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> Named(string name) { }
         public TMat Run(Akka.Streams.IMaterializer materializer) { }
+        public TMat Run(Akka.Actor.ActorSystem actorSystem) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
     public class Sample<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, T>>
@@ -2190,13 +2192,21 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.Source<TOut, TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> mapFunc) { }
         public Akka.Streams.Dsl.Source<TOut, TMat> Named(string name) { }
         public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Streams.IMaterializer materializer) { }
+        public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Actor.ActorSystem actorSystem) { }
         public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Actor.ActorSystem materializer) { }
         public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Actor.ActorSystem materializer) { }
         public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Streams.IMaterializer materializer) { }
+        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Actor.ActorSystem materializer) { }
         public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Streams.IMaterializer materializer, int minBuffer = 4, int maxBuffer = 16) { }
+        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Actor.ActorSystem materializer, int minBuffer = 4, int maxBuffer = 16) { }
         public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Actor.ActorSystem materializer) { }
         public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Actor.ActorSystem materializer) { }
         public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Streams.IMaterializer materializer) { }
+        public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Actor.ActorSystem materializer) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> To<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat3> ToMaterialized<TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, System.Func<TMat, TMat2, TMat3> combine) { }
         public override string ToString() { }
@@ -3637,7 +3647,7 @@ namespace Akka.Streams.Implementation
     }
     public class static StreamLayout
     {
-        public static readonly bool IsDebug;
+        public const bool IsDebug = false;
         public static void Validate(Akka.Streams.Implementation.IModule module, int level = 0, bool shouldPrint = False, System.Collections.Generic.IDictionary<object, int> idMap = null) { }
         public sealed class Atomic : Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode
         {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
@@ -1619,6 +1619,7 @@ namespace Akka.Streams.Dsl
         Akka.Streams.Dsl.IRunnableGraph<TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> func);
         Akka.Streams.Dsl.IRunnableGraph<TMat> Named(string name);
         TMat Run(Akka.Streams.IMaterializer materializer);
+        TMat Run(Akka.Actor.ActorSystem actorSystem);
         Akka.Streams.Dsl.IRunnableGraph<TMat> WithAttributes(Akka.Streams.Attributes attributes);
     }
     public interface IUnzipWithCreator<out TIn, in TOut, out T>
@@ -1924,6 +1925,7 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.IRunnableGraph<TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> func) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> Named(string name) { }
         public TMat Run(Akka.Streams.IMaterializer materializer) { }
+        public TMat Run(Akka.Actor.ActorSystem actorSystem) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
     public class Sample<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, T>>
@@ -2190,13 +2192,21 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.Source<TOut, TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> mapFunc) { }
         public Akka.Streams.Dsl.Source<TOut, TMat> Named(string name) { }
         public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Streams.IMaterializer materializer) { }
+        public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Actor.ActorSystem actorSystem) { }
         public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Actor.ActorSystem materializer) { }
         public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Actor.ActorSystem materializer) { }
         public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Streams.IMaterializer materializer) { }
+        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Actor.ActorSystem materializer) { }
         public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Streams.IMaterializer materializer, int minBuffer = 4, int maxBuffer = 16) { }
+        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Actor.ActorSystem materializer, int minBuffer = 4, int maxBuffer = 16) { }
         public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Actor.ActorSystem materializer) { }
         public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Actor.ActorSystem materializer) { }
         public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Streams.IMaterializer materializer) { }
+        public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Actor.ActorSystem materializer) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> To<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat3> ToMaterialized<TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, System.Func<TMat, TMat2, TMat3> combine) { }
         public override string ToString() { }
@@ -3637,7 +3647,7 @@ namespace Akka.Streams.Implementation
     }
     public class static StreamLayout
     {
-        public static readonly bool IsDebug;
+        public const bool IsDebug = false;
         public static void Validate(Akka.Streams.Implementation.IModule module, int level = 0, bool shouldPrint = False, System.Collections.Generic.IDictionary<object, int> idMap = null) { }
         public sealed class Atomic : Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode
         {

--- a/src/core/Akka.Streams.Tests/ActorMaterializerSpec.cs
+++ b/src/core/Akka.Streams.Tests/ActorMaterializerSpec.cs
@@ -89,5 +89,12 @@ namespace Akka.Streams.Tests
             sys.Terminate().Wait();
             m.IsShutdown.Should().BeTrue();
         }
+
+        [Fact]
+        public async Task CanMaterializeStreamsUsingActorSystem()
+        {
+            Func<Task> task = () => Source.Single(1).RunForeach(i => { }, Sys);
+            await task.Should().NotThrowAsync();
+        }
     }
 }

--- a/src/core/Akka.Streams.Tests/ActorMaterializerSpec.cs
+++ b/src/core/Akka.Streams.Tests/ActorMaterializerSpec.cs
@@ -96,5 +96,16 @@ namespace Akka.Streams.Tests
             Func<Task> task = () => Source.Single(1).RunForeach(i => { }, Sys);
             await task.Should().NotThrowAsync();
         }
+        
+        [Fact]
+        public void ShouldReturnSameMaterializerForActorSystem()
+        {
+            var mat1 = Sys.Materializer();
+            var mat2 = Sys.Materializer();
+            var mat3 = Sys.Materializer(namePrefix: "different");
+            
+            mat1.Should().Be(mat2);
+            mat1.Should().NotBe(mat3);
+        }
     }
 }

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
@@ -265,7 +265,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             this.AssertAllStagesStopped(() =>
             {
-                var tempMap = ActorMaterializer.Create(Sys);
+                var tempMap = ActorMaterializer.Create(Sys, ActorMaterializerSettings.Create(Sys)); // need to create a new materializer to be able to shutdown it
                 var s = this.CreateManualSubscriberProbe<int>();
                 var queue = Source.Queue<int>(1, OverflowStrategy.Fail)
                     .To(Sink.FromSubscriber(s))

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
@@ -266,7 +266,8 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             this.AssertAllStagesStopped(() =>
             {
-                var materializer = ActorMaterializer.Create(Sys);
+                // force the system to create a new materializer
+                var materializer = ActorMaterializer.Create(Sys, ActorMaterializerSettings.Create(Sys));
                 var gotStop = new TestLatch(1);
                 var downstream = this.CreateSubscriberProbe<string>();
 

--- a/src/core/Akka.Streams/ActorMaterializer.cs
+++ b/src/core/Akka.Streams/ActorMaterializer.cs
@@ -26,6 +26,53 @@ using Decider = Akka.Streams.Supervision.Decider;
 namespace Akka.Streams
 {
     /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    internal sealed class DefaultMaterializerExt : ExtensionIdProvider<DefaultMaterializer>
+    {
+        public override DefaultMaterializer CreateExtension(ExtendedActorSystem system)
+        {
+            return new DefaultMaterializer(system);
+        }
+    }
+    
+    /// <summary>
+    /// INTERNAL API
+    /// </summary>
+    /// <remarks>
+    /// Caches a default materializer instance for each actor system. Prevents the need to create a new materializer
+    /// for trivial changes.
+    /// </remarks>
+    internal sealed class DefaultMaterializer : IExtension
+    {
+        public ActorMaterializer Materializer { get; }
+        
+        public DefaultMaterializer(ActorSystem system)
+        {
+            var haveShutDown = new AtomicBoolean();
+            
+            // Inject the top-level fallback config for the Materializer once, and only once.
+            // This is a performance optimization to avoid having to do this on every materialization.
+            system.Settings.InjectTopLevelFallback(ActorMaterializer.DefaultConfig());
+            
+            var settings = ActorMaterializerSettings.Create(system);
+            
+            Materializer = new ActorMaterializerImpl(
+                system: system,
+                settings: settings,
+                dispatchers: system.Dispatchers,
+                supervisor: system.ActorOf(StreamSupervisor.Props(settings, haveShutDown).WithDispatcher(settings.Dispatcher), StreamSupervisor.NextName()),
+                haveShutDown: haveShutDown,
+                flowNames: EnumerableActorName.Create("Flow"));
+        }
+        
+        public static DefaultMaterializer Get(ActorSystem system)
+        {
+            return system.WithExtension<DefaultMaterializer, DefaultMaterializerExt>();
+        }
+    }
+
+    /// <summary>
     /// A ActorMaterializer takes the list of transformations comprising a
     /// <see cref="IFlow{TOut,TMat}"/> and materializes them in the form of
     /// <see cref="IProcessor{T1,T2}"/> instances. How transformation
@@ -44,18 +91,6 @@ namespace Akka.Streams
             => DefaultMaterializerConfig;
 
         #region static
-
-        /// <summary>
-        /// Injecting the top-level Materializer HOCON configuration over and over again is expensive, so we want to avoid
-        /// doing it each time a materializer is instantiated. This flag will be set to true once the configuration has been
-        /// injected the first time.
-        /// </summary>
-        private static readonly ConcurrentDictionary<ActorSystem, bool> InjectedConfig = new();
-        
-        /// <summary>
-        /// Cache the default materializer settings so we don't constantly parse them
-        /// </summary>
-        private static readonly ConcurrentDictionary<ActorSystem, ActorMaterializerSettings> DefaultSettings = new();
 
         /// <summary>
         /// <para>
@@ -86,31 +121,21 @@ namespace Akka.Streams
         /// <returns>TBD</returns>
         public static ActorMaterializer Create(IActorRefFactory context, ActorMaterializerSettings settings = null, string namePrefix = null)
         {
-            var haveShutDown = new AtomicBoolean();
             var system = ActorSystemOf(context);
+            
+            // forces settings to get injected into the ActorSystem the first time we materialize
+            var defaultMaterializer = DefaultMaterializer.Get(system).Materializer;
 
-            if(!InjectedConfig.TryGetValue(system, out _) && InjectedConfig.TryAdd(system, true))
-            {
-                // Inject the top-level fallback config for the Materializer once, and only once.
-                // This is a performance optimization to avoid having to do this on every materialization.
-                system.Settings.InjectTopLevelFallback(DefaultConfig());
-
-                static async Task CleanUp(ActorSystem sys)
-                {
-                    // remove ActorSystem from cache when it terminates so we don't leak memory
-                    await sys.WhenTerminated.ConfigureAwait(false);
-                    InjectedConfig.TryRemove(sys, out _);
-                    DefaultSettings.TryRemove(sys, out _);
-                }
-
-#pragma warning disable CS4014
-                CleanUp(system);
-#pragma warning restore CS4014
-
-            }
+            // optimized paths for non-allocation
+            if (context.Equals(system) && settings == null && namePrefix == null)
+                return defaultMaterializer;
+            if (context.Equals(system) && settings == null && namePrefix != null)
+                return (ActorMaterializer)defaultMaterializer.WithNamePrefix(namePrefix);
 
             // use the default settings if none have been passed in
-            settings ??= DefaultSettings.GetOrAdd(system, ActorMaterializerSettings.Create);
+            settings ??= defaultMaterializer.Settings;
+            
+            var haveShutDown = new AtomicBoolean();
 
             return new ActorMaterializerImpl(
                 system: system,
@@ -243,8 +268,7 @@ namespace Akka.Streams
         internal static ActorMaterializer Downcast(IMaterializer materializer)
         {
             //FIXME this method is going to cause trouble for other Materializer implementations
-            var downcast = materializer as ActorMaterializer;
-            if (downcast != null)
+            if (materializer is ActorMaterializer downcast)
                 return downcast;
 
             throw new ArgumentException($"Expected {typeof(ActorMaterializer)} but got {materializer.GetType()}");

--- a/src/core/Akka.Streams/Dsl/RunnableGraph.cs
+++ b/src/core/Akka.Streams/Dsl/RunnableGraph.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using Akka.Actor;
 using Akka.Streams.Implementation;
 
 namespace Akka.Streams.Dsl
@@ -30,6 +31,13 @@ namespace Akka.Streams.Dsl
         /// <param name="materializer">TBD</param>
         /// <returns>TBD</returns>
         TMat Run(IMaterializer materializer);
+        
+        /// <summary>
+        /// Run this flow and return the materialized instance from the flow.
+        /// </summary>
+        /// <param name="actorSystem">The actorSystem</param>
+        /// <returns>TBD</returns>
+        TMat Run(ActorSystem actorSystem);
 
 
         /// <summary>
@@ -63,9 +71,9 @@ namespace Akka.Streams.Dsl
     }
 
     /// <summary>
-    /// TBD
+    /// A completed Akka.Streams graph that can be executed.
     /// </summary>
-    /// <typeparam name="TMat">TBD</typeparam>
+    /// <typeparam name="TMat">The type of materialized value.</typeparam>
     public sealed class RunnableGraph<TMat> : IRunnableGraph<TMat>
     {
         /// <summary>
@@ -140,11 +148,19 @@ namespace Akka.Streams.Dsl
             => new RunnableGraph<TMat2>(Module.TransformMaterializedValue(func));
 
         /// <summary>
-        /// TBD
+        /// Compiles the graph and executes it, returning the materialized value of the flow.
         /// </summary>
-        /// <param name="materializer">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="materializer">A materializer instance.</param>
+        /// <returns>The materialized value.</returns>
         public TMat Run(IMaterializer materializer) => materializer.Materialize(this);
+
+        /// <summary>
+        /// Compiles the graph and executes it, returning the materialized value of the flow.
+        /// </summary>
+        /// <param name="actorSystem">The <see cref="ActorSystem"/>.</param>
+        /// <returns>The materialized value.</returns>
+        public TMat Run(ActorSystem actorSystem) =>
+            actorSystem.Materializer().Materialize(this);
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -194,7 +194,7 @@ namespace Akka.Streams.Dsl
                     switch (reply)
                     {
                         case TOut2 a: return a;
-                        case Status.Success s when s.Status is TOut2 a: return a;
+                        case Status.Success { Status: TOut2 a }: return a;
                         case Status.Failure f:
                             ExceptionDispatchInfo.Capture(f.Cause).Throw();
                             return default(TOut2);
@@ -292,6 +292,18 @@ namespace Akka.Streams.Dsl
             var tup = ToMaterialized(Sink.AsPublisher<TOut>(fanout: true), Keep.Both).Run(materializer);
             return (tup.Item1, Source.FromPublisher(tup.Item2));
         }
+        
+        /// <summary>
+        ///  Materializes this Source immediately.
+        /// </summary>
+        /// <param name="actorSystem">The ActorSystem.</param>
+        /// <returns>A tuple containing the (1) materialized value and (2) a new <see cref="Source"/>
+        ///  that can be used to consume elements from the newly materialized <see cref="Source"/>.</returns>
+        public (TMat, Source<TOut, NotUsed>) PreMaterialize(ActorSystem actorSystem)
+        {
+            var tup = ToMaterialized(Sink.AsPublisher<TOut>(fanout: true), Keep.Both).Run(actorSystem);
+            return (tup.Item1, Source.FromPublisher(tup.Item2));
+        }
 
         /// <summary>
         /// Connect this <see cref="Source{TOut,TMat}"/> to a <see cref="Sink{TIn,TMat}"/> and run it. The returned value is the materialized value
@@ -302,6 +314,17 @@ namespace Akka.Streams.Dsl
         /// <param name="materializer">TBD</param>
         /// <returns>TBD</returns>
         public TMat2 RunWith<TMat2>(IGraph<SinkShape<TOut>, TMat2> sink, IMaterializer materializer)
+            => ToMaterialized(sink, Keep.Right).Run(materializer);
+        
+        /// <summary>
+        /// Connect this <see cref="Source{TOut,TMat}"/> to a <see cref="Sink{TIn,TMat}"/> and run it. The returned value is the materialized value
+        /// of the <see cref="Sink{TIn,TMat}"/> , e.g. the <see cref="IPublisher{TIn}"/> of a <see cref="Sink.Publisher{TIn}"/>.
+        /// </summary>
+        /// <typeparam name="TMat2">TBD</typeparam>
+        /// <param name="sink">TBD</param>
+        /// <param name="materializer">TBD</param>
+        /// <returns>TBD</returns>
+        public TMat2 RunWith<TMat2>(IGraph<SinkShape<TOut>, TMat2> sink, ActorSystem materializer)
             => ToMaterialized(sink, Keep.Right).Run(materializer);
 
         /// <summary>
@@ -319,6 +342,22 @@ namespace Akka.Streams.Dsl
         /// <returns>TBD</returns>
         public Task<TOut2> RunAggregate<TOut2>(TOut2 zero, Func<TOut2, TOut, TOut2> aggregate, IMaterializer materializer)
             => RunWith(Sink.Aggregate(zero, aggregate), materializer);
+        
+        /// <summary>
+        /// Shortcut for running this <see cref="Source{TOut,TMat}"/> with a fold function.
+        /// The given function is invoked for every received element, giving it its previous
+        /// output (or the given <paramref name="zero"/> value) and the element as input.
+        /// The returned <see cref="Task{TOut2}"/> will be completed with value of the final
+        /// function evaluation when the input stream ends, or completed with Failure
+        /// if there is a failure signaled in the stream.
+        /// </summary>
+        /// <typeparam name="TOut2">TBD</typeparam>
+        /// <param name="zero">TBD</param>
+        /// <param name="aggregate">TBD</param>
+        /// <param name="materializer">TBD</param>
+        /// <returns>TBD</returns>
+        public Task<TOut2> RunAggregate<TOut2>(TOut2 zero, Func<TOut2, TOut, TOut2> aggregate, ActorSystem materializer)
+            => RunWith(Sink.Aggregate(zero, aggregate), materializer);
 
         /// <summary>
         /// Shortcut for running this <see cref="Source{TOut,TMat}"/> with a async <paramref name="aggregate"/> function.
@@ -335,6 +374,22 @@ namespace Akka.Streams.Dsl
         /// <returns>TBD</returns>
         public Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, Func<TOut2, TOut, Task<TOut2>> aggregate, IMaterializer materializer)
             => RunWith(Sink.AggregateAsync(zero, aggregate), materializer);
+        
+        /// <summary>
+        /// Shortcut for running this <see cref="Source{TOut,TMat}"/> with a async <paramref name="aggregate"/> function.
+        /// The given function is invoked for every received element, giving it its previous
+        /// output (or the given <paramref name="zero"/> value) and the element as input.
+        /// The returned <see cref="Task{TOut2}"/> will be completed with value of the final
+        /// function evaluation when the input stream ends, or completed with Failure
+        /// if there is a failure signaled in the stream.
+        /// </summary>
+        /// <typeparam name="TOut2">TBD</typeparam>
+        /// <param name="zero">TBD</param>
+        /// <param name="aggregate">TBD</param>
+        /// <param name="materializer">TBD</param>
+        /// <returns>TBD</returns>
+        public Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, Func<TOut2, TOut, Task<TOut2>> aggregate, ActorSystem materializer)
+            => RunWith(Sink.AggregateAsync(zero, aggregate), materializer);
 
         /// <summary>
         /// Shortcut for running this <see cref="Source{TOut,TMat}"/> with a reduce function.
@@ -349,6 +404,21 @@ namespace Akka.Streams.Dsl
         /// <returns>TBD</returns>
         public Task<TOut> RunSum(Func<TOut, TOut, TOut> reduce, IMaterializer materializer)
             => RunWith(Sink.Sum(reduce), materializer);
+        
+        /// <summary>
+        /// Shortcut for running this <see cref="Source{TOut,TMat}"/> with a reduce function.
+        /// The given function is invoked for every received element, giving it its previous
+        /// output (from the second element) and the element as input.
+        /// The returned <see cref="Task{TOut}"/> will be completed with value of the final
+        /// function evaluation when the input stream ends, or completed with Failure
+        /// if there is a failure signaled in the stream.
+        /// </summary>
+        /// <param name="reduce">TBD</param>
+        /// <param name="materializer">TBD</param>
+        /// <returns>TBD</returns>
+        public Task<TOut> RunSum(Func<TOut, TOut, TOut> reduce, ActorSystem materializer)
+            => RunWith(Sink.Sum(reduce), materializer);
+
 
         /// <summary>
         /// Shortcut for running this <see cref="Source{TOut,TMat}"/> with a foreach procedure. The given procedure is invoked
@@ -362,6 +432,19 @@ namespace Akka.Streams.Dsl
         /// <returns>TBD</returns>
         public Task RunForeach(Action<TOut> action, IMaterializer materializer)
             => RunWith(Sink.ForEach(action), materializer);
+        
+        /// <summary>
+        /// Shortcut for running this <see cref="Source{TOut,TMat}"/> with a foreach procedure. The given procedure is invoked
+        /// for each received element.
+        /// The returned <see cref="Task"/> will be completed with Success when reaching the
+        /// normal end of the stream, or completed with Failure if there is a failure signaled in
+        /// the stream.
+        /// </summary>
+        /// <param name="action">TBD</param>
+        /// <param name="materializer">TBD</param>
+        /// <returns>TBD</returns>
+        public Task RunForeach(Action<TOut> action, ActorSystem materializer)
+            => RunWith(Sink.ForEach(action), materializer);
 
         /// <summary>
         /// Shortcut for running this <see cref="Source{TOut,TMat}"/> as an <see cref="IAsyncEnumerable{TOut}"/>.
@@ -374,6 +457,19 @@ namespace Akka.Streams.Dsl
         public IAsyncEnumerable<TOut> RunAsAsyncEnumerable(
             IMaterializer materializer) =>
             new StreamsAsyncEnumerableRerunnable<TOut,TMat>(this, materializer);
+        
+        /// <summary>
+        /// Shortcut for running this <see cref="Source{TOut,TMat}"/> as an <see cref="IAsyncEnumerable{TOut}"/>.
+        /// The given enumerable is re-runnable but will cause a re-materialization of the stream each time.
+        /// This is implemented using a SourceQueue and will buffer elements based on configured stream defaults.
+        /// For custom buffers Please use <see cref="RunAsAsyncEnumerableBuffer"/>
+        /// </summary>
+        /// <param name="materializer">The materializer to use for each enumeration</param>
+        /// <returns>A lazy <see cref="IAsyncEnumerable{T}"/> that will run each time it is enumerated.</returns>
+        public IAsyncEnumerable<TOut> RunAsAsyncEnumerable(
+            ActorSystem materializer) =>
+            new StreamsAsyncEnumerableRerunnable<TOut,TMat>(this, materializer.Materializer());
+
 
         /// <summary>
         /// Shortcut for running this <see cref="Source{TOut,TMat}"/> as an <see cref="IAsyncEnumerable{TOut}"/>.
@@ -390,6 +486,22 @@ namespace Akka.Streams.Dsl
             int maxBuffer = 16) =>
             new StreamsAsyncEnumerableRerunnable<TOut,TMat>(
                 this, materializer,minBuffer,maxBuffer);
+        
+        /// <summary>
+        /// Shortcut for running this <see cref="Source{TOut,TMat}"/> as an <see cref="IAsyncEnumerable{TOut}"/>.
+        /// The given enumerable is re-runnable but will cause a re-materialization of the stream each time.
+        /// This is implemented using a SourceQueue and will buffer elements and/or backpressure,
+        /// based on the buffer values provided.
+        /// </summary>
+        /// <param name="materializer">The materializer to use for each enumeration</param>
+        /// <param name="minBuffer">The minimum input buffer size</param>
+        /// <param name="maxBuffer">The Max input buffer size.</param>
+        /// <returns>A lazy <see cref="IAsyncEnumerable{T}"/> that will run each time it is enumerated.</returns>
+        public IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(
+            ActorSystem materializer, int minBuffer = 4,
+            int maxBuffer = 16) =>
+            new StreamsAsyncEnumerableRerunnable<TOut,TMat>(
+                this, materializer.Materializer(),minBuffer,maxBuffer);
         
 
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
+++ b/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
@@ -74,29 +74,27 @@ namespace Akka.Streams.Implementation
         [InternalApi]
         protected IActorRef ActorOf(Props props, string name, string dispatcher)
         {
-            var localActorRef = Supervisor as LocalActorRef;
-            if (localActorRef != null)
-                return ((ActorCell) localActorRef.Underlying).AttachChild(props.WithDispatcher(dispatcher),
-                    isSystemService: false, name: name);
-
-
-            var repointableActorRef = Supervisor as RepointableActorRef;
-            if (repointableActorRef != null)
+            switch (Supervisor)
             {
-                if (repointableActorRef.IsStarted)
+                case LocalActorRef localActorRef:
+                    return ((ActorCell) localActorRef.Underlying).AttachChild(props.WithDispatcher(dispatcher),
+                        isSystemService: false, name: name);
+                case RepointableActorRef { IsStarted: true } repointableActorRef:
                     return ((ActorCell)repointableActorRef.Underlying).AttachChild(props.WithDispatcher(dispatcher), isSystemService: false, name: name);
-
-                var timeout = repointableActorRef.Underlying.System.Settings.CreationTimeout;
-                var f = repointableActorRef.Ask<IActorRef>(new StreamSupervisor.Materialize(props.WithDispatcher(dispatcher), name), timeout);
-                return f.Result;
+                case RepointableActorRef repointableActorRef:
+                {
+                    var timeout = repointableActorRef.Underlying.System.Settings.CreationTimeout;
+                    var f = repointableActorRef.Ask<IActorRef>(new StreamSupervisor.Materialize(props.WithDispatcher(dispatcher), name), timeout);
+                    return f.Result;
+                }
+                default:
+                    throw new IllegalStateException($"Stream supervisor must be a local actor, was [{Supervisor.GetType()}]");
             }
-
-            throw new IllegalStateException($"Stream supervisor must be a local actor, was [{Supervisor.GetType()}]");
         }
     }
 
     /// <summary>
-    /// TBD
+    /// Default implementation of <see cref="ActorMaterializer"/>.
     /// </summary>
     public sealed class ActorMaterializerImpl : ExtendedActorMaterializer
     {
@@ -226,17 +224,7 @@ namespace Akka.Streams.Implementation
         private readonly AtomicBoolean _haveShutDown;
         private readonly EnumerableActorName _flowNames;
         private ILoggingAdapter _logger;
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="system">TBD</param>
-        /// <param name="settings">TBD</param>
-        /// <param name="dispatchers">TBD</param>
-        /// <param name="supervisor">TBD</param>
-        /// <param name="haveShutDown">TBD</param>
-        /// <param name="flowNames">TBD</param>
-        /// <returns>TBD</returns>
+        
         public ActorMaterializerImpl(ActorSystem system, ActorMaterializerSettings settings, Dispatchers dispatchers, IActorRef supervisor, AtomicBoolean haveShutDown, EnumerableActorName flowNames)
         {
             _system = system;
@@ -279,7 +267,7 @@ namespace Akka.Streams.Implementation
         /// INTERNAL API
         /// </summary>
         [InternalApi]
-        public override ILoggingAdapter Logger => _logger ?? (_logger = GetLogger());
+        public override ILoggingAdapter Logger => _logger ??= GetLogger();
 
         /// <summary>
         /// TBD
@@ -305,19 +293,13 @@ namespace Akka.Streams.Implementation
         {
             return attributes.AttributeList.Aggregate(Settings, (settings, attribute) =>
             {
-                var buffer = attribute as Attributes.InputBuffer;
-                if (buffer != null)
-                    return settings.WithInputBuffer(buffer.Initial, buffer.Max);
-
-                var dispatcher = attribute as ActorAttributes.Dispatcher;
-                if (dispatcher != null)
-                    return settings.WithDispatcher(dispatcher.Name);
-                
-                var strategy = attribute as ActorAttributes.SupervisionStrategy;
-                if (strategy != null)
-                    return settings.WithSupervisionStrategy(strategy.Decider);
-
-                return settings;
+                return attribute switch
+                {
+                    Attributes.InputBuffer buffer => settings.WithInputBuffer(buffer.Initial, buffer.Max),
+                    ActorAttributes.Dispatcher dispatcher => settings.WithDispatcher(dispatcher.Name),
+                    ActorAttributes.SupervisionStrategy strategy => settings.WithSupervisionStrategy(strategy.Decider),
+                    _ => settings
+                };
             });
         }
 

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -824,7 +824,7 @@ namespace Akka.Streams.Implementation.Fusing
                 _stage = stage;
                 _left = stage._count;
 
-                SetHandler(stage.Inlet, stage.Outlet, this);
+                SetHandlers(stage.Inlet, stage.Outlet, this);
             }
 
             public override void OnPush()


### PR DESCRIPTION
## Changes

For instances where the `ActorSystem` can be used as the materializer, should use an `ActorSystem`-specific singleton.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue https://github.com/akkadotnet/akka.net/pull/6440#issuecomment-1445019935
* [x] Changes in public API reviewed, if any.
