### PR TITLE
Reduced nesting levels through block-scoped `using` statements in `SqliteSnapshotStore.cs` (`Akka.Persistence.Custom`)

### DIFF
--- a/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
+++ b/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
@@ -132,22 +132,19 @@ namespace Akka.Persistence.Custom.Snapshot
             // Create SQLite journal tables 
             try
             {
-                using (var connection = new SqliteConnection(_connectionString))
-                using (var cts = CancellationTokenSource
-                           .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
-                {
-                    await connection.OpenAsync(cts.Token);
-                    
-                    using (var command = GetCommand(connection, CreateSnapshotTableSql, _timeout))
-                    using (var tx = connection.BeginTransaction())
-                    {
-                        command.Transaction = tx;
-                        await command.ExecuteNonQueryAsync(cts.Token);
-                        tx.Commit();
-                    }
-                    
-                    return Status.Success.Instance;
-                }
+                using var connection = new SqliteConnection(_connectionString);
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token);
+
+                await connection.OpenAsync(cts.Token);
+
+                using var command = GetCommand(connection, CreateSnapshotTableSql, _timeout);
+                using var tx = connection.BeginTransaction();
+
+                command.Transaction = tx;
+                await command.ExecuteNonQueryAsync(cts.Token);
+                tx.Commit();
+
+                return Status.Success.Instance;
             }
             catch (Exception e)
             {
@@ -187,47 +184,41 @@ namespace Akka.Persistence.Custom.Snapshot
             SnapshotSelectionCriteria criteria)
         {
             // Create a new DbConnection instance
-            using (var connection = new SqliteConnection(_connectionString))
-            using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
-            {
-                await connection.OpenAsync(cts.Token);
-                
-                // Create new DbCommand instance
-                using (var command = GetCommand(connection, SelectSnapshotSql, _timeout))
-                {
-                    // Populate the SQL parameters
-                    AddParameter(command, "@PersistenceId", DbType.String, persistenceId);
-                    AddParameter(command, "@SequenceNr", DbType.Int64, criteria.MaxSequenceNr);
-                    AddParameter(command, "@Timestamp", DbType.DateTime2, criteria.MaxTimeStamp);
+            using var connection = new SqliteConnection(_connectionString);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token);
 
-                    // Create a DbDataReader to sequentially read the returned query result
-                    using (var reader = await command.ExecuteReaderAsync(
-                               CommandBehavior.SequentialAccess,
-                               cts.Token))
-                    {
-                        // Return null if no snapshot is found
-                        if (!await reader.ReadAsync(cts.Token)) 
-                            return null;
-                        
-                        var id = reader.GetString(0);
-                        var sequenceNr = reader.GetInt64(1);
-                        var timestamp = reader.GetDateTime(2);
+            await connection.OpenAsync(cts.Token);
 
-                        var metadata = new SnapshotMetadata(id, sequenceNr, timestamp);
-                            
-                        var manifest = reader.GetString(3);
-                        var binary = (byte[])reader[4];
-                        
-                        var serializerId = reader.GetInt32(5);
-                        
-                        // Deserialize the snapshot payload using the data we read from the reader
-                        var snapshot = _serialization.Deserialize(binary, serializerId, manifest);
+            // Create new DbCommand instance
+            using var command = GetCommand(connection, SelectSnapshotSql, _timeout); 3
 
-                        return new SelectedSnapshot(metadata, snapshot);
-                    }
-                }
-            }
+            // Populate the SQL parameters
+            AddParameter(command, "@PersistenceId", DbType.String, persistenceId);
+            AddParameter(command, "@SequenceNr", DbType.Int64, criteria.MaxSequenceNr);
+            AddParameter(command, "@Timestamp", DbType.DateTime2, criteria.MaxTimeStamp);
+
+            // Create a DbDataReader to sequentially read the returned query result
+            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cts.Token);
+
+            // Return null if no snapshot is found
+            if (!await reader.ReadAsync(cts.Token))
+                return null;
+
+            var id = reader.GetString(0);
+            var sequenceNr = reader.GetInt64(1);
+            var timestamp = reader.GetDateTime(2);
+
+            var metadata = new SnapshotMetadata(id, sequenceNr, timestamp);
+
+            var manifest = reader.GetString(3);
+            var binary = (byte[])reader[4];
+
+            var serializerId = reader.GetInt32(5);
+
+            // Deserialize the snapshot payload using the data we read from the reader
+            var snapshot = _serialization.Deserialize(binary, serializerId, manifest);
+
+            return new SelectedSnapshot(metadata, snapshot);
         }
         //</LoadAsync>
 
