### PR TITLE
remove ancient Mono work-around in `ActorSystemImpl`

### DIFF
--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -210,9 +210,6 @@ namespace Akka.Actor.Internal
         {
             try
             {
-                // Force TermInfoDriver to initialize in order to protect us from the issue seen in #2432
-                typeof(Console).GetProperty("BackgroundColor").GetValue(null); // HACK: Only needed for MONO
-
                 RegisterOnTermination(StopScheduler);
                 _provider.Init(this);
                 LoadExtensions();


### PR DESCRIPTION
## Changes

close https://github.com/akkadotnet/akka.net/issues/6459

This was a very old (7-8 years old) workaround for a Mono bug - it's very likely no longer needed and that version of Mono probably doesn't exist much in the wild these days, now that .NET Core is x-plat.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).

