### PR TITLE
Drop support for `.NETCore3.1` in Tests and samples

### DIFF
--- a/build-system/azure-pipeline.mntr-template.yaml
+++ b/build-system/azure-pipeline.mntr-template.yaml
@@ -20,11 +20,6 @@ jobs:
         displayName: 'Use .NET 7 SDK 7.0.100'
         inputs:
           version: 7.0.100
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core Runtime 3.1.10'
-        inputs:
-          packageType: runtime
-          version: 3.1.10
       - task: Bash@3 
         displayName: Linux / OSX Build
         inputs:

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -27,15 +27,6 @@ jobs:
         displayName: 'Use .NET 7 SDK 7.0.100'
         inputs:
           version: 7.0.100
-      - task: UseDotNet@2 # to keep DocFx happy
-        displayName: "Use .NET 6 SDK 6.0.100" 
-        inputs:
-          version: 6.0.100
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core Runtime 3.1.10'
-        inputs:
-          packageType: runtime
-          version: 3.1.10
       - task: Bash@3 
         displayName: Linux / OSX Build
         inputs:

--- a/build-system/nightly-builds.yaml
+++ b/build-system/nightly-builds.yaml
@@ -2,7 +2,7 @@
 # See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-latest
   demands: Cmd
 
 trigger: none
@@ -23,15 +23,6 @@ steps:
   displayName: 'Use .NET 7 SDK 7.0.100'
   inputs:
     version: 7.0.100
-- task: UseDotNet@2
-  displayName: 'Use .NET 5 SDK 6.0.100'
-  inputs:
-    version: 6.0.100
-- task: UseDotNet@2
-  displayName: 'Use .NET Core Runtime 3.1.10'
-  inputs:
-    packageType: runtime
-    version: 3.1.10
 - task: BatchScript@1
   displayName: 'FAKE Build'
   inputs:

--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -19,7 +19,7 @@ jobs:
   - job: DocsSpellcheck
     displayName: "Docs: Spellcheck"
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
     steps:
       - checkout: self # self represents the repo where the initial Pipelines YAML file was found
         clean: false # whether to fetch clean each time
@@ -55,7 +55,7 @@ jobs:
   - job: WindowsBuild
     displayName: Windows Build
     pool:
-      vmImage: windows-2019
+      vmImage: windows-latest
       demands: Cmd
     steps:
       - checkout: self # self represents the repo where the initial Pipelines YAML file was found
@@ -66,11 +66,6 @@ jobs:
         displayName: "Use .NET 7 SDK 7.0.100"
         inputs:
           version: 7.0.100
-      - task: UseDotNet@2
-        displayName: "Use .NET Core Runtime 3.1.10"
-        inputs:
-          packageType: runtime
-          version: 3.1.10
       - task: BatchScript@1
         displayName: Windows Build
         inputs:
@@ -98,7 +93,7 @@ jobs:
     parameters:
       name: "netfx_tests_windows"
       displayName: ".NET Framework Unit Tests (Windows)"
-      vmImage: "windows-2019"
+      vmImage: "windows-latest"
       scriptFileName: build.cmd
       scriptArgs: runTests incremental
       outputDirectory: "TestResults"
@@ -106,29 +101,9 @@ jobs:
 
   - template: azure-pipeline.template.yaml
     parameters:
-      name: "net_core_tests_windows"
-      displayName: ".NET Core Unit Tests (Windows)"
-      vmImage: "windows-2019"
-      scriptFileName: build.cmd
-      scriptArgs: runTestsNetCore incremental
-      outputDirectory: "TestResults"
-      artifactName: "net_core_tests_windows-$(Build.BuildId)"
-
-  - template: azure-pipeline.template.yaml
-    parameters:
-      name: "net_core_tests_linux"
-      displayName: ".NET Core Unit Tests (Linux)"
-      vmImage: "ubuntu-latest"
-      scriptFileName: "./build.sh"
-      scriptArgs: runTestsNetCore incremental
-      outputDirectory: "TestResults"
-      artifactName: "net_core_tests_linux-$(Build.BuildId)"
-
-  - template: azure-pipeline.template.yaml
-    parameters:
       name: "docfx_test"
       displayName: "DocFX warning check"
-      vmImage: "windows-2019"
+      vmImage: "windows-latest"
       scriptFileName: build.cmd
       scriptArgs: docfx
       outputDirectory: "TestResults"
