### PR TITLE
Fixed DDataShardCoordinator NullReferenceException

### DIFF
--- a/src/core/Akka.API.Tests/Akka.API.Tests.csproj
+++ b/src/core/Akka.API.Tests/Akka.API.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="PublicApiGenerator" Version="9.3.0" />
-    <PackageReference Include="Verify.Xunit" Version="20.8.0" />
+    <PackageReference Include="Verify.Xunit" Version="20.8.1" />
     <PackageReference Include="Verify.DiffPlex" Version="2.2.1" />
   </ItemGroup>
 

--- a/src/core/Akka.API.Tests/Akka.API.Tests.csproj
+++ b/src/core/Akka.API.Tests/Akka.API.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="PublicApiGenerator" Version="9.3.0" />
-    <PackageReference Include="Verify.Xunit" Version="20.8.1" />
+    <PackageReference Include="Verify.Xunit" Version="20.8.0" />
     <PackageReference Include="Verify.DiffPlex" Version="2.2.1" />
   </ItemGroup>
 


### PR DESCRIPTION
## Changes

This code was not handling null checks appropriately - enabled `nullability` for both shard coordinators and found the problem.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).