### PR TITLE
[CS1998] This async method lacks 'await' operators and will run synchronously

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/ClusterMetricsExtensionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/ClusterMetricsExtensionSpec.cs
@@ -109,11 +109,11 @@ namespace Akka.Cluster.Metrics.Tests.MultiNode
                 MetricsView.ClusterMetrics.Count.Should().Be(Roles.Count);
             }, TimeSpan.FromSeconds(30));
             
-            await WithinAsync(10.Seconds(), async () =>
-            {
+            await WithinAsync(10.Seconds(), () => {
                 var collector = new MetricsCollectorBuilder().Build(Cluster.System);
                 collector.Sample().Metrics.Count.Should().BeGreaterThan(3);
                 EnterBarrier("after");
+                return Task.CompletedTask;
             });
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/ClustetMetricsRoutingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/ClustetMetricsRoutingSpec.cs
@@ -246,11 +246,11 @@ namespace Akka.Cluster.Metrics.Tests.MultiNode
             
             await RunOnAsync(async () =>
             {
-                await WithinAsync(20.Seconds(), async () =>
-                {
-                   Sys.ActorOf(Props.Create<AdaptiveLoadBalancingRouterConfig.MemoryAllocator>(), "memory-allocator")
-                       .Tell(AdaptiveLoadBalancingRouterConfig.AllocateMemory.Instance);
-                   ExpectMsg("done");
+                await WithinAsync(20.Seconds(), () => {
+                    Sys.ActorOf(Props.Create<AdaptiveLoadBalancingRouterConfig.MemoryAllocator>(), "memory-allocator")
+                                                                             .Tell(AdaptiveLoadBalancingRouterConfig.AllocateMemory.Instance);
+                    ExpectMsg("done");
+                    return Task.CompletedTask;
                 });
             }, _config.Node2);
             

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/Sample/StatsSampleSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/Sample/StatsSampleSpec.cs
@@ -88,8 +88,7 @@ namespace Akka.Cluster.Metrics.Tests.MultiNode
 
         private async Task Should_startup_cluster()
         {
-            await WithinAsync(15.Seconds(), async () =>
-            {
+            await WithinAsync(15.Seconds(), () => {
                 var cluster = Cluster.Get(Sys);
                 cluster.Subscribe(TestActor, typeof(ClusterEvent.MemberUp));
                 ExpectMsg<ClusterEvent.CurrentClusterState>();
@@ -97,7 +96,7 @@ namespace Akka.Cluster.Metrics.Tests.MultiNode
                 var firstAddress = Node(_config.First).Address;
                 var secondAddress = Node(_config.Second).Address;
                 var thirdAddress = Node(_config.Third).Address;
-                
+
                 cluster.Join(firstAddress);
 
                 Sys.ActorOf(Props.Create<StatsWorker>(), "statsWorker");
@@ -105,10 +104,11 @@ namespace Akka.Cluster.Metrics.Tests.MultiNode
 
                 ReceiveN(3).Select(m => (m as ClusterEvent.MemberUp).Member.Address).Distinct()
                     .Should().BeEquivalentTo(firstAddress, secondAddress, thirdAddress);
-                
+
                 cluster.Unsubscribe(TestActor);
-                
+
                 EnterBarrier("all-up");
+                return Task.CompletedTask;
             });
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorSpec.cs
@@ -80,7 +80,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
 
             // assert
             await EventFilter.DeadLetter<object>().ExpectAsync(1,
-                async () => { mediator.Tell(new Publish("pub-sub", "hit")); });
+                () => { mediator.Tell(new Publish("pub-sub", "hit")); return Task.CompletedTask; });
         }
     }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonProxySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonProxySpec.cs
@@ -53,7 +53,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             
             // have to wait for cluster singleton to be ready, otherwise message will be rejected
             await AwaitConditionAsync(
-                async () => Cluster.Get(testSystem.Sys).State.Members.Count(m => m.Status == MemberStatus.Up) == 2,
+                () => Task.FromResult(Cluster.Get(testSystem.Sys).State.Members.Count(m => m.Status == MemberStatus.Up) == 2),
                 TimeSpan.FromSeconds(30));
 
             try

--- a/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorSpecs.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorSpecs.cs
@@ -173,7 +173,7 @@ namespace Akka.DistributedData.Tests
             await ReplicatorDuplicatePublish();
         }
 
-        private async Task ReplicatorDuplicatePublish()
+        private Task ReplicatorDuplicatePublish()
         {
             var p1 = CreateTestProbe(_sys1);
             var p2 = CreateTestProbe(_sys2);
@@ -205,6 +205,7 @@ namespace Akka.DistributedData.Tests
 
             // no probe should receive an update
             p2.ExpectNoMsg(TimeSpan.FromSeconds(1));
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -217,7 +218,7 @@ namespace Akka.DistributedData.Tests
             await PNCounterDictionary_Should_Merge();
         }
 
-        private async Task PNCounterDictionary_Should_Merge()
+        private Task PNCounterDictionary_Should_Merge()
         {
             var p1 = CreateTestProbe(_sys1);
             var p2 = CreateTestProbe(_sys2);
@@ -262,6 +263,7 @@ namespace Akka.DistributedData.Tests
             });
 
             Sys.Log.Info("Done");
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -366,7 +368,7 @@ namespace Akka.DistributedData.Tests
             await ORMultiValueDictionary_Should_Merge();
         }
 
-        private async Task ORMultiValueDictionary_Should_Merge()
+        private Task ORMultiValueDictionary_Should_Merge()
         {
             var changedProbe = CreateTestProbe(_sys2);
 
@@ -475,6 +477,7 @@ namespace Akka.DistributedData.Tests
                         changedProbe.ExpectMsg<Changed>(g => Equals(g.Key, _keyJ)).Get(_keyJ).Entries);
                 });
             });
+            return Task.CompletedTask;
         }
 
         private void VerifyMultiValueDictionaryEntries(

--- a/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
@@ -52,7 +52,7 @@ namespace Akka.Cluster.Tests
         {
             await WithinAsync(TimeSpan.FromSeconds(10), async() =>
             {
-                await AwaitConditionAsync(async () => ClusterView.IsSingletonCluster);
+                await AwaitConditionAsync(() => Task.FromResult(ClusterView.IsSingletonCluster));
                 ClusterView.Self.Address.ShouldBe(_selfAddress);
                 ClusterView.Members.Select(m => m.Address).ShouldBe(new Address[] { _selfAddress });
                 await AwaitAssertAsync(() => ClusterView.Status.ShouldBe(MemberStatus.Up));

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -80,7 +80,7 @@ namespace Akka.Cluster.Tests
             ClusterView.Members.Count.Should().Be(0);
             _cluster.Join(_selfAddress);
             LeaderActions(); // Joining -> Up
-            await AwaitConditionAsync(async () => ClusterView.IsSingletonCluster);
+            await AwaitConditionAsync(() => Task.FromResult(ClusterView.IsSingletonCluster));
             ClusterView.Self.Address.Should().Be(_selfAddress);
             ClusterView.Members.Select(m => m.Address).ToImmutableHashSet()
                 .Should().BeEquivalentTo(ImmutableHashSet.Create(_selfAddress));
@@ -259,7 +259,7 @@ namespace Akka.Cluster.Tests
 
             // Cancelling the first task
             cts.Cancel();
-            await AwaitConditionAsync(async () => task1.IsCanceled, null, "Task should be cancelled");
+            await AwaitConditionAsync(() => Task.FromResult(task1.IsCanceled), null, "Task should be cancelled");
 
             await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
@@ -274,12 +274,12 @@ namespace Akka.Cluster.Tests
                 ExpectMsg<ClusterEvent.MemberRemoved>().Member.Address.Should().Be(_selfAddress);
 
                 // Second task should complete (not cancelled)
-                await AwaitConditionAsync(async () => task2.IsCompleted && !task2.IsCanceled, null, "Task should be completed, but not cancelled.");
+                await AwaitConditionAsync(() => Task.FromResult(task2.IsCompleted && !task2.IsCanceled), null, "Task should be completed, but not cancelled.");
             }, cancellationToken: cts.Token);
 
             // Subsequent LeaveAsync() tasks expected to complete immediately (not cancelled)
             var task3 = _cluster.LeaveAsync();
-            await AwaitConditionAsync(async () => task3.IsCompleted && !task3.IsCanceled, null, "Task should be completed, but not cancelled.");
+            await AwaitConditionAsync(() => Task.FromResult(task3.IsCompleted && !task3.IsCanceled), null, "Task should be completed, but not cancelled.");
         }
 
         [Fact]

--- a/src/core/Akka.Docs.Tests/Actors/ReceiveTimeoutSpecs.cs
+++ b/src/core/Akka.Docs.Tests/Actors/ReceiveTimeoutSpecs.cs
@@ -47,7 +47,7 @@ namespace DocsExamples.Actors
         // </ReceiveTimeoutActor>
 
         [Fact]
-        public async Task ShouldReceiveTimeoutActors()
+        public Task ShouldReceiveTimeoutActors()
         {
             var receiveTimeout = Sys.ActorOf(
                 Props.Create(() => new ReceiveTimeoutActor(TimeSpan.FromMilliseconds(100), TestActor)), 
@@ -58,6 +58,7 @@ namespace DocsExamples.Actors
             
             // then should receive timeout due to inactivity
             ExpectMsg("timeout", TimeSpan.FromSeconds(30));
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
@@ -533,9 +533,9 @@ namespace Akka.Persistence.Tests
 
                 RecoverAny(o => { });
 
-                CommandAsync<string>(async m =>
-                {
+                CommandAsync<string>(m => {
                     ThrowException();
+                    return Task.CompletedTask;
                 });
             }
 
@@ -599,8 +599,7 @@ namespace Akka.Persistence.Tests
 
                 RecoverAny(o => { });
 
-                CommandAsync<string>(async msg =>
-                {
+                CommandAsync<string>(msg => {
                     var sender = Sender;
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                     Task.Run(() =>
@@ -612,6 +611,7 @@ namespace Akka.Persistence.Tests
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
                     Thread.Sleep(3000);
+                    return Task.CompletedTask;
                 });
             }
         }
@@ -635,7 +635,7 @@ namespace Akka.Persistence.Tests
         }
 
         [Fact]
-        public async Task Actor_receiveasync_overloads_should_work()
+        public Task Actor_receiveasync_overloads_should_work()
         {
             var actor = Sys.ActorOf(Props.Create(() => new AsyncAwaitActor("pid")));
 
@@ -647,8 +647,7 @@ namespace Akka.Persistence.Tests
 
             actor.Tell(1.0);
             ExpectMsg<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000));
-
-
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -184,7 +184,8 @@ namespace Akka.Persistence.Journal
         
         private async Task<(IEnumerable<string> Ids, int LastOrdering)> SelectAllPersistenceIdsAsync(int offset)
         {
-            return (new HashSet<string>(_allMessages.Skip(offset).Select(p => p.PersistenceId)), _allMessages.Count); 
+            return await Task.FromResult((new HashSet<string>(_allMessages.Skip(offset).Select(p => p.PersistenceId)), _allMessages.Count));
+            //return (new HashSet<string>(_allMessages.Skip(offset).Select(p => p.PersistenceId)), _allMessages.Count); 
         }
         
         /// <summary>
@@ -207,7 +208,8 @@ namespace Akka.Persistence.Journal
                 index++;
             }
 
-            return _tagsToMessagesMapping[replay.Tag].Count - 1;
+            return await Task.FromResult(_tagsToMessagesMapping[replay.Tag].Count - 1);
+            //return _tagsToMessagesMapping[replay.Tag].Count - 1;
         }
         
         private async Task<int> ReplayAllEventsAsync(ReplayAllEvents replay)
@@ -222,8 +224,8 @@ namespace Akka.Persistence.Journal
                 replay.ReplyTo.Tell(new ReplayedEvent(message, replay.FromOffset + index), ActorRefs.NoSender);
                 index++;
             }
