### PR TITLE
use correct capacity when creating DynamicQueue when FixedQueue is full

### DIFF
--- a/src/core/Akka.Streams/Implementation/Buffers.cs
+++ b/src/core/Akka.Streams/Implementation/Buffers.cs
@@ -375,7 +375,7 @@ namespace Akka.Streams.Implementation
             {
                 if (_tail - _head == Size)
                 {
-                    var queue = new DynamicQueue(_head);
+                    var queue = new DynamicQueue(Capacity);
                     while (NonEmpty)
                         queue.Enqueue(Dequeue());
                     queue.Enqueue(element);


### PR DESCRIPTION
Fixes #6631

## Changes

When DynamicQueue is allocated, it's capacity is set to the original capacity of the buffer using it.
