### PR TITLE
Akka.Cluster: enable `keep-majority` default SBR

### DIFF
--- a/docs/articles/clustering/split-brain-resolver.md
+++ b/docs/articles/clustering/split-brain-resolver.md
@@ -41,6 +41,16 @@ Beginning in Akka.NET v1.4.16, the Akka.NET project has ported the original spli
 > [!IMPORTANT]
 > As of Akka.NET v1.5.2, the `keep-majority` split brain resolution strategy is now enabled by default. This should be acceptable for the majority of Akka.Cluster users, but please read on.
 
+### Disabling the Default Downing Provider
+
+To disable the default Akka.Cluster downing provider, simply configure the following in your HOCON:
+
+```hocon
+akka.cluster.downing-provider-class = ""
+```
+
+This will disable the split brain resolver / downing provider functionality altogether in Akka.NET. This was the default behavior for Akka.Cluster as of Akka.NET v1.5.1 and earlier.
+
 ### Picking a Strategy
 
 In order to enable an Akka.NET split brain resolver in your cluster (they are not enabled by default), you will want to update your `akka.cluster` HOCON configuration to the following:

--- a/docs/articles/clustering/split-brain-resolver.md
+++ b/docs/articles/clustering/split-brain-resolver.md
@@ -38,6 +38,9 @@ Keep in mind that split brain resolver will NOT work when `akka.cluster.auto-dow
 
 Beginning in Akka.NET v1.4.16, the Akka.NET project has ported the original split brain resolver implementations from Lightbend as they are now open source. The following section of documentation describes how Akka.NET's hand-rolled split brain resolvers are implemented.
 
+> [!IMPORTANT]
+> As of Akka.NET v1.5.2, the `keep-majority` split brain resolution strategy is now enabled by default. This should be acceptable for the majority of Akka.Cluster users, but please read on.
+
 ### Picking a Strategy
 
 In order to enable an Akka.NET split brain resolver in your cluster (they are not enabled by default), you will want to update your `akka.cluster` HOCON configuration to the following:
@@ -59,7 +62,7 @@ This will cause the [`Akka.Cluster.SBR.SplitBrainResolverProvider`](xref:Akka.Cl
 The following strategies are supported:
 
 * `static-quorum`
-* `keep-majority`
+* `keep-majority` **(default)**
 * `keep-oldest`
 * `down-all`
 * `lease-majority`
@@ -143,6 +146,9 @@ akka.cluster.split-brain-resolver {
 ```
 
 #### Keep Majority
+
+> [!NOTE]
+> `keep-majority` is the default SBR strategy for Akka.Cluster as of Akka.NET v1.5.2+.
 
 The `keep-majority` strategy will down this part of the cluster, which sees a lesser part of the whole cluster. This choice is made based on the latest known state of the cluster. When cluster will split into two equal parts, the one which contains the lowest address, will survive.
 