@@ -137,53 +112,41 @@ jobs:
       
   - template: azure-pipeline.template.yaml
     parameters:
-      name: "net_6_tests_windows"
-      displayName: ".NET 6 Unit Tests (Windows)"
-      vmImage: "windows-2019"
+      name: "net_7_tests_windows"
+      displayName: ".NET 7 Unit Tests (Windows)"
+      vmImage: "windows-latest"
       scriptFileName: build.cmd
       scriptArgs: runTestsNet incremental
       outputDirectory: "TestResults"
-      artifactName: "net_6_tests_windows-$(Build.BuildId)"
+      artifactName: "net_7_tests_windows-$(Build.BuildId)"
 
   - template: azure-pipeline.template.yaml
     parameters:
-      name: "net_6_tests_linux"
-      displayName: ".NET 6 Unit Tests (Linux)"
+      name: "net_7_tests_linux"
+      displayName: ".NET 7 Unit Tests (Linux)"
       vmImage: "ubuntu-latest"
       scriptFileName: "./build.sh"
       scriptArgs: runTestsNet incremental
       outputDirectory: "TestResults"
-      artifactName: "net_6_tests_linux-$(Build.BuildId)"
+      artifactName: "net_7_tests_linux-$(Build.BuildId)"
 
   - template: azure-pipeline.mntr-template.yaml
     parameters:
-      name: "net_core_mntr_windows"
-      displayName: ".NET Core Multi-Node Tests (Windows)"
-      vmImage: "windows-2019"
-      scriptFileName: "build.cmd"
-      scriptArgs: MultiNodeTestsNetCore incremental
-      outputDirectory: "TestResults"
-      artifactName: "net_core_mntr_windows-$(Build.BuildId)"
-      mntrFailuresDir: 'TestResults\\multinode'
-      mntrFailuresArtifactName: "net_core_mntr_FAILED_windows-$(Build.BuildId)"
-
-  - template: azure-pipeline.mntr-template.yaml
-    parameters:
-      name: "net_6_mntr_windows"
-      displayName: ".NET 6 Multi-Node Tests (Windows)"
-      vmImage: "windows-2019"
+      name: "net_7_mntr_windows"
+      displayName: ".NET 7 Multi-Node Tests (Windows)"
+      vmImage: "windows-latest"
       scriptFileName: "build.cmd"
       scriptArgs: MultiNodeTestsNet incremental
       outputDirectory: "TestResults"
-      artifactName: "net_6_mntr_windows-$(Build.BuildId)"
+      artifactName: "net_7_mntr_windows-$(Build.BuildId)"
       mntrFailuresDir: 'TestResults\\multinode'
-      mntrFailuresArtifactName: "net_6_mntr_FAILED_windows-$(Build.BuildId)"
+      mntrFailuresArtifactName: "net_7_mntr_FAILED_windows-$(Build.BuildId)"
 
   - template: azure-pipeline.template.yaml
     parameters:
       name: "nuget_pack"
       displayName: "NuGet Pack"
-      vmImage: "windows-2019"
+      vmImage: "windows-latest"
       scriptFileName: build.cmd
       scriptArgs: CreateNuget nugetprerelease=dev incremental
       outputDirectory: "bin/nuget"

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -2,7 +2,7 @@
 # See https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema for reference
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-latest
   demands: Cmd
 
 trigger:
@@ -26,15 +26,6 @@ steps:
   displayName: 'Use .NET 7 SDK 7.0.100'
   inputs:
     version: 7.0.100
-- task: UseDotNet@2
-  displayName: 'Use .NET 6 SDK 6.0.100'
-  inputs:
-    version: 6.0.100
-- task: UseDotNet@2
-  displayName: 'Use .NET Core Runtime 3.1.10'
-  inputs:
-    packageType: runtime
-    version: 3.1.10
 - task: BatchScript@1
   displayName: 'FAKE Build'
   inputs:

--- a/build.fsx
+++ b/build.fsx
@@ -56,7 +56,6 @@ let incrementalistReport = output @@ "incrementalist.txt"
 
 // Configuration values for tests
 let testNetFrameworkVersion = "net471"
