### PR TITLE
Revert "Make `HandleActorTaskSchedulerMessage` method `protected virtual` (#6763)"

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -100,8 +100,6 @@ namespace Akka.Actor
         public static Akka.Actor.IActorRef GetCurrentSelfOrNoSender() { }
         public static Akka.Actor.IActorRef GetCurrentSenderOrNoSender() { }
         public Akka.Actor.IInternalActorRef GetSingleChild(string name) { }
-        [Akka.Annotations.InternalApiAttribute()]
-        protected virtual void HandleActorTaskSchedulerMessage(Akka.Dispatch.SysMsg.ActorTaskSchedulerMessage m) { }
         public void Init(bool sendSupervise, Akka.Dispatch.MailboxType mailboxType) { }
         public Akka.Actor.Internal.ChildRestartStats InitChild(Akka.Actor.IInternalActorRef actor) { }
         public void Invoke(Akka.Actor.Envelope envelope) { }
@@ -3128,16 +3126,6 @@ namespace Akka.Dispatch.SysMsg
     {
         public ActorTask(System.Threading.Tasks.Task task) { }
         public System.Threading.Tasks.Task Task { get; }
-    }
-    [Akka.Annotations.InternalApiAttribute()]
-    public sealed class ActorTaskSchedulerMessage : Akka.Dispatch.SysMsg.SystemMessage
-    {
-        public ActorTaskSchedulerMessage(Akka.Dispatch.ActorTaskScheduler scheduler, System.Threading.Tasks.Task task, object message) { }
-        public ActorTaskSchedulerMessage(System.Exception exception, object message) { }
-        public System.Exception Exception { get; }
-        public object Message { get; }
-        public void ExecuteTask() { }
-        public override string ToString() { }
     }
     public sealed class Create : Akka.Dispatch.SysMsg.SystemMessage
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -100,8 +100,6 @@ namespace Akka.Actor
         public static Akka.Actor.IActorRef GetCurrentSelfOrNoSender() { }
         public static Akka.Actor.IActorRef GetCurrentSenderOrNoSender() { }
         public Akka.Actor.IInternalActorRef GetSingleChild(string name) { }
-        [Akka.Annotations.InternalApiAttribute()]
-        protected virtual void HandleActorTaskSchedulerMessage(Akka.Dispatch.SysMsg.ActorTaskSchedulerMessage m) { }
         public void Init(bool sendSupervise, Akka.Dispatch.MailboxType mailboxType) { }
         public Akka.Actor.Internal.ChildRestartStats InitChild(Akka.Actor.IInternalActorRef actor) { }
         public void Invoke(Akka.Actor.Envelope envelope) { }
@@ -3120,16 +3118,6 @@ namespace Akka.Dispatch.SysMsg
     {
         public ActorTask(System.Threading.Tasks.Task task) { }
         public System.Threading.Tasks.Task Task { get; }
-    }
-    [Akka.Annotations.InternalApiAttribute()]
-    public sealed class ActorTaskSchedulerMessage : Akka.Dispatch.SysMsg.SystemMessage
-    {
-        public ActorTaskSchedulerMessage(Akka.Dispatch.ActorTaskScheduler scheduler, System.Threading.Tasks.Task task, object message) { }
-        public ActorTaskSchedulerMessage(System.Exception exception, object message) { }
-        public System.Exception Exception { get; }
-        public object Message { get; }
-        public void ExecuteTask() { }
-        public override string ToString() { }
     }
     public sealed class Create : Akka.Dispatch.SysMsg.SystemMessage
     {

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -14,7 +14,6 @@ using Akka.Dispatch.SysMsg;
 using Akka.Event;
 using Debug = Akka.Event.Debug;
 using System.Globalization;
-using Akka.Annotations;
 
 namespace Akka.Actor
 {
@@ -335,8 +334,7 @@ namespace Akka.Actor
             SysMsgInvokeAll(new EarliestFirstSystemMessageList((SystemMessage)envelope), CalculateState());
         }
 
-        [InternalApi]
-        protected virtual void HandleActorTaskSchedulerMessage(ActorTaskSchedulerMessage m)
+        private void HandleActorTaskSchedulerMessage(ActorTaskSchedulerMessage m)
         {
             //set the current message captured in the async operation
             //current message was cleared earlier when the async receive handler completed

--- a/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
+++ b/src/core/Akka/Dispatch/SysMsg/ISystemMessage.cs
@@ -588,8 +588,7 @@ namespace Akka.Dispatch.SysMsg
     /// <summary>
     /// TBD
     /// </summary>
-    [InternalApi] 
-    public sealed class ActorTaskSchedulerMessage : SystemMessage
+    internal sealed class ActorTaskSchedulerMessage : SystemMessage
     {
         private readonly ActorTaskScheduler _scheduler;
         private readonly Task _task;


### PR DESCRIPTION
This reverts commit 1345e5849d2cfb4958543806a460dfbd850aed8d.

Reverting #6763 for now, will need to re-implement later in 1.5.8