### PR TITLE
Add deferred startup for Akka.TestKit

### DIFF
--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -63,6 +63,13 @@ namespace Akka.TestKit
         private readonly ITestKitAssertions _assertions;
         private TestState _testState;
 
+        private readonly ActorSystem _ctorSystem;
+        private readonly ActorSystemSetup _ctorConfig;
+        private readonly string _ctorSystemName;
+        private readonly string _ctorTestActorName;
+        
+        protected virtual bool DeferredStart => false;
+
         /// <summary>
         /// Create a new instance of the <see cref="TestKitBase"/> class.
         /// If no <paramref name="system"/> is passed in, a new system 
@@ -117,9 +124,27 @@ namespace Akka.TestKit
 
             _assertions = assertions;
             
-            InitializeTest(system, config, actorSystemName, testActorName);
+            if (DeferredStart)
+            {
+                _ctorSystem = system;
+                _ctorConfig = config;
+                _ctorSystemName = actorSystemName;
+                _ctorTestActorName = testActorName;
+            }
+            else
+            {
+                InitializeTest(system, config, actorSystemName, testActorName);
+            }
         }
 
+        public void Start()
+        {
+            if (!DeferredStart)
+                return;
+            
+            InitializeTest(_ctorSystem, _ctorConfig, _ctorSystemName, _ctorTestActorName);
+        }
+        
         /// <summary>
         /// Initializes the <see cref="TestState"/> for a new spec.
         /// </summary>

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -68,6 +68,10 @@ namespace Akka.TestKit
         private readonly string _ctorSystemName;
         private readonly string _ctorTestActorName;
         
+        /// <summary>
+        /// If overriden to return <c>true</c>, <see cref="ActorSystem"/> would not be started automatically.
+        /// You would need to call the <see cref="Start"/> method to start the TestKit <see cref="ActorSystem"/>
+        /// </summary>
         protected virtual bool DeferredStart => false;
 
         /// <summary>
@@ -137,6 +141,9 @@ namespace Akka.TestKit
             }
         }
 
+        /// <summary>
+        /// Start the <see cref="ActorSystem"/> if TestKit is set to deferred mode.
+        /// </summary>
         public void Start()
         {
             if (!DeferredStart)


### PR DESCRIPTION
## Changes

Add overridable `DeferredStart` read only propery. When this is set to true, the actor system would not be instantiated in the constructor, it would be started when the `Start` method is called.