### PR TITLE
Fix of duplication info message for unhandled message (#6532).

### DIFF
--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/UnhandledMessageEventFilterTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/UnhandledMessageEventFilterTests.cs
@@ -5,7 +5,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -32,7 +31,7 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         public async Task Unhandled_message_should_produce_info_message()
         {
             await EventFilter
-                .Info(new Regex("^Unhandled message from"))
+                .Info()
                 .ExpectOneAsync(() => {
                     _unhandledMessageActor.Tell("whatever");
                     return Task.CompletedTask;

--- a/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
+++ b/src/core/Akka.TestKit/EventFilter/TestEventListener.cs
@@ -74,16 +74,7 @@ namespace Akka.TestKit
                 case DeadLetter letter:
                     HandleDeadLetter(letter);
                     break;
-                
-                case UnhandledMessage un:
-                {
-                    var rcp = un.Recipient;
-                    var info = new Info(rcp.Path.ToString(), rcp.GetType(), "Unhandled message from " + un.Sender + ": " + un.Message);
-                    if (!ShouldFilter(info))
-                        Print(info);
-                    break;
-                }
-                
+
                 default:
                     Print(new Debug(Context.System.Name,GetType(),message));
                     break;


### PR DESCRIPTION
Fixes #6532 

## Changes

Code that duplicates info message in TestKit has been removed. For TestKit we can use usual 
`case LogEvent logEvent:`
in the same file because every unhandled message generates Info LogEvent by default behaviour.