### PR TITLE
DistributedPubSub: make query to count local subscribers for topic public

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/TopicMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/TopicMessages.cs
@@ -42,9 +42,9 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
     }
 
     /// <summary>
-    /// TBD
+    /// Get all subscribers for a given topic.
     /// </summary>
-    internal sealed class CountSubscribers
+    public sealed class CountSubscribers
     {
         public string Topic { get; }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/TopicMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/TopicMessages.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
+using Akka.Annotations;
 using Akka.Event;
 using Akka.Routing;
 
@@ -44,6 +45,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
     /// <summary>
     /// Get all subscribers for a given topic.
     /// </summary>
+    [ApiMayChange]
     public sealed class CountSubscribers
     {
         public string Topic { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -318,6 +318,14 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override string ToString() { }
     }
 }
+namespace Akka.Cluster.Tools.PublishSubscribe.Internal
+{
+    public sealed class CountSubscribers
+    {
+        public CountSubscribers(string topic) { }
+        public string Topic { get; }
+    }
+}
 namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
 {
     public class DistributedPubSubMessageSerializer : Akka.Serialization.SerializerWithStringManifest

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -320,6 +320,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
 }
 namespace Akka.Cluster.Tools.PublishSubscribe.Internal
 {
+    [Akka.Annotations.ApiMayChangeAttribute()]
     public sealed class CountSubscribers
     {
         public CountSubscribers(string topic) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -318,6 +318,14 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override string ToString() { }
     }
 }
+namespace Akka.Cluster.Tools.PublishSubscribe.Internal
+{
+    public sealed class CountSubscribers
+    {
+        public CountSubscribers(string topic) { }
+        public string Topic { get; }
+    }
+}
 namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
 {
     public class DistributedPubSubMessageSerializer : Akka.Serialization.SerializerWithStringManifest

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -320,6 +320,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
 }
 namespace Akka.Cluster.Tools.PublishSubscribe.Internal
 {
+    [Akka.Annotations.ApiMayChangeAttribute()]
     public sealed class CountSubscribers
     {
         public CountSubscribers(string topic) { }


### PR DESCRIPTION
## Changes

close #3663 - between this and `Topic`s all local data should be queryable for distributed pub-sub

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #3663
* [x] Changes in public API reviewed, if any.
