### PR TITLE
Fix `ByteString.Copy` when requested length is zero

### DIFF
--- a/src/core/Akka.Tests/Delivery/TestConsumer.cs
+++ b/src/core/Akka.Tests/Delivery/TestConsumer.cs
@@ -192,6 +192,70 @@ public sealed class TestConsumer : ReceiveActor, IWithTimers
 }
 
 /// <summary>
+/// For testing purposes
+/// </summary>
+public sealed class ZeroLengthSerializer : SerializerWithStringManifest
+{
+    public static readonly Config Config = ConfigurationFactory.ParseString(@"
+        akka.actor {
+            serializers {
+                delivery-zero-length = ""Akka.Tests.Delivery.ZeroLengthSerializer, Akka.Tests""
+            }
+            serialization-bindings {
+                ""Akka.Tests.Delivery.ZeroLengthSerializer+TestMsg, Akka.Tests"" = delivery-zero-length
+            }
+        }");
+    
+    public class TestMsg
+    {
+        private TestMsg()
+        {
+        }
+        public static readonly TestMsg Instance = new();
+    }
+
+    public ZeroLengthSerializer(ExtendedActorSystem system) : base(system)
+    {
+    }
+
+    public override byte[] ToBinary(object obj)
+    {
+        switch (obj)
+        {
+            case TestMsg _:
+                return Array.Empty<byte>();
+            default:
+                throw new ArgumentException($"Can't serialize object of type [{obj.GetType()}]");
+        }
+    }
+
+    public override object FromBinary(byte[] bytes, string manifest)
+    {
+        switch (manifest)
+        {
+            case "A":
+                return TestMsg.Instance;
+            default:
+                throw new ArgumentException($"Unimplemented deserialization of message with manifest [{manifest}] in [{GetType()}]");
+        }
+       
+    }
+
+    public override string Manifest(object obj)
+    {
+        switch (obj)
+        {
+            case TestMsg _:
+                return "A";
+            default:
+                throw new ArgumentException($"Can't serialize object of type [{obj.GetType()}]");
+        }
+    }
+    
+    public override int Identifier => 919191;
+}
+
+/// <summary>
 /// INTERNAL API
 /// </summary>
 public sealed class TestSerializer : SerializerWithStringManifest

--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -539,6 +539,7 @@ namespace Akka.IO
         /// <returns>TBD</returns>
         public int CopyTo(byte[] buffer, int index, int count)
         {
+            if(buffer.Length == 0 && count == 0) return 0; // edge case for no-copy
             if (buffer == null) throw new ArgumentNullException(nameof(buffer));
             if (index < 0 || index >= buffer.Length) throw new ArgumentOutOfRangeException(nameof(index), "Provided index is outside the bounds of the buffer to copy to.");
             if (count > buffer.Length - index) throw new ArgumentException("Provided number of bytes to copy won't fit into provided buffer", nameof(count));
@@ -575,6 +576,7 @@ namespace Akka.IO
         /// <returns>The number of bytes copied</returns>
         public int CopyTo(ref Memory<byte> buffer, int index, int count)
         {
+            if(buffer.Length == 0 && count == 0) return 0; // edge case for no-copy
             if (index < 0 || index >= buffer.Length) throw new ArgumentOutOfRangeException(nameof(index), "Provided index is outside the bounds of the buffer to copy to.");
             if (count > buffer.Length - index) throw new ArgumentException("Provided number of bytes to copy won't fit into provided buffer", nameof(count));
 
@@ -613,6 +615,7 @@ namespace Akka.IO
         /// <returns>The number of bytes copied</returns>
         public int CopyTo(ref Span<byte> buffer, int index, int count)
         {
+            if(buffer.Length == 0 && count == 0) return 0; // edge case for no-copy
             if (index < 0 || index >= buffer.Length) throw new ArgumentOutOfRangeException(nameof(index), "Provided index is outside the bounds of the buffer to copy to.");
             if (count > buffer.Length - index) throw new ArgumentException("Provided number of bytes to copy won't fit into provided buffer", nameof(count));
 


### PR DESCRIPTION


## Changes

Fixes #6748 - underlying issue was really a `ByteString.Copy` bug that occurs when the requested length is zero and the buffer length is zero. This is a perfectly legal bounds check, but an unhandled edge case. We now no-op it properly.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).