### PR TITLE
[obsolete] `ExpectNext(params T[] elems)` 

### DIFF
--- a/src/core/Akka.Persistence.TCK/Query/CurrentEventsByPersistenceIdSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/CurrentEventsByPersistenceIdSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -47,7 +48,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.CurrentEventsByPersistenceId("a", 0, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer);
             probe.Request(2)
-                .ExpectNext("a-1", "a-2")
+                .ExpectNext(CancellationToken.None, "a-1", "a-2")
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(500));
             probe.Request(2)
                 .ExpectNext("a-3")
@@ -62,7 +63,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.CurrentEventsByPersistenceId("b", 0L, 2L);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer)
                 .Request(5)
-                .ExpectNext("b-1", "b-2")
+                .ExpectNext(CancellationToken.None, "b-1", "b-2")
                 .ExpectComplete();
         }
 
@@ -74,7 +75,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.CurrentEventsByPersistenceId("f", 0L, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer);
             probe.Request(2)
-                .ExpectNext("f-1", "f-2")
+                .ExpectNext(CancellationToken.None, "f-1", "f-2")
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             pref.Tell("f-4");

--- a/src/core/Akka.Persistence.TCK/Query/CurrentEventsByPersistenceIdSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/CurrentEventsByPersistenceIdSpec.cs
@@ -48,7 +48,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.CurrentEventsByPersistenceId("a", 0, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer);
             probe.Request(2)
-                .ExpectNext(CancellationToken.None, "a-1", "a-2")
+                .ExpectNext( "a-1", "a-2")
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(500));
             probe.Request(2)
                 .ExpectNext("a-3")
@@ -63,7 +63,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.CurrentEventsByPersistenceId("b", 0L, 2L);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer)
                 .Request(5)
-                .ExpectNext(CancellationToken.None, "b-1", "b-2")
+                .ExpectNext( "b-1", "b-2")
                 .ExpectComplete();
         }
 
@@ -75,7 +75,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.CurrentEventsByPersistenceId("f", 0L, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer);
             probe.Request(2)
-                .ExpectNext(CancellationToken.None, "f-1", "f-2")
+                .ExpectNext( "f-1", "f-2")
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             pref.Tell("f-4");

--- a/src/core/Akka.Persistence.TCK/Query/EventsByPersistenceIdSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/EventsByPersistenceIdSpec.cs
@@ -48,7 +48,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.EventsByPersistenceId("c", 0, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer)
                 .Request(5)
-                .ExpectNext(CancellationToken.None, "c-1", "c-2", "c-3");
+                .ExpectNext( "c-1", "c-2", "c-3");
 
             pref.Tell("c-4");
             ExpectMsg("c-4-done");
@@ -65,7 +65,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.EventsByPersistenceId("d", 0, 4);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer)
                 .Request(5)
-                .ExpectNext(CancellationToken.None, "d-1", "d-2", "d-3");
+                .ExpectNext( "d-1", "d-2", "d-3");
 
             pref.Tell("d-4");
             ExpectMsg("d-4-done");
@@ -82,7 +82,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.EventsByPersistenceId("e", 0, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer);
             probe.Request(2)
-                .ExpectNext(CancellationToken.None, "e-1", "e-2")
+                .ExpectNext( "e-1", "e-2")
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             pref.Tell("e-4");

--- a/src/core/Akka.Persistence.TCK/Query/EventsByPersistenceIdSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/EventsByPersistenceIdSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -47,7 +48,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.EventsByPersistenceId("c", 0, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer)
                 .Request(5)
-                .ExpectNext("c-1", "c-2", "c-3");
+                .ExpectNext(CancellationToken.None, "c-1", "c-2", "c-3");
 
             pref.Tell("c-4");
             ExpectMsg("c-4-done");
@@ -64,7 +65,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.EventsByPersistenceId("d", 0, 4);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer)
                 .Request(5)
-                .ExpectNext("d-1", "d-2", "d-3");
+                .ExpectNext(CancellationToken.None, "d-1", "d-2", "d-3");
 
             pref.Tell("d-4");
             ExpectMsg("d-4-done");
@@ -81,7 +82,7 @@ namespace Akka.Persistence.TCK.Query
             var src = queries.EventsByPersistenceId("e", 0, long.MaxValue);
             var probe = src.Select(x => x.Event).RunWith(this.SinkProbe<object>(), Materializer);
             probe.Request(2)
-                .ExpectNext("e-1", "e-2")
+                .ExpectNext(CancellationToken.None, "e-1", "e-2")
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             pref.Tell("e-4");

--- a/src/core/Akka.Streams.TestKit/TestSubscriber_Fluent.cs
+++ b/src/core/Akka.Streams.TestKit/TestSubscriber_Fluent.cs
@@ -66,7 +66,6 @@ namespace Akka.Streams.TestKit
             /// <summary>
             /// Fluent DSL. Expect multiple stream elements.
             /// </summary>
-            [Obsolete("Use the method with CancellationToken support instead")]
             public ManualProbe<T> ExpectNext(params T[] elems)
             {
                 ExpectNextTask(this, null, default, elems)

--- a/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -132,7 +133,7 @@ namespace Akka.Streams.Tests.Dsl
                 actorRef.Tell(3);
                 actorRef.Tell(new Status.Success("ok"));
                 sub.Request(10);
-                s.ExpectNext(1, 2, 3);
+                s.ExpectNext(CancellationToken.None, 1, 2, 3);
                 s.ExpectComplete();
             }, Materializer);
         }
@@ -155,7 +156,7 @@ namespace Akka.Streams.Tests.Dsl
                 actorRef.Tell(100);
                 actorRef.Tell(100);
                 sub.Request(10);
-                s.ExpectNext(1, 2, 3);
+                s.ExpectNext(CancellationToken.None, 1, 2, 3);
                 s.ExpectComplete();
 
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
@@ -133,7 +133,7 @@ namespace Akka.Streams.Tests.Dsl
                 actorRef.Tell(3);
                 actorRef.Tell(new Status.Success("ok"));
                 sub.Request(10);
-                s.ExpectNext(CancellationToken.None, 1, 2, 3);
+                s.ExpectNext( 1, 2, 3);
                 s.ExpectComplete();
             }, Materializer);
         }
@@ -156,7 +156,7 @@ namespace Akka.Streams.Tests.Dsl
                 actorRef.Tell(100);
                 actorRef.Tell(100);
                 sub.Request(10);
-                s.ExpectNext(CancellationToken.None, 1, 2, 3);
+                s.ExpectNext( 1, 2, 3);
                 s.ExpectComplete();
 
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
@@ -184,7 +184,7 @@ namespace Akka.Streams.Tests.Dsl
             source.SendNext(1);
 
             sink.Request(4)
-                .ExpectNext(CancellationToken.None, (1, 0), (1, 1), (1, 2))
+                .ExpectNext( (1, 0), (1, 1), (1, 2))
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             source.SendNext(2).SendComplete();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
@@ -184,7 +184,7 @@ namespace Akka.Streams.Tests.Dsl
             source.SendNext(1);
 
             sink.Request(4)
-                .ExpectNext((1, 0), (1, 1), (1, 2))
+                .ExpectNext(CancellationToken.None, (1, 0), (1, 1), (1, 2))
                 .ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             source.SendNext(2).SendComplete();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowInterleaveSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowInterleaveSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Util.Internal;
@@ -68,7 +69,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 probe.ExpectSubscription().Request(10);
-                probe.ExpectNext(0, 1, 3, 4, 2, 5);
+                probe.ExpectNext(CancellationToken.None, 0, 1, 3, 4, 2, 5);
                 probe.ExpectComplete();
             }, Materializer);
         }
@@ -85,7 +86,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 probe.ExpectSubscription().Request(10);
-                probe.ExpectNext(0, 3, 1, 4, 2, 5);
+                probe.ExpectNext(CancellationToken.None, 0, 3, 1, 4, 2, 5);
                 probe.ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowInterleaveSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowInterleaveSpec.cs
@@ -69,7 +69,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 probe.ExpectSubscription().Request(10);
-                probe.ExpectNext(CancellationToken.None, 0, 1, 3, 4, 2, 5);
+                probe.ExpectNext( 0, 1, 3, 4, 2, 5);
                 probe.ExpectComplete();
             }, Materializer);
         }