-let testNetCoreVersion = "netcoreapp3.1"
 let testNetVersion = "net7.0"
 
 Target "Clean" (fun _ ->
@@ -202,13 +201,11 @@ Target "Build" (fun _ ->
 // Tests targets
 //--------------------------------------------------------------------------------
 type Runtime =
-    | NetCore
     | Net
     | NetFramework
 
 let getTestAssembly runtime project =
     let assemblyPath = match runtime with
-                        | NetCore -> !! ("src" @@ "**" @@ "bin" @@ "Release" @@ testNetCoreVersion @@ fileNameWithoutExt project + ".dll")
                         | NetFramework -> !! ("src" @@ "**" @@ "bin" @@ "Release" @@ testNetFrameworkVersion @@ fileNameWithoutExt project + ".dll")
                         | Net -> !! ("src" @@ "**" @@ "bin" @@ "Release" @@ testNetVersion @@ fileNameWithoutExt project + ".dll")
 
@@ -264,35 +261,6 @@ Target "RunTests" (fun _ ->
     projects |> Seq.iter (runSingleProject)
 )
 
-Target "RunTestsNetCore" (fun _ ->
-    if not skipBuild.Value then
-        let projects =
-            let rawProjects = match (isWindows) with
-                                | true -> !! "./src/**/*.Tests.*sproj"
-                                          ++ "./src/**/Akka.Streams.Tests.TCK.csproj"
-                                          -- "./src/**/*.Tests.MultiNode.csproj"
-                                          -- "./src/examples/**"
-                                | _ -> !! "./src/**/*.Tests.*sproj" // if you need to filter specs for Linux vs. Windows, do it here
-                                       -- "./src/**/*.Tests.MultiNode.csproj"
-                                       -- "./src/examples/**"
-            rawProjects |> Seq.choose filterProjects
-
-        let runSingleProject project =
-            let arguments =
-                match (hasTeamCity) with
-                | true -> (sprintf "test -c Release --blame-crash --blame-hang-timeout 30s --no-build --logger:trx --logger:\"console;verbosity=normal\" --framework %s --results-directory \"%s\" -- -parallel none -teamcity" testNetCoreVersion outputTests)
-                | false -> (sprintf "test -c Release --blame-crash --blame-hang-timeout 30s --no-build --logger:trx --logger:\"console;verbosity=normal\" --framework %s --results-directory \"%s\" -- -parallel none" testNetCoreVersion outputTests)
-
-            let result = ExecProcess(fun info ->
-                info.FileName <- "dotnet"
-                info.WorkingDirectory <- (Directory.GetParent project).FullName
-                info.Arguments <- arguments) (TimeSpan.FromMinutes 30.0)
-
-            ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.Error result
-
-        CreateDir outputTests
-        projects |> Seq.iter (runSingleProject)
-)
 
 Target "RunTestsNet" (fun _ ->
     if not skipBuild.Value then
@@ -322,45 +290,6 @@ Target "RunTestsNet" (fun _ ->
 
         CreateDir outputTests
         projects |> Seq.iter (runSingleProject)
-)
-
-Target "MultiNodeTestsNetCore" (fun _ ->
-    if not skipBuild.Value then
-        setEnvironVar "AKKA_CLUSTER_ASSERT" "on" // needed to enable assert invariants for Akka.Cluster
-
-        let projects =
-            let rawProjects = match (isWindows) with
-                                | true -> !! "./src/**/*.Tests.MultiNode.csproj"
-                                | _ -> !! "./src/**/*.Tests.MultiNode.csproj" // if you need to filter specs for Linux vs. Windows, do it here
-            rawProjects |> Seq.choose filterProjects
-
-        let projectDlls = projects |> Seq.map ( fun project ->
-                let assemblyName = fileNameWithoutExt project
-                (directory project) @@ "bin" @@ "Release" @@ testNetCoreVersion @@ assemblyName + ".dll" 
-            )
-        
-        let runSingleProject projectDll =
-            let arguments =
-                match (hasTeamCity) with
-                | true -> (sprintf "test \"%s\" -l:\"console;verbosity=detailed\" --framework %s --results-directory \"%s\" -- -teamcity" projectDll testNetCoreVersion outputMultiNode)
-                | false -> (sprintf "test \"%s\" -l:\"console;verbosity=detailed\" --framework %s --results-directory \"%s\"" projectDll testNetCoreVersion outputMultiNode)
-
-            let resultPath = (directory projectDll)
-            File.WriteAllText(
-                (resultPath @@ "xunit.multinode.runner.json"),
-                (sprintf "{\"outputDirectory\":\"%s\", \"useBuiltInTrxReporter\":true}" outputMultiNode).Replace("\\", "\\\\"))
-            
-            let result = ExecProcess(fun info ->
-                info.FileName <- "dotnet"
-                info.WorkingDirectory <- outputMultiNode
-                info.Arguments <- arguments) (TimeSpan.FromMinutes 90.0)
-
-            ResultHandling.failBuildIfXUnitReportedError TestRunnerErrorLevel.Error result
-
-        CreateDir outputMultiNode
-        projectDlls |> Seq.iter ( fun projectDll -> 
-            runSingleProject projectDll
-        )
 )
 
 Target "MultiNodeTestsNet" (fun _ ->

--- a/build.fsx
+++ b/build.fsx
@@ -570,7 +570,6 @@ Target "BuildRelease" DoNothing
 Target "All" DoNothing
 Target "Nuget" DoNothing
 Target "RunTestsFull" DoNothing
-Target "RunTestsNetCoreFull" DoNothing
 
 // build dependencies
 "Clean" ==> "AssemblyInfo" ==> "Build"
@@ -579,11 +578,9 @@ Target "RunTestsNetCoreFull" DoNothing
 
 // tests dependencies
 "Build" ==> "RunTests"
-"Build" ==> "RunTestsNetCore"
 "Build" ==> "RunTestsNet"
 "Build" ==> "NBench"
 
-"BuildRelease" ==> "MultiNodeTestsNetCore"
 "BuildRelease" ==> "MultiNodeTestsNet"
 
 // nuget dependencies
@@ -595,9 +592,7 @@ Target "RunTestsNetCoreFull" DoNothing
 // all
 "BuildRelease" ==> "All"
 "RunTests" ==> "All"
-"RunTestsNetCore" ==> "All"
 "RunTestsNet" ==> "All"
-"MultiNodeTestsNetCore" ==> "All"
 "MultiNodeTestsNet" ==> "All"
 "NBench" ==> "All"
 

--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
@@ -2,7 +2,7 @@
     <Import Project="..\..\common.props" />
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+        <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/benchmark/Akka.Cluster.Cpu.Benchmark/Akka.Cluster.Cpu.Benchmark.csproj
+++ b/src/benchmark/Akka.Cluster.Cpu.Benchmark/Akka.Cluster.Cpu.Benchmark.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/benchmark/PingPong/PingPong.csproj
+++ b/src/benchmark/PingPong/PingPong.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 

--- a/src/benchmark/RemotePingPong/RemotePingPong.csproj
+++ b/src/benchmark/RemotePingPong/RemotePingPong.csproj
@@ -6,7 +6,7 @@
   <AssemblyTitle>RemotePingPong</AssemblyTitle>
   <AssemblyName>RemotePingPong</AssemblyName>
   <Authors>Akka.NET Team</Authors>
-  <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+  <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   <OutputType>Exe</OutputType>
 </PropertyGroup>
 

--- a/src/benchmark/SpawnBenchmark/SpawnBenchmark.csproj
+++ b/src/benchmark/SpawnBenchmark/SpawnBenchmark.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 

--- a/src/common.props
+++ b/src/common.props
@@ -22,7 +22,6 @@
     <NBenchVersion>2.0.1</NBenchVersion>
     <ProtobufVersion>3.22.1</ProtobufVersion>
     <BenchmarkDotNetVersion>0.13.2</BenchmarkDotNetVersion>
-    <NetCoreTestVersion>netcoreapp3.1</NetCoreTestVersion>
     <NetTestVersion>net7.0</NetTestVersion>
     <NetFrameworkTestVersion>net471</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/Akka.Cluster.Metrics.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/Akka.Cluster.Metrics.Tests.MultiNode.csproj
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
         <AssemblyTitle>Akka.Cluster.Metrics.Tests.MultiNode</AssemblyTitle>
-        <TargetFrameworks>$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+        <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Akka.Cluster.Metrics.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Akka.Cluster.Metrics.Tests.csproj
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <AssemblyTitle>Akka.Cluster.Metrics.Tests</AssemblyTitle>
-        <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+        <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
         <LangVersion>8.0</LangVersion>
     </PropertyGroup>
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Akka.Cluster.Sharding.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Akka.Cluster.Sharding.Tests.MultiNode.csproj
@@ -3,7 +3,7 @@
     
   <PropertyGroup>
     <AssemblyTitle>Akka.Cluster.Sharding.Tests.MultiNode</AssemblyTitle>
-    <TargetFrameworks>$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Cluster.Sharding.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Akka.Cluster.Tools.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Akka.Cluster.Tools.Tests.MultiNode.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Cluster.Tools.Tests.MultiNode</AssemblyTitle>
-    <TargetFrameworks>$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Akka.Cluster.Tools.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Akka.Cluster.Tools.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Cluster.Tools.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/Akka.DistributedData.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/Akka.DistributedData.Tests.MultiNode.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.DistributedData.Tests.MultiNode</AssemblyTitle>
-    <TargetFrameworks>$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
  
   <ItemGroup>

--- a/src/contrib/cluster/Akka.DistributedData.Tests/Akka.DistributedData.Tests.csproj
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/Akka.DistributedData.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.DistributedData.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
  

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/Akka.DependencyInjection.Tests.csproj
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/Akka.DependencyInjection.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.DependencyInjection.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/Akka.Persistence.Query.InMemory.Tests.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/Akka.Persistence.Query.InMemory.Tests.csproj
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <AssemblyTitle>Akka.Persistence.Query.InMemory.Tests</AssemblyTitle>
-        <TargetFrameworks>$(NetFrameworkTestVersion);$(NetCoreTestVersion);$(NetTestVersion)</TargetFrameworks>
+        <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Akka.Persistence.Sqlite.Tests.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Akka.Persistence.Sqlite.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence.Sqlite.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
    
   </PropertyGroup>
  

--- a/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/Akka.Serialization.Hyperion.Tests.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/Akka.Serialization.Hyperion.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\xunitSettings.props" />
   <PropertyGroup>
     <AssemblyTitle>Akka.Serialization.Hyperion.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
  
   <ItemGroup>

--- a/src/contrib/serializers/Akka.Serialization.TestKit/Akka.Serialization.TestKit.csproj
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/Akka.Serialization.TestKit.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Akka.Serialization.TestKit</AssemblyTitle>
     <Description>Serialization TestKit for Akka.NET</Description>
     <VersionSuffix>beta</VersionSuffix>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
     <PackageTags>$(AkkaPackageTags);hyperion;serializer;serialize;testkit</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/core/Akka.API.Tests/Akka.API.Tests.csproj
+++ b/src/core/Akka.API.Tests/Akka.API.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\xunitSettings.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Cluster.Tests.MultiNode/Akka.Cluster.Tests.MultiNode.csproj
+++ b/src/core/Akka.Cluster.Tests.MultiNode/Akka.Cluster.Tests.MultiNode.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Cluster.Tests.MultiNode</AssemblyTitle>
-    <TargetFrameworks>$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Cluster.Tests.Performance/Akka.Cluster.Tests.Performance.csproj
+++ b/src/core/Akka.Cluster.Tests.Performance/Akka.Cluster.Tests.Performance.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
   <PropertyGroup>
-    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>

--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Cluster.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Coordination.Tests/Akka.Coordination.Tests.csproj
+++ b/src/core/Akka.Coordination.Tests/Akka.Coordination.Tests.csproj
@@ -4,7 +4,7 @@
   
   <PropertyGroup>
     <AssemblyTitle>Akka.Coordination.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
  
   <ItemGroup>

--- a/src/core/Akka.Discovery.Tests/Akka.Discovery.Tests.csproj
+++ b/src/core/Akka.Discovery.Tests/Akka.Discovery.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Discovery.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Docs.Tests/Akka.Docs.Tests.csproj
+++ b/src/core/Akka.Docs.Tests/Akka.Docs.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\xunitSettings.props" />
   <PropertyGroup>
     <AssemblyTitle>Akka.Docs.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
     <RootNamespace>DocsExamples</RootNamespace>
   </PropertyGroup>
 

--- a/src/core/Akka.Docs.Tutorials/Akka.Docs.Tutorials.csproj
+++ b/src/core/Akka.Docs.Tutorials/Akka.Docs.Tutorials.csproj
@@ -2,7 +2,7 @@
     <Import Project="..\..\common.props" />
   <PropertyGroup>
       <AssemblyTitle>Akka.Docs.Tutorials</AssemblyTitle>
-      <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+      <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
       <RootNamespace>Tutorials</RootNamespace>
       <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.FSharp.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -34,7 +34,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>
 
-    <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
+    <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetTestVersion)'">
         <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
     </PropertyGroup>
 

--- a/src/core/Akka.Persistence.Query.Tests/Akka.Persistence.Query.Tests.csproj
+++ b/src/core/Akka.Persistence.Query.Tests/Akka.Persistence.Query.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence.Query.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
  
   <ItemGroup>

--- a/src/core/Akka.Persistence.TCK.Tests/Akka.Persistence.TCK.Tests.csproj
+++ b/src/core/Akka.Persistence.TCK.Tests/Akka.Persistence.TCK.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence.TCK.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
  
   <ItemGroup>

--- a/src/core/Akka.Persistence.TestKit.Tests/Akka.Persistence.TestKit.Tests.csproj
+++ b/src/core/Akka.Persistence.TestKit.Tests/Akka.Persistence.TestKit.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence.TestKit.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
+++ b/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence.Tests</AssemblyTitle>
-   <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+   <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Remote.TestKit.Tests/Akka.Remote.TestKit.Tests.csproj
+++ b/src/core/Akka.Remote.TestKit.Tests/Akka.Remote.TestKit.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Remote.TestKit.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Remote.Tests.MultiNode/Akka.Remote.Tests.MultiNode.csproj
+++ b/src/core/Akka.Remote.Tests.MultiNode/Akka.Remote.Tests.MultiNode.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Remote.Tests.MultiNode</AssemblyTitle>
-    <TargetFrameworks>$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
+++ b/src/core/Akka.Remote.Tests.Performance/Akka.Remote.Tests.Performance.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
   <PropertyGroup>
-    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Remote.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Streams.TestKit.Tests/Akka.Streams.TestKit.Tests.csproj
+++ b/src/core/Akka.Streams.TestKit.Tests/Akka.Streams.TestKit.Tests.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <AssemblyName>Akka.Streams.TestKit.Tests</AssemblyName>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/core/Akka.Streams.Tests.Performance/Akka.Streams.Tests.Performance.csproj
+++ b/src/core/Akka.Streams.Tests.Performance/Akka.Streams.Tests.Performance.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
   <PropertyGroup>
-    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>

--- a/src/core/Akka.Streams.Tests.TCK/Akka.Streams.Tests.TCK.csproj
+++ b/src/core/Akka.Streams.Tests.TCK/Akka.Streams.Tests.TCK.csproj
@@ -24,7 +24,7 @@
     <!-- !!!WARNING!!! 
          NUNIT VERSION HAVE TO MATCH WITH THE VERSION USED BY REACTIVE TCK. 
          !!!WARNING!!! -->
-    <PackageReference Include="NUnit" Version="3.7.1" Condition="'$(TargetFramework)' == '$(NetCoreTestVersion)'"/>
+    <!--<PackageReference Include="NUnit" Version="3.7.1" Condition="'$(TargetFramework)' == '$(NetCoreTestVersion)'"/>-->
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">

--- a/src/core/Akka.Streams.Tests.TCK/Akka.Streams.Tests.TCK.csproj
+++ b/src/core/Akka.Streams.Tests.TCK/Akka.Streams.Tests.TCK.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Akka.Streams.Tests.TCK</AssemblyName>
     <!-- Reactive.Streams.TCK isn't compatible with .NET Core -->
     <!--UNit.Framework does not yet support .NET 5 - build will fail-->
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion)</TargetFrameworks>
   </PropertyGroup>
  
   <ItemGroup>

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -27,11 +27,12 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">
+<!--
+<ItemGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' ">
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
   </ItemGroup>
+-->  
 
   <ItemGroup>
     <None Update="xunit.runner.json">

--- a/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
+++ b/src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyName>Akka.Streams.Tests</AssemblyName>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
+++ b/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\xunitSettings.props" />
   <PropertyGroup>
     <AssemblyTitle>Akka.TestKit.Tests</AssemblyTitle>
-    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Akka\Akka.csproj" />

--- a/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
+++ b/src/core/Akka.Tests.Performance/Akka.Tests.Performance.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\common.props" />
   <PropertyGroup>
-    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -4,8 +4,8 @@
 
   <PropertyGroup>
     <AssemblyTitle>Akka.Tests</AssemblyTitle>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">$(NetTestVersion)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetCoreTestVersion)' OR '$(TargetFramework)' == '$(NetTestVersion)'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetTestVersion)'">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 

--- a/src/examples/Akka.Persistence.Custom.Tests/Akka.Persistence.Custom.Tests.csproj
+++ b/src/examples/Akka.Persistence.Custom.Tests/Akka.Persistence.Custom.Tests.csproj
@@ -3,7 +3,7 @@
     <Import Project="..\..\xunitSettings.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion);$(NetCoreTestVersion)</TargetFrameworks>
+        <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/examples/AspNetCore/Akka.AspNetCore/Akka.AspNetCore.csproj
+++ b/src/examples/AspNetCore/Akka.AspNetCore/Akka.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/examples/AspNetCore/Samples.Akka.AspNetCore/Samples.Akka.AspNetCore.csproj
+++ b/src/examples/AspNetCore/Samples.Akka.AspNetCore/Samples.Akka.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\common.props" />
   <PropertyGroup>
-    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="app.conf" />

--- a/src/examples/Chat/ChatClient/ChatClient.csproj
+++ b/src/examples/Chat/ChatClient/ChatClient.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\..\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/examples/Chat/ChatServer/ChatServer.csproj
+++ b/src/examples/Chat/ChatServer/ChatServer.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\..\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/examples/Cluster/ClusterSharding/ShoppingCart/ShoppingCart.csproj
+++ b/src/examples/Cluster/ClusterSharding/ShoppingCart/ShoppingCart.csproj
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+        <TargetFramework>$(NetTestVersion)</TargetFramework>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     </PropertyGroup>
 

--- a/src/examples/Cluster/DData/DDataStressTest/DDataStressTest.csproj
+++ b/src/examples/Cluster/DData/DDataStressTest/DDataStressTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/examples/Cluster/Metrics/Samples.Cluster.AdaptiveGroup/Samples.Cluster.AdaptiveGroup.csproj
+++ b/src/examples/Cluster/Metrics/Samples.Cluster.AdaptiveGroup/Samples.Cluster.AdaptiveGroup.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/examples/Cluster/Metrics/Samples.Cluster.Metrics/Samples.Cluster.Metrics.csproj
+++ b/src/examples/Cluster/Metrics/Samples.Cluster.Metrics/Samples.Cluster.Metrics.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/examples/Cluster/PublishSubscribe/SampleDestination/SampleDestination.csproj
+++ b/src/examples/Cluster/PublishSubscribe/SampleDestination/SampleDestination.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/examples/Cluster/PublishSubscribe/SamplePublishSubscribe/SampleSubscriber.csproj
+++ b/src/examples/Cluster/PublishSubscribe/SamplePublishSubscribe/SampleSubscriber.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/examples/Cluster/PublishSubscribe/SamplePublisher/SamplePublisher.csproj
+++ b/src/examples/Cluster/PublishSubscribe/SamplePublisher/SamplePublisher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/examples/Cluster/PublishSubscribe/SampleSender/SampleSender.csproj
+++ b/src/examples/Cluster/PublishSubscribe/SampleSender/SampleSender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/examples/HeadlessService/AkkaHeadlesssService/AkkaHeadlesssService.csproj
+++ b/src/examples/HeadlessService/AkkaHeadlesssService/AkkaHeadlesssService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/examples/HelloAkka/HelloWorld/HelloWorld.csproj
+++ b/src/examples/HelloAkka/HelloWorld/HelloWorld.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/examples/PersistenceExample/PersistenceExample.csproj
+++ b/src/examples/PersistenceExample/PersistenceExample.csproj
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+        <TargetFramework>$(NetTestVersion)</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/examples/TcpEchoService.Server/TcpEchoService.Server.csproj
+++ b/src/examples/TcpEchoService.Server/TcpEchoService.Server.csproj
@@ -3,7 +3,7 @@
     
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+        <TargetFramework>$(NetTestVersion)</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/examples/WindowsService/AkkaWindowsService/AkkaWindowsService.csproj
+++ b/src/examples/WindowsService/AkkaWindowsService/AkkaWindowsService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Changes

Drop support for .NET Core 3.1

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue https://github.com/akkadotnet/akka.net/discussions/6527