### PR TITLE
[Obsolete] GetFirstAttribute

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
@@ -57,7 +57,9 @@ namespace Akka.Streams.Tests.Dsl
 
         [Fact]
         public void Attributes_must_give_access_to_first_attribute()
-            => Attributes.GetAttribute<Attributes.Name>().Value.Should().Be("a");
+#pragma warning disable CS0618 // Type or member is obsolete
+            => Attributes.GetFirstAttribute<Attributes.Name>().Value.Should().Be("a");
+#pragma warning restore CS0618 // Type or member is obsolete
 
         [Fact]
         public void Attributes_must_give_access_to_attribute_by_type()

--- a/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
@@ -57,7 +57,7 @@ namespace Akka.Streams.Tests.Dsl
 
         [Fact]
         public void Attributes_must_give_access_to_first_attribute()
-            => Attributes.GetFirstAttribute<Attributes.Name>().Value.Should().Be("a");
+            => Attributes.GetAttribute<Attributes.Name>().Value.Should().Be("a");
 
         [Fact]
         public void Attributes_must_give_access_to_attribute_by_type()

--- a/src/core/Akka.Streams.Tests/Dsl/BidiFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/BidiFlowSpec.cs
@@ -209,8 +209,8 @@ namespace Akka.Streams.Tests.Dsl
             var b = (BidiFlow<int, long, ByteString, string, NotUsed>)
                 Bidi().WithAttributes(Attributes.CreateName("")).Async().Named("name");
 
-            b.Module.Attributes.GetFirstAttribute<Attributes.Name>().Value.Should().Be("name");
-            b.Module.Attributes.GetFirstAttribute<Attributes.AsyncBoundary>()
+            b.Module.Attributes.GetAttribute<Attributes.Name>().Value.Should().Be("name");
+            b.Module.Attributes.GetAttribute<Attributes.AsyncBoundary>()
                 .Should()
                 .Be(Attributes.AsyncBoundary.Instance);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/GraphDslCompileSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphDslCompileSpec.cs
@@ -481,8 +481,8 @@ namespace Akka.Streams.Tests.Dsl
                 return new FlowShape<int, int>(id.Inlet, id.Outlet);
             }).Async().AddAttributes(Attributes.None).Named("useless");
 
-            ga.Module.Attributes.GetFirstAttribute<Attributes.Name>().Value.Should().Be("useless");
-            ga.Module.Attributes.GetFirstAttribute<Attributes.AsyncBoundary>()
+            ga.Module.Attributes.GetAttribute<Attributes.Name>().Value.Should().Be("useless");
+            ga.Module.Attributes.GetAttribute<Attributes.AsyncBoundary>()
                 .Should()
                 .Be(Attributes.AsyncBoundary.Instance);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/RunnableGraphSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/RunnableGraphSpec.cs
@@ -29,8 +29,8 @@ namespace Akka.Streams.Tests.Dsl
                     .AddAttributes(Attributes.None)
                     .Named("useless");
 
-            r.Module.Attributes.GetFirstAttribute<Attributes.Name>().Value.Should().Be("useless");
-            r.Module.Attributes.GetFirstAttribute<Attributes.AsyncBoundary>()
+            r.Module.Attributes.GetAttribute<Attributes.Name>().Value.Should().Be("useless");
+            r.Module.Attributes.GetAttribute<Attributes.AsyncBoundary>()
                 .Should()
                 .Be(Attributes.AsyncBoundary.Instance);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
@@ -179,7 +179,7 @@ namespace Akka.Streams.Tests.Dsl
             var s = Sink.First<int>().Async().AddAttributes(Attributes.None).Named("name");
 
             s.Module.Attributes.GetAttribute<Attributes.Name>().Value.Should().Be("name");
-            s.Module.Attributes.GetFirstAttribute<Attributes.AsyncBoundary>()
+            s.Module.Attributes.GetAttribute<Attributes.AsyncBoundary>()
                 .Should()
                 .Be(Attributes.AsyncBoundary.Instance);
         }


### PR DESCRIPTION
## Changes

- Change `GetFirstAttribute<TAttr>()` to `GetAttribute<TAttr>()`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).