### PR TITLE
fix MergeHub_must_work_with_long_streams_when_buffer_size_is_1

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -185,25 +185,17 @@ namespace Akka.Streams.Tests.Dsl
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
-                var (sink, probe) = MergeHub.Source<int>(1)
-                    .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                var (sink, result) = MergeHub.Source<int>(1)
+                    .Take(20000)
+                    .ToMaterialized(Sink.Seq<int>(), Keep.Both)
                     .Run(Materializer);
-
+                
+                
                 Source.From(Enumerable.Range(1, 10000)).RunWith(sink, Materializer);
                 Source.From(Enumerable.Range(10001, 10000)).RunWith(sink, Materializer);
-
-                await probe.RequestAsync(int.MaxValue);
-                var result = new List<int>();
-                foreach (var i in Enumerable.Range(1, 20000))
-                {
-                    var evt = await probe.ExpectEventAsync();
-                    if (evt is TestSubscriber.OnNext<int> next)
-                        result.Add(next.Element);
-                    else
-                        throw new Exception($"For element [{i}]: Expected OnNext<int> but received {evt.GetType()}");
-                }
-                result.OrderBy(x => x).Should().BeEquivalentTo(Enumerable.Range(1, 20000));
-            }, Materializer, 300.Seconds());
+                
+                (await result).OrderBy(x => x).Should().BeEquivalentTo(Enumerable.Range(1, 20000));
+            }, Materializer, 3.Seconds());
         }
 
         [Fact]

--- a/src/core/Akka.Streams/Dsl/Hub.cs
+++ b/src/core/Akka.Streams/Dsl/Hub.cs
@@ -78,7 +78,6 @@ namespace Akka.Streams.Dsl
             /// <param name="cause">The exception that is the cause of the current exception.</param>
             public ProducerFailed(string message, Exception cause) : base(message, cause)
             {
-
             }
         }
     }
@@ -233,35 +232,29 @@ namespace Akka.Streams.Dsl
 
             private void TryProcessNext(bool firstAttempt)
             {
-                while (true)
+                // That we dequeue elements from the queue when there is demand means that Register and Deregister messages
+                // might be delayed for arbitrary long. This is not a problem as Register is only interesting if it is followed
+                // by actual elements, which would be delayed anyway by the backpressure.
+                // Unregister is only used to keep the map growing too large, but otherwise it is not critical to process it
+                // timely. In fact, the only way the map could keep growing would mean that we dequeue Registers from the
+                // queue, but then we will eventually reach the Deregister message, too.
+                if (_queue.TryDequeue(out var nextElement))
                 {
-                    // That we dequeue elements from the queue when there is demand means that Register and Deregister messages
-                    // might be delayed for arbitrary long. This is not a problem as Register is only interesting if it is followed
-                    // by actual elements, which would be delayed anyway by the backpressure.
-                    // Unregister is only used to keep the map growing too large, but otherwise it is not critical to process it
-                    // timely. In fact, the only way the map could keep growing would mean that we dequeue Registers from the
-                    // queue, but then we will eventually reach the Deregister message, too.
-                    if (_queue.TryDequeue(out var nextElement))
+                    _needWakeup = false;
+                    if (OnEvent(nextElement))
                     {
-                        _needWakeup = false;
-                        if (OnEvent(nextElement))
-                        {
-                            firstAttempt = true;
-                            continue;
-                        }
+                        TryProcessNext(true);
                     }
-                    else
+                }
+                else
+                {
+                    // additional poll to grab any elements that might missed the needWakeup
+                    // and have been enqueued just after it
+                    _needWakeup = true;
+                    if (firstAttempt)
                     {
-                        // additional poll to grab any elements that might missed the needWakeup
-                        // and have been enqueued just after it
-                        _needWakeup = true;
-                        if (firstAttempt)
-                        {
-                            firstAttempt = false;
-                            continue;
-                        }
+                        TryProcessNext(false);
                     }
-                    break;
                 }
             }
 
@@ -459,7 +452,8 @@ namespace Akka.Streams.Dsl
         /// </summary>
         /// <param name="inheritedAttributes">TBD</param>
         /// <returns>TBD</returns>
