### PR TITLE
copy `Obsolete` attributes to Akka.Persistence.TCK

### DIFF
--- a/src/core/Akka.Persistence.TCK/PluginSpec.cs
+++ b/src/core/Akka.Persistence.TCK/PluginSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.Configuration;
@@ -65,8 +66,8 @@ namespace Akka.Persistence.TCK
             Sys.EventStream.Subscribe(subscriber, typeof (T));
         }
 
-        
-        public void Dispose()
+        [Obsolete("Dispose() is obsolete, please use DisposeAsync() instead")]
+        public override void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
@@ -77,7 +78,8 @@ namespace Akka.Persistence.TCK
         /// user's code. Managed and unmanaged resources will be disposed.<br />
         /// if set to <c>false</c> the method has been called by the runtime from inside the finalizer and only
         /// unmanaged resources can be disposed.</param>
-        protected virtual void Dispose(bool disposing)
+        [Obsolete("Dispose(bool) is deprecated, please use DisposeAsync() instead")]
+        protected override void Dispose(bool disposing)
         {
             //if (disposing) FSMBase.Shutdown();
         }

--- a/src/core/Akka.Persistence.TCK/PluginSpec.cs
+++ b/src/core/Akka.Persistence.TCK/PluginSpec.cs
@@ -65,25 +65,6 @@ namespace Akka.Persistence.TCK
         {
             Sys.EventStream.Subscribe(subscriber, typeof (T));
         }
-
-        public override async Task DisposeAsync()
-        {
-            await base.DisposeAsync();
-#pragma warning disable CS0618
-            Dispose(true);
-#pragma warning restore CS0618
-        }
-
-        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
-        /// <param name="disposing">if set to <c>true</c> the method has been called directly or indirectly by a
-        /// user's code. Managed and unmanaged resources will be disposed.<br />
-        /// if set to <c>false</c> the method has been called by the runtime from inside the finalizer and only
-        /// unmanaged resources can be disposed.</param>
-        [Obsolete("Dispose(bool) is deprecated, please use DisposeAsync() instead")]
-        protected override void Dispose(bool disposing)
-        {
-            //if (disposing) FSMBase.Shutdown();
-        }
     }
 }
 

--- a/src/core/Akka.Persistence.TCK/PluginSpec.cs
+++ b/src/core/Akka.Persistence.TCK/PluginSpec.cs
@@ -66,13 +66,6 @@ namespace Akka.Persistence.TCK
             Sys.EventStream.Subscribe(subscriber, typeof (T));
         }
 
-        [Obsolete("Dispose() is obsolete, please use DisposeAsync() instead")]
-        public override void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
         /// <param name="disposing">if set to <c>true</c> the method has been called directly or indirectly by a
         /// user's code. Managed and unmanaged resources will be disposed.<br />

--- a/src/core/Akka.Persistence.TCK/PluginSpec.cs
+++ b/src/core/Akka.Persistence.TCK/PluginSpec.cs
@@ -66,6 +66,14 @@ namespace Akka.Persistence.TCK
             Sys.EventStream.Subscribe(subscriber, typeof (T));
         }
 
+        public override async Task DisposeAsync()
+        {
+            await base.DisposeAsync();
+#pragma warning disable CS0618
+            Dispose(true);
+#pragma warning restore CS0618
+        }
+
         /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
         /// <param name="disposing">if set to <c>true</c> the method has been called directly or indirectly by a
         /// user's code. Managed and unmanaged resources will be disposed.<br />


### PR DESCRIPTION
## Changes

copy `Obsolete` attributes to Akka.Persistence.TCK - same changes as we made to the TestKit base classes for Xunit.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).