### PR TITLE
Remove obsolete methods from Akka.Actor

### DIFF
--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -228,17 +228,6 @@ namespace Akka.Actor
             }
         }
 
-        /// <summary>
-        /// Obsolete. Use <see cref="TryGetChildStatsByName(string, out IChildStats)"/> instead.
-        /// </summary>
-        /// <param name="name">N/A</param>
-        /// <returns>N/A</returns>
-        [Obsolete("Use TryGetChildStatsByName [0.7.1]", true)]
-        public IInternalActorRef GetChildByName(string name)   //TODO: Should return  Option[ChildStats]
-        {
-            return GetSingleChild(name);
-        }
-
         IActorRef IActorContext.Child(string name)
         {
             if (TryGetChildStatsByName(name, out var child) && child is ChildRestartStats s)

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -434,14 +434,6 @@ namespace Akka.Actor
         void Suspend();
 
         /// <summary>
-        /// Obsolete. Use <see cref="SendSystemMessage(ISystemMessage)"/> instead.
-        /// </summary>
-        /// <param name="message">N/A</param>
-        /// <param name="sender">N/A</param>
-        [Obsolete("Use SendSystemMessage(message) [1.1.0]")]
-        void SendSystemMessage(ISystemMessage message, IActorRef sender);
-
-        /// <summary>
         /// Sends an <see cref="ISystemMessage"/> to the underlying actor.
         /// </summary>
         /// <param name="message">The system message we're sending.</param>
@@ -485,13 +477,6 @@ namespace Akka.Actor
 
         /// <inheritdoc cref="IInternalActorRef"/>
         public abstract bool IsLocal { get; }
-
-        /// <inheritdoc cref="IInternalActorRef"/>
-        [Obsolete("Use SendSystemMessage(message) instead [1.1.0]")]
-        public void SendSystemMessage(ISystemMessage message, IActorRef sender)
-        {
-            SendSystemMessage(message);
-        }
 
         /// <inheritdoc cref="IInternalActorRef"/>
         public abstract void SendSystemMessage(ISystemMessage message);

--- a/src/core/Akka/Actor/Cell.cs
+++ b/src/core/Akka/Actor/Cell.cs
@@ -89,7 +89,7 @@ namespace Akka.Actor
         /// TBD
         /// </summary>
         /// <returns>TBD</returns>
-        [Obsolete("Used ChildrenRefs instead [1.1.0]")]
+        // [Obsolete("Used ChildrenRefs instead [1.1.0]")] // ChildrenRefs was never implemented 
         IEnumerable<IInternalActorRef> GetChildren();    //TODO: Should be replaced by childrenRefs: ChildrenContainer
 
         /// <summary>
@@ -104,13 +104,6 @@ namespace Akka.Actor
         /// <param name="name">TBD</param>
         /// <returns>TBD</returns>
         IInternalActorRef GetSingleChild(string name);
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="name">TBD</param>
-        /// <returns>TBD</returns>
-        IInternalActorRef GetChildByName(string name);
 
         /// <summary>
         /// Tries to get the stats for the child with the specified name. The stats can be either <see cref="ChildNameReserved"/> 

--- a/src/core/Akka/Actor/FSM.cs
+++ b/src/core/Akka/Actor/FSM.cs
@@ -749,18 +749,6 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// Obsolete. Use <c>GoTo(nextStateName).Using(stateData) instead.</c>
-        /// </summary>
-        /// <param name="nextStateName">N/A</param>
-        /// <param name="stateData">N/A</param>
-        /// <returns>N/A</returns>
-        [Obsolete("This method is obsoleted. Use GoTo(nextStateName).Using(newStateData) [1.2.0]")]
-        public State<TState, TData> GoTo(TState nextStateName, TData stateData)
-        {
-            return new State<TState, TData>(nextStateName, stateData);
-        }
-
-        /// <summary>
         /// Produce "empty" transition descriptor. Return this from a state function
         /// when no state change is to be effected.
         /// </summary>


### PR DESCRIPTION
Some "obsolete" methods, classes, and properties are not removed:
* `IInternalActorRef.IsTerminated`: Ingrained inside Akka.NET, requires extensive surgery to remove.
* `ActorCell.GetChildren()`: Removed the obsolete attribute, the replacement methods was never implemented (since v1.1.0).
* `Akka.Actor.Failure`: Ingrained inside Akka.NET, requires extensive surgery to remove.
* `ActorProducerPipeline`: Promised to be removed in v1.5, but replacement was never implemented