### PR TITLE
 [CS4014] warning disable -  Because this call is not awaited

### DIFF
--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
@@ -576,11 +576,13 @@ namespace Akka.Persistence.Tests
                 {
                     var sender = Sender;
                     var self = Self;
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                     Task.Run(() =>
                     {
                         Thread.Sleep(10);
                         return msg;
                     }).PipeTo(sender, self); 
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
                     await Task.Delay(3000);
                 });
@@ -600,12 +602,14 @@ namespace Akka.Persistence.Tests
                 CommandAsync<string>(async msg =>
                 {
                     var sender = Sender;
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                     Task.Run(() =>
                     {
                         //Sleep to make sure the task is not completed when ContinueWith is called
                         Thread.Sleep(100);
                         return msg;
                     }).ContinueWith(_ => sender.Tell(msg)); // ContinueWith will schedule with the implicit ActorTaskScheduler
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
                     Thread.Sleep(3000);
                 });

--- a/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs
@@ -180,7 +180,9 @@ namespace Akka.Persistence.Tests
 
             protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
             {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 base.DeleteAsync(persistenceId, criteria); // we actually delete it properly, but act as if it failed
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 var promise = new TaskCompletionSource<object>();
                 promise.SetException(new InvalidOperationException("Failed to delete snapshot for some reason."));
                 return promise.Task;

--- a/src/core/Akka.Remote.TestKit/Player.cs
+++ b/src/core/Akka.Remote.TestKit/Player.cs
@@ -667,7 +667,9 @@ namespace Akka.Remote.TestKit
             Task.Factory.StartNew(() =>
             {
                 RemoteConnection.Shutdown(context.Channel);
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 RemoteConnection.ReleaseAll(); // yep, let it run asynchronously.
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             }, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
             context.FireChannelInactive();
         }

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/AllTestForEventFilterBase.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/AllTestForEventFilterBase.cs
@@ -234,7 +234,9 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         {
             await _testingEventFilter.ForLogLevel(LogLevel).ExpectAsync(1, TimeSpan.FromSeconds(2), async () =>
             {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 Task.Delay(TimeSpan.FromMilliseconds(10)).ContinueWith(t => { LogMessage("whatever"); });
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             });
         }
 

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -189,11 +189,13 @@ namespace Akka.Tests.Actor
                 callbackWasRun = true;
             });
 
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             new TaskFactory().StartNew(() =>
             {
                 Task.Delay(Dilated(TimeSpan.FromMilliseconds(200))).Wait();
                 actorSystem.Terminate();
             });
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
             await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(5));
             Assert.True(callbackWasRun);

--- a/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
@@ -500,6 +500,7 @@ namespace Akka.Tests.Actor.Dispatch
 
             foreach (var i in Enumerable.Range(1, 10))
             {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 Task.Run(() =>
                 {
                     foreach (var c in Enumerable.Range(1, 20))
@@ -507,6 +508,7 @@ namespace Akka.Tests.Actor.Dispatch
                         a.Tell(new CountDown(counter));
                     }
                 });
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             }
 
             try

--- a/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
+++ b/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
@@ -42,7 +42,9 @@ namespace Akka.Tests.Actor
         public async Task Should_immediately_PipeTo_completed_Task()
         {
             var task = Task.FromResult("foo");
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             task.PipeTo(TestActor);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             await ExpectMsgAsync("foo");
         }
 
@@ -50,14 +52,18 @@ namespace Akka.Tests.Actor
         public async Task ValueTask_Should_immediately_PipeTo_completed_Task()
         {
             var task = new ValueTask<string>("foo");
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             task.PipeTo(TestActor);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             await ExpectMsgAsync("foo");
         }
 
         [Fact]
         public async Task Should_by_default_send_task_result_as_message()
         {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _task.PipeTo(TestActor);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("Hello");
             await ExpectMsgAsync("Hello");
         }
