### PR TITLE
harden ReliableDeliveryShardingSpecs

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/ReliableDeliveryShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/ReliableDeliveryShardingSpec.cs
@@ -86,7 +86,7 @@ public class ReliableDeliveryShardingSpec : TestKit.Xunit2.TestKit
             $"producer-{_idCount}");
 
         // expecting 3 end messages, one for each entity: "entity-0", "entity-1", "entity-2"
-        await consumerEndProbe.ReceiveNAsync(3, TimeSpan.FromSeconds(25)).ToListAsync();
+        await consumerEndProbe.ReceiveNAsync(3, TimeSpan.FromSeconds(5)).ToListAsync();
     }
 
     [Fact]
@@ -128,12 +128,13 @@ public class ReliableDeliveryShardingSpec : TestKit.Xunit2.TestKit
             $"p2-{_idCount}");
 
         // expecting 3 end messages, one for each entity: "entity-0", "entity-1", "entity-2"
-        var endMessages = await consumerEndProbe.ReceiveNAsync(3, TimeSpan.FromSeconds(25)).ToListAsync();
+        var endMessages = await consumerEndProbe.ReceiveNAsync(3, TimeSpan.FromSeconds(5)).ToListAsync();
 
         var producerIds = endMessages.Cast<Collected>().SelectMany(c => c.ProducerIds).ToList();
         producerIds
             .Should().BeEquivalentTo($"p1-{_idCount}-entity-0", $"p1-{_idCount}-entity-1", $"p1-{_idCount}-entity-2",
                 $"p2-{_idCount}-entity-0", $"p2-{_idCount}-entity-1", $"p2-{_idCount}-entity-2");
+       
     }
 
     [Fact]

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/ReliableDeliveryShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/ReliableDeliveryShardingSpec.cs
@@ -413,7 +413,7 @@ public class ReliableDeliveryShardingSpec : TestKit.Xunit2.TestKit
         }
 
         // redeliver also when no more messages are sent to the entity
-        await consumerProbes[1].GracefulStop(RemainingOrDefault);
+        Sys.Stop(consumerProbes[1]); // don't wait for termination
 
         var delivery4b = await consumerProbes[2].ExpectMsgAsync<ConsumerController.Delivery<Job>>();
         delivery4b.Message.Should().BeEquivalentTo(new Job("msg-4"));

--- a/src/core/Akka.Tests/Delivery/ReliableDeliverySpecs.cs
+++ b/src/core/Akka.Tests/Delivery/ReliableDeliverySpecs.cs
@@ -133,7 +133,7 @@ public class ReliableDeliverySpecs : TestKit.Xunit2.TestKit
         
         var consumerEndProbe2 = CreateTestProbe();
         var consumerController2 = Sys.ActorOf(ConsumerController.Create<Job>(Sys, Option<IActorRef>.None), $"consumerController2-{_idCount}");
-        var testConsumer2 = Sys.ActorOf(TestConsumer.PropsFor(DefaultConsumerDelay, 42, consumerEndProbe2.Ref, consumerController2), $"destination2-{_idCount}");
+        var testConsumer2 = Sys.ActorOf(TestConsumer.PropsFor(DefaultConsumerDelay, 42, consumerEndProbe2.Ref, consumerController2, supportsRestarts:true), $"destination2-{_idCount}");
         
         consumerController2.Tell(new ConsumerController.RegisterToProducerController<Job>(producerController));
         


### PR DESCRIPTION
## Changes

Fixes the following test race condition caused by forcing the test to wait until a probe gracefully stops, which can cause a re-delivery.

```
Akka.Cluster.Sharding.Tests.Delivery.ReliableDeliveryShardingSpec.ReliableDelivery_with_Sharding_must_deliver_unconfirmed_if_ShardingConsumerController_is_terminated
Expected delivery4b.Message to be Job(msg-4), but found Job(msg-3).

With configuration:
- Use declared types and members
- Compare enums by value
- Match member by name (or throw)
- Without automatic conversion.
- Be strict about the order of items in byte arrays
```