-        public override ILogicAndMaterializedValue<Sink<T, NotUsed>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
+        public override ILogicAndMaterializedValue<Sink<T, NotUsed>> CreateLogicAndMaterializedValue(
+            Attributes inheritedAttributes)
         {
             var idCounter = new AtomicCounterLong();
             var logic = new HubLogic(this, idCounter);
@@ -530,7 +524,9 @@ namespace Akka.Streams.Dsl
     {
         #region internal classes
 
-        private interface IHubEvent { }
+        private interface IHubEvent
+        {
+        }
 
         private sealed class RegistrationPending : IHubEvent
         {
@@ -538,7 +534,6 @@ namespace Akka.Streams.Dsl
 
             private RegistrationPending()
             {
-
             }
         }
 
@@ -607,12 +602,13 @@ namespace Akka.Streams.Dsl
 
             private Completed()
             {
-
             }
         }
 
 
-        private interface IHubState { }
+        private interface IHubState
+        {
+        }
 
         private sealed class Open : IHubState
         {
@@ -638,7 +634,9 @@ namespace Akka.Streams.Dsl
         }
 
 
-        private interface IConsumerEvent { }
+        private interface IConsumerEvent
+        {
+        }
 
         private sealed class Wakeup : IConsumerEvent
         {
@@ -646,7 +644,6 @@ namespace Akka.Streams.Dsl
 
             private Wakeup()
             {
-
             }
         }
 
@@ -672,7 +669,7 @@ namespace Akka.Streams.Dsl
 
         #endregion
 
-        #region Logic 
+        #region Logic
 
         private sealed class HubLogic : InGraphStageLogic
         {
@@ -784,6 +781,7 @@ namespace Akka.Streams.Dsl
                     }
                     else
                         CheckUnblock(unregister.PreviousOffset);
+
                     return;
                 }
 
@@ -933,6 +931,7 @@ namespace Akka.Streams.Dsl
                         else
                             continue;
                     }
+
                     // Already closed, ignore
                     break;
                 }
