### PR TITLE
Do not use expression based props for long lived streams

### DIFF
--- a/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
+++ b/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
@@ -648,7 +648,7 @@ namespace Akka.Streams.Implementation
         /// </summary>
         /// <param name="settings">TBD</param>
         /// <param name="haveShutdown">TBD</param>
-        /// If this changes you must also change <see cref="StreamSupervisor.Props"/> as well!
+        /// If this changes you must also change StreamSupervisor.Props as well!
         public StreamSupervisor(ActorMaterializerSettings settings, AtomicBoolean haveShutdown)
         {
             Settings = settings;

--- a/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
+++ b/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
@@ -624,7 +624,7 @@ namespace Akka.Streams.Implementation
         /// <param name="haveShutdown">TBD</param>
         /// <returns>TBD</returns>
         public static Props Props(ActorMaterializerSettings settings, AtomicBoolean haveShutdown)
-            => Actor.Props.Create(() => new StreamSupervisor(settings, haveShutdown)).WithDeploy(Deploy.Local);
+            => Actor.Props.Create<StreamSupervisor>(settings, haveShutdown).WithDeploy(Deploy.Local);
 
         /// <summary>
         /// TBD
@@ -648,6 +648,7 @@ namespace Akka.Streams.Implementation
         /// </summary>
         /// <param name="settings">TBD</param>
         /// <param name="haveShutdown">TBD</param>
+        /// If this changes you must also change <see cref="StreamSupervisor.Props"/> as well!
         public StreamSupervisor(ActorMaterializerSettings settings, AtomicBoolean haveShutdown)
         {
             Settings = settings;

--- a/src/core/Akka.Streams/Implementation/ActorRefSinkActor.cs
+++ b/src/core/Akka.Streams/Implementation/ActorRefSinkActor.cs
@@ -24,7 +24,7 @@ namespace Akka.Streams.Implementation
         /// <param name="onCompleteMessage">TBD</param>
         /// <returns>TBD</returns>
         public static Props Props(IActorRef @ref, int highWatermark, object onCompleteMessage)
-            => Actor.Props.Create(() => new ActorRefSinkActor(@ref, highWatermark, onCompleteMessage));
+            => Actor.Props.Create<ActorRefSinkActor>(@ref, highWatermark, onCompleteMessage);
 
         private ILoggingAdapter _log;
 
@@ -47,6 +47,7 @@ namespace Akka.Streams.Implementation
         /// <param name="ref">TBD</param>
         /// <param name="highWatermark">TBD</param>
         /// <param name="onCompleteMessage">TBD</param>
+        /// If this gets changed you must change <see cref="ActorRefSinkActor.Props"/> as well!
         public ActorRefSinkActor(IActorRef @ref, int highWatermark, object onCompleteMessage)
         {
             Ref = @ref;

--- a/src/core/Akka.Streams/Implementation/ActorRefSourceActor.cs
+++ b/src/core/Akka.Streams/Implementation/ActorRefSourceActor.cs
@@ -34,7 +34,7 @@ namespace Akka.Streams.Implementation
                 throw new NotSupportedException("Backpressure overflow strategy not supported");
 
             var maxFixedBufferSize = settings.MaxFixedBufferSize;
-            return Actor.Props.Create(() => new ActorRefSourceActor<T>(bufferSize, overflowStrategy, maxFixedBufferSize));
+            return Actor.Props.Create<ActorRefSourceActor<T>>(bufferSize, overflowStrategy, maxFixedBufferSize);
         }
 
         /// <summary>
@@ -58,6 +58,7 @@ namespace Akka.Streams.Implementation
         /// <param name="bufferSize">TBD</param>
         /// <param name="overflowStrategy">TBD</param>
         /// <param name="maxFixedBufferSize">TBD</param>
+        /// If this changes you must also change <see cref="ActorRefSourceActor{T}.Props"/> as well!
         public ActorRefSourceActor(int bufferSize, OverflowStrategy overflowStrategy, int maxFixedBufferSize)
         {
             BufferSize = bufferSize;

--- a/src/core/Akka.Streams/Implementation/FanOut.cs
+++ b/src/core/Akka.Streams/Implementation/FanOut.cs
@@ -708,7 +708,7 @@ namespace Akka.Streams.Implementation
         /// <param name="settings">TBD</param>
         /// <returns>TBD</returns>
         public static Props Props<T>(ActorMaterializerSettings settings)
-            => Actor.Props.Create(() => new Unzip<T>(settings, 2)).WithDeploy(Deploy.Local);
+            => Actor.Props.Create<Unzip<T>>(settings, 2).WithDeploy(Deploy.Local);
     }
 
     /// <summary>
@@ -728,6 +728,7 @@ namespace Akka.Streams.Implementation
         /// This exception is thrown when the elements in <see cref="Akka.Streams.Implementation.FanOut{T}.PrimaryInputs"/>
         /// are of an unknown type.
         /// </exception>>
+        /// If this gets changed you must change <see cref="Akka.Streams.Implementation.FanOut.Unzip{T}"/> as well!
         public Unzip(ActorMaterializerSettings settings, int outputCount = 2) : base(settings, outputCount)
         {
             OutputBunch.MarkAllOutputs();

--- a/src/core/Akka.Streams/Implementation/FanoutProcessorImpl.cs
+++ b/src/core/Akka.Streams/Implementation/FanoutProcessorImpl.cs
@@ -227,7 +227,7 @@ namespace Akka.Streams.Implementation
         /// <param name="onTerminated">TBD</param>
         /// <returns>TBD</returns>
         public static Props Props(ActorMaterializerSettings settings, Action onTerminated = null)
-            => Actor.Props.Create(() => new FanoutProcessorImpl<T, TStreamBuffer>(settings, onTerminated)).WithDeploy(Deploy.Local);
+            => Actor.Props.Create<FanoutProcessorImpl<T, TStreamBuffer>>(settings, onTerminated).WithDeploy(Deploy.Local);
 
         /// <summary>
         /// TBD
@@ -239,6 +239,7 @@ namespace Akka.Streams.Implementation
         /// </summary>
         /// <param name="settings">TBD</param>
         /// <param name="onTerminated">TBD</param>
+        /// If this gets changed you must change <see cref="FanoutProcessorImpl{T,TStreamBuffer}.Props"/> as well!
         public FanoutProcessorImpl(ActorMaterializerSettings settings, Action onTerminated) : base(settings)
         {
             PrimaryOutputs = new FanoutOutputs<T, TStreamBuffer>(settings.MaxInputBufferSize,

--- a/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
@@ -1315,7 +1315,8 @@ namespace Akka.Streams.Implementation.Fusing
         /// </summary>
         /// <param name="shell">TBD</param>
         /// <returns>TBD</returns>
-        public static Props Props(GraphInterpreterShell shell) => Actor.Props.Create(() => new ActorGraphInterpreter(shell)).WithDeploy(Deploy.Local);
+        public static Props Props(GraphInterpreterShell shell) => Actor.Props
+            .Create<ActorGraphInterpreter>(shell).WithDeploy(Deploy.Local);
 
         private ISet<GraphInterpreterShell> _activeInterpreters = new HashSet<GraphInterpreterShell>();
         private readonly Queue<GraphInterpreterShell> _newShells = new Queue<GraphInterpreterShell>();
@@ -1332,6 +1333,7 @@ namespace Akka.Streams.Implementation.Fusing
         /// TBD
         /// </summary>
         /// <param name="shell">TBD</param>
+        /// If this ctor gets changed you -must- change <see cref="ActorGraphInterpreter.Props"/> as well!
         public ActorGraphInterpreter(GraphInterpreterShell shell)
         {
             _initial = shell;

--- a/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
+++ b/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
@@ -57,7 +57,7 @@ namespace Akka.Streams.Implementation.IO
             if (maxBuffer < initialBuffer)
                 throw new ArgumentException($"maxBuffer must be >= initialBuffer (was {maxBuffer})", nameof(maxBuffer));
 
-            return Actor.Props.Create(() => new FilePublisher(f, completionPromise, chunkSize, startPosition, maxBuffer))
+            return Actor.Props.Create<FilePublisher>( f, completionPromise, chunkSize, startPosition, maxBuffer)
                 .WithDeploy(Deploy.Local);
         }
 
@@ -86,6 +86,7 @@ namespace Akka.Streams.Implementation.IO
         /// <param name="chunkSize">TBD</param>
         /// <param name="startPosition">TBD</param>
         /// <param name="maxBuffer">TBD</param>
+        /// If this changes you must also change <see cref="FilePublisher.Props"/> as well!
         public FilePublisher(FileInfo f, TaskCompletionSource<IOResult> completionPromise, int chunkSize, long startPosition, int maxBuffer)
         {
             _f = f;

--- a/src/core/Akka.Streams/Implementation/IO/FileSubscriber.cs
+++ b/src/core/Akka.Streams/Implementation/IO/FileSubscriber.cs
@@ -48,7 +48,7 @@ namespace Akka.Streams.Implementation.IO
             if (startPosition < 0)
                 throw new ArgumentException($"startPosition must be >= 0 (was {startPosition})", nameof(startPosition));
 
-            return Actor.Props.Create(() => new FileSubscriber(f, completionPromise, bufferSize, startPosition, fileMode, autoFlush, flushCommand))
+            return Actor.Props.Create<FileSubscriber>(f, completionPromise, bufferSize, startPosition, fileMode, autoFlush, flushCommand)
                 .WithDeploy(Deploy.Local);
         }
 
@@ -72,6 +72,7 @@ namespace Akka.Streams.Implementation.IO
         /// <param name="fileMode">TBD</param>
         /// <param name="autoFlush"></param>
         /// <param name="flushSignaler"></param>
+        /// If this changes you must change <see cref="FileSubscriber.Props"/> as well!
         public FileSubscriber(
             FileInfo f,
             TaskCompletionSource<IOResult> completionPromise,

--- a/src/core/Akka.Streams/Implementation/IO/InputStreamPublisher.cs
+++ b/src/core/Akka.Streams/Implementation/IO/InputStreamPublisher.cs
@@ -37,7 +37,7 @@ namespace Akka.Streams.Implementation.IO
             if (chunkSize <= 0)
                 throw new ArgumentException($"chunkSize must be > 0 was {chunkSize}", nameof(chunkSize));
 
-            return Actor.Props.Create(()=> new InputStreamPublisher(inputstream, completionSource, chunkSize)).WithDeploy(Deploy.Local);
+            return Actor.Props.Create<InputStreamPublisher>(inputstream, completionSource, chunkSize).WithDeploy(Deploy.Local);
         }
 
         private struct Continue : IDeadLetterSuppression
@@ -58,6 +58,7 @@ namespace Akka.Streams.Implementation.IO
         /// <param name="inputstream">TBD</param>
         /// <param name="completionSource">TBD</param>
         /// <param name="chunkSize">TBD</param>
+        /// If this gets changed you must change <see cref="InputStreamPublisher.Props"/> as well!
         public InputStreamPublisher(Stream inputstream, TaskCompletionSource<IOResult> completionSource, int chunkSize)
         {
             _inputstream = inputstream;

--- a/src/core/Akka.Streams/Implementation/IO/OutputStreamSubscriber.cs
+++ b/src/core/Akka.Streams/Implementation/IO/OutputStreamSubscriber.cs
@@ -36,7 +36,7 @@ namespace Akka.Streams.Implementation.IO
                 throw new ArgumentException("Buffer size must be > 0");
 
             return
-                Actor.Props.Create(() => new OutputStreamSubscriber(os, completionPromise, bufferSize, autoFlush))
+                Actor.Props.Create<OutputStreamSubscriber>(os, completionPromise, bufferSize, autoFlush)
                     .WithDeploy(Deploy.Local);
         }
 
@@ -53,6 +53,7 @@ namespace Akka.Streams.Implementation.IO
         /// <param name="completionPromise">TBD</param>
         /// <param name="bufferSize">TBD</param>
         /// <param name="autoFlush">TBD</param>
+        /// If this gets changed you must change <see cref="OutputStreamSubscriber.Props"/> as well!
         public OutputStreamSubscriber(Stream outputStream, TaskCompletionSource<IOResult> completionPromise, int bufferSize, bool autoFlush)
         {
             _outputStream = outputStream;


### PR DESCRIPTION
Fixes #6806 . See https://github.com/akkadotnet/akka.net/issues/4698 for background.

## Changes

Akka.Streams no longer uses Expression based Props (at least, in easily located scenarios.)