-
-            return _allMessages.Count - 1;
+            return await Task.FromResult(_allMessages.Count - 1);
+            //return _allMessages.Count - 1;
         }
         
         #region QueryAPI
@@ -439,7 +441,6 @@ namespace Akka.Persistence.Journal
             /// TBD
             /// </summary>
             /// <param name="persistent">TBD</param>
-            /// <param name="tag">TBD</param>
             /// <param name="offset">TBD</param>
             public ReplayedEvent(IPersistentRepresentation persistent, int offset)
             {

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -182,10 +182,9 @@ namespace Akka.Persistence.Journal
             }
         }
         
-        private async Task<(IEnumerable<string> Ids, int LastOrdering)> SelectAllPersistenceIdsAsync(int offset)
+        private Task<(IEnumerable<string> Ids, int LastOrdering)> SelectAllPersistenceIdsAsync(int offset)
         {
-            return await Task.FromResult((new HashSet<string>(_allMessages.Skip(offset).Select(p => p.PersistenceId)), _allMessages.Count));
-            //return (new HashSet<string>(_allMessages.Skip(offset).Select(p => p.PersistenceId)), _allMessages.Count); 
+            return Task.FromResult<(IEnumerable<string> Ids, int LastOrdering)>((new HashSet<string>(_allMessages.Skip(offset).Select(p => p.PersistenceId)), _allMessages.Count)); 
         }
         
         /// <summary>
@@ -193,10 +192,10 @@ namespace Akka.Persistence.Journal
         /// </summary>
         /// <param name="replay">TBD</param>
         /// <returns>TBD</returns>
-        private async Task<int> ReplayTaggedMessagesAsync(ReplayTaggedMessages replay)
+        private Task<int> ReplayTaggedMessagesAsync(ReplayTaggedMessages replay)
         {
             if (!_tagsToMessagesMapping.ContainsKey(replay.Tag))
-                return 0;
+                return Task.FromResult(0);
 
             int index = 0;
             foreach (var persistence in _tagsToMessagesMapping[replay.Tag]
@@ -208,11 +207,10 @@ namespace Akka.Persistence.Journal
                 index++;
             }
 
-            return await Task.FromResult(_tagsToMessagesMapping[replay.Tag].Count - 1);
-            //return _tagsToMessagesMapping[replay.Tag].Count - 1;
+            return Task.FromResult(_tagsToMessagesMapping[replay.Tag].Count - 1);
         }
         
-        private async Task<int> ReplayAllEventsAsync(ReplayAllEvents replay)
+        private Task<int> ReplayAllEventsAsync(ReplayAllEvents replay)
         {
             int index = 0;
             var replayed = _allMessages
@@ -224,8 +222,7 @@ namespace Akka.Persistence.Journal
                 replay.ReplyTo.Tell(new ReplayedEvent(message, replay.FromOffset + index), ActorRefs.NoSender);
                 index++;
             }
-            return await Task.FromResult(_allMessages.Count - 1);
-            //return _allMessages.Count - 1;
+            return Task.FromResult(_allMessages.Count - 1);
         }
         
         #region QueryAPI

--- a/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
+++ b/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
@@ -234,7 +234,7 @@ namespace Akka.Remote.Tests
              * Wait for the ReliableDeliverySupervisor to receive its "TooLongIdle" message,
              * which will throw a HopelessAssociation wrapped around a TimeoutException.
              */
-            await EventFilter.Exception<TimeoutException>().ExpectOneAsync(async () => { });
+            await EventFilter.Exception<TimeoutException>().ExpectOneAsync(() => { return Task.CompletedTask; });
 
             await AwaitAssertAsync(() =>
             {

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -505,7 +505,7 @@ namespace Akka.Remote.Tests
                     (new ActorAssociationEventListener(remoteTransportProbe)));
 
                 // Hijack associations through the test transport
-                await AwaitConditionAsync(async () => registry.TransportsReady(rawLocalAddress, rawRemoteAddress));
+                await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(rawLocalAddress, rawRemoteAddress)));
                 var testTransport = registry.TransportFor(rawLocalAddress).Value.Item1;
                 testTransport.WriteBehavior.PushConstant(true);
 
@@ -588,7 +588,7 @@ namespace Akka.Remote.Tests
                     (new ActorAssociationEventListener(remoteTransportProbe)));
 
                 // Hijack associations through the test transport
-                await AwaitConditionAsync(async () => registry.TransportsReady(rawLocalAddress, rawRemoteAddress));
+                await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(rawLocalAddress, rawRemoteAddress)));
                 var testTransport = registry.TransportFor(rawLocalAddress).Value.Item1;
                 testTransport.WriteBehavior.PushConstant(true);
 

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
@@ -166,7 +166,7 @@ namespace Akka.Remote.Tests.Transport
 
             reader.Tell(TestAssociate(33), TestActor);
 
-            await AwaitConditionAsync(async () => collaborators.FailureDetector.IsMonitoring, DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(collaborators.FailureDetector.IsMonitoring), DefaultTimeout);
 
             var wrappedHandle = await ExpectMsgOfAsync(DefaultTimeout, "expected InboundAssociation", o =>
             {
@@ -183,7 +183,7 @@ namespace Akka.Remote.Tests.Transport
             Assert.True(collaborators.FailureDetector.IsMonitoring);
 
             // Heartbeat was sent in response to Associate
-            await AwaitConditionAsync(async () => LastActivityIsHeartbeat(collaborators.Registry), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsHeartbeat(collaborators.Registry)), DefaultTimeout);
 
             reader.Tell(_testPayload, TestActor);
             await ExpectMsgAsync<InboundPayload>(inbound =>
@@ -211,10 +211,10 @@ namespace Akka.Remote.Tests.Transport
             //this associate will now be ignored
             reader.Tell(TestAssociate(33), TestActor);
 
-            await AwaitConditionAsync(async () =>
+            await AwaitConditionAsync(() =>
             {
                 var snapshots = collaborators.Registry.LogSnapshot();
-                return snapshots.Any(x => x is DisassociateAttempt);
+                return Task.FromResult(snapshots.Any(x => x is DisassociateAttempt));
             }, DefaultTimeout);
         }
 
@@ -234,12 +234,12 @@ namespace Akka.Remote.Tests.Transport
                 codec: _codec,
                 failureDetector: collaborators.FailureDetector));
 
-            await AwaitConditionAsync(async () => LastActivityIsAssociate(collaborators.Registry, 42), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
             
-            await AwaitConditionAsync(async () => collaborators.FailureDetector.IsMonitoring, DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(collaborators.FailureDetector.IsMonitoring), DefaultTimeout);
 
             //keeps sending heartbeats
-            await AwaitConditionAsync(async () => LastActivityIsHeartbeat(collaborators.Registry), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsHeartbeat(collaborators.Registry)), DefaultTimeout);
 
             Assert.False(statusPromise.Task.IsCompleted);
 
