### PR TITLE
Added spec to demonstrate failed snapshot-only recovery

### DIFF
--- a/src/core/Akka.Persistence.TestKit/Akka.Persistence.TestKit.csproj
+++ b/src/core/Akka.Persistence.TestKit/Akka.Persistence.TestKit.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence.TestKit</AssemblyTitle>
     <Description>TestKit for writing tests for Akka.NET Persistance module.</Description>
-    <TargetFrameworks>$(NetStandardLibVersion)</TargetFrameworks>
+    <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
     <PackageTags>$(AkkaPackageTags);testkit;persistance</PackageTags>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
+++ b/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\contrib\serializers\Akka.Serialization.Hyperion\Akka.Serialization.Hyperion.csproj" />
+    <ProjectReference Include="..\Akka.Persistence.TestKit.Xunit2\Akka.Persistence.TestKit.Xunit2.csproj" />
     <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj" />
     <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj" />
     <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />

--- a/src/core/Akka.Persistence.Tests/FailedSnapshotStoreRecoverySpec.cs
+++ b/src/core/Akka.Persistence.Tests/FailedSnapshotStoreRecoverySpec.cs
@@ -137,10 +137,13 @@ public class FailedSnapshotStoreRecoverySpec : PersistenceTestKit
         // act
         await WithSnapshotLoad(SelectBehavior, async () =>
         {
-            var actor2 = Sys.ActorOf(Props.Create(() => new PersistentActor("p1", probe.Ref)));
-            Watch(actor2);
-            await probe.ExpectNoMsgAsync();
-            await ExpectTerminatedAsync(actor2);
+            await WithinAsync(RemainingOrDefault, async () =>
+            {
+                var actor2 = Sys.ActorOf(Props.Create(() => new PersistentActor("p1", probe.Ref)));
+                Watch(actor2);
+                await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(150));
+                await ExpectTerminatedAsync(actor2);
+            });
         });
 
     }

--- a/src/core/Akka.Persistence.Tests/FailedSnapshotStoreRecoverySpec.cs
+++ b/src/core/Akka.Persistence.Tests/FailedSnapshotStoreRecoverySpec.cs
@@ -1,0 +1,147 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="FailedSnapshotStoreRecoverySpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Persistence.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Tests;
+
+/// <summary>
+/// Scenario: actor that uses ONLY the SnapshotStore fails to recover - what happens?
+/// </summary>
+public class FailedSnapshotStoreRecoverySpec : PersistenceTestKit
+{
+    public enum FailureMode
+    {
+        Explicit,
+        Timeout
+    }
+
+    public static readonly Config Config = ConfigurationFactory.ParseString(@"
+        # need to set recovery timeout to 1s
+        akka.persistence.journal-plugin-fallback.recovery-event-timeout = 1s
+    ");
+    
+    public FailedSnapshotStoreRecoverySpec(ITestOutputHelper output) : base(Config, output:output){}
+    
+    private record Save(string Data);
+
+    private record Fetch();
+
+    private record SnapshotSaved();
+    private record RecoveryCompleted();
+    
+    public sealed class PersistentActor : UntypedPersistentActor
+    {
+        public PersistentActor(string persistenceId, IActorRef targetActor)
+        {
+            PersistenceId = persistenceId;
+            _targetActor = targetActor;
+        }
+
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+        private readonly IActorRef _targetActor;
+
+        public override string PersistenceId { get; }
+        public string CurrentData { get; set; } = "none";
+        protected override void OnCommand(object message)
+        {
+            switch (message)
+            {
+                case Save s:
+                {
+                    CurrentData = s.Data;
+                    SaveSnapshot(CurrentData);
+                    Sender.Tell("ack");
+                    break;
+                }
+                case Fetch:
+                {
+                    Sender.Tell(CurrentData);
+                    break;
+                }
+                case SaveSnapshotSuccess success:
+                {
+                    _log.Info("Snapshot saved");
+                    _targetActor.Tell(new SnapshotSaved());
+                    break;
+                }
+                case SaveSnapshotFailure failure:
+                {
+                    _log.Error(failure.Cause, "Snapshot failed");
+                    break;
+                }
+            }
+        }
+
+        protected override void OnRecover(object message)
+        {
+            switch (message)
+            {
+                case SnapshotOffer { Snapshot: string str }:
+                {
+                    CurrentData = str;
+                    break;
+                }
+            }
+        }
+
+        protected override void OnReplaySuccess()
+        {
+            _targetActor.Tell(new RecoveryCompleted());
+        }
+
+        protected override void OnRecoveryFailure(Exception reason, object message = null)
+        {
+            _log.Error(reason, "Recovery failed");
+            base.OnRecoveryFailure(reason, message);
+        }
+    }
+
+    [Theory(DisplayName = "PersistentActor using Snapshots only must fail if snapshots are irrecoverable")]
+    [InlineData(FailureMode.Explicit)]
+    [InlineData(FailureMode.Timeout)]
+    public async Task PersistentActor_using_Snapshots_only_must_fail_if_snapshots_irrecoverable(FailureMode mode)
+    {
+        // arrange
+        var probe = CreateTestProbe();
+        var actor = Sys.ActorOf(Props.Create(() => new PersistentActor("p1", probe.Ref)));
+        await probe.ExpectMsgAsync<RecoveryCompleted>();
+        actor.Tell(new Save("a"), probe);
+        await probe.ExpectMsgAsync("ack");
+        await probe.ExpectMsgAsync<SnapshotSaved>();
+        await actor.GracefulStop(RemainingOrDefault);
+
+        Task SelectBehavior(SnapshotStoreLoadBehavior behavior)
+        {
+            switch (mode)
+            {
+                case FailureMode.Timeout:
+                    return behavior.FailWithDelay(TimeSpan.FromMinutes(1));
+                case FailureMode.Explicit:
+                default:
+                    return behavior.Fail();
+            }
+        }
+
+        // act
+        await WithSnapshotLoad(SelectBehavior, async () =>
+        {
+            var actor2 = Sys.ActorOf(Props.Create(() => new PersistentActor("p1", probe.Ref)));
+            Watch(actor2);
+            await probe.ExpectNoMsgAsync();
+            await ExpectTerminatedAsync(actor2);
+        });
+
+    }
+}


### PR DESCRIPTION
## Changes

Tests whether a persistent actor will properly fail during a failed snapshot recovery or during a timed out one. This is all without ever having saved an event to the journal, so the `MaxSeqNo` is set to `0`.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.
