### PR TITLE
WARNING CS0105 

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/ClusterMetricsExtensionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/ClusterMetricsExtensionSpec.cs
@@ -14,7 +14,6 @@ using Akka.Cluster.TestKit;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using FluentAssertions;
-using Akka.Configuration;
 using Akka.MultiNode.TestAdapter;
 using FluentAssertions.Extensions;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/ClustetMetricsRoutingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/ClustetMetricsRoutingSpec.cs
@@ -21,7 +21,6 @@ using Akka.Event;
 using Akka.Remote.TestKit;
 using Akka.Routing;
 using FluentAssertions;
-using Akka.Configuration;
 using Akka.MultiNode.TestAdapter;
 using FluentAssertions.Extensions;
 using Address = Akka.Actor.Address;

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/Sample/StatsSampleSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/Sample/StatsSampleSpec.cs
@@ -13,7 +13,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.TestKit;
 using FluentAssertions;
-using Akka.Configuration;
 using Akka.MultiNode.TestAdapter;
 using FluentAssertions.Extensions;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/ClusterMetricsSettingsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/ClusterMetricsSettingsSpec.cs
@@ -15,7 +15,6 @@ using Akka.Util;
 using Xunit;
 using FluentAssertions;
 using FsCheck;
-using Akka.Configuration;
 using FluentAssertions.Extensions;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;
 

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/WeightedRouteesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/WeightedRouteesSpec.cs
@@ -16,7 +16,6 @@ using Akka.Routing;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions;
-using Akka.Configuration;
 using Xunit;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;
 

--- a/src/contrib/cluster/Akka.Cluster.Metrics/Routing/ClusterMetricsRouting.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/Routing/ClusterMetricsRouting.cs
@@ -18,7 +18,6 @@ using Akka.Dispatch;
 using Akka.Routing;
 using Akka.Util;
 using Akka.Util.Extensions;
-using Akka.Configuration;
 
 namespace Akka.Cluster.Metrics
 {

--- a/src/contrib/cluster/Akka.Cluster.Metrics/Routing/MetricSelectors.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/Routing/MetricSelectors.cs
@@ -12,7 +12,6 @@ using Akka.Cluster.Metrics.Helpers;
 using Akka.Cluster.Metrics.Serialization;
 using Akka.Configuration;
 using Akka.Util;
-using Akka.Configuration;
 
 namespace Akka.Cluster.Metrics
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
@@ -12,8 +12,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Remote.TestKit;
 using FluentAssertions;
-using System.Threading.Tasks;
-using System.Threading;
 using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 


### PR DESCRIPTION
## Changes

Remove `The using directive for 'System.Threading' appeared previously in this  namespace`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).