### PR TITLE
Fix persistence allocations part 2.

### DIFF
--- a/src/core/Akka.Persistence/Eventsourced.Recovery.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Recovery.cs
@@ -6,8 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Akka.Actor;
 using Akka.Persistence.Internal;
 
@@ -334,11 +332,11 @@ namespace Akka.Persistence
         {
             if (_eventBatch.Count > 0)
             {
-                foreach (var p in _eventBatch.Reverse())
+                foreach (var p in _eventBatch)
                 {
                     _journalBatch.Add(p);
                 }
-                _eventBatch = new LinkedList<IPersistentEnvelope>();
+                _eventBatch.Clear();
             }
 
             FlushJournalBatch();

--- a/src/core/Akka.Persistence/Eventsourced.cs
+++ b/src/core/Akka.Persistence/Eventsourced.cs
@@ -303,7 +303,7 @@ namespace Akka.Persistence
 
             _pendingStashingPersistInvocations++;
             _pendingInvocations.AddLast(new StashingHandlerInvocation(@event, o => handler((TEvent)o)));
-            _eventBatch.AddFirst(new AtomicWrite(new Persistent(@event, persistenceId: PersistenceId,
+            _eventBatch.AddLast(new AtomicWrite(new Persistent(@event, persistenceId: PersistenceId,
                 sequenceNr: NextSequenceNr(), writerGuid: _writerGuid, sender: Sender)));
         }
 
@@ -335,7 +335,7 @@ namespace Akka.Persistence
             }
 
             if (persistents.Count > 0)
-                _eventBatch.AddFirst(new AtomicWrite(persistents.ToImmutable()));
+                _eventBatch.AddLast(new AtomicWrite(persistents.ToImmutable()));
         }
 
         /// <summary>
@@ -374,7 +374,7 @@ namespace Akka.Persistence
             }
 
             _pendingInvocations.AddLast(new AsyncHandlerInvocation(@event, o => handler((TEvent)o)));
-            _eventBatch.AddFirst(new AtomicWrite(new Persistent(@event, persistenceId: PersistenceId,
+            _eventBatch.AddLast(new AtomicWrite(new Persistent(@event, persistenceId: PersistenceId,
                 sequenceNr: NextSequenceNr(), writerGuid: _writerGuid, sender: Sender)));
         }
 
@@ -400,7 +400,7 @@ namespace Akka.Persistence
                 _pendingInvocations.AddLast(new AsyncHandlerInvocation(@event, Inv));
             }
 
-            _eventBatch.AddFirst(new AtomicWrite(enumerable.Select(e => new Persistent(e, persistenceId: PersistenceId,
+            _eventBatch.AddLast(new AtomicWrite(enumerable.Select(e => new Persistent(e, persistenceId: PersistenceId,
                     sequenceNr: NextSequenceNr(), writerGuid: _writerGuid, sender: Sender))
                 .ToImmutableList<IPersistentRepresentation>()));
         }
@@ -440,7 +440,7 @@ namespace Akka.Persistence
             else
             {
                 _pendingInvocations.AddLast(new AsyncHandlerInvocation(evt, o => handler((TEvent)o)));
-                _eventBatch.AddFirst(new NonPersistentMessage(evt, Sender));
+                _eventBatch.AddLast(new NonPersistentMessage(evt, Sender));
             }
         }
 

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -341,7 +341,7 @@ namespace Akka.Persistence.Journal
              */
             var self = Self;
             _resequencerCounter += message.Messages.Aggregate(1, (acc, m) => acc + m.Size);
-            var atomicWriteCount = message.Messages.OfType<AtomicWrite>().Count();
+            var atomicWriteCount = message.Messages.Count(x => x is AtomicWrite);
             
             // Using an async local function instead of ContinueWith
 #pragma warning disable CS4014

--- a/src/core/Akka.Persistence/JournalProtocol.cs
+++ b/src/core/Akka.Persistence/JournalProtocol.cs
@@ -46,7 +46,6 @@ namespace Akka.Persistence
         /// Inclusive upper sequence number bound where a replay should end.
         /// </summary>
         public long ToSequenceNr { get; }
-
         
         public bool Equals(DeleteMessagesSuccess other)
         {
@@ -55,13 +54,10 @@ namespace Akka.Persistence
 
             return ToSequenceNr == other.ToSequenceNr;
         }
-
         
         public override bool Equals(object obj) => Equals(obj as DeleteMessagesSuccess);
-
         
         public override int GetHashCode() => ToSequenceNr.GetHashCode();
-
         
         public override string ToString() => $"DeleteMessagesSuccess<toSequenceNr: {ToSequenceNr}>";
     }
@@ -107,11 +103,9 @@ namespace Akka.Persistence
 
             return Equals(Cause, other.Cause) && ToSequenceNr == other.ToSequenceNr;
         }
-
-       
+        
         public override bool Equals(object obj) => Equals(obj as DeleteMessagesFailure);
-
-       
+        
         public override int GetHashCode()
         {
             unchecked
@@ -119,7 +113,6 @@ namespace Akka.Persistence
                 return ((Cause != null ? Cause.GetHashCode() : 0) * 397) ^ ToSequenceNr.GetHashCode();
             }
         }
