### PR TITLE
Add SQL query isolation level

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Extensions/DbConnectionExtensions.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Extensions/DbConnectionExtensions.cs
@@ -1,0 +1,74 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="DbConnectionExtensions.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Akka.Persistence.Sql.Common.Extensions
+{
+    public static class DbConnectionExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static async Task ExecuteInTransaction(
+            this DbConnection connection,
+            IsolationLevel isolationLevel,
+            CancellationToken token,
+            Func<DbTransaction, CancellationToken, Task> task)
+        {
+            using var tx = connection.BeginTransaction(isolationLevel);
+            try
+            {
+                await task(tx, token);
+                tx.Commit();
+            }
+            catch (Exception ex1)
+            {
+                try
+                {
+                    tx.Rollback();
+                }
+                catch (Exception ex2)
+                {
+                    throw new AggregateException(ex2, ex1);
+                }
+                throw;
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static async Task<T> ExecuteInTransaction<T>(
+            this DbConnection connection,
+            IsolationLevel isolationLevel,
+            CancellationToken token,
+            Func<DbTransaction, CancellationToken, Task<T>> task)
+        {
+            using var tx = connection.BeginTransaction(isolationLevel);
+            try
+            {
+                var result = await task(tx, token);
+                tx.Commit();
+                return result;
+            }
+            catch (Exception ex1)
+            {
+                try
+                {
+                    tx.Rollback();
+                }
+                catch (Exception ex2)
+                {
+                    throw new AggregateException(ex2, ex1);
+                }
+                throw;
+            }
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Extensions/IsolationLevelExtensions.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Extensions/IsolationLevelExtensions.cs
@@ -22,7 +22,8 @@ namespace Akka.Persistence.Sql.Common.Extensions
             => level switch
             {
                 null => IsolationLevel.Unspecified,
-                "chaos" => IsolationLevel.Chaos,
+                "chaos" => // IsolationLevel.Chaos,
+                    throw new ConfigurationException($"{nameof(IsolationLevel)}.{IsolationLevel.Chaos} is not supported."),
                 "read-committed" => IsolationLevel.ReadCommitted,
                 "read-uncommitted" => IsolationLevel.ReadUncommitted,
                 "repeatable-read" => IsolationLevel.RepeatableRead,
@@ -30,7 +31,7 @@ namespace Akka.Persistence.Sql.Common.Extensions
                 "snapshot" => IsolationLevel.Snapshot,
                 "unspecified" => IsolationLevel.Unspecified,
                 _ => throw new ConfigurationException(
-                    "Unknown isolation-level value. Should be one of: chaos | read-committed | read-uncommitted | repeatable-read | serializable | snapshot | unspecified")
+                    "Unknown isolation-level value. Should be one of: read-committed | read-uncommitted | repeatable-read | serializable | snapshot | unspecified")
             };
         
     }

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Extensions/IsolationLevelExtensions.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Extensions/IsolationLevelExtensions.cs
@@ -1,0 +1,37 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="HoconExtensions.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Data;
+using System.Runtime.CompilerServices;
+using Akka.Configuration;
+
+namespace Akka.Persistence.Sql.Common.Extensions
+{
+    public static class IsolationLevelExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IsolationLevel GetIsolationLevel(this Config config, string key)
+            => config.GetString(key).ToIsolationLevel();
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IsolationLevel ToIsolationLevel(this string level)
+            => level switch
+            {
+                null => IsolationLevel.Unspecified,
+                "chaos" => IsolationLevel.Chaos,
+                "read-committed" => IsolationLevel.ReadCommitted,
+                "read-uncommitted" => IsolationLevel.ReadUncommitted,
+                "repeatable-read" => IsolationLevel.RepeatableRead,
+                "serializable" => IsolationLevel.Serializable,
+                "snapshot" => IsolationLevel.Snapshot,
+                "unspecified" => IsolationLevel.Unspecified,
+                _ => throw new ConfigurationException(
+                    "Unknown isolation-level value. Should be one of: chaos | read-committed | read-uncommitted | repeatable-read | serializable | snapshot | unspecified")
+            };
+        
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/BatchingSqlJournal.cs
@@ -22,6 +22,7 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.Pattern;
 using Akka.Persistence.Journal;
+using Akka.Persistence.Sql.Common.Extensions;
 using Akka.Persistence.Sql.Common.Journal;
 using Akka.Serialization;
 using Akka.Util;
@@ -210,9 +211,10 @@ namespace Akka.Persistence.Sql.Common.Journal
         public TimeSpan ConnectionTimeout { get; }
 
         /// <summary>
-        /// Isolation level of transactions used during query execution.
+        /// Isolation level of transactions used during write query execution.
         /// </summary>
-        public IsolationLevel IsolationLevel { get; }
+        [Obsolete("Use WriteIsolationLevel property instead")]
+        public IsolationLevel IsolationLevel => WriteIsolationLevel;
 
         /// <summary>
         /// Settings specific to <see cref="CircuitBreaker"/>, which is used internally 
@@ -241,6 +243,16 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// The fully qualified name of the type that should be used as timestamp provider.
         /// </summary>
         public string TimestampProviderTypeName { get; }
+        
+        /// <summary>
+        /// Isolation level of transactions used during read query execution.
+        /// </summary>
+        public IsolationLevel ReadIsolationLevel { get; }
+
+        /// <summary>
+        /// Isolation level of transactions used during write query execution.
+        /// </summary>
+        public IsolationLevel WriteIsolationLevel { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BatchingSqlJournalSetup" /> class.
@@ -276,18 +288,13 @@ namespace Akka.Persistence.Sql.Common.Journal
             if (string.IsNullOrWhiteSpace(connectionString))
                 throw new ConfigurationException("No connection string for Sql Event Journal was specified");
 
-            IsolationLevel level;
-            switch (config.GetString("isolation-level", "unspecified"))
-            {
-                case "chaos": level = IsolationLevel.Chaos; break;
-                case "read-committed": level = IsolationLevel.ReadCommitted; break;
-                case "read-uncommitted": level = IsolationLevel.ReadUncommitted; break;
-                case "repeatable-read": level = IsolationLevel.RepeatableRead; break;
-                case "serializable": level = IsolationLevel.Serializable; break;
-                case "snapshot": level = IsolationLevel.Snapshot; break;
-                case "unspecified": level = IsolationLevel.Unspecified; break;
-                default: throw new ConfigurationException("Unknown isolation-level value. Should be one of: chaos | read-committed | read-uncommitted | repeatable-read | serializable | snapshot | unspecified");
-            }
+            ReadIsolationLevel = namingConventions.ReadIsolationLevel;
+            WriteIsolationLevel = namingConventions.WriteIsolationLevel;
+            
+            // backward compatibility
+            var level = config.GetString("isolation-level");
+            if (level is { })
+                WriteIsolationLevel = level.ToIsolationLevel();
 
             ConnectionString = connectionString;
             MaxConcurrentOperations = config.GetInt("max-concurrent-operations", 64);
@@ -295,11 +302,12 @@ namespace Akka.Persistence.Sql.Common.Journal
             MaxBufferSize = config.GetInt("max-buffer-size", 500000);
             AutoInitialize = config.GetBoolean("auto-initialize", false);
             ConnectionTimeout = config.GetTimeSpan("connection-timeout", TimeSpan.FromSeconds(30));
-            IsolationLevel = level;
             CircuitBreakerSettings = new CircuitBreakerSettings(config.GetConfig("circuit-breaker"));
             ReplayFilterSettings = new ReplayFilterSettings(config.GetConfig("replay-filter"));
             NamingConventions = namingConventions;
+#pragma warning disable CS0618
             DefaultSerializer = config.GetString("serializer", null);
+#pragma warning restore CS0618
             TimestampProviderTypeName = config.GetString("timestamp-provider", null);
         }
 
@@ -323,7 +331,68 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="replayFilterSettings">The settings used when replaying events from database back to the persistent actors.</param>
         /// <param name="namingConventions">The naming conventions used by the database to construct valid SQL statements.</param>
         /// <param name="defaultSerializer">The serializer used when no specific type matching can be found.</param>
-        protected BatchingSqlJournalSetup(string connectionString, int maxConcurrentOperations, int maxBatchSize, int maxBufferSize, bool autoInitialize, TimeSpan connectionTimeout, IsolationLevel isolationLevel, CircuitBreakerSettings circuitBreakerSettings, ReplayFilterSettings replayFilterSettings, QueryConfiguration namingConventions, string defaultSerializer)
+        [Obsolete("Use constructor with separate read and write isolation level instead. (since v1.5.2)")]
+        protected BatchingSqlJournalSetup(
+            string connectionString,
+            int maxConcurrentOperations,
+            int maxBatchSize,
+            int maxBufferSize,
+            bool autoInitialize,
+            TimeSpan connectionTimeout,
+            IsolationLevel isolationLevel,
+            CircuitBreakerSettings circuitBreakerSettings,
+            ReplayFilterSettings replayFilterSettings,
+            QueryConfiguration namingConventions,
+            string defaultSerializer)
+            : this(
+                connectionString: connectionString,
+                maxConcurrentOperations: maxConcurrentOperations,
+                maxBatchSize: maxBatchSize,
+                maxBufferSize: maxBufferSize,
+                autoInitialize: autoInitialize,
+                connectionTimeout: connectionTimeout,
+                writeIsolationLevel: isolationLevel,
+                readIsolationLevel: isolationLevel,
+                circuitBreakerSettings: circuitBreakerSettings,
+                replayFilterSettings: replayFilterSettings,
+                namingConventions: namingConventions,
+                defaultSerializer: defaultSerializer)
+        { }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BatchingSqlJournalSetup" /> class.
+        /// </summary>
+        /// <param name="connectionString">The connection string used to connect to the database.</param>
+        /// <param name="maxConcurrentOperations">The maximum number of batch operations allowed to be executed at the same time.</param>
+        /// <param name="maxBatchSize">The maximum size of single batch of operations to be executed over a single <see cref="DbConnection"/>.</param>
+        /// <param name="maxBufferSize">The maximum size of requests stored in journal buffer.</param>
+        /// <param name="autoInitialize">
+        /// If set to <c>true</c>, the journal executes all SQL scripts stored under the
+        /// <see cref="BatchingSqlJournal{TConnection,TCommand}.Initializers"/> collection prior
+        /// to starting executing any requests.
+        /// </param>
+        /// <param name="connectionTimeout">The maximum time given for executed <see cref="DbCommand"/> to complete.</param>
+        /// <param name="readIsolationLevel">The isolation level of transactions used during read query execution.</param>
+        /// <param name="writeIsolationLevel">The isolation level of transactions used during write query execution.</param>
+        /// <param name="circuitBreakerSettings">
+        /// The settings used by the <see cref="CircuitBreaker"/> when for executing request batches.
+        /// </param>
+        /// <param name="replayFilterSettings">The settings used when replaying events from database back to the persistent actors.</param>
+        /// <param name="namingConventions">The naming conventions used by the database to construct valid SQL statements.</param>
+        /// <param name="defaultSerializer">The serializer used when no specific type matching can be found.</param>
+        protected BatchingSqlJournalSetup(
+            string connectionString,
+            int maxConcurrentOperations,
+            int maxBatchSize,
+            int maxBufferSize,
+            bool autoInitialize,
+            TimeSpan connectionTimeout,
+            IsolationLevel readIsolationLevel,
+            IsolationLevel writeIsolationLevel,
+            CircuitBreakerSettings circuitBreakerSettings,
+            ReplayFilterSettings replayFilterSettings,
+            QueryConfiguration namingConventions,
+            string defaultSerializer)
         {
             ConnectionString = connectionString;
             MaxConcurrentOperations = maxConcurrentOperations;
@@ -331,11 +400,15 @@ namespace Akka.Persistence.Sql.Common.Journal
             MaxBufferSize = maxBufferSize;
             AutoInitialize = autoInitialize;
             ConnectionTimeout = connectionTimeout;
-            IsolationLevel = isolationLevel;
+            WriteIsolationLevel = writeIsolationLevel;
+            ReadIsolationLevel = readIsolationLevel;
+            ReadIsolationLevel = writeIsolationLevel;
             CircuitBreakerSettings = circuitBreakerSettings;
             ReplayFilterSettings = replayFilterSettings;
             NamingConventions = namingConventions;
+#pragma warning disable CS0618
             DefaultSerializer = defaultSerializer;
+#pragma warning restore CS0618
         }
     }
 
@@ -547,6 +620,8 @@ namespace Akka.Persistence.Sql.Common.Journal
 
         private readonly Akka.Serialization.Serialization _serialization;
         private readonly CircuitBreaker _circuitBreaker;
+        private readonly IsolationLevel _writeIsolationLevel;
+        private readonly IsolationLevel _readIsolationLevel;
         private int _remainingOperations;
 
         /// <summary>
@@ -574,6 +649,9 @@ namespace Akka.Persistence.Sql.Common.Journal
                 maxFailures: Setup.CircuitBreakerSettings.MaxFailures,
                 callTimeout: Setup.CircuitBreakerSettings.CallTimeout,
                 resetTimeout: Setup.CircuitBreakerSettings.ResetTimeout);
+            
+            _writeIsolationLevel = Setup.WriteIsolationLevel;
+            _readIsolationLevel = Setup.ReadIsolationLevel;
 
             var conventions = Setup.NamingConventions;
 
@@ -862,17 +940,16 @@ namespace Akka.Persistence.Sql.Common.Journal
             {
                 _remainingOperations--;
 
-                var chunk = DequeueChunk(_remainingOperations);
+                var (chunk, isWrite) = DequeueChunk(_remainingOperations);
                 var context = Context;
-                _circuitBreaker.WithCircuitBreaker(() => ExecuteChunk(chunk, context))
+                _circuitBreaker.WithCircuitBreaker(() => ExecuteChunk(chunk, context, isWrite))
                     .PipeTo(Self, failure: ex => new ChunkExecutionFailure(ex, chunk.Requests, chunk.ChunkId));
             }
         }
 