@@ -86,7 +86,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 probe.ExpectSubscription().Request(10);
-                probe.ExpectNext(CancellationToken.None, 0, 3, 1, 4, 2, 5);
+                probe.ExpectNext( 0, 3, 1, 4, 2, 5);
                 probe.ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowKillSwitchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowKillSwitchSpec.cs
@@ -220,7 +220,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 downstream2.Request(2);
                 upstream2.SendNext("A").SendNext("B");
-                downstream2.ExpectNext(CancellationToken.None, "A", "B");
+                downstream2.ExpectNext( "A", "B");
 
                 killSwitch.Shutdown();
 
@@ -258,7 +258,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 downstream2.Request(2);
                 upstream2.SendNext("A").SendNext("B");
-                downstream2.ExpectNext(CancellationToken.None, "A", "B");
+                downstream2.ExpectNext( "A", "B");
 
                 var testException = new TestException("Abort");
                 killSwitch.Abort(testException);
@@ -591,7 +591,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 downstream2.Request(2);
                 upstream2.SendNext("A").SendNext("B");
-                downstream2.ExpectNext(CancellationToken.None, "A", "B");
+                downstream2.ExpectNext( "A", "B");
 
                 cancel.Cancel();
 
@@ -629,7 +629,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 downstream2.Request(2);
                 upstream2.SendNext("A").SendNext("B");
-                downstream2.ExpectNext(CancellationToken.None, "A", "B");
+                downstream2.ExpectNext( "A", "B");
 
                 cancel.Cancel();
                 upstream1.ExpectCancellation();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowKillSwitchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowKillSwitchSpec.cs
@@ -220,7 +220,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 downstream2.Request(2);
                 upstream2.SendNext("A").SendNext("B");
-                downstream2.ExpectNext("A", "B");
+                downstream2.ExpectNext(CancellationToken.None, "A", "B");
 
                 killSwitch.Shutdown();
 
@@ -258,7 +258,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 downstream2.Request(2);
                 upstream2.SendNext("A").SendNext("B");
-                downstream2.ExpectNext("A", "B");
+                downstream2.ExpectNext(CancellationToken.None, "A", "B");
 
                 var testException = new TestException("Abort");
                 killSwitch.Abort(testException);
@@ -591,7 +591,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 downstream2.Request(2);
                 upstream2.SendNext("A").SendNext("B");
-                downstream2.ExpectNext("A", "B");
+                downstream2.ExpectNext(CancellationToken.None, "A", "B");
 
                 cancel.Cancel();
 
@@ -629,7 +629,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 downstream2.Request(2);
                 upstream2.SendNext("A").SendNext("B");
-                downstream2.ExpectNext("A", "B");
+                downstream2.ExpectNext(CancellationToken.None, "A", "B");
 
                 cancel.Cancel();
                 upstream1.ExpectCancellation();

--- a/src/core/Akka.Streams.Tests/Dsl/FlowRecoverSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowRecoverSpec.cs
@@ -81,7 +81,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Recover(_ => Option<int>.Create(0))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
-                    .ExpectNext(CancellationToken.None, 1, 2, 3)
+                    .ExpectNext( 1, 2, 3)
                     .ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowRecoverSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowRecoverSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.Util;
@@ -80,7 +81,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Recover(_ => Option<int>.Create(0))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
-                    .ExpectNext(1, 2, 3)
+                    .ExpectNext(CancellationToken.None, 1, 2, 3)
                     .ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowRecoverWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowRecoverWithSpec.cs
@@ -72,7 +72,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 probe
                     .Request(2)
-                    .ExpectNext(CancellationToken.None, 1, 2);
+                    .ExpectNext( 1, 2);
 
                 probe
                     .Request(1)
@@ -119,15 +119,15 @@ namespace Akka.Streams.Tests.Dsl
 
                 probe
                     .Request(2)
-                    .ExpectNext(CancellationToken.None, 1, 2);
+                    .ExpectNext( 1, 2);
 
                 probe
                     .Request(2)
-                    .ExpectNext(CancellationToken.None, 1, 2);
+                    .ExpectNext( 1, 2);
 
                 probe
                     .Request(2)
-                    .ExpectNext(CancellationToken.None, 1, 2);
+                    .ExpectNext( 1, 2);
 
                 probe.Cancel();
             }, Materializer);
@@ -143,7 +143,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RecoverWithRetries(_ => Source.Single(0), -1)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
-                    .ExpectNext(CancellationToken.None, 1, 2, 3)
+                    .ExpectNext( 1, 2, 3)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -188,11 +188,11 @@ namespace Akka.Streams.Tests.Dsl
 
                 probe
                     .Request(2)
-                    .ExpectNext(CancellationToken.None, 1, 2);
+                    .ExpectNext( 1, 2);
 
                 probe
                     .Request(2)
-                    .ExpectNext(CancellationToken.None, 11, 33);
+                    .ExpectNext( 11, 33);
 
                 probe
                     .Request(1)
@@ -228,7 +228,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 probe
                     .Request(2)
-                    .ExpectNext(CancellationToken.None, 1, 2);
+                    .ExpectNext( 1, 2);
 
                 probe
                     .Request(1)
@@ -261,10 +261,10 @@ namespace Akka.Streams.Tests.Dsl
                         }), 3)
                     .RunWith(this.SinkProbe<int>(), Materializer);
 
-                probe.Request(2).ExpectNext(CancellationToken.None, 1, 2);
-                probe.Request(2).ExpectNext(CancellationToken.None, 11, 22);
-                probe.Request(2).ExpectNext(CancellationToken.None, 11, 22);
-                probe.Request(2).ExpectNext(CancellationToken.None, 11, 22);
+                probe.Request(2).ExpectNext( 1, 2);
+                probe.Request(2).ExpectNext( 11, 22);
+                probe.Request(2).ExpectNext( 11, 22);
+                probe.Request(2).ExpectNext( 11, 22);
                 probe.Request(1).ExpectError().Should().Be(Ex);
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowRecoverWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowRecoverWithSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.Stage;
 using Akka.Streams.TestKit;
@@ -71,7 +72,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 probe
                     .Request(2)
-                    .ExpectNext(1, 2);
+                    .ExpectNext(CancellationToken.None, 1, 2);
 
                 probe
                     .Request(1)
@@ -118,15 +119,15 @@ namespace Akka.Streams.Tests.Dsl
 
                 probe
                     .Request(2)
-                    .ExpectNext(1, 2);
+                    .ExpectNext(CancellationToken.None, 1, 2);
 
                 probe
                     .Request(2)
-                    .ExpectNext(1, 2);
+                    .ExpectNext(CancellationToken.None, 1, 2);
 
                 probe
                     .Request(2)
-                    .ExpectNext(1, 2);
+                    .ExpectNext(CancellationToken.None, 1, 2);
 
                 probe.Cancel();
             }, Materializer);
@@ -142,7 +143,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RecoverWithRetries(_ => Source.Single(0), -1)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
-                    .ExpectNext(1, 2, 3)
+                    .ExpectNext(CancellationToken.None, 1, 2, 3)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -187,11 +188,11 @@ namespace Akka.Streams.Tests.Dsl
 
                 probe
                     .Request(2)
-                    .ExpectNext(1, 2);
+                    .ExpectNext(CancellationToken.None, 1, 2);
 
                 probe
                     .Request(2)
-                    .ExpectNext(11, 33);
+                    .ExpectNext(CancellationToken.None, 11, 33);
 
                 probe
                     .Request(1)
@@ -227,7 +228,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 probe
                     .Request(2)
-                    .ExpectNext(1, 2);
+                    .ExpectNext(CancellationToken.None, 1, 2);
 
                 probe
                     .Request(1)
@@ -260,10 +261,10 @@ namespace Akka.Streams.Tests.Dsl
                         }), 3)
                     .RunWith(this.SinkProbe<int>(), Materializer);
 
