### PR TITLE
[Issue #6667] New methods and tests to enable "ExpectAll" with Predicates

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/ExpectTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/ExpectTests.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="ExpectTests.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -62,7 +62,105 @@ namespace Akka.TestKit.Tests.TestKitBaseTests
                 await ExpectMsgAllOfAsync(TimeSpan.FromMilliseconds(100), new[] { "3", "1", "2" }).ToListAsync();
             }).Should().ThrowAsync<XunitException>().WithMessage("Timeout (*");
         }
-
+        
+        // Tests for "ExpectMsgAllOfMatchingPredicates" methods
+        [Fact]
+        public void ExpectMsgAllOfMatchingPredicatesAsync_should_receive_correct_messages()
+        {
+            TestActor.Tell("1");
+            TestActor.Tell("2");
+            TestActor.Tell("3");
+            TestActor.Tell("4");
+            ExpectMsgAllOfMatchingPredicates(new[]
+            {
+                PredicateInfo.Create<string>(s => s.Equals("3")), 
+                PredicateInfo.Create<string>(s => s.Equals("1")),
+                PredicateInfo.Create<string>(s => s.Equals("4")), 
+                PredicateInfo.Create<string>(s => s.Equals("2"))
+            });
+        }
+        
+        [Fact]
+        public void ExpectMsgAllOfMatchingPredicatesAsync_with_mixed_message_types_should_receive_correct_messages()
+        {
+            TestActor.Tell(1);
+            TestActor.Tell("2");
+            TestActor.Tell(3);
+            TestActor.Tell("4");
+            ExpectMsgAllOfMatchingPredicates(new[]
+            {
+                PredicateInfo.Create<int>(s => s.Equals(3)),         // type `int`
+                PredicateInfo.Create<int>(s => s.Equals(1)),         // type `int`
+                PredicateInfo.Create<string>(s => s.Equals("4")),     // type `string`
+                PredicateInfo.Create<string>(s => s.Equals("2"))      // type `string`
+            });
+        }
+        
+        [Fact]
+        public async Task ExpectMsgAllOfMatchingPredicatesAsync_with_mixed_message_types_should_receive_correct_messages_in_order()
+        {
+            TestActor.Tell(1);
+            TestActor.Tell("2");
+            TestActor.Tell(3);
+            TestActor.Tell("4");
+            await ExpectMsgAllOfMatchingPredicatesAsync(new[]
+            {
+                PredicateInfo.Create<int>(s => s.Equals(3)),         // type `int`
+                PredicateInfo.Create<int>(s => s.Equals(1)),         // type `int`
+                PredicateInfo.Create<string>(s => s.Equals("4")),     // type `string`
+                PredicateInfo.Create<string>(s => s.Equals("2"))      // type `string`
+            })
+            .ShouldOnlyContainInOrderAsync(1, "2",3, "4");
+        } 
+        
+        [Fact]
+        public async Task ExpectMsgAllOfMatchingPredicatesAsync_should_fail_when_receiving_unexpected()
+        {
+            TestActor.Tell(1);
+            TestActor.Tell("2");
+            TestActor.Tell("Totally unexpected");
+            TestActor.Tell(3);
+            await Awaiting(async () =>
+            {
+                await ExpectMsgAllOfMatchingPredicatesAsync(new []
+                {   
+                    new Predicate<int>(s => s == 3).CreatePredicateInfo(),
+                    new Predicate<int>(s => s == 1).CreatePredicateInfo(),
+                    new Predicate<string>(s => s.Equals("4")).CreatePredicateInfo(),
+                    new Predicate<string>(s => s.Equals("2")).CreatePredicateInfo()
+                }).ToListAsync();
+            }).Should().ThrowAsync<XunitException>().WithMessage("not found [*");
+        }
+        
+        [Fact]
+        public async Task ExpectMsgAllOfMatchingPredicatesAsync_should_timeout_when_not_receiving_any_messages()
+        {
+            await Awaiting(async () =>
+            {
+                await ExpectMsgAllOfMatchingPredicatesAsync(TimeSpan.FromMilliseconds(100), new []
+                {
+                    new Predicate<int>(s => s.Equals(3)).CreatePredicateInfo(),
+                    new Predicate<int>(s => s.Equals(1)).CreatePredicateInfo(),
+                    new Predicate<string>(s => s.Equals("2")).CreatePredicateInfo()
+                }).ToListAsync();
+            }).Should().ThrowAsync<XunitException>().WithMessage("Timeout (*");
+        }
+        
+        [Fact]
+        public async Task ExpectMsgAllOfMatchingPredicatesAsync_should_timeout_if_to_few_messages()
+        {
+            TestActor.Tell("1");
+            TestActor.Tell("2");
+            await Awaiting(async () =>
+            {
+                await ExpectMsgAllOfMatchingPredicatesAsync(TimeSpan.FromMilliseconds(100), new []
+                    {
+                        new Predicate<int>(s => s.Equals(3)).CreatePredicateInfo(),
+                        new Predicate<int>(s => s.Equals(1)).CreatePredicateInfo(),
+                        new Predicate<string>(s => s.Equals("2")).CreatePredicateInfo(),
+                    })
+                    .ToListAsync();
+            }).Should().ThrowAsync<XunitException>().WithMessage("Timeout (*");
+        }
     }
 }
