### PR TITLE
added dotTrace diagnoser to Benchmark.NET projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ PerfResults/
 # BenchmarkDotNet files
 [rR]esults/
 
+# dotTrace files
+*.dtp
+*.dtp.*
+
 # Visual Studo 2015 cache/options directory
 .vs/
 

--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.13.6" />
     <!-- FluentAssertions is used in some benchmarks to validate internal behaviors -->
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>

--- a/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+        <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.13.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
@@ -14,10 +14,12 @@ using Akka.Benchmarks.Configurations;
 using Akka.Cluster.Sharding;
 using Akka.Routing;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnostics.dotTrace;
 using static Akka.Cluster.Benchmarks.Sharding.ShardingHelper;
 
 namespace Akka.Cluster.Benchmarks.Sharding
 {
+    [DotTraceDiagnoser]
     [Config(typeof(MonitoringConfig))]
     public class ShardMessageRoutingBenchmarks
     {

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
@@ -26,10 +26,9 @@ namespace Akka.Cluster.Benchmarks.Sharding
         [Params(StateStoreMode.Persistence, StateStoreMode.DData)]
         public StateStoreMode StateMode;
 
-        [Params(10000)]
-        public int MsgCount;
+        public const int MsgCount = 10000;
 
-        public int BatchSize = 20;
+        public const int BatchSize = 20;
 
         private ActorSystem _sys1;
         private ActorSystem _sys2;
@@ -143,21 +142,21 @@ namespace Akka.Cluster.Benchmarks.Sharding
             _batchActor = _sys1.ActorOf(Props.Create(() => new BulkSendActor(tcs, MsgCount)));
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = MsgCount)]
         public async Task SingleRequestResponseToLocalEntity()
         {
             for (var i = 0; i < MsgCount; i++)
                 await _shardRegion1.Ask<ShardedMessage>(_messageToSys1);
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = MsgCount * BatchSize)]
         public async Task StreamingToLocalEntity()
         {
             _batchActor.Tell(new BulkSendActor.BeginSend(_messageToSys1, _shardRegion1, BatchSize));
             await _batchComplete;
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = MsgCount)]
         public async Task SingleRequestResponseToRemoteEntity()
         {
             for (var i = 0; i < MsgCount; i++)
@@ -165,14 +164,14 @@ namespace Akka.Cluster.Benchmarks.Sharding
         }
 
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = MsgCount)]
         public async Task SingleRequestResponseToRemoteEntityWithLocalProxy()
         {
             for (var i = 0; i < MsgCount; i++)
                 await _localRouter.Ask<ShardedMessage>(new SendShardedMessage(_messageToSys2.EntityId, _messageToSys2));
         }
 
-        [Benchmark]
+        [Benchmark(OperationsPerInvoke = MsgCount*BatchSize)]
         public async Task StreamingToRemoteEntity()
         {
             _batchActor.Tell(new BulkSendActor.BeginSend(_messageToSys2, _shardRegion1, BatchSize));


### PR DESCRIPTION
## Changes

added dotTrace diagnoser to Benchmark.NET projects for diagnosing performance issues with tracing, optionally. 