### PR TITLE
Expose `Tags` property in `EventEnvelope`

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByTagSpec.cs
@@ -32,5 +32,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
         {
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
+
+        protected override bool SupportsTagsInEventEnvelope => true;
     }
 }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
@@ -32,5 +32,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
         {
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
+
+        protected override bool SupportsTagsInEventEnvelope => true;
     }
 }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory/AllEventsPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory/AllEventsPublisher.cs
@@ -108,12 +108,14 @@ namespace Akka.Persistence.Query.InMemory
                     if (replayed.Offset > ToOffset)
                         return true;
 
+                    // NOTES: tags is empty because tags are not retrieved from the database query (as of this writing)
                     Buffer.Add(new EventEnvelope(
                         offset: new Sequence(replayed.Offset),
                         persistenceId: replayed.Persistent.PersistenceId,
                         sequenceNr: replayed.Persistent.SequenceNr,
                         @event: replayed.Persistent.Payload,
-                        timestamp: replayed.Persistent.Timestamp));
+                        timestamp: replayed.Persistent.Timestamp,
+                        tags: Array.Empty<string>()));
 
                     CurrentOffset = replayed.Offset + 1;
                     Buffer.DeliverBuffer(TotalDemand);

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory/EventsByPersistenceIdPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory/EventsByPersistenceIdPublisher.cs
@@ -121,12 +121,14 @@ namespace Akka.Persistence.Query.InMemory
                 {
                     case ReplayedMessage replayed:
                         var seqNr = replayed.Persistent.SequenceNr;
+                        // NOTES: tags is empty because tags are not retrieved from the database query (as of this writing)
                         Buffer.Add(new EventEnvelope(
                             offset: new Sequence(seqNr),
                             persistenceId: PersistenceId,
                             sequenceNr: seqNr,
                             @event: replayed.Persistent.Payload,
-                            timestamp: replayed.Persistent.Timestamp));
+                            timestamp: replayed.Persistent.Timestamp,
+                            tags: Array.Empty<string>()));
                         CurrentSequenceNr = seqNr + 1;
                         Buffer.DeliverBuffer(TotalDemand);
                         return true;

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory/EventsByTagPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory/EventsByTagPublisher.cs
@@ -120,7 +120,8 @@ namespace Akka.Persistence.Query.InMemory
                             persistenceId: replayed.Persistent.PersistenceId,
                             sequenceNr: replayed.Persistent.SequenceNr,
                             @event: replayed.Persistent.Payload,
-                            timestamp: replayed.Persistent.Timestamp));
+                            timestamp: replayed.Persistent.Timestamp,
+                            tags: new [] { replayed.Tag }));
 
                         CurrentOffset = replayed.Offset + 1;
                         Buffer.DeliverBuffer(TotalDemand);

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/AllEventsPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/AllEventsPublisher.cs
@@ -139,12 +139,14 @@ namespace Akka.Persistence.Query.Sql
                     if (replayed.Offset > ToOffset)
                         return true;
 
+                    // NOTES: tags is empty because tags are not retrieved from the database query (as of this writing)
                     Buffer.Add(new EventEnvelope(
                         offset: new Sequence(replayed.Offset),
                         persistenceId: replayed.Persistent.PersistenceId,
                         sequenceNr: replayed.Persistent.SequenceNr,
                         @event: replayed.Persistent.Payload,
-                        timestamp: replayed.Persistent.Timestamp));
+                        timestamp: replayed.Persistent.Timestamp,
+                        tags: Array.Empty<string>()));
 
                     CurrentOffset = replayed.Offset;
                     Buffer.DeliverBuffer(TotalDemand);

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByPersistenceIdPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByPersistenceIdPublisher.cs
@@ -153,12 +153,14 @@ namespace Akka.Persistence.Query.Sql
             {
                 case ReplayedMessage replayed:
                     var seqNr = replayed.Persistent.SequenceNr;
+                    // NOTES: tags is empty because tags are not retrieved from the database query (as of this writing)
                     Buffer.Add(new EventEnvelope(
                         offset: new Sequence(seqNr),
                         persistenceId: PersistenceId,
                         sequenceNr: seqNr,
                         @event: replayed.Persistent.Payload,
-                        timestamp: replayed.Persistent.Timestamp));
+                        timestamp: replayed.Persistent.Timestamp,
+                        tags: Array.Empty<string>()));
                     CurrentSequenceNr = seqNr + 1;
                     Buffer.DeliverBuffer(TotalDemand);
                     return true;