-

--- a/src/core/Akka.TestKit/TestKitBase_ExpectAllWithPredicates.cs
+++ b/src/core/Akka.TestKit/TestKitBase_ExpectAllWithPredicates.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.TestKit.Internal;
+
+namespace Akka.TestKit;
+
+public abstract partial class TestKitBase
+{
+    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(params PredicateInfo[] predicates)
+    {
+        using var cts = new CancellationTokenSource(RemainingOrDefault);
+        return ExpectMsgAllOfMatchingPredicates(predicates, cts.Token);
+    }
+
+    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(IReadOnlyCollection<PredicateInfo> predicates,
+        CancellationToken cancellationToken)
+    {
+        return ExpectMsgAllOfMatchingPredicatesAsync(predicates, cancellationToken)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
+    public async IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(
+        IReadOnlyCollection<PredicateInfo> predicates,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var enumerable = InternalExpectMsgAllOfMatchingPredicatesAsync(new TimeSpan(0, 0, 60), predicates,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false).WithCancellation(cancellationToken);
+        await foreach (var item in enumerable)
+        {
+            yield return item;
+        }
+    }
+
+    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(TimeSpan max, params PredicateInfo[] predicates)
+    {
+        using var cts = new CancellationTokenSource(RemainingOrDefault);
+        return ExpectMsgAllOfMatchingPredicates(max, predicates, cts.Token);
+    }
+
+    public IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(TimeSpan max,
+        IReadOnlyCollection<PredicateInfo> predicates, CancellationToken cancellationToken)
+    {
+        return ExpectMsgAllOfMatchingPredicatesAsync(max, predicates, cancellationToken)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false).GetAwaiter().GetResult();
+    }
+
+    public async IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(
+        TimeSpan max,
+        IReadOnlyCollection<PredicateInfo> predicates,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        max.EnsureIsPositiveFinite("max");
+        var enumerable = InternalExpectMsgAllOfAsync(Dilated(max), predicates, cancellationToken: cancellationToken)
+            .ConfigureAwait(false).WithCancellation(cancellationToken);
+        await foreach (var item in enumerable)
+        {
+            yield return item;
+        }
+    }
+
+    private async IAsyncEnumerable<object> InternalExpectMsgAllOfMatchingPredicatesAsync(
+        TimeSpan max,
+        IReadOnlyCollection<PredicateInfo> predicateInfos,
+        bool shouldLog = false,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var predicateInfoList = predicateInfos.ToList();
+
+        ConditionalLog(shouldLog, "Expecting {0} messages during {1}", predicateInfos.Count, max);
+        var start = Now;
+
+        var unexpectedMessages = new List<object>();
+        var receivedMessages = InternalReceiveNAsync(predicateInfos.Count, max, shouldLog, cancellationToken)
+            .ConfigureAwait(false).WithCancellation(cancellationToken);
+        await foreach (var msg in receivedMessages)
+        {
+            var foundPredicateInfo = predicateInfoList.FirstOrDefault(p =>
+                p.Type == msg.GetType() && (bool)p.PredicateT.DynamicInvoke(msg));
+            if (foundPredicateInfo == null)
+                unexpectedMessages.Add(msg);
+            else
+            {
+                predicateInfoList.Remove(foundPredicateInfo);
+            }
+
+            yield return msg;
+        }
+
+        CheckMissingAndUnexpected(predicateInfoList, unexpectedMessages, "not found", "found unexpected", shouldLog,
+            $"Expected {predicateInfos.Count} messages during {max}. Failed after {Now - start}. ");
+    }
+}
+
+public class PredicateInfo
+{
+    public Type Type { get; }
+    public Delegate PredicateT { get; }
+
+    private PredicateInfo(Delegate predicateT, Type type)
+    {
+        Type = type;
+        PredicateT = predicateT;
+    }
+
+    public static PredicateInfo Create<T>(Predicate<T> predicateT)
+    {
+        return new PredicateInfo(predicateT, typeof(T));
+    }
+
+    public override string ToString()
+    {
+        return $"{GetType().FullName}<{Type.FullName}>";
+    }
+}
+
+
+
+public static class PredicateInfoFactory
+{
+    public static PredicateInfo CreatePredicateInfo<T>(this Predicate<T> predicateT)
+    {
+        return PredicateInfo.Create(predicateT);
+    }
+
+    public static PredicateInfo CreatePredicateInfo<T>(this Delegate predicateT)
+    {
+        var error = "";
+
+        var method = predicateT.Method;
+        if (method.ReturnType != typeof(bool))
+        {
+            error = "Return type of this Delegate is not a boolean. ";
+        }
+
+        var parameters = method.GetParameters();
+        if (parameters.Length != 1)
+        {
+            error += "Delegate does not take exactly one parameter.";
+        }
+
+        if (error.Length != 0)
+            throw new ArgumentException(error);
+
+        var predicate =
+            (Predicate<int>)Delegate.CreateDelegate(typeof(Predicate<int>), predicateT.Target, predicateT.Method);
+        return PredicateInfo.Create(predicate);
+    }
+}

--- a/src/core/Akka.TestKit/TestKitBase_ExpectAllWithPredicates.cs
+++ b/src/core/Akka.TestKit/TestKitBase_ExpectAllWithPredicates.cs
@@ -149,7 +149,7 @@ public static class PredicateInfoFactory
             throw new ArgumentException(error);
 
         var predicate =
-            (Predicate<int>)Delegate.CreateDelegate(typeof(Predicate<int>), predicateT.Target, predicateT.Method);
+            (Predicate<T>)Delegate.CreateDelegate(typeof(Predicate<T>), predicateT.Target, predicateT.Method);
         return PredicateInfo.Create(predicate);
     }
 }


### PR DESCRIPTION
## Changes
Adds new methods to Akka.TestKit

A new set of methods named as ExpectMsgAllOfWithPredicates that would allow setting the expectations for sets of messages using predicates. This would be similar to how the ExpectMsg methods accept Predicate<T> as a parameter.

To enable heterogeneous message types in the set, the methods would accept a collection of a new type, PredicateInfo, that would contain the type of the expected input as an instance of Type.

The wrapper class PredicateInfo would have only two properties of the types Delegate and Type. Static helper methods will be supplied as factories for safety and convenience.

