### PR TITLE
Fix: `ProducerControllerImpl` now respects bounds when chunking large messages

### DIFF
--- a/src/core/Akka.Tests/Delivery/ProducerControllerSpec.cs
+++ b/src/core/Akka.Tests/Delivery/ProducerControllerSpec.cs
@@ -493,23 +493,6 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         seqMsg2.IsFirstChunk.Should().BeFalse();
         seqMsg2.IsLastChunk.Should().BeFalse();
         seqMsg2.SeqNr.Should().Be(2);
-        
-        // producerController.Tell(new ProducerController.Request(0L, 10L, true, false));
-        //
-        // var seqMsg3 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
-        // seqMsg3.Message.IsMessage.Should().BeFalse();
-        // seqMsg3.Message.Chunk.HasValue.Should().BeTrue();
-        // seqMsg3.IsFirstChunk.Should().BeFalse();
-        // seqMsg3.IsLastChunk.Should().BeTrue();
-        // seqMsg3.SeqNr.Should().Be(3);
-        //
-        // (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
-        //     .SendNextTo.Tell(new Job("d"));
-        // var seqMsg4 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
-        // seqMsg4.Message.IsMessage.Should().BeFalse();
-        // seqMsg4.Message.Chunk.HasValue.Should().BeTrue();
-        // seqMsg4.IsFirstChunk.Should().BeTrue();
-        // seqMsg4.IsLastChunk.Should().BeTrue();
-        // seqMsg4.SeqNr.Should().Be(4);
+       
     }
 }

--- a/src/core/Akka/Delivery/Internal/ProducerControllerImpl.cs
+++ b/src/core/Akka/Delivery/Internal/ProducerControllerImpl.cs
@@ -757,7 +757,8 @@ internal sealed class ProducerController<T> : ReceiveActor, IWithTimers
             for (var i = 0; i < chunkCount; i++)
             {
                 var isLast = i == chunkCount - 1;
-                var chunkedMessage = new ChunkedMessage(ByteString.CopyFrom(bytes, i * chunkSize, chunkSize), first,
+                var nextChunk = Math.Min(chunkSize, bytes.Length - i * chunkSize); // needs to be the next chunkSize or remaining bytes, whichever is smaller.
+                var chunkedMessage = new ChunkedMessage(ByteString.FromBytes(bytes, i * chunkSize, nextChunk), first,
                     isLast, serializerId, manifest);
 
                 first = false;

--- a/src/core/Akka/Delivery/Internal/ProducerControllerImpl.cs
+++ b/src/core/Akka/Delivery/Internal/ProducerControllerImpl.cs
@@ -747,7 +747,7 @@ internal sealed class ProducerController<T> : ReceiveActor, IWithTimers
         var bytes = serialization.Serialize(msg);
         if (bytes.Length <= chunkSize)
         {
-            var chunkedMessage = new ChunkedMessage(ByteString.CopyFrom(bytes), true, true, serializerId, manifest);
+            var chunkedMessage = new ChunkedMessage(ByteString.FromBytes(bytes), true, true, serializerId, manifest);
             yield return chunkedMessage;
         }
         else


### PR DESCRIPTION
## Changes

close #6754 

Error was caused by requesting a chunkSize greater than the remaining bytes. Also - changed methods so we no longer copy memory during chunking.

Also - fixed the `BytesString` calls so we no longer copy memory when creating chunks, instead we re-use the same `byte[]` produced initially by the serializer.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #6754
