### PR TITLE
Cluster heartbeat creation_time to TimeSpan fix #6496.

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterHeartbeatReceiverSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterHeartbeatReceiverSpec.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -67,8 +68,8 @@ akka.cluster.use-legacy-heartbeat-message = {(useLegacyHeartbeat ? "true" : "fal
             var heartbeater = Sys.ActorOf(Props.Create(() => new ClusterHeartbeatSender(Cluster.Get(Sys))));
             heartbeater.Tell(new ClusterEvent.CurrentClusterState());
             
-            EventFilter.Debug(contains: "- Sequence number [2] - Creation time [3]")
-                .ExpectOne(() => heartbeater.Tell(new HeartbeatRsp(Cluster.Get(Sys).SelfUniqueAddress, 2, 3)));
+            EventFilter.Debug(contains: "- Sequence number [2] - Creation time [00:00:03]")
+                .ExpectOne(() => heartbeater.Tell(new HeartbeatRsp(Cluster.Get(Sys).SelfUniqueAddress, 2, 3000000000)));
         }
     }
 }

--- a/src/core/Akka.Cluster/ClusterHeartbeat.cs
+++ b/src/core/Akka.Cluster/ClusterHeartbeat.cs
@@ -259,7 +259,7 @@ namespace Akka.Cluster
             if (_cluster.Settings.VerboseHeartbeatLogging)
             {
                 _log.Debug("Cluster Node [{0}] - Heartbeat response from [{1}] - Sequence number [{2}] - Creation time [{3}]", _cluster.SelfAddress, rsp.From.Address,
-                    rsp.SequenceNr.ToString(CultureInfo.InvariantCulture), rsp.CreationTimeNanos.ToString(CultureInfo.InvariantCulture));
+                    rsp.SequenceNr.ToString(CultureInfo.InvariantCulture), new TimeSpan(rsp.CreationTimeNanos.ToTicks()).ToString());
             }
             _state = _state.HeartbeatRsp(rsp.From);
         }


### PR DESCRIPTION
Fixes #6496 

## Changes

Cluster heartbeat creation_time to TimeSpan fix #6496.

## Checklist

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