@@ -237,67 +228,65 @@ namespace Akka.Persistence.Custom.Snapshot
             object snapshot)
         {
             // Create a new DbConnection instance
-            using (var connection = new SqliteConnection(_connectionString))
-            using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
-            {
-                await connection.OpenAsync(cts.Token);
-                
-                // Create new DbCommand instance
-                using (var command = GetCommand(connection, InsertSnapshotSql, _timeout)) 
-                // Create a new DbTransaction instance
-                using (var tx = connection.BeginTransaction())
+            using var connection = new SqliteConnection(_connectionString);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token);
+
+            await connection.OpenAsync(cts.Token);
+
+            // Create new DbCommand instance
+            using var command = GetCommand(connection, InsertSnapshotSql, _timeout);
+
+            // Create a new DbTransaction instance
+            using var tx = connection.BeginTransaction();
+
+            command.Transaction = tx;
+
+            var snapshotType = snapshot.GetType();
+
+            // Get the serializer associated with the payload type
+            var serializer = _serialization.FindSerializerForType(objectType: snapshotType);
+
+            // This WithTransport method call is important, it allows for proper
+            // local IActorRef serialization by switching the serialization information
+            // context during the serialization process
+            var (binary, manifest) = Akka.Serialization.Serialization.WithTransport(
+                system: _serialization.System,
+                state: (snapshot, serializer),
+                action: state =>
                 {
-                    command.Transaction = tx;
-                    
-                    var snapshotType = snapshot.GetType();
-                    
-                    // Get the serializer associated with the payload type
-                    var serializer = _serialization.FindSerializerForType(objectType: snapshotType);
+                    var (thePayload, theSerializer) = state;
+                    var thisManifest = "";
 
-                    // This WithTransport method call is important, it allows for proper
-                    // local IActorRef serialization by switching the serialization information
-                    // context during the serialization process
-                    var (binary, manifest) = Akka.Serialization.Serialization.WithTransport(
-                        system: _serialization.System,
-                        state: (snapshot, serializer),
-                        action: state =>
-                        {
-                            var (thePayload, theSerializer) = state;
-                            var thisManifest = "";
-                                    
-                            // There are two kinds of serializer when it comes to manifest
-                            // support, we have to support both of them for proper payload
-                            // serialization
-                            if (theSerializer is SerializerWithStringManifest stringManifest)
-                            {
-                                thisManifest = stringManifest.Manifest(thePayload);
-                            }
-                            else if (theSerializer.IncludeManifest)
-                            {
-                                thisManifest = thePayload.GetType().TypeQualifiedName();
-                            }
-                                    
-                            // Return the serialized byte array and the manifest for the
-                            // serialized data
-                            return (theSerializer.ToBinary(thePayload), thisManifest);
-                        });
-                    
-                    // Populate the SQL parameters
-                    AddParameter(command, "@PersistenceId", DbType.String, metadata.PersistenceId);
-                    AddParameter(command, "@SequenceNr", DbType.Int64, metadata.SequenceNr);
-                    AddParameter(command, "@Timestamp", DbType.DateTime2, metadata.Timestamp);
-                    AddParameter(command, "@Manifest", DbType.String, manifest);
-                    AddParameter(command, "@SerializerId", DbType.Int32, serializer.Identifier);
-                    AddParameter(command, "@Payload", DbType.Binary, binary);
+                    // There are two kinds of serializer when it comes to manifest
+                    // support, we have to support both of them for proper payload
+                    // serialization
+                    if (theSerializer is SerializerWithStringManifest stringManifest)
+                    {
+                        thisManifest = stringManifest.Manifest(thePayload);
+                    }
+                    else if (theSerializer.IncludeManifest)
+                    {
+                        thisManifest = thePayload.GetType().TypeQualifiedName();
+                    }
 
-                    // Execute the SQL query
-                    await command.ExecuteNonQueryAsync(cts.Token);
+                    // Return the serialized byte array and the manifest for the
+                    // serialized data
+                    return (theSerializer.ToBinary(thePayload), thisManifest);
+                });
 
-                    // Commit the DbTransaction
-                    tx.Commit();
-                }
-            }
+            // Populate the SQL parameters
+            AddParameter(command, "@PersistenceId", DbType.String, metadata.PersistenceId);
+            AddParameter(command, "@SequenceNr", DbType.Int64, metadata.SequenceNr);
+            AddParameter(command, "@Timestamp", DbType.DateTime2, metadata.Timestamp);
+            AddParameter(command, "@Manifest", DbType.String, manifest);
+            AddParameter(command, "@SerializerId", DbType.Int32, serializer.Identifier);
+            AddParameter(command, "@Payload", DbType.Binary, binary);
+
+            // Execute the SQL query
+            await command.ExecuteNonQueryAsync(cts.Token);
+
+            // Commit the DbTransaction
+            tx.Commit();
         }
         //</SaveAsync>
 