--- a/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByTagPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.Sql/EventsByTagPublisher.cs
@@ -153,7 +153,8 @@ namespace Akka.Persistence.Query.Sql
                         persistenceId: replayed.Persistent.PersistenceId,
                         sequenceNr: replayed.Persistent.SequenceNr,
                         @event: replayed.Persistent.Payload,
-                        timestamp: replayed.Persistent.Timestamp));
+                        timestamp: replayed.Persistent.Timestamp,
+                        tags: new [] { replayed.Tag }));
 
                     CurrentOffset = replayed.Offset;
                     Buffer.DeliverBuffer(TotalDemand);

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteCurrentEventsByTagSpec.cs
@@ -44,5 +44,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
         {
             ReadJournal = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
         }
+
+        protected override bool SupportsTagsInEventEnvelope => true;
     }
 }

--- a/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite.Tests/Query/SqliteEventsByTagSpec.cs
@@ -44,5 +44,7 @@ namespace Akka.Persistence.Sqlite.Tests.Query
         {
             ReadJournal = Sys.ReadJournalFor<SqlReadJournal>(SqlReadJournal.Identifier);
         }
+
+        protected override bool SupportsTagsInEventEnvelope => true;
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
@@ -11,16 +11,11 @@ namespace Akka.Persistence.Query
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event) { }
         [System.ObsoleteAttribute("For binary compatibility with previous releases. Since 1.5.11")]
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp) { }
-        public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] string[] tags) { }
+        public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp, string[] tags) { }
         public object Event { get; }
         public Akka.Persistence.Query.Offset Offset { get; }
         public string PersistenceId { get; }
         public long SequenceNr { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})]
         public string[] Tags { get; }
         public long Timestamp { get; }
         public bool Equals(Akka.Persistence.Query.EventEnvelope other) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
@@ -4,15 +4,24 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Persistence.Query
 {
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class EventEnvelope : System.IEquatable<Akka.Persistence.Query.EventEnvelope>
     {
-        [System.ObsoleteAttribute("For binary compatibility with previous releases")]
+        [System.ObsoleteAttribute("For binary compatibility with previous releases. Since 1.4.14")]
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event) { }
+        [System.ObsoleteAttribute("For binary compatibility with previous releases. Since 1.5.11")]
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp) { }
+        public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})] string[] tags) { }
         public object Event { get; }
         public Akka.Persistence.Query.Offset Offset { get; }
         public string PersistenceId { get; }
         public long SequenceNr { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})]
+        public string[] Tags { get; }
         public long Timestamp { get; }
         public bool Equals(Akka.Persistence.Query.EventEnvelope other) { }
         public override bool Equals(object obj) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
@@ -4,15 +4,24 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Persistence.Query
 {
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class EventEnvelope : System.IEquatable<Akka.Persistence.Query.EventEnvelope>
     {
-        [System.ObsoleteAttribute("For binary compatibility with previous releases")]
+        [System.ObsoleteAttribute("For binary compatibility with previous releases. Since 1.4.14")]
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event) { }
+        [System.ObsoleteAttribute("For binary compatibility with previous releases. Since 1.5.11")]
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp) { }
+        public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})] string[] tags) { }
         public object Event { get; }
         public Akka.Persistence.Query.Offset Offset { get; }
         public string PersistenceId { get; }
         public long SequenceNr { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})]
+        public string[] Tags { get; }
         public long Timestamp { get; }
         public bool Equals(Akka.Persistence.Query.EventEnvelope other) { }
         public override bool Equals(object obj) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