-                probe.Request(2).ExpectNext(1, 2);
-                probe.Request(2).ExpectNext(11, 22);
-                probe.Request(2).ExpectNext(11, 22);
-                probe.Request(2).ExpectNext(11, 22);
+                probe.Request(2).ExpectNext(CancellationToken.None, 1, 2);
+                probe.Request(2).ExpectNext(CancellationToken.None, 11, 22);
+                probe.Request(2).ExpectNext(CancellationToken.None, 11, 22);
+                probe.Request(2).ExpectNext(CancellationToken.None, 11, 22);
                 probe.Request(1).ExpectError().Should().Be(Ex);
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowScanAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowScanAsyncSpec.cs
@@ -54,7 +54,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Via(SumScanFlow)
                 .RunWith(this.SinkProbe<int>(), Materializer)
                 .Request(2)
-                .ExpectNext(CancellationToken.None, 0, 1)
+                .ExpectNext( 0, 1)
                 .ExpectComplete();
         }
 
@@ -102,7 +102,7 @@ namespace Akka.Streams.Tests.Dsl
             var elements = new[] { 1, -1, 1 };
 
             WhenFailedScan(elements, 0, decider: Deciders.RestartingDecider)
-                .ExpectNext(CancellationToken.None, 1, 1)
+                .ExpectNext( 1, 1)
                 .ExpectComplete();
         }
 
@@ -112,7 +112,7 @@ namespace Akka.Streams.Tests.Dsl
             var elements = new[] { 1, -1, 1 };
 
             WhenFailedTask(elements, 0, decider: Deciders.RestartingDecider)
-                .ExpectNext(CancellationToken.None, 1, 1)
+                .ExpectNext( 1, 1)
                 .ExpectComplete();
         }
 
@@ -122,7 +122,7 @@ namespace Akka.Streams.Tests.Dsl
             var elements = new[] { 1, -1, 1 };
 
             WhenFailedScan(elements, 0, decider: Deciders.ResumingDecider)
-                .ExpectNext(CancellationToken.None, 1, 2)
+                .ExpectNext( 1, 2)
                 .ExpectComplete();
         }
 
@@ -132,7 +132,7 @@ namespace Akka.Streams.Tests.Dsl
             var elements = new[] { 1, -1, 1 };
 
             WhenFailedTask(elements, 0, decider: Deciders.ResumingDecider)
-                .ExpectNext(CancellationToken.None, 1, 2)
+                .ExpectNext( 1, 2)
                 .ExpectComplete();
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowScanAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowScanAsyncSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Implementation;
@@ -53,7 +54,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Via(SumScanFlow)
                 .RunWith(this.SinkProbe<int>(), Materializer)
                 .Request(2)
-                .ExpectNext(0, 1)
+                .ExpectNext(CancellationToken.None, 0, 1)
                 .ExpectComplete();
         }
 
@@ -101,7 +102,7 @@ namespace Akka.Streams.Tests.Dsl
             var elements = new[] { 1, -1, 1 };
 
             WhenFailedScan(elements, 0, decider: Deciders.RestartingDecider)
-                .ExpectNext(1, 1)
+                .ExpectNext(CancellationToken.None, 1, 1)
                 .ExpectComplete();
         }
 
@@ -111,7 +112,7 @@ namespace Akka.Streams.Tests.Dsl
             var elements = new[] { 1, -1, 1 };
 
             WhenFailedTask(elements, 0, decider: Deciders.RestartingDecider)
-                .ExpectNext(1, 1)
+                .ExpectNext(CancellationToken.None, 1, 1)
                 .ExpectComplete();
         }
 
@@ -121,7 +122,7 @@ namespace Akka.Streams.Tests.Dsl
             var elements = new[] { 1, -1, 1 };
 
             WhenFailedScan(elements, 0, decider: Deciders.ResumingDecider)
-                .ExpectNext(1, 2)
+                .ExpectNext(CancellationToken.None, 1, 2)
                 .ExpectComplete();
         }
 
@@ -131,7 +132,7 @@ namespace Akka.Streams.Tests.Dsl
             var elements = new[] { 1, -1, 1 };
 
             WhenFailedTask(elements, 0, decider: Deciders.ResumingDecider)
-                .ExpectNext(1, 2)
+                .ExpectNext(CancellationToken.None, 1, 2)
                 .ExpectComplete();
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectManySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectManySpec.cs
@@ -90,7 +90,7 @@ namespace Akka.Streams.Tests.Dsl
                 })
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                 .RunWith(this.SinkProbe<int>(), Materializer)
-                .Request(4).ExpectNext(1, 2, 4, 5)
+                .Request(4).ExpectNext(CancellationToken.None, 1, 2, 4, 5)
                 .ExpectComplete();
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectManySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectManySpec.cs
@@ -90,7 +90,7 @@ namespace Akka.Streams.Tests.Dsl
                 })
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                 .RunWith(this.SinkProbe<int>(), Materializer)
-                .Request(4).ExpectNext(CancellationToken.None, 1, 2, 4, 5)
+                .Request(4).ExpectNext( 1, 2, 4, 5)
                 .ExpectComplete();
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhileSpec.cs
@@ -36,7 +36,7 @@ namespace Akka.Streams.Tests.Dsl
                     .SkipWhile(x => x < 3)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(2)
-                    .ExpectNext(CancellationToken.None, 3, 4)
+                    .ExpectNext( 3, 4)
                     .ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSkipWhileSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
@@ -35,7 +36,7 @@ namespace Akka.Streams.Tests.Dsl
                     .SkipWhile(x => x < 3)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(2)
-                    .ExpectNext(3, 4)
+                    .ExpectNext(CancellationToken.None, 3, 4)
                     .ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowStatefulSelectManySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowStatefulSelectManySpec.cs
@@ -92,8 +92,8 @@ namespace Akka.Streams.Tests.Dsl
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.RestartingDecider))
                 .RunWith(this.SinkProbe<int>(), Materializer);
 
-            probe.Request(2).ExpectNext(CancellationToken.None, 1, 1);
-            probe.Request(4).ExpectNext(CancellationToken.None, 1, 1, 1, 1);
+            probe.Request(2).ExpectNext( 1, 1);
+            probe.Request(4).ExpectNext( 1, 1, 1, 1);
             probe.ExpectComplete();
         }
 
@@ -123,9 +123,9 @@ namespace Akka.Streams.Tests.Dsl
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                 .RunWith(this.SinkProbe<int>(), Materializer);
 
-            probe.Request(2).ExpectNext(CancellationToken.None, 1, 1);
+            probe.Request(2).ExpectNext( 1, 1);
             probe.RequestNext(4);
-            probe.Request(4).ExpectNext(CancellationToken.None, 1, 1, 1, 1);
+            probe.Request(4).ExpectNext( 1, 1, 1, 1);
             probe.ExpectComplete();
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowStatefulSelectManySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowStatefulSelectManySpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
@@ -91,8 +92,8 @@ namespace Akka.Streams.Tests.Dsl
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.RestartingDecider))
                 .RunWith(this.SinkProbe<int>(), Materializer);
 
-            probe.Request(2).ExpectNext(1, 1);
-            probe.Request(4).ExpectNext(1, 1, 1, 1);
+            probe.Request(2).ExpectNext(CancellationToken.None, 1, 1);
+            probe.Request(4).ExpectNext(CancellationToken.None, 1, 1, 1, 1);
             probe.ExpectComplete();
         }
 
@@ -122,9 +123,9 @@ namespace Akka.Streams.Tests.Dsl
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                 .RunWith(this.SinkProbe<int>(), Materializer);
 
-            probe.Request(2).ExpectNext(1, 1);
+            probe.Request(2).ExpectNext(CancellationToken.None, 1, 1);
             probe.RequestNext(4);
-            probe.Request(4).ExpectNext(1, 1, 1, 1);
+            probe.Request(4).ExpectNext(CancellationToken.None, 1, 1, 1, 1);
             probe.ExpectComplete();
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowTakeWhileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowTakeWhileSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
@@ -35,7 +36,7 @@ namespace Akka.Streams.Tests.Dsl
                     .TakeWhile(i => i < 3)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
-                    .ExpectNext(1, 2)
+                    .ExpectNext(CancellationToken.None, 1, 2)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -69,7 +70,7 @@ namespace Akka.Streams.Tests.Dsl
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(4)
-                    .ExpectNext(1, 2, 4)
+                    .ExpectNext(CancellationToken.None, 1, 2, 4)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -83,7 +84,7 @@ namespace Akka.Streams.Tests.Dsl
                 .TakeWhile(i => i < 3, true)
                 .RunWith(this.SinkProbe<int>(), Materializer)
                 .Request(4)
