### PR TITLE
[fix][DependencyResolverSetup] Ambiguous reference in `cref` attribute

### DIFF
--- a/src/contrib/dependencyinjection/Akka.DependencyInjection/DependencyResolverSetup.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection/DependencyResolverSetup.cs
@@ -46,7 +46,7 @@ namespace Akka.DependencyInjection
     /// The <see cref="IDependencyResolver"/> will be used to access previously registered services
     /// in the creation of actors and other pieces of infrastructure inside Akka.NET.
     ///
-    /// The constructor is internal. Please use <see cref="DependencyResolverSetup.Create"/> to create a new instance.
+    /// The constructor is internal. Please use <see cref="Create(IServiceProvider)"/> to create a new instance.
     /// </summary>
     public class DependencyResolverSetup : Setup
     {


### PR DESCRIPTION
## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).