@@ -275,7 +275,7 @@ namespace Akka.Remote.Tests.Transport
                 codec: _codec,
                 failureDetector: collaborators.FailureDetector));
 
-            await AwaitConditionAsync(async () => LastActivityIsAssociate(collaborators.Registry, 42), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
 
             reader.Tell(TestAssociate(33), TestActor);
 
@@ -323,7 +323,7 @@ namespace Akka.Remote.Tests.Transport
                 codec: _codec,
                 failureDetector: collaborators.FailureDetector));
 
-            await AwaitConditionAsync(async () => LastActivityIsAssociate(collaborators.Registry, 42), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
 
             reader.Tell(TestAssociate(33), TestActor);
 
@@ -371,7 +371,7 @@ namespace Akka.Remote.Tests.Transport
                 codec: _codec,
                 failureDetector: collaborators.FailureDetector));
 
-            await AwaitConditionAsync(async () => LastActivityIsAssociate(collaborators.Registry, 42), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
 
             stateActor.Tell(TestAssociate(33), TestActor);
 
@@ -391,7 +391,7 @@ namespace Akka.Remote.Tests.Transport
             wrappedHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
 
             //wait for one heartbeat
-            await AwaitConditionAsync(async () => LastActivityIsHeartbeat(collaborators.Registry), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsHeartbeat(collaborators.Registry)), DefaultTimeout);
 
             collaborators.FailureDetector.SetAvailable(false);
 
@@ -422,7 +422,7 @@ namespace Akka.Remote.Tests.Transport
                 codec: _codec,
                 failureDetector: collaborators.FailureDetector));
 
-            await AwaitConditionAsync(async () => LastActivityIsAssociate(collaborators.Registry, 42), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
 
             stateActor.Tell(TestAssociate(33), TestActor);
 

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
@@ -227,9 +227,9 @@ namespace Akka.Remote.Tests.Transport
             // skip this test due to linux/mono certificate issues
             if (IsMono) return;
 
-            var aggregateException = await Assert.ThrowsAsync<AggregateException>(async () =>
-            {
+            var aggregateException = await Assert.ThrowsAsync<AggregateException>(() => {
                 Setup(true, null, Password);
+                return Task.CompletedTask;
             });
 
             var realException = GetInnerMostException<ArgumentNullException>(aggregateException);
@@ -243,9 +243,9 @@ namespace Akka.Remote.Tests.Transport
             // skip this test due to linux/mono certificate issues
             if (IsMono) return;
 
-            var aggregateException = await Assert.ThrowsAsync<AggregateException>(async () =>
-            {
+            var aggregateException = await Assert.ThrowsAsync<AggregateException>(() => {
                 Setup(true, ValidCertPath, null);
+                return Task.CompletedTask;
             });
 
             var realException = GetInnerMostException<CryptographicException>(aggregateException);

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
@@ -95,8 +95,8 @@ namespace Akka.Remote.Tests.Transport
                 var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>()).Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                await AwaitConditionAsync(async () => t1.ConnectionGroup.Count == 2);
-                await AwaitConditionAsync(async () => t2.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2));
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2));
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -106,8 +106,8 @@ namespace Akka.Remote.Tests.Transport
 
                 // verify that the connections are terminated
                 await p1.ExpectMsgAsync<Disassociated>();
-                await AwaitConditionAsync(async () => t1.ConnectionGroup.Count == 1);
-                await AwaitConditionAsync(async () => t2.ConnectionGroup.Count == 1);
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1));
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 1));
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -145,8 +145,8 @@ namespace Akka.Remote.Tests.Transport
                 var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>()).Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                await AwaitConditionAsync(async () => t1.ConnectionGroup.Count == 2);
-                await AwaitConditionAsync(async () => t2.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2));
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2));
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -156,8 +156,8 @@ namespace Akka.Remote.Tests.Transport
 
                 await p2.ExpectMsgAsync<Disassociated>();
                 // verify that the connections are terminated
-                await AwaitConditionAsync(async () => t1.ConnectionGroup.Count == 0, null, message: $"Expected 0 open connection but found {t1.ConnectionGroup.Count}");
-                await AwaitConditionAsync(async () => t2.ConnectionGroup.Count == 1, null,message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 0), null, message: $"Expected 0 open connection but found {t1.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 1), null,message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -195,8 +195,8 @@ namespace Akka.Remote.Tests.Transport
                 var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>()).Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                await AwaitConditionAsync(async () => t1.ConnectionGroup.Count == 2);
-                await AwaitConditionAsync(async () => t2.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2));
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2));
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -205,8 +205,8 @@ namespace Akka.Remote.Tests.Transport
                 inboundHandle.Disassociate("Dissociation test", Log);
 
                 // verify that the connections are terminated
-                await AwaitConditionAsync(async () => t1.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
-                await AwaitConditionAsync(async () => t2.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1), null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 1), null, message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -244,8 +244,8 @@ namespace Akka.Remote.Tests.Transport
                 var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>()).Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                await AwaitConditionAsync(async () => t1.ConnectionGroup.Count == 2);
-                await AwaitConditionAsync(async () => t2.ConnectionGroup.Count == 2);
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2));
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2));
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -254,8 +254,8 @@ namespace Akka.Remote.Tests.Transport
                 await t2.Shutdown();
 
                 // verify that the connections are terminated
-                await AwaitConditionAsync(async () => t1.ConnectionGroup.Count == 1, null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
-                await AwaitConditionAsync(async () => t2.ConnectionGroup.Count == 0, null, message: $"Expected 0 open connection but found {t2.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1), null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 0), null, message: $"Expected 0 open connection but found {t2.ConnectionGroup.Count}");
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -290,7 +290,7 @@ namespace Akka.Remote.Tests.Transport
                 });
 
 
-                await AwaitConditionAsync(async () => t1.ConnectionGroup.Count == 1);
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1));
             }
             finally
             {

--- a/src/core/Akka.Remote.Tests/Transport/GenericTransportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/GenericTransportSpec.cs
@@ -88,7 +88,7 @@ namespace Akka.Remote.Tests.Transport
             (await transportA.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
             (await transportB.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
-            await AwaitConditionAsync(async () => registry.TransportsReady(_addressATest, _addressBTest));
+            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest, _addressBTest)));
 
             // task is not awaited deliberately
             var task = transportA.Associate(_addressB);
@@ -101,7 +101,7 @@ namespace Akka.Remote.Tests.Transport
             });
 
             Assert.Contains(registry.LogSnapshot().OfType<AssociateAttempt>(), x => x.LocalAddress == _addressATest && x.RemoteAddress == _addressBTest);
-            await AwaitConditionAsync(async () => registry.ExistsAssociation(_addressATest, _addressBTest));
+            await AwaitConditionAsync(() => Task.FromResult(registry.ExistsAssociation(_addressATest, _addressBTest)));
         }
 
         [Fact]
@@ -111,7 +111,7 @@ namespace Akka.Remote.Tests.Transport
             var transportA = NewTransportA(registry);
 
             (await transportA.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
-            await AwaitConditionAsync(async () => registry.TransportsReady(_addressATest));
+            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest)));
 
             // Transport throws InvalidAssociationException when trying to associate with non-existing system
             await Assert.ThrowsAsync<InvalidAssociationException>(async () =>
@@ -129,7 +129,7 @@ namespace Akka.Remote.Tests.Transport
             (await transportA.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
             (await transportB.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
-            await AwaitConditionAsync(async () => registry.TransportsReady(_addressATest, _addressBTest));
+            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest, _addressBTest)));
 
             var associate = transportA.Associate(_addressB);
             var handleB = await ExpectMsgOfAsync(DefaultTimeout, "Expect InboundAssociation from A", o =>
@@ -149,7 +149,7 @@ namespace Akka.Remote.Tests.Transport
             var payload = ByteString.CopyFromUtf8("PDU");
             var pdu = _withAkkaProtocol ? new AkkaPduProtobuffCodec(Sys).ConstructPayload(payload) : payload;
             
-            await AwaitConditionAsync(async () => registry.ExistsAssociation(_addressATest, _addressBTest));
+            await AwaitConditionAsync(() => Task.FromResult(registry.ExistsAssociation(_addressATest, _addressBTest)));
 
             handleA.Write(payload);
             await ExpectMsgOfAsync(DefaultTimeout, "Expect InboundPayload from A", o =>
@@ -173,7 +173,7 @@ namespace Akka.Remote.Tests.Transport
             (await transportA.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
             (await transportB.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
-            await AwaitConditionAsync(async () => registry.TransportsReady(_addressATest, _addressBTest));
+            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest, _addressBTest)));
 
             var associate = transportA.Associate(_addressB);
             var handleB = await ExpectMsgOfAsync(DefaultTimeout, "Expect InboundAssociation from A", o =>
@@ -190,16 +190,17 @@ namespace Akka.Remote.Tests.Transport
             handleA.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
             handleB.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
 
-            await AwaitConditionAsync(async () => registry.ExistsAssociation(_addressATest, _addressBTest));
+            await AwaitConditionAsync(() => Task.FromResult(registry.ExistsAssociation(_addressATest, _addressBTest)));
 
             handleA.Disassociate("Disassociation test", Log);
 
             await ExpectMsgOfAsync(DefaultTimeout, "Should receive Disassociated", o => o as Disassociated);
 
-            await AwaitConditionAsync(async () => !registry.ExistsAssociation(_addressATest, _addressBTest));
+            await AwaitConditionAsync(() => Task.FromResult(!registry.ExistsAssociation(_addressATest, _addressBTest)));
 
-            await AwaitConditionAsync(async () =>
-                registry.LogSnapshot().OfType<DisassociateAttempt>().Any(x => x.Requestor == _addressATest && x.Remote == _addressBTest)
+            await AwaitConditionAsync(() =>
+                Task.FromResult(registry.LogSnapshot().OfType<DisassociateAttempt>().Any(x => x.Requestor == _addressATest && x.Remote == _addressBTest))
+
             );
         }
     }

--- a/src/core/Akka.Streams.TestKit/TestPublisher.cs
+++ b/src/core/Akka.Streams.TestKit/TestPublisher.cs
@@ -205,7 +205,7 @@ namespace Akka.Streams.TestKit
                 TimeSpan max,
                 Func<TOther> execute,
                 CancellationToken cancellationToken = default)
