### PR TITLE
Modernize AkkaSpec and Akka.Remote DotNetty transport settings

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.DotNet.verified.txt
@@ -856,3 +856,12 @@ namespace Akka.Remote.Transport
         public Akka.Actor.Address Sender { get; }
     }
 }
+namespace Akka.Remote.Transport.DotNetty
+{
+    public sealed class DotNettySslSetup : Akka.Actor.Setup.Setup
+    {
+        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get; }
+        public bool SuppressValidation { get; }
+    }
+}

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.Net.verified.txt
@@ -856,3 +856,12 @@ namespace Akka.Remote.Transport
         public Akka.Actor.Address Sender { get; }
     }
 }
+namespace Akka.Remote.Transport.DotNetty
+{
+    public sealed class DotNettySslSetup : Akka.Actor.Setup.Setup
+    {
+        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation) { }
+        public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get; }
+        public bool SuppressValidation { get; }
+    }
+}

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -1,0 +1,123 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DotNettySslSupportSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Configuration;
+using Akka.Remote.Transport.DotNetty;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+using static Akka.Util.RuntimeDetector;
+
+namespace Akka.Remote.Tests.Transport
+{
+    public class DotNettySslSetupSpec : AkkaSpec
+    {
+        #region Setup / Config
+
+        // valid to 01/01/2037
+        private const string ValidCertPath = "Resources/akka-validcert.pfx";
+
+        private const string Password = "password";
+
+        private static ActorSystemSetup TestActorSystemSetup(bool enableSsl)
+        {
+            var setup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create()
+                    .WithConfig(ConfigurationFactory.ParseString($@"
+akka {{
+  loglevel = DEBUG
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote {{
+    dot-netty.tcp {{
+      port = 0
+      hostname = ""127.0.0.1""
+      enable-ssl = ""{enableSsl.ToString().ToLowerInvariant()}""
+      log-transport = true
+    }}
+  }}
+}}")));
+
+            if (!enableSsl)
+                return setup;
+            
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+            return setup.And(new DotNettySslSetup(certificate, true));
+        }
+
+        private ActorSystem _sys2;
+        private ActorPath _echoPath;
+
+        private void Setup(bool enableSsl)
+        {
+            _sys2 = ActorSystem.Create("sys2", TestActorSystemSetup(enableSsl));
+            InitializeLogger(_sys2);
+
+            _sys2.ActorOf(Props.Create<Echo>(), "echo");
+
+            var address = RARP.For(_sys2).Provider.DefaultAddress;
+            _echoPath = new RootActorPath(address) / "user" / "echo";
+        }
+
+        #endregion
+
+        public DotNettySslSetupSpec(ITestOutputHelper output) : base(TestActorSystemSetup(true), output)
+        {
+        }
+
+        [Fact]
+        public async Task Secure_transport_should_be_possible_between_systems_sharing_the_same_certificate()
+        {
+            // skip this test due to linux/mono certificate issues
+            if (IsMono) return;
+
+            Setup(true);
+
+            var probe = CreateTestProbe();
+
+            await AwaitAssertAsync(async () =>
+            {
+                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+        }
+
+        [Fact]
+        public async Task Secure_transport_should_NOT_be_possible_between_systems_using_SSL_and_one_not_using_it()
+        {
+            Setup(false);
+
+            var probe = CreateTestProbe();
+            await Assert.ThrowsAsync<RemoteTransportException>(async () =>
+            {
+                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+                await probe.ExpectNoMsgAsync();
+            });
+        }
+
+        #region helper classes / methods
+
+        protected override void AfterAll()
+        {
+            base.AfterAll();
+            Shutdown(_sys2, TimeSpan.FromSeconds(3));
+        }
+
+        private class Echo : ReceiveActor
+        {
+            public Echo()
+            {
+                Receive<string>(str => Sender.Tell(str));
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -7,12 +7,12 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
     <ItemGroup>
-        <EmbeddedResource Include="Configuration\Remote.conf"/>
-        <ProjectReference Include="..\Akka\Akka.csproj"/>
+        <EmbeddedResource Include="Configuration\Remote.conf" />
+        <ProjectReference Include="..\Akka\Akka.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="DotNetty.Handlers" Version="0.6.0"/>
-        <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)"/>
+        <PackageReference Include="DotNetty.Handlers" Version="0.6.0" />
+        <PackageReference Include="Google.Protobuf" Version="$(ProtobufVersion)" />
     </ItemGroup>
     <PropertyGroup>
         <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/core/Akka.Remote/AkkaProtocolSettings.cs
+++ b/src/core/Akka.Remote/AkkaProtocolSettings.cs
@@ -51,11 +51,9 @@ namespace Akka.Remote
             // backwards compatibility with the existing dot-netty.tcp.connection-timeout
             var enabledTransports = config.GetStringList("akka.remote.enabled-transports", new string[] { });
             if (enabledTransports.Contains("akka.remote.dot-netty.tcp"))
-                HandshakeTimeout = config.GetTimeSpan("akka.remote.dot-netty.tcp.connection-timeout", null);
-            else if (enabledTransports.Contains("akka.remote.dot-netty.ssl"))
-                HandshakeTimeout = config.GetTimeSpan("akka.remote.dot-netty.ssl.connection-timeout", null);
+                HandshakeTimeout = config.GetTimeSpan("akka.remote.dot-netty.tcp.connection-timeout", TimeSpan.FromSeconds(15), allowInfinite:false);
             else
-                HandshakeTimeout = config.GetTimeSpan("akka.remote.handshake-timeout", TimeSpan.FromSeconds(20), allowInfinite:false);
+                HandshakeTimeout = config.GetTimeSpan("akka.remote.handshake-timeout", TimeSpan.FromSeconds(15), allowInfinite:false);
         }
     }
 }

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -352,9 +352,6 @@ akka {
       trttl = "Akka.Remote.Transport.ThrottlerProvider,Akka.Remote"
     }
 
-	# necessary to keep backwards compatibility
-	helios.tcp.transport-class = "Akka.Remote.Transport.Helios.HeliosTcpTransport, Akka.Remote.Transport.Helios"
-
     ### Default configuration for the DotNetty based transport drivers
 
     dot-netty.tcp {
@@ -481,10 +478,10 @@ akka {
       # Sets the size of the connection backlog
       backlog = 4096
 
-      # Enables the TCP_NODELAY flag, i.e. disables Nagleâ€™s algorithm
+      # Enables the TCP_NODELAY flag, i.e. disables Nagle's algorithm
       tcp-nodelay = on
 
-      # Enables TCP Keepalive, subject to the O/S kernelâ€™s configuration
+      # Enables TCP Keepalive, subject to the O/S kernel's configuration
       tcp-keepalive = on
 
       # Enables SO_REUSEADDR, which determines when an ActorSystem can open
@@ -524,46 +521,43 @@ akka {
         pool-size-max = 2
       }
 
-
+      ssl {
+        certificate {
+          # Valid certificate path required
+          path = ""
+          # Valid certificate password required
+          password = ""
+          # Default key storage flag is "default-key-set"
+          # Available flags include: 
+          #     default-key-set | exportable | machine-key-set | persist-key-set | user-key-set | user-protected
+          # flags = [ "default-key-set" ]
+          
+          # To use a Thumbprint instead of a file, set this to true
+          # And specify a thumbprint and it's storage location below
+          use-thumbprint-over-file = false
+          
+          # Valid Thumbprint required (if use-thumbprint-over-file is true)
+          # A typical thumbprint is a format similar to: "45df32e258c92a7abf6c112e54912ab15bbb9eb0"
+          # On Windows machines, The thumbprint for an installed certificate can be located
+          # By using certlm.msc and opening the certificate under the 'Details' tab.
+          thumbprint = ""
+          
+          # The Store name. Under windows The most common option is "My", which indicates the personal store.
+          # See System.Security.Cryptography.X509Certificates.StoreName for other common values.
+          store-name = ""
+          
+          # Valid options : local-machine or current-user
+          # current-user indicates a certificate stored under the user's account
+          # local-machine indicates a certificate stored at an operating system level (potentially shared by users)
+          store-location = "current-user"
+        }
+        suppress-validation = false
+      }
     }
 
     dot-netty.udp = ${akka.remote.dot-netty.tcp}
     dot-netty.udp {
       transport-protocol = udp
-    }
-
-    dot-netty.ssl = ${akka.remote.dot-netty.tcp}
-    dot-netty.ssl = {
-		certificate {
-			# Valid certificate path required
-			path = ""
-			# Valid certificate password required
-			password = ""
-			# Default key storage flag is "default-key-set"
-			# Available flags include: 
-			#     default-key-set | exportable | machine-key-set | persist-key-set | user-key-set | user-protected
-			# flags = [ "default-key-set" ]
-
-			# To use a Thumbprint instead of a file, set this to true
-			# And specify a thumprint and it's storage location below
-			use-thumbprint-over-file = false
-
-			# Valid Thumprint required (if use-thumbprint-over-file is true)
-			# A typical thumbprint is a format similar to: "45df32e258c92a7abf6c112e54912ab15bbb9eb0"
-			# On Windows machines, The thumprint for an installed certificate can be located
-			# By using certlm.msc and opening the certificate under the 'Details' tab.
-			thumbprint = ""
-
-			# The Store name. Under windows The most common option is "My", which indicates the personal store.
-			# See System.Security.Cryptography.X509Certificates.StoreName for other common values.
-			store-name = ""
-
-			# Valid options : local-machine or current-user
-			# current-user indicates a certificate stored under the user's account
-			# local-machine indicates a certificate stored at an operating system level (potentially shared by users)
-			store-location = "current-user"
-		}
-		suppress-validation = false
     }
 
     ### Default configuration for the failure injector transport adapter

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettySslSetup.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettySslSetup.cs
@@ -1,0 +1,24 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SslSetup.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Security.Cryptography.X509Certificates;
+using Akka.Actor.Setup;
+
+namespace Akka.Remote.Transport.DotNetty;
+
+public sealed class DotNettySslSetup: Setup
+{
+    public DotNettySslSetup(X509Certificate2 certificate, bool suppressValidation)
+    {
+        Certificate = certificate;
+        SuppressValidation = suppressValidation;
+    }
+    
+    public X509Certificate2 Certificate { get; }
+    public bool SuppressValidation { get; }
+
+    internal SslSettings Settings => new SslSettings(Certificate, SuppressValidation);
+}

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -131,13 +131,17 @@ namespace Akka.Remote.Transport.DotNetty
             System = system;
             Config = config;
 
+            // Helios compatibility
             if (system.Settings.Config.HasPath("akka.remote.helios.tcp"))
             {
-                var heliosFallbackConfig = system.Settings.Config.GetConfig("akka.remote.helios.tcp");
+                var heliosFallbackConfig = system.Settings.Config.GetConfig("akka.remote.helios.tcp")
+                    .WithFallback("transport-class = \"Akka.Remote.Transport.Helios.HeliosTcpTransport, Akka.Remote.Transport.Helios\"");
                 config = heliosFallbackConfig.WithFallback(config);
             }
 
-            Settings = DotNettyTransportSettings.Create(config);
+            var setup = system.Settings.Setup.Get<DotNettySslSetup>();
+            var sslSettings = setup.HasValue ? setup.Value.Settings : null;
+            Settings = DotNettyTransportSettings.Create(config, sslSettings);
             Log = Logging.GetLogger(System, GetType());
             _serverEventLoopGroup = new MultithreadEventLoopGroup(Settings.ServerSocketWorkerPoolSize);
             _clientEventLoopGroup = new MultithreadEventLoopGroup(Settings.ClientSocketWorkerPoolSize);

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -6,7 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
@@ -16,21 +15,136 @@ using Akka.Dispatch;
 using Akka.Util;
 using DotNetty.Buffers;
 
+#nullable enable
 namespace Akka.Remote.Transport.DotNetty
 {
     /// <summary>
-    /// INTERNAL API.
+    ///     INTERNAL API.
     ///
-    /// Defines the settings for the <see cref="DotNettyTransport"/>.
+    ///     Defines the settings for the <see cref="DotNettyTransport"/>.
     /// </summary>
-    internal sealed class DotNettyTransportSettings
+    /// <param name="TransportMode">
+    ///     Transport mode used by underlying socket channel.
+    ///     Currently only TCP is supported.
+    /// </param>
+    /// <param name="EnableSsl">
+    ///     If set to true, a Secure Socket Layer will be established
+    ///     between remote endpoints. They need to share a X509 certificate
+    ///     which path is specified in `akka.remote.dot-netty.tcp.ssl.certificate.path`
+    /// </param>
+    /// <param name="ConnectTimeout">
+    ///     Sets a connection timeout for all outbound connections
+    ///     i.e. how long a connect may take until it is timed out.
+    /// </param>
+    /// <param name="Hostname">
+    ///     If this value is set, this becomes the public address for the actor system on this
+    ///     transport, which might be different than the physical ip address (hostname)
+    ///     this is designed to make it easy to support private / public addressing schemes
+    /// </param>
+    /// <param name="PublicHostname">
+    ///     The hostname or IP to bind the remoting to.
+    /// </param>
+    /// <param name="Port">
+    ///     The default remote server port clients should connect to.
+    ///     Default is 2552 (AKKA), use 0 if you want a random available port
+    ///     This port needs to be unique for each actor system on the same machine.
+    /// </param>
+    /// <param name="PublicPort">
+    ///     If this value is set, this becomes the public port for the actor system on this
+    ///     transport, which might be different than the physical port
+    ///     this is designed to make it easy to support private / public addressing schemes
+    /// </param>
+    /// <param name="ServerSocketWorkerPoolSize">TBD</param>
+    /// <param name="ClientSocketWorkerPoolSize">TBD</param>
+    /// <param name="MaxFrameSize">TBD</param>
+    /// <param name="Ssl">TBD</param>
+    /// <param name="DnsUseIpv6">
+    ///     If set to true, we will use IPv6 addresses upon DNS resolution for
+    ///     host names. Otherwise IPv4 will be used.
+    /// </param>
+    /// <param name="TcpReuseAddr">
+    ///     Enables SO_REUSEADDR, which determines when an ActorSystem can open
+    ///     the specified listen port (the meaning differs between *nix and Windows).
+    /// </param>
+    /// <param name="TcpKeepAlive">
+    ///     Enables TCP Keepalive, subject to the O/S kernel's configuration.
+    /// </param>
+    /// <param name="TcpNoDelay">
+    ///     Enables the TCP_NODELAY flag, i.e. disables Nagle's algorithm
+    /// </param>
+    /// <param name="Backlog">
+    ///     Sets the size of the connection backlog.
+    /// </param>
+    /// <param name="EnforceIpFamily">
+    ///     If set to true, we will enforce usage of IPv4 or IPv6 addresses upon DNS
+    ///     resolution for host names. If true, we will use IPv6 enforcement. Otherwise,
+    ///     we will use IPv4.
+    /// </param>
+    /// <param name="ReceiveBufferSize">
+    ///     Sets the default receive buffer size of the Sockets.
+    /// </param>
+    /// <param name="SendBufferSize">
+    ///     Sets the default send buffer size of the Sockets.
+    /// </param>
+    /// <param name="WriteBufferHighWaterMark">TBD</param>
+    /// <param name="WriteBufferLowWaterMark">TBD</param>
+    /// <param name="BackwardsCompatibilityModeEnabled">
+    ///     Enables backwards compatibility with Akka.Remote clients running Helios 1.*
+    /// </param>
+    /// <param name="LogTransport">
+    ///     When set to true, it will enable logging of DotNetty user events
+    ///     and message frames.
+    /// </param>
+    /// <param name="ByteOrder">
+    ///     Byte order used by DotNetty, either big or little endian.
+    ///     By default a little endian is used to achieve compatibility with Helios.
+    /// </param>
+    /// <param name="EnableBufferPooling">
+    ///     Used mostly as a work-around for https://github.com/akkadotnet/akka.net/issues/3370
+    ///     on .NET Core on Linux. Should always be left to <c>true</c> unless running DotNetty v0.4.6
+    ///     on Linux, which can accidentally release buffers early and corrupt frames. Turn this setting
+    ///     to <c>false</c> to disable pooling and work-around this issue at the cost of some performance.
+    /// </param>
+    /// <param name="BatchWriterSettings">
+    ///     Used for performance-tuning the DotNetty channels to maximize I/O performance.
+    /// </param>
+    internal sealed record DotNettyTransportSettings(
+        TransportMode TransportMode, 
+        bool EnableSsl,
+        TimeSpan ConnectTimeout,
+        string Hostname, 
+        string PublicHostname,
+        int Port,
+        int? PublicPort,
+        int ServerSocketWorkerPoolSize,
+        int ClientSocketWorkerPoolSize,
+        int MaxFrameSize,
+        SslSettings Ssl,
+        bool DnsUseIpv6,
+        bool TcpReuseAddr,
+        bool TcpKeepAlive,
+        bool TcpNoDelay,
+        int Backlog,
+        bool EnforceIpFamily,
+        int? ReceiveBufferSize,
+        int? SendBufferSize, 
+        int? WriteBufferHighWaterMark,
+        int? WriteBufferLowWaterMark,
+        bool BackwardsCompatibilityModeEnabled,
+        bool LogTransport,
+        ByteOrder ByteOrder,
+        bool EnableBufferPooling,
+        BatchWriterSettings BatchWriterSettings)
     {
         public static DotNettyTransportSettings Create(ActorSystem system)
         {
             var config = system.Settings.Config.GetConfig("akka.remote.dot-netty.tcp");
             if (config.IsNullOrEmpty())
                 throw ConfigurationException.NullOrEmptyConfig<DotNettyTransportSettings>("akka.remote.dot-netty.tcp");
-            return Create(config);
+            
+            var setup = system.Settings.Setup.Get<DotNettySslSetup>();
+            var sslSettings = setup.HasValue ? setup.Value.Settings : null;
+            return Create(config, sslSettings);
         }
 
         /// <summary>
@@ -38,76 +152,75 @@ namespace Akka.Remote.Transport.DotNetty
         /// </summary>
         /// <param name="hoconTcpReuseAddr">The HOCON string for the akka.remote.dot-netty.tcp.reuse-addr option</param>
         /// <returns><c>true</c> if we should enable REUSE_ADDR for tcp. <c>false</c> otherwise.</returns>
-        internal static bool ResolveTcpReuseAddrOption(string hoconTcpReuseAddr)
+        private static bool ResolveTcpReuseAddrOption(string hoconTcpReuseAddr)
         {
-            switch (hoconTcpReuseAddr.ToLowerInvariant())
+            return hoconTcpReuseAddr.ToLowerInvariant() switch
             {
-                case "off-for-windows" when RuntimeDetector.IsWindows:
-                    return false;
-                case "off-for-windows":
-                    return true;
-                case "on":
-                    return true;
-                case "off":
-                default:
-                    return false;
-            }
+                "off-for-windows" when RuntimeDetector.IsWindows => false,
+                "off-for-windows" => true,
+                "on" => true,
+                "off" => false,
+                _ => false
+            };
         }
 
-        public static DotNettyTransportSettings Create(Config config)
+        public static DotNettyTransportSettings Create(Config config, SslSettings? sslSettings = null)
         {
             if (config.IsNullOrEmpty())
                 throw ConfigurationException.NullOrEmptyConfig<DotNettyTransportSettings>();
 
             var transportMode = config.GetString("transport-protocol", "tcp").ToLower();
-            var host = config.GetString("hostname", null);
-            if (string.IsNullOrEmpty(host)) host = IPAddress.Any.ToString();
-            var publicHost = config.GetString("public-hostname", null);
-            var publicPort = config.GetInt("public-port", 0);
+            var host = config.GetString("hostname");
+            if (string.IsNullOrWhiteSpace(host)) 
+                host = IPAddress.Any.ToString();
 
-            var order = ByteOrder.LittleEndian;
+            var publicHost = config.GetString("public-hostname");
+            var publicPort = config.GetInt("public-port");
+
             var byteOrderString = config.GetString("byte-order", "little-endian").ToLowerInvariant();
-            switch (byteOrderString)
+            var order = byteOrderString switch
             {
-                case "little-endian": order = ByteOrder.LittleEndian; break;
-                case "big-endian": order = ByteOrder.BigEndian; break;
-                default: throw new ArgumentException($"Unknown byte-order option [{byteOrderString}]. Supported options are: big-endian, little-endian.");
-            }
+                "little-endian" => ByteOrder.LittleEndian,
+                "big-endian" => ByteOrder.BigEndian,
+                _ => throw new ArgumentException(
+                    $"Unknown byte-order option [{byteOrderString}]. Supported options are: big-endian, little-endian.")
+            };
 
             var batchWriterSettings = new BatchWriterSettings(config.GetConfig("batching"));
 
-            var enableSsl = config.GetBoolean("enable-ssl", false);
+            var enableSsl = config.GetBoolean("enable-ssl");
 
             return new DotNettyTransportSettings(
-                transportMode: transportMode == "tcp" ? TransportMode.Tcp : TransportMode.Udp,
-                enableSsl: enableSsl,
-                connectTimeout: config.GetTimeSpan("connection-timeout", TimeSpan.FromSeconds(15)),
-                hostname: host,
-                publicHostname: !string.IsNullOrEmpty(publicHost) ? publicHost : host,
-                port: config.GetInt("port", 2552),
-                publicPort: publicPort > 0 ? publicPort : (int?)null,
-                serverSocketWorkerPoolSize: ComputeWorkerPoolSize(config.GetConfig("server-socket-worker-pool")),
-                clientSocketWorkerPoolSize: ComputeWorkerPoolSize(config.GetConfig("client-socket-worker-pool")),
-                maxFrameSize: ToNullableInt(config.GetByteSize("maximum-frame-size", null)) ?? 128000,
-                ssl: config.HasPath("ssl") && enableSsl ? SslSettings.Create(config.GetConfig("ssl")) : SslSettings.Empty,
-                dnsUseIpv6: config.GetBoolean("dns-use-ipv6", false),
-                tcpReuseAddr: ResolveTcpReuseAddrOption(config.GetString("tcp-reuse-addr", "off-for-windows")),
-                tcpKeepAlive: config.GetBoolean("tcp-keepalive", true),
-                tcpNoDelay: config.GetBoolean("tcp-nodelay", true),
-                backlog: config.GetInt("backlog", 4096),
-                enforceIpFamily: RuntimeDetector.IsMono || config.GetBoolean("enforce-ip-family", false),
-                receiveBufferSize: ToNullableInt(config.GetByteSize("receive-buffer-size", null) ?? 256000),
-                sendBufferSize: ToNullableInt(config.GetByteSize("send-buffer-size", null) ?? 256000),
-                writeBufferHighWaterMark: ToNullableInt(config.GetByteSize("write-buffer-high-water-mark", null)),
-                writeBufferLowWaterMark: ToNullableInt(config.GetByteSize("write-buffer-low-water-mark", null)),
-                backwardsCompatibilityModeEnabled: config.GetBoolean("enable-backwards-compatibility", false),
-                logTransport: config.HasPath("log-transport") && config.GetBoolean("log-transport", false),
-                byteOrder: order,
-                enableBufferPooling: config.GetBoolean("enable-pooling", true),
-                batchWriterSettings: batchWriterSettings);
+                TransportMode: transportMode == "tcp" ? TransportMode.Tcp : TransportMode.Udp,
+                EnableSsl: enableSsl,
+                ConnectTimeout: config.GetTimeSpan("connection-timeout", TimeSpan.FromSeconds(15)),
+                Hostname: host,
+                PublicHostname: !string.IsNullOrEmpty(publicHost) ? publicHost : host,
+                Port: config.GetInt("port", 2552),
+                PublicPort: publicPort > 0 ? publicPort : null,
+                ServerSocketWorkerPoolSize: ComputeWorkerPoolSize(config.GetConfig("server-socket-worker-pool")),
+                ClientSocketWorkerPoolSize: ComputeWorkerPoolSize(config.GetConfig("client-socket-worker-pool")),
+                MaxFrameSize: ToNullableInt(config.GetByteSize("maximum-frame-size", null)) ?? 128000,
+                Ssl: enableSsl ? SslSettings.CreateOrDefault(config.GetConfig("ssl"), sslSettings) : SslSettings.Empty,
+                DnsUseIpv6: config.GetBoolean("dns-use-ipv6"),
+                TcpReuseAddr: ResolveTcpReuseAddrOption(config.GetString("tcp-reuse-addr", "off-for-windows")),
+                TcpKeepAlive: config.GetBoolean("tcp-keepalive", true),
+                TcpNoDelay: config.GetBoolean("tcp-nodelay", true),
+                Backlog: config.GetInt("backlog", 4096),
+                EnforceIpFamily: RuntimeDetector.IsMono || config.GetBoolean("enforce-ip-family"),
+                ReceiveBufferSize: ToNullableInt(config.GetByteSize("receive-buffer-size", null) ?? 256000),
+                SendBufferSize: ToNullableInt(config.GetByteSize("send-buffer-size", null) ?? 256000),
+                WriteBufferHighWaterMark: ToNullableInt(config.GetByteSize("write-buffer-high-water-mark", null)),
+                WriteBufferLowWaterMark: ToNullableInt(config.GetByteSize("write-buffer-low-water-mark", null)),
+                BackwardsCompatibilityModeEnabled: config.GetBoolean("enable-backwards-compatibility"),
+                LogTransport: config.HasPath("log-transport") && config.GetBoolean("log-transport"),
+                ByteOrder: order,
+                EnableBufferPooling: config.GetBoolean("enable-pooling", true),
+                BatchWriterSettings: batchWriterSettings
+            ).Validate();
         }
 
-        private static int? ToNullableInt(long? value) => value.HasValue && value.Value > 0 ? (int?)value.Value : null;
+        private static int? ToNullableInt(long? value) => value is > 0 ? (int?)value.Value : null;
 
         private static int ComputeWorkerPoolSize(Config config)
         {
@@ -115,171 +228,17 @@ namespace Akka.Remote.Transport.DotNetty
                 return ThreadPoolConfig.ScaledPoolSize(2, 1.0, 2);
 
             return ThreadPoolConfig.ScaledPoolSize(
-                floor: config.GetInt("pool-size-min", 0),
-                scalar: config.GetDouble("pool-size-factor", 0),
-                ceiling: config.GetInt("pool-size-max", 0));
+                floor: config.GetInt("pool-size-min", 2),
+                scalar: config.GetDouble("pool-size-factor", 1.0),
+                ceiling: config.GetInt("pool-size-max", 2));
         }
 
-        /// <summary>
-        /// Transport mode used by underlying socket channel.
-        /// Currently only TCP is supported.
-        /// </summary>
-        public readonly TransportMode TransportMode;
-
-        /// <summary>
-        /// If set to true, a Secure Socket Layer will be established
-        /// between remote endpoints. They need to share a X509 certificate
-        /// which path is specified in `akka.remote.dot-netty.tcp.ssl.certificate.path`
-        /// </summary>
-        public readonly bool EnableSsl;
-
-        /// <summary>
-        /// Sets a connection timeout for all outbound connections
-        /// i.e. how long a connect may take until it is timed out.
-        /// </summary>
-        public readonly TimeSpan ConnectTimeout;
-
-        /// <summary>
-        /// The hostname or IP to bind the remoting to.
-        /// </summary>
-        public readonly string Hostname;
-
-        /// <summary>
-        /// If this value is set, this becomes the public address for the actor system on this
-        /// transport, which might be different than the physical ip address (hostname)
-        /// this is designed to make it easy to support private / public addressing schemes
-        /// </summary>
-        public readonly string PublicHostname;
-
-        /// <summary>
-        /// The default remote server port clients should connect to.
-        /// Default is 2552 (AKKA), use 0 if you want a random available port
-        /// This port needs to be unique for each actor system on the same machine.
-        /// </summary>
-        public readonly int Port;
-
-        /// <summary>
-        /// If this value is set, this becomes the public port for the actor system on this
-        /// transport, which might be different than the physical port
-        /// this is designed to make it easy to support private / public addressing schemes
-        /// </summary>
-        public readonly int? PublicPort;
-
-        public readonly int ServerSocketWorkerPoolSize;
-        public readonly int ClientSocketWorkerPoolSize;
-        public readonly int MaxFrameSize;
-        public readonly SslSettings Ssl;
-
-        /// <summary>
-        /// If set to true, we will use IPv6 addresses upon DNS resolution for
-        /// host names. Otherwise IPv4 will be used.
-        /// </summary>
-        public readonly bool DnsUseIpv6;
-
-        /// <summary>
-        /// Enables SO_REUSEADDR, which determines when an ActorSystem can open
-        /// the specified listen port (the meaning differs between *nix and Windows).
-        /// </summary>
-        public readonly bool TcpReuseAddr;
-
-        /// <summary>
-        /// Enables TCP Keepalive, subject to the O/S kernel's configuration.
-        /// </summary>
-        public readonly bool TcpKeepAlive;
-
-        /// <summary>
-        /// Enables the TCP_NODELAY flag, i.e. disables Nagle's algorithm
-        /// </summary>
-        public readonly bool TcpNoDelay;
-
-        /// <summary>
-        /// If set to true, we will enforce usage of IPv4 or IPv6 addresses upon DNS
-        /// resolution for host names. If true, we will use IPv6 enforcement. Otherwise,
-        /// we will use IPv4.
-        /// </summary>
-        public readonly bool EnforceIpFamily;
-
-        /// <summary>
-        /// Sets the size of the connection backlog.
-        /// </summary>
-        public readonly int Backlog;
-
-        /// <summary>
-        /// Sets the default receive buffer size of the Sockets.
-        /// </summary>
-        public readonly int? ReceiveBufferSize;
-
-        /// <summary>
-        /// Sets the default send buffer size of the Sockets.
-        /// </summary>
-        public readonly int? SendBufferSize;
-        public readonly int? WriteBufferHighWaterMark;
-        public readonly int? WriteBufferLowWaterMark;
-
-        /// <summary>
-        /// Enables backwards compatibility with Akka.Remote clients running Helios 1.*
-        /// </summary>
-        public readonly bool BackwardsCompatibilityModeEnabled;
-
-        /// <summary>
-        /// When set to true, it will enable logging of DotNetty user events
-        /// and message frames.
-        /// </summary>
-        public readonly bool LogTransport;
-
-        /// <summary>
-        /// Byte order used by DotNetty, either big or little endian.
-        /// By default a little endian is used to achieve compatibility with Helios.
-        /// </summary>
-        public readonly ByteOrder ByteOrder;
-
-        /// <summary>
-        /// Used mostly as a work-around for https://github.com/akkadotnet/akka.net/issues/3370
-        /// on .NET Core on Linux. Should always be left to <c>true</c> unless running DotNetty v0.4.6
-        /// on Linux, which can accidentally release buffers early and corrupt frames. Turn this setting
-        /// to <c>false</c> to disable pooling and work-around this issue at the cost of some performance.
-        /// </summary>
-        public readonly bool EnableBufferPooling;
-
-        /// <summary>
-        /// Used for performance-tuning the DotNetty channels to maximize I/O performance.
-        /// </summary>
-        public readonly BatchWriterSettings BatchWriterSettings;
-
-        public DotNettyTransportSettings(TransportMode transportMode, bool enableSsl, TimeSpan connectTimeout, string hostname, string publicHostname,
-            int port, int? publicPort, int serverSocketWorkerPoolSize, int clientSocketWorkerPoolSize, int maxFrameSize, SslSettings ssl,
-            bool dnsUseIpv6, bool tcpReuseAddr, bool tcpKeepAlive, bool tcpNoDelay, int backlog, bool enforceIpFamily,
-            int? receiveBufferSize, int? sendBufferSize, int? writeBufferHighWaterMark, int? writeBufferLowWaterMark, bool backwardsCompatibilityModeEnabled, bool logTransport, ByteOrder byteOrder,
-            bool enableBufferPooling, BatchWriterSettings batchWriterSettings)
+        internal DotNettyTransportSettings Validate()
         {
-            if (maxFrameSize < 32000) throw new ArgumentException("maximum-frame-size must be at least 32000 bytes", nameof(maxFrameSize));
+            if (MaxFrameSize < 32000) 
+                throw new ArgumentException("maximum-frame-size must be at least 32000 bytes", nameof(MaxFrameSize));
 
-            TransportMode = transportMode;
-            EnableSsl = enableSsl;
-            ConnectTimeout = connectTimeout;
-            Hostname = hostname;
-            PublicHostname = publicHostname;
-            Port = port;
-            PublicPort = publicPort;
-            ServerSocketWorkerPoolSize = serverSocketWorkerPoolSize;
-            ClientSocketWorkerPoolSize = clientSocketWorkerPoolSize;
-            MaxFrameSize = maxFrameSize;
-            Ssl = ssl;
-            DnsUseIpv6 = dnsUseIpv6;
-            TcpReuseAddr = tcpReuseAddr;
-            TcpKeepAlive = tcpKeepAlive;
-            TcpNoDelay = tcpNoDelay;
-            Backlog = backlog;
-            EnforceIpFamily = enforceIpFamily;
-            ReceiveBufferSize = receiveBufferSize;
-            SendBufferSize = sendBufferSize;
-            WriteBufferHighWaterMark = writeBufferHighWaterMark;
-            WriteBufferLowWaterMark = writeBufferLowWaterMark;
-            BackwardsCompatibilityModeEnabled = backwardsCompatibilityModeEnabled;
-            LogTransport = logTransport;
-            ByteOrder = byteOrder;
-            EnableBufferPooling = enableBufferPooling;
-            BatchWriterSettings = batchWriterSettings;
+            return this;
         }
     }
     internal enum TransportMode
@@ -291,98 +250,114 @@ namespace Akka.Remote.Transport.DotNetty
     internal sealed class SslSettings
     {
         public static readonly SslSettings Empty = new();
-        public static SslSettings Create(Config config)
+
+        public static SslSettings CreateOrDefault(Config config, SslSettings? @default = null)
+        {
+            try
+            {
+                return Create(config);
+            }
+            catch(Exception e)
+            {
+                return @default ?? throw e;
+            }
+        }
+
+        private static SslSettings Create(Config config)
         {
             if (config.IsNullOrEmpty())
-                throw new ConfigurationException($"Failed to create {typeof(DotNettyTransportSettings)}: DotNetty SSL HOCON config was not found (default path: `akka.remote.dot-netty.ssl`)");
+                throw new ConfigurationException($"Failed to create {typeof(DotNettyTransportSettings)}: DotNetty SSL HOCON config was not found (default path: `akka.remote.dot-netty.tcp.ssl`)");
 
-            if (config.GetBoolean("certificate.use-thumprint-over-file", false)
-                || config.GetBoolean("certificate.use-thumbprint-over-file", false))
+            if (config.GetBoolean("certificate.use-thumprint-over-file")
+                || config.GetBoolean("certificate.use-thumbprint-over-file"))
             {
-                var thumbprint = config.GetString("certificate.thumbprint", null) 
-                                 ?? config.GetString("certificate.thumpbrint", null);
+                var thumbprint = config.GetString("certificate.thumbprint") 
+                                 ?? config.GetString("certificate.thumpbrint");
                 if (string.IsNullOrWhiteSpace(thumbprint))
-                    throw new Exception("`akka.remote.dot-netty.ssl.certificate.use-thumbprint-over-file` is set to true but `akka.remote.dot-netty.ssl.certificate.thumbprint` is null or empty");
+                    throw new Exception("`akka.remote.dot-netty.tcp.ssl.certificate.use-thumbprint-over-file` is set to true but `akka.remote.dot-netty.tcp.ssl.certificate.thumbprint` is null or empty");
                 
-                return new SslSettings(thumbprint,
-                    config.GetString("certificate.store-name", null),
-                    ParseStoreLocationName(config.GetString("certificate.store-location", null)),
-                        config.GetBoolean("suppress-validation", false));
-
+                return new SslSettings(certificateThumbprint: thumbprint,
+                    storeName: config.GetString("certificate.store-name"),
+                    storeLocation: ParseStoreLocationName(config.GetString("certificate.store-location")),
+                    suppressValidation: config.GetBoolean("suppress-validation"));
             }
-            else
-            {
-                var flagsRaw = config.GetStringList("certificate.flags", new string[] { });
-                var flags = flagsRaw.Aggregate(X509KeyStorageFlags.DefaultKeySet, (flag, str) => flag | ParseKeyStorageFlag(str));
 
-                return new SslSettings(
-                    certificatePath: config.GetString("certificate.path", null),
-                    certificatePassword: config.GetString("certificate.password", null),
-                    flags: flags,
-                    suppressValidation: config.GetBoolean("suppress-validation", false));
-            }
+            var flagsRaw = config.GetStringList("certificate.flags", new string[] { });
+            var flags = flagsRaw.Aggregate(X509KeyStorageFlags.DefaultKeySet, (flag, str) => flag | ParseKeyStorageFlag(str));
+
+            return new SslSettings(
+                certificatePath: config.GetString("certificate.path"),
+                certificatePassword: config.GetString("certificate.password"),
+                flags: flags,
+                suppressValidation: config.GetBoolean("suppress-validation"));
 
         }
 
         private static StoreLocation ParseStoreLocationName(string str)
         {
-            switch (str)
+            return str switch
             {
-                case "local-machine": return StoreLocation.LocalMachine;
-                case "current-user": return StoreLocation.CurrentUser;
-                default: throw new ArgumentException($"Unrecognized flag in X509 certificate config [{str}]. Available flags: local-machine | current-user");
-            }
+                "local-machine" => StoreLocation.LocalMachine,
+                "current-user" => StoreLocation.CurrentUser,
+                _ => throw new ArgumentException(
+                    $"Unrecognized flag in X509 certificate config [{str}]. Available flags: local-machine | current-user")
+            };
         }
 
         private static X509KeyStorageFlags ParseKeyStorageFlag(string str)
         {
-            switch (str)
+            return str switch
             {
-                case "default-key-set": return X509KeyStorageFlags.DefaultKeySet;
-                case "exportable": return X509KeyStorageFlags.Exportable;
-                case "machine-key-set": return X509KeyStorageFlags.MachineKeySet;
-                case "persist-key-set": return X509KeyStorageFlags.PersistKeySet;
-                case "user-key-set": return X509KeyStorageFlags.UserKeySet;
-                case "user-protected": return X509KeyStorageFlags.UserProtected;
-                default: throw new ArgumentException($"Unrecognized flag in X509 certificate config [{str}]. Available flags: default-key-set | exportable | machine-key-set | persist-key-set | user-key-set | user-protected");
-            }
+                "default-key-set" => X509KeyStorageFlags.DefaultKeySet,
+                "exportable" => X509KeyStorageFlags.Exportable,
+                "machine-key-set" => X509KeyStorageFlags.MachineKeySet,
+                "persist-key-set" => X509KeyStorageFlags.PersistKeySet,
+                "user-key-set" => X509KeyStorageFlags.UserKeySet,
+                "user-protected" => X509KeyStorageFlags.UserProtected,
+                _ => throw new ArgumentException(
+                    $"Unrecognized flag in X509 certificate config [{str}]. Available flags: default-key-set | exportable | machine-key-set | persist-key-set | user-key-set | user-protected")
+            };
         }
 
         /// <summary>
         /// X509 certificate used to establish Secure Socket Layer (SSL) between two remote endpoints.
         /// </summary>
-        public readonly X509Certificate2 Certificate;
+        public readonly X509Certificate2? Certificate;
 
         /// <summary>
         /// Flag used to suppress certificate validation - use true only, when on dev machine or for testing.
         /// </summary>
         public readonly bool SuppressValidation;
 
-        public SslSettings()
+        private SslSettings()
         {
             Certificate = null;
             SuppressValidation = false;
         }
 
-        public SslSettings(string certificateThumbprint, string storeName, StoreLocation storeLocation, bool suppressValidation)
+        public SslSettings(X509Certificate2 certificate, bool suppressValidation)
         {
-            using (var store = new X509Store(storeName, storeLocation))
-            {
-                store.Open(OpenFlags.ReadOnly);
-
-                var find = store.Certificates.Find(X509FindType.FindByThumbprint, certificateThumbprint, !suppressValidation);
-                if (find.Count == 0)
-                {
-                    throw new ArgumentException(
-                        "Could not find Valid certificate for thumbprint (by default it can be found under `akka.remote.dot-netty.tcp.ssl.certificate.thumbprint`. Also check `akka.remote.dot-netty.tcp.ssl.certificate.store-name` and `akka.remote.dot-netty.tcp.ssl.certificate.store-location`)");
-                }
-
-                Certificate = find[0];
-                SuppressValidation = suppressValidation;
-            }
+            Certificate = certificate;
+            SuppressValidation = suppressValidation;
         }
 
-        public SslSettings(string certificatePath, string certificatePassword, X509KeyStorageFlags flags, bool suppressValidation)
+        private SslSettings(string certificateThumbprint, string storeName, StoreLocation storeLocation, bool suppressValidation)
+        {
+            using var store = new X509Store(storeName, storeLocation);
+            store.Open(OpenFlags.ReadOnly);
+
+            var find = store.Certificates.Find(X509FindType.FindByThumbprint, certificateThumbprint, !suppressValidation);
+            if (find.Count == 0)
+            {
+                throw new ArgumentException(
+                    "Could not find Valid certificate for thumbprint (by default it can be found under `akka.remote.dot-netty.tcp.ssl.certificate.thumbprint`. Also check `akka.remote.dot-netty.tcp.ssl.certificate.store-name` and `akka.remote.dot-netty.tcp.ssl.certificate.store-location`)");
+            }
+
+            Certificate = find[0];
+            SuppressValidation = suppressValidation;
+        }
+
+        private SslSettings(string certificatePath, string certificatePassword, X509KeyStorageFlags flags, bool suppressValidation)
         {
             if (string.IsNullOrEmpty(certificatePath))
                 throw new ArgumentNullException(nameof(certificatePath), "Path to SSL certificate was not found (by default it can be found under `akka.remote.dot-netty.tcp.ssl.certificate.path`)");

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -53,6 +53,14 @@ namespace Akka.TestKit
 
         private static int _systemNumber = 0;
 
+        private static ActorSystemSetup FromActorSystemSetup(ActorSystemSetup setup)
+        {
+            var bootstrapOptions = setup.Get<BootstrapSetup>();
+            var bootstrap = bootstrapOptions.HasValue ? bootstrapOptions.Value : BootstrapSetup.Create();
+            bootstrap = bootstrap.WithConfigFallback(_akkaSpecConfig);
+            return setup.And(bootstrap);
+        }
+        
         public AkkaSpec(string config, ITestOutputHelper output = null)
             : this(ConfigurationFactory.ParseString(config).WithFallback(_akkaSpecConfig), output)
         {
@@ -65,7 +73,7 @@ namespace Akka.TestKit
         }
 
         public AkkaSpec(ActorSystemSetup setup, ITestOutputHelper output = null)
-            : base(setup, GetCallerName(), output)
+            : base(FromActorSystemSetup(setup), GetCallerName(), output)
         {
             BeforeAll();
         }


### PR DESCRIPTION
* The Akka.Remote code is full of byte rot and needs cleaning.
* AkkaSpec failed to inject its internal configuration with its `ActorSystemSetup` constructor variant

## Changes

* Makes sure that `AkkaSpec` injects `_akkaSpecConfig` into the `ActorSystemSetup` ctor argument
* Modernize `DotNettyTransportSettings`:
  * Change to `record`
  * Use `#nullable enable`
  * Add `Setup` support.
  * Use pattern matching
* Add `DotNettySslSetup`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).