### PR TITLE
bug fix: timing regressions in `Cluster.JoinAsync` methods

### DIFF
--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -378,7 +378,7 @@ namespace Akka.Cluster
                 {
                     timeoutCts.Dispose();
                     completion.TrySetException(new ClusterJoinFailedException(
-                        $"Node has not managed to join the cluster using provided address: {address}"));
+                        $"Node has not managed to join the cluster using provided addresses: [{string.Join(",", nodes)}]"));
                 });
             }
             

--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -248,9 +248,9 @@ namespace Akka.Cluster
         /// </summary>
         private TimeSpan ComputeJoinTimeLimit()
         {
-            return TimeSpan.FromSeconds(Math.Max(
-                (Settings.RetryUnsuccessfulJoinAfter ?? TimeSpan.FromSeconds(10)).TotalSeconds,
-                TimeSpan.FromSeconds(20).TotalSeconds));
+            return TimeSpan.FromMilliseconds(Math.Max(
+                (Settings.RetryUnsuccessfulJoinAfter ?? TimeSpan.FromSeconds(10)).TotalMilliseconds,
+                TimeSpan.FromSeconds(10).TotalMilliseconds));
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

We used the `cluster.seed-node-timeout` property incorrectly in https://github.com/akkadotnet/akka.net/pull/6033 - that is a "how long did it take from me to hear back from a seed" setting, but we're using it like a "how much time do I have to join the cluster?" setting.

Added a function designed to give us at least 20s of leeway if the user does not provide a `CancellationToken` of their own.

If the user does provide their own `CancellationToken`, that should be the single source of truth for this operation - second-guessing it without own un-overridable timeout adds zero value.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