-                .ExpectNext(1, 2, 3)
+                .ExpectNext(CancellationToken.None, 1, 2, 3)
                 .ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowTakeWhileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowTakeWhileSpec.cs
@@ -36,7 +36,7 @@ namespace Akka.Streams.Tests.Dsl
                     .TakeWhile(i => i < 3)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
-                    .ExpectNext(CancellationToken.None, 1, 2)
+                    .ExpectNext( 1, 2)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -70,7 +70,7 @@ namespace Akka.Streams.Tests.Dsl
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(4)
-                    .ExpectNext(CancellationToken.None, 1, 2, 4)
+                    .ExpectNext( 1, 2, 4)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -84,7 +84,7 @@ namespace Akka.Streams.Tests.Dsl
                 .TakeWhile(i => i < 3, true)
                 .RunWith(this.SinkProbe<int>(), Materializer)
                 .Request(4)
-                .ExpectNext(CancellationToken.None, 1, 2, 3)
+                .ExpectNext( 1, 2, 3)
                 .ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Akka.IO;
 using Akka.Streams.Actors;
 using Akka.Streams.Dsl;
@@ -53,7 +54,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Throttle(1, TimeSpan.FromMilliseconds(100), 0, ThrottleMode.Shaping)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(5)
-                    .ExpectNext(1, 2, 3, 4, 5)
+                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -67,7 +68,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Throttle(1, TimeSpan.FromTicks(1), 0, ThrottleMode.Shaping)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(5)
-                    .ExpectNext(1, 2, 3, 4, 5)
+                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -308,7 +309,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Throttle(1, TimeSpan.FromMilliseconds(100), 5, ThrottleMode.Enforcing)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(5)
-                    .ExpectNext(1, 2, 3, 4, 5)
+                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -324,7 +325,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Throttle(1, TimeSpan.FromMilliseconds(100), 0, _ => 1, ThrottleMode.Shaping)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(5)
-                    .ExpectNext(1, 2, 3, 4, 5)
+                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -511,7 +512,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Throttle(1, TimeSpan.FromMilliseconds(100), 5, ThrottleMode.Enforcing)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(5)
-                    .ExpectNext(1, 2, 3, 4, 5)
+                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
@@ -54,7 +54,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Throttle(1, TimeSpan.FromMilliseconds(100), 0, ThrottleMode.Shaping)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(5)
-                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
+                    .ExpectNext( 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -68,7 +68,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Throttle(1, TimeSpan.FromTicks(1), 0, ThrottleMode.Shaping)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(5)
-                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
+                    .ExpectNext( 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -309,7 +309,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Throttle(1, TimeSpan.FromMilliseconds(100), 5, ThrottleMode.Enforcing)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(5)
-                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
+                    .ExpectNext( 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -325,7 +325,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Throttle(1, TimeSpan.FromMilliseconds(100), 0, _ => 1, ThrottleMode.Shaping)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(5)
-                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
+                    .ExpectNext( 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }
@@ -512,7 +512,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Throttle(1, TimeSpan.FromMilliseconds(100), 5, ThrottleMode.Enforcing)
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(5)
-                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
+                    .ExpectNext( 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowWatchTerminationSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowWatchTerminationSpec.cs
@@ -40,7 +40,7 @@ namespace Akka.Streams.Tests.Dsl
                 var future = t.Item1;
                 var p = t.Item2;
 
-                p.Request(4).ExpectNext(CancellationToken.None, 1, 2, 3, 4);
+                p.Request(4).ExpectNext( 1, 2, 3, 4);
                 future.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 p.ExpectComplete();
             }, Materializer);
@@ -59,7 +59,7 @@ namespace Akka.Streams.Tests.Dsl
                 var future = t.Item1;
                 var p = t.Item2;
 
-                p.Request(3).ExpectNext(CancellationToken.None, 1, 2, 3);
+                p.Request(3).ExpectNext( 1, 2, 3);
                 p.Cancel();
                 future.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowWatchTerminationSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowWatchTerminationSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
@@ -39,7 +40,7 @@ namespace Akka.Streams.Tests.Dsl
                 var future = t.Item1;
                 var p = t.Item2;
 
-                p.Request(4).ExpectNext(1, 2, 3, 4);
+                p.Request(4).ExpectNext(CancellationToken.None, 1, 2, 3, 4);
                 future.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
                 p.ExpectComplete();
             }, Materializer);
@@ -58,7 +59,7 @@ namespace Akka.Streams.Tests.Dsl
                 var future = t.Item1;
                 var p = t.Item2;
 
-                p.Request(3).ExpectNext(1, 2, 3);
+                p.Request(3).ExpectNext(CancellationToken.None, 1, 2, 3);
                 p.Cancel();
                 future.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowWhereSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowWhereSpec.cs
@@ -81,7 +81,7 @@ namespace Akka.Streams.Tests.Dsl
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
-                    .ExpectNext(CancellationToken.None, 1, 3)
+                    .ExpectNext( 1, 3)
                     .ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowWhereSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowWhereSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
@@ -80,7 +81,7 @@ namespace Akka.Streams.Tests.Dsl
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(3)
-                    .ExpectNext(1, 3)
+                    .ExpectNext(CancellationToken.None, 1, 3)
                     .ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -55,7 +56,7 @@ namespace Akka.Streams.Tests.Dsl
                 c1.ExpectNext(1).ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
                 sub2.Request(2);
-                c2.ExpectNext(2, 3);
+                c2.ExpectNext(CancellationToken.None, 2, 3);
                 c1.ExpectComplete();
                 c2.ExpectComplete();
             }, Materializer);
@@ -92,7 +93,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 sub2.Request(2);
                 s1.ExpectNext(1);
-                s2.ExpectNext(2, 3);
+                s2.ExpectNext(CancellationToken.None, 2, 3);
                 s1.ExpectComplete();
                 s2.ExpectComplete();
             }, Materializer);
@@ -140,7 +141,7 @@ namespace Akka.Streams.Tests.Dsl
                 sub3.Cancel();
 
                 s1.ExpectNext(1);
-                s2.ExpectNext(2, 3);
+                s2.ExpectNext(CancellationToken.None, 2, 3);
                 s1.ExpectComplete();
                 s2.ExpectComplete();
             }, Materializer);
@@ -283,7 +284,7 @@ namespace Akka.Streams.Tests.Dsl
                 sub1.Cancel();
                 var sub2 = c2.ExpectSubscription();
                 sub2.Request(3);
-                c2.ExpectNext(1, 2, 3);
+                c2.ExpectNext(CancellationToken.None, 1, 2, 3);
                 c2.ExpectComplete();
             }, Materializer);
         }
@@ -310,7 +311,7 @@ namespace Akka.Streams.Tests.Dsl
                 var sub2 = c2.ExpectSubscription();
                 sub2.Cancel();
                 sub1.Request(3);
-                c1.ExpectNext(1, 2, 3);
+                c1.ExpectNext(CancellationToken.None, 1, 2, 3);
                 c1.ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
@@ -56,7 +56,7 @@ namespace Akka.Streams.Tests.Dsl
                 c1.ExpectNext(1).ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
                 sub2.Request(2);
-                c2.ExpectNext(CancellationToken.None, 2, 3);
+                c2.ExpectNext( 2, 3);
                 c1.ExpectComplete();
                 c2.ExpectComplete();
             }, Materializer);
@@ -93,7 +93,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 sub2.Request(2);
                 s1.ExpectNext(1);
-                s2.ExpectNext(CancellationToken.None, 2, 3);
+                s2.ExpectNext( 2, 3);
                 s1.ExpectComplete();
                 s2.ExpectComplete();
             }, Materializer);
@@ -141,7 +141,7 @@ namespace Akka.Streams.Tests.Dsl
                 sub3.Cancel();
 
                 s1.ExpectNext(1);
-                s2.ExpectNext(CancellationToken.None, 2, 3);
+                s2.ExpectNext( 2, 3);
                 s1.ExpectComplete();
                 s2.ExpectComplete();
             }, Materializer);
@@ -284,7 +284,7 @@ namespace Akka.Streams.Tests.Dsl
                 sub1.Cancel();
                 var sub2 = c2.ExpectSubscription();
                 sub2.Request(3);
