### PR TITLE
Akka.Persistence.TCK: added `ActorSystemSetup` support to ` SnapshotStoreSerializationSpec `

### DIFF
--- a/src/core/Akka.Persistence.TCK/Serialization/SnapshotStoreSerializationSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Serialization/SnapshotStoreSerializationSpec.cs
@@ -20,7 +20,7 @@ namespace Akka.Persistence.TCK.Serialization
 {
     public abstract class SnapshotStoreSerializationSpec : PluginSpec
     {
-        protected static readonly Config SerializerConfig = ConfigurationFactory.ParseString(@"
+        public static readonly Config SerializerConfig = ConfigurationFactory.ParseString(@"
                 akka.actor {
                   serializers {
                     my-snapshot = ""Akka.Persistence.TCK.Serialization.Test+MySnapshotSerializer, Akka.Persistence.TCK""
@@ -33,7 +33,7 @@ namespace Akka.Persistence.TCK.Serialization
                 }
             ");
 
-        protected ActorSystemSetup TransformSetup(ActorSystemSetup setup)
+        public static ActorSystemSetup TransformSetup(ActorSystemSetup setup)
         {
             // need to add SerializerConfig if it's not already there
             if (setup.Get<BootstrapSetup>().HasValue)
@@ -54,7 +54,7 @@ namespace Akka.Persistence.TCK.Serialization
         }
 
         protected SnapshotStoreSerializationSpec(ActorSystemSetup setup, string actorSystemName,
-            ITestOutputHelper output) : base(setup., actorSystemName, output)
+            ITestOutputHelper output) : base(TransformSetup(setup), actorSystemName, output)
         {
             
         }


### PR DESCRIPTION
## Changes

added `ActorSystemSetup` support to ` SnapshotStoreSerializationSpec `

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.
