### PR TITLE
Improve Streams Throttle. Log errors, improve tests, and add supervisor strategy support

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
@@ -351,7 +351,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(1, 2, 3, 4, 5)                                                                             
                     .ExpectComplete()
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);;
+                    .ShouldCompleteWithin(RemainingOrDefault);
             }, Materializer);
         }
 
@@ -367,7 +367,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(1, 2, 3, 4, 5)                                                                             
                     .ExpectComplete()
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);;
+                    .ShouldCompleteWithin(RemainingOrDefault);
             }, Materializer);
         }
 
@@ -391,7 +391,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(list[3])
                     .ExpectComplete()
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);;
+                    .ShouldCompleteWithin(RemainingOrDefault);
             }, Materializer);
         }
 
@@ -566,7 +566,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(1, 2, 3, 4, 5)
                     .ExpectComplete()
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);;
+                    .ShouldCompleteWithin(RemainingOrDefault);
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -1893,7 +1893,7 @@ namespace Akka.Streams.Dsl.Internal
             int maximumBurst, ThrottleMode mode)
         {
             if (elements <= 0) throw new ArgumentException("Throttle elements must be > 0", nameof(elements));
-            if (per == TimeSpan.Zero) throw new ArgumentException("Throttle per timeout must not be zero", nameof(per));
+            if (per <= TimeSpan.Zero) throw new ArgumentException("Throttle per timeout must not be less than or equal to zero", nameof(per));
             if (mode == ThrottleMode.Enforcing && maximumBurst < 0)
                 throw new ArgumentException("Throttle maximumBurst must be > 0 in Enforcing mode", nameof(maximumBurst));
             if (per.Ticks < elements)
@@ -1950,7 +1950,7 @@ namespace Akka.Streams.Dsl.Internal
             int maximumBurst, Func<T, int> calculateCost, ThrottleMode mode)
         {
             if (cost <= 0) throw new ArgumentException("cost must be > 0", nameof(cost));
-            if (per == TimeSpan.Zero) throw new ArgumentException("Throttle per timeout must not be zero", nameof(per));
+            if (per <= TimeSpan.Zero) throw new ArgumentException("Throttle per timeout must not be less than or equal to zero", nameof(per));
             if (mode == ThrottleMode.Enforcing && maximumBurst < 0)
                 throw new ArgumentException("Throttle maximumBurst must be > 0 in Enforcing mode", nameof(maximumBurst));
             if (per.Ticks < cost)


### PR DESCRIPTION
Fixes #6406

## Changes

* Add supervisor strategy support for failing colculateCost delegate
* Add unit test
* Rewrite nonsensical tests to proper async tests