### PR TITLE
[CS0168] `ShardRegion` - 'ex' never used

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -967,7 +967,7 @@ namespace Akka.Cluster.Sharding
                         sender.Tell(new EntityLocation(getEntityLocation.EntityId, shardId, destinationAddress,
                             Option<IActorRef>.Create(entityRef)));
                     }
-                    catch (ActorNotFoundException ex)
+                    catch (ActorNotFoundException)
                     {
                         // entity does not exist
                         sender.Tell(new EntityLocation(getEntityLocation.EntityId, shardId, destinationAddress,


### PR DESCRIPTION
## Changes

Please provide a brief description of the changes here.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).