-
         
         public override string ToString() => $"DeleteMessagesFailure<cause: {Cause}, toSequenceNr: {ToSequenceNr}>";
     }
@@ -163,8 +156,7 @@ namespace Akka.Persistence
         /// Requesting persistent actor.
         /// </summary>
         public IActorRef PersistentActor { get; }
-
-       
+        
         public bool Equals(DeleteMessagesTo other)
         {
             if (ReferenceEquals(other, null)) return false;
@@ -174,10 +166,8 @@ namespace Akka.Persistence
                    ToSequenceNr == other.ToSequenceNr &&
                    Equals(PersistentActor, other.PersistentActor);
         }
-
-       
+        
         public override bool Equals(object obj) => Equals(obj as DeleteMessagesTo);
-
         
         public override int GetHashCode()
         {
@@ -189,7 +179,6 @@ namespace Akka.Persistence
                 return hashCode;
             }
         }
-
         
         public override string ToString() => $"DeleteMessagesTo<pid: {PersistenceId}, seqNr: {ToSequenceNr}, persistentActor: {PersistentActor}>";
     }
@@ -227,22 +216,19 @@ namespace Akka.Persistence
         /// TBD
         /// </summary>
         public int ActorInstanceId { get; }
-
-       
+        
         public bool Equals(WriteMessages other)
         {
             if (ReferenceEquals(other, null)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Equals(ActorInstanceId, other.ActorInstanceId)
+            return ActorInstanceId == other.ActorInstanceId
                    && Equals(PersistentActor, other.PersistentActor)
                    && Equals(Messages, other.Messages);
         }
-
         
         public override bool Equals(object obj) => Equals(obj as WriteMessages);
-
-       
+        
         public override int GetHashCode()
         {
             unchecked
@@ -253,7 +239,6 @@ namespace Akka.Persistence
                 return hashCode;
             }
         }
-
         
         public override string ToString() => $"WriteMessages<actorInstanceId: {ActorInstanceId}, actor: {PersistentActor}>";
     }
@@ -303,7 +288,6 @@ namespace Akka.Persistence
         /// The number of atomic writes that failed.
         /// </summary>
         public int WriteCount { get; }
-
         
         public bool Equals(WriteMessagesFailed other)
         {
@@ -312,14 +296,11 @@ namespace Akka.Persistence
 
             return Equals(Cause, other.Cause);
         }
-
         
         public override bool Equals(object obj) => Equals(obj as WriteMessagesFailed);
-
-       
+        
         public override int GetHashCode() => Cause != null ? Cause.GetHashCode() : 0;
-
-       
+        
         public override string ToString() => $"WriteMessagesFailed<cause: {Cause}>";
     }
 
@@ -350,20 +331,17 @@ namespace Akka.Persistence
         /// TBD
         /// </summary>
         public int ActorInstanceId { get; }
-
-       
+        
         public bool Equals(WriteMessageSuccess other)
         {
             if (ReferenceEquals(other, null)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Equals(ActorInstanceId, other.ActorInstanceId)
+            return ActorInstanceId == other.ActorInstanceId
                    && Equals(Persistent, other.Persistent);
         }
-
         
         public override bool Equals(object obj) => Equals(obj as WriteMessageSuccess);
-
         
         public override int GetHashCode()
         {
@@ -372,8 +350,7 @@ namespace Akka.Persistence
                 return ((Persistent != null ? Persistent.GetHashCode() : 0) * 397) ^ ActorInstanceId;
             }
         }