-        private async Task<BatchComplete> ExecuteChunk(RequestChunk chunk, IActorContext context)
+        private async Task<BatchComplete> ExecuteChunk(RequestChunk chunk, IActorContext context, bool isWriteOperation)
         {
             var writeResults = new Queue<WriteMessagesResult>();
-            var isWriteOperation = false;
             var stopwatch = new Stopwatch();
             using (var connection = CreateConnection(Setup.ConnectionString))
             {
@@ -880,7 +957,7 @@ namespace Akka.Persistence.Sql.Common.Journal
 
                 // In the grand scheme of thing, using a transaction in an all read batch operation
                 // should not hurt performance by much, because it is done only once at the start.
-                using (var tx = connection.BeginTransaction(Setup.IsolationLevel))
+                using (var tx = connection.BeginTransaction(isWriteOperation ? _writeIsolationLevel : _readIsolationLevel))
                 using (var command = (TCommand)connection.CreateCommand())
                 {
                     command.CommandTimeout = (int)Setup.ConnectionTimeout.TotalSeconds;
@@ -895,11 +972,9 @@ namespace Akka.Persistence.Sql.Common.Journal
                             switch (req)
                             {
                                 case WriteMessages msg:
-                                    isWriteOperation = true;
                                     writeResults.Enqueue(await HandleWriteMessages(msg, command)); 
                                     break;
                                 case DeleteMessagesTo msg:
-                                    isWriteOperation = true;
                                     await HandleDeleteMessagesTo(msg, command);
                                     break;
                                 case ReplayMessages msg:
@@ -1331,7 +1406,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// Select the buffer that has the smallest id on its first item, retrieve a maximum Setup.MaxBatchSize
         /// items from it, and return it as a chunk that needs to be batched
         /// </summary>
-        private RequestChunk DequeueChunk(int chunkId)
+        private (RequestChunk chunk, bool isWrite) DequeueChunk(int chunkId)
         {
             var currentBuffer = _buffers
                 .Where(q => q.Count > 0)
@@ -1350,18 +1425,16 @@ namespace Akka.Persistence.Sql.Common.Journal
                     if (operations.Count == Setup.MaxBatchSize)
                         break;
                 }
-            }
-            else
-            {
-                while(currentBuffer.Count > 0)
-                {
-                    operations.Add(currentBuffer.Dequeue().request);
-                    if (operations.Count == Setup.MaxBatchSize)
-                        break;
-                }
+                return (new RequestChunk(chunkId, operations.ToArray()), true);
             }
             
-            return new RequestChunk(chunkId, operations.ToArray());
+            while(currentBuffer.Count > 0)
+            {
+                operations.Add(currentBuffer.Dequeue().request);
+                if (operations.Count == Setup.MaxBatchSize)
+                    break;
+            }
+            return (new RequestChunk(chunkId, operations.ToArray()), false);
         }
 
         private void CompleteBatch(BatchComplete msg)

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
@@ -312,8 +312,8 @@ namespace Akka.Persistence.Sql.Common.Journal
 #pragma warning restore CS0618
             SerializerIdColumnName = serializerIdColumnName;
             UseSequentialAccess = useSequentialAccess;
-            ReadIsolationLevel = readIsolationLevel ?? IsolationLevel.ReadCommitted;
-            WriteIsolationLevel = writeIsolationLevel ?? IsolationLevel.ReadCommitted;
+            ReadIsolationLevel = readIsolationLevel ?? IsolationLevel.Unspecified;
+            WriteIsolationLevel = writeIsolationLevel ?? IsolationLevel.Unspecified;
         }
 
         /// <summary>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/QueryExecutor.cs
@@ -6,7 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Data;
 using System.Data.Common;
@@ -15,6 +14,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
+using Akka.Persistence.Sql.Common.Extensions;
 using Akka.Serialization;
 using Akka.Util;
 
@@ -188,6 +188,16 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// Uses the CommandBehavior.SequentialAccess when creating the command, providing a performance improvement for reading large BLOBS.
         /// </summary>
         public bool UseSequentialAccess { get; }
+        
+        /// <summary>
+        /// Isolation level of transactions used during write query execution.
+        /// </summary>
+        public IsolationLevel WriteIsolationLevel { get; }
+        
+        /// <summary>
+        /// Isolation level of transactions used during read query execution.
+        /// </summary>
+        public IsolationLevel ReadIsolationLevel { get; }
 
         /// <summary>
         /// TBD
@@ -207,6 +217,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="timeout">TBD</param>
         /// <param name="defaultSerializer">The default serializer used when not type override matching is found</param>
         /// <param name="useSequentialAccess">Uses the CommandBehavior.SequentialAccess when creating the command, providing a performance improvement for reading large BLOBS.</param>
+        [Obsolete("Use .ctor that accepts read and write IsolationLevel instead (since v1.5.2)")]
         public QueryConfiguration(
             string schemaName,
             string journalEventsTableName,
@@ -223,6 +234,66 @@ namespace Akka.Persistence.Sql.Common.Journal
             TimeSpan timeout,
             string defaultSerializer,
             bool useSequentialAccess)
+            : this(
+                schemaName,
+                journalEventsTableName,
+                metaTableName,
+                persistenceIdColumnName,
+                sequenceNrColumnName,
+                payloadColumnName,
+                manifestColumnName,
+                timestampColumnName,
+                isDeletedColumnName,
+                tagsColumnName,
+                orderingColumnName,
+                serializerIdColumnName,
+                timeout,
+                defaultSerializer,
+                useSequentialAccess,
+                // ReSharper disable once IntroduceOptionalParameters.Global
+                null,
+                null)
+        {
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="schemaName">TBD</param>
+        /// <param name="journalEventsTableName">TBD</param>
+        /// <param name="metaTableName">TBD</param>
+        /// <param name="persistenceIdColumnName">TBD</param>
+        /// <param name="sequenceNrColumnName">TBD</param>
+        /// <param name="payloadColumnName">TBD</param>
+        /// <param name="manifestColumnName">TBD</param>
+        /// <param name="timestampColumnName">TBD</param>
+        /// <param name="isDeletedColumnName">TBD</param>
+        /// <param name="tagsColumnName">TBD</param>
+        /// <param name="orderingColumnName">TBD</param>
+        /// <param name="serializerIdColumnName">TBD</param>
+        /// <param name="timeout">TBD</param>
+        /// <param name="defaultSerializer">The default serializer used when not type override matching is found</param>
+        /// <param name="useSequentialAccess">Uses the CommandBehavior.SequentialAccess when creating the command, providing a performance improvement for reading large BLOBS.</param>
+        /// <param name="readIsolationLevel">Isolation level of transactions used during read query execution.</param>
+        /// <param name="writeIsolationLevel">Isolation level of transactions used during write query execution.</param>
+        public QueryConfiguration(
+            string schemaName,
+            string journalEventsTableName,
+            string metaTableName,
+            string persistenceIdColumnName,
+            string sequenceNrColumnName,
+            string payloadColumnName,
+            string manifestColumnName,
+            string timestampColumnName,
+            string isDeletedColumnName,
+            string tagsColumnName,
+            string orderingColumnName,
+            string serializerIdColumnName,
+            TimeSpan timeout,
+            string defaultSerializer,
+            bool useSequentialAccess,
+            IsolationLevel? readIsolationLevel,
+            IsolationLevel? writeIsolationLevel)
         {
             SchemaName = schemaName;
             JournalEventsTableName = journalEventsTableName;
@@ -236,9 +307,13 @@ namespace Akka.Persistence.Sql.Common.Journal
             Timeout = timeout;
             TagsColumnName = tagsColumnName;
             OrderingColumnName = orderingColumnName;
+#pragma warning disable CS0618
             DefaultSerializer = defaultSerializer;
+#pragma warning restore CS0618
             SerializerIdColumnName = serializerIdColumnName;
             UseSequentialAccess = useSequentialAccess;
+            ReadIsolationLevel = readIsolationLevel ?? IsolationLevel.ReadCommitted;
+            WriteIsolationLevel = writeIsolationLevel ?? IsolationLevel.ReadCommitted;
         }
 
         /// <summary>
@@ -310,16 +385,31 @@ namespace Akka.Persistence.Sql.Common.Journal
         public QueryConfiguration Configuration { get; }
 
         /// <summary>
+        /// Isolation level of transactions used during write query execution.
+        /// </summary>
+        public IsolationLevel WriteIsolationLevel { get; }
+        
+        /// <summary>
+        /// Isolation level of transactions used during read query execution.
+        /// </summary>
+        public IsolationLevel ReadIsolationLevel { get; }
+        
+        /// <summary>
         /// TBD
         /// </summary>
         /// <param name="configuration">TBD</param>
         /// <param name="serialization">TBD</param>
         /// <param name="timestampProvider">TBD</param>
-        protected AbstractQueryExecutor(QueryConfiguration configuration, Akka.Serialization.Serialization serialization, ITimestampProvider timestampProvider)
+        protected AbstractQueryExecutor(
+            QueryConfiguration configuration,
+            Akka.Serialization.Serialization serialization,
+            ITimestampProvider timestampProvider)
         {
             TimestampProvider = timestampProvider;
             Serialization = serialization;
             Configuration = configuration;
+            WriteIsolationLevel = Configuration.WriteIsolationLevel;
+            ReadIsolationLevel = Configuration.ReadIsolationLevel;
 
             var allEventColumnNames = $@"
                 e.{Configuration.PersistenceIdColumnName} as PersistenceId, 
@@ -487,22 +577,25 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="cancellationToken">TBD</param>
         /// <param name="offset">TBD</param>
         /// <returns>TBD</returns>
-        public virtual async Task<ImmutableArray<string>> SelectAllPersistenceIdsAsync(DbConnection connection, CancellationToken cancellationToken, long offset)
+        public virtual async Task<ImmutableArray<string>> SelectAllPersistenceIdsAsync(
+            DbConnection connection, 
+            CancellationToken cancellationToken,
+            long offset)
         {
-            using (var command = GetCommand(connection, AllPersistenceIdsSql))
+            return await connection.ExecuteInTransaction(ReadIsolationLevel, cancellationToken, async (tx, token) =>
             {
+                using var command = GetCommand(connection, AllPersistenceIdsSql);
+                command.Transaction = tx;
                 AddParameter(command, "@Ordering", DbType.Int64, offset);
 
-                using (var reader = await command.ExecuteReaderAsync(cancellationToken))
+                using var reader = await command.ExecuteReaderAsync(token);
+                var builder = ImmutableArray.CreateBuilder<string>();
+                while (await reader.ReadAsync(token))
                 {
-                    var builder = ImmutableArray.CreateBuilder<string>();
-                    while (await reader.ReadAsync(cancellationToken))
-                    {
-                        builder.Add(reader.GetString(0));
-                    }
-                    return builder.ToImmutable();
+                    builder.Add(reader.GetString(0));
                 }
-            }
+                return builder.ToImmutable();
+            });
         }
 
         /// <summary>
@@ -516,37 +609,35 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="max">TBD</param>
         /// <param name="callback">TBD</param>
         /// <returns>TBD</returns>
-        public virtual async Task SelectByPersistenceIdAsync(DbConnection connection, CancellationToken cancellationToken, string persistenceId, long fromSequenceNr, long toSequenceNr,
-            long max, Action<IPersistentRepresentation> callback)
+        public virtual async Task SelectByPersistenceIdAsync(
+            DbConnection connection,
+            CancellationToken cancellationToken,
+            string persistenceId,
+            long fromSequenceNr,
+            long toSequenceNr,
+            long max,
+            Action<IPersistentRepresentation> callback)
         {
-            using (var command = GetCommand(connection, ByPersistenceIdSql))
+            await connection.ExecuteInTransaction(ReadIsolationLevel, cancellationToken, async (tx, token) =>
             {
+                using var command = GetCommand(connection, ByPersistenceIdSql);
+                command.Transaction = tx;
                 AddParameter(command, "@PersistenceId", DbType.String, persistenceId);
                 AddParameter(command, "@FromSequenceNr", DbType.Int64, fromSequenceNr);
                 AddParameter(command, "@ToSequenceNr", DbType.Int64, toSequenceNr);
 
-                CommandBehavior commandBehavior;
+                var commandBehavior = Configuration.UseSequentialAccess 
+                    ? CommandBehavior.SequentialAccess : CommandBehavior.Default;
 
-                if (Configuration.UseSequentialAccess)
+                using var reader = await command.ExecuteReaderAsync(commandBehavior, token);
+                var i = 0L;
+                while (i++ < max && await reader.ReadAsync(token))
                 {
-                    commandBehavior = CommandBehavior.SequentialAccess;
+                    var persistent = ReadEvent(reader);
+                    callback(persistent);
                 }
-                else
-                {
-                    commandBehavior = CommandBehavior.Default;
-                }
-
-                using (var reader = await command.ExecuteReaderAsync(commandBehavior, cancellationToken))
-                {
-                    var i = 0L;
-                    while ((i++) < max && await reader.ReadAsync(cancellationToken))
-                    {
-                        var persistent = ReadEvent(reader);
-                        callback(persistent);
-                    }
-                    command.Cancel();
-                }
-            }
+                command.Cancel();
+            });
         }
 
         /// <summary>
@@ -560,45 +651,48 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="max">TBD</param>
         /// <param name="callback">TBD</param>
         /// <returns>TBD</returns>
-        public virtual async Task<long> SelectByTagAsync(DbConnection connection, CancellationToken cancellationToken, string tag, long fromOffset, long toOffset, long max,
+        public virtual async Task<long> SelectByTagAsync(
+            DbConnection connection,
+            CancellationToken cancellationToken,
+            string tag, 
+            long fromOffset,
+            long toOffset,
+            long max,
             Action<ReplayedTaggedMessage> callback)
         {
-            using (var command = GetCommand(connection, ByTagSql))
+            return await connection.ExecuteInTransaction(ReadIsolationLevel, cancellationToken, async (tx, token) =>
             {
-                var take = Math.Min(toOffset - fromOffset, max);
-                AddParameter(command, "@Tag", DbType.String, "%;" + tag + ";%");
-                AddParameter(command, "@Ordering", DbType.Int64, fromOffset);
-                AddParameter(command, "@Take", DbType.Int64, take);
-
-                CommandBehavior commandBehavior;
-
-                if (Configuration.UseSequentialAccess)
+                using (var command = GetCommand(connection, ByTagSql))
                 {
-                    commandBehavior = CommandBehavior.SequentialAccess;
-                }
-                else
-                {
-                    commandBehavior = CommandBehavior.Default;
-                }
+                    command.Transaction = tx;
+                    var take = Math.Min(toOffset - fromOffset, max);
+                    AddParameter(command, "@Tag", DbType.String, "%;" + tag + ";%");
+                    AddParameter(command, "@Ordering", DbType.Int64, fromOffset);
+                    AddParameter(command, "@Take", DbType.Int64, take);
 
-                using (var reader = await command.ExecuteReaderAsync(commandBehavior, cancellationToken))
-                {
-                    while (await reader.ReadAsync(cancellationToken))
+                    var commandBehavior = Configuration.UseSequentialAccess 
+                        ? CommandBehavior.SequentialAccess : CommandBehavior.Default;
+
+                    using (var reader = await command.ExecuteReaderAsync(commandBehavior, token))
                     {
-                        var persistent = ReadEvent(reader);
-                        var ordering = reader.GetInt64(OrderingIndex);
-                        callback(new ReplayedTaggedMessage(persistent, tag, ordering));
+                        while (await reader.ReadAsync(token))
+                        {
+                            var persistent = ReadEvent(reader);
+                            var ordering = reader.GetInt64(OrderingIndex);
+                            callback(new ReplayedTaggedMessage(persistent, tag, ordering));
+                        }
                     }
                 }
-            }
 
-            using (var command = GetCommand(connection, HighestTagOrderingSql))
-            {
-                AddParameter(command, "@Tag", DbType.String, "%;" + tag + ";%");
-                AddParameter(command, "@Ordering", DbType.Int64, fromOffset);
-                var maxOrdering = (await command.ExecuteScalarAsync(cancellationToken)) as long? ?? 0L;
-                return maxOrdering;
-            }
+                using (var command = GetCommand(connection, HighestTagOrderingSql))
+                {
+                    command.Transaction = tx;
+                    AddParameter(command, "@Tag", DbType.String, "%;" + tag + ";%");
+                    AddParameter(command, "@Ordering", DbType.Int64, fromOffset);
+                    var maxOrdering = (await command.ExecuteScalarAsync(token)) as long? ?? 0L;
+                    return maxOrdering;
+                }
+            });
         }
 
         public virtual async Task<long> SelectAllEventsAsync(
@@ -609,35 +703,40 @@ namespace Akka.Persistence.Sql.Common.Journal
             long max, 
             Action<ReplayedEvent> callback)
         {
-            long maxOrdering;
-            using (var command = GetCommand(connection, HighestOrderingSql))
+            return await connection.ExecuteInTransaction(ReadIsolationLevel, cancellationToken, async (tx, token) =>
             {
-                maxOrdering = (await command.ExecuteScalarAsync(cancellationToken)) as long? ?? 0L;
-            }
-
-            using (var command = GetCommand(connection, AllEventsSql))
-            {
-                var take = Math.Min(toOffset - fromOffset, max);
-
-                AddParameter(command, "@Ordering", DbType.Int64, fromOffset);
-                AddParameter(command, "@Take", DbType.Int64, take);
-
-                var commandBehavior = Configuration.UseSequentialAccess ? 
-                    CommandBehavior.SequentialAccess : 
-                    CommandBehavior.Default;
-
-                using (var reader = await command.ExecuteReaderAsync(commandBehavior, cancellationToken))
+                long maxOrdering;
+                using (var command = GetCommand(connection, HighestOrderingSql))
                 {
-                    while (await reader.ReadAsync(cancellationToken))
+                    command.Transaction = tx;
+                    maxOrdering = (await command.ExecuteScalarAsync(token)) as long? ?? 0L;
+                }
+
+                using (var command = GetCommand(connection, AllEventsSql))
+                {
+                    command.Transaction = tx;
+                    var take = Math.Min(toOffset - fromOffset, max);
+
+                    AddParameter(command, "@Ordering", DbType.Int64, fromOffset);
+                    AddParameter(command, "@Take", DbType.Int64, take);
+
+                    var commandBehavior = Configuration.UseSequentialAccess ? 
+                        CommandBehavior.SequentialAccess : 
+                        CommandBehavior.Default;
+
+                    using (var reader = await command.ExecuteReaderAsync(commandBehavior, token))
                     {
-                        var persistent = ReadEvent(reader);
-                        var ordering = reader.GetInt64(OrderingIndex);
-                        callback(new ReplayedEvent(persistent, ordering));
+                        while (await reader.ReadAsync(token))
+                        {
+                            var persistent = ReadEvent(reader);
+                            var ordering = reader.GetInt64(OrderingIndex);
+                            callback(new ReplayedEvent(persistent, ordering));
+                        }
                     }
                 }
-            }
 
-            return maxOrdering;
+                return maxOrdering;
+            });
         }
 
         /// <summary>