-                c2.ExpectNext(CancellationToken.None, 1, 2, 3);
+                c2.ExpectNext( 1, 2, 3);
                 c2.ExpectComplete();
             }, Materializer);
         }
@@ -311,7 +311,7 @@ namespace Akka.Streams.Tests.Dsl
                 var sub2 = c2.ExpectSubscription();
                 sub2.Cancel();
                 sub1.Request(3);
-                c1.ExpectNext(CancellationToken.None, 1, 2, 3);
+                c1.ExpectNext( 1, 2, 3);
                 c1.ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
@@ -58,9 +58,9 @@ namespace Akka.Streams.Tests.Dsl
                 sub2.Request(2);
 
                 c1.ExpectNext(1).ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-                c2.ExpectNext(CancellationToken.None, 1, 2).ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+                c2.ExpectNext( 1, 2).ExpectNoMsg(TimeSpan.FromMilliseconds(100));
                 sub1.Request(3);
-                c1.ExpectNext(CancellationToken.None, 2, 3).ExpectComplete();
+                c1.ExpectNext( 2, 3).ExpectComplete();
                 sub2.Request(3);
                 c2.ExpectNext(3).ExpectComplete();
             }, Materializer);
@@ -191,7 +191,7 @@ namespace Akka.Streams.Tests.Dsl
                 sub1.Cancel();
                 var sub2 = c2.ExpectSubscription();
                 sub2.Request(3);
-                c2.ExpectNext(CancellationToken.None, 1, 2, 3);
+                c2.ExpectNext( 1, 2, 3);
                 c2.ExpectComplete();
             }, Materializer);
         }
@@ -221,7 +221,7 @@ namespace Akka.Streams.Tests.Dsl
                 var sub2 = c2.ExpectSubscription();
                 sub2.Cancel();
                 sub1.Request(3);
-                c1.ExpectNext(CancellationToken.None, 1, 2, 3);
+                c1.ExpectNext( 1, 2, 3);
                 c1.ExpectComplete();
             }, Materializer);
         }
@@ -317,8 +317,8 @@ namespace Akka.Streams.Tests.Dsl
 
                 ps1.Request(6);
                 ps2.Request(6);
-                ps1.ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5, 6);
-                ps2.ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5, 6);
+                ps1.ExpectNext( 1, 2, 3, 4, 5, 6);
+                ps2.ExpectNext( 1, 2, 3, 4, 5, 6);
                 ps1.ExpectComplete();
                 ps2.ExpectComplete();
             }, Materializer);
@@ -343,7 +343,7 @@ namespace Akka.Streams.Tests.Dsl
                 
                 ps2.Request(6);
                 ps1.Cancel();
-                ps2.ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5, 6);
+                ps2.ExpectNext( 1, 2, 3, 4, 5, 6);
                 ps2.ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -57,9 +58,9 @@ namespace Akka.Streams.Tests.Dsl
                 sub2.Request(2);
 
                 c1.ExpectNext(1).ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-                c2.ExpectNext(1, 2).ExpectNoMsg(TimeSpan.FromMilliseconds(100));
+                c2.ExpectNext(CancellationToken.None, 1, 2).ExpectNoMsg(TimeSpan.FromMilliseconds(100));
                 sub1.Request(3);
-                c1.ExpectNext(2, 3).ExpectComplete();
+                c1.ExpectNext(CancellationToken.None, 2, 3).ExpectComplete();
                 sub2.Request(3);
                 c2.ExpectNext(3).ExpectComplete();
             }, Materializer);
@@ -190,7 +191,7 @@ namespace Akka.Streams.Tests.Dsl
                 sub1.Cancel();
                 var sub2 = c2.ExpectSubscription();
                 sub2.Request(3);
-                c2.ExpectNext(1, 2, 3);
+                c2.ExpectNext(CancellationToken.None, 1, 2, 3);
                 c2.ExpectComplete();
             }, Materializer);
         }
@@ -220,7 +221,7 @@ namespace Akka.Streams.Tests.Dsl
                 var sub2 = c2.ExpectSubscription();
                 sub2.Cancel();
                 sub1.Request(3);
-                c1.ExpectNext(1, 2, 3);
+                c1.ExpectNext(CancellationToken.None, 1, 2, 3);
                 c1.ExpectComplete();
             }, Materializer);
         }
@@ -316,8 +317,8 @@ namespace Akka.Streams.Tests.Dsl
 
                 ps1.Request(6);
                 ps2.Request(6);
-                ps1.ExpectNext(1, 2, 3, 4, 5, 6);
-                ps2.ExpectNext(1, 2, 3, 4, 5, 6);
+                ps1.ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5, 6);
+                ps2.ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5, 6);
                 ps1.ExpectComplete();
                 ps2.ExpectComplete();
             }, Materializer);
@@ -342,7 +343,7 @@ namespace Akka.Streams.Tests.Dsl
                 
                 ps2.Request(6);
                 ps1.Cancel();
-                ps2.ExpectNext(1, 2, 3, 4, 5, 6);
+                ps2.ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5, 6);
                 ps2.ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/GraphConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphConcatSpec.cs
@@ -86,13 +86,13 @@ namespace Akka.Streams.Tests.Dsl
                 var subscription1 = subscriber1.ExpectSubscription();
 
                 subscription1.Request(5);
-                subscriber1.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
+                subscriber1.ExpectNext( 1, 2, 3, 4).ExpectComplete();
 
                 var subscriber2 = Setup(NonEmptyPublisher(Enumerable.Range(1, 4)), CompletedPublisher<int>());
                 var subscription2 = subscriber2.ExpectSubscription();
 
                 subscription2.Request(5);
-                subscriber2.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
+                subscriber2.ExpectNext( 1, 2, 3, 4).ExpectComplete();
             }, Materializer);
         }
 
@@ -105,13 +105,13 @@ namespace Akka.Streams.Tests.Dsl
                 var subscription1 = subscriber1.ExpectSubscription();
 
                 subscription1.Request(5);
-                subscriber1.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
+                subscriber1.ExpectNext( 1, 2, 3, 4).ExpectComplete();
 
                 var subscriber2 = Setup(NonEmptyPublisher(Enumerable.Range(1, 4)), SoonToCompletePublisher<int>());
                 var subscription2 = subscriber2.ExpectSubscription();
 
                 subscription2.Request(5);
-                subscriber2.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
+                subscriber2.ExpectNext( 1, 2, 3, 4).ExpectComplete();
             }, Materializer);
         }
 
@@ -193,7 +193,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 var subscription = subscriber.ExpectSubscription();
                 subscription.Request(4);
-                subscriber.ExpectNext(CancellationToken.None, 1, 2, 3);
+                subscriber.ExpectNext( 1, 2, 3);
                 promise.SetException(TestException());
                 subscriber.ExpectError().Should().Be(TestException());
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/GraphConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphConcatSpec.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -85,13 +86,13 @@ namespace Akka.Streams.Tests.Dsl
                 var subscription1 = subscriber1.ExpectSubscription();
 
                 subscription1.Request(5);
-                subscriber1.ExpectNext(1, 2, 3, 4).ExpectComplete();
+                subscriber1.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
 
                 var subscriber2 = Setup(NonEmptyPublisher(Enumerable.Range(1, 4)), CompletedPublisher<int>());
                 var subscription2 = subscriber2.ExpectSubscription();
 
                 subscription2.Request(5);
-                subscriber2.ExpectNext(1, 2, 3, 4).ExpectComplete();
+                subscriber2.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
             }, Materializer);
         }
 
@@ -104,13 +105,13 @@ namespace Akka.Streams.Tests.Dsl
                 var subscription1 = subscriber1.ExpectSubscription();
 
                 subscription1.Request(5);
-                subscriber1.ExpectNext(1, 2, 3, 4).ExpectComplete();
+                subscriber1.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
 
                 var subscriber2 = Setup(NonEmptyPublisher(Enumerable.Range(1, 4)), SoonToCompletePublisher<int>());
                 var subscription2 = subscriber2.ExpectSubscription();
 
                 subscription2.Request(5);
-                subscriber2.ExpectNext(1, 2, 3, 4).ExpectComplete();
+                subscriber2.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
             }, Materializer);
         }
 
