### PR TITLE
Change LogEvent time format from 12 to 24 hours

### DIFF
--- a/src/core/Akka/Event/LogEvent.cs
+++ b/src/core/Akka/Event/LogEvent.cs
@@ -94,8 +94,8 @@ namespace Akka.Event
         public override string ToString()
         {
             return Cause == null
-                ? $"[{LogLevel().PrettyNameFor()}][{Timestamp:MM/dd/yyyy hh:mm:ss.fffK}][Thread {Thread.ManagedThreadId:0000}][{LogSource}] {Message}"
-                : $"[{LogLevel().PrettyNameFor()}][{Timestamp:MM/dd/yyyy hh:mm:ss.fffK}][Thread {Thread.ManagedThreadId:0000}][{LogSource}] {Message}{Environment.NewLine}Cause: {Cause}";
+                ? $"[{LogLevel().PrettyNameFor()}][{Timestamp:MM/dd/yyyy HH:mm:ss.fffK}][Thread {Thread.ManagedThreadId:0000}][{LogSource}] {Message}"
+                : $"[{LogLevel().PrettyNameFor()}][{Timestamp:MM/dd/yyyy HH:mm:ss.fffK}][Thread {Thread.ManagedThreadId:0000}][{LogSource}] {Message}{Environment.NewLine}Cause: {Cause}";
         }
     }
 }


### PR DESCRIPTION
## Changes
* Change `LogEvent.ToString()` time format from 12 to 24 hours