@@ -649,22 +748,26 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <returns>TBD</returns>
         public virtual async Task<long> SelectHighestSequenceNrAsync(DbConnection connection, CancellationToken cancellationToken, string persistenceId)
         {
-            using (var command = GetCommand(connection, HighestSequenceNrSql))
+            return await connection.ExecuteInTransaction(ReadIsolationLevel, cancellationToken, async (tx, token) =>
             {
+                using var command = GetCommand(connection, HighestSequenceNrSql);
+                command.Transaction = tx;
                 AddParameter(command, "@PersistenceId", DbType.String, persistenceId);
 
-                var result = await command.ExecuteScalarAsync(cancellationToken);
+                var result = await command.ExecuteScalarAsync(token);
                 return result is long ? Convert.ToInt64(result) : 0L;
-            }
+            });
         }
 
         public virtual async Task<long> SelectHighestSequenceNrAsync(DbConnection connection, CancellationToken cancellationToken)
         {
-            using (var command = GetCommand(connection, HighestOrderingSql))
+            return await connection.ExecuteInTransaction(ReadIsolationLevel, cancellationToken, async (tx, token) =>
             {
-                var result = await command.ExecuteScalarAsync(cancellationToken);
+                using var command = GetCommand(connection, HighestOrderingSql);
+                command.Transaction = tx;
+                var result = await command.ExecuteScalarAsync(token);
                 return result is long ? Convert.ToInt64(result) : 0L;
-            }
+            });
         }
 
         /// <summary>
@@ -676,12 +779,9 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <returns>TBD</returns>
         public virtual async Task InsertBatchAsync(DbConnection connection, CancellationToken cancellationToken, WriteJournalBatch write)
         {
-            using var command = GetCommand(connection, InsertEventSql);
-            // Isolation.Serializable: Enforce a table lock during the transaction when we're writing the event to database
-            // This is to prevent a racy condition when a high volume write is coupled with eager reading of the table
-            // that results in an event row missing on the read side because 2 transactions were completed out of order
-            using (var tx = connection.BeginTransaction(IsolationLevel.Serializable))
+            await connection.ExecuteInTransaction(WriteIsolationLevel, cancellationToken, async (tx, token) =>
             {
+                using var command = GetCommand(connection, InsertEventSql);
                 command.Transaction = tx;
 
                 foreach (var entry in write.EntryTags)
@@ -690,12 +790,10 @@ namespace Akka.Persistence.Sql.Common.Journal
                     var tags = entry.Value;
 
                     WriteEvent(command, evt.WithTimestamp(TimestampProvider.GenerateTimestamp(evt)), tags);
-                    await command.ExecuteScalarAsync(cancellationToken);
+                    await command.ExecuteScalarAsync(token);
                     command.Parameters.Clear();
                 }
-
-                tx.Commit();
-            }
+            });
         }
 
         /// <summary>
