### PR TITLE
Reduced nesting levels through block-scoped using statements in `AkkaCluster.Tests`

### DIFF
--- a/src/core/Akka.Cluster.Tests/ActorRefProvidersConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ActorRefProvidersConfigSpec.cs
@@ -42,12 +42,10 @@ namespace Akka.Cluster.Tests
         {
             var config = ConfigurationFactory.ParseString(@"akka.actor.provider = " + alias)
                 .WithFallback(ConfigurationFactory.ParseString("akka.remote.dot-netty.tcp.port = 0")); // use a random port to avoid issues with async and parallelization
-            using (var system = ActorSystem.Create(nameof(ActorRefProvidersConfigSpec), config))
-            {
-                var ext = (ExtendedActorSystem) system;
-                ext.Provider.GetType().ShouldBe(actorProviderType);
-                system.Terminate().Wait(TimeSpan.FromSeconds(3)); // force the system to cleanup and shutdown
-            }
+            using var system = ActorSystem.Create(nameof(ActorRefProvidersConfigSpec), config);
+            var ext = (ExtendedActorSystem)system;
+            ext.Provider.GetType().ShouldBe(actorProviderType);
+            system.Terminate().Wait(TimeSpan.FromSeconds(3)); // force the system to cleanup and shutdown
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
+++ b/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
@@ -6,7 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Threading;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
@@ -94,14 +93,12 @@ namespace Akka.Cluster.Tests
         {
             var config = ConfigurationFactory.ParseString(
                 @"akka.cluster.downing-provider-class = ""Akka.Cluster.Tests.DummyDowningProvider, Akka.Cluster.Tests""");
-            using (var system = ActorSystem.Create("auto-downing", config.WithFallback(BaseConfig)))
-            {
-                var downingProvider = Cluster.Get(system).DowningProvider;
-                downingProvider.Should().BeOfType<DummyDowningProvider>();
-                AwaitCondition(() =>
-                    ((DummyDowningProvider)downingProvider).ActorPropsAccessed.Value,
-                    TimeSpan.FromSeconds(3));
-            }
+            using var system = ActorSystem.Create("auto-downing", config.WithFallback(BaseConfig));
+            var downingProvider = Cluster.Get(system).DowningProvider;
+            downingProvider.Should().BeOfType<DummyDowningProvider>();
+            AwaitCondition(() =>
+                ((DummyDowningProvider)downingProvider).ActorPropsAccessed.Value,
+                TimeSpan.FromSeconds(3));
         }
 
         [LocalFact(SkipLocal = "Racy on Azure DevOps")]

--- a/src/core/Akka.Cluster.Tests/ProviderSelectionSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ProviderSelectionSpec.cs
@@ -73,11 +73,8 @@ namespace Akka.Cluster.Tests
         {
             var other = ProviderSelection.ClusterActorRefProvider;
             var ps = new ProviderSelection.Custom(other, "test");
-            using (var actorSystem = ActorSystem.Create("Test1", BootstrapSetup.Create().WithActorRefProvider(ps)))
-            {
-                actorSystem.Settings.ProviderClass.Should().Be(ps.Fqn);
-            }
-
+            using var actorSystem = ActorSystem.Create("Test1", BootstrapSetup.Create().WithActorRefProvider(ps));
+            actorSystem.Settings.ProviderClass.Should().Be(ps.Fqn);
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests/SplitBrainResolverConfigSpec.cs
+++ b/src/core/Akka.Cluster.Tests/SplitBrainResolverConfigSpec.cs
@@ -80,17 +80,16 @@ namespace Akka.Cluster.Tests
                     }
                 }");
 
-            using (var system = ActorSystem.Create("system", config))
-            {
-                var cluster = Cluster.Get(system);
+            using var system = ActorSystem.Create("system", config);
 
-                cluster.DowningProvider.Should().BeOfType<SplitBrainResolver>();
-                var provider = (SplitBrainResolver)cluster.DowningProvider;
+            var cluster = Cluster.Get(system);
 
-                provider.Strategy.Should().BeOfType<StaticQuorum>();
-                provider.DownRemovalMargin.Should().Be(TimeSpan.FromSeconds(10));
-                provider.StableAfter.Should().Be(TimeSpan.FromSeconds(40));
-            }
+            cluster.DowningProvider.Should().BeOfType<SplitBrainResolver>();
+            var provider = (SplitBrainResolver)cluster.DowningProvider;
+
+            provider.Strategy.Should().BeOfType<StaticQuorum>();
+            provider.DownRemovalMargin.Should().Be(TimeSpan.FromSeconds(10));
+            provider.StableAfter.Should().Be(TimeSpan.FromSeconds(40));
         }
 
         [Fact]
@@ -108,17 +107,16 @@ namespace Akka.Cluster.Tests
                     }
                 }");
 
-            using (var system = ActorSystem.Create("system", config))
-            {
-                var cluster = Cluster.Get(system);
+            using var system = ActorSystem.Create("system", config);
 
-                cluster.DowningProvider.Should().BeOfType<SplitBrainResolver>();
-                var provider = (SplitBrainResolver)cluster.DowningProvider;
+            var cluster = Cluster.Get(system);
 
-                provider.Strategy.Should().BeOfType<KeepMajority>();
-                provider.DownRemovalMargin.Should().Be(TimeSpan.Zero);      // default is zero
-                provider.StableAfter.Should().Be(TimeSpan.FromSeconds(20)); // default is 20s
-            }
+            cluster.DowningProvider.Should().BeOfType<SplitBrainResolver>();
+            var provider = (SplitBrainResolver)cluster.DowningProvider;
+
+            provider.Strategy.Should().BeOfType<KeepMajority>();
+            provider.DownRemovalMargin.Should().Be(TimeSpan.Zero);      // default is zero
+            provider.StableAfter.Should().Be(TimeSpan.FromSeconds(20)); // default is 20s
         }
     }
 }


### PR DESCRIPTION
## Changes

Reformatting. There was some deeply nested code because it (presumably) was written before the block-scoped `using` statement was available in C#

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue
* [x] Changes in public API reviewed, if any. (no changes in public API)
* [ ] I have added website documentation for this feature. (not applicable)