@@ -65,7 +71,9 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task ValueTask_Should_by_default_send_task_result_as_message()
         {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _valueTask.PipeTo(TestActor);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("Hello");
             await ExpectMsgAsync("Hello");
         }
@@ -73,7 +81,9 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task Should_by_default_not_send_a_success_message_if_the_task_does_not_produce_a_result()
         {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskWithoutResult.PipeTo(TestActor);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("Hello");
             await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
         }
@@ -81,7 +91,9 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task ValueTask_Should_by_default_not_send_a_success_message_if_the_task_does_not_produce_a_result()
         {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _valueTaskWithoutResult.PipeTo(TestActor);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("Hello");
             await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
         }
@@ -89,8 +101,12 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task Should_by_default_send_task_exception_as_status_failure_message()
         {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _task.PipeTo(TestActor);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskWithoutResult.PipeTo(TestActor);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetException(new Exception("Boom"));
             await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom");
             await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom");
@@ -99,8 +115,12 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task ValueTask_Should_by_default_send_task_exception_as_status_failure_message()
         {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _valueTask.PipeTo(TestActor);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _valueTaskWithoutResult.PipeTo(TestActor);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetException(new Exception("Boom"));
             await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom");
             await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom");
@@ -109,8 +129,12 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task Should_use_success_handling_to_transform_task_result()
         {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _task.PipeTo(TestActor, success: x => "Hello " + x);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskWithoutResult.PipeTo(TestActor, success: () => "Hello");
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("World");
             var pipeTo = await ReceiveNAsync(2, default).Cast<string>().ToListAsync();
             pipeTo.Should().Contain("Hello");
@@ -120,8 +144,12 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task ValueTask_Should_use_success_handling_to_transform_task_result()
         {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _valueTask.PipeTo(TestActor, success: x => "Hello " + x);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _valueTaskWithoutResult.PipeTo(TestActor, success: () => "Hello");
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("World");
             var pipeTo = await ReceiveNAsync(2, default).Cast<string>().ToListAsync();
             pipeTo.Should().Contain("Hello");
@@ -131,8 +159,12 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task Should_use_failure_handling_to_transform_task_exception()
         {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _task.PipeTo(TestActor, failure: e => "Such a " + e.Message);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskWithoutResult.PipeTo(TestActor, failure: e => "Such a " + e.Message);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetException(new Exception("failure..."));
             await ExpectMsgAsync("Such a failure...");
             await ExpectMsgAsync("Such a failure...");
@@ -141,8 +173,12 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task ValueTask_Should_use_failure_handling_to_transform_task_exception()
         {
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _valueTask.PipeTo(TestActor, failure: e => "Such a " + e.Message);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _valueTaskWithoutResult.PipeTo(TestActor, failure: e => "Such a " + e.Message);
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetException(new Exception("failure..."));
             await ExpectMsgAsync("Such a failure...");
             await ExpectMsgAsync("Such a failure...");

--- a/src/core/Akka/Util/Internal/AtomicState.cs
+++ b/src/core/Akka/Util/Internal/AtomicState.cs
@@ -263,7 +263,9 @@ namespace Akka.Util.Internal
         public void Enter()
         {
             EnterInternal();
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             NotifyTransitionListeners();
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
         }
 
     }

--- a/src/examples/AspNetCore/Akka.AspNetCore/AkkaService.cs
+++ b/src/examples/AspNetCore/Akka.AspNetCore/AkkaService.cs
@@ -49,9 +49,11 @@ namespace Akka.AspNetCore
             //await _actorSystem.WhenTerminated.ContinueWith(tr => {
             //   _applicationLifetime.StopApplication();
             //});
+#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _actorSystem.WhenTerminated.ContinueWith(tr => {
                 _applicationLifetime.StopApplication();
               });
+#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             await Task.CompletedTask;
         }
 


### PR DESCRIPTION
## Changes

 [CS4014] warning disable

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