-                => WithinAsync(min, max, async () => execute(), cancellationToken)
+                => WithinAsync(min, max, () => Task.FromResult(execute()), cancellationToken)
                     .ConfigureAwait(false).GetAwaiter().GetResult();
 
             /// <summary>
@@ -244,7 +244,7 @@ namespace Akka.Streams.TestKit
             /// Sane as calling Within(TimeSpan.Zero, max, function, cancellationToken).
             /// </summary>
             public TOther Within<TOther>(TimeSpan max, Func<TOther> execute, CancellationToken cancellationToken = default)
-                => WithinAsync(max, async () => execute(), cancellationToken)
+                => WithinAsync(max, () => Task.FromResult(execute()), cancellationToken)
                     .ConfigureAwait(false).GetAwaiter().GetResult();
             
             /// <summary>

--- a/src/core/Akka.Streams.TestKit/Utils.cs
+++ b/src/core/Akka.Streams.TestKit/Utils.cs
@@ -32,10 +32,10 @@ namespace Akka.Streams.TestKit
             IMaterializer materializer,
             TimeSpan? timeout = null,
             CancellationToken cancellationToken = default)
-            => AssertAllStagesStoppedAsync(spec, async () =>
+            => AssertAllStagesStoppedAsync(spec, () =>
                 {
                     block();
-                    return NotUsed.Instance;
+                    return Task.FromResult(NotUsed.Instance);
                 }, materializer, timeout, cancellationToken)
                 .ConfigureAwait(false).GetAwaiter().GetResult();
 
@@ -45,7 +45,7 @@ namespace Akka.Streams.TestKit
             IMaterializer materializer,
             TimeSpan? timeout = null,
             CancellationToken cancellationToken = default)