@@ -708,40 +806,35 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <returns>TBD</returns>
         public virtual async Task DeleteBatchAsync(DbConnection connection, CancellationToken cancellationToken, string persistenceId, long toSequenceNr)
         {
-            using (var deleteCommand = GetCommand(connection, DeleteBatchSql))
-            using (var highestSeqNrCommand = GetCommand(connection, HighestSequenceNrSql))
+            await connection.ExecuteInTransaction(WriteIsolationLevel, cancellationToken, async (tx, token) =>
             {
+                using var deleteCommand = GetCommand(connection, DeleteBatchSql);
+                using var highestSeqNrCommand = GetCommand(connection, HighestSequenceNrSql);
+                
+                deleteCommand.Transaction = tx;
+                highestSeqNrCommand.Transaction = tx;
+
                 AddParameter(highestSeqNrCommand, "@PersistenceId", DbType.String, persistenceId);
 
                 AddParameter(deleteCommand, "@PersistenceId", DbType.String, persistenceId);
                 AddParameter(deleteCommand, "@ToSequenceNr", DbType.Int64, toSequenceNr);
 
-                using (var tx = connection.BeginTransaction())
+                var res = await highestSeqNrCommand.ExecuteScalarAsync(token);
+                var highestSeqNr = res is long ? Convert.ToInt64(res) : 0L;
+
+                await deleteCommand.ExecuteNonQueryAsync(token);
+
+                if (highestSeqNr <= toSequenceNr)
                 {
-                    deleteCommand.Transaction = tx;
-                    highestSeqNrCommand.Transaction = tx;
+                    using var updateCommand = GetCommand(connection, UpdateSequenceNrSql);
+                    updateCommand.Transaction = tx;
 
-                    var res = await highestSeqNrCommand.ExecuteScalarAsync(cancellationToken);
-                    var highestSeqNr = res is long ? Convert.ToInt64(res) : 0L;
+                    AddParameter(updateCommand, "@PersistenceId", DbType.String, persistenceId);
+                    AddParameter(updateCommand, "@SequenceNr", DbType.Int64, highestSeqNr);
 
-                    await deleteCommand.ExecuteNonQueryAsync(cancellationToken);
-
-                    if (highestSeqNr <= toSequenceNr)
-                    {
-                        using (var updateCommand = GetCommand(connection, UpdateSequenceNrSql))
-                        {
-                            updateCommand.Transaction = tx;
-
-                            AddParameter(updateCommand, "@PersistenceId", DbType.String, persistenceId);
-                            AddParameter(updateCommand, "@SequenceNr", DbType.Int64, highestSeqNr);
-
-                            await updateCommand.ExecuteNonQueryAsync(cancellationToken);
-                            tx.Commit();
-                        }
-                    }
-                    else tx.Commit();
+                    await updateCommand.ExecuteNonQueryAsync(token);
                 }
-            }
+            });
         }
 
         /// <summary>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -27,7 +27,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         private IImmutableDictionary<string, long> _tagSequenceNr = ImmutableDictionary<string, long>.Empty;
 
         private readonly CancellationTokenSource _pendingRequestsCancellation;
-        private readonly JournalSettings _settings;
+        protected readonly JournalSettings Settings;
 
         private ILoggingAdapter _log;
 
@@ -37,7 +37,7 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <param name="journalConfig">TBD</param>
         protected SqlJournal(Config journalConfig)
         {
-            _settings = new JournalSettings(journalConfig);
+            Settings = new JournalSettings(journalConfig);
             _pendingRequestsCancellation = new CancellationTokenSource();
         }
 
@@ -267,7 +267,7 @@ namespace Akka.Persistence.Sql.Common.Journal
 
         private async Task<object> Initialize()
         {
-            if (!_settings.AutoInitialize) 
+            if (!Settings.AutoInitialize) 
                 return new Status.Success(NotUsed.Instance);
 
             try
@@ -358,11 +358,11 @@ namespace Akka.Persistence.Sql.Common.Journal
         /// <returns>TBD</returns>
         protected virtual string GetConnectionString()
         {
-            var connectionString = _settings.ConnectionString;
+            var connectionString = Settings.ConnectionString;
 
             if (string.IsNullOrEmpty(connectionString))
             {
-                connectionString = System.Configuration.ConfigurationManager.ConnectionStrings[_settings.ConnectionStringName].ConnectionString;
+                connectionString = System.Configuration.ConfigurationManager.ConnectionStrings[Settings.ConnectionStringName].ConnectionString;
             }
 
             return connectionString;

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Settings.cs
@@ -6,7 +6,9 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Data;
 using Akka.Configuration;
+using Akka.Persistence.Sql.Common.Extensions;
 using Akka.Persistence.Sql.Common.Journal;
 
 namespace Akka.Persistence.Sql.Common
@@ -55,6 +57,16 @@ namespace Akka.Persistence.Sql.Common
         /// Flag determining in in case of event journal or metadata table missing, they should be automatically initialized.
         /// </summary>
         public bool AutoInitialize { get; private set; }
+        
+        /// <summary>
+        /// Isolation level of transactions used during read query execution.
+        /// </summary>
+        public IsolationLevel ReadIsolationLevel { get; }
+
+        /// <summary>
+        /// Isolation level of transactions used during write query execution.
+        /// </summary>
+        public IsolationLevel WriteIsolationLevel { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JournalSettings"/> class.
@@ -76,6 +88,9 @@ namespace Akka.Persistence.Sql.Common
             MetaTableName = config.GetString("metadata-table-name");
             TimestampProvider = config.GetString("timestamp-provider");
             AutoInitialize = config.GetBoolean("auto-initialize");
+
+            ReadIsolationLevel = config.GetIsolationLevel("read-isolation-level");
+            WriteIsolationLevel = config.GetIsolationLevel("write-isolation-level");
         }
     }
 
@@ -119,6 +134,16 @@ namespace Akka.Persistence.Sql.Common
         /// </summary>
         [Obsolete(message: "This property should never be used, use the default `System.Object` serializer instead")]
         public string DefaultSerializer { get; private set; }
+        
+        /// <summary>
+        /// Isolation level of transactions used during read query execution.
+        /// </summary>
+        public IsolationLevel ReadIsolationLevel { get; }
+
+        /// <summary>
+        /// Isolation level of transactions used during write query execution.
+        /// </summary>
+        public IsolationLevel WriteIsolationLevel { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SnapshotStoreSettings"/> class.
@@ -138,7 +163,12 @@ namespace Akka.Persistence.Sql.Common
             SchemaName = config.GetString("schema-name", null);
             TableName = config.GetString("table-name");
             AutoInitialize = config.GetBoolean("auto-initialize");
+#pragma warning disable CS0618
             DefaultSerializer = config.GetString("serializer", null);
+#pragma warning restore CS0618
+
+            ReadIsolationLevel = config.GetIsolationLevel("read-isolation-level");
+            WriteIsolationLevel = config.GetIsolationLevel("write-isolation-level");
         }
 
         /// <summary>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/QueryExecutor.cs
@@ -10,6 +10,7 @@ using System.Data;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Akka.Persistence.Sql.Common.Extensions;
 using Akka.Serialization;
 using Akka.Util;
 
@@ -119,6 +120,16 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         public bool UseSequentialAccess { get; }
 
         /// <summary>
+        /// Isolation level of transactions used during write query execution.
+        /// </summary>
+        public IsolationLevel WriteIsolationLevel { get; }
+        
+        /// <summary>
+        /// Isolation level of transactions used during read query execution.
+        /// </summary>
+        public IsolationLevel ReadIsolationLevel { get; }
+
+        /// <summary>
         /// TBD
         /// </summary>
         /// <param name="schemaName">TBD</param>
@@ -132,6 +143,7 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         /// <param name="timeout">TBD</param>
         /// <param name="defaultSerializer">The default serializer used when not type override matching is found</param>
         /// <param name="useSequentialAccess">Uses the CommandBehavior.SequentialAccess when creating the command, providing a performance improvement for reading large BLOBS.</param>
+        [Obsolete("Use the constructor that takes read and write isolation level argument (since v1.5.2)")]
         public QueryConfiguration(
             string schemaName,
             string snapshotTableName,
@@ -144,6 +156,53 @@ namespace Akka.Persistence.Sql.Common.Snapshot
             TimeSpan timeout,
             string defaultSerializer,
             bool useSequentialAccess)
+            : this(
+                schemaName: schemaName,
+                snapshotTableName: snapshotTableName,
+                persistenceIdColumnName: persistenceIdColumnName,
+                sequenceNrColumnName: sequenceNrColumnName,
+                payloadColumnName: payloadColumnName,
+                manifestColumnName: manifestColumnName,
+                timestampColumnName: timestampColumnName,
+                serializerIdColumnName: serializerIdColumnName,
+                timeout: timeout,
+                defaultSerializer: defaultSerializer,
+                useSequentialAccess: useSequentialAccess,
+                readIsolationLevel: null,
+                writeIsolationLevel: null)
+        {
+        }
+            
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="schemaName">TBD</param>
+        /// <param name="snapshotTableName">TBD</param>
+        /// <param name="persistenceIdColumnName">TBD</param>
+        /// <param name="sequenceNrColumnName">TBD</param>
+        /// <param name="payloadColumnName">TBD</param>
+        /// <param name="manifestColumnName">TBD</param>
+        /// <param name="timestampColumnName">TBD</param>
+        /// <param name="serializerIdColumnName">TBD</param>
+        /// <param name="timeout">TBD</param>
+        /// <param name="defaultSerializer">The default serializer used when not type override matching is found</param>
+        /// <param name="useSequentialAccess">Uses the CommandBehavior.SequentialAccess when creating the command, providing a performance improvement for reading large BLOBS.</param>
+        /// <param name="readIsolationLevel">Isolation level of transactions used during read query execution.</param>
+        /// <param name="writeIsolationLevel">Isolation level of transactions used during write query execution.</param>
+        public QueryConfiguration(
+            string schemaName,
+            string snapshotTableName,
+            string persistenceIdColumnName,
+            string sequenceNrColumnName,
+            string payloadColumnName,
+            string manifestColumnName,
+            string timestampColumnName,
+            string serializerIdColumnName,
+            TimeSpan timeout,
+            string defaultSerializer,
+            bool useSequentialAccess,
+            IsolationLevel? readIsolationLevel,
+            IsolationLevel? writeIsolationLevel)
         {
             SchemaName = schemaName;
             SnapshotTableName = snapshotTableName;
@@ -154,8 +213,12 @@ namespace Akka.Persistence.Sql.Common.Snapshot
             TimestampColumnName = timestampColumnName;
             SerializerIdColumnName = serializerIdColumnName;
             Timeout = timeout;
+#pragma warning disable CS0618
             DefaultSerializer = defaultSerializer;
+#pragma warning restore CS0618
             UseSequentialAccess = useSequentialAccess;
+            ReadIsolationLevel = readIsolationLevel ?? IsolationLevel.Unspecified;
+            WriteIsolationLevel = writeIsolationLevel ?? IsolationLevel.Unspecified;
         }
 
         /// <summary>
@@ -262,6 +325,16 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         protected abstract string CreateSnapshotTableSql { get; }
 
         /// <summary>
+        /// Isolation level of transactions used during write query execution.
+        /// </summary>
+        public IsolationLevel WriteIsolationLevel { get; }
+        
+        /// <summary>
+        /// Isolation level of transactions used during read query execution.
+        /// </summary>
+        public IsolationLevel ReadIsolationLevel { get; }
+        
+        /// <summary>
         /// TBD
         /// </summary>
         /// <param name="configuration">TBD</param>
@@ -270,6 +343,8 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         {
             Configuration = configuration;
             Serialization = serialization;
+            WriteIsolationLevel = Configuration.WriteIsolationLevel;
+            ReadIsolationLevel = Configuration.ReadIsolationLevel;
 
             SelectSnapshotSql = $@"
                 SELECT {Configuration.PersistenceIdColumnName},
@@ -378,16 +453,20 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         /// <param name="sequenceNr">TBD</param>
         /// <param name="timestamp">TBD</param>
         /// <returns>TBD</returns>
-        public virtual async Task DeleteAsync(DbConnection connection, CancellationToken cancellationToken, string persistenceId, long sequenceNr,
+        public virtual async Task DeleteAsync(
+            DbConnection connection,
+            CancellationToken cancellationToken,
+            string persistenceId,
+            long sequenceNr,
             DateTime? timestamp)
         {
-            var sql = timestamp.HasValue
-                ? DeleteSnapshotRangeSql + " AND { Configuration.TimestampColumnName} = @Timestamp"
-                : DeleteSnapshotSql;
-
-            using (var command = GetCommand(connection, sql))
-            using (var tx = connection.BeginTransaction())
+            await connection.ExecuteInTransaction(WriteIsolationLevel, cancellationToken, async (tx, token) =>
             {
+                var sql = timestamp.HasValue
+                    ? DeleteSnapshotRangeSql + " AND { Configuration.TimestampColumnName} = @Timestamp"
+                    : DeleteSnapshotSql;
+
+                using var command = GetCommand(connection, sql); 
                 command.Transaction = tx;
 
                 SetPersistenceIdParameter(persistenceId, command);
@@ -398,10 +477,8 @@ namespace Akka.Persistence.Sql.Common.Snapshot
                     SetTimestampParameter(timestamp.Value, command);
                 }
 
-                await command.ExecuteNonQueryAsync(cancellationToken);
-
-                tx.Commit();
-            }
+                await command.ExecuteNonQueryAsync(token);
+            });
         }
 
         /// <summary>
@@ -413,22 +490,24 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         /// <param name="maxSequenceNr">TBD</param>
         /// <param name="maxTimestamp">TBD</param>
         /// <returns>TBD</returns>
-        public virtual async Task DeleteBatchAsync(DbConnection connection, CancellationToken cancellationToken, string persistenceId,
-            long maxSequenceNr, DateTime maxTimestamp)
+        public virtual async Task DeleteBatchAsync(
+            DbConnection connection,
+            CancellationToken cancellationToken,
+            string persistenceId,
+            long maxSequenceNr,
+            DateTime maxTimestamp)
         {
-            using (var command = GetCommand(connection, DeleteSnapshotRangeSql))
-            using (var tx = connection.BeginTransaction())
+            await connection.ExecuteInTransaction(WriteIsolationLevel, cancellationToken, async (tx, token) =>
             {
+                using var command = GetCommand(connection, DeleteSnapshotRangeSql);
                 command.Transaction = tx;
 
                 SetPersistenceIdParameter(persistenceId, command);
                 SetSequenceNrParameter(maxSequenceNr, command);
                 SetTimestampParameter(maxTimestamp, command);
 
-                await command.ExecuteNonQueryAsync(cancellationToken);
-
-                tx.Commit();
-            }
+                await command.ExecuteNonQueryAsync(token);
+            });
         }
 
         /// <summary>
