### PR TITLE
[Obsolete] `IWithBoundedStash` > `IWithStash` 

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
@@ -1166,7 +1166,6 @@ namespace Akka.Actor
         void Become(Akka.Actor.UntypedReceive receive);
         void BecomeStacked(Akka.Actor.UntypedReceive receive);
     }
-    [System.ObsoleteAttribute("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
     public interface IWithBoundedStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics> { }
     public interface IWithStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IDequeBasedMessageQueueSemantics> { }
     public interface IWithTimers

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -1168,7 +1168,6 @@ namespace Akka.Actor
         void Become(Akka.Actor.UntypedReceive receive);
         void BecomeStacked(Akka.Actor.UntypedReceive receive);
     }
-    [System.ObsoleteAttribute("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
     public interface IWithBoundedStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics> { }
     public interface IWithStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IDequeBasedMessageQueueSemantics> { }
     public interface IWithTimers

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -1166,7 +1166,6 @@ namespace Akka.Actor
         void Become(Akka.Actor.UntypedReceive receive);
         void BecomeStacked(Akka.Actor.UntypedReceive receive);
     }
-    [System.ObsoleteAttribute("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
     public interface IWithBoundedStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics> { }
     public interface IWithStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IDequeBasedMessageQueueSemantics> { }
     public interface IWithTimers

--- a/src/core/Akka.Tests/Actor/Stash/ActorWithBoundedStashSpec.cs
+++ b/src/core/Akka.Tests/Actor/Stash/ActorWithBoundedStashSpec.cs
@@ -18,7 +18,7 @@ using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor.Stash
 {
-    public class StashingActor : UntypedActor, IWithBoundedStash
+    public class StashingActor : UntypedActor, IWithStash
     {
         public IStash Stash { get; set; }
 
@@ -39,7 +39,7 @@ namespace Akka.Tests.Actor.Stash
         private void AfterWorldBehavior(object message) => Stash.Stash();
     }
 
-    public class StashingActorWithOverflow : UntypedActor, IWithBoundedStash
+    public class StashingActorWithOverflow : UntypedActor, IWithStash
     {
         private int numStashed = 0;
 

--- a/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
+++ b/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
@@ -157,7 +157,7 @@ namespace Akka.Tests.Actor.Stash
             public IStash Stash { get; set; }
         }
 
-        private class BoundedStashActor : BlackHoleActor, IWithBoundedStash
+        private class BoundedStashActor : BlackHoleActor, IWithStash
         {
             public IStash Stash { get; set; }
         }

--- a/src/core/Akka.Tests/Actor/StashMailboxSpec.cs
+++ b/src/core/Akka.Tests/Actor/StashMailboxSpec.cs
@@ -46,7 +46,7 @@ namespace Akka.Tests.Actor
         {
             public IStash Stash { get; set; }
         }
-        private class BoundedStashActor : BlackHoleActor, IWithBoundedStash
+        private class BoundedStashActor : BlackHoleActor, IWithStash
         {
             public IStash Stash { get; set; }
         }

--- a/src/core/Akka.Tests/Actor/StashMailboxSpec.cs
+++ b/src/core/Akka.Tests/Actor/StashMailboxSpec.cs
@@ -46,7 +46,7 @@ namespace Akka.Tests.Actor
         {
             public IStash Stash { get; set; }
         }
-        private class BoundedStashActor : BlackHoleActor, IWithStash
+        private class BoundedStashActor : BlackHoleActor, IWithBoundedStash
         {
             public IStash Stash { get; set; }
         }

--- a/src/core/Akka/Actor/Stash/IWithBoundedStash.cs
+++ b/src/core/Akka/Actor/Stash/IWithBoundedStash.cs
@@ -17,7 +17,7 @@ namespace Akka.Actor
     /// <code>public IStash Stash { get; set; }</code>
     /// </summary>
     // ReSharper disable once InconsistentNaming
-    [Obsolete("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
+    
     public interface IWithBoundedStash : IWithUnrestrictedStash, IRequiresMessageQueue<IBoundedDequeBasedMessageQueueSemantics>
     { }
 }

--- a/src/core/Akka/Actor/Stash/StashFactory.cs
+++ b/src/core/Akka/Actor/Stash/StashFactory.cs
@@ -48,7 +48,7 @@ namespace Akka.Actor
         /// <returns>TBD</returns>
         public static IStash CreateStash(this IActorContext context, Type actorType)
         {
-            if (actorType.Implements<IWithBoundedStash>())
+            if (actorType.Implements<IWithStash>())
                 return new BoundedStashImpl(context);
 
             if (actorType.Implements<IWithUnboundedStash>())


### PR DESCRIPTION
## Changes

"Use `IWithStash` with a configured BoundedDeque-based mailbox instead."

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
