### PR TITLE
Do not use expression based options for backoff props

### DIFF
--- a/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
+++ b/src/core/Akka/Pattern/BackoffOnRestartSupervisor.cs
@@ -24,6 +24,10 @@ namespace Akka.Pattern
         private readonly OneForOneStrategy _strategy;
         private readonly ILoggingAdapter _log = Context.GetLogger();
 
+        /// <devremarks>
+        /// If the arguments here change, you -must- change the invocation in <see cref="BackoffOptions"/> accordingly!
+        /// Expression based props are too slow for many scenarios, so we must drop compile time safety for that sake.
+        /// </devremarks>
         public BackoffOnRestartSupervisor(
             Props childProps,
             string childName,

--- a/src/core/Akka/Pattern/BackoffOptions.cs
+++ b/src/core/Akka/Pattern/BackoffOptions.cs
@@ -210,9 +210,9 @@ namespace Akka.Pattern
                 switch (_backoffType)
                 {
                     case RestartImpliesFailure _:
-                        return Props.Create(() => new BackoffOnRestartSupervisor(_childProps, _childName, _minBackoff, _maxBackoff, _reset, _randomFactor, _strategy, _replyWhileStopped, _finalStopMessage));
+                        return Props.Create<BackoffOnRestartSupervisor>(_childProps, _childName, _minBackoff, _maxBackoff, _reset, _randomFactor, _strategy, _replyWhileStopped, _finalStopMessage);
                     case StopImpliesFailure _:
-                        return Props.Create(() => new BackoffSupervisor(_childProps, _childName, _minBackoff, _maxBackoff, _reset, _randomFactor, _strategy, _replyWhileStopped, _finalStopMessage));
+                        return Props.Create<BackoffSupervisor>(_childProps, _childName, _minBackoff, _maxBackoff, _reset, _randomFactor, _strategy, _replyWhileStopped, _finalStopMessage);
                     default:
                         return Props.Empty;
                 }

--- a/src/core/Akka/Pattern/BackoffSupervisor.cs
+++ b/src/core/Akka/Pattern/BackoffSupervisor.cs
@@ -117,6 +117,10 @@ namespace Akka.Pattern
         {
         }
 
+        /// <summary>
+        /// If the arguments here change, you -must- change the invocation in <see cref="BackoffOptions"/> accordingly!
+        /// Expression based props are too slow for many scenarios, so we must drop compile time safety for that sake.  
+        /// </summary>
         public BackoffSupervisor(
             Props childProps,
             string childName,


### PR DESCRIPTION
Fixes #6804. See #4698 for background.

## Changes

Change `BackoffOptions` props to be non-expression based