@@ -439,11 +518,15 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         /// <param name="snapshot">TBD</param>
         /// <param name="metadata">TBD</param>
         /// <returns>TBD</returns>
-        public virtual async Task InsertAsync(DbConnection connection, CancellationToken cancellationToken, object snapshot, SnapshotMetadata metadata)
+        public virtual async Task InsertAsync(
+            DbConnection connection,
+            CancellationToken cancellationToken,
+            object snapshot,
+            SnapshotMetadata metadata)
         {
-            using (var command = GetCommand(connection, InsertSnapshotSql))
-            using(var tx = connection.BeginTransaction())
+            await connection.ExecuteInTransaction(WriteIsolationLevel, cancellationToken, async (tx, token) =>
             {
+                using var command = GetCommand(connection, InsertSnapshotSql);
                 command.Transaction = tx;
 
                 SetPersistenceIdParameter(metadata.PersistenceId, command);
@@ -452,10 +535,8 @@ namespace Akka.Persistence.Sql.Common.Snapshot
                 SetManifestParameters(snapshot, command);
                 SetPayloadParameter(snapshot, command);
 
-                await command.ExecuteNonQueryAsync(cancellationToken);
-
-                tx.Commit();
-            }
+                await command.ExecuteNonQueryAsync(token);
+            });
         }
 
         /// <summary>
@@ -467,36 +548,33 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         /// <param name="maxSequenceNr">TBD</param>
         /// <param name="maxTimestamp">TBD</param>
         /// <returns>TBD</returns>
-        public virtual async Task<SelectedSnapshot> SelectSnapshotAsync(DbConnection connection, CancellationToken cancellationToken, string persistenceId,
-            long maxSequenceNr, DateTime maxTimestamp)
+        public virtual async Task<SelectedSnapshot> SelectSnapshotAsync(
+            DbConnection connection,
+            CancellationToken cancellationToken,
+            string persistenceId,
+            long maxSequenceNr,
+            DateTime maxTimestamp)
         {
-            using (var command = GetCommand(connection, SelectSnapshotSql))
+            return await connection.ExecuteInTransaction(ReadIsolationLevel, cancellationToken, async (tx, token) =>
             {
+                using var command = GetCommand(connection, SelectSnapshotSql);
+                command.Transaction = tx;
+                
                 SetPersistenceIdParameter(persistenceId, command);
                 SetSequenceNrParameter(maxSequenceNr, command);
                 SetTimestampParameter(maxTimestamp, command);
 
-                CommandBehavior commandBehavior;
+                var commandBehavior = Configuration.UseSequentialAccess 
+                    ? CommandBehavior.SequentialAccess : CommandBehavior.Default;
 
-                if (Configuration.UseSequentialAccess)
+                using var reader = await command.ExecuteReaderAsync(commandBehavior, token);
+                if (await reader.ReadAsync(token))
                 {
-                    commandBehavior = CommandBehavior.SequentialAccess;
-                }
-                else
-                {
-                    commandBehavior = CommandBehavior.Default;
+                    return ReadSnapshot(reader);
                 }
 
-                using (var reader = await command.ExecuteReaderAsync(commandBehavior, cancellationToken))
-                {
-                    if (await reader.ReadAsync(cancellationToken))
-                    {
-                        return ReadSnapshot(reader);
-                    }
-                }
-            }
-
-            return null;
+                return null;
+            });
         }
 
         /// <summary>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/SqlSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/SqlSnapshotStore.cs
@@ -38,7 +38,7 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         /// </summary>
         private readonly CancellationTokenSource _pendingRequestsCancellation;
 
-        private readonly SnapshotStoreSettings _settings;
+        protected readonly SnapshotStoreSettings Settings;
 
         private readonly ExtendedActorSystem _actorSystem;
 
@@ -49,7 +49,7 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         protected SqlSnapshotStore(Config config)
         {
             _actorSystem = Context.System.AsInstanceOf<ExtendedActorSystem>();
-            _settings = new SnapshotStoreSettings(config);
+            Settings = new SnapshotStoreSettings(config);
             _pendingRequestsCancellation = new CancellationTokenSource();
         }
 
@@ -91,7 +91,7 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         protected override void PreStart()
         {
             base.PreStart();
-            if (_settings.AutoInitialize)
+            if (Settings.AutoInitialize)
             {
                 Initialize().PipeTo(Self);
                 BecomeStacked(WaitingForInitialization);
@@ -151,11 +151,11 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         /// <returns>TBD</returns>
         protected virtual string GetConnectionString()
         {
-            var connectionString = _settings.ConnectionString;
+            var connectionString = Settings.ConnectionString;
 
             if (string.IsNullOrEmpty(connectionString))
             {
-                connectionString = System.Configuration.ConfigurationManager.ConnectionStrings[_settings.ConnectionStringName].ConnectionString;
+                connectionString = System.Configuration.ConfigurationManager.ConnectionStrings[Settings.ConnectionStringName].ConnectionString;
             }
 
             return connectionString;

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
@@ -43,8 +43,8 @@ namespace Akka.Persistence.Sqlite.Tests
             Assert.Equal("journal_metadata", config.GetString("metadata-table-name"));
             Assert.False(config.GetBoolean("auto-initialize"));
             Assert.Equal("Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common", config.GetString("timestamp-provider"));
-            Assert.Equal("read-committed", config.GetString("read-isolation-level"));
-            Assert.Equal("read-committed", config.GetString("write-isolation-level"));
+            Assert.Equal("unspecified", config.GetString("read-isolation-level"));
+            Assert.Equal("unspecified", config.GetString("write-isolation-level"));
             Assert.False(config.HasPath("schema-name"));
         }
 
@@ -62,8 +62,8 @@ namespace Akka.Persistence.Sqlite.Tests
             settings.SchemaName.Should().BeNull();
             settings.MetaTableName.Should().Be("journal_metadata");
             settings.TimestampProvider.Should().Be("Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common");
-            settings.ReadIsolationLevel.Should().Be(IsolationLevel.ReadCommitted);
-            settings.WriteIsolationLevel.Should().Be(IsolationLevel.ReadCommitted);
+            settings.ReadIsolationLevel.Should().Be(IsolationLevel.Unspecified);
+            settings.WriteIsolationLevel.Should().Be(IsolationLevel.Unspecified);
             settings.AutoInitialize.Should().BeFalse();
 
             // values should reflect configuration
@@ -94,8 +94,8 @@ namespace Akka.Persistence.Sqlite.Tests
             Assert.Equal(TimeSpan.FromSeconds(30), config.GetTimeSpan("connection-timeout", null));
             // This is changed from "snapshot-store" to "snapshot"
             Assert.Equal("snapshot", config.GetString("table-name", null));
-            Assert.Equal("read-committed", config.GetString("read-isolation-level"));
-            Assert.Equal("read-committed", config.GetString("write-isolation-level"));
+            Assert.Equal("unspecified", config.GetString("read-isolation-level"));
+            Assert.Equal("unspecified", config.GetString("write-isolation-level"));
             Assert.False(config.GetBoolean("auto-initialize", false));
         }
 
@@ -115,8 +115,8 @@ namespace Akka.Persistence.Sqlite.Tests
 #pragma warning disable CS0618
             settings.DefaultSerializer.Should().BeNull();
 #pragma warning restore CS0618
-            settings.ReadIsolationLevel.Should().Be(IsolationLevel.ReadCommitted);
-            settings.WriteIsolationLevel.Should().Be(IsolationLevel.ReadCommitted);
+            settings.ReadIsolationLevel.Should().Be(IsolationLevel.Unspecified);
+            settings.WriteIsolationLevel.Should().Be(IsolationLevel.Unspecified);
             settings.FullTableName.Should().Be(settings.TableName);
 
             // values should reflect configuration

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/SqliteConfigSpec.cs
@@ -7,10 +7,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Sql.TestKit;
 using Akka.Persistence.Sql.Common;
+using Akka.Persistence.Sql.Common.Extensions;
 using Akka.Util.Internal;
 using Xunit;
 using Xunit.Abstractions;
@@ -41,6 +43,8 @@ namespace Akka.Persistence.Sqlite.Tests
             Assert.Equal("journal_metadata", config.GetString("metadata-table-name"));
             Assert.False(config.GetBoolean("auto-initialize"));
             Assert.Equal("Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common", config.GetString("timestamp-provider"));
+            Assert.Equal("read-committed", config.GetString("read-isolation-level"));
+            Assert.Equal("read-committed", config.GetString("write-isolation-level"));
             Assert.False(config.HasPath("schema-name"));
         }
 
@@ -53,22 +57,26 @@ namespace Akka.Persistence.Sqlite.Tests
             // values should be correct
             settings.ConnectionString.Should().Be(string.Empty);
             settings.ConnectionStringName.Should().Be(string.Empty);
