### PR TITLE
fix state update timeout for remember-entities

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -1117,7 +1117,7 @@ namespace Akka.Cluster.Sharding
                 Timers.StartSingleTimer(
                     RememberEntityTimeoutKey,
                     new RememberEntityTimeout(RememberEntitiesShardStore.GetEntities.Instance),
-                    _settings.TuningParameters.WaitingForStateTimeout);
+                    _settings.TuningParameters.UpdatingStateTimeout);
                 Context.Become(AwaitingRememberedEntities);
             }
             else
@@ -1254,7 +1254,7 @@ namespace Akka.Cluster.Sharding
             Timers.StartSingleTimer(
                 RememberEntityTimeoutKey,
                 new RememberEntityTimeout(update),
-                _settings.TuningParameters.UpdatingStateTimeout);
+                _settings.TuningParameters.WaitingForStateTimeout);
 
             Context.Become(WaitingForRememberEntitiesStore(update, startTime));
         }


### PR DESCRIPTION
## Changes

We were using the wrong state timeout value, which only gave us 2s to recover R-E data. We're now using the correct value.

Addresses part of #6478 but there's still an issue with shard backoff + recreation that isn't handled correctly.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #6478