### PR TITLE
Akka.Remote: log all layers of wrapped messages during errors

### DIFF
--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Dsl;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.Remote.Transport;
 using Akka.Routing;
 using Akka.TestKit;
@@ -649,6 +650,21 @@ namespace Akka.Remote.Tests
                 {
                     await VerifySendAsync(oversized, async () => { await ExpectNoMsgAsync(); });
                 });
+        }
+
+        /// <summary>
+        /// Validate that we can accurately log wrapped messages that fail to be delivered
+        /// </summary>
+        [Fact]
+        public void Log_Wrapped_messages_that_fail_to_Send()
+        {
+            // 2x wrapped message
+            var wrappedMessage =
+                new DeadLetter(new ActorSelectionMessage("hit", Array.Empty<SelectionPathElement>(), false), TestActor,
+                    TestActor);
+
+            var loggedType = EndpointWriter.LogPossiblyWrappedMessageType(wrappedMessage);
+            loggedType.Should().Contain("DeadLetter").And.Contain("ActorSelectionMessage").And.Contain("String");
         }
 
         [Fact]


### PR DESCRIPTION
## Changes

Make sure we capture what the real underlying message types are when we encounter issues like serialization errors, oversized payload exceptions, and so on.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