@@ -11,16 +11,11 @@ namespace Akka.Persistence.Query
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event) { }
         [System.ObsoleteAttribute("For binary compatibility with previous releases. Since 1.5.11")]
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp) { }
-        public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] string[] tags) { }
+        public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp, string[] tags) { }
         public object Event { get; }
         public Akka.Persistence.Query.Offset Offset { get; }
         public string PersistenceId { get; }
         public long SequenceNr { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})]
         public string[] Tags { get; }
         public long Timestamp { get; }
         public bool Equals(Akka.Persistence.Query.EventEnvelope other) { }

--- a/src/core/Akka.Persistence.Query/EventEnvelope.cs
+++ b/src/core/Akka.Persistence.Query/EventEnvelope.cs
@@ -26,7 +26,7 @@ namespace Akka.Persistence.Query
         /// </summary>
         [Obsolete("For binary compatibility with previous releases. Since 1.4.14")]
         public EventEnvelope(Offset offset, string persistenceId, long sequenceNr, object @event)
-            : this(offset, persistenceId, sequenceNr, @event, 0L, null)
+            : this(offset, persistenceId, sequenceNr, @event, 0L, Array.Empty<string>())
         { }
         
         /// <summary>
@@ -34,17 +34,17 @@ namespace Akka.Persistence.Query
         /// </summary>
         [Obsolete("For binary compatibility with previous releases. Since 1.5.11")]
         public EventEnvelope(Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp)
-            : this(offset, persistenceId, sequenceNr, @event, timestamp, null)
+            : this(offset, persistenceId, sequenceNr, @event, timestamp, Array.Empty<string>())
         { }        
 
-        public EventEnvelope(Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp, string[]? tags)
+        public EventEnvelope(Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp, string[] tags)
         {
             Offset = offset;
             PersistenceId = persistenceId;
             SequenceNr = sequenceNr;
             Event = @event;
             Timestamp = timestamp;
-            Tags = tags;
+            Tags = tags ?? Array.Empty<string>();
         }        
 
         public Offset Offset { get; }
@@ -57,7 +57,7 @@ namespace Akka.Persistence.Query
         
         public long Timestamp { get; }
 
