### PR TITLE
Add Cluster.Sharding DData backward compatibility wire format mode

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/Properties/AssemblyInfo.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Properties/AssemblyInfo.cs
@@ -14,6 +14,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: InternalsVisibleTo("Akka.DistributedData.Tests")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Serialization/ClusterShardingMessageSerializer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Serialization/ClusterShardingMessageSerializer.cs
@@ -446,7 +446,7 @@ namespace Akka.Cluster.Sharding.Serialization
         }
 
         //
-        // ShardCoordinator.State
+        // ShardCoordinator.CoordinatorState
         //
         private static Proto.Msg.CoordinatorState CoordinatorStateToProto(ShardCoordinator.CoordinatorState state)
         {

--- a/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
@@ -214,6 +214,10 @@ akka.cluster.sharding {
     # can become to large if including to many in same message. Limit to
     # the same number as the number of ORSet per shard.
     max-delta-elements = 5
+    
+    # Turn on backward compatibility wire format mode that allows Akka.Cluster.Sharding 
+    # v1.5.8 distributed data to communicate with v1.4.x
+    backward-compatible-wire-format = false
   }
   # The id of the dispatcher to use for ClusterSharding actors.
   # If not specified, the internal dispatcher is used.

--- a/src/contrib/cluster/Akka.DistributedData.Tests/Akka.DistributedData.Tests.csproj
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/Akka.DistributedData.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
  
   <ItemGroup>
+    <ProjectReference Include="..\Akka.Cluster.Sharding\Akka.Cluster.Sharding.csproj" />
     <ProjectReference Include="..\Akka.DistributedData.LightningDB\Akka.DistributedData.LightningDB.csproj" />
     <ProjectReference Include="..\Akka.DistributedData\Akka.DistributedData.csproj" />
     <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />

--- a/src/contrib/cluster/Akka.DistributedData.Tests/Serialization/ReplicatedDataSerializerBackCompatSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/Serialization/ReplicatedDataSerializerBackCompatSpec.cs
@@ -1,0 +1,49 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ReplicatedDataSerializerBackCompatSpec.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Cluster.Sharding;
+using Akka.DistributedData.Serialization;
+using Akka.DistributedData.Serialization.Proto.Msg;
+using FluentAssertions;
+using Xunit;
+using UniqueAddress = Akka.Cluster.UniqueAddress;
+using static FluentAssertions.FluentActions;
+
+namespace Akka.DistributedData.Tests.Serialization;
+
+public class ReplicatedDataSerializerBackCompatSpec
+{
+    private readonly ReplicatedDataSerializer _serializer;
+    private readonly UniqueAddress _address;
+    
+    public ReplicatedDataSerializerBackCompatSpec()
+    {
+        var sys = ActorSystem.Create("test", @"
+akka.actor.provider = cluster
+akka.cluster.sharding.distributed-data.backward-compatible-wire-format = true");
+        _serializer = new ReplicatedDataSerializer((ExtendedActorSystem)sys);
+        _address = Cluster.Cluster.Get(sys).SelfUniqueAddress;
+        sys.Terminate();
+    }
+
+    [Fact(DisplayName = "DData replicated data serializer should serialize and deserialize correct backward compatible proto message")]
+    public void SerializeTest()
+    {
+        var lwwReg = new LWWRegister<ShardCoordinator.CoordinatorState>(_address, ShardCoordinator.CoordinatorState.Empty);
+        var bytes = _serializer.ToBinary(lwwReg);
+        var proto = LWWRegister.Parser.ParseFrom(bytes);
+        
+        // Serialized type name should be equal to the old v1.4 coordinator state FQCN
+        proto.TypeInfo.TypeName.Should().Be("Akka.Cluster.Sharding.PersistentShardCoordinator+State, Akka.Cluster.Sharding");
+        
+        // Deserializing the same message should succeed
+        Invoking(() => _serializer.FromBinary(bytes, _serializer.Manifest(lwwReg)))
+            .Should().NotThrow()
+            .And.Subject().Should().BeOfType<LWWRegister<ShardCoordinator.CoordinatorState>>();
+    }
+}

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
@@ -1,6 +1,7 @@
 ﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData.Tests")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("a05c31e8-0246-46a1-b3bc-4d6fe7a9aa49")]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
@@ -1,6 +1,7 @@
 ﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData.Tests")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("a05c31e8-0246-46a1-b3bc-4d6fe7a9aa49")]
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]


### PR DESCRIPTION
Fixes #6704

## Changes

- Add `akka.cluster.sharding.distributed-data.backward-compatible-wire-format` to allow v1.5 to talk with v1.4
- Add DData hack to convert v1.4 to v1.5 data structure serialization

## NOTES

- When `backward-compatible-wire-format` is set to true, `Cluster.Sharding` will not be able to talk to any Cluster.Sharding v1.5.0-v1.5.7, so if `Cluster.Sharding` were to talk to v1.4.x, all v1.5 nodes have to be updated to the version with this fix.