@@ -192,7 +193,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 var subscription = subscriber.ExpectSubscription();
                 subscription.Request(4);
-                subscriber.ExpectNext(1, 2, 3);
+                subscriber.ExpectNext(CancellationToken.None, 1, 2, 3);
                 promise.SetException(TestException());
                 subscriber.ExpectError().Should().Be(TestException());
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
@@ -156,12 +156,12 @@ namespace Akka.Streams.Tests.Dsl
                 var subscriber1 = Setup(CompletedPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.ExpectSubscription();
                 subscription1.Request(4);
-                subscriber1.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
+                subscriber1.ExpectNext( 1, 2, 3, 4).ExpectComplete();
 
                 var subscriber2 = Setup(NonEmptyPublisher(Enumerable.Range(1, 4)), CompletedPublisher<int>());
                 var subscription2 = subscriber2.ExpectSubscription();
                 subscription2.Request(4);
-                subscriber2.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
+                subscriber2.ExpectNext( 1, 2, 3, 4).ExpectComplete();
             }, Materializer);
         }
 
@@ -173,12 +173,12 @@ namespace Akka.Streams.Tests.Dsl
                 var subscriber1 = Setup(SoonToCompletePublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.ExpectSubscription();
                 subscription1.Request(4);
-                subscriber1.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
+                subscriber1.ExpectNext( 1, 2, 3, 4).ExpectComplete();
 
                 var subscriber2 = Setup(NonEmptyPublisher(Enumerable.Range(1, 4)), SoonToCompletePublisher<int>());
                 var subscription2 = subscriber2.ExpectSubscription();
                 subscription2.Request(4);
-                subscriber2.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
+                subscriber2.ExpectNext( 1, 2, 3, 4).ExpectComplete();
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
@@ -155,12 +156,12 @@ namespace Akka.Streams.Tests.Dsl
                 var subscriber1 = Setup(CompletedPublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.ExpectSubscription();
                 subscription1.Request(4);
-                subscriber1.ExpectNext(1, 2, 3, 4).ExpectComplete();
+                subscriber1.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
 
                 var subscriber2 = Setup(NonEmptyPublisher(Enumerable.Range(1, 4)), CompletedPublisher<int>());
                 var subscription2 = subscriber2.ExpectSubscription();
                 subscription2.Request(4);
-                subscriber2.ExpectNext(1, 2, 3, 4).ExpectComplete();
+                subscriber2.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
             }, Materializer);
         }
 
@@ -172,12 +173,12 @@ namespace Akka.Streams.Tests.Dsl
                 var subscriber1 = Setup(SoonToCompletePublisher<int>(), NonEmptyPublisher(Enumerable.Range(1, 4)));
                 var subscription1 = subscriber1.ExpectSubscription();
                 subscription1.Request(4);
-                subscriber1.ExpectNext(1, 2, 3, 4).ExpectComplete();
+                subscriber1.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
 
                 var subscriber2 = Setup(NonEmptyPublisher(Enumerable.Range(1, 4)), SoonToCompletePublisher<int>());
                 var subscription2 = subscriber2.ExpectSubscription();
                 subscription2.Request(4);
-                subscriber2.ExpectNext(1, 2, 3, 4).ExpectComplete();
+                subscriber2.ExpectNext(CancellationToken.None, 1, 2, 3, 4).ExpectComplete();
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphOpsIntegrationSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphOpsIntegrationSpec.cs
@@ -228,7 +228,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var sub = s.ExpectSubscription();
             sub.Request(10);
-            s.ExpectNext(CancellationToken.None, 1 *2, 2*2, 3*2).ExpectComplete();
+            s.ExpectNext( 1 *2, 2*2, 3*2).ExpectComplete();
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/GraphOpsIntegrationSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphOpsIntegrationSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -227,7 +228,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var sub = s.ExpectSubscription();
             sub.Request(10);
-            s.ExpectNext(1*2, 2*2, 3*2).ExpectComplete();
+            s.ExpectNext(CancellationToken.None, 1 *2, 2*2, 3*2).ExpectComplete();
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/GraphPartitionSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphPartitionSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -82,7 +83,7 @@ namespace Akka.Streams.Tests.Dsl
                 c1.Request(1);
                 c2.Request(4);
                 c1.ExpectNext("another");
-                c2.ExpectNext("this", "is", "just", "test");
+                c2.ExpectNext(CancellationToken.None, "this", "is", "just", "test");
                 c1.ExpectComplete();
                 c2.ExpectComplete();
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/GraphPartitionSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphPartitionSpec.cs
@@ -83,7 +83,7 @@ namespace Akka.Streams.Tests.Dsl
                 c1.Request(1);
                 c2.Request(4);
                 c1.ExpectNext("another");
-                c2.ExpectNext(CancellationToken.None, "this", "is", "just", "test");
+                c2.ExpectNext( "this", "is", "just", "test");
                 c1.ExpectComplete();
                 c2.ExpectComplete();
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
@@ -112,7 +112,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
                 downstream.Request(5);
-                downstream.ExpectNext(CancellationToken.None, 1, 2, 3);
+                downstream.ExpectNext( 1, 2, 3);
 
                 downstream.ExpectNoMsg(TimeSpan.FromSeconds(1));
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphStageTimersSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Streams.Dsl;
@@ -111,7 +112,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.FromSubscriber(downstream), Materializer);
 
                 downstream.Request(5);
-                downstream.ExpectNext(1, 2, 3);
+                downstream.ExpectNext(CancellationToken.None, 1, 2, 3);
 
                 downstream.ExpectNoMsg(TimeSpan.FromSeconds(1));
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphUnzipSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphUnzipSpec.cs
@@ -64,10 +64,10 @@ namespace Akka.Streams.Tests.Dsl
                 sub2.Request(2);
                 c1.ExpectNext(1*2);
                 c1.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-                c2.ExpectNext(CancellationToken.None, "a", "b");
+                c2.ExpectNext( "a", "b");
                 c2.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
                 sub1.Request(3);
-                c1.ExpectNext(CancellationToken.None, 2*2, 3*2);
+                c1.ExpectNext( 2*2, 3*2);
                 c1.ExpectComplete();
                 sub2.Request(3);
                 c2.ExpectNext("c");
@@ -106,7 +106,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 sub1.Cancel();
                 sub2.Request(3);
-                c2.ExpectNext(CancellationToken.None, "a", "b", "c");
+                c2.ExpectNext( "a", "b", "c");
                 c2.ExpectComplete();
             }, Materializer);
         }
@@ -142,7 +142,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 sub2.Cancel();
                 sub1.Request(3);
-                c1.ExpectNext(CancellationToken.None, 1, 2, 3);
+                c1.ExpectNext( 1, 2, 3);
                 c1.ExpectComplete();
             }, Materializer);
         }
@@ -175,7 +175,7 @@ namespace Akka.Streams.Tests.Dsl
             sub2.Request(3);
             sub1.Request(3);
             sub2.Cancel();
-            c1.ExpectNext(CancellationToken.None, 1,2,3);
+            c1.ExpectNext( 1,2,3);
             c1.ExpectComplete();
         }
 
@@ -206,7 +206,7 @@ namespace Akka.Streams.Tests.Dsl
             sub2.Request(3);
             sub2.Cancel();
             sub1.Request(3);
-            c1.ExpectNext(CancellationToken.None, 1, 2, 3);
+            c1.ExpectNext( 1, 2, 3);
             c1.ExpectComplete();
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphUnzipSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphUnzipSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
@@ -63,10 +64,10 @@ namespace Akka.Streams.Tests.Dsl
                 sub2.Request(2);
                 c1.ExpectNext(1*2);
                 c1.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
-                c2.ExpectNext("a", "b");
+                c2.ExpectNext(CancellationToken.None, "a", "b");
                 c2.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
                 sub1.Request(3);
-                c1.ExpectNext(2*2, 3*2);
+                c1.ExpectNext(CancellationToken.None, 2*2, 3*2);
                 c1.ExpectComplete();
                 sub2.Request(3);
                 c2.ExpectNext("c");
@@ -105,7 +106,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 sub1.Cancel();
                 sub2.Request(3);
-                c2.ExpectNext("a", "b", "c");
+                c2.ExpectNext(CancellationToken.None, "a", "b", "c");
                 c2.ExpectComplete();
             }, Materializer);
         }