-        public string[]? Tags { get; }
+        public string[] Tags { get; }
 
         public bool Equals(EventEnvelope? other)
         {

--- a/src/core/Akka.Persistence.Query/EventEnvelope.cs
+++ b/src/core/Akka.Persistence.Query/EventEnvelope.cs
@@ -7,6 +7,7 @@
 
 using System;
 
+#nullable enable
 namespace Akka.Persistence.Query
 {
     /// <summary>
@@ -23,21 +24,27 @@ namespace Akka.Persistence.Query
         /// <summary>
         /// Initializes a new instance of the <see cref="EventEnvelope"/> class.
         /// </summary>
-        [Obsolete("For binary compatibility with previous releases")]
+        [Obsolete("For binary compatibility with previous releases. Since 1.4.14")]
         public EventEnvelope(Offset offset, string persistenceId, long sequenceNr, object @event)
-            : this(offset, persistenceId, sequenceNr, @event, 0L)
+            : this(offset, persistenceId, sequenceNr, @event, 0L, null)
         { }
         
         /// <summary>
         /// Initializes a new instance of the <see cref="EventEnvelope"/> class.
         /// </summary>
+        [Obsolete("For binary compatibility with previous releases. Since 1.5.11")]
         public EventEnvelope(Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp)
+            : this(offset, persistenceId, sequenceNr, @event, timestamp, null)
+        { }        
+
+        public EventEnvelope(Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp, string[]? tags)
         {
             Offset = offset;
             PersistenceId = persistenceId;
             SequenceNr = sequenceNr;
             Event = @event;
             Timestamp = timestamp;
+            Tags = tags;
         }        
 
         public Offset Offset { get; }
@@ -50,28 +57,30 @@ namespace Akka.Persistence.Query
         
         public long Timestamp { get; }
 
-        public bool Equals(EventEnvelope other)
+        public string[]? Tags { get; }
+
+        public bool Equals(EventEnvelope? other)
         {
             if (ReferenceEquals(this, other)) return true;
             if (ReferenceEquals(other, null)) return false;
 
-            // timestamp not included in Equals for backwards compatibility
+            // Timestamp and Tags not included in Equals for backwards compatibility
             return Offset == other.Offset
                    && PersistenceId == other.PersistenceId
                    && SequenceNr == other.SequenceNr
                    && Equals(Event, other.Event);
         }
 
-        public override bool Equals(object obj) => obj is EventEnvelope evt && Equals(evt);
+        public override bool Equals(object? obj) => obj is EventEnvelope evt && Equals(evt);
 
         public override int GetHashCode()
         {
             unchecked
             {
                 var hashCode = Offset.GetHashCode();
-                hashCode = (hashCode*397) ^ (PersistenceId != null ? PersistenceId.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ (PersistenceId?.GetHashCode() ?? 0);
                 hashCode = (hashCode*397) ^ SequenceNr.GetHashCode();
-                hashCode = (hashCode*397) ^ (Event != null ? Event.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ (Event?.GetHashCode() ?? 0);
                 return hashCode;
             }
         }

--- a/src/core/Akka.Persistence.TCK/Query/CurrentEventsByTagSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/CurrentEventsByTagSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Query;
@@ -14,6 +15,7 @@ using Akka.Streams.TestKit;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 using static Akka.Persistence.Query.Offset;
 
 namespace Akka.Persistence.TCK.Query
@@ -24,6 +26,8 @@ namespace Akka.Persistence.TCK.Query
 
         protected IReadJournal ReadJournal { get; set; }
 
+        protected virtual bool SupportsTagsInEventEnvelope => false;
+        
         protected CurrentEventsByTagSpec(Config config = null, string actorSystemName = null, ITestOutputHelper output = null)
             : base(config ?? Config.Empty, actorSystemName, output)
         {
@@ -39,7 +43,9 @@ namespace Akka.Persistence.TCK.Query
         [Fact]
         public virtual void ReadJournal_query_CurrentEventsByTag_should_find_existing_events()
         {
-            var queries = ReadJournal as ICurrentEventsByTagQuery;
+            if (ReadJournal is not ICurrentEventsByTagQuery queries)
+                throw IsTypeException.ForMismatchedType(nameof(ICurrentEventsByTagQuery), ReadJournal?.GetType().Name ?? "null");
+
             var a = Sys.ActorOf(Query.TestActor.Props("a"));
             var b = Sys.ActorOf(Query.TestActor.Props("b"));
 
@@ -59,30 +65,32 @@ namespace Akka.Persistence.TCK.Query
             var greenSrc = queries.CurrentEventsByTag("green", offset: NoOffset());
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
             probe.Request(2);
-            probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == "a" && p.SequenceNr == 2L && p.Event.Equals("a green apple"));
-            probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == "a" && p.SequenceNr == 4L && p.Event.Equals("a green banana"));
+            ExpectEnvelope(probe, "a", 2L, "a green apple", "green");
+            ExpectEnvelope(probe, "a", 4L, "a green banana", "green");
             probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
             probe.Request(2);
-            probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == "b" && p.SequenceNr == 2L && p.Event.Equals("a green leaf"));
+            ExpectEnvelope(probe, "b", 2L, "a green leaf", "green");
             probe.ExpectComplete();
 
             var blackSrc = queries.CurrentEventsByTag("black", offset: NoOffset());
             var probe2 = blackSrc.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
             probe2.Request(5);
-            probe2.ExpectNext<EventEnvelope>(p => p.PersistenceId == "b" && p.SequenceNr == 1L && p.Event.Equals("a black car"));
+            ExpectEnvelope(probe2, "b", 1L, "a black car", "black");
             probe2.ExpectComplete();
 
             var appleSrc = queries.CurrentEventsByTag("apple", offset: NoOffset());
             var probe3 = appleSrc.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
             probe3.Request(5);
-            probe3.ExpectNext<EventEnvelope>(p => p.PersistenceId == "a" && p.SequenceNr == 2L && p.Event.Equals("a green apple"));
+            ExpectEnvelope(probe3, "a", 2L, "a green apple", "apple");
             probe3.ExpectComplete();
         }
 
         [Fact]
         public virtual void ReadJournal_query_CurrentEventsByTag_should_complete_when_no_events()
         {
-            var queries = ReadJournal as ICurrentEventsByTagQuery;
+            if (ReadJournal is not ICurrentEventsByTagQuery queries)
+                throw IsTypeException.ForMismatchedType(nameof(ICurrentEventsByTagQuery), ReadJournal?.GetType().Name ?? "null");
+
             var a = Sys.ActorOf(Query.TestActor.Props("a"));
             var b = Sys.ActorOf(Query.TestActor.Props("b"));
 
@@ -100,16 +108,32 @@ namespace Akka.Persistence.TCK.Query
         [Fact]
         public virtual void ReadJournal_query_CurrentEventsByTag_should_not_see_new_events_after_complete()
         {
-            var queries = ReadJournal as ICurrentEventsByTagQuery;
-            ReadJournal_query_CurrentEventsByTag_should_find_existing_events();
+            if (ReadJournal is not ICurrentEventsByTagQuery queries)
+                throw IsTypeException.ForMismatchedType(nameof(ICurrentEventsByTagQuery), ReadJournal?.GetType().Name ?? "null");
+
+            var a = Sys.ActorOf(Query.TestActor.Props("a"));
+            var b = Sys.ActorOf(Query.TestActor.Props("b"));
+
+            a.Tell("hello");
+            ExpectMsg("hello-done");
+            a.Tell("a green apple");
+            ExpectMsg("a green apple-done");
+            b.Tell("a black car");
+            ExpectMsg("a black car-done");
+            a.Tell("something else");
+            ExpectMsg("something else-done");
+            a.Tell("a green banana");
+            ExpectMsg("a green banana-done");
+            b.Tell("a green leaf");
+            ExpectMsg("a green leaf-done");
 
             var c = Sys.ActorOf(Query.TestActor.Props("c"));
 
             var greenSrc = queries.CurrentEventsByTag("green", offset: NoOffset());
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
             probe.Request(2);
-            probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == "a" && p.SequenceNr == 2L && p.Event.Equals("a green apple"));
-            probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == "a" && p.SequenceNr == 4L && p.Event.Equals("a green banana"));
+            ExpectEnvelope(probe, "a", 2L, "a green apple", "green");
+            ExpectEnvelope(probe, "a", 4L, "a green banana", "green");
             probe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             c.Tell("a green cucumber");
@@ -117,14 +141,15 @@ namespace Akka.Persistence.TCK.Query
 
             probe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
             probe.Request(5);
-            probe.ExpectNext<EventEnvelope>(p => p.PersistenceId == "b" && p.SequenceNr == 2L && p.Event.Equals("a green leaf"));
+            ExpectEnvelope(probe, "b", 2L, "a green leaf", "green");
             probe.ExpectComplete(); // green cucumber not seen
         }
 
         [Fact]
         public virtual void ReadJournal_query_CurrentEventsByTag_should_find_events_from_offset_exclusive()
         {
-            var queries = ReadJournal as ICurrentEventsByTagQuery;
+            if (ReadJournal is not ICurrentEventsByTagQuery queries)
+                throw IsTypeException.ForMismatchedType(nameof(ICurrentEventsByTagQuery), ReadJournal?.GetType().Name ?? "null");
 
             var a = Sys.ActorOf(Query.TestActor.Props("a"));
             var b = Sys.ActorOf(Query.TestActor.Props("b"));
@@ -148,25 +173,27 @@ namespace Akka.Persistence.TCK.Query
             var greenSrc1 = queries.CurrentEventsByTag("green", offset: NoOffset());
             var probe1 = greenSrc1.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
             probe1.Request(2);
-            probe1.ExpectNext<EventEnvelope>(p => p.PersistenceId == "a" && p.SequenceNr == 2L && p.Event.Equals("a green apple"));
-            var offs = probe1.ExpectNext<EventEnvelope>(p => p.PersistenceId == "a" && p.SequenceNr == 4L && p.Event.Equals("a green banana")).Offset;
+            ExpectEnvelope(probe1, "a", 2L, "a green apple", "green");
+            var offs = ExpectEnvelope(probe1, "a", 4L, "a green banana", "green").Offset;
             probe1.Cancel();
 
             var greenSrc = queries.CurrentEventsByTag("green", offset: offs);
             var probe2 = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
             probe2.Request(10);
             // note that banana is not included, since exclusive offset
-            probe2.ExpectNext<EventEnvelope>(p => p.PersistenceId == "b" && p.SequenceNr == 2L && p.Event.Equals("a green leaf"));
+            ExpectEnvelope(probe2, "b", 2L, "a green leaf", "green");
             probe2.Cancel();
         }
 
         [Fact]
         public virtual void ReadJournal_query_CurrentEventsByTag_should_see_all_150_events()
         {
-            var queries = ReadJournal as ICurrentEventsByTagQuery;
+            if (ReadJournal is not ICurrentEventsByTagQuery queries)
+                throw IsTypeException.ForMismatchedType(nameof(ICurrentEventsByTagQuery), ReadJournal?.GetType().Name ?? "null");
+
             var a = Sys.ActorOf(Query.TestActor.Props("a"));
 
-            for (int i = 0; i < 150; ++i) 
+            foreach (var _ in Enumerable.Range(1, 150))
             {
                 a.Tell("a green apple");
                 ExpectMsg("a green apple-done");
@@ -175,10 +202,9 @@ namespace Akka.Persistence.TCK.Query
             var greenSrc = queries.CurrentEventsByTag("green", offset: NoOffset());
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
             probe.Request(150);
-            for (int i = 0; i < 150; ++i)
+            foreach (var i in Enumerable.Range(1, 150))
             {
-                probe.ExpectNext<EventEnvelope>(p => 
-                    p.PersistenceId == "a" && p.SequenceNr == (i + 1) && p.Event.Equals("a green apple"));
+                ExpectEnvelope(probe, "a", i, "a green apple", "green");
             }
 
             probe.ExpectComplete();
@@ -188,7 +214,9 @@ namespace Akka.Persistence.TCK.Query
         [Fact]
         public void ReadJournal_query_CurrentEventsByTag_should_include_timestamp_in_EventEnvelope()
         {
-            var queries = ReadJournal as ICurrentEventsByTagQuery;
+            if (ReadJournal is not ICurrentEventsByTagQuery queries)
+                throw IsTypeException.ForMismatchedType(nameof(ICurrentEventsByTagQuery), ReadJournal?.GetType().Name ?? "null");
+
             var a = Sys.ActorOf(Query.TestActor.Props("testTimestamp"));
             
             a.Tell("a green apple");
@@ -204,6 +232,20 @@ namespace Akka.Persistence.TCK.Query
             probe.ExpectNext().Timestamp.Should().BeGreaterThan(0);
             probe.ExpectNext().Timestamp.Should().BeGreaterThan(0);
             probe.Cancel();
+        }
+
+        private EventEnvelope ExpectEnvelope(TestSubscriber.Probe<EventEnvelope> probe, string persistenceId, long sequenceNr, string @event, string tag)
+        {
+            var envelope = probe.ExpectNext<EventEnvelope>(_ => true);
+            envelope.PersistenceId.Should().Be(persistenceId);
+            envelope.SequenceNr.Should().Be(sequenceNr);
+            envelope.Event.Should().Be(@event);
+            if (SupportsTagsInEventEnvelope)
+            {
+                envelope.Tags.Should().NotBeNull();
+                envelope.Tags.Should().Contain(tag);
+            }
+            return envelope;
         }
     }
 }


### PR DESCRIPTION
## Changes

close #6849

* Expose a new property `Tags` in `EventEnvelope`

The `Tags` property is, by default, an empty array. It is up to the plugin implementation to populate it.

The built-in SQLite and in-mem journal is set to populate the property only for `EventsByTag` and `CurrentEventsByTag` queries, all SQL based plugin "should" automatically inherit this. It is not populated on any other persistence queries at the moment. 

Full support is planned for `Akka.Persistence.Sql` plugin.

Changes have been tested on `Akka.Persistence.SqlServer` and `Akka.Persistence.MongoDb` to see if it breaks any API or unit test, they worked just fine.