@@ -305,41 +294,38 @@ namespace Akka.Persistence.Custom.Snapshot
         protected sealed override async Task DeleteAsync(SnapshotMetadata metadata)
         {
             // Create a new DbConnection instance
-            using (var connection = new SqliteConnection(_connectionString))
-            using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))    
+            using var connection = new SqliteConnection(_connectionString);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token);
+
+            await connection.OpenAsync(cts.Token);
+            var timestamp = metadata.Timestamp != DateTime.MinValue
+                ? metadata.Timestamp
+                : (DateTime?)null;
+
+            var sql = timestamp.HasValue
+                ? DeleteSnapshotRangeSql + " AND { Configuration.TimestampColumnName} = @Timestamp"
+                : DeleteSnapshotSql;
+
+            // Create new DbCommand instance
+            using var command = GetCommand(connection, sql, _timeout);
+
+            // Create a new DbTransaction instance
+            using var tx = connection.BeginTransaction();
+            command.Transaction = tx;
+
+            // Populate the SQL parameters
+            AddParameter(command, "@PersistenceId", DbType.String, metadata.PersistenceId);
+            AddParameter(command, "@SequenceNr", DbType.Int64, metadata.SequenceNr);
+            if (timestamp.HasValue)
             {
-                await connection.OpenAsync(cts.Token);
-                var timestamp = metadata.Timestamp != DateTime.MinValue 
-                    ? metadata.Timestamp 
-                    : (DateTime?)null;
-                
-                var sql = timestamp.HasValue
-                    ? DeleteSnapshotRangeSql + " AND { Configuration.TimestampColumnName} = @Timestamp"
-                    : DeleteSnapshotSql;
-
-                // Create new DbCommand instance
-                using (var command = GetCommand(connection, sql, _timeout))
-                // Create a new DbTransaction instance
-                using (var tx = connection.BeginTransaction())
-                {
-                    command.Transaction = tx;
-                    
-                    // Populate the SQL parameters
-                    AddParameter(command, "@PersistenceId", DbType.String, metadata.PersistenceId);
-                    AddParameter(command, "@SequenceNr", DbType.Int64, metadata.SequenceNr);
-                    if (timestamp.HasValue)
-                    {
-                        AddParameter(command, "@Timestamp", DbType.DateTime2, metadata.Timestamp);
-                    }
-
-                    // Execute the SQL query
-                    await command.ExecuteNonQueryAsync(cts.Token);
-
-                    // Commit the DbTransaction
-                    tx.Commit();
-                }
+                AddParameter(command, "@Timestamp", DbType.DateTime2, metadata.Timestamp);
             }
+
+            // Execute the SQL query
+            await command.ExecuteNonQueryAsync(cts.Token);
+
+            // Commit the DbTransaction
+            tx.Commit();
         }
         //</DeleteAsync>
 
@@ -349,31 +335,28 @@ namespace Akka.Persistence.Custom.Snapshot
             SnapshotSelectionCriteria criteria)
         {
             // Create a new DbConnection instance
-            using (var connection = new SqliteConnection(_connectionString))
-            using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
-            {
-                await connection.OpenAsync(cts.Token);
-                
-                // Create new DbCommand instance
-                using (var command = GetCommand(connection, DeleteSnapshotRangeSql, _timeout))
-                // Create a new DbTransaction instance
-                using (var tx = connection.BeginTransaction())
-                {
-                    command.Transaction = tx;
-                    
-                    // Populate the SQL parameters
-                    AddParameter(command, "@PersistenceId", DbType.String, persistenceId);
-                    AddParameter(command, "@SequenceNr", DbType.Int64, criteria.MaxSequenceNr);
-                    AddParameter(command, "@Timestamp", DbType.DateTime2, criteria.MaxTimeStamp);
-                    
-                    // Execute the SQL query
-                    await command.ExecuteNonQueryAsync(cts.Token);
+            using var connection = new SqliteConnection(_connectionString);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token);
 
-                    // Commit the DbTransaction
-                    tx.Commit();
-                }
-            }
+            await connection.OpenAsync(cts.Token);
+
+            // Create new DbCommand instance
+            using var command = GetCommand(connection, DeleteSnapshotRangeSql, _timeout);
+
+            // Create a new DbTransaction instance
+            using var tx = connection.BeginTransaction();
+            command.Transaction = tx;
+
+            // Populate the SQL parameters
+            AddParameter(command, "@PersistenceId", DbType.String, persistenceId);
+            AddParameter(command, "@SequenceNr", DbType.Int64, criteria.MaxSequenceNr);
+            AddParameter(command, "@Timestamp", DbType.DateTime2, criteria.MaxTimeStamp);
+
+            // Execute the SQL query
+            await command.ExecuteNonQueryAsync(cts.Token);
+
+            // Commit the DbTransaction
+            tx.Commit();
         }
         //</DeleteAsync2>
 

--- a/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
+++ b/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
@@ -190,7 +190,7 @@ namespace Akka.Persistence.Custom.Snapshot
             await connection.OpenAsync(cts.Token);
 
             // Create new DbCommand instance
-            using var command = GetCommand(connection, SelectSnapshotSql, _timeout); 3
+            using var command = GetCommand(connection, SelectSnapshotSql, _timeout);
 
             // Populate the SQL parameters
             AddParameter(command, "@PersistenceId", DbType.String, persistenceId);


### PR DESCRIPTION
## Changes

Reformatting. There was some deeply nested code because it (presumably) was written before the block-scoped `using` statement was available in C#

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue
* [x] Changes in public API reviewed, if any. (no changes in public API)
* [ ] I have added website documentation for this feature. (not applicable)