@@ -141,7 +142,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 sub2.Cancel();
                 sub1.Request(3);
-                c1.ExpectNext(1, 2, 3);
+                c1.ExpectNext(CancellationToken.None, 1, 2, 3);
                 c1.ExpectComplete();
             }, Materializer);
         }
@@ -174,7 +175,7 @@ namespace Akka.Streams.Tests.Dsl
             sub2.Request(3);
             sub1.Request(3);
             sub2.Cancel();
-            c1.ExpectNext(1,2,3);
+            c1.ExpectNext(CancellationToken.None, 1,2,3);
             c1.ExpectComplete();
         }
 
@@ -205,7 +206,7 @@ namespace Akka.Streams.Tests.Dsl
             sub2.Request(3);
             sub2.Cancel();
             sub1.Request(3);
-            c1.ExpectNext(1, 2, 3);
+            c1.ExpectNext(CancellationToken.None, 1, 2, 3);
             c1.ExpectComplete();
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphUnzipWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphUnzipWithSpec.cs
@@ -102,7 +102,7 @@ namespace Akka.Streams.Tests.Dsl
                 leftSubscription.Request(2);
                 rightSubscription.Request(1);
 
-                leftProbe.ExpectNext(CancellationToken.None, 2, 4);
+                leftProbe.ExpectNext( 2, 4);
                 leftProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
                 rightProbe.ExpectNext("1+1");
@@ -114,7 +114,7 @@ namespace Akka.Streams.Tests.Dsl
                 leftProbe.ExpectNext(6);
                 leftProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
-                rightProbe.ExpectNext(CancellationToken.None, "2+2", "3+3");
+                rightProbe.ExpectNext( "2+2", "3+3");
                 rightProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
                 leftSubscription.Request(1);

--- a/src/core/Akka.Streams.Tests/Dsl/GraphUnzipWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphUnzipWithSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Streams.Dsl;
@@ -101,7 +102,7 @@ namespace Akka.Streams.Tests.Dsl
                 leftSubscription.Request(2);
                 rightSubscription.Request(1);
 
-                leftProbe.ExpectNext(2, 4);
+                leftProbe.ExpectNext(CancellationToken.None, 2, 4);
                 leftProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
                 rightProbe.ExpectNext("1+1");
@@ -113,7 +114,7 @@ namespace Akka.Streams.Tests.Dsl
                 leftProbe.ExpectNext(6);
                 leftProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
-                rightProbe.ExpectNext("2+2", "3+3");
+                rightProbe.ExpectNext(CancellationToken.None, "2+2", "3+3");
                 rightProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
                 leftSubscription.Request(1);

--- a/src/core/Akka.Streams.Tests/Dsl/GraphWireTapSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphWireTapSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Streams.Tests.Dsl
                 tps.Request(2);
                 mps.RequestNext(1);
                 mps.RequestNext(2);
-                tps.ExpectNext(CancellationToken.None, 1, 2);
+                tps.ExpectNext( 1, 2);
                 mps.ExpectComplete();
                 tps.ExpectComplete();
             }, Materializer);
@@ -56,12 +56,12 @@ namespace Akka.Streams.Tests.Dsl
                     .Run(Materializer);
 
                 mps.Request(3);
-                mps.ExpectNext(CancellationToken.None, 1, 2, 3);
+                mps.ExpectNext( 1, 2, 3);
                 tps.Request(4);
                 mps.RequestNext(4);
                 mps.RequestNext(5);
                 mps.RequestNext(6);
-                tps.ExpectNext(CancellationToken.None, 3, 4, 5, 6);
+                tps.ExpectNext( 3, 4, 5, 6);
                 mps.ExpectComplete();
                 tps.ExpectComplete();
             }, Materializer);
@@ -95,7 +95,7 @@ namespace Akka.Streams.Tests.Dsl
                 
                 tps.Cancel();
                 mps.Request(6);
-                mps.ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5, 6);
+                mps.ExpectNext( 1, 2, 3, 4, 5, 6);
                 mps.ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/GraphWireTapSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphWireTapSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
@@ -38,7 +39,7 @@ namespace Akka.Streams.Tests.Dsl
                 tps.Request(2);
                 mps.RequestNext(1);
                 mps.RequestNext(2);
-                tps.ExpectNext(1, 2);
+                tps.ExpectNext(CancellationToken.None, 1, 2);
                 mps.ExpectComplete();
                 tps.ExpectComplete();
             }, Materializer);
@@ -55,12 +56,12 @@ namespace Akka.Streams.Tests.Dsl
                     .Run(Materializer);
 
                 mps.Request(3);
-                mps.ExpectNext(1, 2, 3);
+                mps.ExpectNext(CancellationToken.None, 1, 2, 3);
                 tps.Request(4);
                 mps.RequestNext(4);
                 mps.RequestNext(5);
                 mps.RequestNext(6);
-                tps.ExpectNext(3, 4, 5, 6);
+                tps.ExpectNext(CancellationToken.None, 3, 4, 5, 6);
                 mps.ExpectComplete();
                 tps.ExpectComplete();
             }, Materializer);
@@ -94,7 +95,7 @@ namespace Akka.Streams.Tests.Dsl
                 
                 tps.Cancel();
                 mps.Request(6);
-                mps.ExpectNext(1, 2, 3, 4, 5, 6);
+                mps.ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5, 6);
                 mps.ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/GraphZipWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphZipWithSpec.cs
@@ -110,7 +110,7 @@ namespace Akka.Streams.Tests.Dsl
                 var subscription = probe.ExpectSubscription();
 
                 subscription.Request(2);
-                probe.ExpectNext(CancellationToken.None, 11, 22);
+                probe.ExpectNext( 11, 22);
 
                 subscription.Request(1);
                 probe.ExpectNext(33);
@@ -146,7 +146,7 @@ namespace Akka.Streams.Tests.Dsl
                 var subscription = probe.ExpectSubscription();
 
                 subscription.Request(2);
-                probe.ExpectNext(CancellationToken.None, 1/-2, 2/-1);
+                probe.ExpectNext( 1/-2, 2/-1);
                 EventFilter.Exception<DivideByZeroException>().ExpectOne(() => subscription.Request(2));
                 probe.ExpectError().Should().BeOfType<DivideByZeroException>();
                 probe.ExpectNoMsg(TimeSpan.FromMilliseconds(200));

--- a/src/core/Akka.Streams.Tests/Dsl/GraphZipWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphZipWithSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using FluentAssertions;
@@ -109,7 +110,7 @@ namespace Akka.Streams.Tests.Dsl
                 var subscription = probe.ExpectSubscription();
 
                 subscription.Request(2);
-                probe.ExpectNext(11, 22);
+                probe.ExpectNext(CancellationToken.None, 11, 22);
 
                 subscription.Request(1);
                 probe.ExpectNext(33);
@@ -145,7 +146,7 @@ namespace Akka.Streams.Tests.Dsl
                 var subscription = probe.ExpectSubscription();
 
                 subscription.Request(2);
-                probe.ExpectNext(1/-2, 2/-1);
+                probe.ExpectNext(CancellationToken.None, 1/-2, 2/-1);
                 EventFilter.Exception<DivideByZeroException>().ExpectOne(() => subscription.Request(2));
                 probe.ExpectError().Should().BeOfType<DivideByZeroException>();
                 probe.ExpectNoMsg(TimeSpan.FromMilliseconds(200));

--- a/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
@@ -31,7 +31,7 @@ namespace Akka.Streams.Tests.Dsl
             var probe = t.Item2;
 
             probe.Request(3)
-                .ExpectNext(CancellationToken.None, 1, 2, 3)
+                .ExpectNext( 1, 2, 3)
                 .ExpectComplete();
 
             lastElement.AwaitResult(TimeSpan.FromSeconds(1)).Should().Be(Option<int>.Create(3));

--- a/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Streams.Util;
@@ -30,7 +31,7 @@ namespace Akka.Streams.Tests.Dsl
             var probe = t.Item2;
 
             probe.Request(3)
-                .ExpectNext(1, 2, 3)
+                .ExpectNext(CancellationToken.None, 1, 2, 3)
                 .ExpectComplete();
 
             lastElement.AwaitResult(TimeSpan.FromSeconds(1)).Should().Be(Option<int>.Create(3));

