### PR TITLE
[Obsolete] `IInternalActorRef.IsTerminated` warning disable CS0618

### DIFF
--- a/src/core/Akka.TestKit/TestProbe.cs
+++ b/src/core/Akka.TestKit/TestProbe.cs
@@ -127,7 +127,9 @@ namespace Akka.TestKit
 
         IActorRefProvider IInternalActorRef.Provider { get { return ((IInternalActorRef)TestActor).Provider; } }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         bool IInternalActorRef.IsTerminated { get { return ((IInternalActorRef)TestActor).IsTerminated; } }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         IActorRef IInternalActorRef.GetChild(IReadOnlyList<string> name)
         {

--- a/src/core/Akka/Dispatch/AbstractDispatcher.cs
+++ b/src/core/Akka/Dispatch/AbstractDispatcher.cs
@@ -389,7 +389,9 @@ channel-executor.priority = normal");
                     Console.WriteLine("{0} inhabitants {1}", dispatcher, dispatcher.Inhabitants);
                     foreach (var actor in a)
                     {
+#pragma warning disable CS0618 // Type or member is obsolete
                         var status = actor.IsTerminated ? "(terminated)" : "(active)";
+#pragma warning restore CS0618 // Type or member is obsolete
                         var messages = actor is ActorRefWithCell
                             ? " " + actor.AsInstanceOf<ActorRefWithCell>().Underlying.NumberOfMessages + " messages"
                             : " " + actor.GetType();


### PR DESCRIPTION
## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).