### PR TITLE
Polyfill 1.28

### DIFF
--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-      <PackageReference Include="Polyfill" Version="1.27.1" PrivateAssets="all" />
+      <PackageReference Include="Polyfill" Version="1.28.0" PrivateAssets="all" />
       <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.10" />
       <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
       <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />     


### PR DESCRIPTION
some incorrect target framework matches were causing redundant polyfills to be included in some frameworks

resulting in slightly larger assemblies