### PR TITLE
[PORT #6250] Make transport adapter messages public

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.verified.txt
@@ -580,6 +580,58 @@ namespace Akka.Remote.Transport
         public FailureInjectorProvider() { }
         public Akka.Remote.Transport.Transport Create(Akka.Remote.Transport.Transport wrappedTransport, Akka.Actor.ExtendedActorSystem system) { }
     }
+    public class FailureInjectorTransportAdapter : Akka.Remote.Transport.AbstractTransportAdapter, Akka.Remote.Transport.IAssociationEventListener
+    {
+        public readonly Akka.Actor.ExtendedActorSystem ExtendedActorSystem;
+        public const string FailureInjectorSchemeIdentifier = "gremlin";
+        protected int MaximumOverhead;
+        public FailureInjectorTransportAdapter(Akka.Remote.Transport.Transport wrappedTransport, Akka.Actor.ExtendedActorSystem extendedActorSystem) { }
+        protected override Akka.Remote.Transport.SchemeAugmenter SchemeAugmenter { get; }
+        protected override void InterceptAssociate(Akka.Actor.Address remoteAddress, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.AssociationHandle> statusPromise) { }
+        protected override System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener> InterceptListen(Akka.Actor.Address listenAddress, System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener> listenerTask) { }
+        public override System.Threading.Tasks.Task<bool> ManagementCommand(object message) { }
+        public void Notify(Akka.Remote.Transport.IAssociationEvent ev) { }
+        public bool ShouldDropInbound(Akka.Actor.Address remoteAddress, object instance, string debugMessage) { }
+        public bool ShouldDropOutbound(Akka.Actor.Address remoteAddress, object instance, string debugMessage) { }
+        public sealed class All
+        {
+            public All(Akka.Remote.Transport.FailureInjectorTransportAdapter.IGremlinMode mode) { }
+            public Akka.Remote.Transport.FailureInjectorTransportAdapter.IGremlinMode Mode { get; }
+        }
+        public sealed class Drop : Akka.Remote.Transport.FailureInjectorTransportAdapter.IGremlinMode
+        {
+            public Drop(double outboundDropP, double inboundDropP) { }
+            public double InboundDropP { get; }
+            public double OutboundDropP { get; }
+        }
+        public interface IFailureInjectorCommand { }
+        public interface IGremlinMode { }
+        public sealed class One
+        {
+            public One(Akka.Actor.Address remoteAddress, Akka.Remote.Transport.FailureInjectorTransportAdapter.IGremlinMode mode) { }
+            public Akka.Remote.Transport.FailureInjectorTransportAdapter.IGremlinMode Mode { get; }
+            public Akka.Actor.Address RemoteAddress { get; }
+        }
+        public sealed class PassThru : Akka.Remote.Transport.FailureInjectorTransportAdapter.IGremlinMode
+        {
+            public static Akka.Remote.Transport.FailureInjectorTransportAdapter.PassThru Instance { get; }
+        }
+    }
+    public sealed class ForceDisassociate
+    {
+        public ForceDisassociate(Akka.Actor.Address address) { }
+        public Akka.Actor.Address Address { get; }
+    }
+    public sealed class ForceDisassociateAck
+    {
+        public static Akka.Remote.Transport.ForceDisassociateAck Instance { get; }
+    }
+    public sealed class ForceDisassociateExplicitly
+    {
+        public ForceDisassociateExplicitly(Akka.Actor.Address address, Akka.Remote.Transport.DisassociateInfo reason) { }
+        public Akka.Actor.Address Address { get; }
+        public Akka.Remote.Transport.DisassociateInfo Reason { get; }
+    }
     public interface IAssociationEvent : Akka.Actor.INoSerializationVerificationNeeded { }
     public interface IAssociationEventListener
     {
@@ -710,6 +762,16 @@ namespace Akka.Remote.Transport
     {
         public ThrottlerProvider() { }
         public Akka.Remote.Transport.Transport Create(Akka.Remote.Transport.Transport wrappedTransport, Akka.Actor.ExtendedActorSystem system) { }
+    }
+    public sealed class TokenBucket : Akka.Remote.Transport.ThrottleMode
+    {
+        public TokenBucket(int capacity, double tokensPerSecond, long nanoTimeOfLastSend, int availableTokens) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+        public override System.TimeSpan TimeToAvailable(long currentNanoTime, int tokens) { }
+        public override System.ValueTuple<Akka.Remote.Transport.ThrottleMode, bool> TryConsumeTokens(long nanoTimeOfSend, int tokens) { }
+        public static bool ==(Akka.Remote.Transport.TokenBucket left, Akka.Remote.Transport.TokenBucket right) { }
+        public static bool !=(Akka.Remote.Transport.TokenBucket left, Akka.Remote.Transport.TokenBucket right) { }
     }
     public abstract class Transport
     {

--- a/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/FailureInjectorTransportAdapter.cs
@@ -67,7 +67,7 @@ namespace Akka.Remote.Transport
     /// <summary>
     /// TBD
     /// </summary>
-    internal class FailureInjectorTransportAdapter : AbstractTransportAdapter, IAssociationEventListener
+    public class FailureInjectorTransportAdapter : AbstractTransportAdapter, IAssociationEventListener
     {
 #region Internal message classes
 

--- a/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
+++ b/src/core/Akka.Remote/Transport/ThrottleTransportAdapter.cs
@@ -139,7 +139,7 @@ namespace Akka.Remote.Transport
     /// <summary>
     /// Management command to force disassociation of an address
     /// </summary>
-    internal sealed class ForceDisassociate
+    public sealed class ForceDisassociate
     {
         /// <summary>
         /// TBD
@@ -159,7 +159,7 @@ namespace Akka.Remote.Transport
     /// <summary>
     /// Management command to force disassociation of an address with an explicit error.
     /// </summary>
-    internal sealed class ForceDisassociateExplicitly
+    public sealed class ForceDisassociateExplicitly
     {
         /// <summary>
         /// TBD
@@ -186,7 +186,7 @@ namespace Akka.Remote.Transport
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal sealed class ForceDisassociateAck
+    public sealed class ForceDisassociateAck
     {
         private ForceDisassociateAck() { }
         // ReSharper disable once InconsistentNaming
@@ -665,7 +665,7 @@ namespace Akka.Remote.Transport
     /// <summary>
     /// Applies token-bucket throttling to introduce latency to a connection
     /// </summary>
-    sealed class TokenBucket : ThrottleMode
+    public sealed class TokenBucket : ThrottleMode
     {
         readonly int _capacity;
         readonly double _tokensPerSecond;
@@ -738,7 +738,6 @@ namespace Akka.Remote.Transport
                 && _availableTokens == other._availableTokens;
         }
 
-        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj)) return false;
@@ -746,7 +745,6 @@ namespace Akka.Remote.Transport
             return obj is TokenBucket && Equals((TokenBucket)obj);
         }
 
-        /// <inheritdoc/>
         public override int GetHashCode()
         {
             unchecked


### PR DESCRIPTION
* Make transport adapter messages public so it can be used in Petabridge.Cmd for testing network disruptions

* Update API Verify list

* Fixing DocFx complaints

Co-authored-by: Aaron Stannard <aaron@petabridge.com>
(cherry picked from commit e94913cabd222f478dc2d4849667f82f2c8ae781)