### PR TITLE
[WARNING CS0659] `overrides Object.Equals(object o)` but does not `override Object.GetHashCode()`

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData/Durable/Messages.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Durable/Messages.cs
@@ -55,7 +55,9 @@ namespace Akka.DistributedData.Durable
     /// If the `LoadAll` fails it can throw `LoadFailedException` and the `Replicator` supervisor
     /// will stop itself and the durable store.
     /// </summary>
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public sealed class LoadAll : IEquatable<LoadAll>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         public static readonly LoadAll Instance = new LoadAll();
         private LoadAll() { }
@@ -73,7 +75,9 @@ namespace Akka.DistributedData.Durable
         }
     }
 
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public sealed class LoadAllCompleted : IEquatable<LoadAllCompleted>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         public static readonly LoadAllCompleted Instance = new LoadAllCompleted();
         private LoadAllCompleted() { }

--- a/src/contrib/cluster/Akka.DistributedData/ORDictionary.cs
+++ b/src/contrib/cluster/Akka.DistributedData/ORDictionary.cs
@@ -447,7 +447,9 @@ namespace Akka.DistributedData
         {
         }
 
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         internal abstract class AtomicDeltaOperation : IDeltaOperation, IReplicatedDeltaSize, ORDictionary.IDeltaOperation
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         {
             public abstract ORSet<TKey>.IDeltaOperation Underlying { get; }
             public virtual IReplicatedData Merge(IReplicatedData other)

--- a/src/contrib/cluster/Akka.DistributedData/Replicator.Messages.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Replicator.Messages.cs
@@ -981,7 +981,9 @@ namespace Akka.DistributedData
     /// with the configured `notify-subscribers-interval`.
     /// </summary>
     [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public sealed class FlushChanges
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         public static readonly FlushChanges Instance = new FlushChanges();
 

--- a/src/contrib/cluster/Akka.DistributedData/VersionVector.cs
+++ b/src/contrib/cluster/Akka.DistributedData/VersionVector.cs
@@ -23,7 +23,9 @@ namespace Akka.DistributedData
     /// This class is immutable, i.e. "modifying" methods return a new instance.
     /// </summary>
     [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public abstract class VersionVector : IReplicatedData<VersionVector>, IReplicatedDataSerialization, IRemovedNodePruning<VersionVector>, IEquatable<VersionVector>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         public enum Ordering
         {

--- a/src/contrib/cluster/Akka.DistributedData/WriteAggregator.cs
+++ b/src/contrib/cluster/Akka.DistributedData/WriteAggregator.cs
@@ -181,7 +181,9 @@ namespace Akka.DistributedData
         TimeSpan Timeout { get; }
     }
 
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public sealed class WriteLocal : IWriteConsistency
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         public static readonly WriteLocal Instance = new WriteLocal();
 

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -225,7 +225,7 @@ namespace Akka.Cluster
             {
                 if (ReferenceEquals(null, obj)) return false;
                 if (ReferenceEquals(this, obj)) return true;
-                return obj is Welcome welcome && Equals(welcome);
+                return obj is Welcome && Equals((Welcome)obj);
             }
 
             private bool Equals(Welcome other)
@@ -283,22 +283,14 @@ namespace Akka.Cluster
         }
 
         /// <inheritdoc cref="JoinSeenNode"/>
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         internal class InitJoin : IClusterMessage, IDeadLetterSuppression
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         {
             /// <inheritdoc/>
             public override bool Equals(object obj)
             {
                 return obj is InitJoin;
-            }
-
-            protected bool Equals(InitJoin other)
-            {
-                return true;
-            }
-
-            public override int GetHashCode()
-            {
-                return 1;
             }
         }
 

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryReceiveActorSpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryReceiveActorSpec.cs
@@ -115,7 +115,9 @@ namespace Akka.Persistence.Tests
         }
 
         [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         private sealed class InvalidReq
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         {
             public static readonly InvalidReq Instance = new InvalidReq();
 
@@ -259,7 +261,9 @@ namespace Akka.Persistence.Tests
         }
 
         [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         private sealed class ReqAck
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         {
             public static readonly ReqAck Instance = new ReqAck();
 

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliverySpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliverySpec.cs
@@ -216,7 +216,9 @@ namespace Akka.Persistence.Tests
         }
         
         [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         sealed class ReqAck
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         {
             public static readonly ReqAck Instance = new ReqAck();
             private ReqAck() { }
@@ -227,7 +229,9 @@ namespace Akka.Persistence.Tests
         }
 
         [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         sealed class InvalidReq
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         {
             public static readonly InvalidReq Instance = new InvalidReq();
             private InvalidReq() { }

--- a/src/core/Akka.Persistence.Tests/MemoryEventAdapterSpec.cs
+++ b/src/core/Akka.Persistence.Tests/MemoryEventAdapterSpec.cs
@@ -27,7 +27,9 @@ namespace Akka.Persistence.Tests
         }
 
         [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         public sealed class Tagged : IJournalModel, IEquatable<IJournalModel>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         {
             public object Payload { get; private set; }
             public ISet<string> Tags { get; private set; }
@@ -50,7 +52,9 @@ namespace Akka.Persistence.Tests
         }
 
         [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         public sealed class NotTagged : IJournalModel, IEquatable<IJournalModel>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         {
             public object Payload { get; private set; }
             public ISet<string> Tags { get { return new HashSet<string>(); } }
@@ -74,7 +78,9 @@ namespace Akka.Persistence.Tests
         public interface IDomainEvent { }
 
         [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         public sealed class TaggedDataChanged : IDomainEvent, IEquatable<TaggedDataChanged>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         {
             public readonly ISet<string> Tags;
             public readonly int Value;
@@ -97,7 +103,9 @@ namespace Akka.Persistence.Tests
         }
 
         [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         public sealed class UserDataChanged : IDomainEvent, IEquatable<UserDataChanged>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         {
             public readonly string CountryCode;
             public readonly int Age;

--- a/src/core/Akka.Persistence/Journal/EventSequences.cs
+++ b/src/core/Akka.Persistence/Journal/EventSequences.cs
@@ -31,7 +31,9 @@ namespace Akka.Persistence.Journal
     /// TBD
     /// </summary>
     [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public sealed class EmptyEventSequence : IEmptyEventSequence, IEquatable<IEventSequence>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         /// <summary>
         /// TBD
@@ -63,7 +65,9 @@ namespace Akka.Persistence.Journal
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
     [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public class EventSequence<T> : IEventSequence, IEquatable<IEventSequence>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         private readonly IList<object> _events;
         /// <summary>
@@ -97,7 +101,9 @@ namespace Akka.Persistence.Journal
     /// TBD
     /// </summary>
     [Serializable]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public struct SingleEventSequence : IEventSequence, IEquatable<IEventSequence>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         private readonly object[] _events;
         /// <summary>

--- a/src/core/Akka.Streams/ActorMaterializer.cs
+++ b/src/core/Akka.Streams/ActorMaterializer.cs
@@ -355,7 +355,9 @@ namespace Akka.Streams
     /// This class describes the configurable properties of the <see cref="ActorMaterializer"/>. 
     /// Please refer to the withX methods for descriptions of the individual settings.
     /// </summary>
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public sealed class ActorMaterializerSettings
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka.Streams/Attributes.cs
+++ b/src/core/Akka.Streams/Attributes.cs
@@ -177,7 +177,9 @@ namespace Akka.Streams
         /// <summary>
         /// TBD
         /// </summary>
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         public sealed class AsyncBoundary : IAttribute, IEquatable<AsyncBoundary>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
         {
             /// <summary>
             /// TBD

--- a/src/core/Akka/Routing/RouterConfig.cs
+++ b/src/core/Akka/Routing/RouterConfig.cs
@@ -20,7 +20,9 @@ namespace Akka.Routing
     /// <summary>
     /// This class provides base functionality used in the creation and configuration of the various routers in the system.
     /// </summary>
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public abstract class RouterConfig : ISurrogated, IEquatable<RouterConfig>
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RouterConfig"/> class.


### PR DESCRIPTION
## Changes
- warning disable CS0659

Please provide a brief description of the changes here.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).