@@ -1024,7 +1023,8 @@ namespace Akka.Streams.Dsl
                         if (state is Open open)
                         {
                             var newRegistrations = open.Registrations.Insert(0, new Consumer(_id, callback));
-                            if (_stage._hubLogic.State.CompareAndSet(state, new Open(open.CallbackTask, newRegistrations)))
+                            if (_stage._hubLogic.State.CompareAndSet(state,
+                                    new Open(open.CallbackTask, newRegistrations)))
                             {
                                 var readyCallback = GetAsyncCallback((Action<Result<Action<IHubEvent>>>)OnHubReady);
                                 open.CallbackTask.ContinueWith(t => readyCallback(Result.FromTask(t)));
@@ -1159,7 +1159,8 @@ namespace Akka.Streams.Dsl
         /// </summary>
         /// <param name="inheritedAttributes">TBD</param>
         /// <returns>TBD</returns>
-        public override ILogicAndMaterializedValue<Source<T, NotUsed>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
+        public override ILogicAndMaterializedValue<Source<T, NotUsed>> CreateLogicAndMaterializedValue(
+            Attributes inheritedAttributes)
         {
             var idCounter = new AtomicCounterLong();
             var logic = new HubLogic(this);
@@ -1339,7 +1340,9 @@ namespace Akka.Streams.Dsl
         private sealed class PartitionQueue : IPartitionQueue
         {
             private readonly AtomicCounter _totalSize = new AtomicCounter();
-            private readonly ConcurrentDictionary<long, ConsumerQueue> _queues = new ConcurrentDictionary<long, ConsumerQueue>();
+
+            private readonly ConcurrentDictionary<long, ConsumerQueue> _queues =
+                new ConcurrentDictionary<long, ConsumerQueue>();
 
             public void Init(long id) => _queues.TryAdd(id, ConsumerQueue.Empty);
 
@@ -1402,20 +1405,26 @@ namespace Akka.Streams.Dsl
 
         #region internal classes
 
-        private interface IConsumerEvent { }
+        private interface IConsumerEvent
+        {
+        }
 
         private sealed class Wakeup : IConsumerEvent
         {
             public static Wakeup Instance { get; } = new Wakeup();
 
-            private Wakeup() { }
+            private Wakeup()
+            {
+            }
         }
 
         private sealed class Initialize : IConsumerEvent
         {
             public static Initialize Instance { get; } = new Initialize();
 
-            private Initialize() { }
+            private Initialize()
+            {
+            }
         }
 
         private sealed class HubCompleted : IConsumerEvent
@@ -1429,13 +1438,17 @@ namespace Akka.Streams.Dsl
         }
 
 
-        private interface IHubEvent { }
+        private interface IHubEvent
+        {
+        }
 
         private sealed class RegistrationPending : IHubEvent
         {
             public static RegistrationPending Instance { get; } = new RegistrationPending();
 
-            private RegistrationPending() { }
+            private RegistrationPending()
+            {
+            }
         }
 
         private sealed class UnRegister : IHubEvent
@@ -1456,7 +1469,6 @@ namespace Akka.Streams.Dsl
             {
                 Consumer = consumer;
             }
-
         }
 
         private sealed class Consumer : IHubEvent
@@ -1475,18 +1487,24 @@ namespace Akka.Streams.Dsl
         {
             public static TryPull Instance { get; } = new TryPull();
 
-            private TryPull() { }
+            private TryPull()
+            {
+            }
         }
 
         private sealed class Completed
         {
             public static Completed Instance { get; } = new Completed();
 
-            private Completed() { }
+            private Completed()
+            {
+            }
         }
 
 
-        private interface IHubState { }
+        private interface IHubState
+        {
+        }
 
         private sealed class Open : IHubState
         {
@@ -1510,7 +1528,7 @@ namespace Akka.Streams.Dsl
             }
         }
 
-        #endregion  
+        #endregion
 
         private sealed class PartitionSinkLogic : InGraphStageLogic
         {
@@ -1540,7 +1558,10 @@ namespace Akka.Streams.Dsl
             private readonly PartitionHub<T> _hub;
             private readonly int _demandThreshold;
             private readonly Func<PartitionHub.IConsumerInfo, T, long> _materializedPartitioner;
-            private readonly TaskCompletionSource<Action<IHubEvent>> _callbackCompletion = new TaskCompletionSource<Action<IHubEvent>>();
+
+            private readonly TaskCompletionSource<Action<IHubEvent>> _callbackCompletion =
+                new TaskCompletionSource<Action<IHubEvent>>();
+
             private readonly IHubState _noRegistrationsState;
             private bool _initialized;
             private readonly IPartitionQueue _queue = new PartitionQueue();
@@ -1651,7 +1672,8 @@ namespace Akka.Streams.Dsl
                     var o = (Open)State.GetAndSet(_noRegistrationsState);
                     foreach (var consumer in o.Registrations)
                     {
-                        var newConsumers = _consumerInfo.Consumers.Add(consumer).Sort((c1, c2) => c1.Id.CompareTo(c2.Id));
+                        var newConsumers = _consumerInfo.Consumers.Add(consumer)
+                            .Sort((c1, c2) => c1.Id.CompareTo(c2.Id));
                         _consumerInfo = new ConsumerInfo(this, newConsumers);
                         _queue.Init(consumer.Id);
                         if (newConsumers.Count >= _hub._startAfterNrOfConsumers)
@@ -1850,7 +1872,8 @@ namespace Akka.Streams.Dsl
         private readonly int _startAfterNrOfConsumers;
         private readonly int _bufferSize;
 
-        public PartitionHub(Func<Func<PartitionHub.IConsumerInfo, T, long>> partitioner, int startAfterNrOfConsumers, int bufferSize)
+        public PartitionHub(Func<Func<PartitionHub.IConsumerInfo, T, long>> partitioner, int startAfterNrOfConsumers,
+            int bufferSize)
         {
             _partitioner = partitioner;
             _startAfterNrOfConsumers = startAfterNrOfConsumers;
@@ -1862,7 +1885,8 @@ namespace Akka.Streams.Dsl
 
         public override SinkShape<T> Shape { get; }
 
-        public override ILogicAndMaterializedValue<Source<T, NotUsed>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
+        public override ILogicAndMaterializedValue<Source<T, NotUsed>> CreateLogicAndMaterializedValue(
+            Attributes inheritedAttributes)
         {
             var idCounter = new AtomicCounterLong();
             var logic = new PartitionSinkLogic(this);

--- a/src/core/Akka.Streams/Dsl/Hub.cs
+++ b/src/core/Akka.Streams/Dsl/Hub.cs
@@ -86,7 +86,7 @@ namespace Akka.Streams.Dsl
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    /// <typeparam name="T">TBD</typeparam>
+    /// <typeparam name="T">The type of element emitted by the MergeHub</typeparam>
     internal class MergeHub<T> : GraphStageWithMaterializedValue<SourceShape<T>, Sink<T, NotUsed>>
     {
         #region Internal classes
@@ -426,14 +426,14 @@ namespace Akka.Streams.Dsl
         /// TBD
         /// </summary>
         /// <param name="perProducerBufferSize">TBD</param>
-        /// <exception cref="ArgumentException">
-        /// This exception is thrown when the specified <paramref name="perProducerBufferSize"/> is less than or equal to zero.
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// This exception is thrown when the specified <paramref name="perProducerBufferSize"/>is less than or equal to zero.
         /// </exception>
         public MergeHub(int perProducerBufferSize)
         {
             if (perProducerBufferSize <= 0)
-                throw new ArgumentException("Buffer size must be positive", nameof(perProducerBufferSize));
-
+                throw new ArgumentOutOfRangeException(nameof(perProducerBufferSize), perProducerBufferSize, "Buffer size must be positive");
+            
             _perProducerBufferSize = perProducerBufferSize;
             DemandThreshold = perProducerBufferSize / 2 + perProducerBufferSize % 2;
             Shape = new SourceShape<T>(Out);


### PR DESCRIPTION
## Changes

This is currently the raciest test in the entire test suite.

99% sure that trying to ReSharper this into a method that doesn't use tail recursion actually created a bug here that can occur for really small partitions - making the `firstAttempt` value mutable across all possible instances results in behavior that actually isn't comparable to using isolated function invocations in all instances. Going to run this through CI and see if that adds up.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).