-            settings.ConnectionTimeout.Should().Equals(TimeSpan.FromSeconds(30));
-            settings.JournalTableName.Should().Equals("event_journal");
+            settings.ConnectionTimeout.Should().Be(TimeSpan.FromSeconds(30));
+            settings.JournalTableName.Should().Be("event_journal");
             settings.SchemaName.Should().BeNull();
-            settings.MetaTableName.Should().Equals("journal_metadata");
+            settings.MetaTableName.Should().Be("journal_metadata");
             settings.TimestampProvider.Should().Be("Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common");
+            settings.ReadIsolationLevel.Should().Be(IsolationLevel.ReadCommitted);
+            settings.WriteIsolationLevel.Should().Be(IsolationLevel.ReadCommitted);
             settings.AutoInitialize.Should().BeFalse();
 
             // values should reflect configuration
-            settings.ConnectionString.Should().Equals(config.GetString("connection-string"));
-            settings.ConnectionStringName.Should().Equals(config.GetString("connection-string-name"));
-            settings.ConnectionTimeout.Should().Equals(config.GetTimeSpan("connection-timeout"));
-            settings.JournalTableName.Should().Equals(config.GetString("table-name"));
-            settings.SchemaName.Should().Equals(config.GetString("schema-name", null));
-            settings.MetaTableName.Should().Equals(config.GetString("metadata-table-name"));
+            settings.ConnectionString.Should().Be(config.GetString("connection-string"));
+            settings.ConnectionStringName.Should().Be(config.GetString("connection-string-name"));
+            settings.ConnectionTimeout.Should().Be(config.GetTimeSpan("connection-timeout"));
+            settings.JournalTableName.Should().Be(config.GetString("table-name"));
+            settings.SchemaName.Should().Be(config.GetString("schema-name", null));
+            settings.MetaTableName.Should().Be(config.GetString("metadata-table-name"));
             settings.TimestampProvider.Should().Be(config.GetString("timestamp-provider"));
-            settings.AutoInitialize.Should().Equals(config.GetBoolean("auto-initialize"));
+            settings.ReadIsolationLevel.Should().Be(config.GetIsolationLevel("read-isolation-level"));
+            settings.WriteIsolationLevel.Should().Be(config.GetIsolationLevel("write-isolation-level"));
+            settings.AutoInitialize.Should().Be(config.GetBoolean("auto-initialize"));
         }
 
         [Fact]
@@ -86,6 +94,8 @@ namespace Akka.Persistence.Sqlite.Tests
             Assert.Equal(TimeSpan.FromSeconds(30), config.GetTimeSpan("connection-timeout", null));
             // This is changed from "snapshot-store" to "snapshot"
             Assert.Equal("snapshot", config.GetString("table-name", null));
+            Assert.Equal("read-committed", config.GetString("read-isolation-level"));
+            Assert.Equal("read-committed", config.GetString("write-isolation-level"));
             Assert.False(config.GetBoolean("auto-initialize", false));
         }
 
@@ -102,7 +112,11 @@ namespace Akka.Persistence.Sqlite.Tests
             settings.SchemaName.Should().BeNull();
             settings.TableName.Should().Be("snapshot");
             settings.AutoInitialize.Should().BeFalse();
+#pragma warning disable CS0618
             settings.DefaultSerializer.Should().BeNull();
+#pragma warning restore CS0618
+            settings.ReadIsolationLevel.Should().Be(IsolationLevel.ReadCommitted);
+            settings.WriteIsolationLevel.Should().Be(IsolationLevel.ReadCommitted);
             settings.FullTableName.Should().Be(settings.TableName);
 
             // values should reflect configuration
@@ -111,8 +125,12 @@ namespace Akka.Persistence.Sqlite.Tests
             settings.ConnectionTimeout.Should().Be(config.GetTimeSpan("connection-timeout"));
             settings.SchemaName.Should().Be(config.GetString("schema-name", null));
             settings.TableName.Should().Be(config.GetString("table-name"));
+            settings.ReadIsolationLevel.Should().Be(config.GetIsolationLevel("read-isolation-level"));
+            settings.WriteIsolationLevel.Should().Be(config.GetIsolationLevel("write-isolation-level"));
             settings.AutoInitialize.Should().Be(config.GetBoolean("auto-initialize"));
+#pragma warning disable CS0618
             settings.DefaultSerializer.Should().Be(config.GetString("serializer", null));
+#pragma warning restore CS0618
         }
 
     }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/BatchingSqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/BatchingSqliteJournal.cs
@@ -13,6 +13,7 @@ using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Akka.Configuration;
 using Akka.Pattern;
+using Akka.Persistence.Sql.Common.Extensions;
 using Akka.Persistence.Sql.Common.Journal;
 
 namespace Akka.Persistence.Sqlite.Journal
@@ -41,7 +42,9 @@ namespace Akka.Persistence.Sqlite.Journal
                     serializerIdColumnName: "serializer_id",
                     timeout: config.GetTimeSpan("connection-timeout", null),
                     defaultSerializer: config.GetString("serializer", null),
-                    useSequentialAccess: config.GetBoolean("use-sequential-access", false)))
+                    useSequentialAccess: config.GetBoolean("use-sequential-access", false),
+                    readIsolationLevel: config.GetIsolationLevel("read-isolation-level"),
+                    writeIsolationLevel: config.GetIsolationLevel("write-isolation-level")))
         {
         }
 
@@ -58,16 +61,89 @@ namespace Akka.Persistence.Sqlite.Journal
         /// to starting executing any requests.
         /// </param>
         /// <param name="connectionTimeout">The maximum time given for executed <see cref="DbCommand"/> to complete.</param>
-        /// <param name="isolationLevel">The isolation level of transactions used during query execution.</param>
+        /// <param name="isolationLevel">The isolation level of transactions used during read AND write query execution.</param>
         /// <param name="circuitBreakerSettings">
         /// The settings used by the <see cref="CircuitBreaker"/> when for executing request batches.
         /// </param>
         /// <param name="replayFilterSettings">The settings used when replaying events from database back to the persistent actors.</param>
         /// <param name="namingConventions">The naming conventions used by the database to construct valid SQL statements.</param>
         /// <param name="defaultSerializer">The serializer used when no specific type matching can be found.</param>
-        public BatchingSqliteJournalSetup(string connectionString, int maxConcurrentOperations, int maxBatchSize, int maxBufferSize, bool autoInitialize, 
-            TimeSpan connectionTimeout, IsolationLevel isolationLevel, CircuitBreakerSettings circuitBreakerSettings, ReplayFilterSettings replayFilterSettings, QueryConfiguration namingConventions, string defaultSerializer) 
-            : base(connectionString, maxConcurrentOperations, maxBatchSize, maxBufferSize, autoInitialize, connectionTimeout, isolationLevel, circuitBreakerSettings, replayFilterSettings, namingConventions, defaultSerializer)
+        [Obsolete("Use the constructor with read and write IsolationLevel arguments (since v1.5.2)")]
+        public BatchingSqliteJournalSetup(
+            string connectionString,
+            int maxConcurrentOperations,
+            int maxBatchSize,
+            int maxBufferSize,
+            bool autoInitialize, 
+            TimeSpan connectionTimeout,
+            IsolationLevel isolationLevel,
+            CircuitBreakerSettings circuitBreakerSettings,
+            ReplayFilterSettings replayFilterSettings,
+            QueryConfiguration namingConventions,
+            string defaultSerializer) 
+            : base(
+                connectionString: connectionString,
+                maxConcurrentOperations: maxConcurrentOperations,
+                maxBatchSize: maxBatchSize,
+                maxBufferSize: maxBufferSize,
+                autoInitialize: autoInitialize,
+                connectionTimeout: connectionTimeout,
+                readIsolationLevel: isolationLevel,
+                writeIsolationLevel: isolationLevel,
+                circuitBreakerSettings: circuitBreakerSettings,
+                replayFilterSettings: replayFilterSettings,
+                namingConventions: namingConventions,
+                defaultSerializer: defaultSerializer)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BatchingSqliteJournalSetup" /> class.
+        /// </summary>
+        /// <param name="connectionString">The connection string used to connect to the database.</param>
+        /// <param name="maxConcurrentOperations">The maximum number of batch operations allowed to be executed at the same time.</param>
+        /// <param name="maxBatchSize">The maximum size of single batch of operations to be executed over a single <see cref="DbConnection"/>.</param>
+        /// <param name="maxBufferSize">The maximum size of requests stored in journal buffer.</param>
+        /// <param name="autoInitialize">
+        /// If set to <c>true</c>, the journal executes all SQL scripts stored under the
+        /// <see cref="BatchingSqlJournal{TConnection,TCommand}.Initializers"/> collection prior
+        /// to starting executing any requests.
+        /// </param>
+        /// <param name="connectionTimeout">The maximum time given for executed <see cref="DbCommand"/> to complete.</param>
+        /// <param name="readIsolationLevel">The isolation level of transactions used during read query execution.</param>
+        /// <param name="writeIsolationLevel">The isolation level of transactions used during write query execution.</param>
+        /// <param name="circuitBreakerSettings">
+        /// The settings used by the <see cref="CircuitBreaker"/> when for executing request batches.
+        /// </param>
+        /// <param name="replayFilterSettings">The settings used when replaying events from database back to the persistent actors.</param>
+        /// <param name="namingConventions">The naming conventions used by the database to construct valid SQL statements.</param>
+        /// <param name="defaultSerializer">The serializer used when no specific type matching can be found.</param>
+        public BatchingSqliteJournalSetup(
+            string connectionString,
+            int maxConcurrentOperations,
+            int maxBatchSize,
+            int maxBufferSize,
+            bool autoInitialize, 
+            TimeSpan connectionTimeout,
+            IsolationLevel readIsolationLevel,
+            IsolationLevel writeIsolationLevel,
+            CircuitBreakerSettings circuitBreakerSettings,
+            ReplayFilterSettings replayFilterSettings,
+            QueryConfiguration namingConventions,
+            string defaultSerializer) 
+            : base(
+                connectionString: connectionString,
+                maxConcurrentOperations: maxConcurrentOperations,
+                maxBatchSize: maxBatchSize,
+                maxBufferSize: maxBufferSize,
+                autoInitialize: autoInitialize,
+                connectionTimeout: connectionTimeout,
+                writeIsolationLevel: readIsolationLevel,
+                readIsolationLevel: writeIsolationLevel,
+                circuitBreakerSettings: circuitBreakerSettings,
+                replayFilterSettings: replayFilterSettings,
+                namingConventions: namingConventions,
+                defaultSerializer: defaultSerializer)
         {
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Journal/SqliteJournal.cs
@@ -45,7 +45,9 @@ namespace Akka.Persistence.Sqlite.Journal
                 serializerIdColumnName: "serializer_id",
                 timeout: config.GetTimeSpan("connection-timeout", null),
                 defaultSerializer: config.GetString("serializer", null),
-                useSequentialAccess: config.GetBoolean("use-sequential-access", false)), 
+                useSequentialAccess: config.GetBoolean("use-sequential-access", false),
+                readIsolationLevel: Settings.ReadIsolationLevel,
+                writeIsolationLevel: Settings.WriteIsolationLevel), 
                     Context.System.Serialization, 
                     GetTimestampProvider(config.GetString("timestamp-provider", null)));
         }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/SqliteSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/SqliteSnapshotStore.cs
@@ -123,7 +123,9 @@ namespace Akka.Persistence.Sqlite.Snapshot
                 serializerIdColumnName: "serializer_id",
                 timeout: config.GetTimeSpan("connection-timeout"),
                 defaultSerializer: config.GetString("serializer", null),
-                useSequentialAccess: config.GetBoolean("use-sequential-access", false)),
+                useSequentialAccess: config.GetBoolean("use-sequential-access", false), 
+                readIsolationLevel: Settings.ReadIsolationLevel,
+                writeIsolationLevel: Settings.WriteIsolationLevel),
                 Context.System.Serialization);
         }
 

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
@@ -32,11 +32,11 @@
 			timestamp-provider = "Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common"
 			
 			# The isolation level of all database read query
