### PR TITLE
Reduced nesting levels through block-scoped using statements in `AkkaDistributedData` and `Akka.DistributedData.LightningDB`

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData/ORSet.cs
+++ b/src/contrib/cluster/Akka.DistributedData/ORSet.cs
@@ -722,13 +722,11 @@ namespace Akka.DistributedData
             {
                 if (thisDot != null)
                 {
-                    using (var e = thisDot.VersionEnumerator)
-                    {
-                        var allContains = true;
-                        while (e.MoveNext()) allContains &= deleteDotNodes.Contains(e.Current.Key);
-                        if (allContains)
-                            newElementsMap = ElementsMap.Remove(elem);
-                    }
+                    using var e = thisDot.VersionEnumerator;
+                    var allContains = true;
+                    while (e.MoveNext()) allContains &= deleteDotNodes.Contains(e.Current.Key);
+                    if (allContains)
+                        newElementsMap = ElementsMap.Remove(elem);
                 }
             }
 

--- a/src/contrib/cluster/Akka.DistributedData/Serialization/SerializationSupport.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Serialization/SerializationSupport.cs
@@ -83,42 +83,33 @@ namespace Akka.DistributedData.Serialization
 
         public static byte[] Compress(IMessage msg)
         {
-            using (var memStream = new MemoryStream(BufferSize))
-            {
-                using (var gzip = new GZipStream(memStream, CompressionMode.Compress))
-                {
-                    msg.WriteTo(gzip);
-                }
-
-                return memStream.ToArray();
-            }
+            using var memStream = new MemoryStream(BufferSize);
+            using var gzip = new GZipStream(memStream, CompressionMode.Compress);
+            msg.WriteTo(gzip);
+            return memStream.ToArray();
         }
 
         public static byte[] Decompress(byte[] input)
         {
-            using (var memStream = new MemoryStream())
-            {
-                using(var inputStr = new MemoryStream(input))
-                using (var gzipStream = new GZipStream(inputStr, CompressionMode.Decompress))
-                {
-                    var buf = new byte[BufferSize];
-                    while (gzipStream.CanRead)
-                    {
-                        var read = gzipStream.Read(buf, 0, BufferSize);
-                        if (read > 0)
-                        {
-                            memStream.Write(buf, 0, read);
-                        }
-                        else
-                        {
-                            break;
-                        }
-                    }
-                }
+            using var memStream = new MemoryStream();
+            using var inputStr = new MemoryStream(input);
+            using var gzipStream = new GZipStream(inputStr, CompressionMode.Decompress);
 
-                return memStream.ToArray();
+            var buf = new byte[BufferSize];
+            while (gzipStream.CanRead)
+            {
+                var read = gzipStream.Read(buf, 0, BufferSize);
+                if (read > 0)
+                {
+                    memStream.Write(buf, 0, read);
+                }
+                else
+                {
+                    break;
+                }
             }
-           
+
+            return memStream.ToArray();
         }
 
         public static Proto.Msg.Address AddressToProto(Address address)
@@ -149,17 +140,16 @@ namespace Akka.DistributedData.Serialization
         {
             var b = new Proto.Msg.VersionVector();
 
-            using (var enumerator = versionVector.VersionEnumerator)
+            using var enumerator = versionVector.VersionEnumerator;
+
+            while (enumerator.MoveNext())
             {
-                while (enumerator.MoveNext())
+                var current = enumerator.Current;
+                b.Entries.Add(new Proto.Msg.VersionVector.Types.Entry()
                 {
-                    var current = enumerator.Current;
-                    b.Entries.Add(new Proto.Msg.VersionVector.Types.Entry()
-                    {
-                        Node = UniqueAddressToProto(current.Key),
-                        Version = current.Value
-                    });
-                }
+                    Node = UniqueAddressToProto(current.Key),
+                    Version = current.Value
+                });
             }
 
             return b;


### PR DESCRIPTION
## Changes

Reformatting. There was some deeply nested code because it (presumably) was written before the block-scoped `using` statement was available in C#
_In this particular pull request, the changes may not be semantically identical_ (for example, before the change, a variable would be returned after the `using` block is closed, and now it is returned before it is closed), but they must be pretty safe still.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue
* [x] Changes in public API reviewed, if any. (no changes in public API)
* [ ] I have added website documentation for this feature. (not applicable)