--- a/src/core/Akka.Streams.Tests/Dsl/PartitionWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/PartitionWithSpec.cs
@@ -51,7 +51,7 @@ namespace Akka.Streams.Tests.Dsl
             source.SendNext(1);
             source.SendNext(2);
             source.SendNext(3);
-            sink.ExpectNext(CancellationToken.None, 2, 1, 8);
+            sink.ExpectNext( 2, 1, 8);
             source.SendComplete();
             sink.ExpectComplete();
         }

--- a/src/core/Akka.Streams.Tests/Dsl/PartitionWithSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/PartitionWithSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Util;
@@ -50,7 +51,7 @@ namespace Akka.Streams.Tests.Dsl
             source.SendNext(1);
             source.SendNext(2);
             source.SendNext(3);
-            sink.ExpectNext(2, 1, 8);
+            sink.ExpectNext(CancellationToken.None, 2, 1, 8);
             source.SendComplete();
             sink.ExpectComplete();
         }

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Pattern;
@@ -238,7 +239,7 @@ namespace Akka.Streams.Tests.Dsl
                 queue.Complete();
 
                 probe.Request(6)
-                    .ExpectNext(2, 3, 4, 5, 6)
+                    .ExpectNext(CancellationToken.None, 2, 3, 4, 5, 6)
                     .ExpectComplete();
             }, _materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
@@ -239,7 +239,7 @@ namespace Akka.Streams.Tests.Dsl
                 queue.Complete();
 
                 probe.Request(6)
-                    .ExpectNext(CancellationToken.None, 2, 3, 4, 5, 6)
+                    .ExpectNext( 2, 3, 4, 5, 6)
                     .ExpectComplete();
             }, _materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/ReverseArrowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ReverseArrowSpec.cs
@@ -76,7 +76,7 @@ namespace Akka.Streams.Tests.Dsl
             })).Run(Materializer);
             
             sub.ExpectSubscription().Request(10);
-            sub.ExpectNext(CancellationToken.None, 1, 2, 3);
+            sub.ExpectNext( 1, 2, 3);
             sub.ExpectComplete();
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/ReverseArrowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ReverseArrowSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -75,7 +76,7 @@ namespace Akka.Streams.Tests.Dsl
             })).Run(Materializer);
             
             sub.ExpectSubscription().Request(10);
-            sub.ExpectNext(1, 2, 3);
+            sub.ExpectNext(CancellationToken.None, 1, 2, 3);
             sub.ExpectComplete();
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
@@ -147,7 +148,7 @@ namespace Akka.Streams.Tests.Dsl
             subscriptions.ForEach(s=>s.Request(2));
             probes.ForEach(p =>
             {
-                p.ExpectNext(1, 2);
+                p.ExpectNext(CancellationToken.None, 1, 2);
                 p.ExpectComplete();
             });
         }
@@ -167,7 +168,7 @@ namespace Akka.Streams.Tests.Dsl
             subscriptions.ForEach(s => s.Request(2));
             probes.ForEach(p =>
             {
-                p.ExpectNext(1, 2);
+                p.ExpectNext(CancellationToken.None, 1, 2);
                 p.ExpectComplete();
             });
         }

--- a/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
@@ -148,7 +148,7 @@ namespace Akka.Streams.Tests.Dsl
             subscriptions.ForEach(s=>s.Request(2));
             probes.ForEach(p =>
             {
-                p.ExpectNext(CancellationToken.None, 1, 2);
+                p.ExpectNext( 1, 2);
                 p.ExpectComplete();
             });
         }
@@ -168,7 +168,7 @@ namespace Akka.Streams.Tests.Dsl
             subscriptions.ForEach(s => s.Request(2));
             probes.ForEach(p =>
             {
-                p.ExpectNext(CancellationToken.None, 1, 2);
+                p.ExpectNext( 1, 2);
                 p.ExpectComplete();
             });
         }

--- a/src/core/Akka.Streams.Tests/Dsl/ValveSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ValveSpec.cs
@@ -53,10 +53,10 @@ namespace Akka.Streams.Tests.Dsl
             var flip = valveSwitch.Flip(SwitchMode.Open);
             flip.AwaitResult().Should().BeTrue();
 
-            probe.ExpectNext(1, 2);
+            probe.ExpectNext(CancellationToken.None, 1, 2);
 
             probe.Request(3);
-            probe.ExpectNext(3, 4, 5);
+            probe.ExpectNext(CancellationToken.None, 3, 4, 5);
 
             probe.ExpectComplete();
         }
@@ -99,7 +99,7 @@ namespace Akka.Streams.Tests.Dsl
             sourceProbe.SendNext(3);
             sourceProbe.SendComplete();
 
-            sinkProbe.ExpectNext(2, 3);
+            sinkProbe.ExpectNext(CancellationToken.None, 2, 3);
 
             sinkProbe.ExpectComplete();
         }
@@ -232,7 +232,7 @@ namespace Akka.Streams.Tests.Dsl
             sourceProbe.SendNext(3);
             sourceProbe.SendComplete();
 
-            sinkProbe.ExpectNext(2, 3);
+            sinkProbe.ExpectNext(CancellationToken.None, 2, 3);
 
             sinkProbe.ExpectComplete();
         }

--- a/src/core/Akka.Streams.Tests/Dsl/ValveSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ValveSpec.cs
@@ -53,10 +53,10 @@ namespace Akka.Streams.Tests.Dsl
             var flip = valveSwitch.Flip(SwitchMode.Open);
             flip.AwaitResult().Should().BeTrue();
 
-            probe.ExpectNext(CancellationToken.None, 1, 2);
+            probe.ExpectNext(1, 2);
 
             probe.Request(3);
-            probe.ExpectNext(CancellationToken.None, 3, 4, 5);
+            probe.ExpectNext(3, 4, 5);
 
             probe.ExpectComplete();
         }
@@ -99,7 +99,7 @@ namespace Akka.Streams.Tests.Dsl
             sourceProbe.SendNext(3);
             sourceProbe.SendComplete();
 
-            sinkProbe.ExpectNext(CancellationToken.None, 2, 3);
+            sinkProbe.ExpectNext( 2, 3);
 
             sinkProbe.ExpectComplete();
         }
@@ -232,7 +232,7 @@ namespace Akka.Streams.Tests.Dsl
             sourceProbe.SendNext(3);
             sourceProbe.SendComplete();
 
-            sinkProbe.ExpectNext(CancellationToken.None, 2, 3);
+            sinkProbe.ExpectNext( 2, 3);
 
             sinkProbe.ExpectComplete();
         }

--- a/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
@@ -281,7 +281,7 @@ namespace Akka.Streams.Tests.Implementation
                 .Via(new ReadNEmitN(2))
                 .RunWith(this.SinkProbe<int>(), Materializer)
                 .Request(10)
-                .ExpectNext(CancellationToken.None, 1, 2)
+                .ExpectNext( 1, 2)
                 .ExpectComplete();
             }, Materializer);
         }
@@ -328,7 +328,7 @@ namespace Akka.Streams.Tests.Implementation
                     .Via(new ReadNEmitRestOnComplete(6))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(10)
-                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
+                    .ExpectNext( 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Event;
@@ -280,7 +281,7 @@ namespace Akka.Streams.Tests.Implementation
                 .Via(new ReadNEmitN(2))
                 .RunWith(this.SinkProbe<int>(), Materializer)
                 .Request(10)
-                .ExpectNext(1, 2)
+                .ExpectNext(CancellationToken.None, 1, 2)
                 .ExpectComplete();
             }, Materializer);
         }
@@ -327,7 +328,7 @@ namespace Akka.Streams.Tests.Implementation
                     .Via(new ReadNEmitRestOnComplete(6))
                     .RunWith(this.SinkProbe<int>(), Materializer)
                     .Request(10)
-                    .ExpectNext(1, 2, 3, 4, 5)
+                    .ExpectNext(CancellationToken.None, 1, 2, 3, 4, 5)
                     .ExpectComplete();
             }, Materializer);
         }


### PR DESCRIPTION
## Changes

- `ExpectNext(CancellationToken cancellationToken, params T[] elems)`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