-			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
+			# Valid values: "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
 			read-isolation-level = unspecified
 			
 			# The isolation level of all database write query
-			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
+			# Valid values: "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
 			write-isolation-level = unspecified
 			
 			circuit-breaker {
@@ -73,11 +73,11 @@
 			auto-initialize = off
 
 			# The isolation level of all database read query
-			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
+			# Valid values: "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
 			read-isolation-level = unspecified
 			
 			# The isolation level of all database write query
-			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
+			# Valid values: "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
 			write-isolation-level = unspecified
 		}
 	}

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
@@ -33,11 +33,11 @@
 			
 			# The isolation level of all database read query
 			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
-			read-isolation-level = read-committed
+			read-isolation-level = unspecified
 			
 			# The isolation level of all database write query
 			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
-			write-isolation-level = read-committed
+			write-isolation-level = unspecified
 			
 			circuit-breaker {
 				max-failures = 5
@@ -74,11 +74,11 @@
 
 			# The isolation level of all database read query
 			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
-			read-isolation-level = read-committed
+			read-isolation-level = unspecified
 			
 			# The isolation level of all database write query
 			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
-			write-isolation-level = read-committed
+			write-isolation-level = unspecified
 		}
 	}
 }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
@@ -31,6 +31,14 @@
 			# timestamp provider used for generation of journal entries timestamps
 			timestamp-provider = "Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common"
 			
+			# The isolation level of all database read query
+			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
+			read-isolation-level = read-committed
+			
+			# The isolation level of all database write query
+			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
+			write-isolation-level = read-committed
+			
 			circuit-breaker {
 				max-failures = 5
 				call-timeout = 20s
@@ -64,6 +72,13 @@
 			# should corresponding journal table be initialized automatically
 			auto-initialize = off
 
+			# The isolation level of all database read query
+			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
+			read-isolation-level = read-committed
+			
+			# The isolation level of all database write query
+			# Valid values: "chaos", "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
+			write-isolation-level = read-committed
 		}
 	}
 }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/sqlite.conf
@@ -31,11 +31,15 @@
 			# timestamp provider used for generation of journal entries timestamps
 			timestamp-provider = "Akka.Persistence.Sql.Common.Journal.DefaultTimestampProvider, Akka.Persistence.Sql.Common"
 			
-			# The isolation level of all database read query
+			# The isolation level of all database read query.
+			# Isolation level documentation can be read here: 
+			#   https://learn.microsoft.com/en-us/dotnet/api/system.data.isolationlevel?#fields
 			# Valid values: "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
 			read-isolation-level = unspecified
 			
-			# The isolation level of all database write query
+			# The isolation level of all database read query.
+			# Isolation level documentation can be read here: 
+			#   https://learn.microsoft.com/en-us/dotnet/api/system.data.isolationlevel?#fields
 			# Valid values: "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
 			write-isolation-level = unspecified
 			
@@ -72,11 +76,15 @@
 			# should corresponding journal table be initialized automatically
 			auto-initialize = off
 
-			# The isolation level of all database read query
+			# The isolation level of all database read query.
+			# Isolation level documentation can be read here: 
+			#   https://learn.microsoft.com/en-us/dotnet/api/system.data.isolationlevel?#fields
 			# Valid values: "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
 			read-isolation-level = unspecified
 			
