### PR TITLE
Upgrade Akka.MultiNodeTestRunner to 1.5.6

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,7 @@
     <FsCheckVersion>2.16.5</FsCheckVersion>
     <HoconVersion>2.0.3</HoconVersion>
     <ConfigurationManagerVersion>6.0.1</ConfigurationManagerVersion>
-    <MultiNodeAdapterVersion>1.5.0</MultiNodeAdapterVersion>
+    <MultiNodeAdapterVersion>1.5.6</MultiNodeAdapterVersion>
     <MicrosoftLibVersion>5.0.0</MicrosoftLibVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>


### PR DESCRIPTION
working on resolving some binary compatibility issues that emerged after adding Polyfill, we think.