-
-       
+        
         public override string ToString() => $"WriteMessageSuccess<actorInstanceId: {ActorInstanceId}, message: {Persistent}>";
     }
 
@@ -418,21 +395,18 @@ namespace Akka.Persistence
         /// TBD
         /// </summary>
         public int ActorInstanceId { get; }
-
         
         public bool Equals(WriteMessageRejected other)
         {
             if (ReferenceEquals(other, null)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Equals(ActorInstanceId, other.ActorInstanceId)
+            return ActorInstanceId == other.ActorInstanceId
                    && Equals(Persistent, other.Persistent)
                    && Equals(Cause, other.Cause);
         }
-
         
         public override bool Equals(object obj) => Equals(obj as WriteMessageRejected);
-
         
         public override int GetHashCode()
         {
@@ -444,7 +418,6 @@ namespace Akka.Persistence
                 return hashCode;
             }
         }
-
         
         public override string ToString() => $"WriteMessageRejected<actorInstanceId: {ActorInstanceId}, message: {Persistent}, cause: {Cause}>";
     }
@@ -489,19 +462,17 @@ namespace Akka.Persistence
         /// TBD
         /// </summary>
         public int ActorInstanceId { get; }
-
         
         public bool Equals(WriteMessageFailure other)
         {
             if (ReferenceEquals(other, null)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Equals(ActorInstanceId, other.ActorInstanceId)
+            return ActorInstanceId == other.ActorInstanceId
                    && Equals(Persistent, other.Persistent)
                    && Equals(Cause, other.Cause);
         }
-
-       
+        
         public override bool Equals(object obj) => Equals(obj as WriteMessageFailure);
 
         
@@ -515,7 +486,6 @@ namespace Akka.Persistence
                 return hashCode;
             }
         }
-
         
         public override string ToString() => $"WriteMessageFailure<actorInstanceId: {ActorInstanceId}, message: {Persistent}, cause: {Cause}>";
     }
@@ -546,21 +516,18 @@ namespace Akka.Persistence
         /// TBD
         /// </summary>
         public int ActorInstanceId { get; }
-
-       
+        
         public bool Equals(LoopMessageSuccess other)
         {
             if (ReferenceEquals(other, null)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Equals(ActorInstanceId, other.ActorInstanceId)
+            return ActorInstanceId == other.ActorInstanceId
                    && Equals(Message, other.Message);
         }
-
         
         public override bool Equals(object obj) => Equals(obj as LoopMessageSuccess);
 
-        
         public override int GetHashCode()
         {
             unchecked
@@ -568,7 +535,6 @@ namespace Akka.Persistence
                 return ((Message != null ? Message.GetHashCode() : 0) * 397) ^ ActorInstanceId;
             }
         }
-
         
         public override string ToString() => $"LoopMessageSuccess<actorInstanceId: {ActorInstanceId}, message: {Message}>";
     }
@@ -620,7 +586,6 @@ namespace Akka.Persistence
         /// Requesting persistent actor.
         /// </summary>
         public IActorRef PersistentActor { get; }
-
         
         public bool Equals(ReplayMessages other)
         {
@@ -629,14 +594,12 @@ namespace Akka.Persistence
 
             return Equals(PersistenceId, other.PersistenceId)
                    && Equals(PersistentActor, other.PersistentActor)
-                   && Equals(FromSequenceNr, other.FromSequenceNr)
-                   && Equals(ToSequenceNr, other.ToSequenceNr)
-                   && Equals(Max, other.Max);
+                   && FromSequenceNr == other.FromSequenceNr
+                   && ToSequenceNr == other.ToSequenceNr
+                   && Max == other.Max;
         }
-
         
         public override bool Equals(object obj) => Equals(obj as ReplayMessages);
-
         
         public override int GetHashCode()
         {
@@ -650,7 +613,6 @@ namespace Akka.Persistence
                 return hashCode;
             }
         }