-			# The isolation level of all database write query
+			# The isolation level of all database read query.
+			# Isolation level documentation can be read here: 
+			#   https://learn.microsoft.com/en-us/dotnet/api/system.data.isolationlevel?#fields
 			# Valid values: "read-committed", "read-uncommitted", "repeatable-read", "serializable", "snapshot", or "unspecified"
 			write-isolation-level = unspecified
 		}

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.DotNet.verified.txt
@@ -2,6 +2,19 @@
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("e438d2c3-1075-4b01-bb84-e9efd3a36691")]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+namespace Akka.Persistence.Sql.Common.Extensions
+{
+    public class static DbConnectionExtensions
+    {
+        public static System.Threading.Tasks.Task ExecuteInTransaction(this System.Data.Common.DbConnection connection, System.Data.IsolationLevel isolationLevel, System.Threading.CancellationToken token, System.Func<System.Data.Common.DbTransaction, System.Threading.CancellationToken, System.Threading.Tasks.Task> task) { }
+        public static System.Threading.Tasks.Task<T> ExecuteInTransaction<T>(this System.Data.Common.DbConnection connection, System.Data.IsolationLevel isolationLevel, System.Threading.CancellationToken token, System.Func<System.Data.Common.DbTransaction, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> task) { }
+    }
+    public class static IsolationLevelExtensions
+    {
+        public static System.Data.IsolationLevel GetIsolationLevel(this Akka.Configuration.Config config, string key) { }
+        public static System.Data.IsolationLevel ToIsolationLevel(this string level) { }
+    }
+}
 namespace Akka.Persistence.Sql.Common.Journal
 {
     public abstract class AbstractQueryExecutor : Akka.Persistence.Sql.Common.Journal.IJournalQueryExecutor
@@ -32,7 +45,9 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected virtual string InsertEventSql { get; }
         [System.ObsoleteAttribute()]
         protected string QueryEventsSql { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         protected virtual string UpdateSequenceNrSql { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
         protected void AddParameter(System.Data.Common.DbCommand command, string parameterName, System.Data.DbType parameterType, object value) { }
         protected abstract System.Data.Common.DbCommand CreateCommand(System.Data.Common.DbConnection connection);
         public virtual System.Threading.Tasks.Task CreateTablesAsync(System.Data.Common.DbConnection connection, System.Threading.CancellationToken cancellationToken) { }
@@ -57,7 +72,10 @@ namespace Akka.Persistence.Sql.Common.Journal
     public abstract class BatchingSqlJournalSetup
     {
         protected BatchingSqlJournalSetup(Akka.Configuration.Config config, Akka.Persistence.Sql.Common.Journal.QueryConfiguration namingConventions) { }
+        [System.ObsoleteAttribute("Use constructor with separate read and write isolation level instead. (since v1.5" +
+            ".2)")]
         protected BatchingSqlJournalSetup(string connectionString, int maxConcurrentOperations, int maxBatchSize, int maxBufferSize, bool autoInitialize, System.TimeSpan connectionTimeout, System.Data.IsolationLevel isolationLevel, Akka.Persistence.Sql.Common.Journal.CircuitBreakerSettings circuitBreakerSettings, Akka.Persistence.Sql.Common.Journal.ReplayFilterSettings replayFilterSettings, Akka.Persistence.Sql.Common.Journal.QueryConfiguration namingConventions, string defaultSerializer) { }
+        protected BatchingSqlJournalSetup(string connectionString, int maxConcurrentOperations, int maxBatchSize, int maxBufferSize, bool autoInitialize, System.TimeSpan connectionTimeout, System.Data.IsolationLevel readIsolationLevel, System.Data.IsolationLevel writeIsolationLevel, Akka.Persistence.Sql.Common.Journal.CircuitBreakerSettings circuitBreakerSettings, Akka.Persistence.Sql.Common.Journal.ReplayFilterSettings replayFilterSettings, Akka.Persistence.Sql.Common.Journal.QueryConfiguration namingConventions, string defaultSerializer) { }
         public bool AutoInitialize { get; }
         public Akka.Persistence.Sql.Common.Journal.CircuitBreakerSettings CircuitBreakerSettings { get; }
         public string ConnectionString { get; }
@@ -65,13 +83,16 @@ namespace Akka.Persistence.Sql.Common.Journal
         [System.ObsoleteAttribute("This property should never be used for writes, use the default `System.Object` se" +
             "rializer instead")]
         public string DefaultSerializer { get; }
+        [System.ObsoleteAttribute("Use WriteIsolationLevel property instead")]
         public System.Data.IsolationLevel IsolationLevel { get; }
         public int MaxBatchSize { get; }
         public int MaxBufferSize { get; }
         public int MaxConcurrentOperations { get; }
         public Akka.Persistence.Sql.Common.Journal.QueryConfiguration NamingConventions { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         public Akka.Persistence.Sql.Common.Journal.ReplayFilterSettings ReplayFilterSettings { get; }
         public string TimestampProviderTypeName { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
     }
     public abstract class BatchingSqlJournal<TConnection, TCommand> : Akka.Persistence.Journal.WriteJournalBase
         where TConnection : System.Data.Common.DbConnection
@@ -222,13 +243,34 @@ namespace Akka.Persistence.Sql.Common.Journal
         public readonly string TagsColumnName;
         public readonly System.TimeSpan Timeout;
         public readonly string TimestampColumnName;
+        [System.ObsoleteAttribute("Use .ctor that accepts read and write IsolationLevel instead (since v1.5.2)")]
         public QueryConfiguration(string schemaName, string journalEventsTableName, string metaTableName, string persistenceIdColumnName, string sequenceNrColumnName, string payloadColumnName, string manifestColumnName, string timestampColumnName, string isDeletedColumnName, string tagsColumnName, string orderingColumnName, string serializerIdColumnName, System.TimeSpan timeout, string defaultSerializer, bool useSequentialAccess) { }
+        public QueryConfiguration(
+                    string schemaName, 
+                    string journalEventsTableName, 
+                    string metaTableName, 
+                    string persistenceIdColumnName, 
+                    string sequenceNrColumnName, 
+                    string payloadColumnName, 
+                    string manifestColumnName, 
+                    string timestampColumnName, 
+                    string isDeletedColumnName, 
+                    string tagsColumnName, 
+                    string orderingColumnName, 
+                    string serializerIdColumnName, 
+                    System.TimeSpan timeout, 
+                    string defaultSerializer, 
+                    bool useSequentialAccess, 
+                    System.Nullable<System.Data.IsolationLevel> readIsolationLevel, 
+                    System.Nullable<System.Data.IsolationLevel> writeIsolationLevel) { }
         [System.ObsoleteAttribute("This property should never be used for writes, use the default `System.Object` se" +
             "rializer instead")]
         public string DefaultSerializer { get; }
         public string FullJournalTableName { get; }
         public string FullMetaTableName { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         public bool UseSequentialAccess { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
     }
     public sealed class ReplayAllEvents : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
     {
@@ -278,6 +320,7 @@ namespace Akka.Persistence.Sql.Common.Journal
     }
     public abstract class SqlJournal : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
+        protected readonly Akka.Persistence.Sql.Common.JournalSettings Settings;
         protected SqlJournal(Akka.Configuration.Config journalConfig) { }
         protected abstract string JournalConfigPath { get; }
         protected Akka.Event.ILoggingAdapter Log { get; }
@@ -346,8 +389,10 @@ namespace Akka.Persistence.Sql.Common
         public System.TimeSpan ConnectionTimeout { get; }
         public string JournalTableName { get; }
         public string MetaTableName { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         public string SchemaName { get; }
         public string TimestampProvider { get; set; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
     }
     public class SnapshotStoreSettings
     {
@@ -360,8 +405,10 @@ namespace Akka.Persistence.Sql.Common
             "stead")]
         public string DefaultSerializer { get; }
         public string FullTableName { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         public string SchemaName { get; }
         public string TableName { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
     }
 }
 namespace Akka.Persistence.Sql.Common.Snapshot
@@ -375,7 +422,9 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         protected virtual string DeleteSnapshotRangeSql { get; }
         protected virtual string DeleteSnapshotSql { get; }
         protected virtual string InsertSnapshotSql { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         protected virtual string SelectSnapshotSql { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
         protected void AddParameter(System.Data.Common.DbCommand command, string parameterName, System.Data.DbType parameterType, object value) { }
         protected abstract System.Data.Common.DbCommand CreateCommand(System.Data.Common.DbConnection connection);
         public virtual System.Threading.Tasks.Task CreateTableAsync(System.Data.Common.DbConnection connection, System.Threading.CancellationToken cancellationToken) { }
@@ -416,9 +465,14 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         public readonly string SnapshotTableName;
         public readonly System.TimeSpan Timeout;
         public readonly string TimestampColumnName;
+        [System.ObsoleteAttribute("Use the constructor that takes read and write isolation level argument (since v1." +
+            "5.2)")]
         public QueryConfiguration(string schemaName, string snapshotTableName, string persistenceIdColumnName, string sequenceNrColumnName, string payloadColumnName, string manifestColumnName, string timestampColumnName, string serializerIdColumnName, System.TimeSpan timeout, string defaultSerializer, bool useSequentialAccess) { }
+        public QueryConfiguration(string schemaName, string snapshotTableName, string persistenceIdColumnName, string sequenceNrColumnName, string payloadColumnName, string manifestColumnName, string timestampColumnName, string serializerIdColumnName, System.TimeSpan timeout, string defaultSerializer, bool useSequentialAccess, System.Nullable<System.Data.IsolationLevel> readIsolationLevel, System.Nullable<System.Data.IsolationLevel> writeIsolationLevel) { }
         public string FullSnapshotTableName { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         public bool UseSequentialAccess { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
     }
     public class SnapshotEntry
     {
@@ -431,6 +485,7 @@ namespace Akka.Persistence.Sql.Common.Snapshot
     }
     public abstract class SqlSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
+        protected readonly Akka.Persistence.Sql.Common.SnapshotStoreSettings Settings;
         protected SqlSnapshotStore(Akka.Configuration.Config config) { }
         protected Akka.Event.ILoggingAdapter Log { get; }
         public abstract Akka.Persistence.Sql.Common.Snapshot.ISnapshotQueryExecutor QueryExecutor { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Net.verified.txt
@@ -2,6 +2,19 @@
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("e438d2c3-1075-4b01-bb84-e9efd3a36691")]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+namespace Akka.Persistence.Sql.Common.Extensions
+{
+    public class static DbConnectionExtensions
+    {
+        public static System.Threading.Tasks.Task ExecuteInTransaction(this System.Data.Common.DbConnection connection, System.Data.IsolationLevel isolationLevel, System.Threading.CancellationToken token, System.Func<System.Data.Common.DbTransaction, System.Threading.CancellationToken, System.Threading.Tasks.Task> task) { }
+        public static System.Threading.Tasks.Task<T> ExecuteInTransaction<T>(this System.Data.Common.DbConnection connection, System.Data.IsolationLevel isolationLevel, System.Threading.CancellationToken token, System.Func<System.Data.Common.DbTransaction, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> task) { }
+    }
+    public class static IsolationLevelExtensions
+    {
+        public static System.Data.IsolationLevel GetIsolationLevel(this Akka.Configuration.Config config, string key) { }
+        public static System.Data.IsolationLevel ToIsolationLevel(this string level) { }
+    }
+}
 namespace Akka.Persistence.Sql.Common.Journal
 {
     public abstract class AbstractQueryExecutor : Akka.Persistence.Sql.Common.Journal.IJournalQueryExecutor
@@ -32,7 +45,9 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected virtual string InsertEventSql { get; }
         [System.ObsoleteAttribute()]
         protected string QueryEventsSql { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         protected virtual string UpdateSequenceNrSql { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
         protected void AddParameter(System.Data.Common.DbCommand command, string parameterName, System.Data.DbType parameterType, object value) { }
         protected abstract System.Data.Common.DbCommand CreateCommand(System.Data.Common.DbConnection connection);
         public virtual System.Threading.Tasks.Task CreateTablesAsync(System.Data.Common.DbConnection connection, System.Threading.CancellationToken cancellationToken) { }
@@ -57,7 +72,10 @@ namespace Akka.Persistence.Sql.Common.Journal
     public abstract class BatchingSqlJournalSetup
     {
         protected BatchingSqlJournalSetup(Akka.Configuration.Config config, Akka.Persistence.Sql.Common.Journal.QueryConfiguration namingConventions) { }
+        [System.ObsoleteAttribute("Use constructor with separate read and write isolation level instead. (since v1.5" +
+            ".2)")]
         protected BatchingSqlJournalSetup(string connectionString, int maxConcurrentOperations, int maxBatchSize, int maxBufferSize, bool autoInitialize, System.TimeSpan connectionTimeout, System.Data.IsolationLevel isolationLevel, Akka.Persistence.Sql.Common.Journal.CircuitBreakerSettings circuitBreakerSettings, Akka.Persistence.Sql.Common.Journal.ReplayFilterSettings replayFilterSettings, Akka.Persistence.Sql.Common.Journal.QueryConfiguration namingConventions, string defaultSerializer) { }
+        protected BatchingSqlJournalSetup(string connectionString, int maxConcurrentOperations, int maxBatchSize, int maxBufferSize, bool autoInitialize, System.TimeSpan connectionTimeout, System.Data.IsolationLevel readIsolationLevel, System.Data.IsolationLevel writeIsolationLevel, Akka.Persistence.Sql.Common.Journal.CircuitBreakerSettings circuitBreakerSettings, Akka.Persistence.Sql.Common.Journal.ReplayFilterSettings replayFilterSettings, Akka.Persistence.Sql.Common.Journal.QueryConfiguration namingConventions, string defaultSerializer) { }
         public bool AutoInitialize { get; }
         public Akka.Persistence.Sql.Common.Journal.CircuitBreakerSettings CircuitBreakerSettings { get; }
         public string ConnectionString { get; }
@@ -65,13 +83,16 @@ namespace Akka.Persistence.Sql.Common.Journal
         [System.ObsoleteAttribute("This property should never be used for writes, use the default `System.Object` se" +
             "rializer instead")]
         public string DefaultSerializer { get; }
+        [System.ObsoleteAttribute("Use WriteIsolationLevel property instead")]
         public System.Data.IsolationLevel IsolationLevel { get; }
         public int MaxBatchSize { get; }
         public int MaxBufferSize { get; }
         public int MaxConcurrentOperations { get; }
         public Akka.Persistence.Sql.Common.Journal.QueryConfiguration NamingConventions { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         public Akka.Persistence.Sql.Common.Journal.ReplayFilterSettings ReplayFilterSettings { get; }
         public string TimestampProviderTypeName { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
     }
     public abstract class BatchingSqlJournal<TConnection, TCommand> : Akka.Persistence.Journal.WriteJournalBase
         where TConnection : System.Data.Common.DbConnection
@@ -222,13 +243,34 @@ namespace Akka.Persistence.Sql.Common.Journal
         public readonly string TagsColumnName;
         public readonly System.TimeSpan Timeout;
         public readonly string TimestampColumnName;
+        [System.ObsoleteAttribute("Use .ctor that accepts read and write IsolationLevel instead (since v1.5.2)")]
         public QueryConfiguration(string schemaName, string journalEventsTableName, string metaTableName, string persistenceIdColumnName, string sequenceNrColumnName, string payloadColumnName, string manifestColumnName, string timestampColumnName, string isDeletedColumnName, string tagsColumnName, string orderingColumnName, string serializerIdColumnName, System.TimeSpan timeout, string defaultSerializer, bool useSequentialAccess) { }
+        public QueryConfiguration(
+                    string schemaName, 
+                    string journalEventsTableName, 
+                    string metaTableName, 
+                    string persistenceIdColumnName, 
+                    string sequenceNrColumnName, 
+                    string payloadColumnName, 
+                    string manifestColumnName, 
+                    string timestampColumnName, 
+                    string isDeletedColumnName, 
+                    string tagsColumnName, 
+                    string orderingColumnName, 
+                    string serializerIdColumnName, 
+                    System.TimeSpan timeout, 
+                    string defaultSerializer, 
+                    bool useSequentialAccess, 
+                    System.Nullable<System.Data.IsolationLevel> readIsolationLevel, 
+                    System.Nullable<System.Data.IsolationLevel> writeIsolationLevel) { }
         [System.ObsoleteAttribute("This property should never be used for writes, use the default `System.Object` se" +
             "rializer instead")]
         public string DefaultSerializer { get; }
         public string FullJournalTableName { get; }
         public string FullMetaTableName { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         public bool UseSequentialAccess { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
     }
     public sealed class ReplayAllEvents : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
     {
@@ -278,6 +320,7 @@ namespace Akka.Persistence.Sql.Common.Journal
     }
     public abstract class SqlJournal : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
+        protected readonly Akka.Persistence.Sql.Common.JournalSettings Settings;
         protected SqlJournal(Akka.Configuration.Config journalConfig) { }
         protected abstract string JournalConfigPath { get; }
         protected Akka.Event.ILoggingAdapter Log { get; }
@@ -346,8 +389,10 @@ namespace Akka.Persistence.Sql.Common
         public System.TimeSpan ConnectionTimeout { get; }
         public string JournalTableName { get; }
         public string MetaTableName { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         public string SchemaName { get; }
         public string TimestampProvider { get; set; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
     }
     public class SnapshotStoreSettings
     {
@@ -360,8 +405,10 @@ namespace Akka.Persistence.Sql.Common
             "stead")]
         public string DefaultSerializer { get; }
         public string FullTableName { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         public string SchemaName { get; }
         public string TableName { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
     }
 }
 namespace Akka.Persistence.Sql.Common.Snapshot
@@ -375,7 +422,9 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         protected virtual string DeleteSnapshotRangeSql { get; }
         protected virtual string DeleteSnapshotSql { get; }
         protected virtual string InsertSnapshotSql { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         protected virtual string SelectSnapshotSql { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
         protected void AddParameter(System.Data.Common.DbCommand command, string parameterName, System.Data.DbType parameterType, object value) { }
         protected abstract System.Data.Common.DbCommand CreateCommand(System.Data.Common.DbConnection connection);
         public virtual System.Threading.Tasks.Task CreateTableAsync(System.Data.Common.DbConnection connection, System.Threading.CancellationToken cancellationToken) { }
@@ -416,9 +465,14 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         public readonly string SnapshotTableName;
         public readonly System.TimeSpan Timeout;
         public readonly string TimestampColumnName;
+        [System.ObsoleteAttribute("Use the constructor that takes read and write isolation level argument (since v1." +
+            "5.2)")]
         public QueryConfiguration(string schemaName, string snapshotTableName, string persistenceIdColumnName, string sequenceNrColumnName, string payloadColumnName, string manifestColumnName, string timestampColumnName, string serializerIdColumnName, System.TimeSpan timeout, string defaultSerializer, bool useSequentialAccess) { }
+        public QueryConfiguration(string schemaName, string snapshotTableName, string persistenceIdColumnName, string sequenceNrColumnName, string payloadColumnName, string manifestColumnName, string timestampColumnName, string serializerIdColumnName, System.TimeSpan timeout, string defaultSerializer, bool useSequentialAccess, System.Nullable<System.Data.IsolationLevel> readIsolationLevel, System.Nullable<System.Data.IsolationLevel> writeIsolationLevel) { }
         public string FullSnapshotTableName { get; }
+        public System.Data.IsolationLevel ReadIsolationLevel { get; }
         public bool UseSequentialAccess { get; }
+        public System.Data.IsolationLevel WriteIsolationLevel { get; }
     }
     public class SnapshotEntry
     {
@@ -431,6 +485,7 @@ namespace Akka.Persistence.Sql.Common.Snapshot
     }
     public abstract class SqlSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
+        protected readonly Akka.Persistence.Sql.Common.SnapshotStoreSettings Settings;
         protected SqlSnapshotStore(Akka.Configuration.Config config) { }
         protected Akka.Event.ILoggingAdapter Log { get; }
         public abstract Akka.Persistence.Sql.Common.Snapshot.ISnapshotQueryExecutor QueryExecutor { get; }


### PR DESCRIPTION
Fixes #6640

## Changes

* Add transaction to all database queries
* Add separate read and write isolation level to queries
* Add isolation level settings to sql journal and snapshot settings
* Add new HOCON key to control journal and snapshot query transaction level