### PR TITLE
Sealed uninherited `internal` classes in `Akka.Streams`

### DIFF
--- a/src/core/Akka.Streams.Tests/Implementation/FixedBufferSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/FixedBufferSpec.cs
@@ -164,8 +164,8 @@ namespace Akka.Streams.Tests.Implementation
                     buf.Dequeue().Should().Be(elem);
             }
         }
-        
-        private class CheatPowerOfTwoFixedSizeBuffer : PowerOfTwoFixedSizeBuffer<int>
+
+        private sealed class CheatPowerOfTwoFixedSizeBuffer : PowerOfTwoFixedSizeBuffer<int>
         {
             public CheatPowerOfTwoFixedSizeBuffer(int size) : base(size)
             {
@@ -174,7 +174,7 @@ namespace Akka.Streams.Tests.Implementation
             }
         }
 
-        private class CheatModuloFixedSizeBuffer : ModuloFixedSizeBuffer<int>
+        private sealed class CheatModuloFixedSizeBuffer : ModuloFixedSizeBuffer<int>
         {
             public CheatModuloFixedSizeBuffer(int size) : base(size)
             {

--- a/src/core/Akka.Streams/Actors/ActorPublisher.cs
+++ b/src/core/Akka.Streams/Actors/ActorPublisher.cs
@@ -747,7 +747,7 @@ namespace Akka.Streams.Actors
     /// <summary>
     /// TBD
     /// </summary>
-    internal class ActorPublisherState : ExtensionIdProvider<ActorPublisherState>, IExtension
+    internal sealed class ActorPublisherState : ExtensionIdProvider<ActorPublisherState>, IExtension
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka.Streams/Dsl/Hub.cs
+++ b/src/core/Akka.Streams/Dsl/Hub.cs
@@ -87,7 +87,7 @@ namespace Akka.Streams.Dsl
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="T">The type of element emitted by the MergeHub</typeparam>
-    internal class MergeHub<T> : GraphStageWithMaterializedValue<SourceShape<T>, Sink<T, NotUsed>>
+    internal sealed class MergeHub<T> : GraphStageWithMaterializedValue<SourceShape<T>, Sink<T, NotUsed>>
     {
         #region Internal classes
 
@@ -526,7 +526,7 @@ namespace Akka.Streams.Dsl
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal class BroadcastHub<T> : GraphStageWithMaterializedValue<SinkShape<T>, Source<T, NotUsed>>
+    internal sealed class BroadcastHub<T> : GraphStageWithMaterializedValue<SinkShape<T>, Source<T, NotUsed>>
     {
         #region internal classes
 
@@ -1296,7 +1296,7 @@ namespace Akka.Streams.Dsl
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal class PartitionHub<T> : GraphStageWithMaterializedValue<SinkShape<T>, Source<T, NotUsed>>
+    internal sealed class PartitionHub<T> : GraphStageWithMaterializedValue<SinkShape<T>, Source<T, NotUsed>>
     {
         #region queue implementation
 

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -1421,7 +1421,7 @@ namespace Akka.Streams.Dsl.Internal
         /// <typeparam name="TOut">TBD</typeparam>
         /// <typeparam name="TMat">TBD</typeparam>
         /// <typeparam name="TKey">TBD</typeparam>
-        internal class GroupByMergeBack<TOut, TMat, TKey> : IMergeBack<TOut, TMat>
+        internal sealed class GroupByMergeBack<TOut, TMat, TKey> : IMergeBack<TOut, TMat>
         {
             private readonly IFlow<TOut, TMat> _self;
             private readonly int _maxSubstreams;
@@ -1539,7 +1539,7 @@ namespace Akka.Streams.Dsl.Internal
         /// </summary>
         /// <typeparam name="TOut">TBD</typeparam>
         /// <typeparam name="TMat">TBD</typeparam>
-        internal class SplitWhenMergeBack<TOut, TMat> : IMergeBack<TOut, TMat>
+        internal sealed class SplitWhenMergeBack<TOut, TMat> : IMergeBack<TOut, TMat>
         {
             private readonly IFlow<TOut, TMat> _self;
             private readonly Func<TOut, bool> _predicate;
@@ -1644,7 +1644,7 @@ namespace Akka.Streams.Dsl.Internal
         /// </summary>
         /// <typeparam name="TOut">TBD</typeparam>
         /// <typeparam name="TMat">TBD</typeparam>
-        internal class SplitAfterMergeBack<TOut, TMat> : IMergeBack<TOut, TMat>
+        internal sealed class SplitAfterMergeBack<TOut, TMat> : IMergeBack<TOut, TMat>
         {
             private readonly IFlow<TOut, TMat> _self;
             private readonly Func<TOut, bool> _predicate;

--- a/src/core/Akka.Streams/Dsl/RestartFlow.cs
+++ b/src/core/Akka.Streams/Dsl/RestartFlow.cs
@@ -454,13 +454,13 @@ namespace Akka.Streams.Dsl
         public override string ToString() => $"Duration({Duration})";
     }
     }
-    
+
     /// <summary>
     /// Returns a flow that is almost identical but delays propagation of cancellation from downstream to upstream.
     /// Once the down stream is finished calls to onPush are ignored
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal class DelayCancellationStage<T> : SimpleLinearGraphStage<T>
+    internal sealed class DelayCancellationStage<T> : SimpleLinearGraphStage<T>
     {
         private readonly TimeSpan _delay;
 

--- a/src/core/Akka.Streams/Dsl/UnfoldFlow.cs
+++ b/src/core/Akka.Streams/Dsl/UnfoldFlow.cs
@@ -75,7 +75,7 @@ namespace Akka.Streams.Dsl
     }
 
     [InternalApi]
-    internal class FanOut2UnfoldingStage<TIn, TState, TOut> : GraphStage<FanOutShape<TIn, TState, TOut>>
+    internal sealed class FanOut2UnfoldingStage<TIn, TState, TOut> : GraphStage<FanOutShape<TIn, TState, TOut>>
     {
         private readonly Func<FanOutShape<TIn, TState, TOut>, UnfoldFlowGraphStageLogic<TIn, TState, TOut>> _generateGraphStageLogic;
 

--- a/src/core/Akka.Streams/Implementation/ActorProcessor.cs
+++ b/src/core/Akka.Streams/Implementation/ActorProcessor.cs
@@ -41,7 +41,7 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
-    internal class ActorProcessor<TIn, TOut> : ActorPublisher<TOut>, IProcessor<TIn, TOut>
+    internal sealed class ActorProcessor<TIn, TOut> : ActorPublisher<TOut>, IProcessor<TIn, TOut>
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka.Streams/Implementation/ActorRefBackpressureSinkStage.cs
+++ b/src/core/Akka.Streams/Implementation/ActorRefBackpressureSinkStage.cs
@@ -17,7 +17,7 @@ namespace Akka.Streams.Implementation
     /// INTERNAL API
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
-    internal class ActorRefBackpressureSinkStage<TIn> : GraphStage<SinkShape<TIn>>
+    internal sealed class ActorRefBackpressureSinkStage<TIn> : GraphStage<SinkShape<TIn>>
     {
         #region internal classes 
 

--- a/src/core/Akka.Streams/Implementation/EnumerableActorName.cs
+++ b/src/core/Akka.Streams/Implementation/EnumerableActorName.cs
@@ -41,7 +41,7 @@ namespace Akka.Streams.Implementation
     /// <summary>
     /// TBD
     /// </summary>
-    internal class EnumerableActorNameImpl : EnumerableActorName
+    internal sealed class EnumerableActorNameImpl : EnumerableActorName
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
@@ -1149,7 +1149,7 @@ namespace Akka.Streams.Implementation.Fusing
         /// TBD
         /// </summary>
         /// <typeparam name="T">TBD</typeparam>
-        internal class ActorOutputBoundary<T> : DownstreamBoundaryStageLogic, IActorOutputBoundary
+        internal sealed class ActorOutputBoundary<T> : DownstreamBoundaryStageLogic, IActorOutputBoundary
         {
             #region InHandler
             private sealed class InHandler : Stage.InHandler

--- a/src/core/Akka.Streams/Implementation/Fusing/StreamOfStreams.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/StreamOfStreams.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using Akka.Annotations;
 using Akka.Event;
 using Akka.Pattern;
 using Akka.Streams.Actors;
@@ -1000,7 +999,7 @@ namespace Akka.Streams.Implementation.Fusing
         /// <summary>
         /// Not yet materialized and no command has been scheduled
         /// </summary>
-        internal class Uninitialized : IState
+        internal sealed class Uninitialized : IState
         {
             public static readonly Uninitialized Instance = new();
 
@@ -1025,7 +1024,7 @@ namespace Akka.Streams.Implementation.Fusing
         /// <summary>
         /// A RequestOne command was scheduled before materialization
         /// </summary>
-        internal class RequestOneScheduledBeforeMaterialization : CommandScheduledBeforeMaterialization
+        internal sealed class RequestOneScheduledBeforeMaterialization : CommandScheduledBeforeMaterialization
         {
             public static readonly RequestOneScheduledBeforeMaterialization Instance = new(RequestOne.Instance);
 
@@ -1054,7 +1053,7 @@ namespace Akka.Streams.Implementation.Fusing
         {
         }
 
-        internal class RequestOne : ICommand
+        internal sealed class RequestOne : ICommand
         {
             public static readonly RequestOne Instance = new();
 

--- a/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
+++ b/src/core/Akka.Streams/Implementation/IO/FilePublisher.cs
@@ -23,7 +23,7 @@ namespace Akka.Streams.Implementation.IO
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal class FilePublisher : Actors.ActorPublisher<ByteString>
+    internal sealed class FilePublisher : Actors.ActorPublisher<ByteString>
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka.Streams/Implementation/IO/FileSubscriber.cs
+++ b/src/core/Akka.Streams/Implementation/IO/FileSubscriber.cs
@@ -20,7 +20,7 @@ namespace Akka.Streams.Implementation.IO
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal class FileSubscriber : ActorSubscriber
+    internal sealed class FileSubscriber : ActorSubscriber
     {
         /// <summary>
         /// TBD
@@ -208,7 +208,7 @@ namespace Akka.Streams.Implementation.IO
             }
         }
 
-        internal class FlushSignal
+        internal sealed class FlushSignal
         {
             public static readonly FlushSignal Instance = new();
             private FlushSignal() { }

--- a/src/core/Akka.Streams/Implementation/IO/InputStreamPublisher.cs
+++ b/src/core/Akka.Streams/Implementation/IO/InputStreamPublisher.cs
@@ -13,14 +13,13 @@ using Akka.Event;
 using Akka.IO;
 using Akka.Streams.Actors;
 using Akka.Streams.IO;
-using Akka.Util;
 
 namespace Akka.Streams.Implementation.IO
 {
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal class InputStreamPublisher : Actors.ActorPublisher<ByteString>
+    internal sealed class InputStreamPublisher : Actors.ActorPublisher<ByteString>
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka.Streams/Implementation/IO/InputStreamSinkStage.cs
+++ b/src/core/Akka.Streams/Implementation/IO/InputStreamSinkStage.cs
@@ -19,7 +19,7 @@ namespace Akka.Streams.Implementation.IO
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal class InputStreamSinkStage : GraphStageWithMaterializedValue<SinkShape<ByteString>, Stream>
+    internal sealed class InputStreamSinkStage : GraphStageWithMaterializedValue<SinkShape<ByteString>, Stream>
     {
         #region internal classes
 
@@ -33,7 +33,7 @@ namespace Akka.Streams.Implementation.IO
         /// <summary>
         /// TBD
         /// </summary>
-        internal class ReadElementAcknowledgement : IAdapterToStageMessage
+        internal sealed class ReadElementAcknowledgement : IAdapterToStageMessage
         {
             /// <summary>
             /// TBD
@@ -49,7 +49,7 @@ namespace Akka.Streams.Implementation.IO
         /// <summary>
         /// TBD
         /// </summary>
-        internal class Close : IAdapterToStageMessage
+        internal sealed class Close : IAdapterToStageMessage
         {
             /// <summary>
             /// TBD
@@ -92,7 +92,7 @@ namespace Akka.Streams.Implementation.IO
         /// <summary>
         /// TBD
         /// </summary>
-        internal class Finished : IStreamToAdapterMessage
+        internal sealed class Finished : IStreamToAdapterMessage
         {
             /// <summary>
             /// TBD
@@ -108,7 +108,7 @@ namespace Akka.Streams.Implementation.IO
         /// <summary>
         /// TBD
         /// </summary>
-        internal class Initialized : IStreamToAdapterMessage
+        internal sealed class Initialized : IStreamToAdapterMessage
         {
             /// <summary>
             /// TBD
@@ -272,7 +272,7 @@ namespace Akka.Streams.Implementation.IO
     /// INTERNAL API
     /// InputStreamAdapter that interacts with InputStreamSinkStage
     /// </summary>
-    internal class InputStreamAdapter : Stream
+    internal sealed class InputStreamAdapter : Stream
     {
 #region not supported 
 

--- a/src/core/Akka.Streams/Implementation/IO/OutputStreamSourceStage.cs
+++ b/src/core/Akka.Streams/Implementation/IO/OutputStreamSourceStage.cs
@@ -23,7 +23,7 @@ namespace Akka.Streams.Implementation.IO
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal class OutputStreamSourceStage : GraphStageWithMaterializedValue<SourceShape<ByteString>, Stream>
+    internal sealed class OutputStreamSourceStage : GraphStageWithMaterializedValue<SourceShape<ByteString>, Stream>
     {
         #region internal classes
 
@@ -37,7 +37,7 @@ namespace Akka.Streams.Implementation.IO
         /// <summary>
         /// TBD
         /// </summary>
-        internal class Flush : IAdapterToStageMessage
+        internal sealed class Flush : IAdapterToStageMessage
         {
             /// <summary>
             /// TBD
@@ -52,7 +52,7 @@ namespace Akka.Streams.Implementation.IO
         /// <summary>
         /// TBD
         /// </summary>
-        internal class Close : IAdapterToStageMessage
+        internal sealed class Close : IAdapterToStageMessage
         {
             /// <summary>
             /// TBD
@@ -74,7 +74,7 @@ namespace Akka.Streams.Implementation.IO
         /// <summary>
         /// TBD
         /// </summary>
-        internal class Ok : IDownstreamStatus
+        internal sealed class Ok : IDownstreamStatus
         {
             /// <summary>
             /// TBD
@@ -89,7 +89,7 @@ namespace Akka.Streams.Implementation.IO
         /// <summary>
         /// TBD
         /// </summary>
-        internal class Canceled : IDownstreamStatus
+        internal sealed class Canceled : IDownstreamStatus
         {
             /// <summary>
             /// TBD
@@ -315,7 +315,7 @@ namespace Akka.Streams.Implementation.IO
     /// <summary>
     /// TBD
     /// </summary>
-    internal class OutputStreamAdapter : Stream
+    internal sealed class OutputStreamAdapter : Stream
     {
         #region not supported
 

--- a/src/core/Akka.Streams/Implementation/IO/OutputStreamSubscriber.cs
+++ b/src/core/Akka.Streams/Implementation/IO/OutputStreamSubscriber.cs
@@ -19,7 +19,7 @@ namespace Akka.Streams.Implementation.IO
     /// <summary>
     /// INTERNAL API
     /// </summary>
-    internal class OutputStreamSubscriber : ActorSubscriber
+    internal sealed class OutputStreamSubscriber : ActorSubscriber
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -150,7 +150,7 @@ namespace Akka.Streams.Implementation
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     [InternalApi]
-    internal class PublisherSink<TIn> : SinkModule<TIn, IPublisher<TIn>>
+    internal sealed class PublisherSink<TIn> : SinkModule<TIn, IPublisher<TIn>>
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka.Streams/Implementation/Transfer.cs
+++ b/src/core/Akka.Streams/Implementation/Transfer.cs
@@ -303,7 +303,7 @@ namespace Akka.Streams.Implementation
     /// <summary>
     /// TBD
     /// </summary>
-    internal class WaitingForUpstreamSubscription : TransferState
+    internal sealed class WaitingForUpstreamSubscription : TransferState
     {
         /// <summary>
         /// TBD

--- a/src/core/Akka.Streams/Stage/AbstractStage.cs
+++ b/src/core/Akka.Streams/Stage/AbstractStage.cs
@@ -16,7 +16,7 @@ namespace Akka.Streams.Stage
     /// </summary>
     /// <typeparam name="TIn">TBD</typeparam>
     /// <typeparam name="TOut">TBD</typeparam>
-    internal class PushPullGraphLogic<TIn, TOut> : GraphStageLogic, IDetachedContext<TOut>
+    internal sealed class PushPullGraphLogic<TIn, TOut> : GraphStageLogic, IDetachedContext<TOut>
     {
 #pragma warning disable CS0618 // Type or member is obsolete
         private AbstractStage<TIn, TOut> _currentStage;

--- a/src/core/Akka.Streams/Util/IteratorAdapter.cs
+++ b/src/core/Akka.Streams/Util/IteratorAdapter.cs
@@ -34,7 +34,7 @@ namespace Akka.Streams.Util
     /// TBD
     /// </summary>
     /// <typeparam name="T">TBD</typeparam>
-    internal class IteratorAdapter<T> : IIterator<T>
+    internal sealed class IteratorAdapter<T> : IIterator<T>
     {
         private readonly IEnumerator<T> _enumerator;
         private bool? _hasNext;


### PR DESCRIPTION
## Changes
Adding `sealed` to `class`es that:
- Are in the `Akka.Streams` project
- Are `internal` or `private` (i.e. not part of the public API)
- Don't define any new `protected` or `virtual` members
- Aren't inherited by any other class

This helps us ensure more invariants (in this case, the certainty that the code of the class doesn't need to take inherited classes into account) at the language level. This could make the logic easier to understand