-
         
         public override string ToString() => $"ReplayMessages<fromSequenceNr: {FromSequenceNr}, toSequenceNr: {ToSequenceNr}, max: {Max}, persistenceId: {PersistenceId}>";
     }
@@ -674,7 +636,6 @@ namespace Akka.Persistence
         /// Replayed message.
         /// </summary>
         public IPersistentRepresentation Persistent { get; }
-
         
         public bool Equals(ReplayedMessage other)
         {
@@ -683,13 +644,10 @@ namespace Akka.Persistence
 
             return Equals(Persistent, other.Persistent);
         }
-
         
         public override bool Equals(object obj) => Equals(obj as ReplayedMessage);
-
         
         public override int GetHashCode() => Persistent != null ? Persistent.GetHashCode() : 0;
-
         
         public override string ToString() => $"ReplayedMessage<message: {Persistent}>";
     }
@@ -717,22 +675,18 @@ namespace Akka.Persistence
         /// Highest stored sequence number.
         /// </summary>
         public long HighestSequenceNr { get; }
-
-       
+        
         public bool Equals(RecoverySuccess other)
         {
             if (ReferenceEquals(other, null)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Equals(HighestSequenceNr, other.HighestSequenceNr);
+            return HighestSequenceNr == other.HighestSequenceNr;
         }
-
         
         public override bool Equals(object obj) => Equals(obj as RecoverySuccess);
-
         
         public override int GetHashCode() => HighestSequenceNr.GetHashCode();
-
         
         public override string ToString() => $"RecoverySuccess<highestSequenceNr: {HighestSequenceNr}>";
     }


### PR DESCRIPTION
## Changes

Next optimization of persistence allocation that was started in https://github.com/akkadotnet/akka.net/pull/5505
Now excessive object allocation was eliminated in Eventsourced class when using linked list. Benchmark shows kinda 10% lower memory usage.

## Checklist

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

BenchmarkDotNet=v0.13.2, OS=macOS Monterey 12.5.1 (21G83) [Darwin 21.6.0]
Apple M1 2.40GHz, 1 CPU, 8 logical and 8 physical cores
.NET SDK=7.0.101
  [Host] : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT SSE4.2 DEBUG

Toolchain=InProcessEmitToolchain  InvocationCount=1  UnrollFactor=1  

|             Method | PersistentActors | WriteMsgCount |        Mean |     Error |   StdDev |      Gen0 |      Gen1 |   Allocated |
|------------------- |----------------- |-------------- |------------:|----------:|---------:|----------:|----------:|------------:|
| WriteToPersistence |                1 |           100 |    696.0 us |  44.63 us | 122.9 us |         - |         - |   146.88 KB |
| WriteToPersistence |               10 |           100 |  1,704.8 us |  44.52 us | 129.2 us |         - |         - |  1420.27 KB |
| WriteToPersistence |              100 |           100 | 23,525.9 us | 458.53 us | 657.6 us | 2000.0000 | 1000.0000 | 13786.62 KB |


### This PR's Benchmarks

BenchmarkDotNet=v0.13.2, OS=macOS Monterey 12.5.1 (21G83) [Darwin 21.6.0]
Apple M1 2.40GHz, 1 CPU, 8 logical and 8 physical cores
.NET SDK=7.0.101
  [Host] : .NET 7.0.1 (7.0.122.56804), X64 RyuJIT SSE4.2 DEBUG

Toolchain=InProcessEmitToolchain  InvocationCount=1  UnrollFactor=1  

|             Method | PersistentActors | WriteMsgCount |        Mean |     Error |    StdDev |      Median |      Gen0 |      Gen1 |   Allocated |
|------------------- |----------------- |-------------- |------------:|----------:|----------:|------------:|----------:|----------:|------------:|
| WriteToPersistence |                1 |           100 |    654.4 us |  31.10 us |  87.20 us |    647.0 us |         - |         - |    131.8 KB |
| WriteToPersistence |               10 |           100 |  1,786.2 us |  75.45 us | 215.27 us |  1,712.7 us |         - |         - |  1287.63 KB |
| WriteToPersistence |              100 |           100 | 23,127.9 us | 454.94 us | 637.76 us | 23,165.5 us | 2000.0000 | 1000.0000 | 12685.84 KB |


