### PR TITLE
Log send time and sqNbr in verbose cluster heartbeat messages #6496.

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterHeartbeatReceiverSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterHeartbeatReceiverSpec.cs
@@ -32,10 +32,12 @@ namespace Akka.Cluster.Tests
     public abstract class ClusterHeartbeatReceiverBase : AkkaSpec
     {
         private static Config Config(bool useLegacyHeartbeat) => $@"
+akka.loglevel=DEBUG
+akka.cluster.debug.verbose-heartbeat-logging = on
 akka.actor.provider = cluster
 akka.cluster.use-legacy-heartbeat-message = {(useLegacyHeartbeat ? "true" : "false")}
 ";
-
+        
         protected ClusterHeartbeatReceiverBase(ITestOutputHelper output, bool useLegacyHeartbeat)
             : base(Config(useLegacyHeartbeat), output)
         {
@@ -48,6 +50,25 @@ akka.cluster.use-legacy-heartbeat-message = {(useLegacyHeartbeat ? "true" : "fal
             var heartbeater = Sys.ActorOf(ClusterHeartbeatReceiver.Props(Cluster.Get(Sys)));
             heartbeater.Tell(new Heartbeat(Cluster.Get(Sys).SelfAddress, 1, 2));
             await ExpectMsgAsync<HeartbeatRsp>(new HeartbeatRsp(Cluster.Get(Sys).SelfUniqueAddress, 1, 2));
+        }
+        
+        [Fact]
+        public async Task ClusterHeartbeatReceiver_should_write_correct_debug_messages_on_heartbeat()
+        {
+            var heartbeater = Sys.ActorOf(ClusterHeartbeatReceiver.Props(Cluster.Get(Sys)));
+
+            EventFilter.Debug(contains: "- Sequence number [2]")
+                .ExpectOne(() => heartbeater.Tell(new Heartbeat(Cluster.Get(Sys).SelfAddress, 2, 3)));
+        }
+        
+        [Fact]
+        public async Task ClusterHeartbeatSender_should_write_correct_debug_messages_on_heartbeat_rsp()
+        {
+            var heartbeater = Sys.ActorOf(Props.Create(() => new ClusterHeartbeatSender(Cluster.Get(Sys))));
+            heartbeater.Tell(new ClusterEvent.CurrentClusterState());
+            
+            EventFilter.Debug(contains: "- Sequence number [2] - Creation time [3]")
+                .ExpectOne(() => heartbeater.Tell(new HeartbeatRsp(Cluster.Get(Sys).SelfUniqueAddress, 2, 3)));
         }
     }
 }

--- a/src/core/Akka.Cluster/ClusterHeartbeat.cs
+++ b/src/core/Akka.Cluster/ClusterHeartbeat.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Linq;
 using Akka.Actor;
 using Akka.Event;
@@ -43,8 +44,7 @@ namespace Akka.Cluster
             switch (message)
             {
                 case ClusterHeartbeatSender.Heartbeat hb:
-                    // TODO log the sequence nr once serializer is enabled
-                    if(VerboseHeartbeat) _cluster.CurrentInfoLogger.LogDebug("Heartbeat from [{0}]", hb.From);
+                    if (VerboseHeartbeat) _cluster.CurrentInfoLogger.LogDebug($"Heartbeat from [{hb.From}] - Sequence number [{hb.SequenceNr.ToString(CultureInfo.InvariantCulture)}]");
                     Sender.Tell(new ClusterHeartbeatSender.HeartbeatRsp(_cluster.SelfUniqueAddress,
                         hb.SequenceNr, hb.CreationTimeNanos));
                     break;
@@ -58,7 +58,6 @@ namespace Akka.Cluster
         {
             return Akka.Actor.Props.Create(() => new ClusterHeartbeatReceiver(getCluster));
         }
-
     }
 
     /// <summary>
@@ -248,7 +247,8 @@ namespace Akka.Cluster
                     "Previous heartbeat was sent [{1}] ms ago, expected interval is [{2}] ms. This may cause failure detection " +
                     "to mark members as unreachable. The reason can be thread starvation, e.g. by running blocking tasks on the " +
                     "default dispatcher, CPU overload, or GC.",
-                    _cluster.SelfAddress, (now - _tickTimestamp).TotalMilliseconds, _cluster.Settings.HeartbeatInterval.TotalMilliseconds);
+                    _cluster.SelfAddress, (now - _tickTimestamp).TotalMilliseconds.ToString(CultureInfo.InvariantCulture), 
+                    _cluster.Settings.HeartbeatInterval.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
             }
             
             _tickTimestamp = DateTime.UtcNow;
@@ -258,8 +258,8 @@ namespace Akka.Cluster
         {
             if (_cluster.Settings.VerboseHeartbeatLogging)
             {
-                // TODO: log response time and validate sequence nrs once serialisation of sendTime is released
-                _log.Debug("Cluster Node [{0}] - Heartbeat response from [{1}]", _cluster.SelfAddress, rsp.From.Address);
+                _log.Debug("Cluster Node [{0}] - Heartbeat response from [{1}] - Sequence number [{2}] - Creation time [{3}]", _cluster.SelfAddress, rsp.From.Address,
+                    rsp.SequenceNr.ToString(CultureInfo.InvariantCulture), rsp.CreationTimeNanos.ToString(CultureInfo.InvariantCulture));
             }
             _state = _state.HeartbeatRsp(rsp.From);
         }
@@ -769,4 +769,3 @@ namespace Akka.Cluster
         #endregion
     }
 }
-


### PR DESCRIPTION
Fixes #6496 

## Changes

Log send time and sqNbr in verbose cluster heartbeat messages

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).