-            => AssertAllStagesStoppedAsync(spec, async () => block(), materializer, timeout, cancellationToken)
+            => AssertAllStagesStoppedAsync(spec, () => Task.FromResult(block()), materializer, timeout, cancellationToken)
                 .ConfigureAwait(false).GetAwaiter().GetResult();
 
         public static async Task AssertAllStagesStoppedAsync(

--- a/src/core/Akka.Streams.Tests/Dsl/TickSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/TickSourceSpec.cs
@@ -148,7 +148,7 @@ namespace Akka.Streams.Tests.Dsl
                 await c.ExpectNextAsync("tick");
                 
                 cancelable.Cancel();
-                await AwaitConditionAsync(async () => cancelable.IsCancellationRequested);
+                await AwaitConditionAsync(() => Task.FromResult(cancelable.IsCancellationRequested));
                 
                 sub.Request(3);
                 await c.ExpectCompleteAsync();

--- a/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceAsyncSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceAsyncSourceSpec.cs
@@ -457,8 +457,7 @@ namespace Akka.Streams.Tests.Dsl
             // use a separate materializer to ensure we know what child is our stream
             var materializer = Sys.Materializer();
             
-            await this.AssertAllStagesStoppedAsync(async () =>
-            {
+            await this.AssertAllStagesStoppedAsync(() => {
                 var tcs = new TaskCompletionSource<Task>();
                 try
                 {
@@ -478,6 +477,8 @@ namespace Akka.Streams.Tests.Dsl
                 {
                     tcs.TrySetResult(Task.CompletedTask);
                 }
+
+                return Task.CompletedTask;
             }, materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
@@ -313,7 +313,7 @@ namespace Akka.Streams.Tests.IO
                 // LazySink must wait for result of initialization even if got UpstreamComplete
                 TargetFile(f => 
                 {
-                    var lazySink = Sink.LazyInitAsync(async () => FileIO.ToFile(f))
+                    var lazySink = Sink.LazyInitAsync(() => Task.FromResult(FileIO.ToFile(f)))
                         // map a Task<Option<Task<IOResult>>> into a Task<IOResult>
                         .MapMaterializedValue(t => t.Result.GetOrElse(Task.FromResult(IOResult.Success(0))));
 

--- a/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
@@ -31,7 +31,7 @@ namespace Akka.Streams.Tests.Implementation
         #region from writer
 
         [Fact]
-        public async Task ChannelSink_writer_when_isOwner_should_complete_channel_with_success_when_upstream_completes()
+        public Task ChannelSink_writer_when_isOwner_should_complete_channel_with_success_when_upstream_completes()
         {
             var probe = this.CreateManualPublisherProbe<int>();
             var channel = Channel.CreateBounded<int>(10);
@@ -44,6 +44,7 @@ namespace Akka.Streams.Tests.Implementation
             subscription.SendComplete();
 
             channel.Reader.Completion.Wait(1.Seconds()).Should().BeTrue();
+            return Task.CompletedTask;
         }
 
         [Fact]
@@ -158,7 +159,7 @@ namespace Akka.Streams.Tests.Implementation
         #region as reader
 
         [Fact]
-        public async Task ChannelSink_reader_should_complete_channel_with_success_when_upstream_completes()
+        public Task ChannelSink_reader_should_complete_channel_with_success_when_upstream_completes()
         {
             var probe = this.CreateManualPublisherProbe<int>();
 
@@ -170,6 +171,7 @@ namespace Akka.Streams.Tests.Implementation
             subscription.SendComplete();
 
             reader.Completion.Wait(1.Seconds()).Should().BeTrue();
+            return Task.CompletedTask;
         }
 
         [Fact]

--- a/src/core/Akka.Streams/Implementation/AsyncEnumerable.cs
+++ b/src/core/Akka.Streams/Implementation/AsyncEnumerable.cs
@@ -68,13 +68,14 @@ namespace Akka.Streams.Dsl
             _killSwitch = queueAndSwitch.killSwitch;
             _token = token;
         }
-        public async ValueTask DisposeAsync()
+        public ValueTask DisposeAsync()
         {
             //If we are disposing, let's shut down the stream
             //so that we don't have data hanging around.
             _killSwitch.Shutdown();
             _killSwitch = null;
             _sinkQueue = null;
+            return new ValueTask();
         }
 
         public async ValueTask<bool> MoveNextAsync()

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/AllTestForEventFilterBase.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/AllTestForEventFilterBase.cs
@@ -45,7 +45,7 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task Single_message_is_intercepted()
         {
             await _testingEventFilter.ForLogLevel(LogLevel)
-                .ExpectOneAsync(async () => LogMessage("whatever"));
+                .ExpectOneAsync(() => { LogMessage("whatever"); return Task.CompletedTask; });
             TestSuccessful = true;
         }
 
@@ -54,17 +54,17 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task Can_intercept_messages_when_start_is_specified()
         {
             await _testingEventFilter.ForLogLevel(LogLevel, start: "what")
-                .ExpectOneAsync(async () => LogMessage("whatever"));
+                .ExpectOneAsync(() => { LogMessage("whatever"); return Task.CompletedTask; });
             TestSuccessful = true;
         }
 
         [Fact]
         public async Task Do_not_intercept_messages_when_start_does_not_match()
         {
-            await _testingEventFilter.ForLogLevel(LogLevel, start: "what").ExpectOneAsync(async () =>
-            {
+            await _testingEventFilter.ForLogLevel(LogLevel, start: "what").ExpectOneAsync(() => {
                 LogMessage("let-me-thru");
                 LogMessage("whatever");
+                return Task.CompletedTask;
             });
             await ExpectMsgAsync<TLogEvent>(err => (string)err.Message == "let-me-thru");
             TestSuccessful = true;
@@ -74,17 +74,17 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task Can_intercept_messages_when_message_is_specified()
         {
             await _testingEventFilter.ForLogLevel(LogLevel, message: "whatever")
-                .ExpectOneAsync(async () => LogMessage("whatever"));
+                .ExpectOneAsync(() => { LogMessage("whatever"); return Task.CompletedTask; });
             TestSuccessful = true;
         }
 
         [Fact]
         public async Task Do_not_intercept_messages_when_message_does_not_match()
         {
-            await EventFilter.ForLogLevel(LogLevel, message: "whatever").ExpectOneAsync(async () =>
-            {
+            await EventFilter.ForLogLevel(LogLevel, message: "whatever").ExpectOneAsync(() => {
                 LogMessage("let-me-thru");
                 LogMessage("whatever");
+                return Task.CompletedTask;
             });
             await ExpectMsgAsync<TLogEvent>(err => (string)err.Message == "let-me-thru");
             TestSuccessful = true;
@@ -94,17 +94,17 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task Can_intercept_messages_when_contains_is_specified()
         {
             await _testingEventFilter.ForLogLevel(LogLevel, contains: "ate")
-                .ExpectOneAsync(async () => LogMessage("whatever"));
+                .ExpectOneAsync(() => { LogMessage("whatever"); return Task.CompletedTask; });
             TestSuccessful = true;
         }
 
         [Fact]
         public async Task Do_not_intercept_messages_when_contains_does_not_match()
         {
-            await _testingEventFilter.ForLogLevel(LogLevel, contains: "eve").ExpectOneAsync(async () =>
-            {
+            await _testingEventFilter.ForLogLevel(LogLevel, contains: "eve").ExpectOneAsync(() => {
                 LogMessage("let-me-thru");
                 LogMessage("whatever");
+                return Task.CompletedTask;
             });
             ExpectMsg<TLogEvent>(err => (string)err.Message == "let-me-thru");
             TestSuccessful = true;
@@ -115,17 +115,17 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task Can_intercept_messages_when_source_is_specified()
         {
             await _testingEventFilter.ForLogLevel(LogLevel, source: LogSource.FromType(GetType(), Sys))
-                .ExpectOneAsync(async () => LogMessage("whatever"));
+                .ExpectOneAsync(() => { LogMessage("whatever"); return Task.CompletedTask; });
             TestSuccessful = true;
         }
 
         [Fact]
         public async Task Do_not_intercept_messages_when_source_does_not_match()
         {
-            await _testingEventFilter.ForLogLevel(LogLevel, source: "expected-source").ExpectOneAsync(async () =>
-            {
+            await _testingEventFilter.ForLogLevel(LogLevel, source: "expected-source").ExpectOneAsync(() => {
                 PublishMessage("message", source: "expected-source");
                 PublishMessage("message", source: "let-me-thru");
+                return Task.CompletedTask;
             });
             await ExpectMsgAsync<TLogEvent>(err => err.LogSource == "let-me-thru");
             TestSuccessful = true;
@@ -134,10 +134,10 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         [Fact]
         public async Task Specified_numbers_of_messages_can_be_intercepted()
         {
-            await _testingEventFilter.ForLogLevel(LogLevel).ExpectAsync(2, async () =>
-            {
+            await _testingEventFilter.ForLogLevel(LogLevel).ExpectAsync(2, () => {
                 LogMessage("whatever");
                 LogMessage("whatever");
+                return Task.CompletedTask;
             });
             TestSuccessful = true;
         }
@@ -147,9 +147,9 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         {
             await Awaiting(async () =>
             {
-                await EventFilter.Error().ExpectAsync(0, async () =>
-                {
+                await EventFilter.Error().ExpectAsync(0, () => {
                     Log.Error("something");
+                    return Task.CompletedTask;
                 });
             }).Should().ThrowAsync<Exception>("Expected 0 events");
         }
@@ -198,10 +198,10 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         [Fact]
         public async Task Messages_can_be_muted()
         {
-            await _testingEventFilter.ForLogLevel(LogLevel).MuteAsync(async () =>
-            {
+            await _testingEventFilter.ForLogLevel(LogLevel).MuteAsync(() => {
                 LogMessage("whatever");
                 LogMessage("whatever");
+                return Task.CompletedTask;
             });
             TestSuccessful = true;
         }
@@ -232,11 +232,10 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         [Fact]
         public async Task Make_sure_async_works()
         {
-            await _testingEventFilter.ForLogLevel(LogLevel).ExpectAsync(1, TimeSpan.FromSeconds(2), async () =>
-            {
+            await _testingEventFilter.ForLogLevel(LogLevel).ExpectAsync(1, TimeSpan.FromSeconds(2), () => {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 Task.Delay(TimeSpan.FromMilliseconds(10)).ContinueWith(t => { LogMessage("whatever"); });
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
+                return Task.CompletedTask;
             });
         }
 
@@ -246,12 +245,11 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
             await _testingEventFilter
                 .ForLogLevel(LogLevel,message:"Message 1").And
                 .ForLogLevel(LogLevel,message:"Message 3")
-                .ExpectAsync(2, async () =>
-                {
+                .ExpectAsync(2, () => {
                     LogMessage("Message 1");
                     LogMessage("Message 2");
                     LogMessage("Message 3");
-
+                    return Task.CompletedTask;
                 });
             await ExpectMsgAsync<TLogEvent>(m => (string) m.Message == "Message 2");
         }
@@ -262,9 +260,9 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         {
             await Awaiting(async () =>
             {
-                await _testingEventFilter.ForLogLevel(LogLevel).ExpectAsync(2, TimeSpan.FromMilliseconds(50), async () =>
-                {
+                await _testingEventFilter.ForLogLevel(LogLevel).ExpectAsync(2, TimeSpan.FromMilliseconds(50), () => {
                     LogMessage("whatever");
+                    return Task.CompletedTask;
                 });
             }).Should().ThrowAsync<TrueException>().WithMessage("Timeout (*");
         }

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/CustomEventFilterTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/CustomEventFilterTests.cs
@@ -27,9 +27,9 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         {
             var eventFilter = CreateTestingEventFilter();
             await eventFilter.Custom(logEvent => logEvent is Error && (string) logEvent.Message == "whatever")
-                .ExpectOneAsync(async () =>
-                {
+                .ExpectOneAsync(() => {
                     Log.Error("whatever");
+                    return Task.CompletedTask;
                 });
         }
 
@@ -38,9 +38,9 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         {
             var eventFilter = CreateTestingEventFilter();
             await eventFilter.Custom<Error>(logEvent => (string)logEvent.Message == "whatever")
-                .ExpectOneAsync(async () =>
-                {
+                .ExpectOneAsync(() => {
                     Log.Error("whatever");
+                    return Task.CompletedTask;
                 });
         }
     }

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/DeadLettersEventFilterTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/DeadLettersEventFilterTests.cs
@@ -37,29 +37,29 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task Should_be_able_to_filter_dead_letters()
         {
             var eventFilter = CreateTestingEventFilter();
-            await eventFilter.DeadLetter().ExpectOneAsync(async () =>
-            {
+            await eventFilter.DeadLetter().ExpectOneAsync(() => {
                 _deadActor.Tell("whatever");
+                return Task.CompletedTask;
             });
         }
         
         [Fact]
         public async Task Should_check_properly_type_parameters()
         {
-            await EventFilter.DeadLetter<int>().And.DeadLetter<double>().ExpectAsync(2, async () =>
-            {
+            await EventFilter.DeadLetter<int>().And.DeadLetter<double>().ExpectAsync(2, () => {
                 _deadActor.Tell(5);
                 _deadActor.Tell(1.2);
+                return Task.CompletedTask;
             });
         }
 
         [Fact]
         public async Task Should_check_properly_type_parameters_when_one_of_them_string()
         {
-            await EventFilter.DeadLetter<string>().And.DeadLetter<double>().ExpectAsync(2, async () =>
-            {
+            await EventFilter.DeadLetter<string>().And.DeadLetter<double>().ExpectAsync(2, () => {
                 _deadActor.Tell("asd");
                 _deadActor.Tell(1.2);
+                return Task.CompletedTask;
             });
         }
     }

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/ExceptionEventFilterTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/ExceptionEventFilterTests.cs
@@ -33,7 +33,7 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task SingleExceptionIsIntercepted()
         {
             await EventFilter.Exception<SomeException>()
-                .ExpectOneAsync(async () => Log.Error(new SomeException(), "whatever"));
+                .ExpectOneAsync(() => { Log.Error(new SomeException(), "whatever"); return Task.CompletedTask; });
             await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
         }
 
@@ -41,7 +41,7 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task CanInterceptMessagesWhenStartIsSpecified()
         {
             await EventFilter.Exception<SomeException>(start: "what")
-                .ExpectOneAsync(async () => Log.Error(new SomeException(), "whatever"));
+                .ExpectOneAsync(() => { Log.Error(new SomeException(), "whatever"); return Task.CompletedTask; });
             await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
         }
 
@@ -57,7 +57,7 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task CanInterceptMessagesWhenMessageIsSpecified()
         {
             await EventFilter.Exception<SomeException>(message: "whatever")
-                .ExpectOneAsync(async () => Log.Error(new SomeException(), "whatever"));
+                .ExpectOneAsync(() => { Log.Error(new SomeException(), "whatever"); return Task.CompletedTask; });
             await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
         }
 
@@ -73,7 +73,7 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task CanInterceptMessagesWhenContainsIsSpecified()
         {
             await EventFilter.Exception<SomeException>(contains: "ate")
-                .ExpectOneAsync(async () => Log.Error(new SomeException(), "whatever"));
+                .ExpectOneAsync(() => { Log.Error(new SomeException(), "whatever"); return Task.CompletedTask; });
             await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
         }
 
@@ -90,7 +90,7 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task CanInterceptMessagesWhenSourceIsSpecified()
         {
             await EventFilter.Exception<SomeException>(source: LogSource.Create(this, Sys).Source)
-                .ExpectOneAsync(async () => Log.Error(new SomeException(), "whatever"));
+                .ExpectOneAsync(() => { Log.Error(new SomeException(), "whatever"); return Task.CompletedTask; });
             await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
         }
 
@@ -107,10 +107,10 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task SpecifiedNumbersOfExceptionsCanBeIntercepted()
         {
             await EventFilter.Exception<SomeException>()
-                .ExpectAsync(2, async () =>
-                {
+                .ExpectAsync(2, () => {
                     Log.Error(new SomeException(), "whatever");
                     Log.Error(new SomeException(), "whatever");
+                    return Task.CompletedTask;
                 });
             await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
         }
@@ -120,11 +120,11 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         {
             await Awaiting(async () =>
                 {
-                    await EventFilter.Exception<SomeException>().ExpectAsync(2, async () =>
-                    {
+                    await EventFilter.Exception<SomeException>().ExpectAsync(2, () => {
                         Log.Error(new SomeException(), "whatever");
                         Log.Error(new SomeException(), "whatever");
                         Log.Error(new SomeException(), "whatever");
+                        return Task.CompletedTask;
                     });                    
                 })
                 .Should().ThrowAsync<TrueException>().WithMessage("Received 1 message too many.*");
@@ -139,7 +139,7 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
             await EventFilter
                 .Exception<InvalidOperationException>(source: actor.Path.ToString())
                 // expecting 2 because the same exception is logged in PostRestart
-                .ExpectAsync(2, async () => actor.Tell( toSend ));
+                .ExpectAsync(2, () => { actor.Tell( toSend ); return Task.CompletedTask; });
         }
 
         internal sealed class ExceptionTestActor : UntypedActor

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/UnhandledMessageEventFilterTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/UnhandledMessageEventFilterTests.cs
@@ -33,9 +33,9 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         {
             await EventFilter
                 .Info(new Regex("^Unhandled message from"))
-                .ExpectOneAsync(async () =>
-                {
+                .ExpectOneAsync(() => {
                     _unhandledMessageActor.Tell("whatever");
+                    return Task.CompletedTask;
                 });
         }
         
@@ -46,9 +46,9 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
                 .Warning()
                 .And
                 .Error()
-                .ExpectAsync(0, async () =>
-                {
+                .ExpectAsync(0, () => {
                     _unhandledMessageActor.Tell("whatever");
+                    return Task.CompletedTask;
                 });
         }
     }

--- a/src/core/Akka.TestKit.Tests/TestFSMRefTests/TestFSMRefSpec.cs
+++ b/src/core/Akka.TestKit.Tests/TestFSMRefTests/TestFSMRefSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.TestKit.Tests.TestFSMRefTests
 
             fsm.SetStateTimeout(100.Milliseconds());
             await WithinAsync(80.Milliseconds(), 500.Milliseconds(), async () =>
-                await AwaitConditionAsync(async () => fsm.StateName == 2 && fsm.StateData == "timeout")
+                await AwaitConditionAsync(() => Task.FromResult(fsm.StateName == 2 && fsm.StateData == "timeout"))
             );
         }
 

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/DilatedTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/DilatedTests.cs
@@ -39,7 +39,7 @@ namespace Akka.TestKit.Tests.TestKitBaseTests
         public async Task AwaitConditionAsync_should_dilate_timeout()
         {
             var stopwatch = Stopwatch.StartNew();
-            await Awaiting(() => AwaitConditionAsync(async () => false, TimeSpan.FromMilliseconds(Timeout)))
+            await Awaiting(() => AwaitConditionAsync(() => Task.FromResult(false), TimeSpan.FromMilliseconds(Timeout)))
                 .Should().ThrowAsync<TrueException>();
             stopwatch.Stop();
             AssertDilated(stopwatch.ElapsedMilliseconds, $"Expected the timeout to be {ExpectedTimeout} but in fact it was {stopwatch.ElapsedMilliseconds}.");

--- a/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
+++ b/src/core/Akka.TestKit/EventFilter/Internal/EventFilterApplier.cs
@@ -45,7 +45,7 @@ namespace Akka.TestKit.Internal
         /// <param name="cancellationToken"></param>
         public void ExpectOne(Action action, CancellationToken cancellationToken = default)
         {
-            ExpectOneAsync(async () => action(), cancellationToken)
+            ExpectOneAsync(() => { action(); return Task.CompletedTask; }, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
@@ -97,7 +97,7 @@ namespace Akka.TestKit.Internal
             Action action,
             CancellationToken cancellationToken = default)
         {
-            ExpectOneAsync(timeout, async () => action(), cancellationToken)
+            ExpectOneAsync(timeout, () => { action(); return Task.CompletedTask; }, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
@@ -130,7 +130,7 @@ namespace Akka.TestKit.Internal
             Action action,
             CancellationToken cancellationToken = default)
         {
-            ExpectAsync(expectedCount, async () => action(), cancellationToken)
+            ExpectAsync(expectedCount, () => { action(); return Task.CompletedTask; }, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
 
@@ -180,7 +180,7 @@ namespace Akka.TestKit.Internal
             Action action,
             CancellationToken cancellationToken = default)
         {
-            ExpectAsync(expectedCount, timeout, async () => action(), cancellationToken)
+            ExpectAsync(expectedCount, timeout, () => { action(); return Task.CompletedTask; }, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken); 
         }
         
@@ -222,7 +222,7 @@ namespace Akka.TestKit.Internal
         /// <returns>TBD</returns>
         public T ExpectOne<T>(Func<T> func, CancellationToken cancellationToken = default)
         {
-            return ExpectOneAsync(async () => func(), cancellationToken)
+            return ExpectOneAsync(() => Task.FromResult(func()), cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
@@ -255,7 +255,7 @@ namespace Akka.TestKit.Internal
             Func<T> func,
             CancellationToken cancellationToken = default)
         {
-            return ExpectOneAsync(timeout, async () => func(), cancellationToken)
+            return ExpectOneAsync(timeout, () => Task.FromResult(func()), cancellationToken)
                 .WaitAndUnwrapException();
         }
         
@@ -290,7 +290,7 @@ namespace Akka.TestKit.Internal
             Func<T> func,
             CancellationToken cancellationToken = default)
         {
-            return ExpectAsync(expectedCount, async () => func(), cancellationToken)
+            return ExpectAsync(expectedCount, () => Task.FromResult(func()), cancellationToken)
                 .WaitAndUnwrapException();
         }
 
@@ -327,7 +327,7 @@ namespace Akka.TestKit.Internal
             Func<T> func,
             CancellationToken cancellationToken = default)
         {
-            return ExpectAsync(expectedCount, timeout, async () => func(), cancellationToken)
+            return ExpectAsync(expectedCount, timeout, () => Task.FromResult(func()), cancellationToken)
                 .WaitAndUnwrapException();
         }
         
@@ -360,7 +360,7 @@ namespace Akka.TestKit.Internal
         /// <returns>TBD</returns>
         public T Mute<T>(Func<T> func, CancellationToken cancellationToken = default)
         {
-            return MuteAsync(async () => func(), cancellationToken)
+            return MuteAsync(() => Task.FromResult(func()), cancellationToken)
                 .WaitAndUnwrapException();
         }
         
@@ -386,7 +386,7 @@ namespace Akka.TestKit.Internal
         /// <param name="cancellationToken"></param>
         public void Mute(Action action, CancellationToken cancellationToken = default)
         {
-            MuteAsync(async () => action(), cancellationToken)
+            MuteAsync(() => { action(); return Task.CompletedTask; }, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
@@ -461,7 +461,7 @@ namespace Akka.TestKit.Internal
             CancellationToken cancellationToken = default)
         {
             return InterceptAsync(
-                    func: async () => func(),
+                    func: () => Task.FromResult(func()),
                     system: system,
                     timeout: timeout,
                     expectedOccurrences: expectedOccurrences,
@@ -569,13 +569,13 @@ namespace Akka.TestKit.Internal
                 var expected = expectedOccurrences.GetValueOrDefault();
                 if (expected > 0)
                 {
-                    await _testkit.AwaitConditionNoThrowAsync(async () => matchedEventHandler.ReceivedCount >= expected, timeout, cancellationToken: cancellationToken);
+                    await _testkit.AwaitConditionNoThrowAsync(() => Task.FromResult(matchedEventHandler.ReceivedCount >= expected), timeout, cancellationToken: cancellationToken);
                     return matchedEventHandler.ReceivedCount == expected;
                 }
                 else
                 {
                     // if expecting no events to arrive - assert that given condition will never match
-                    var foundEvent = await _testkit.AwaitConditionNoThrowAsync(async () => matchedEventHandler.ReceivedCount > 0, timeout, cancellationToken: cancellationToken);
+                    var foundEvent = await _testkit.AwaitConditionNoThrowAsync(() => Task.FromResult(matchedEventHandler.ReceivedCount > 0), timeout, cancellationToken: cancellationToken);
                     return foundEvent == false;
                 }
             }

--- a/src/core/Akka.TestKit/Internal/BlockingQueue.cs
+++ b/src/core/Akka.TestKit/Internal/BlockingQueue.cs
@@ -33,9 +33,10 @@ namespace Akka.TestKit.Internal
                 throw new InvalidOperationException("Failed to enqueue item into the queue.");
         }
 
-        public async ValueTask EnqueueAsync(T item)
+        public ValueTask EnqueueAsync(T item)
         {
             Enqueue(item);
+            return new ValueTask();
         }
 
         [Obsolete("This method will be removed from the public API in the future")] 
@@ -50,9 +51,9 @@ namespace Akka.TestKit.Internal
             return _collection.TryAdd(new Positioned(item), millisecondsTimeout, cancellationToken);
         }
 
-        public async ValueTask<bool> TryEnqueueAsync(T item, int millisecondsTimeout, CancellationToken cancellationToken)
+        public ValueTask<bool> TryEnqueueAsync(T item, int millisecondsTimeout, CancellationToken cancellationToken)
         {
-            return TryEnqueue(item, millisecondsTimeout, cancellationToken);
+            return new ValueTask<bool>(TryEnqueue(item, millisecondsTimeout, cancellationToken));
         }
 
         public bool TryTake(out T item, CancellationToken cancellationToken = default)
@@ -66,10 +67,10 @@ namespace Akka.TestKit.Internal
             return false;
         }
 
-        public async ValueTask<(bool success, T item)> TryTakeAsync(CancellationToken cancellationToken)
+        public ValueTask<(bool success, T item)> TryTakeAsync(CancellationToken cancellationToken)
         {
             var result = TryTake(out var item);
-            return (result, item);
+            return new ValueTask<(bool success, T item)>((result, item));
         }
 
         public bool TryTake(out T item, int millisecondsTimeout, CancellationToken cancellationToken)
@@ -83,10 +84,10 @@ namespace Akka.TestKit.Internal
             return false;
         }
 
-        public async ValueTask<(bool success, T item)> TryTakeAsync(int millisecondsTimeout, CancellationToken cancellationToken)
+        public ValueTask<(bool success, T item)> TryTakeAsync(int millisecondsTimeout, CancellationToken cancellationToken)
         {
             var result = TryTake(out var item, millisecondsTimeout, cancellationToken);
-            return (result, item);
+            return new ValueTask<(bool success, T item)>((result, item));
         }
 
         public T Take(CancellationToken cancellationToken)
@@ -95,9 +96,9 @@ namespace Akka.TestKit.Internal
             return p.Value;
         }
 
-        public async ValueTask<T> TakeAsync(CancellationToken cancellationToken)
+        public ValueTask<T> TakeAsync(CancellationToken cancellationToken)
         {
-            return _collection.Take(cancellationToken).Value;
+            return new ValueTask<T>(_collection.Take(cancellationToken).Value);
         }
 
         #region Peek methods
@@ -116,7 +117,7 @@ namespace Akka.TestKit.Internal
             return false;
         }
 
-        public async ValueTask<(bool success, T item)> TryPeekAsync(CancellationToken cancellationToken)
+        public ValueTask<(bool success, T item)> TryPeekAsync(CancellationToken cancellationToken)
         {
             if(_collection.TryTake(out var p))
             {
@@ -124,9 +125,9 @@ namespace Akka.TestKit.Internal
 #pragma warning disable CS0618
                 AddFirst(item);
 #pragma warning restore CS0618                
-                return (true, item);
+                return new ValueTask<(bool success, T item)>((true, item));
             }
-            return (false, default);
+            return new ValueTask<(bool success, T item)>((false, default));
         }
 
         public bool TryPeek(out T item, int millisecondsTimeout, CancellationToken cancellationToken)
@@ -143,7 +144,7 @@ namespace Akka.TestKit.Internal
             return false;
         }
 
-        public async ValueTask<(bool success, T item)> TryPeekAsync(int millisecondsTimeout, CancellationToken cancellationToken)
+        public ValueTask<(bool success, T item)> TryPeekAsync(int millisecondsTimeout, CancellationToken cancellationToken)
         {
             if(_collection.TryTake(out var p, millisecondsTimeout, cancellationToken))
             {
@@ -151,9 +152,9 @@ namespace Akka.TestKit.Internal
 #pragma warning disable CS0618
                 AddFirst(item);
 #pragma warning restore CS0618
-                return (true, item);
+                return new ValueTask<(bool success, T item)>((true, item));
             }
-            return (false, default);
+            return new ValueTask<(bool success, T item)>((false, default));
         }
         
         public T Peek(CancellationToken cancellationToken)
@@ -165,13 +166,13 @@ namespace Akka.TestKit.Internal
             return p.Value;
         }
 
-        public async ValueTask<T> PeekAsync(CancellationToken cancellationToken)
+        public ValueTask<T> PeekAsync(CancellationToken cancellationToken)
         {
             var val = _collection.Take(cancellationToken).Value;
 #pragma warning disable CS0618
             AddFirst(val);
 #pragma warning restore CS0618            
-            return val;
+            return new ValueTask<T>(val);
         }
         #endregion
         

--- a/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitConditions.cs
@@ -74,7 +74,7 @@ namespace Akka.TestKit
         /// <param name="cancellationToken"></param>
         public void AwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan? max, CancellationToken cancellationToken = default)
         {
-            AwaitConditionAsync(async () => conditionIsFulfilled(), max, cancellationToken)
+            AwaitConditionAsync(() => Task.FromResult(conditionIsFulfilled()), max, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
         }
         
@@ -280,7 +280,7 @@ namespace Akka.TestKit
         /// <returns>TBD</returns>
         protected static bool InternalAwaitCondition(Func<bool> conditionIsFulfilled, TimeSpan max, TimeSpan? interval, Action<string, object[]> fail, ILoggingAdapter logger, CancellationToken cancellationToken = default)
         {
-            return InternalAwaitConditionAsync(async () => conditionIsFulfilled(), max, interval, fail, logger, cancellationToken)
+            return InternalAwaitConditionAsync(() => Task.FromResult(conditionIsFulfilled()), max, interval, fail, logger, cancellationToken)
                 .WaitAndUnwrapException(cancellationToken);
             
         }

--- a/src/core/Akka.TestKit/TestKitBase_Within.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Within.cs
@@ -39,10 +39,10 @@ namespace Akka.TestKit
             WithinAsync(
                     min: TimeSpan.Zero,
                     max: max,
-                    function: async () =>
+                    function: () =>
                     {
                         action();
-                        return NotUsed.Instance;
+                        return Task.FromResult(NotUsed.Instance);
                     },
                     hint: null,
                     epsilonValue: epsilonValue,
@@ -98,10 +98,10 @@ namespace Akka.TestKit
             WithinAsync(
                     min: min, 
                     max: max, 
-                    function: async () =>
+                    function: () =>
                     {
                         action();
-                        return NotUsed.Instance;
+                        return Task.FromResult(NotUsed.Instance);
                     }, 
                     hint: hint, 
                     epsilonValue: epsilonValue, 
@@ -157,7 +157,7 @@ namespace Akka.TestKit
             return WithinAsync(
                     min: TimeSpan.Zero,
                     max: max,
-                    function: async () => function(),
+                    function: () => Task.FromResult(function()),
                     hint: null,
                     epsilonValue: epsilonValue,
                     cancellationToken: cancellationToken)
@@ -219,7 +219,7 @@ namespace Akka.TestKit
             return WithinAsync(
                     min: min,
                     max: max,
-                    function: async () => function(),
+                    function: () => Task.FromResult(function()),
                     hint: hint,
                     epsilonValue: epsilonValue,
                     cancellationToken: cancellationToken)

--- a/src/core/Akka.Tests/Actor/ActorLifeCycleSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLifeCycleSpec.cs
@@ -202,10 +202,10 @@ namespace Akka.Tests
         public async Task Log_failures_in_PostStop()
         {
             var a = Sys.ActorOf<EmptyActor>();
-            await EventFilter.Exception<Exception>(message: "hurrah").ExpectOneAsync(async () =>
-                {
-                    a.Tell(PoisonPill.Instance);
-                });            
+            await EventFilter.Exception<Exception>(message: "hurrah").ExpectOneAsync(() => {
+                a.Tell(PoisonPill.Instance);
+                return Task.CompletedTask;
+            });            
         }
 
         public class Become

--- a/src/core/Akka.Tests/Actor/ActorProducerPipelineTests.cs
+++ b/src/core/Akka.Tests/Actor/ActorProducerPipelineTests.cs
@@ -187,16 +187,16 @@ namespace Akka.Tests.Actor
         {
             // we'll send 3 int messages to stash by the actor and then stop it,
             // all stashed messages should then be unstashed back and sent to dead letters
-            await EventFilter.DeadLetter<int>().ExpectAsync(3, async () =>
-            {
+            await EventFilter.DeadLetter<int>().ExpectAsync(3, () => {
                 var actor = ActorOf<StashingActor>();
                 // send some messages to stash
                 actor.Tell(1);
                 actor.Tell(2);
                 actor.Tell(3);
-                
+
                 // stop actor
                 actor.Tell(PoisonPill.Instance);
+                return Task.CompletedTask;
             });
         }
     }

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -78,7 +78,7 @@ namespace Akka.Tests.Actor
 
             // Notice here we forcedly start actor system again to monitor how it processes
             var expected = "log-config-on-start : on";
-            await eventFilter.Info(contains:expected).ExpectOneAsync(async () => system.Start());
+            await eventFilter.Info(contains:expected).ExpectOneAsync(() => { system.Start(); return Task.CompletedTask; });
 
             await system.Terminate();
         }
@@ -96,7 +96,7 @@ namespace Akka.Tests.Actor
             var eventFilter = new EventFilterFactory(new TestKit.Xunit2.TestKit(system));
 
             // Notice here we forcedly start actor system again to monitor how it processes
-            await eventFilter.Info().ExpectAsync(0, async () => system.Start());
+            await eventFilter.Info().ExpectAsync(0, () => { system.Start(); return Task.CompletedTask; });
 
             await system.Terminate();
         }
@@ -120,10 +120,10 @@ namespace Akka.Tests.Actor
                 var a = sys.ActorOf(Props.Create<Terminater>());
 
                 var eventFilter = new EventFilterFactory(new TestKit.Xunit2.TestKit(sys));
-                await eventFilter.Info(contains: "not delivered").ExpectAsync(1, async () =>
-                {
+                await eventFilter.Info(contains: "not delivered").ExpectAsync(1, () => {
                     a.Tell("run");
                     a.Tell("boom");
+                    return Task.CompletedTask;
                 });
             }
             finally { Shutdown(sys); }

--- a/src/core/Akka.Tests/Actor/DeadLetterSuspensionSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeadLetterSuspensionSpec.cs
@@ -85,19 +85,19 @@ namespace Akka.Tests.Actor
         {
             await EventFilter
                 .Info(start: ExpectedDeadLettersLogMessage(1))
-                .ExpectAsync(1, async () => _deadActor.Tell(1));
+                .ExpectAsync(1, () => { _deadActor.Tell(1); return Task.CompletedTask; });
 
             await EventFilter
                 .Info(start: ExpectedDroppedLogMessage(2))
-                .ExpectAsync(1, async () => _droppingActor.Tell(2));
+                .ExpectAsync(1, () => { _droppingActor.Tell(2); return Task.CompletedTask; });
 
             await EventFilter
                 .Info(start: ExpectedUnhandledLogMessage(3))
-                .ExpectAsync(1, async () => _unhandledActor.Tell(3));
+                .ExpectAsync(1, () => { _unhandledActor.Tell(3); return Task.CompletedTask; });
 
             await EventFilter
                 .Info(start: ExpectedDeadLettersLogMessage(4) + ", no more dead letters will be logged in next")
-                .ExpectAsync(1, async () => _deadActor.Tell(4));
+                .ExpectAsync(1, () => { _deadActor.Tell(4); return Task.CompletedTask; });
             _deadActor.Tell(5);
             _droppingActor.Tell(6);
 
@@ -107,12 +107,12 @@ namespace Akka.Tests.Actor
             // re-enabled
             await EventFilter
                 .Info(start: ExpectedDeadLettersLogMessage(7) + ", of which 2 were not logged")
-                .ExpectAsync(1, async () => _deadActor.Tell(7));
+                .ExpectAsync(1, () => { _deadActor.Tell(7); return Task.CompletedTask; });
 
             // reset count
             await EventFilter
                 .Info(start: ExpectedDeadLettersLogMessage(1))
-                .ExpectAsync(1, async () => _deadActor.Tell(8));
+                .ExpectAsync(1, () => { _deadActor.Tell(8); return Task.CompletedTask; });
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
@@ -124,7 +124,7 @@ namespace Akka.Tests.Actor.Dispatch
 
             Sys.Stop(actor);
             await ExpectTerminatedAsync(actor);
-            await AwaitConditionAsync(async () => !thread.IsAlive); // wait for thread to terminate
+            await AwaitConditionAsync(() => Task.FromResult(!thread.IsAlive)); // wait for thread to terminate
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/FSMActorSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMActorSpec.cs
@@ -436,10 +436,10 @@ namespace Akka.Tests.Actor
             latches.TransitionCallBackLatch.Ready(timeout);
             latches.LockedLatch.Ready(timeout);
 
-            await EventFilter.Warning("unhandled event").ExpectOneAsync(async () =>
-            {
+            await EventFilter.Warning("unhandled event").ExpectOneAsync(() => {
                 lockFsm.Tell("not_handled");
                 latches.UnhandledLatch.Ready(timeout);
+                return Task.CompletedTask;
             });
 
             var answerLatch = new TestLatch();

--- a/src/core/Akka.Tests/Actor/HotSwapSpec.cs
+++ b/src/core/Akka.Tests/Actor/HotSwapSpec.cs
@@ -95,8 +95,10 @@ namespace Akka.Tests.Actor {
             a.Tell("state");
             await ExpectMsgAsync("1");
 
-            await EventFilter.Exception<Exception>("Crash (expected)!").ExpectAsync(1, async () => {
+            await EventFilter.Exception<Exception>("Crash (expected)!").ExpectAsync(1, () =>
+            {
                 a.Tell("crash");
+                return Task.CompletedTask;
             });
 
             a.Tell("state");

--- a/src/core/Akka.Tests/Actor/InboxSpec.cs
+++ b/src/core/Akka.Tests/Actor/InboxSpec.cs
@@ -95,7 +95,7 @@ namespace Akka.Tests.Actor
                 await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
 
                 //The inbox is full. Sending another message should result in a Warning message
-                await EventFilter.Warning(start: "Dropping message").ExpectOneAsync(async () => _inbox.Receiver.Tell(42));
+                await EventFilter.Warning(start: "Dropping message").ExpectOneAsync(() => { _inbox.Receiver.Tell(42); return Task.CompletedTask; });
 
                 //The inbox is still full. But since the warning message has already been sent, no more warnings should be sent
                 _inbox.Receiver.Tell(42);

--- a/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
+++ b/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
@@ -52,7 +52,7 @@ namespace Akka.Tests.Actor
                 var timeout = Dilated(TimeSpan.FromSeconds(5));
                 var address = "new-actor" + i;
                 var actors = Enumerable.Range(0, 4)
-                    .Select(async x => Sys.ActorOf(Props.Create(() => new BlackHoleActor()), address)).ToArray();
+                    .Select(x => Task.FromResult(Sys.ActorOf(Props.Create(() => new BlackHoleActor()), address))).ToArray();
                 // Use WhenAll with empty ContinueWith to swallow all exceptions, so we can inspect the tasks afterwards.
                 await Task.WhenAll(actors).ContinueWith(a => { }).AwaitWithTimeout(timeout);
                 Assert.True(actors.Any(x => x.Status == TaskStatus.RanToCompletion && x.Result != null), "Failed to create any Actors");
@@ -64,10 +64,10 @@ namespace Akka.Tests.Actor
         public async Task An_ActorRefFactory_must_only_create_one_instance_of_an_actor_from_within_the_same_message_invocation()
         {
             var supervisor = Sys.ActorOf(Props.Create<ActorWithDuplicateChild>());
-            await EventFilter.Exception<InvalidActorNameException>(message: "Actor name \"duplicate\" is not unique!").ExpectOneAsync(async () =>
-                {
-                    supervisor.Tell("");
-                });
+            await EventFilter.Exception<InvalidActorNameException>(message: "Actor name \"duplicate\" is not unique!").ExpectOneAsync(() => {
+                supervisor.Tell("");
+                return Task.CompletedTask;
+            });
         }
 
         [Theory]

--- a/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
+++ b/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
@@ -52,7 +52,7 @@ namespace Akka.Tests.Actor
                 var timeout = Dilated(TimeSpan.FromSeconds(5));
                 var address = "new-actor" + i;
                 var actors = Enumerable.Range(0, 4)
-                    .Select(x => Task.FromResult(Sys.ActorOf(Props.Create(() => new BlackHoleActor()), address))).ToArray();
+                    .Select(x => Task.Run(() => Sys.ActorOf(Props.Create(() => new BlackHoleActor()), address))).ToArray();
                 // Use WhenAll with empty ContinueWith to swallow all exceptions, so we can inspect the tasks afterwards.
                 await Task.WhenAll(actors).ContinueWith(a => { }).AwaitWithTimeout(timeout);
                 Assert.True(actors.Any(x => x.Status == TaskStatus.RanToCompletion && x.Result != null), "Failed to create any Actors");

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Schedule_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Schedule_Tests.cs
@@ -286,7 +286,7 @@ namespace Akka.Tests.Actor.Scheduler
                     Interlocked.Increment(ref timesCalled);
                     throw new Exception("Crash");
                 });
-                await AwaitConditionAsync(async () => timesCalled >= 1);
+                await AwaitConditionAsync(() => Task.FromResult(timesCalled >= 1));
                 await Task.Delay(200); //Allow any scheduled actions to be fired. 
 
                 //We expect only one of the scheduled actions to actually fire

--- a/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
@@ -197,10 +197,11 @@ namespace Akka.Tests.Actor
             //Check everything is in place by sending ping to worker and expect it to respond with pong
             worker.Tell("ping");
             await ExpectMsgAsync("pong");
-            await EventFilter.Warning("expected").ExpectOneAsync(async () => //expected exception is thrown by the boss when it crashes
-            {
-                middle.Tell("fail");    //Throws an exception, and then it's resumed
-            });
+            await EventFilter.Warning("expected").ExpectOneAsync(() => //expected exception is thrown by the boss when it crashes
+{
+    middle.Tell("fail");    //Throws an exception, and then it's resumed
+    return Task.CompletedTask;
+});
 
             //verify that middle answers
             middle.Tell("ping");

--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -100,7 +100,6 @@ namespace Akka.Tests.Configuration
             Output.WriteLine("This test is skipped.");
 #endif
         }
-
     }
 
 }

--- a/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
@@ -484,8 +484,7 @@ namespace Akka.Tests.Dispatch
         {
             public AsyncReentrantActor()
             {
-                ReceiveAsync<string>(async msg =>
-                {
+                ReceiveAsync<string>(msg => {
                     var sender = Sender;
 #pragma warning disable CS4014
                     Task.Run(() =>
@@ -497,6 +496,7 @@ namespace Akka.Tests.Dispatch
 #pragma warning restore CS4014
 
                     Thread.Sleep(3000);
+                    return Task.CompletedTask;
                 });
             }
             


### PR DESCRIPTION
## Changes

"warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread."

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
