### PR TITLE
[Fix][CS0168] `RemoteDeploymentDeathWatchSpec` - The variable 'ex' never used

### DIFF
--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteDeploymentDeathWatchSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteDeploymentDeathWatchSpec.cs
@@ -69,7 +69,7 @@ namespace Akka.Remote.Tests.MultiNode
                 {
                     Sys.WhenTerminated.Wait(timeOut);
                 }
-                catch (TimeoutException ex)
+                catch (TimeoutException)
                 {
                     //TODO: add printTree
 


### PR DESCRIPTION
## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