--- a/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
+++ b/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
@@ -24,7 +24,7 @@ We meant to include both of these changes in Akka.NET v1.5.0 but simply ran out 
 
 The impact of [Akka.Persistence: need to remove hard-coded Newtonsoft.Json `object` serializer](https://github.com/akkadotnet/akka.net/issues/6389) is pretty minor: all versions of Akka.NET prior to 1.5.2 used Newtonsoft.Json as the `object` serializer for Akka.Persistence regardless of whether or not you [used a custom `object` serializer, such as Hyperion](xref:serialization#complex-object-serialization-using-hyperion).
 
-Going forward your user-defined `object` serialization binding will now be respected by Akka.Persistence. Any old data previously saved using Newtonsoft.Json will continue to be recovered automatically by Newtonsoft.Json - it's only the serialziation of new objects inserted after upgrading to v1.5.2 that will be affected.
+Going forward your user-defined `object` serialization binding will now be respected by Akka.Persistence. Any old data previously saved using Newtonsoft.Json will continue to be recovered automatically by Newtonsoft.Json - it's only the serialization of new objects inserted after upgrading to v1.5.2 that will be affected.
 
 If you _never changed your `object`_ serializer (most users don't) then this change doesn't affect you.
 
@@ -36,7 +36,7 @@ If you were already running with a custom SBR enabled, this change won't affect 
 
 If you weren't running with an SBR enabled, you should read the [Akka.Cluster Split Brain Resolver documentation](xref:split-brain-resolver).
 
-Also worth noting: we've disabled the `akka.cluster.auto-down-unreachable-after` setting as it's always been a poor and shoddy way to manage network partitions inside Akka.Cluster. If you have that seting enabled it will be ignored and you'll see the following warning appear instead:
+Also worth noting: we've disabled the `akka.cluster.auto-down-unreachable-after` setting as it's always been a poor and shoddy way to manage network partitions inside Akka.Cluster. If you have that setting enabled it will be ignored and you'll see the following warning appear instead:
 
 ```shell
 The `auto-down-unreachable-after` feature has been deprecated as of Akka.NET v1.5.2 and will be removed in a future version of Akka.NET.

--- a/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
+++ b/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
@@ -36,7 +36,7 @@ If you were already running with a custom SBR enabled, this change won't affect 
 
 If you weren't running with an SBR enabled, you should read the [Akka.Cluster Split Brain Resolver documentation](xref:split-brain-resolver).
 
-Also worth noting: we've disabled the `akka.cluster.auto-down-unreachable-after` setting as it's always been a poor and shoddy way to manage network partitions inside Akka.Cluster. If you have that setting enabled it will be ignored and you'll see the following warning appear instead:
+Also worth noting: we've deprecated the `akka.cluster.auto-down-unreachable-after` setting as it's always been a poor and shoddy way to manage network partitions inside Akka.Cluster. If you have that setting enabled you'll see the following warning appear:
 
 ```shell
 The `auto-down-unreachable-after` feature has been deprecated as of Akka.NET v1.5.2 and will be removed in a future version of Akka.NET.

--- a/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
+++ b/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
@@ -11,6 +11,38 @@ This document contains specific upgrade suggestions, warnings, and notices that 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/-UPestlIw4k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 <!-- markdownlint-enable MD033 -->
 
+## Upgrading to Akka.NET v1.5.2
+
+Akka.NET v1.5.2 introduces two important behavioral changes:
+
+* [Akka.Persistence: need to remove hard-coded Newtonsoft.Json `object` serializer](https://github.com/akkadotnet/akka.net/issues/6389)
+* [Akka.Cluster: enable `keep-majority` as default Split Brain Resolver](https://github.com/akkadotnet/akka.net/pull/6628)
+
+We meant to include both of these changes in Akka.NET v1.5.0 but simply ran out of time before making them into that release.
+
+### Akka.Persistence Changes
+
+The impact of [Akka.Persistence: need to remove hard-coded Newtonsoft.Json `object` serializer](https://github.com/akkadotnet/akka.net/issues/6389) is pretty minor: all versions of Akka.NET prior to 1.5.2 used Newtonsoft.Json as the `object` serializer for Akka.Persistence regardless of whether or not you [used a custom `object` serializer, such as Hyperion](xref:serialization#complex-object-serialization-using-hyperion).
+
+Going forward your user-defined `object` serialization binding will now be respected by Akka.Persistence. Any old data previously saved using Newtonsoft.Json will continue to be recovered automatically by Newtonsoft.Json - it's only the serialziation of new objects inserted after upgrading to v1.5.2 that will be affected.
+
+If you _never changed your `object`_ serializer (most users don't) then this change doesn't affect you.
+
+### Akka.Cluster Split Brain Resolver Changes
+
+As of Akka.NET v1.5.2 we've now enabled the `keep-majority` [Split Brain Resolver](xref:split-brain-resolver) by default.
+
+If you were already running with a custom SBR enabled, this change won't affect you.
+
+If you weren't running with an SBR enabled, you should read the [Akka.Cluster Split Brain Resolver documentation](xref:split-brain-resolver).
+
+Also worth noting: we've disabled the `akka.cluster.auto-down-unreachable-after` setting as it's always been a poor and shoddy way to manage network partitions inside Akka.Cluster. If you have that seting enabled it will be ignored and you'll see the following warning appear instead:
+
+```shell
+The `auto-down-unreachable-after` feature has been deprecated as of Akka.NET v1.5.2 and will be removed in a future version of Akka.NET.
+The `keep-majority` split brain resolver will be used instead. See https://getakka.net/articles/cluster/split-brain-resolver.html for more details.
+```
+
 ## Upgrading From Akka.NET v1.4 to v1.5
 
 In case you need help upgrading:

--- a/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
+++ b/docs/community/whats-new/akkadotnet-v1.5-upgrade-advisories.md
@@ -43,6 +43,16 @@ The `auto-down-unreachable-after` feature has been deprecated as of Akka.NET v1.
 The `keep-majority` split brain resolver will be used instead. See https://getakka.net/articles/cluster/split-brain-resolver.html for more details.
 ```
 
+#### Disabling the Default Downing Provider
+
+To disable the default Akka.Cluster downing provider, simply configure the following in your HOCON:
+
+```hocon
+akka.cluster.downing-provider-class = ""
+```
+
+This will disable the split brain resolver / downing provider functionality altogether in Akka.NET. This was the default behavior for Akka.Cluster as of Akka.NET v1.5.1 and earlier.
+
 ## Upgrading From Akka.NET v1.4 to v1.5
 
 In case you need help upgrading:

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -58,9 +58,7 @@ namespace Akka.Cluster.Sharding.Tests
             CommonConfig = ConfigurationFactory.ParseString($@"
                 akka.cluster.sharding.verbose-debug-logging = on
                 #akka.loggers = [""akka.testkit.SilenceAllTestEventListener""]
-                akka.cluster.downing-provider-class = ""Akka.Cluster.SBR.SplitBrainResolverProvider, Akka.Cluster""
-                akka.cluster.split-brain-resolver.stable-after = 1s
-                akka.cluster.down-removal-margin = 1s
+                akka.cluster.auto-down-unreachable-after = 0s
                 akka.cluster.roles = [""backend""]
                 akka.cluster.distributed-data.gossip-interval = 1s
                 akka.persistence.journal.sqlite-shared.timeout = 10s #the original default, base test uses 5s

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -60,6 +60,7 @@ namespace Akka.Cluster.Sharding.Tests
                 #akka.loggers = [""akka.testkit.SilenceAllTestEventListener""]
                 akka.cluster.downing-provider-class = ""Akka.Cluster.SBR.SplitBrainResolverProvider, Akka.Cluster""
                 akka.cluster.split-brain-resolver.stable-after = 1s
+                akka.cluster.down-removal-margin = 1s
                 akka.cluster.roles = [""backend""]
                 akka.cluster.distributed-data.gossip-interval = 1s
                 akka.persistence.journal.sqlite-shared.timeout = 10s #the original default, base test uses 5s

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -58,7 +58,8 @@ namespace Akka.Cluster.Sharding.Tests
             CommonConfig = ConfigurationFactory.ParseString($@"
                 akka.cluster.sharding.verbose-debug-logging = on
                 #akka.loggers = [""akka.testkit.SilenceAllTestEventListener""]
-
+                akka.cluster.downing-provider-class = ""Akka.Cluster.SBR.SplitBrainResolverProvider, Akka.Cluster""
+                akka.cluster.split-brain-resolver.stable-after = 1s
                 akka.cluster.roles = [""backend""]
                 akka.cluster.distributed-data.gossip-interval = 1s
                 akka.persistence.journal.sqlite-shared.timeout = 10s #the original default, base test uses 5s

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
@@ -58,9 +58,7 @@ namespace Akka.Cluster.Sharding.Tests
             Common =
                 ConfigurationFactory.ParseString($@"
                     akka.actor.provider = ""cluster""
-                    akka.cluster.downing-provider-class = ""Akka.Cluster.SBR.SplitBrainResolverProvider, Akka.Cluster""
-                    akka.cluster.split-brain-resolver.stable-after = 1s
-                    akka.cluster.down-removal-margin = 1s
+                    akka.cluster.auto-down-unreachable-after = 0s
                     akka.cluster.sharding.state-store-mode = ""{mode}""
                     akka.cluster.sharding.remember-entities = {rememberEntities.ToString().ToLowerInvariant()}
                     akka.cluster.sharding.remember-entities-store = ""{rememberEntitiesStore}""

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
@@ -58,7 +58,9 @@ namespace Akka.Cluster.Sharding.Tests
             Common =
                 ConfigurationFactory.ParseString($@"
                     akka.actor.provider = ""cluster""
-                    akka.cluster.auto-down-unreachable-after = 0s
+                    akka.cluster.downing-provider-class = ""Akka.Cluster.SBR.SplitBrainResolverProvider, Akka.Cluster""
+                    akka.cluster.split-brain-resolver.stable-after = 1s
+                    akka.cluster.down-removal-margin = 1s
                     akka.cluster.sharding.state-store-mode = ""{mode}""
                     akka.cluster.sharding.remember-entities = {rememberEntities.ToString().ToLowerInvariant()}
                     akka.cluster.sharding.remember-entities-store = ""{rememberEntitiesStore}""

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonConfigSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             clusterSingletonManagerSettings.SingletonName.ShouldBe("singleton");
             clusterSingletonManagerSettings.Role.ShouldBe(null);
             clusterSingletonManagerSettings.HandOverRetryInterval.TotalSeconds.ShouldBe(1);
-            clusterSingletonManagerSettings.RemovalMargin.TotalSeconds.ShouldBe(0);
+            clusterSingletonManagerSettings.RemovalMargin.TotalSeconds.ShouldBe(20); // now 20 due to default SBR settings
 
             var config = Sys.Settings.Config.GetConfig("akka.cluster.singleton");
             Assert.False(config.IsNullOrEmpty());

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
@@ -18,6 +18,7 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Cluster
 {
+    [System.ObsoleteAttribute("No longer used as of Akka.NET v1.5.2")]
     public sealed class AutoDowning : Akka.Cluster.IDowningProvider
     {
         public AutoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
@@ -192,6 +193,8 @@ namespace Akka.Cluster
         public ClusterSettings(Akka.Configuration.Config config, string systemName) { }
         public bool AllowWeaklyUpMembers { get; }
         public Akka.Util.AppVersion AppVersion { get; }
+        [System.ObsoleteAttribute("No longer used as of Akka.NET v1.5.2 - clustering defaults to using KeepMajority " +
+            "SBR instead")]
         public System.Nullable<System.TimeSpan> AutoDownUnreachableAfter { get; }
         public System.Type DowningProviderType { get; }
         public Akka.Configuration.Config FailureDetectorConfig { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
@@ -18,7 +18,7 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Cluster
 {
-    [System.ObsoleteAttribute("No longer used as of Akka.NET v1.5.2")]
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class AutoDowning : Akka.Cluster.IDowningProvider
     {
         public AutoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
@@ -193,8 +193,8 @@ namespace Akka.Cluster
         public ClusterSettings(Akka.Configuration.Config config, string systemName) { }
         public bool AllowWeaklyUpMembers { get; }
         public Akka.Util.AppVersion AppVersion { get; }
-        [System.ObsoleteAttribute("No longer used as of Akka.NET v1.5.2 - clustering defaults to using KeepMajority " +
-            "SBR instead")]
+        [System.ObsoleteAttribute("Deprecated as of Akka.NET v1.5.2 - clustering defaults to using KeepMajority SBR " +
+            "instead")]
         public System.Nullable<System.TimeSpan> AutoDownUnreachableAfter { get; }
         public System.Type DowningProviderType { get; }
         public Akka.Configuration.Config FailureDetectorConfig { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
@@ -18,6 +18,7 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Cluster
 {
+    [System.ObsoleteAttribute("No longer used as of Akka.NET v1.5.2")]
     public sealed class AutoDowning : Akka.Cluster.IDowningProvider
     {
         public AutoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
@@ -192,6 +193,8 @@ namespace Akka.Cluster
         public ClusterSettings(Akka.Configuration.Config config, string systemName) { }
         public bool AllowWeaklyUpMembers { get; }
         public Akka.Util.AppVersion AppVersion { get; }
+        [System.ObsoleteAttribute("No longer used as of Akka.NET v1.5.2 - clustering defaults to using KeepMajority " +
+            "SBR instead")]
         public System.Nullable<System.TimeSpan> AutoDownUnreachableAfter { get; }
         public System.Type DowningProviderType { get; }
         public Akka.Configuration.Config FailureDetectorConfig { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
@@ -18,7 +18,7 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Cluster
 {
-    [System.ObsoleteAttribute("No longer used as of Akka.NET v1.5.2")]
+    [Akka.Annotations.InternalApiAttribute()]
     public sealed class AutoDowning : Akka.Cluster.IDowningProvider
     {
         public AutoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
@@ -193,8 +193,8 @@ namespace Akka.Cluster
         public ClusterSettings(Akka.Configuration.Config config, string systemName) { }
         public bool AllowWeaklyUpMembers { get; }
         public Akka.Util.AppVersion AppVersion { get; }
-        [System.ObsoleteAttribute("No longer used as of Akka.NET v1.5.2 - clustering defaults to using KeepMajority " +
-            "SBR instead")]
+        [System.ObsoleteAttribute("Deprecated as of Akka.NET v1.5.2 - clustering defaults to using KeepMajority SBR " +
+            "instead")]
         public System.Nullable<System.TimeSpan> AutoDownUnreachableAfter { get; }
         public System.Type DowningProviderType { get; }
         public Akka.Configuration.Config FailureDetectorConfig { get; }

--- a/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
@@ -59,6 +59,7 @@ namespace Akka.Cluster.TestKit
                         retry-interval = 200ms
                         waiting-for-state-timeout = 200ms
                     }
+                    downing-provider-class = """" # disable default SBR
                 }
                 akka.loglevel = INFO
                 akka.log-dead-letters = off

--- a/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
@@ -59,7 +59,7 @@ namespace Akka.Cluster.TestKit
                         retry-interval = 200ms
                         waiting-for-state-timeout = 200ms
                     }
-                    downing-provider-class = """" # disable default SBR
+                    #downing-provider-class = """" # disable default SBR
                 }
                 akka.loglevel = INFO
                 akka.log-dead-letters = off

--- a/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
@@ -66,7 +66,6 @@ namespace Akka.Cluster.TestKit
                 #akka.remote.log-remote-lifecycle-events = off
                 akka.coordinated-shutdown.run-by-clr-shutdown-hook = off
                 akka.coordinated-shutdown.terminate-actor-system = off
-                akka.
                 #akka.loggers = [""Akka.TestKit.TestEventListener, Akka.TestKit""]
                 akka.test {
                     single-expect-default = 15 s

--- a/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
@@ -66,6 +66,7 @@ namespace Akka.Cluster.TestKit
                 #akka.remote.log-remote-lifecycle-events = off
                 akka.coordinated-shutdown.run-by-clr-shutdown-hook = off
                 akka.coordinated-shutdown.terminate-actor-system = off
+                akka.
                 #akka.loggers = [""Akka.TestKit.TestEventListener, Akka.TestKit""]
                 akka.test {
                     single-expect-default = 15 s

--- a/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
@@ -91,5 +91,17 @@ namespace Akka.Cluster.Tests
             var settings = new ClusterSettings(config.WithFallback(Sys.Settings.Config), Sys.Name);
             settings.AppVersion.Should().Be(AppVersion.Zero);
         }
+
+        /// <summary>
+        /// Validate that we can disable the default downing provider if needed
+        /// </summary>
+        [Fact]
+        public void Cluster_should_allow_disabling_of_default_DowningProvider()
+        {
+            // configure HOCON to disable the default akka.cluster downing provider
+            Config config = "akka.cluster.downing-provider-class = \"\"";
+            var settings = new ClusterSettings(config.WithFallback(Sys.Settings.Config), Sys.Name);
+            settings.DowningProviderType.Should().Be<NoDowning>();
+        }
     }
 }

--- a/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using Akka.Actor;
+using Akka.Cluster.SBR;
 using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Remote;
@@ -71,6 +72,13 @@ namespace Akka.Cluster.Tests
             settings.VerboseHeartbeatLogging.Should().BeFalse();
             settings.VerboseGossipReceivedLogging.Should().BeFalse();
             settings.RunCoordinatedShutdownWhenDown.Should().BeTrue();
+            
+            // downing provider settings
+            settings.DowningProviderType.Should().Be<SplitBrainResolverProvider>();
+            var sbrSettings = new SplitBrainResolverSettings(Sys.Settings.Config);
+            sbrSettings.DowningStableAfter.Should().Be(20.Seconds());
+            sbrSettings.DownAllWhenUnstable.Should().Be(15.Seconds()); // 3/4 OF DowningStableAfter
+            sbrSettings.DowningStrategy.Should().Be("keep-majority");
         }
 
         /// <summary>

--- a/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterConfigSpec.cs
@@ -45,7 +45,9 @@ namespace Akka.Cluster.Tests
             settings.AllowWeaklyUpMembers.Should().BeTrue();
             settings.WeaklyUpAfter.Should().Be(7.Seconds());
             settings.PublishStatsInterval.Should().NotHaveValue();
+#pragma warning disable CS0618
             settings.AutoDownUnreachableAfter.Should().NotHaveValue();
+#pragma warning restore CS0618
             settings.DownRemovalMargin.Should().Be(TimeSpan.Zero);
             settings.MinNrOfMembers.Should().Be(1);
             settings.MinNrOfMembersOfRole.Should().Equal(ImmutableDictionary<string, int>.Empty);

--- a/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
+++ b/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
@@ -80,10 +80,12 @@ namespace Akka.Cluster.Tests
         [Fact]
         public void Downing_provider_should_ignore_AutoDowning_if_auto_down_unreachable_after_is_configured()
         {
-            var config = ConfigurationFactory.ParseString(@"akka.cluster.auto-down-unreachable-after=18s");
+            var config = ConfigurationFactory.ParseString(@"
+                akka.cluster.downing-provider-class = """"
+                akka.cluster.auto-down-unreachable-after=18s");
             using (var system = ActorSystem.Create("auto-downing", config.WithFallback(BaseConfig)))
             {
-                Cluster.Get(system).DowningProvider.Should().BeOfType<Akka.Cluster.SBR.SplitBrainResolverProvider>();
+                Cluster.Get(system).DowningProvider.Should().BeOfType<AutoDowning>();
             }
         }
 

--- a/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
+++ b/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
@@ -34,7 +34,7 @@ namespace Akka.Cluster.Tests
         }
     }
 
-    class DummyDowningProvider : IDowningProvider
+    internal class DummyDowningProvider : IDowningProvider
     {
         public readonly AtomicBoolean ActorPropsAccessed = new AtomicBoolean(false);
         public DummyDowningProvider(ActorSystem system, Cluster cluster)
@@ -97,7 +97,7 @@ namespace Akka.Cluster.Tests
                 var downingProvider = Cluster.Get(system).DowningProvider;
                 downingProvider.Should().BeOfType<DummyDowningProvider>();
                 AwaitCondition(() =>
-                    (downingProvider as DummyDowningProvider).ActorPropsAccessed.Value,
+                    ((DummyDowningProvider)downingProvider).ActorPropsAccessed.Value,
                     TimeSpan.FromSeconds(3));
             }
         }

--- a/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
+++ b/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
@@ -69,21 +69,21 @@ namespace Akka.Cluster.Tests
         ");
 
         [Fact]
-        public void Downing_provider_should_default_to_NoDowning()
+        public void Downing_provider_should_default_to_KeepMajority()
         {
             using (var system = ActorSystem.Create("default", BaseConfig))
             {
-                Cluster.Get(system).DowningProvider.Should().BeOfType<NoDowning>();
+                Cluster.Get(system).DowningProvider.Should().BeOfType<Akka.Cluster.SBR.SplitBrainResolverProvider>();
             }
         }
 
         [Fact]
-        public void Downing_provider_should_use_AutoDowning_if_auto_down_unreachable_after_is_configured()
+        public void Downing_provider_should_ignore_AutoDowning_if_auto_down_unreachable_after_is_configured()
         {
             var config = ConfigurationFactory.ParseString(@"akka.cluster.auto-down-unreachable-after=18s");
             using (var system = ActorSystem.Create("auto-downing", config.WithFallback(BaseConfig)))
             {
-                Cluster.Get(system).DowningProvider.Should().BeOfType<AutoDowning>();
+                Cluster.Get(system).DowningProvider.Should().BeOfType<Akka.Cluster.SBR.SplitBrainResolverProvider>();
             }
         }
 

--- a/src/core/Akka.Cluster/AutoDown.cs
+++ b/src/core/Akka.Cluster/AutoDown.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Event;
 using Akka.Configuration;
 using static Akka.Cluster.MembershipState;
@@ -270,7 +271,7 @@ namespace Akka.Cluster
     /// <summary>
     /// Used when no custom provider is configured and 'auto-down-unreachable-after' is enabled.
     /// </summary>
-    [Obsolete("No longer used as of Akka.NET v1.5.2")]
+    [InternalApi] // really only used during MNTR for Akka.Cluster.Sharding
     public sealed class AutoDowning : IDowningProvider
     {
         private readonly ActorSystem _system;

--- a/src/core/Akka.Cluster/AutoDown.cs
+++ b/src/core/Akka.Cluster/AutoDown.cs
@@ -270,6 +270,7 @@ namespace Akka.Cluster
     /// <summary>
     /// Used when no custom provider is configured and 'auto-down-unreachable-after' is enabled.
     /// </summary>
+    [Obsolete("No longer used as of Akka.NET v1.5.2")]
     public sealed class AutoDowning : IDowningProvider
     {
         private readonly ActorSystem _system;
@@ -296,7 +297,9 @@ namespace Akka.Cluster
         {
             get
             {
+#pragma warning disable CS0618 // disable obsolete warning here because this entire class is obsolete
                 var autoDownUnreachableAfter = _cluster.Settings.AutoDownUnreachableAfter;
+#pragma warning restore CS0618
                 if (!autoDownUnreachableAfter.HasValue)
                     throw new ConfigurationException("AutoDowning downing provider selected but 'akka.cluster.auto-down-unreachable-after' not set");
 

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -285,11 +285,6 @@ namespace Akka.Cluster
         /// <inheritdoc cref="JoinSeenNode"/>
         internal class InitJoin : IClusterMessage, IDeadLetterSuppression
         {
-            /// <inheritdoc/>
-            public override bool Equals(object obj)
-            {
-                return obj is InitJoin;
-            }
         }
 
         /// <inheritdoc cref="JoinSeenNode"/>

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -285,6 +285,21 @@ namespace Akka.Cluster
         /// <inheritdoc cref="JoinSeenNode"/>
         internal class InitJoin : IClusterMessage, IDeadLetterSuppression
         {
+            /// <inheritdoc/>
+            public override bool Equals(object obj)
+            {
+                return obj is InitJoin;
+            }
+
+            protected bool Equals(InitJoin other)
+            {
+                return true;
+            }
+
+            public override int GetHashCode()
+            {
+                return 1;
+            }
         }
 
         /// <inheritdoc cref="JoinSeenNode"/>

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -225,7 +225,7 @@ namespace Akka.Cluster
             {
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
-                return obj is Welcome && Equals((Welcome)obj);
+                return obj is Welcome welcome && Equals(welcome);
             }
 
             private bool Equals(Welcome other)

--- a/src/core/Akka.Cluster/ClusterSettings.cs
+++ b/src/core/Akka.Cluster/ClusterSettings.cs
@@ -68,6 +68,8 @@ namespace Akka.Cluster
 
 #pragma warning disable CS0618
             AutoDownUnreachableAfter = clusterConfig.GetTimeSpanWithOffSwitch("auto-down-unreachable-after");
+            if (AutoDownUnreachableAfter == default(TimeSpan)) // need to restore correct defaults now that it's been deleted from HOCON file
+                AutoDownUnreachableAfter = null;
 #pragma warning restore CS0618
 
             Roles = clusterConfig.GetStringList("roles", new string[] { }).ToImmutableHashSet();

--- a/src/core/Akka.Cluster/ClusterSettings.cs
+++ b/src/core/Akka.Cluster/ClusterSettings.cs
@@ -22,8 +22,8 @@ namespace Akka.Cluster
     /// </summary>
     public sealed class ClusterSettings
     {
-        readonly Config _failureDetectorConfig;
-        readonly string _useDispatcher;
+        private readonly Config _failureDetectorConfig;
+        private readonly string _useDispatcher;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClusterSettings"/> class.
@@ -87,16 +87,10 @@ namespace Akka.Cluster
             VerboseGossipReceivedLogging = clusterConfig.GetBoolean("debug.verbose-receive-gossip-logging", false);
 
             var downingProviderClassName = clusterConfig.GetString("downing-provider-class", null);
-            if (!string.IsNullOrEmpty(downingProviderClassName))
-                DowningProviderType = Type.GetType(downingProviderClassName, true);
-            else if (AutoDownUnreachableAfter.HasValue)
-                DowningProviderType = typeof(AutoDowning);
-            else
-                DowningProviderType = typeof(NoDowning);
+            DowningProviderType = !string.IsNullOrEmpty(downingProviderClassName) ? Type.GetType(downingProviderClassName, true) : typeof(NoDowning);
 
             RunCoordinatedShutdownWhenDown = clusterConfig.GetBoolean("run-coordinated-shutdown-when-down", false);
-
-            // TODO: replace with a switch expression when we upgrade to C#8 or later
+            
             TimeSpan GetWeaklyUpDuration()
             {
                 var cKey = "allow-weakly-up-members";
@@ -207,8 +201,9 @@ namespace Akka.Cluster
         public TimeSpan? PublishStatsInterval { get; }
 
         /// <summary>
-        /// TBD
+        /// Obsolete. No longer used as of Akka.NET v1.5.
         /// </summary>
+        [Obsolete(message:"No longer used as of Akka.NET v1.5.2 - clustering defaults to using KeepMajority SBR instead")]
         public TimeSpan? AutoDownUnreachableAfter { get; }
 
         /// <summary>

--- a/src/core/Akka.Cluster/ClusterSettings.cs
+++ b/src/core/Akka.Cluster/ClusterSettings.cs
@@ -66,7 +66,9 @@ namespace Akka.Cluster
                 ) ? TimeSpan.Zero :
                 clusterConfig.GetTimeSpan("down-removal-margin", null);
 
+#pragma warning disable CS0618
             AutoDownUnreachableAfter = clusterConfig.GetTimeSpanWithOffSwitch("auto-down-unreachable-after");
+#pragma warning restore CS0618
 
             Roles = clusterConfig.GetStringList("roles", new string[] { }).ToImmutableHashSet();
             AppVersion = Util.AppVersion.Create(clusterConfig.GetString("app-version"));

--- a/src/core/Akka.Cluster/Configuration/Cluster.conf
+++ b/src/core/Akka.Cluster/Configuration/Cluster.conf
@@ -63,7 +63,9 @@ akka {
     # `Akka.Cluster.IDowningProvider` having two argument constructor:
     #   - argument 1: accepting an `ActorSystem`
     #   - argument 2: accepting an `Akka.Cluster.Cluster`
-    downing-provider-class = ""
+    downing-provider-class = "Akka.Cluster.SBR.SplitBrainResolverProvider, Akka.Cluster"
+    
+    
 
     # If this is set to "off", the leader will not move 'Joining' members to 'Up' during a network
     # split. This feature allows the leader to accept 'Joining' members to be 'WeaklyUp'

--- a/src/core/Akka.Cluster/Configuration/Cluster.conf
+++ b/src/core/Akka.Cluster/Configuration/Cluster.conf
@@ -56,8 +56,6 @@ akka {
     #   - argument 1: accepting an `ActorSystem`
     #   - argument 2: accepting an `Akka.Cluster.Cluster`
     downing-provider-class = "Akka.Cluster.SBR.SplitBrainResolverProvider, Akka.Cluster"
-    
-    
 
     # If this is set to "off", the leader will not move 'Joining' members to 'Up' during a network
     # split. This feature allows the leader to accept 'Joining' members to be 'WeaklyUp'

--- a/src/core/Akka.Cluster/Configuration/Cluster.conf
+++ b/src/core/Akka.Cluster/Configuration/Cluster.conf
@@ -35,14 +35,6 @@ akka {
     # attempts.
     shutdown-after-unsuccessful-join-seed-nodes = off
 
-    # Should the 'leader' in the cluster be allowed to automatically mark
-    # unreachable nodes as DOWN after a configured time of unreachability?
-    # Using auto-down implies that two separate clusters will automatically be
-    # formed in case of network partition.
-    # Disable with "off" or specify a duration to enable auto-down.
-	# If a downing-provider-class is configured this setting is ignored.
-    auto-down-unreachable-after = off
-
     # Time margin after which shards or singletons that belonged to a downed/removed
     # partition are created in surviving partition. The purpose of this margin is that
     # in case of a network partition the persistent actors in the non-surviving partitions

--- a/src/core/Akka.Cluster/Configuration/Cluster.conf
+++ b/src/core/Akka.Cluster/Configuration/Cluster.conf
@@ -25,6 +25,14 @@ akka {
     # If a join request fails it will be retried after this period.
     # Disable join retry by specifying "off".
     retry-unsuccessful-join-after = 10s
+    
+    # Should the 'leader' in the cluster be allowed to automatically mark
+    # unreachable nodes as DOWN after a configured time of unreachability?
+    # Using auto-down implies that two separate clusters will automatically be
+    # formed in case of network partition.
+    # Disable with "off" or specify a duration to enable auto-down.
+    # If a downing-provider-class is configured this setting is ignored.
+    auto-down-unreachable-after = off
 
     # The joining of given seed nodes will by default be retried indefinitely until
     # a successful join. That process can be aborted if unsuccessful by defining this

--- a/src/core/Akka.Cluster/SBR/SplitBrainResolverSettings.cs
+++ b/src/core/Akka.Cluster/SBR/SplitBrainResolverSettings.cs
@@ -23,10 +23,10 @@ namespace Akka.Cluster.SBR
         public static readonly ImmutableHashSet<string> AllStrategyNames = ImmutableHashSet.Create(KeepMajorityName,
             LeaseMajorityName, StaticQuorumName, KeepOldestName, DownAllName);
 
-        private readonly Lazy<string> lazyKeepMajorityRole;
-        private readonly Lazy<KeepOldestSettings> lazyKeepOldestSettings;
-        private readonly Lazy<LeaseMajoritySettings> lazyLeaseMajoritySettings;
-        private readonly Lazy<StaticQuorumSettings> lazyStaticQuorumSettings;
+        private readonly Lazy<string> _lazyKeepMajorityRole;
+        private readonly Lazy<KeepOldestSettings> _lazyKeepOldestSettings;
+        private readonly Lazy<LeaseMajoritySettings> _lazyLeaseMajoritySettings;
+        private readonly Lazy<StaticQuorumSettings> _lazyStaticQuorumSettings;
 
         public SplitBrainResolverSettings(Config config)
         {
@@ -82,9 +82,9 @@ namespace Akka.Cluster.SBR
                 return r;
             }
 
-            lazyKeepMajorityRole = new Lazy<string>(() => { return Role(StrategyConfig(KeepMajorityName)); });
+            _lazyKeepMajorityRole = new Lazy<string>(() => { return Role(StrategyConfig(KeepMajorityName)); });
 
-            lazyStaticQuorumSettings = new Lazy<StaticQuorumSettings>(() =>
+            _lazyStaticQuorumSettings = new Lazy<StaticQuorumSettings>(() =>
             {
                 var c = StrategyConfig(StaticQuorumName);
                 var size = c.GetInt("quorum-size");
@@ -95,7 +95,7 @@ namespace Akka.Cluster.SBR
                 return new StaticQuorumSettings(size, Role(c));
             });
 
-            lazyKeepOldestSettings = new Lazy<KeepOldestSettings>(() =>
+            _lazyKeepOldestSettings = new Lazy<KeepOldestSettings>(() =>
             {
                 var c = StrategyConfig(KeepOldestName);
                 var downIfAlone = c.GetBoolean("down-if-alone");
@@ -103,7 +103,7 @@ namespace Akka.Cluster.SBR
                 return new KeepOldestSettings(downIfAlone, Role(c));
             });
 
-            lazyLeaseMajoritySettings = new Lazy<LeaseMajoritySettings>(() =>
+            _lazyLeaseMajoritySettings = new Lazy<LeaseMajoritySettings>(() =>
             {
                 var c = StrategyConfig(LeaseMajorityName);
                 var leaseImplementation = c.GetString("lease-implementation");
@@ -129,13 +129,13 @@ namespace Akka.Cluster.SBR
 
         public TimeSpan DownAllWhenUnstable { get; }
 
-        public string KeepMajorityRole => lazyKeepMajorityRole.Value;
+        public string KeepMajorityRole => _lazyKeepMajorityRole.Value;
 
-        public StaticQuorumSettings StaticQuorumSettings => lazyStaticQuorumSettings.Value;
+        public StaticQuorumSettings StaticQuorumSettings => _lazyStaticQuorumSettings.Value;
 
-        public KeepOldestSettings KeepOldestSettings => lazyKeepOldestSettings.Value;
+        public KeepOldestSettings KeepOldestSettings => _lazyKeepOldestSettings.Value;
 
-        public LeaseMajoritySettings LeaseMajoritySettings => lazyLeaseMajoritySettings.Value;
+        public LeaseMajoritySettings LeaseMajoritySettings => _lazyLeaseMajoritySettings.Value;
     }
 
     public sealed class StaticQuorumSettings

--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -379,6 +379,7 @@ namespace Akka.Remote.TestKit
                             }
                           }
                         }
+                        cluster.downing-provider-class = """" #disable SBR by default
                       }").WithFallback(TestKitBase.DefaultConfig);
             }
         }


### PR DESCRIPTION
## Changes

Enables `keep-majority` as the default SBR and turns it on by default for Akka.Cluster. This was a planned change for Akka.NET v1.5.0 but we didn't implement it.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] I have added documentation for this PR.
