### PR TITLE
Convert all unit test to proper async

### DIFF
--- a/src/Akka.sln
+++ b/src/Akka.sln
@@ -277,6 +277,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Query.InMe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Akka.Persistence.Query.InMemory.Tests", "contrib\persistence\Akka.Persistence.Query.InMemory.Tests\Akka.Persistence.Query.InMemory.Tests.csproj", "{407DD6E2-F274-4773-BA5E-43541D5C8D0F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Junk", "Junk", "{CB7C415C-FD58-4527-AB88-FD084445A6A3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1418,6 +1420,7 @@ Global
 		{4022147A-4F95-4A04-BE09-01B7952BBDD9} = {A640E39E-F45C-4AE9-AABF-7F1432D357DA}
 		{A310BC3F-065A-4D0D-BC6A-9E444E96F10F} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
 		{407DD6E2-F274-4773-BA5E-43541D5C8D0F} = {264C22A4-CAFC-41F6-B82C-4DDC5C196767}
+		{CB7C415C-FD58-4527-AB88-FD084445A6A3} = {D3AF8295-AEB5-4324-AA82-FCC0014AC310}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {03AD8E21-7507-4E68-A4E9-F4A7E7273164}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,10 +6,6 @@
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
-    <!-- 
-      xUnit1031 is a temporary fix, we will need to pay this technical debt 
-      and make everything fully async in the future 
-    -->
     <NoWarn>$(NoWarn);CS1591;xUnit1013;xUnit1031</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
-    <NoWarn>$(NoWarn);CS1591;xUnit1013;xUnit1031</NoWarn>
+    <NoWarn>$(NoWarn);CS1591;xUnit1013</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <!-- Set the language version for C# if we're not inside an F# project -->

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/ClustetMetricsRoutingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/ClustetMetricsRoutingSpec.cs
@@ -245,11 +245,10 @@ namespace Akka.Cluster.Metrics.Tests.MultiNode
             
             await RunOnAsync(async () =>
             {
-                await WithinAsync(20.Seconds(), () => {
+                await WithinAsync(20.Seconds(), async () => {
                     Sys.ActorOf(Props.Create<AdaptiveLoadBalancingRouterConfig.MemoryAllocator>(), "memory-allocator")
                                                                              .Tell(AdaptiveLoadBalancingRouterConfig.AllocateMemory.Instance);
-                    ExpectMsg("done");
-                    return Task.CompletedTask;
+                    await ExpectMsgAsync("done");
                 });
             }, _config.Node2);
             

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DeprecatedLeastShardAllocationStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DeprecatedLeastShardAllocationStrategySpec.cs
@@ -8,8 +8,10 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
+using Akka.TestKit.Extensions;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
@@ -77,146 +79,208 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_allocate_to_region_with_least_number_of_shards_1_1_0()
+        public async Task LeastShardAllocationStrategy_must_allocate_to_region_with_least_number_of_shards_1_1_0()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 3, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 1, bCount: 1);
-            allocationStrategy.AllocateShard(regionA, "003", allocations).Result.Should().Be(regionC);
+            var result = await allocationStrategy.AllocateShard(regionA, "003", allocations)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().Be(regionC);
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_2_0_0_rebalanceThreshold_1()
+        public async Task LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_2_0_0_rebalanceThreshold_1()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 2);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEmpty();
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("001");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_not_rebalance_when_diff_equal_to_threshold_1_1_0_rebalanceThreshold_1()
+        public async Task LeastShardAllocationStrategy_must_not_rebalance_when_diff_equal_to_threshold_1_1_0_rebalanceThreshold_1()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 1, bCount: 1);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_1_2_0_rebalanceThreshold_1()
+        public async Task LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_1_2_0_rebalanceThreshold_1()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 1, bCount: 2);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("002");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002")).Result.Should().BeEmpty();
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("002");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_3_0_0_rebalanceThreshold_1()
+        public async Task LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_3_0_0_rebalanceThreshold_1()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 3);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEquivalentTo("002");
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("001");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("002");
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_0_rebalanceThreshold_1()
+        public async Task LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_0_rebalanceThreshold_1()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 4, bCount: 4);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEquivalentTo("005");
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("001");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("005");
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_2_rebalanceThreshold_1()
+        public async Task LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_2_rebalanceThreshold_1()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 1, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 4, bCount: 4, cCount: 2);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("001");
             // not optimal, 005 stopped and started again, but ok
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEquivalentTo("005");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("005");
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_rebalance_rebalance_from_region_with_most_number_of_shards_1_3_0_rebalanceThreshold_2()
+        public async Task LeastShardAllocationStrategy_must_rebalance_rebalance_from_region_with_most_number_of_shards_1_3_0_rebalanceThreshold_2()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 1, bCount: 2);
 
             // so far regionB has 2 shards and regionC has 0 shards, but the diff is <= rebalanceThreshold
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
 
             var allocations2 = CreateAllocations(aCount: 1, bCount: 3);
-            allocationStrategy.Rebalance(allocations2, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("002");
-            allocationStrategy.Rebalance(allocations2, ImmutableHashSet<string>.Empty.Add("002")).Result.Should().BeEmpty();
+            result = await allocationStrategy.Rebalance(allocations2, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("002");
+            result = await allocationStrategy.Rebalance(allocations2, ImmutableHashSet<string>.Empty.Add("002"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_not_rebalance_when_diff_equal_to_threshold_2_2_0_rebalanceThreshold_2()
+        public async Task LeastShardAllocationStrategy_must_not_rebalance_when_diff_equal_to_threshold_2_2_0_rebalanceThreshold_2()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 2, bCount: 2);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_3_3_0_rebalanceThreshold_2()
+        public async Task LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_3_3_0_rebalanceThreshold_2()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 3, bCount: 3);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001")).Result.Should().BeEquivalentTo("004");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("004")).Result.Should().BeEmpty();
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("001");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("004");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("004"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_0_rebalanceThreshold_2()
+        public async Task LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_4_4_0_rebalanceThreshold_2()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 4, bCount: 4);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001", "002");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002")).Result.Should().BeEquivalentTo("005", "006");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002").Add("005").Add("006")).Result.Should().BeEmpty();
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("001", "002");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("005", "006");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002").Add("005").Add("006"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_5_5_0_rebalanceThreshold_2()
+        public async Task LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_5_5_0_rebalanceThreshold_2()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 10);
             var allocations = CreateAllocations(aCount: 5, bCount: 5);
             // optimal would => [4, 4, 2] or even => [3, 4, 3]
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001", "002");
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("001", "002");
             // if 001 and 002 are not started quickly enough this is stopping more than optimal
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002")).Result.Should().BeEquivalentTo("006", "007");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002").Add("006").Add("007")).Result.Should().BeEquivalentTo("003");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("006", "007");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002").Add("006").Add("007"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("003");
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_50_50_0_rebalanceThreshold_2()
+        public async Task LeastShardAllocationStrategy_must_rebalance_from_region_with_most_number_of_shards_50_50_0_rebalanceThreshold_2()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 2, maxSimultaneousRebalance: 100);
             var allocations = CreateAllocations(aCount: 50, bCount: 50);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("001", "002");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002")).Result.Should().BeEquivalentTo("051", "052");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002").Add("051").Add("052")).Result.Should().BeEquivalentTo("003", "004");
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("001", "002");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("051", "052");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("001").Add("002").Add("051").Add("052"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("003", "004");
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_limit_number_of_simultaneous_rebalance_1_10_0()
+        public async Task LeastShardAllocationStrategy_must_limit_number_of_simultaneous_rebalance_1_10_0()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 3, maxSimultaneousRebalance: 2);
             var allocations = CreateAllocations(aCount: 1, bCount: 10);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEquivalentTo("002", "003");
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002").Add("003")).Result.Should().BeEmpty();
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("002", "003");
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002").Add("003"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_not_pick_shards_that_are_in_progress_10_0_0()
+        public async Task LeastShardAllocationStrategy_must_not_pick_shards_that_are_in_progress_10_0_0()
         {
             var allocationStrategy = AllocationStrategyWithFakeCluster(rebalanceThreshold: 3, maxSimultaneousRebalance: 4);
             var allocations = CreateAllocations(aCount: 10);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002").Add("003")).Result.Should().BeEquivalentTo("001", "004");
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty.Add("002").Add("003"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEquivalentTo("001", "004");
         }
 
         [Fact]
@@ -260,7 +324,7 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_not_rebalance_when_rolling_update_in_progress()
+        public async Task LeastShardAllocationStrategy_must_not_rebalance_when_rolling_update_in_progress()
         {
             var member1 = NewUpMember("127.0.0.1", version: AppVersion.Create("1.0.0"));
             var member2 = NewUpMember("127.0.0.1", version: AppVersion.Create("1.0.1"));
@@ -270,14 +334,20 @@ namespace Akka.Cluster.Sharding.Tests
                 new TestLeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 100, () => new CurrentClusterState().Copy(members: ImmutableSortedSet.Create(member1, member2)), () => member1);
 
             var allocations = CreateAllocations(aCount: 5, bCount: 5);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002")).Result.Should().BeEmpty();
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002", "051", "052")).Result.Should().BeEmpty();
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002", "051", "052"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
         }
 
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_not_rebalance_when_regions_are_unreachable()
+        public async Task LeastShardAllocationStrategy_must_not_rebalance_when_regions_are_unreachable()
         {
             var member1 = NewUpMember("127.0.0.1");
             var member2 = NewUpMember("127.0.0.2");
@@ -287,13 +357,19 @@ namespace Akka.Cluster.Sharding.Tests
                 new TestLeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 100, () => new CurrentClusterState().Copy(members: ImmutableSortedSet.Create(member1, member2), unreachable: ImmutableHashSet.Create(member2)), () => member2);
 
             var allocations = CreateAllocations(aCount: 5, bCount: 5);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002")).Result.Should().BeEmpty();
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002", "051", "052")).Result.Should().BeEmpty();
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002", "051", "052"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
         }
 
         [Fact]
-        public void LeastShardAllocationStrategy_must_not_rebalance_when_members_are_joining_dc()
+        public async Task LeastShardAllocationStrategy_must_not_rebalance_when_members_are_joining_dc()
         {
             var member1 = NewUpMember("127.0.0.1");
             var member2 =
@@ -307,9 +383,15 @@ namespace Akka.Cluster.Sharding.Tests
                 new TestLeastShardAllocationStrategy(rebalanceThreshold: 2, maxSimultaneousRebalance: 100, () => new CurrentClusterState().Copy(members: ImmutableSortedSet.Create(member1, member2), unreachable: ImmutableHashSet.Create(member2)), () => member2);
 
             var allocations = CreateAllocations(aCount: 5, bCount: 5);
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty).Result.Should().BeEmpty();
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002")).Result.Should().BeEmpty();
-            allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002", "051", "052")).Result.Should().BeEmpty();
+            var result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet<string>.Empty)
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
+            result = await allocationStrategy.Rebalance(allocations, ImmutableHashSet.Create("001", "002", "051", "052"))
+                .ShouldCompleteWithin(RemainingOrDefault);
+            result.Should().BeEmpty();
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Internal/RememberEntitiesStarterSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Internal/RememberEntitiesStarterSpec.cs
@@ -143,8 +143,8 @@ namespace Akka.Cluster.Sharding.Tests.Internal
             ExpectTerminated(rememberEntityStarter);
         }
 
-        // TODO: check the timing code to make sure that this actually works, it was flaky/racy even when run locally.
-        [LocalFact(SkipLocal = "Racy unit test, suspected bad code underneath")]
+        // TODO: check the timing code to make sure that this actually works, it was failing even when run locally.
+        [LocalFact(SkipLocal = "Failing unit test, suspected bad code underneath")]
         public void RememberEntitiesStarter_must_try_start_all_entities_in_a_throttled_way_with_entity_recovery_strategy_constant()
         {
             var regionProbe = CreateTestProbe();

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
@@ -76,10 +77,10 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void ProxyShardingSpec_Proxy_should_be_found()
+        public async Task ProxyShardingSpec_Proxy_should_be_found()
         {
-            IActorRef proxyActor = Sys.ActorSelection("akka://test/system/sharding/myTypeProxy")
-                    .ResolveOne(TimeSpan.FromSeconds(5)).Result;
+            IActorRef proxyActor = await Sys.ActorSelection("akka://test/system/sharding/myTypeProxy")
+                    .ResolveOne(TimeSpan.FromSeconds(5));
 
             proxyActor.Path.Should().NotBeNull();
             proxyActor.Path.ToString().Should().EndWith("Proxy");
@@ -95,12 +96,12 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void ProxyShardingSpec_Shard_coordinator_should_be_found()
+        public async Task ProxyShardingSpec_Shard_coordinator_should_be_found()
         {
             var shardRegion = clusterSharding.Start("myType", SimpleEchoActor.Props(), shardingSettings, messageExtractor);
 
-            IActorRef shardCoordinator = Sys.ActorSelection("akka://test/system/sharding/myTypeCoordinator")
-                    .ResolveOne(TimeSpan.FromSeconds(5)).Result;
+            IActorRef shardCoordinator = await Sys.ActorSelection("akka://test/system/sharding/myTypeCoordinator")
+                    .ResolveOne(TimeSpan.FromSeconds(5));
 
             shardCoordinator.Path.Should().NotBeNull();
             shardCoordinator.Path.ToString().Should().EndWith("Coordinator");

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/StartEntitySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/StartEntitySpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
@@ -196,7 +197,7 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void StartEntity_while_the_entity_is_queued_remember_stop_should_start_it_again_when_that_is_done()
+        public async Task StartEntity_while_the_entity_is_queued_remember_stop_should_start_it_again_when_that_is_done()
         {
             // this is hard to do deterministically
             var sharding = ClusterSharding.Get(Sys).Start(
@@ -211,7 +212,7 @@ namespace Akka.Cluster.Sharding.Tests
             Watch(entity);
 
             // resolve before passivation to save some time
-            var shard = Sys.ActorSelection(entity.Path.Parent).ResolveOne(TimeSpan.FromSeconds(3)).Result;
+            var shard = await Sys.ActorSelection(entity.Path.Parent).ResolveOne(TimeSpan.FromSeconds(3));
 
             // stop passivation
             entity.Tell("passivate");

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorSpec.cs
@@ -71,16 +71,16 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             // act
             // create a topic
             mediator.Tell(new Subscribe("pub-sub", actor));
-            _ = ExpectMsg<SubscribeAck>();
+            _ = await ExpectMsgAsync<SubscribeAck>();
 
             // all subscribers should be removed from this topic
             // topic actor will still be alive for default value of 120s
             mediator.Tell(new Unsubscribe("pub-sub", actor));
-            _ = ExpectMsg<UnsubscribeAck>();
+            _ = await ExpectMsgAsync<UnsubscribeAck>();
 
             // assert
-            await EventFilter.DeadLetter<object>().ExpectAsync(1,
-                () => { mediator.Tell(new Publish("pub-sub", "hit")); return Task.CompletedTask; });
+            EventFilter.DeadLetter<object>().Expect(1,
+                () => { mediator.Tell(new Publish("pub-sub", "hit")); });
         }
     }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonProxySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonProxySpec.cs
@@ -13,6 +13,9 @@ using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit;
+using Akka.TestKit.Extensions;
+using FluentAssertions.Extensions;
+using Nito.AsyncEx;
 using Xunit;
 
 namespace Akka.Cluster.Tools.Tests.Singleton
@@ -20,7 +23,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
     public class ClusterSingletonProxySpec : TestKit.Xunit2.TestKit
     {
         [Fact]
-        public void ClusterSingletonProxy_must_correctly_identify_the_singleton()
+        public async Task ClusterSingletonProxy_must_correctly_identify_the_singleton()
         {
             var seed = new ActorSys();
             seed.Cluster.Join(seed.Cluster.SelfAddress);
@@ -38,8 +41,8 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             finally
             {
                 // force everything to cleanup
-                Task.WhenAll(testSystems.Select(s => s.Sys.Terminate()))
-                    .Wait(TimeSpan.FromSeconds(30));
+                await Task.WhenAll(testSystems.Select(s => s.Sys.Terminate()))
+                    .ShouldCompleteWithin(30.Seconds());
             }
         }
 
@@ -63,7 +66,8 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             finally
             {
                 // force everything to cleanup
-                Task.WhenAll(testSystem.Sys.Terminate()).Wait(TimeSpan.FromSeconds(30));
+                await Task.WhenAll(testSystem.Sys.Terminate())
+                    .ShouldCompleteWithin(30.Seconds());
             }
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
@@ -70,7 +70,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         }
 
         [Fact]
-        public void Restarting_cluster_node_during_hand_over_must_restart_singletons_in_restarted_node()
+        public async Task Restarting_cluster_node_during_hand_over_must_restart_singletons_in_restarted_node()
         {
             Join(_sys1, _sys1);
             Join(_sys2, _sys1);
@@ -107,7 +107,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             Join(_sys4, _sys3);
 
             // let it stabilize
-            Task.Delay(TimeSpan.FromSeconds(5)).Wait();
+            await Task.Delay(TimeSpan.FromSeconds(5));
 
             Within(TimeSpan.FromSeconds(10), () =>
             {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
@@ -70,7 +70,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         }
 
         [Fact]
-        public void Singleton_should_consider_AppVersion_when_handing_over()
+        public async Task Singleton_should_consider_AppVersion_when_handing_over()
         {
             Join(_sys1, _sys1);
             Join(_sys2, _sys1);
@@ -97,7 +97,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             Cluster.Get(_sys1).Leave(Cluster.Get(_sys1).SelfAddress);
 
             // let it stabilize
-            Task.Delay(TimeSpan.FromSeconds(5)).Wait();
+            await Task.Delay(TimeSpan.FromSeconds(5));
 
             Within(TimeSpan.FromSeconds(10), () =>
             {

--- a/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorResiliencySpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/ReplicatorResiliencySpec.cs
@@ -170,11 +170,9 @@ namespace Akka.DistributedData.Tests
             var replicator = DistributedData.Get(_sys1).Replicator;
 
             IActorRef durableStore = null;
-            await AwaitAssertAsync(() =>
+            await AwaitAssertAsync(async () =>
             {
-                durableStore = _sys1.ActorSelection(durableStoreActorPath).ResolveOne(TimeSpan.FromSeconds(3))
-                    .ContinueWith(
-                        m => m.Result).Result;
+                durableStore = await _sys1.ActorSelection(durableStoreActorPath).ResolveOne(TimeSpan.FromSeconds(3));
             }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(100));
 
             Watch(replicator);

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/DelegateInjectionSpecs.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/DelegateInjectionSpecs.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
@@ -52,9 +53,8 @@ namespace Akka.DependencyInjection.Tests
         {
             var actor = _serviceProvider.GetRequiredService<EchoActorProvider>()();
 
-            var task = actor.Ask("echo");
-            task.Wait(TimeSpan.FromSeconds(3));
-            task.Result.ShouldBe("echo");
+            var result = await actor.Ask("echo", RemainingOrDefault);
+            result.Should().Be("echo");
 
             var sys = _serviceProvider.GetRequiredService<AkkaService>().ActorSystem;
             await sys.Terminate();
@@ -66,9 +66,8 @@ namespace Akka.DependencyInjection.Tests
             var system = _serviceProvider.GetRequiredService<AkkaService>().ActorSystem;
             var actor = system.ActorOf(ParentActor.Props(system));
             
-            var task = actor.Ask("echo");
-            task.Wait(TimeSpan.FromSeconds(3));
-            task.Result.ShouldBe("echo");
+            var result = await actor.Ask("echo", RemainingOrDefault);
+            result.Should().Be("echo");
 
             var sys = _serviceProvider.GetRequiredService<AkkaService>().ActorSystem;
             await sys.Terminate();

--- a/src/core/Akka.Cluster.Tests.MultiNode/ClusterDeathWatchSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/ClusterDeathWatchSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
@@ -90,22 +91,22 @@ namespace Akka.Cluster.Tests.MultiNode
 
 
         [MultiNodeFact]
-        public void ClusterDeathWatchSpecTests()
+        public async Task ClusterDeathWatchSpecTests()
         {
-            An_actor_watching_a_remote_actor_in_the_cluster_must_receive_terminated_when_watched_node_becomes_down_removed();
+            await An_actor_watching_a_remote_actor_in_the_cluster_must_receive_terminated_when_watched_node_becomes_down_removed();
             //AnActorWatchingARemoteActorInTheClusterMustReceiveTerminatedWhenWatchedPathDoesNotExist();
             An_actor_watching_a_remote_actor_in_the_cluster_must_be_able_to_watch_actor_before_node_joins_cluster_and_cluster_remote_watcher_takes_over_from_remote_watcher();
             An_actor_watching_a_remote_actor_in_the_cluster_must_be_able_to_shutdown_system_when_using_remote_deployed_actor_on_node_that_crashed();
         }
 
-        public void An_actor_watching_a_remote_actor_in_the_cluster_must_receive_terminated_when_watched_node_becomes_down_removed()
+        public async Task An_actor_watching_a_remote_actor_in_the_cluster_must_receive_terminated_when_watched_node_becomes_down_removed()
         {
-            Within(TimeSpan.FromSeconds(30), () =>
+            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
             {
                 AwaitClusterUp(_config.First, _config.Second, _config.Third, _config.Fourth);
                 EnterBarrier("cluster-up");
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
                     EnterBarrier("subjected-started");
 
@@ -115,17 +116,17 @@ namespace Akka.Cluster.Tests.MultiNode
                     Sys.ActorOf(Props.Create(() => new Observer(path2, path3, watchEstablished, TestActor))
                         .WithDeploy(Deploy.Local), "observer1");
 
-                    watchEstablished.Ready();
+                    await watchEstablished.ReadyAsync();
                     EnterBarrier("watch-established");
                     ExpectMsg(path2);
-                    ExpectNoMsg(TimeSpan.FromSeconds(2));
+                    await ExpectNoMsgAsync(TimeSpan.FromSeconds(2));
                     EnterBarrier("second-terminated");
                     MarkNodeAsUnavailable(GetAddress(_config.Third));
-                    AwaitAssert(() => Assert.Contains(GetAddress(_config.Third), ClusterView.UnreachableMembers.Select(x => x.Address)));
+                    await AwaitAssertAsync(() => Assert.Contains(GetAddress(_config.Third), ClusterView.UnreachableMembers.Select(x => x.Address)));
                     Cluster.Down(GetAddress(_config.Third));
                     //removed
-                    AwaitAssert(() => Assert.DoesNotContain(GetAddress(_config.Third), ClusterView.Members.Select(x => x.Address)));
-                    AwaitAssert(() => Assert.DoesNotContain(GetAddress(_config.Third), ClusterView.UnreachableMembers.Select(x => x.Address)));
+                    await AwaitAssertAsync(() => Assert.DoesNotContain(GetAddress(_config.Third), ClusterView.Members.Select(x => x.Address)));
+                    await AwaitAssertAsync(() => Assert.DoesNotContain(GetAddress(_config.Third), ClusterView.UnreachableMembers.Select(x => x.Address)));
                     ExpectMsg(path3);
                     EnterBarrier("third-terminated");
                 }, _config.First);
@@ -278,12 +279,12 @@ namespace Akka.Cluster.Tests.MultiNode
                     {
                         if (!Sys.WhenTerminated.Wait(timeout)) // TestConductor.Shutdown called by First MUST terminate this actor system
                         {
-                            Assert.True(false, String.Format("Failed to stop [{0}] within [{1}]", Sys.Name, timeout));
+                            Assert.Fail($"Failed to stop [{Sys.Name}] within [{timeout}]");
                         }
                     }
                     catch (TimeoutException)
                     {
-                        Assert.True(false, String.Format("Failed to stop [{0}] within [{1}]", Sys.Name, timeout));
+                        Assert.Fail($"Failed to stop [{Sys.Name}] within [{timeout}]");
                     }
 
                     

--- a/src/core/Akka.Cluster.Tests.MultiNode/MembershipChangeListenerUpSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/MembershipChangeListenerUpSpec.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.MultiNode.TestAdapter;
@@ -72,17 +73,17 @@ namespace Akka.Cluster.Tests.MultiNode
         }
 
         [MultiNodeFact]
-        public void MembershipChangeListenerUpSpecs()
+        public async Task MembershipChangeListenerUpSpecs()
         {
-            Set_of_connected_cluster_systems_must_when_two_nodes_after_cluster_convergence_updates_membership_table_then_all_MembershipChangeListeners_should_be_triggered();
-            Set_of_connected_cluster_systems_must_when_three_nodes_after_cluster_convergence_updates_membership_table_then_all_MembershipChangeListeners_should_be_triggered();
+            await Set_of_connected_cluster_systems_must_when_two_nodes_after_cluster_convergence_updates_membership_table_then_all_MembershipChangeListeners_should_be_triggered();
+            await Set_of_connected_cluster_systems_must_when_three_nodes_after_cluster_convergence_updates_membership_table_then_all_MembershipChangeListeners_should_be_triggered();
         }
 
-        public void Set_of_connected_cluster_systems_must_when_two_nodes_after_cluster_convergence_updates_membership_table_then_all_MembershipChangeListeners_should_be_triggered()
+        public async Task Set_of_connected_cluster_systems_must_when_two_nodes_after_cluster_convergence_updates_membership_table_then_all_MembershipChangeListeners_should_be_triggered()
         {
             AwaitClusterUp(_config.First);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 var latch = new TestLatch();
                 var expectedAddresses = ImmutableList.Create(GetAddress(_config.First), GetAddress(_config.Second));
@@ -90,7 +91,7 @@ namespace Akka.Cluster.Tests.MultiNode
                 Cluster.Subscribe(listener, new[] { typeof(ClusterEvent.IMemberEvent) });
                 EnterBarrier("listener-1-registered");
                 Cluster.Join(GetAddress(_config.First));
-                latch.Ready();
+                await latch.ReadyAsync();
             }, _config.First, _config.Second);
 
             RunOn(() =>
@@ -101,7 +102,7 @@ namespace Akka.Cluster.Tests.MultiNode
             EnterBarrier("after-1");
         }
 
-        public void Set_of_connected_cluster_systems_must_when_three_nodes_after_cluster_convergence_updates_membership_table_then_all_MembershipChangeListeners_should_be_triggered()
+        public async Task Set_of_connected_cluster_systems_must_when_three_nodes_after_cluster_convergence_updates_membership_table_then_all_MembershipChangeListeners_should_be_triggered()
         {
             var latch = new TestLatch();
             var expectedAddresses = ImmutableList.Create(GetAddress(_config.First), GetAddress(_config.Second), GetAddress(_config.Third));
@@ -114,7 +115,7 @@ namespace Akka.Cluster.Tests.MultiNode
                 Cluster.Join(GetAddress(_config.First));
             }, _config.Third);
 
-            latch.Ready();
+            await latch.ReadyAsync();
 
             EnterBarrier("after-2");
         }

--- a/src/core/Akka.Cluster.Tests.MultiNode/MinMembersBeforeUpSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/MinMembersBeforeUpSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.Configuration;
@@ -80,9 +81,9 @@ namespace Akka.Cluster.Tests.MultiNode
         }
 
         [MultiNodeFact]
-        public void Cluster_leader_must_wait_with_moving_members_to_up_until_minimum_number_of_members_have_joined()
+        public async Task Cluster_leader_must_wait_with_moving_members_to_up_until_minimum_number_of_members_have_joined()
         {
-            TestWaitMovingMembersToUp();
+            await TestWaitMovingMembersToUp();
         }
     }
 
@@ -127,9 +128,9 @@ namespace Akka.Cluster.Tests.MultiNode
         }
 
         [MultiNodeFact]
-        public void Cluster_leader_must_wait_with_moving_members_to_up_until_minimum_number_of_members_have_joined_with_WeaklyUp_enabled()
+        public async Task Cluster_leader_must_wait_with_moving_members_to_up_until_minimum_number_of_members_have_joined_with_WeaklyUp_enabled()
         {
-            TestWaitMovingMembersToUp();
+            await TestWaitMovingMembersToUp();
         }
     }
 
@@ -149,9 +150,9 @@ namespace Akka.Cluster.Tests.MultiNode
         }
 
         [MultiNodeFact]
-        public void Cluster_leader_must_wait_with_moving_members_to_up_until_minimum_number_of_members_with_specific_role_have_joined()
+        public async Task Cluster_leader_must_wait_with_moving_members_to_up_until_minimum_number_of_members_with_specific_role_have_joined()
         {
-            TestWaitMovingMembersToUp();
+            await TestWaitMovingMembersToUp();
         }
     }
 
@@ -165,7 +166,7 @@ namespace Akka.Cluster.Tests.MultiNode
         {
         }
 
-        protected void TestWaitMovingMembersToUp()
+        protected async Task TestWaitMovingMembersToUp()
         {
             var onUpLatch = new TestLatch(1);
             Cluster.RegisterOnMemberUp(() =>
@@ -216,7 +217,7 @@ namespace Akka.Cluster.Tests.MultiNode
             }, Third);
             AwaitClusterUp(First, Second, Third);
 
-            onUpLatch.Ready(TestKitSettings.DefaultTimeout);
+            await onUpLatch.ReadyAsync(TestKitSettings.DefaultTimeout);
             EnterBarrier("after-1");
         }
     }

--- a/src/core/Akka.Cluster.Tests.MultiNode/NodeLeavingAndExitingSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/NodeLeavingAndExitingSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.MultiNode.TestAdapter;
@@ -79,16 +80,16 @@ namespace Akka.Cluster.Tests.MultiNode
         }
 
         [MultiNodeFact]
-        public void NodeLeavingAndExitingSpecs()
+        public async Task NodeLeavingAndExitingSpecs()
         {
-            Node_that_is_leaving_non_singleton_cluster_must_be_moved_to_exiting_by_the_leader();
+            await Node_that_is_leaving_non_singleton_cluster_must_be_moved_to_exiting_by_the_leader();
         }
 
-        public void Node_that_is_leaving_non_singleton_cluster_must_be_moved_to_exiting_by_the_leader()
+        public async Task Node_that_is_leaving_non_singleton_cluster_must_be_moved_to_exiting_by_the_leader()
         {
             AwaitClusterUp(_config.First, _config.Second, _config.Third);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 var secondAddress = GetAddress(_config.Second);
                 var exitingLatch = new TestLatch();
@@ -105,7 +106,7 @@ namespace Akka.Cluster.Tests.MultiNode
                 EnterBarrier("second-left");
 
                 // Verify that 'second' node is set to EXITING
-                exitingLatch.Ready();
+                await exitingLatch.ReadyAsync();
             }, _config.First, _config.Third);
 
 

--- a/src/core/Akka.Cluster.Tests/Bugfix5962Spec.cs
+++ b/src/core/Akka.Cluster.Tests/Bugfix5962Spec.cs
@@ -80,7 +80,7 @@ akka {
             // There should be no TimerMsg being sent to dead letter, this signals that the downing provider is dead
             await EventFilter.DeadLetter(_timerMsgType).ExpectAsync(0, async () =>
             {
-                latch.Ready(1.Seconds());
+                await latch.ReadyAsync(1.Seconds());
                 await Task.Delay(2.Seconds());
             });
         }

--- a/src/core/Akka.Discovery.Tests/Aggregate/AggregateServiceDiscoverySpec.cs
+++ b/src/core/Akka.Discovery.Tests/Aggregate/AggregateServiceDiscoverySpec.cs
@@ -72,9 +72,9 @@ namespace Akka.Discovery.Tests.Aggregate
         }
 
         [Fact]
-        public void Aggregate_service_discovery_must_only_call_first_one_if_returns_results()
+        public async Task Aggregate_service_discovery_must_only_call_first_one_if_returns_results()
         {
-            var result = _discovery.Lookup("stubbed", 100.Milliseconds()).Result;
+            var result = await _discovery.Lookup("stubbed", 100.Milliseconds());
             result.Should().Be(new ServiceDiscovery.Resolved(
                 "stubbed",
                 new List<ServiceDiscovery.ResolvedTarget>
@@ -84,9 +84,9 @@ namespace Akka.Discovery.Tests.Aggregate
         }
 
         [Fact]
-        public void Aggregate_service_discovery_must_move_onto_the_next_if_no_resolved_targets()
+        public async Task Aggregate_service_discovery_must_move_onto_the_next_if_no_resolved_targets()
         {
-            var result = _discovery.Lookup("config1", 100.Milliseconds()).Result;
+            var result = await _discovery.Lookup("config1", 100.Milliseconds());
             result.Should().Be(new ServiceDiscovery.Resolved(
                 "config1",
                 new List<ServiceDiscovery.ResolvedTarget>
@@ -97,9 +97,9 @@ namespace Akka.Discovery.Tests.Aggregate
         }
         
         [Fact]
-        public void Aggregate_service_discovery_must_move_onto_next_if_fails()
+        public async Task Aggregate_service_discovery_must_move_onto_next_if_fails()
         {
-            var result = _discovery.Lookup("fail", 100.Milliseconds()).Result;
+            var result = await _discovery.Lookup("fail", 100.Milliseconds());
             // Stub fails then result comes from config
             result.Should().Be(new ServiceDiscovery.Resolved(
                 "fail",

--- a/src/core/Akka.Discovery.Tests/Config/ConfigServiceDiscoverySpec.cs
+++ b/src/core/Akka.Discovery.Tests/Config/ConfigServiceDiscoverySpec.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading.Tasks;
 using Akka.Configuration;
 using FluentAssertions;
 using FluentAssertions.Extensions;
@@ -44,9 +45,9 @@ namespace Akka.Discovery.Tests.Config
         }
 
         [Fact]
-        public void Config_discovery_must_load_from_config()
+        public async Task Config_discovery_must_load_from_config()
         {
-            var result = _discovery.Lookup("service1", 100.Milliseconds()).Result;
+            var result = await _discovery.Lookup("service1", 100.Milliseconds());
             result.ServiceName.Should().Be("service1");
             result.Addresses.Should().Contain(new[]
             {
@@ -56,9 +57,9 @@ namespace Akka.Discovery.Tests.Config
         }
 
         [Fact]
-        public void Config_discovery_must_return_no_resolved_targets_if_not_in_config()
+        public async Task Config_discovery_must_return_no_resolved_targets_if_not_in_config()
         {
-            var result = _discovery.Lookup("dontexist", 100.Milliseconds()).Result;
+            var result = await _discovery.Lookup("dontexist", 100.Milliseconds());
             result.ServiceName.Should().Be("dontexist");
             result.Addresses.Should().BeEmpty();
         }

--- a/src/core/Akka.Docs.Tests/Debugging/RacySpecs.cs
+++ b/src/core/Akka.Docs.Tests/Debugging/RacySpecs.cs
@@ -219,6 +219,7 @@ namespace DocsExamples.Debugging
         }
         // </PoisonPillSysMsgOrdering>
 
+#pragma warning disable xUnit1031
         [Fact(Skip = "Racy by design")]
         // <TooTightTimingSpec>
         public void TooTightTimingSpec()
@@ -231,5 +232,6 @@ namespace DocsExamples.Debugging
             t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 10).Select(i => new List<int> {i}));
         }
         // </TooTightTimingSpec>
+#pragma warning restore xUnit1031
     }
 }

--- a/src/core/Akka.Docs.Tests/Streams/RestartDocTests.cs
+++ b/src/core/Akka.Docs.Tests/Streams/RestartDocTests.cs
@@ -30,6 +30,7 @@ namespace DocsExamples.Streams
         {
         }
 
+#pragma warning disable xUnit1031
         [Fact]
         public void Restart_stages_should_demonstrate_a_restart_with_backoff_source()
         {
@@ -51,6 +52,7 @@ namespace DocsExamples.Streams
                 .Select(c => c.Content.ReadAsStringAsync())
                 .Select(c => c.Result);
             }, settings);
+#pragma warning restore xUnit1031
             #endregion
 
             #region with-kill-switch

--- a/src/core/Akka.Persistence.TestKit.Tests/Bug4762FixSpec.cs
+++ b/src/core/Akka.Persistence.TestKit.Tests/Bug4762FixSpec.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Persistence.TestKit.Tests
 {
@@ -21,6 +22,9 @@ namespace Akka.Persistence.TestKit.Tests
     /// </summary>
     public class Bug4762FixSpec : PersistenceTestKit
     {
+        public Bug4762FixSpec(ITestOutputHelper output): base("akka.loglevel = DEBUG", nameof(Bug4762FixSpec), output)
+        { }
+        
         private class WriteMessage
         { }
 

--- a/src/core/Akka.Persistence.Tests/ManyRecoveriesSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ManyRecoveriesSpec.cs
@@ -35,9 +35,9 @@ namespace Akka.Persistence.Tests
 
             protected override void OnRecover(object message)
             {
-                if (message is Evt)
+                if (message is Evt && Latch is not null)
                 {
-                    Latch?.Ready(TimeSpan.FromSeconds(10));
+                    Latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
                 }
             }
 

--- a/src/core/Akka.Persistence.Tests/ManyRecoveriesSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ManyRecoveriesSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Persistence.Tests
             {
                 if (message is Evt && Latch is not null)
                 {
-                    Latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
+                    Latch.Ready(TimeSpan.FromSeconds(10));
                 }
             }
 

--- a/src/core/Akka.Persistence.Tests/PersistentActorJournalProtocolSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorJournalProtocolSpec.cs
@@ -360,7 +360,7 @@ akka.persistence.snapshot-store.plugin = ""akka.persistence.no-snapshot-store"""
                         evt.ShouldBe(msg.Messages[j]);
                     }
                 }
-                else Assertions.Fail("unexpected ", message);
+                else Assertions.Fail("unexpected {0}", message);
             }
             return w;
         }

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
@@ -821,7 +821,7 @@ namespace Akka.Persistence.Tests
                 if (message is LatchCmd latchCmd)
                 {
                     Sender.Tell(latchCmd.Data);
-                    latchCmd.Latch.Ready(TimeSpan.FromSeconds(5));
+                    latchCmd.Latch.ReadyAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
                     PersistAsync(latchCmd.Data, _ => { });
                 }
                 else if (message is Cmd cmd)

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpec.Actors.cs
@@ -821,7 +821,7 @@ namespace Akka.Persistence.Tests
                 if (message is LatchCmd latchCmd)
                 {
                     Sender.Tell(latchCmd.Data);
-                    latchCmd.Latch.ReadyAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+                    latchCmd.Latch.Ready(TimeSpan.FromSeconds(5));
                     PersistAsync(latchCmd.Data, _ => { });
                 }
                 else if (message is Cmd cmd)

--- a/src/core/Akka.Persistence.Tests/PersistentActorSpecAsyncAwait.Actors.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorSpecAsyncAwait.Actors.cs
@@ -953,15 +953,14 @@ namespace Akka.Persistence.Tests
 
             protected override bool ReceiveCommand(object message)
             {
-                if (message is LatchCmd)
+                if (message is LatchCmd latchCmd)
                 {
                     RunTask(async () =>
                     {
                         await Task.Yield();
                         await Task.Delay(100);
-                        var latchCmd = message as LatchCmd;
                         Sender.Tell(latchCmd.Data);
-                        latchCmd.Latch.Ready(TimeSpan.FromSeconds(5));
+                        await latchCmd.Latch.ReadyAsync(TimeSpan.FromSeconds(5));
                         PersistAsync(latchCmd.Data, _ => { });
                     });
                 }

--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteDeploymentDeathWatchSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteDeploymentDeathWatchSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.MultiNode.TestAdapter;
@@ -53,7 +54,7 @@ namespace Akka.Remote.Tests.MultiNode
         }
 
         [MultiNodeFact]
-        public void An_actor_system_that_deploys_actors_on_another_node_must_be_able_to_shutdown_when_remote_node_crash()
+        public async Task An_actor_system_that_deploys_actors_on_another_node_must_be_able_to_shutdown_when_remote_node_crash()
         {
             RunOn(() =>
             {
@@ -83,15 +84,15 @@ namespace Akka.Remote.Tests.MultiNode
                 EnterBarrier("third-crashed");
             }, _specConfig.Third);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 EnterBarrier("hello-deployed");
                 Sleep();
-                TestConductor.Exit(_specConfig.Third, 0).GetAwaiter().GetResult();
+                await TestConductor.Exit(_specConfig.Third, 0);
                 EnterBarrier("third-crashed");
 
                 //second system will be shutdown
-                TestConductor.Shutdown(_specConfig.Second).GetAwaiter().GetResult();
+                await TestConductor.Shutdown(_specConfig.Second);
 
                 EnterBarrier("after-3");
             }, _specConfig.First);

--- a/src/core/Akka.Remote.Tests/RemoteMessageLocalDeliverySpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteMessageLocalDeliverySpec.cs
@@ -84,7 +84,7 @@ namespace Akka.Remote.Tests
                     var actorPath = new RootActorPath(sys2Address) / "user" / "myActor";
 
                     // get a remoteactorref for the second system
-                    var remoteActorRef = Sys.ActorSelection(actorPath).ResolveOne(TimeSpan.FromSeconds(3)).Result;
+                    var remoteActorRef = await Sys.ActorSelection(actorPath).ResolveOne(TimeSpan.FromSeconds(3));
 
                     // disconnect us from the second actorsystem
                     Assert.True(await RARP.For(Sys)

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -202,11 +202,11 @@ namespace Akka.Remote.Tests
         [Fact]
         public void Resolve_does_not_deadlock_GuiApplication()
         {
-            AsyncContext.Run(() =>
+            AsyncContext.Run(async () =>
             {
                 // here is really an ActorSelection
                 var actorSelection = (ActorSelection)_here;
-                var actorRef = actorSelection.ResolveOne(TimeSpan.FromSeconds(10)).Result;
+                var actorRef = await actorSelection.ResolveOne(TimeSpan.FromSeconds(10));
                 // the only test is that the ResolveOne works, so if we got here, the test passes
                 return Task.Delay(0);
             });

--- a/src/core/Akka.Remote.Tests/RemotingTerminatorSpecs.cs
+++ b/src/core/Akka.Remote.Tests/RemotingTerminatorSpecs.cs
@@ -89,7 +89,7 @@ namespace Akka.Remote.Tests
             Watch(associated);
 
             // verify that the association is open (don't terminate until handshake is finished)
-            associated.Ask<ActorIdentity>(new Identify("foo"), RemainingOrDefault).Result.MessageId.ShouldBe("foo");
+            (await associated.Ask<ActorIdentity>(new Identify("foo"), RemainingOrDefault)).MessageId.ShouldBe("foo");
             
             
             // terminate the DEPLOYED system

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
@@ -241,8 +241,8 @@ namespace Akka.Remote.Tests.Transport
             //finish the connection by sending back an associate message
             reader.Tell(TestAssociate(33), TestActor);
 
-            await statusPromise.Task.WithTimeout(3.Seconds());
-            switch (statusPromise.Task.Result)
+            var result = await statusPromise.Task.WaitAsync(3.Seconds());
+            switch (result)
             {
                 case AkkaProtocolHandle h:
                     Assert.Equal(_remoteAkkaAddress, h.RemoteAddress);
@@ -274,8 +274,7 @@ namespace Akka.Remote.Tests.Transport
 
             reader.Tell(TestAssociate(33), TestActor);
 
-            await statusPromise.Task.WithTimeout(3.Seconds());
-            var result = statusPromise.Task.Result;
+            var result = await statusPromise.Task.WaitAsync(3.Seconds());
             switch (result)
             {
                 case AkkaProtocolHandle h:
@@ -322,8 +321,7 @@ namespace Akka.Remote.Tests.Transport
 
             reader.Tell(TestAssociate(33), TestActor);
 
-            await statusPromise.Task.WithTimeout(TimeSpan.FromSeconds(3));
-            var result = statusPromise.Task.Result;
+            var result = await statusPromise.Task.WaitAsync(3.Seconds());
             switch (result)
             {
                 case AkkaProtocolHandle h:
@@ -370,8 +368,7 @@ namespace Akka.Remote.Tests.Transport
 
             stateActor.Tell(TestAssociate(33), TestActor);
 
-            await statusPromise.Task.WithTimeout(TimeSpan.FromSeconds(3));
-            var result = statusPromise.Task.Result;
+            var result = await statusPromise.Task.WaitAsync(3.Seconds());
             switch (result)
             {
                 case AkkaProtocolHandle h:
@@ -421,8 +418,7 @@ namespace Akka.Remote.Tests.Transport
 
             stateActor.Tell(TestAssociate(33), TestActor);
 
-            await statusPromise.Task.WithTimeout(TimeSpan.FromSeconds(3));
-            var result = statusPromise.Task.Result;
+            var result = await statusPromise.Task.WaitAsync(3.Seconds());
             switch (result)
             {
                 case AkkaProtocolHandle h:
@@ -473,10 +469,8 @@ namespace Akka.Remote.Tests.Transport
 
             Watch(stateActor);
 
-            await Awaiting(async () =>
-            {
-                await statusPromise.Task.WithTimeout(TimeSpan.FromSeconds(5));
-            }).Should().ThrowAsync<TimeoutException>();
+            await Awaiting(() => statusPromise.Task.WithTimeout(TimeSpan.FromSeconds(5)))
+                .Should().ThrowAsync<TimeoutException>();
             
             await ExpectTerminatedAsync(stateActor);
         }

--- a/src/core/Akka.Remote.Tests/Transport/TestTransportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/TestTransportSpec.cs
@@ -129,8 +129,7 @@ namespace Akka.Remote.Tests.Transport
             });
             handleB.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
 
-            await associate.WithTimeout(DefaultTimeout);
-            var handleA = associate.Result;
+            var handleA = await associate.WaitAsync(DefaultTimeout);
 
             //Initialize handles
             handleA.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
@@ -184,8 +183,7 @@ namespace Akka.Remote.Tests.Transport
             });
             handleB.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
 
-            await associate.WithTimeout(DefaultTimeout);
-            var handleA = associate.Result;
+            var handleA = await associate.WaitAsync(DefaultTimeout);
 
             //Initialize handles
             handleA.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));

--- a/src/core/Akka.Streams.Tests.Performance/FusedGraphsBenchmark.cs
+++ b/src/core/Akka.Streams.Tests.Performance/FusedGraphsBenchmark.cs
@@ -275,61 +275,61 @@ namespace Akka.Streams.Tests.Performance
         [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 50)]
-        public void SingleIdentity() => _singleIdentity.Run(_materializer).Ready();
+        public void SingleIdentity() => _singleIdentity.Run(_materializer).ReadyAsync().GetAwaiter().GetResult();
 
 
         [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Measurement, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 100)]
-        public void ChainOfIdentities() => _chainOfIdentities.Run(_materializer).Ready();
+        public void ChainOfIdentities() => _chainOfIdentities.Run(_materializer).ReadyAsync().GetAwaiter().GetResult();
 
 
         [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 50)]
-        public void SingleSelect() => _singleSelect.Run(_materializer).Ready();
+        public void SingleSelect() => _singleSelect.Run(_materializer).ReadyAsync().GetAwaiter().GetResult();
 
         
         [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Measurement, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 110)]
-        public void ChainOfSelects() => _chainOfSelects.Run(_materializer).Ready();
+        public void ChainOfSelects() => _chainOfSelects.Run(_materializer).ReadyAsync().GetAwaiter().GetResult();
 
 
         [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 60)]
-        public void SingleBuffer() => _singleBuffer.Run(_materializer).Ready();
+        public void SingleBuffer() => _singleBuffer.Run(_materializer).ReadyAsync().GetAwaiter().GetResult();
 
 
         [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 350)]
-        public void ChainOfBuffers() => _chainOfBuffers.Run(_materializer).Ready();
+        public void ChainOfBuffers() => _chainOfBuffers.Run(_materializer).ReadyAsync().GetAwaiter().GetResult();
 
 
         [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Measurement, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 3500)]
-        public void RepeatTakeSelectAndAggregate() => _repeatTakeSelectAndAggregate.Run(_materializer).Ready();
+        public void RepeatTakeSelectAndAggregate() => _repeatTakeSelectAndAggregate.Run(_materializer).ReadyAsync().GetAwaiter().GetResult();
 
 
         [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 100)]
-        public void BroadcastZip() => _broadcastZip.Run(_materializer).Ready();
+        public void BroadcastZip() => _broadcastZip.Run(_materializer).ReadyAsync().GetAwaiter().GetResult();
 
 
         [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 50)]
-        public void BalanceMerge() => _balanceMerge.Run(_materializer).Ready();
+        public void BalanceMerge() => _balanceMerge.Run(_materializer).ReadyAsync().GetAwaiter().GetResult();
 
 
         [PerfBenchmark(RunMode = RunMode.Iterations, TestMode = TestMode.Test, NumberOfIterations = 3)]
         [TimingMeasurement]
         [ElapsedTimeAssertion(MaxTimeMilliseconds = 100)]
-        public void BroadcastZipBalanceMerge() => _broadcastZipBalanceMerge.Run(_materializer).Ready();
+        public void BroadcastZipBalanceMerge() => _broadcastZipBalanceMerge.Run(_materializer).ReadyAsync().GetAwaiter().GetResult();
         
     }
 }

--- a/src/core/Akka.Streams.Tests/ActorMaterializerSpec.cs
+++ b/src/core/Akka.Streams.Tests/ActorMaterializerSpec.cs
@@ -82,11 +82,11 @@ namespace Akka.Streams.Tests
         }
 
         [Fact]
-        public void ActorMaterializer_should_report_correctly_if_it_has_been_shut_down_from_the_side()
+        public async Task ActorMaterializer_should_report_correctly_if_it_has_been_shut_down_from_the_side()
         {
             var sys = ActorSystem.Create("test-system");
             var m = sys.Materializer();
-            sys.Terminate().Wait();
+            await sys.Terminate().WaitAsync(3.Seconds());
             m.IsShutdown.Should().BeTrue();
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/ActorRefBackpressureSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ActorRefBackpressureSinkSpec.cs
@@ -14,6 +14,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -163,7 +164,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task ActorBackpressureSink_should_keep_on_sending_even_after_the_buffer_has_been_full()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var bufferSize = 16;
                 var streamElementCount = bufferSize + 4;
                 var fw = CreateActor<Fw2>();
@@ -177,7 +178,7 @@ namespace Akka.Streams.Tests.Dsl
                             Keep.Right)
                         .To(sink)
                         .Run(Materializer);
-                probe.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
+                await probe.WaitAsync(3.Seconds());
                 probe.IsCompleted.Should().BeTrue();
                 ExpectMsg(InitMessage);
                 fw.Tell(TriggerAckMessage.Instance);
@@ -187,7 +188,6 @@ namespace Akka.Streams.Tests.Dsl
                     fw.Tell(TriggerAckMessage.Instance);
                 }
                 ExpectMsg(CompleteMessage);
-                return Task.CompletedTask;
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
@@ -180,13 +180,12 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_ActorRefSource_must_complete_and_materialize_the_stream_after_receiving_Status_Success()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var (actorRef, done) = Source.ActorRef<int>(3, OverflowStrategy.DropBuffer)                                                                             
                 .ToMaterialized(Sink.Ignore<int>(), Keep.Both)                                                                             
                 .Run(Materializer);
                 actorRef.Tell(new Status.Success("ok"));
-                done.ContinueWith(_ => Done.Instance).Result.Should().Be(Done.Instance);
-                return Task.CompletedTask;
+                (await done.WaitAsync(RemainingOrDefault)).Should().Be(Done.Instance);
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ActorRefSourceSpec.cs
@@ -115,8 +115,7 @@ namespace Akka.Streams.Tests.Dsl
                 Watch(actorRef);
                 var sub = await s.ExpectSubscriptionAsync();
                 sub.Cancel();
-                ExpectTerminated(actorRef);
-                return Task.CompletedTask;
+                await ExpectTerminatedAsync(actorRef);
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
@@ -18,6 +18,7 @@ using Xunit;
 using Xunit.Abstractions;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Akka.Configuration;
 using Akka.TestKit.Extensions;
 using Akka.Util;
 using FluentAssertions.Extensions;

--- a/src/core/Akka.Streams.Tests/Dsl/BidiFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/BidiFlowSpec.cs
@@ -195,7 +195,6 @@ namespace Akka.Streams.Tests.Dsl
                 m.Result.Should().Be(42);
                 r.Result.Should().BeEquivalentTo(new[] { 3L, 12L });
 #pragma warning restore xUnit1031
-                return Task.CompletedTask;
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
@@ -124,7 +124,6 @@ namespace Akka.Streams.Tests.Dsl
                 
                 (await Awaiting(() => future.WaitAsync(RemainingOrDefault)).Should().ThrowAsync<TestException>())
                     .And.Should().Be(error);
-                return Task.CompletedTask;
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
@@ -126,15 +126,14 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Batch_must_work_with_a_buffer_and_aggregate()
+        public async Task Batch_must_work_with_a_buffer_and_aggregate()
         {
             var future =
                 Source.From(Enumerable.Range(1, 50))
                     .Batch(long.MaxValue, i => i, (sum, i) => sum + i)
                     .Buffer(50, OverflowStrategy.Backpressure)
                     .RunAggregate(0, (sum, i) => sum + i, Materializer);
-            future.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-            future.Result.Should().Be(Enumerable.Range(1, 50).Sum());
+            (await future.WaitAsync(3.Seconds())).Should().Be(Enumerable.Range(1, 50).Sum());
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBufferSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBufferSpec.cs
@@ -14,6 +14,7 @@ using Akka.Streams.TestKit;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -30,33 +31,31 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Buffer_must_pass_elements_through_normally_in_backpressured_mode()
+        public async Task Buffer_must_pass_elements_through_normally_in_backpressured_mode()
         {
             var future = Source.From(Enumerable.Range(1, 1000))
                 .Buffer(100, OverflowStrategy.Backpressure)
                 .Grouped(1001)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-            future.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-            future.Result.Should().BeEquivalentTo(Enumerable.Range(1,1000));
+            (await future.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1,1000));
         }
 
         [Fact]
-        public void Buffer_must_pass_elements_through_normally_in_backpressured_mode_with_buffer_size_one()
+        public async Task Buffer_must_pass_elements_through_normally_in_backpressured_mode_with_buffer_size_one()
         {
             var future = Source.From(Enumerable.Range(1, 1000))
                 .Buffer(1, OverflowStrategy.Backpressure)
                 .Grouped(1001)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-            future.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-            future.Result.Should().BeEquivalentTo(Enumerable.Range(1, 1000));
+            (await future.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 1000));
         }
 
         [Fact]
         public async Task Buffer_must_pass_elements_through_a_chain_of_backpressured_buffers_of_different_size()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var future = Source.From(Enumerable.Range(1, 1000))                                                                             
                 .Buffer(1, OverflowStrategy.Backpressure)                                                                             
                 .Buffer(10, OverflowStrategy.Backpressure)                                                                             
@@ -66,9 +65,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Buffer(128, OverflowStrategy.Backpressure)                                                                             
                 .Grouped(1001)                                                                             
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
-                future.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                future.Result.Should().BeEquivalentTo(Enumerable.Range(1, 1000));
-                return Task.CompletedTask;
+                (await future.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 1000));
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowConcatSpec.cs
@@ -230,7 +230,6 @@ namespace Akka.Streams.Tests.Dsl
                     .ViaMaterialized(testFlow, Keep.Both)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
                 (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
-                return Task.CompletedTask;
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowExpandSpec.cs
@@ -9,11 +9,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 // ReSharper disable InvokeAsExtensionMethod
@@ -108,7 +110,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Expand_must_work_on_a_variable_rate_chain()
+        public async Task Expand_must_work_on_a_variable_rate_chain()
         {
             var future = Source.From(Enumerable.Range(1, 100))
                 .Select(x =>
@@ -124,8 +126,7 @@ namespace Akka.Streams.Tests.Dsl
                     return agg;
                 }, Materializer);
 
-            future.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
-            future.Result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
+            (await future.WaitAsync(10.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 100));
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
@@ -227,7 +227,7 @@ namespace Akka.Streams.Tests.Dsl
                     if (i == 1)
                         return Source.FromPublisher(p);
 
-                    latch.Ready(TimeSpan.FromSeconds(3));
+                    latch.ReadyAsync(TimeSpan.FromSeconds(3)).GetAwaiter().GetResult();
                     throw ex;
                 }).RunWith(Sink.First<int>(), materializer);
                 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
@@ -19,6 +19,7 @@ using Akka.TestKit.Xunit2.Attributes;
 using Akka.Util.Internal;
 using FluentAssertions;
 using FluentAssertions.Extensions;
+using Nito.AsyncEx;
 using Xunit;
 using Xunit.Abstractions;
 using static FluentAssertions.FluentActions;
@@ -55,8 +56,7 @@ namespace Akka.Streams.Tests.Dsl
                 var task = Source.From(new[] {Src10(0), Src10(10), Src10(20), Src10(30)})
                     .MergeMany(4, s => s)
                     .RunWith(ToSet, Materializer);
-                await task.ShouldCompleteWithin(1.Seconds());
-                task.Result.Should().BeEquivalentTo(Enumerable.Range(0, 40));
+                (await task.WaitAsync(1.Seconds())).Should().BeEquivalentTo(Enumerable.Range(0, 40));
             }, Materializer);
         }
 
@@ -69,8 +69,7 @@ namespace Akka.Streams.Tests.Dsl
                     .MergeMany(3, s => s)
                     .Take(40)
                     .RunWith(ToSet, Materializer);
-                await task.ShouldCompleteWithin(1.Seconds());
-                task.Result.Should().BeEquivalentTo(Enumerable.Range(0, 40));
+                (await task.WaitAsync(1.Seconds())).Should().BeEquivalentTo(Enumerable.Range(0, 40));
             }, Materializer);
         }
 
@@ -84,10 +83,10 @@ namespace Akka.Streams.Tests.Dsl
                     .Take(40)
                     .RunWith(ToSeq, Materializer);
 
-                await task.ShouldCompleteWithin(1.Seconds());
+                var result = await task.ShouldCompleteWithin(1.Seconds());
 
-                task.Result.Take(30).Should().BeEquivalentTo(Enumerable.Range(0, 30));
-                task.Result.Drop(30).Should().BeEquivalentTo(Enumerable.Range(30, 10));
+                result.Take(30).Should().BeEquivalentTo(Enumerable.Range(0, 30));
+                result.Drop(30).Should().BeEquivalentTo(Enumerable.Range(30, 10));
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
@@ -227,7 +227,7 @@ namespace Akka.Streams.Tests.Dsl
                     if (i == 1)
                         return Source.FromPublisher(p);
 
-                    latch.ReadyAsync(TimeSpan.FromSeconds(3)).GetAwaiter().GetResult();
+                    latch.Ready(TimeSpan.FromSeconds(3));
                     throw ex;
                 }).RunWith(Sink.First<int>(), materializer);
                 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowGroupBySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowGroupBySpec.cs
@@ -101,8 +101,8 @@ namespace Akka.Streams.Tests.Dsl
                     ((Source<IEnumerable<IEnumerable<string>>, NotUsed>)source).RunWith(
                         Sink.First<IEnumerable<IEnumerable<string>>>(), Materializer);
 
-                await task.ShouldCompleteWithin(3.Seconds());
-                task.Result.OrderBy(e => e.First())
+                var result = await task.ShouldCompleteWithin(3.Seconds());
+                result.OrderBy(e => e.First())
                     .Should().BeEquivalentTo(new[] { "Aaa", "Abb" }, new[] { "Bcc" }, new[] { "Cdd", "Cee" });
             }, Materializer);
         }
@@ -402,9 +402,9 @@ namespace Akka.Streams.Tests.Dsl
                     .PrefixAndTail(0)
                     .Select(t => t.Item2)
                     .ConcatSubstream();
-                var futureGroupSource = source.RunWith(Sink.First<Source<int, NotUsed>>(), Materializer);
-                await futureGroupSource.ShouldCompleteWithin(3.Seconds());
-                var publisher = futureGroupSource.Result.RunWith(Sink.AsPublisher<int>(false), Materializer);
+                var futureGroupSourceTask = source.RunWith(Sink.First<Source<int, NotUsed>>(), Materializer);
+                var futureGroupSource = await futureGroupSourceTask.ShouldCompleteWithin(3.Seconds());
+                var publisher = futureGroupSource.RunWith(Sink.AsPublisher<int>(false), Materializer);
                 
                 var probe = this.CreateSubscriberProbe<int>();
                 publisher.Subscribe(probe);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowGroupedWithinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowGroupedWithinSpec.cs
@@ -14,6 +14,7 @@ using Akka.Streams.TestKit;
 using Akka.Util.Internal;
 using Akka.Util.Internal.Collections;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 using static Akka.Streams.Tests.Dsl.TestConfig;
@@ -262,15 +263,14 @@ namespace Akka.Streams.Tests.Dsl
                 .Select(async _ => await RunScriptAsync(script(), Settings, flow => flow.GroupedWithin(3, TimeSpan.FromMinutes(10))));
         }
 
-        [Fact(Skip = "Skipped for async_testkit conversion build")]
-        public void A_GroupedWithin_must_group_with_small_groups_with_backpressure()
+        [Fact]
+        public async Task A_GroupedWithin_must_group_with_small_groups_with_backpressure()
         {
             var t = Source.From(Enumerable.Range(1, 10))
                 .GroupedWithin(1, TimeSpan.FromDays(1))
                 .Throttle(1, TimeSpan.FromMilliseconds(110), 0, ThrottleMode.Shaping)
                 .RunWith(Sink.Seq<IEnumerable<int>>(), Materializer);
-            t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-            t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 10).Select(i => new List<int> { i }));
+            (await t.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10).Select(i => new List<int> { i }));
         }
     }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowInitialDelaySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowInitialDelaySpec.cs
@@ -13,9 +13,10 @@ using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
-// ReSharper disable InvokeAsExtensionMethod
+using static FluentAssertions.FluentActions;
 
 namespace Akka.Streams.Tests.Dsl
 {
@@ -33,13 +34,12 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task Flow_InitialDelay_must_work_with_zero_delay()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var task = Source.From(Enumerable.Range(1, 10))
                 .InitialDelay(TimeSpan.Zero)
                 .Grouped(100)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
-                task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-                task.Result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await task.WaitAsync(1.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
                 return Task.CompletedTask;
             }, Materializer);
         }
@@ -47,12 +47,14 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task Flow_InitialDelay_must_delay_elements_by_the_specified_time_but_not_more()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var task = Source.From(Enumerable.Range(1, 10))
                 .InitialDelay(TimeSpan.FromSeconds(2))
                 .InitialTimeout(TimeSpan.FromSeconds(1))
                 .RunWith(Sink.Ignore<int>(), Materializer);
-                task.Invoking(t => t.Wait(TimeSpan.FromSeconds(2))).Should().Throw<TimeoutException>();
+                
+                await Awaiting(() => task.WaitAsync(2.Seconds()))
+                    .Should().ThrowAsync<TimeoutException>();
                 return Task.CompletedTask;
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowInitialDelaySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowInitialDelaySpec.cs
@@ -40,7 +40,6 @@ namespace Akka.Streams.Tests.Dsl
                 .Grouped(100)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
                 (await task.WaitAsync(1.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
-                return Task.CompletedTask;
             }, Materializer);
         }
 
@@ -55,7 +54,6 @@ namespace Akka.Streams.Tests.Dsl
                 
                 await Awaiting(() => task.WaitAsync(2.Seconds()))
                     .Should().ThrowAsync<TimeoutException>();
-                return Task.CompletedTask;
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowIntersperseSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowIntersperseSpec.cs
@@ -7,10 +7,12 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -40,7 +42,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Intersperse_must_inject_element_between_existing_elements_when_downstream_is_aggregate()
+        public async Task A_Intersperse_must_inject_element_between_existing_elements_when_downstream_is_aggregate()
         {
             var concated =
                 Source.From(new[] { 1, 2, 3 })
@@ -48,8 +50,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Intersperse(",")
                     .RunAggregate("", (s, s1) => s + s1, Materializer);
 
-            concated.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-            concated.Result.Should().Be("1,2,3");
+            (await concated.WaitAsync(3.Seconds())).Should().Be("1,2,3");
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
@@ -13,6 +13,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 // ReSharper disable InvokeAsExtensionMethod
@@ -73,7 +74,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_Flow_using_Join_must_allow_for_merge_cycle()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var source =                                                                             
                 Source.Single("lonely traveler").MapMaterializedValue(_ => Task.FromResult(""));
 
@@ -89,8 +90,7 @@ namespace Akka.Streams.Tests.Dsl
                 }));
 
                 var t = flow1.Join(Flow.Create<string>()).Run(Materializer);
-                t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                t.Result.Should().Be("lonely traveler");
+                (await t.WaitAsync(3.Seconds())).Should().Be("lonely traveler");
                 return Task.CompletedTask;
             }, Materializer);
         }
@@ -98,7 +98,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_Flow_using_Join_must_allow_for_merge_preferred_cycle()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var source =                                                                             
                 Source.Single("lonely traveler").MapMaterializedValue(_ => Task.FromResult(""));
 
@@ -114,8 +114,7 @@ namespace Akka.Streams.Tests.Dsl
                 }));
 
                 var t = flow1.Join(Flow.Create<string>()).Run(Materializer);
-                t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                t.Result.Should().Be("lonely traveler");
+                (await t.WaitAsync(3.Seconds())).Should().Be("lonely traveler");
                 return Task.CompletedTask;
             }, Materializer);
         }
@@ -158,7 +157,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_Flow_using_Join_must_allow_for_concat_cycle()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var flow = 
                 Flow.FromGraph(GraphDsl.Create(TestSource.SourceProbe<string>(this), 
                 Sink.First<string>(), Keep.Both, (b, source, sink) =>                                                                         
@@ -175,8 +174,7 @@ namespace Akka.Streams.Tests.Dsl
                 var probe = tuple.Item1;
                 var t = tuple.Item2;
                 probe.SendNext("lonely traveler");
-                t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                t.Result.Should().Be("lonely traveler");
+                (await t.WaitAsync(3.Seconds())).Should().Be("lonely traveler");
                 probe.SendComplete();
                 return Task.CompletedTask;
             }, Materializer);
@@ -185,7 +183,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_Flow_using_Join_must_allow_for_interleave_cycle()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var source = Source.Single("lonely traveler").MapMaterializedValue(_ => Task.FromResult(""));
                 var flow = Flow.FromGraph(GraphDsl.Create(Sink.First<string>(), (b, sink) =>
                 {
@@ -199,8 +197,7 @@ namespace Akka.Streams.Tests.Dsl
                 }));
 
                 var t = flow.Join(Flow.Create<string>()).Run(Materializer);
-                t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                t.Result.Should().Be("lonely traveler");
+                (await t.WaitAsync(3.Seconds())).Should().Be("lonely traveler");
                 return Task.CompletedTask;
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowJoinSpec.cs
@@ -91,7 +91,6 @@ namespace Akka.Streams.Tests.Dsl
 
                 var t = flow1.Join(Flow.Create<string>()).Run(Materializer);
                 (await t.WaitAsync(3.Seconds())).Should().Be("lonely traveler");
-                return Task.CompletedTask;
             }, Materializer);
         }
 
@@ -115,7 +114,6 @@ namespace Akka.Streams.Tests.Dsl
 
                 var t = flow1.Join(Flow.Create<string>()).Run(Materializer);
                 (await t.WaitAsync(3.Seconds())).Should().Be("lonely traveler");
-                return Task.CompletedTask;
             }, Materializer);
         }
 
@@ -176,7 +174,6 @@ namespace Akka.Streams.Tests.Dsl
                 probe.SendNext("lonely traveler");
                 (await t.WaitAsync(3.Seconds())).Should().Be("lonely traveler");
                 probe.SendComplete();
-                return Task.CompletedTask;
             }, Materializer);
         }
 
@@ -198,7 +195,6 @@ namespace Akka.Streams.Tests.Dsl
 
                 var t = flow.Join(Flow.Create<string>()).Run(Materializer);
                 (await t.WaitAsync(3.Seconds())).Should().Be("lonely traveler");
-                return Task.CompletedTask;
             }, Materializer);
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowKillSwitchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowKillSwitchSpec.cs
@@ -189,7 +189,6 @@ namespace Akka.Streams.Tests.Dsl
                     .Via(killSwitch.Flow<int>())
                     .RunWith(Sink.Seq<int>(), Materializer);
                 (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 100));
-                return Task.CompletedTask;
             }, Materializer);
         }
 
@@ -380,7 +379,6 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.Seq<int>(), Materializer);
                 (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
                 killSwitch.Shutdown();
-                return Task.CompletedTask;
             }, Materializer);
         }
 
@@ -400,7 +398,6 @@ namespace Akka.Streams.Tests.Dsl
                 killSwitch2.Shutdown();
                 await completion.WaitAsync(3.Seconds());
                 completion.IsFaulted.Should().BeFalse();
-                return Task.CompletedTask;
             }, Materializer);
         }
 
@@ -548,7 +545,6 @@ namespace Akka.Streams.Tests.Dsl
                     .Via(cancel.Token.AsFlow<int>())
                     .RunWith(Sink.Seq<int>(), Materializer);
                 (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 100));
-                return Task.CompletedTask;
             }, Materializer);
         }
 
@@ -705,7 +701,6 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.Seq<int>(), Materializer);
                 (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
                 cancel.Cancel();
-                return Task.CompletedTask;
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
@@ -7,12 +7,14 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Event;
 using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -146,7 +148,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Log_on_Source_must_follow_supervision_strategy_when_Exception_thrown()
+        public async Task A_Log_on_Source_must_follow_supervision_strategy_when_Exception_thrown()
         {
             var ex = new TestException("test");
             var future = Source.From(Enumerable.Range(1, 5))
@@ -154,8 +156,7 @@ namespace Akka.Streams.Tests.Dsl
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                 .RunWith(Sink.Aggregate<int, int>(0, (i, i1) => i + i1), Materializer);
 
-            future.Wait(TimeSpan.FromMilliseconds(500)).Should().BeTrue();
-            future.Result.Should().Be(0);
+            (await future.WaitAsync(500.Milliseconds())).Should().Be(0);
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowScanSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowScanSpec.cs
@@ -14,6 +14,7 @@ using Akka.Streams.Supervision;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -81,7 +82,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(() => Task.FromResult(Scan(Source.Empty<int>()).Should().BeEquivalentTo(new[] {0})), Materializer);
 
         [Fact]
-        public void A_Scan_must_emit_values_promptly()
+        public async Task A_Scan_must_emit_values_promptly()
         {
             var task = Source.Single(1).MapMaterializedValue<TaskCompletionSource<int>>(_ => null)
                 .Concat(Source.Maybe<int>())
@@ -89,8 +90,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Take(2)
                 .RunWith(Sink.Seq<int>(), Materializer);
 
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] {0, 1});
+            (await task.WaitAsync(1.Seconds())).Should().BeEquivalentTo(new[] {0, 1});
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
@@ -28,7 +28,6 @@ using FluentAssertions.Extensions;
 using static FluentAssertions.FluentActions;
 using Directive = Akka.Streams.Supervision.Directive;
 
-// ReSharper disable InvokeAsExtensionMethod
 #pragma warning disable 162
 
 namespace Akka.Streams.Tests.Dsl
@@ -200,7 +199,7 @@ namespace Akka.Streams.Tests.Dsl
                         return Task.FromResult(n);
                     }).RunWith(Sink.Ignore<int>(), Materializer);
 
-                await Awaiting(async () => await done).Should()
+                await Awaiting(() => done.WaitAsync(RemainingOrDefault)).Should()
                     .ThrowAsync<Exception>()
                     .WithMessage("err1")
                     .ShouldCompleteWithin(RemainingOrDefault);
@@ -287,7 +286,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_Flow_with_SelectAsync_must_resume_after_multiple_failures()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var futures = new[]
                 {
                     Task.Run(() => { throw new TestException("failure1"); return "";}),
@@ -303,8 +302,7 @@ namespace Akka.Streams.Tests.Dsl
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                     .RunWith(Sink.First<string>(), Materializer);
 
-                t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                t.Result.Should().Be("happy");
+                (await t.WaitAsync(3.Seconds())).Should().Be("happy");
                 return Task.CompletedTask;
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
@@ -184,7 +184,7 @@ namespace Akka.Streams.Tests.Dsl
                     {
                         if (n != 1)
                             // slow upstream should not block the error
-                            latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
+                            latch.Ready(TimeSpan.FromSeconds(10));
 
                         return n;
                     })
@@ -303,7 +303,6 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.First<string>(), Materializer);
 
                 (await t.WaitAsync(3.Seconds())).Should().Be("happy");
-                return Task.CompletedTask;
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
@@ -184,7 +184,7 @@ namespace Akka.Streams.Tests.Dsl
                     {
                         if (n != 1)
                             // slow upstream should not block the error
-                            latch.Ready(TimeSpan.FromSeconds(10));
+                            latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
 
                         return n;
                     })

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectErrorSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectErrorSpec.cs
@@ -33,15 +33,15 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_SelectError_must_select_when_there_is_a_handler()
         {
-            await this.AssertAllStagesStoppedAsync(async() => {
-                Source.From(Enumerable.Range(1, 3))                                                                             
-                .Select(ThrowOnTwo)                                                                             
-                .SelectError(_ => Boom)                                                                             
-                .RunWith(this.SinkProbe<int>(), Materializer)                                                                             
-                .Request(2)                                                                             
-                .ExpectNext(1)                                                                             
-                .ExpectError().Should().Be(Boom);
-                return Task.CompletedTask;
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var src = Source.From(Enumerable.Range(1, 3))
+                    .Select(ThrowOnTwo)
+                    .SelectError(_ => Boom)
+                    .RunWith(this.SinkProbe<int>(), Materializer);
+                (await src.AsyncBuilder()
+                    .Request(2)
+                    .ExpectNext(1)
+                    .ExpectErrorAsync()).Should().Be(Boom);
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSlidingSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSlidingSpec.cs
@@ -147,7 +147,6 @@ namespace Akka.Streams.Tests.Dsl
                         TestActor.Tell("done");                                                                             
                 });
                 await ExpectMsgAsync("done");
-                return Task.CompletedTask;
             }, Materializer);
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSpec.cs
@@ -389,8 +389,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Limit(100)
                     .RunWith(Sink.Seq<int>(), Materializer);
 
-                await task.ShouldCompleteWithin(3.Seconds());
-                task.Result.Should().BeEquivalentTo(Enumerable.Range(1,10));
+                (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1,10));
 
                 // Reusable:
                 task = Source.From(Enumerable.Range(1, 10))
@@ -398,8 +397,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Limit(100)
                     .RunWith(Sink.Seq<int>(), Materializer);
 
-                await task.ShouldCompleteWithin(3.Seconds());
-                task.Result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
 
@@ -682,8 +680,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Via(Flow.FromFunction<int, int>(i => i + 1))
                     .RunWith(Sink.Seq<int>(), Materializer);
                 
-                await task.ShouldCompleteWithin(3.Seconds());
-                task.Result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
 
@@ -780,8 +777,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ToMaterialized(Sink.First<int>(), Keep.Right);
                 
                 var task = Source.Single(4711).RunWith(sink, noFusingMaterializer);
-                await task.ShouldCompleteWithin(3.Seconds());
-                task.Result.Should().Be(4712);
+                (await task.WaitAsync(3.Seconds())).Should().Be(4712);
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowTakeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowTakeSpec.cs
@@ -59,21 +59,17 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Take_complete_eagerly_when_zero_or_less_is_taken_independently_of_upstream_completion()
+        public async Task A_Take_complete_eagerly_when_zero_or_less_is_taken_independently_of_upstream_completion()
         {
-            Source.Maybe<int>()
+            await Source.Maybe<int>()
                 .Take(0)
                 .RunWith(Sink.Ignore<int>(), Materializer)
-                .Wait(TimeSpan.FromSeconds(3))
-                .Should()
-                .BeTrue();
+                .WaitAsync(TimeSpan.FromSeconds(3));
 
-            Source.Maybe<int>()
+            await Source.Maybe<int>()
                 .Take(-1)
                 .RunWith(Sink.Ignore<int>(), Materializer)
-                .Wait(TimeSpan.FromSeconds(3))
-                .Should()
-                .BeTrue();
+                .WaitAsync(TimeSpan.FromSeconds(3));
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/Dsl/FutureFlattenSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FutureFlattenSourceSpec.cs
@@ -17,6 +17,7 @@ using Akka.TestKit.Extensions;
 using Akka.TestKit.Xunit2.Attributes;
 using FluentAssertions;
 using FluentAssertions.Extensions;
+using Nito.AsyncEx;
 using Xunit;
 using Xunit.Abstractions;
 using static FluentAssertions.FluentActions;
@@ -44,13 +45,9 @@ namespace Akka.Streams.Tests.Dsl
                     .ToMaterialized(Sink.Seq<int>(), Keep.Both)
                     .Run(_materializer);
 
-                // wait until the underlying task is completed
-                await sourceMatVal.ShouldCompleteWithin(3.Seconds());
-                await sinkMatVal.ShouldCompleteWithin(3.Seconds());
-
                 // should complete as soon as inner source has been materialized
-                sourceMatVal.Result.Should().Be("foo");
-                sinkMatVal.Result.Should().BeEquivalentTo(ImmutableList.CreateRange(new List<int>() { 1, 2, 3 }));
+                (await sourceMatVal.WaitAsync(3.Seconds())).Should().Be("foo");
+                (await sinkMatVal.WaitAsync(3.Seconds())).Should().BeEquivalentTo(ImmutableList.CreateRange(new List<int>() { 1, 2, 3 }));
             }, _materializer);
         }
 
@@ -89,13 +86,9 @@ namespace Akka.Streams.Tests.Dsl
 
                 sourcePromise.SetResult(Underlying);
 
-                // wait until the underlying task is completed
-                await sourceMatVal.ShouldCompleteWithin(3.Seconds());
-                await sinkMatVal.ShouldCompleteWithin(3.Seconds());
-                
                 // should complete as soon as inner source has been materialized
-                sourceMatVal.Result.Should().Be("foo");
-                sinkMatVal.Result.Should().BeEquivalentTo(ImmutableList.CreateRange(new List<int>() { 1, 2, 3 }));
+                (await sourceMatVal.WaitAsync(3.Seconds())).Should().Be("foo");
+                (await sinkMatVal.WaitAsync(3.Seconds())).Should().BeEquivalentTo(ImmutableList.CreateRange(new List<int>() { 1, 2, 3 }));
             }, _materializer);
         }
 
@@ -213,9 +206,8 @@ namespace Akka.Streams.Tests.Dsl
                 await subscriber.EnsureSubscriptionAsync();
                 sourcePromise.SetResult(Source.FromPublisher(publisher).MapMaterializedValue(_ => "woho"));
 
-                await matVal.ShouldCompleteWithin(3.Seconds());
                 // materialized value completes but still no demand
-                matVal.Result.Should().Be("woho");
+                (await matVal.WaitAsync(3.Seconds())).Should().Be("woho");
 
                 // then demand and let an element through to see it works
                 await subscriber.AsyncBuilder().Request(1).ExecuteAsync();
@@ -243,9 +235,8 @@ namespace Akka.Streams.Tests.Dsl
                 await subscriber.EnsureSubscriptionAsync();
                 sourcePromise.SetResult(Source.FromPublisher(publisher).MapMaterializedValue(_ => "woho"));
 
-                await matVal.ShouldCompleteWithin(3.Seconds());
                 // materialized value completes but still no demand
-                matVal.Result.Should().Be("woho");
+                (await matVal.WaitAsync(3.Seconds())).Should().Be("woho");
 
                 // then demand and let an element through to see it works
                 await subscriber.AsyncBuilder()

--- a/src/core/Akka.Streams.Tests/Dsl/FutureFlattenSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FutureFlattenSourceSpec.cs
@@ -160,7 +160,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Run(_materializer);
 
                 // we don't know that materialization completed yet
-                materializationLatch.Ready(RemainingOrDefault);                
+                await materializationLatch.ReadyAsync(RemainingOrDefault);                
                 sourcePromise.SetException(failure);
                 
                 // wait until the underlying tasks are completed

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
@@ -15,6 +15,7 @@ using Akka.Streams.TestKit;
 using Akka.TestKit;
 using Akka.TestKit.Xunit2.Attributes;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Reactive.Streams;
 using Xunit;
 // ReSharper disable InvokeAsExtensionMethod
@@ -147,7 +148,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_Balance_must_work_with_1_way_balance()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var task = Source.FromGraph(GraphDsl.Create(b =>                                                                         
                 {                                                                             
                     var balance = b.Add(new Balance<int>(1));                                                                             
@@ -160,8 +161,7 @@ namespace Akka.Streams.Tests.Dsl
                     list.Add(i);                                                                             
                     return list;                                                                         
                 }, Materializer);
-                task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+                (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(new[] { 1, 2, 3 });
                 return Task.CompletedTask;
             }, Materializer);
         }
@@ -169,7 +169,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_Balance_must_work_with_5_way_balance()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var sink = Sink.First<IEnumerable<int>>();
                 var t = RunnableGraph.FromGraph(GraphDsl.Create(sink, sink, sink, sink, sink, ValueTuple.Create,
                     (b, s1, s2, s3, s4, s5) =>
@@ -185,9 +185,8 @@ namespace Akka.Streams.Tests.Dsl
                         return ClosedShape.Instance;
                     })).Run(Materializer);
 
-                var task = Task.WhenAll(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5);
-                task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                task.Result.SelectMany(l => l).Should().BeEquivalentTo(Enumerable.Range(0, 15));
+                (await Task.WhenAll(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5).WaitAsync(3.Seconds()))
+                    .SelectMany(l => l).Should().BeEquivalentTo(Enumerable.Range(0, 15));
                 return Task.CompletedTask;
             }, Materializer);
         }
@@ -195,7 +194,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_Balance_must_balance_between_all_three_outputs()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 const int numElementsForSink = 10000;
                 var outputs = Sink.Aggregate<int, int>(0, (sum, i) => sum + i);
                 var t = RunnableGraph.FromGraph(GraphDsl.Create(outputs, outputs, outputs, ValueTuple.Create,
@@ -213,10 +212,9 @@ namespace Akka.Streams.Tests.Dsl
                         return ClosedShape.Instance;
                     })).Run(Materializer);
 
-                var task = Task.WhenAll(t.Item1, t.Item2, t.Item3);
-                task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                task.Result.Should().NotContain(0);
-                task.Result.Sum().Should().Be(numElementsForSink * 3);
+                var result = await Task.WhenAll(t.Item1, t.Item2, t.Item3).WaitAsync(3.Seconds());
+                result.Should().NotContain(0);
+                result.Sum().Should().Be(numElementsForSink * 3);
                 return Task.CompletedTask;
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBalanceSpec.cs
@@ -162,7 +162,6 @@ namespace Akka.Streams.Tests.Dsl
                     return list;                                                                         
                 }, Materializer);
                 (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(new[] { 1, 2, 3 });
-                return Task.CompletedTask;
             }, Materializer);
         }
 
@@ -187,7 +186,6 @@ namespace Akka.Streams.Tests.Dsl
 
                 (await Task.WhenAll(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5).WaitAsync(3.Seconds()))
                     .SelectMany(l => l).Should().BeEquivalentTo(Enumerable.Range(0, 15));
-                return Task.CompletedTask;
             }, Materializer);
         }
 
@@ -215,7 +213,6 @@ namespace Akka.Streams.Tests.Dsl
                 var result = await Task.WhenAll(t.Item1, t.Item2, t.Item3).WaitAsync(3.Seconds());
                 result.Should().NotContain(0);
                 result.Sum().Should().Be(numElementsForSink * 3);
-                return Task.CompletedTask;
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
@@ -14,6 +14,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 // ReSharper disable InvokeAsExtensionMethod
@@ -68,7 +69,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_Broadcast_must_work_with_one_way_broadcast()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var t = Source.FromGraph(GraphDsl.Create(b =>                                                                         
                 {                                                                             
                     var broadcast = b.Add(new Broadcast<int>(1));                                                                             
@@ -82,17 +83,15 @@ namespace Akka.Streams.Tests.Dsl
                     list.Add(i);                                                                             
                     return list;                                                                         
                 }, Materializer);
-
-                t.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                t.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
-                return Task.CompletedTask;
+                
+                (await t.WaitAsync(3.Seconds())).Should().BeEquivalentTo(new[] { 1, 2, 3 });
             }, Materializer);
         }
 
         [Fact]
         public async Task A_Broadcast_must_work_with_n_way_broadcast()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var headSink = Sink.First<IEnumerable<int>>();
 
                 var t = RunnableGraph.FromGraph(GraphDsl.Create(headSink, headSink, headSink, headSink, headSink, ValueTuple.Create,
@@ -111,8 +110,8 @@ namespace Akka.Streams.Tests.Dsl
                     })).Run(Materializer);
 
                 var task = Task.WhenAll(t.Item1, t.Item2, t.Item3, t.Item4, t.Item5);
-                task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                foreach (var list in task.Result)
+                var result = await task.WaitAsync(3.Seconds());
+                foreach (var list in result)
                     list.Should().BeEquivalentTo(new[] { 1, 2, 3 });
                 return Task.CompletedTask;
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphBroadcastSpec.cs
@@ -113,7 +113,6 @@ namespace Akka.Streams.Tests.Dsl
                 var result = await task.WaitAsync(3.Seconds());
                 foreach (var list in result)
                     list.Should().BeEquivalentTo(new[] { 1, 2, 3 });
-                return Task.CompletedTask;
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphMergeSpec.cs
@@ -14,6 +14,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Reactive.Streams;
 using Xunit;
 using Xunit.Abstractions;
@@ -88,7 +89,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Merge_must_work_with_one_way_merge()
+        public async Task A_Merge_must_work_with_one_way_merge()
         {
             var task = Source.FromGraph(GraphDsl.Create(b =>
             {
@@ -104,8 +105,7 @@ namespace Akka.Streams.Tests.Dsl
                 return list;
             }, Materializer);
 
-            task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(Enumerable.Range(1, 3));
+            (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 3));
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/GraphPartitionSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphPartitionSpec.cs
@@ -179,7 +179,6 @@ namespace Akka.Streams.Tests.Dsl
                 })).Run(Materializer);
 
                 (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(input);
-                return Task.CompletedTask;
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphPartitionSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphPartitionSpec.cs
@@ -14,6 +14,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 // ReSharper disable InvokeAsExtensionMethod
@@ -34,7 +35,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_Partition_must_partition_to_three_subscribers()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var s = Sink.Seq<int>();
                 var t = RunnableGraph.FromGraph(GraphDsl.Create(s, s, s, ValueTuple.Create, (b, sink1, sink2, sink3) =>
                 {
@@ -51,12 +52,10 @@ namespace Akka.Streams.Tests.Dsl
                     return ClosedShape.Instance;
                 })).Run(Materializer);
 
-                var task = Task.WhenAll(t.Item1, t.Item2, t.Item3);
-                task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                task.Result[0].Should().BeEquivalentTo(new[] { 4, 5 });
-                task.Result[1].Should().BeEquivalentTo(new[] { 1, 2 });
-                task.Result[2].Should().BeEquivalentTo(new[] { 3 });
-                return Task.CompletedTask;
+                var result = await Task.WhenAll(t.Item1, t.Item2, t.Item3).WaitAsync(3.Seconds());
+                result[0].Should().BeEquivalentTo(new[] { 4, 5 });
+                result[1].Should().BeEquivalentTo(new[] { 1, 2 });
+                result[2].Should().BeEquivalentTo(new[] { 3 });
             }, Materializer);
         }
 
@@ -161,7 +160,7 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task A_Partition_must_work_with_merge()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var s = Sink.Seq<int>();
                 var input = new[] { 5, 2, 9, 1, 1, 1, 10 };
 
@@ -179,8 +178,7 @@ namespace Akka.Streams.Tests.Dsl
                     return ClosedShape.Instance;
                 })).Run(Materializer);
 
-                task.Wait(RemainingOrDefault).Should().BeTrue();
-                task.Result.Should().BeEquivalentTo(input);
+                (await task.WaitAsync(3.Seconds())).Should().BeEquivalentTo(input);
                 return Task.CompletedTask;
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/GraphZipSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphZipSpec.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 // ReSharper disable InvokeAsExtensionMethod
@@ -99,7 +100,7 @@ namespace Akka.Streams.Tests.Dsl
                 await upstream2.SendNextAsync("A");
                 await upstream2.SendCompleteAsync();
 
-                completed.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
+                await completed.WaitAsync(3.Seconds());
                 await upstream1.ExpectCancellationAsync();
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
@@ -59,7 +59,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_stream_via_LastElement_should_materialize_to_the_last_element_emitted_by_a_source_before_it_failed()
+        public async Task A_stream_via_LastElement_should_materialize_to_the_last_element_emitted_by_a_source_before_it_failed()
         {
             var t = Source.UnfoldInfinite(1, n => n >= 3 ? throw new Exception() : (n + 1, n + 1))
                 .ViaMaterialized(new LastElement<int>(), Keep.Right)
@@ -69,9 +69,9 @@ namespace Akka.Streams.Tests.Dsl
             var lastElement = t.Item1;
             var lastEmitted = t.Item2;
 
-            lastElement.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            lastEmitted.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            lastElement.Result.Should().Be(lastEmitted.Result);
+            var r1 = await lastElement.WaitAsync(1.Seconds());
+            var r2 = await lastEmitted.WaitAsync(1.Seconds());
+            r1.Should().Be(r2);
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
@@ -17,8 +17,10 @@ using Akka.Streams.Util;
 using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
+using static FluentAssertions.FluentActions;
 
 namespace Akka.Streams.Tests.Dsl
 {
@@ -70,7 +72,9 @@ namespace Akka.Streams.Tests.Dsl
                 var sub = probe.ExpectSubscription();
                 var future = queue.PullAsync();
                 var future2 = queue.PullAsync();
-                future2.Invoking(t => t.Wait(RemainingOrDefault)).Should().Throw<IllegalStateException>();
+
+                await Awaiting(() => future2.WaitAsync(RemainingOrDefault))
+                    .Should().ThrowAsync<IllegalStateException>();
 
                 sub.SendNext(1);
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
@@ -131,8 +135,8 @@ namespace Akka.Streams.Tests.Dsl
                 var sub = await probe.ExpectSubscriptionAsync();
 
                 sub.SendError(TestException());
-                queue.Invoking(q => q.PullAsync().Wait(RemainingOrDefault))
-                    .Should().Throw<TestException>();
+                await Awaiting(() => queue.PullAsync().WaitAsync(RemainingOrDefault))
+                    .Should().ThrowAsync<TestException>();
             }, _materializer);
         }
 
@@ -194,7 +198,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Run(_materializer);
                 var probe = tuple.Item1;
                 var queue = tuple.Item2;
-                probe.Wait(TimeSpan.FromMilliseconds(300)).Should().BeTrue();
+                await probe.WaitAsync(300.Milliseconds());
 
                 for (var i = 1; i <= streamElementCount; i++)
                 {
@@ -234,8 +238,8 @@ namespace Akka.Streams.Tests.Dsl
 
                 sub.SendComplete();
                 var future = queue.PullAsync();
-                future.Wait(_pause).Should().BeTrue();
-                future.Result.Should().Be(Option<int>.None);
+                (await future.WaitAsync(_pause))
+                    .Should().Be(Option<int>.None);
             }, _materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
@@ -34,7 +34,7 @@ namespace Akka.Streams.Tests.Dsl
             return new TestException("boom");
         }
 
-        public QueueSinkSpec(ITestOutputHelper output) : base(output)
+        public QueueSinkSpec(ITestOutputHelper output) : base("akka.loglevel = DEBUG", output)
         {
             _materializer = Sys.Materializer();
         }

--- a/src/core/Akka.Streams.Tests/Dsl/RestartSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/RestartSpec.cs
@@ -222,7 +222,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Cancel()
                     .ExecuteAsync();
 
-                tcs.Task.Result.Should().BeSameAs(Done.Instance);
+                (await tcs.Task.WaitAsync(3.Seconds())).Should().Be(Done.Instance);
 
                 // Wait to ensure it isn't restarted
                 await Task.Delay(200);
@@ -422,7 +422,9 @@ namespace Akka.Streams.Tests.Dsl
                     created.IncrementAndGet();
                     return Sink.Seq<string>().MapMaterializedValue(task =>
                     {
+#pragma warning disable xUnit1031
                         task.ContinueWith(c => tcs.SetResult(c.Result));
+#pragma warning restore xUnit1031
                         return Done.Instance;
                     });
                 }, _shortRestartSettings), Keep.Left).Run(Materializer);
@@ -435,7 +437,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExecuteAsync();
 
                 await tcs.Task.ShouldCompleteWithin(3.Seconds());
-                tcs.Task.Result.Should().ContainInOrder("a", "b", "c");
+                (await tcs.Task).Should().ContainInOrder("a", "b", "c");
                 created.Current.Should().Be(1);
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/RestartSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/RestartSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Streams.Tests.Dsl
         private readonly RestartSettings _restartSettings;
 
         public RestartSpec(ITestOutputHelper output)
-            : base("{}", output)
+            : base("akka.loglevel = DEBUG", output)
         {
             Materializer = Sys.Materializer();
 

--- a/src/core/Akka.Streams.Tests/Dsl/ReverseArrowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ReverseArrowSpec.cs
@@ -40,27 +40,27 @@ namespace Akka.Streams.Tests.Dsl
             Flow.Create<int>().Limit(10).ToMaterialized(Streams.Dsl.Sink.Seq<int>(), Keep.Right);
         
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_from_Inlets()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_from_Inlets()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 b.To(s.Inlet).From(Source);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] {1, 2, 3});
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] {1, 2, 3});
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_from_SinkShape()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_from_SinkShape()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 b.To(s).From(Source);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_from_FlowShape()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_from_FlowShape()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
@@ -125,12 +125,12 @@ namespace Akka.Streams.Tests.Dsl
                 b.From(f).To(s);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_from_UniformFanInShape()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_from_UniformFanInShape()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
@@ -140,12 +140,12 @@ namespace Akka.Streams.Tests.Dsl
                 b.From(f).To(s);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_from_UniformFanOutShape()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_from_UniformFanOutShape()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
@@ -155,12 +155,12 @@ namespace Akka.Streams.Tests.Dsl
                 b.From(f).To(s);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_Outlets()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_towards_Outlets()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
@@ -168,12 +168,12 @@ namespace Akka.Streams.Tests.Dsl
                 b.To(s).From(o);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_SourceShape()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_towards_SourceShape()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
@@ -181,24 +181,24 @@ namespace Akka.Streams.Tests.Dsl
                 b.To(s).From(o);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_Source()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_towards_Source()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 b.To(s).From(Source);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_FlowShape()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_towards_FlowShape()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
@@ -207,12 +207,12 @@ namespace Akka.Streams.Tests.Dsl
                 b.From(Source).To(f);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_UniformFanInShape()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_towards_UniformFanInShape()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
@@ -222,12 +222,12 @@ namespace Akka.Streams.Tests.Dsl
                 b.From(Source).To(f);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_fail_towards_already_full_UniformFanInShape()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_fail_towards_already_full_UniformFanInShape()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
@@ -242,12 +242,12 @@ namespace Akka.Streams.Tests.Dsl
 
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_towards_UniformFanOutShape()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_towards_UniformFanOutShape()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
@@ -257,12 +257,12 @@ namespace Akka.Streams.Tests.Dsl
                 b.From(Source).To(f);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_fail_towards_already_full_UniformFanOutShape()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_fail_towards_already_full_UniformFanOutShape()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
@@ -278,24 +278,24 @@ namespace Akka.Streams.Tests.Dsl
 
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_across_a_Flow()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_across_a_Flow()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
                 b.To(s).Via(Flow.Create<int>().MapMaterializedValue(_ => MaterializedValue)).From(Source);
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
         [Fact]
-        public void Reverse_Arrows_in_the_GraphDsl_must_work_across_a_FlowShape()
+        public async Task Reverse_Arrows_in_the_GraphDsl_must_work_across_a_FlowShape()
         {
             var task = RunnableGraph.FromGraph(GraphDsl.Create(Sink, (b, s) =>
             {
@@ -303,8 +303,8 @@ namespace Akka.Streams.Tests.Dsl
                 
                 return ClosedShape.Instance;
             })).Run(Materializer);
-            task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-            task.Result.Should().BeEquivalentTo(new[] { 1, 2, 3 });
+            (await task.WaitAsync(TimeSpan.FromSeconds(1)))
+                .Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/Dsl/SinkForeachAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SinkForeachAsyncSpec.cs
@@ -48,11 +48,10 @@ namespace Akka.Streams.Tests.Dsl
                 .Select(i => (i, new TestLatch(1)))
                 .ToDictionary(t => t.i, t => t.Item2);
 
-            var sink = Sink.ForEachAsync<int>(4, n =>
+            var sink = Sink.ForEachAsync<int>(4, async n =>
             {
-                latch[n].Ready(RemainingOrDefault);
+                await latch[n].ReadyAsync(RemainingOrDefault);
                 probe.Ref.Tell(n);
-                return Task.CompletedTask;
             });
 
             var p = Source.From(Enumerable.Range(1, 4)).RunWith(sink, Materializer);
@@ -79,7 +78,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var sink = Sink.ForEachAsync<Func<int>>(1, async n =>
             {
-                latch[n()].Ready(RemainingOrDefault);
+                await latch[n()].ReadyAsync(RemainingOrDefault);
                 probe.Ref.Tell(n());
                 await Task.Delay(2000);
             });

--- a/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SinkSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
@@ -185,12 +186,12 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Sink_must_support_contramap()
+        public async Task A_Sink_must_support_contramap()
         {
-            Source.From(Enumerable.Range(0, 9))
+            (await Source.From(Enumerable.Range(0, 9))
                 .ToMaterialized(Sink.Seq<int>().ContraMap<int>(i => i + 1), Keep.Right)
-                .Run(Materializer)
-                .Result.Should().BeEquivalentTo(Enumerable.Range(1, 9));
+                .Run(Materializer))
+                .Should().BeEquivalentTo(Enumerable.Range(1, 9));
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
@@ -334,7 +334,7 @@ namespace Akka.Streams.Tests
         }
 
         [Fact]
-        public void SourceRef_must_not_receive_timeout_when_data_is_being_sent()
+        public async Task SourceRef_must_not_receive_timeout_when_data_is_being_sent()
         {
             _remoteActor.Tell("give-infinite");
             var remoteSource = ExpectMsg<ISourceRef<string>>();
@@ -344,7 +344,7 @@ namespace Akka.Streams.Tests
                 .TakeWithin(5.Seconds()) // which is > than the subscription timeout (so we make sure the timeout was cancelled
                 .RunWith(Sink.Seq<string>(), Materializer);
 
-            done.Wait(8.Seconds()).Should().BeTrue();
+            await done.WaitAsync(8.Seconds());
         }
 
         [Fact]
@@ -432,7 +432,7 @@ namespace Akka.Streams.Tests
         }
 
         [Fact]
-        public void SinkRef_must_not_receive_timeout_while_data_is_being_sent()
+        public async Task SinkRef_must_not_receive_timeout_while_data_is_being_sent()
         {
             _remoteActor.Tell("receive-ignore");
             var remoteSink = ExpectMsg<ISinkRef<string>>();
@@ -445,8 +445,7 @@ namespace Akka.Streams.Tests
                     .To(remoteSink.Sink)
                     .Run(Materializer);
 
-            done.Wait(8.Seconds()).Should().BeTrue();
-
+            await done.WaitAsync(8.Seconds());
         }
 
         [Fact(Skip = "FIXME: how to pass test assertions to remote system?")]

--- a/src/core/Akka.Streams.Tests/Dsl/SubscriberSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SubscriberSourceSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.TestKit;
 using FluentAssertions;
@@ -26,15 +27,15 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_SubscriberSource_must_be_able_to_use_Subscribe_in_materialized_value_transformation()
+        public async Task A_SubscriberSource_must_be_able_to_use_Subscribe_in_materialized_value_transformation()
         {
             var f = Source.AsSubscriber<int>()
                 .MapMaterializedValue(
                     s => Source.From(Enumerable.Range(1, 3)).RunWith(Sink.FromSubscriber(s), Materializer))
                 .RunWith(Sink.Aggregate<int, int>(0, (sum, i) => sum + i), Materializer);
 
-            f.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-            f.Result.Should().Be(6);
+            (await f.WaitAsync(TimeSpan.FromSeconds(3)))
+                .Should().Be(6);
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/FusingSpec.cs
+++ b/src/core/Akka.Streams.Tests/FusingSpec.cs
@@ -18,6 +18,7 @@ using Akka.TestKit;
 using Akka.TestKit.Extensions;
 using FluentAssertions;
 using FluentAssertions.Extensions;
+using Nito.AsyncEx;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -50,8 +51,8 @@ namespace Akka.Streams.Tests
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-            await t.ShouldCompleteWithin(3.Seconds());
-            t.Result.Distinct().OrderBy(i => i).Should().BeEquivalentTo(Enumerable.Range(0, 199).Where(i => i%2 == 0));
+            (await t.WaitAsync(3.Seconds()))
+                .Distinct().OrderBy(i => i).Should().BeEquivalentTo(Enumerable.Range(0, 199).Where(i => i%2 == 0));
         }
 
         [Fact]
@@ -78,8 +79,8 @@ namespace Akka.Streams.Tests
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-            await t.ShouldCompleteWithin(3.Seconds());
-            t.Result.Should().BeEquivalentTo(Enumerable.Range(0, 10));
+            (await t.WaitAsync(3.Seconds()))
+                .Should().BeEquivalentTo(Enumerable.Range(0, 10));
 
             var refs = await ReceiveNAsync(20).Distinct().ToListAsync();
             // main flow + 10 sub-flows
@@ -110,8 +111,8 @@ namespace Akka.Streams.Tests
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-            await t.ShouldCompleteWithin(3.Seconds());
-            t.Result.Should().BeEquivalentTo(Enumerable.Range(0, 10));
+            (await t.WaitAsync(3.Seconds()))
+                .Should().BeEquivalentTo(Enumerable.Range(0, 10));
 
             var refs = await ReceiveNAsync(20).Distinct().ToListAsync();
             // main flow + 10 sub-flows

--- a/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
@@ -317,7 +317,9 @@ namespace Akka.Streams.Tests.IO
                 {
                     var lazySink = Sink.LazyInitAsync(() => Task.FromResult(FileIO.ToFile(f)))
                         // map a Task<Option<Task<IOResult>>> into a Task<IOResult>
+#pragma warning disable xUnit1031
                         .MapMaterializedValue(t => t.Result.GetOrElse(Task.FromResult(IOResult.Success(0))));
+#pragma warning restore xUnit1031
 
                     var completion = Source.From(new []{_testByteStrings.Head()})
                         .RunWith(lazySink, _materializer);
@@ -441,9 +443,8 @@ namespace Akka.Streams.Tests.IO
                     CheckFileContent(f, "a\nb\nc\nd\n"); // file content should all be flushed
 
                     actor.Tell(new Status.Success(NotUsed.Instance));
-                    task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                    task.Result.WasSuccessful.Should().BeTrue();
-                    task.Result.Count.Should().Be(8);
+                    var result = await task.WaitAsync(3.Seconds());
+                    result.Count.Should().Be(8);
                 }, _materializer);
             }, _materializer);
         }

--- a/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
@@ -22,6 +22,7 @@ using Akka.Streams.TestKit;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -252,7 +253,7 @@ namespace Akka.Streams.Tests.IO
         [InlineData(512, 4)]
         [InlineData(2048, 2)]
         [InlineData(2048, 4)]
-        public void FileSource_should_count_lines_in_a_real_file(int chunkSize, int readAhead)
+        public async Task FileSource_should_count_lines_in_a_real_file(int chunkSize, int readAhead)
         {
             var s = FileIO.FromFile(ManyLines(), chunkSize)
                 .WithAttributes(Attributes.CreateInputBuffer(readAhead, readAhead));
@@ -260,8 +261,7 @@ namespace Akka.Streams.Tests.IO
                 Sink.Aggregate<ByteString, int>(0, (acc, l) => acc + l.ToString(Encoding.UTF8).Count(c => c == '\n')),
                 _materializer);
 
-            f.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-            var lineCount = f.Result;
+            var lineCount = await f.WaitAsync(5.Seconds());
             lineCount.Should().Be(LinesCount);
         }
 

--- a/src/core/Akka.Streams.Tests/IO/InputStreamSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/InputStreamSourceSpec.cs
@@ -139,7 +139,7 @@ namespace Akka.Streams.Tests.IO
                     return 1;
                 }
 
-                _latch.ReadyAsync().GetAwaiter().GetResult();
+                _latch.Ready();
                 return 0;
             }
 
@@ -167,39 +167,38 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
-        public void InputStreamSource_must_not_signal_when_no_demand()
+        public async Task InputStreamSource_must_not_signal_when_no_demand()
         {
             var f = StreamConverters.FromInputStream(() => new ConstInputStream());
 
-            f.TakeWithin(TimeSpan.FromSeconds(5)).RunForeach(_ => { }, _materializer).Wait(TimeSpan.FromSeconds(10));
+            await f.TakeWithin(TimeSpan.FromSeconds(5)).RunForeach(_ => { }, _materializer)
+                .WaitAsync(TimeSpan.FromSeconds(10));
         }
 
         [Fact]
         public async Task InputStreamSource_must_read_bytes_from_InputStream()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var f = StreamConverters.FromInputStream(() => new ListInputStream(new[] { "a", "b", "c" }))                                                                             
                 .RunWith(Sink.First<ByteString>(), _materializer);
 
-                f.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                f.Result.Should().BeEquivalentTo(ByteString.FromString("abc"));
-                return Task.CompletedTask;
+                (await f.WaitAsync(TimeSpan.FromSeconds(3)))
+                    .Should().BeEquivalentTo(ByteString.FromString("abc"));
             }, _materializer);
         }
 
         [Fact]
         public async Task InputStreamSource_must_emit_as_soon_as_read()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var latch = new TestLatch(1);
                 var probe = StreamConverters.FromInputStream(() => new EmittedInputStream(latch), chunkSize: 1)
                     .RunWith(this.SinkProbe<ByteString>(), _materializer);
 
                 probe.Request(4);
-                probe.ExpectNext(ByteString.FromString("M"));
+                await probe.ExpectNextAsync(ByteString.FromString("M"));
                 latch.CountDown();
-                probe.ExpectComplete();
-                return Task.CompletedTask;
+                await probe.ExpectCompleteAsync();
             }, _materializer);
         }
     }

--- a/src/core/Akka.Streams.Tests/IO/InputStreamSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/InputStreamSourceSpec.cs
@@ -139,7 +139,7 @@ namespace Akka.Streams.Tests.IO
                     return 1;
                 }
 
-                _latch.Ready();
+                _latch.ReadyAsync().GetAwaiter().GetResult();
                 return 0;
             }
 

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
@@ -144,13 +144,13 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         }
 
         [Fact]
-        public void ActorGraphInterpreter_should_be_able_to_report_errors_if_an_error_happens_for_an_already_completed_stage()
+        public async Task ActorGraphInterpreter_should_be_able_to_report_errors_if_an_error_happens_for_an_already_completed_stage()
         {
             var failyStage = new FailyGraphStage();
 
-            EventFilter.Exception<ArgumentException>(new Regex("Error in stage.*")).ExpectOne(() =>
+            await EventFilter.Exception<ArgumentException>(new Regex("Error in stage.*")).ExpectOneAsync(async () =>
             {
-                Source.FromGraph(failyStage).RunWith(Sink.Ignore<int>(), Materializer).Wait(TimeSpan.FromSeconds(3));
+                await Source.FromGraph(failyStage).RunWith(Sink.Ignore<int>(), Materializer).WaitAsync(TimeSpan.FromSeconds(3));
             });
         }
 
@@ -289,7 +289,6 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                 await gotStop.ReadyAsync(RemainingOrDefault);
 
                 (await downstream.ExpectErrorAsync()).Should().BeOfType<AbruptTerminationException>();
-                return Task.CompletedTask;
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/KeepGoingStageSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/KeepGoingStageSpec.cs
@@ -13,6 +13,7 @@ using Akka.Streams.Stage;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 // ReSharper disable MemberHidesStaticFromOuterClass
@@ -202,11 +203,11 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         [Fact]
         public async Task A_stage_with_keep_going_must_still_be_alive_after_all_ports_have_been_closed_until_explicity_closed()
         {
-            await this.AssertAllStagesStoppedAsync(async() => {
+            await this.AssertAllStagesStoppedAsync(async () => {
                 var t = Source.Maybe<int>().ToMaterialized(new PingableSink(true), Keep.Both).Run(Materializer);
                 var maybePromise = t.Item1;
                 var pingerFuture = t.Item2;
-                pingerFuture.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
+                await pingerFuture.WaitAsync(3.Seconds());
                 var pinger = await pingerFuture;
 
                 pinger.Register(TestActor);
@@ -240,7 +241,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                 var t = Source.Maybe<int>().ToMaterialized(new PingableSink(true), Keep.Both).Run(Materializer);
                 var maybePromise = t.Item1;
                 var pingerFuture = t.Item2;
-                pingerFuture.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
+                await pingerFuture.WaitAsync(3.Seconds());
                 var pinger = await pingerFuture;
 
                 pinger.Register(TestActor);
@@ -277,7 +278,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                 var t = Source.Maybe<int>().ToMaterialized(new PingableSink(true), Keep.Both).Run(Materializer);
                 var maybePromise = t.Item1;
                 var pingerFuture = t.Item2;
-                pingerFuture.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
+                await pingerFuture.WaitAsync(3.Seconds());
                 var pinger = await pingerFuture;
 
                 pinger.Register(TestActor);
@@ -316,7 +317,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                 var t = Source.Maybe<int>().ToMaterialized(new PingableSink(false), Keep.Both).Run(Materializer);
                 var maybePromise = t.Item1;
                 var pingerFuture = t.Item2;
-                pingerFuture.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
+                await pingerFuture.WaitAsync(3.Seconds());
                 var pinger = await pingerFuture;
 
                 pinger.Register(TestActor);

--- a/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/GraphStageLogicSpec.cs
@@ -395,26 +395,26 @@ namespace Akka.Streams.Tests.Implementation
         [Fact]
         public async Task A_GraphStageLogic_must_emit_properly_after_empty_iterable()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
-                Source.FromGraph(new EmitEmptyIterable())                                                                             
-                .RunWith(Sink.Seq<int>(), Materializer)                                                                             
-                .Result.Should()                                                                             
-                .HaveCount(1)                                                                             
-                .And.OnlyContain(x => x == 42);
-                return Task.CompletedTask;
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var result = await Source.FromGraph(new EmitEmptyIterable())
+                    .RunWith(Sink.Seq<int>(), Materializer);
+                
+                result.Should()
+                    .HaveCount(1)
+                    .And.OnlyContain(x => x == 42);
             }, Materializer);
         }
 
         [Fact]
-        public void A_GraphStageLogic_must_support_logging_in_custom_graphstage()
+        public async Task A_GraphStageLogic_must_support_logging_in_custom_graphstage()
         {
             const int n = 10;
-            EventFilter.Debug(start: "Randomly generated").Expect(n, () =>
+            await EventFilter.Debug(start: "Randomly generated").ExpectAsync(n, async () =>
             {
-                Source.FromGraph(new RandomLettersSource())
+                await Source.FromGraph(new RandomLettersSource())
                     .Take(n)
                     .RunWith(Sink.Ignore<string>(), Materializer)
-                    .Wait(TimeSpan.FromSeconds(3));
+                    .WaitAsync(TimeSpan.FromSeconds(3));
             });
         }
 

--- a/src/core/Akka.Streams.Tests/Implementation/TimeoutsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/TimeoutsSpec.cs
@@ -40,8 +40,8 @@ namespace Akka.Streams.Tests.Implementation
                     .InitialTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await t.ShouldCompleteWithin(3.Seconds());
-                t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
+                (await t.WaitAsync(3.Seconds()))
+                    .Should().BeEquivalentTo(Enumerable.Range(1, 100));
             }, Materializer);
         }
         
@@ -88,8 +88,8 @@ namespace Akka.Streams.Tests.Implementation
                     .CompletionTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await t.ShouldCompleteWithin(3.Seconds());
-                t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
+                (await t.WaitAsync(3.Seconds()))
+                    .Should().BeEquivalentTo(Enumerable.Range(1, 100));
             }, Materializer);
         }
 
@@ -148,8 +148,8 @@ namespace Akka.Streams.Tests.Implementation
                     .IdleTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await t.ShouldCompleteWithin(3.Seconds());
-                t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
+                (await t.WaitAsync(3.Seconds()))
+                    .Should().BeEquivalentTo(Enumerable.Range(1, 100));
             }, Materializer);
         }
 
@@ -207,8 +207,8 @@ namespace Akka.Streams.Tests.Implementation
                     .Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await task.ShouldCompleteWithin(3.Seconds());
-                task.Result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
+                (await task.WaitAsync(3.Seconds()))
+                    .Should().BeEquivalentTo(Enumerable.Range(1, 100));
             }, Materializer);
         }
 
@@ -368,8 +368,8 @@ namespace Akka.Streams.Tests.Implementation
                     .Via(timeoutIdentity).Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await t.ShouldCompleteWithin(3.Seconds());
-                t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
+                (await t.WaitAsync(3.Seconds()))
+                    .Should().BeEquivalentTo(Enumerable.Range(1, 100));
             }, Materializer);
         }
 

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/TestActorRefSpec.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/TestActorRefSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Dispatch;
@@ -57,21 +58,21 @@ namespace Akka.TestKit.Tests.TestActorRefTests
         }
 
         [Fact]
-        public void TestActorRef_must_support_nested_Actor_creation_when_used_with_TestActorRef()
+        public async Task TestActorRef_must_support_nested_Actor_creation_when_used_with_TestActorRef()
         {
             var a = new TestActorRef<NestingActor>(Sys, Props.Create(() => new NestingActor(true)));
             Assert.NotNull(a);
-            var nested = a.Ask<IActorRef>("any", DefaultTimeout).Result;
+            var nested = await a.Ask<IActorRef>("any", DefaultTimeout);
             Assert.NotNull(nested);
             Assert.NotSame(a, nested);
         }
 
         [Fact]
-        public void TestActorRef_must_support_nested_Actor_creation_when_used_with_ActorRef()
+        public async Task TestActorRef_must_support_nested_Actor_creation_when_used_with_ActorRef()
         {
             var a = new TestActorRef<NestingActor>(Sys, Props.Create(() => new NestingActor(false)));
             Assert.NotNull(a);
-            var nested = a.Ask<IActorRef>("any", DefaultTimeout).Result;
+            var nested = await a.Ask<IActorRef>("any", DefaultTimeout);
             Assert.NotNull(nested);
             Assert.NotSame(a, nested);
         }
@@ -127,13 +128,13 @@ namespace Akka.TestKit.Tests.TestActorRefTests
         }
 
         [Fact]
-        public void TestActorRef_must_support_futures()
+        public async Task TestActorRef_must_support_futures()
         {
             var worker = new TestActorRef<WorkerActor>(Sys, Props.Create(() => new WorkerActor(_thread, _otherThread)));
             var task = worker.Ask("work");
             Assert.True(task.IsCompleted, "Task should be completed");
-            if(!task.Wait(DefaultTimeout)) XAssert.Fail("Timed out");    //Using a timeout to stop the test if there is something wrong with the code
-            Assert.Equal("workDone", task.Result);
+            var result = await task.WaitAsync(DefaultTimeout);    //Using a timeout to stop the test if there is something wrong with the code
+            Assert.Equal("workDone", result);
         }
 
         [Fact]

--- a/src/core/Akka.TestKit/TestKitBase_Receive.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Receive.cs
@@ -763,7 +763,7 @@ namespace Akka.TestKit
         {
             max.EnsureIsPositiveFinite("max");
             var enumerable = InternalReceiveNAsync(numberOfMessages, Dilated(max), true, cancellationToken)
-                .ConfigureAwait(false).WithCancellation(cancellationToken);
+                .ConfigureAwait(false);
             await foreach (var item in enumerable)
             {
                 yield return item;

--- a/src/core/Akka.TestKit/TestLatch.cs
+++ b/src/core/Akka.TestKit/TestLatch.cs
@@ -153,6 +153,16 @@ namespace Akka.TestKit
             }
         }
 
+        public void Ready(CancellationToken token = default)
+        {
+            ReadyAsync(token).GetAwaiter().GetResult();
+        }
+        
+        public void Ready(TimeSpan timeout, CancellationToken token = default)
+        {
+            ReadyAsync(timeout, token).GetAwaiter().GetResult();
+        }
+        
         /// <summary>
         /// Expects the latch to become open within the specified timeout. If the timeout is reached, a
         /// <see cref="TimeoutException"/> is thrown.

--- a/src/core/Akka.TestKit/TestLatch.cs
+++ b/src/core/Akka.TestKit/TestLatch.cs
@@ -8,8 +8,10 @@
 using System;
 using System.ComponentModel;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 
+#nullable enable
 namespace Akka.TestKit
 {
     /// <summary>
@@ -26,8 +28,12 @@ namespace Akka.TestKit
     /// </summary>
     public class TestLatch
     {
-        private readonly CountdownEvent _latch;
-        private readonly Func<TimeSpan, TimeSpan> _dilate;
+        private readonly object _lock = new ();
+        private readonly int _initialCount;
+        private int _count;
+        private TaskCompletionSource<NotUsed>? _tcs;
+        
+        private readonly Func<TimeSpan, TimeSpan>? _dilate;
         private readonly TimeSpan _defaultTimeout;
 
         /// <summary>
@@ -67,7 +73,7 @@ namespace Akka.TestKit
         /// <param name="defaultTimeout">TBD</param>
         public TestLatch(int count, TimeSpan defaultTimeout)
         {
-            _latch = new CountdownEvent(count);
+            _initialCount = _count = count;
             _defaultTimeout = defaultTimeout;
         }
 
@@ -102,7 +108,13 @@ namespace Akka.TestKit
         /// </summary>
         public bool IsOpen
         {
-            get { return _latch.CurrentCount == 0; }
+            get
+            {
+                lock (_lock)
+                {
+                    return _count <= 0;
+                }
+            }
         }
 
         /// <summary>
@@ -110,7 +122,12 @@ namespace Akka.TestKit
         /// </summary>
         public void CountDown()
         {
-            _latch.Signal();
+            lock (_lock)
+            {
+                _count--;
+                if (_count <= 0)
+                    _tcs?.TrySetResult(NotUsed.Instance);
+            }
         }
 
         /// <summary>
@@ -118,7 +135,11 @@ namespace Akka.TestKit
         /// </summary>
         public void Open()
         {
-            while(!IsOpen) CountDown();
+            lock (_lock)
+            {
+                _count = 0;
+                _tcs?.TrySetResult(NotUsed.Instance);
+            }
         }
 
         /// <summary>
@@ -126,7 +147,10 @@ namespace Akka.TestKit
         /// </summary>
         public void Reset()
         {
-            _latch.Reset();
+            lock (_lock)
+            {
+                _count = _initialCount;
+            }
         }
 
         /// <summary>
@@ -138,21 +162,43 @@ namespace Akka.TestKit
         /// </para>
         /// </summary>
         /// <param name="timeout">TBD</param>
+        /// <param name="token">The cancellation token</param>
         /// <exception cref="ArgumentException">
         /// This exception is thrown when a too large timeout has been specified.
         /// </exception>
         /// <exception cref="TimeoutException">
         /// This exception is thrown when the timeout is reached.
         /// </exception>
-        public void Ready(TimeSpan timeout)
+        public async Task ReadyAsync(TimeSpan timeout, CancellationToken token = default)
         {
-            if(timeout == TimeSpan.MaxValue)
+            if(timeout == TimeSpan.MaxValue || timeout <= TimeSpan.Zero)
                 throw new ArgumentException($"TestLatch does not support waiting for {timeout}");
+
+            lock (_lock)
+            {
+                if (_count <= 0)
+                    return;
+                
+                if (_tcs is not null)
+                    throw new Exception("Another ReadyAsync operation has already started");
+
+                _tcs = new TaskCompletionSource<NotUsed>();
+            }
+            
             if(_dilate != null)
                 timeout = _dilate(timeout);
-            var opened = _latch.Wait(timeout);
-            if(!opened)
-                throw new TimeoutException($"Timeout of {timeout}");
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            cts.CancelAfter(timeout);
+
+            var task = await Task.WhenAny(_tcs.Task, Task.Delay(-1, cts.Token));
+            if(task != _tcs.Task)
+                throw new TimeoutException($"TestLatch timed out after {timeout}");
+
+            lock (_lock)
+            {
+                _tcs = null;
+            }
         }
 
         /// <summary>
@@ -167,9 +213,9 @@ namespace Akka.TestKit
         /// <exception cref="TimeoutException">
         /// This exception is thrown when the timeout is reached.
         /// </exception>
-        public void Ready()
+        public Task ReadyAsync(CancellationToken token = default)
         {
-            Ready(_defaultTimeout);
+            return ReadyAsync(_defaultTimeout, token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/ActorLookupSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLookupSpec.cs
@@ -172,8 +172,8 @@ namespace Akka.Tests.Actor
             f.IsCompleted.Should().Be(false);
             a.IsTerminated.Should().Be(false);
             a.Tell(42);
-            await AwaitAssertAsync(() => f.IsCompleted.Should().Be(true));
-            await AwaitAssertAsync(() => f.Result.Should().Be(42));
+
+            (await f.WaitAsync(3.Seconds())).Should().Be(42);
         }
 
         /*

--- a/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
@@ -16,6 +16,7 @@ using Xunit;
 using Akka.Util.Internal;
 using FluentAssertions;
 using System.Threading.Tasks;
+using static FluentAssertions.FluentActions;
 
 namespace Akka.Tests.Actor
 {
@@ -42,17 +43,15 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void IgnoreActorRef_should_make_a_Future_timeout_when_used_in_a_ask()
+        public async Task IgnoreActorRef_should_make_a_Future_timeout_when_used_in_a_ask()
         {
             // this is kind of obvious, the Future won't complete because the ignoreRef is used
 
             var timeout = TimeSpan.FromMilliseconds(500);
             var askMeRef = Sys.ActorOf(Props.Create(() => new AskMeActor()));
 
-            Assert.Throws<AskTimeoutException>(() =>
-            {
-                _ = askMeRef.Ask(new Request(Sys.IgnoreRef), timeout).GetAwaiter().GetResult();
-            });
+            await Awaiting(() => askMeRef.Ask(new Request(Sys.IgnoreRef), timeout))
+                .Should().ThrowAsync<AskTimeoutException>();
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Actor/ActorRefSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefSpec.cs
@@ -169,7 +169,6 @@ namespace Akka.Tests.Actor
 
                 boss.Tell("send kill");
                 await latch.ReadyAsync(TimeSpan.FromSeconds(5));
-                return Task.CompletedTask;
             });
         }
 
@@ -267,13 +266,11 @@ namespace Akka.Tests.Actor
             var t2 = actorRef.Ask(0, timeout);
             actorRef.Tell(PoisonPill.Instance);
 
-            Func<Task> f1 = async () => await t1;
-            await f1.Should().CompleteWithinAsync(timeout);
-            Func<Task> f2 = async () => await t2;
-            await f2.Should().CompleteWithinAsync(timeout);
+            var r1 = await t1.WaitAsync(timeout);
+            var r2 = await t2.WaitAsync(timeout);
             
-            t1.Result.ShouldBe("five");
-            t2.Result.ShouldBe("zero");
+            r1.ShouldBe("five");
+            r2.ShouldBe("zero");
 
             await VerifyActorTermination(actorRef);
         }

--- a/src/core/Akka.Tests/Actor/ActorRefSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefSpec.cs
@@ -145,7 +145,7 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task An_ActorRef_should_restart_when_Killed()
         {
-            await EventFilter.Exception<ActorKilledException>().ExpectOneAsync(() => {
+            await EventFilter.Exception<ActorKilledException>().ExpectOneAsync(async () => {
                 var latch = CreateTestLatch(2);
                 var boss = ActorOf(a =>
                 {
@@ -168,7 +168,7 @@ namespace Akka.Tests.Actor
                 });
 
                 boss.Tell("send kill");
-                latch.Ready(TimeSpan.FromSeconds(5));
+                await latch.ReadyAsync(TimeSpan.FromSeconds(5));
                 return Task.CompletedTask;
             });
         }
@@ -224,7 +224,7 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void An_ActorRef_should_support_reply_via_Sender()
+        public async Task An_ActorRef_should_support_reply_via_Sender()
         {
             var latch = new TestLatch(4);
             var serverRef = Sys.ActorOf(Props.Create<ReplyActor>());
@@ -235,7 +235,7 @@ namespace Akka.Tests.Actor
             clientRef.Tell("simple");
             clientRef.Tell("simple");
 
-            latch.Ready(TimeSpan.FromSeconds(3));
+            await latch.ReadyAsync(TimeSpan.FromSeconds(3));
             latch.Reset();
 
             clientRef.Tell("complex2");
@@ -243,7 +243,7 @@ namespace Akka.Tests.Actor
             clientRef.Tell("simple");
             clientRef.Tell("simple");
 
-            latch.Ready(TimeSpan.FromSeconds(3));
+            await latch.ReadyAsync(TimeSpan.FromSeconds(3));
             Sys.Stop(clientRef);
             Sys.Stop(serverRef);
         }

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -170,7 +170,7 @@ namespace Akka.Tests.Actor
             }
 
             await actorSystem.Terminate();
-            latch.Ready();
+            await latch.ReadyAsync();
 
             expected.Reverse();
 
@@ -538,7 +538,7 @@ namespace Akka.Tests.Actor
             protected override void ExecuteTask(IRunnable run)
             {
                 run.Run();
-                _latch.Ready(TimeSpan.FromSeconds(1));
+                _latch.ReadyAsync(TimeSpan.FromSeconds(1)).GetAwaiter().GetResult();
             }
 
             protected override void Shutdown()

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -288,7 +288,9 @@ namespace Akka.Tests.Actor
             AsyncContext.Run(() =>
             {
                 var actor = Sys.ActorOf<SomeActor>();
+#pragma warning disable xUnit1031
                 var res = actor.Ask<string>("answer", TimeSpan.FromSeconds(3)).Result; // blocking on purpose
+#pragma warning restore xUnit1031
                 res.ShouldBe("answer");
             });
         }

--- a/src/core/Akka.Tests/Actor/Cancellation/CancelableTests.cs
+++ b/src/core/Akka.Tests/Actor/Cancellation/CancelableTests.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Akka.Util.Internal;
@@ -100,33 +101,33 @@ namespace Akka.Tests.Actor.Cancellation
         }
 
         [Fact]
-        public void Should_be_possible_to_call_CancelAfterMs()
+        public async Task Should_be_possible_to_call_CancelAfterMs()
         {
             var c = new Cancelable(Sys.Scheduler);
             var latch = CreateTestLatch();
             c.Token.Register(() => latch.CountDown());
             c.CancelAfter(50);
             c.IsCancellationRequested.ShouldBeFalse();
-            latch.Ready();
+            await latch.ReadyAsync();
             c.IsCancellationRequested.ShouldBeTrue();
             c.Token.IsCancellationRequested.ShouldBeTrue();
         }
 
         [Fact]
-        public void Should_be_possible_to_call_CancelAfterTimespan()
+        public async Task Should_be_possible_to_call_CancelAfterTimespan()
         {
             var c = new Cancelable(Sys.Scheduler);
             var latch = CreateTestLatch();
             c.Token.Register(() => latch.CountDown());
             c.CancelAfter(TimeSpan.FromMilliseconds(50));
             c.IsCancellationRequested.ShouldBeFalse();
-            latch.Ready();
+            await latch.ReadyAsync();
             c.IsCancellationRequested.ShouldBeTrue();
             c.Token.IsCancellationRequested.ShouldBeTrue();
         }
 
         [Fact]
-        public void Given_linked_Cancelable_When_canceling_underlying_Then_linked_should_be_canceled()
+        public async Task Given_linked_Cancelable_When_canceling_underlying_Then_linked_should_be_canceled()
         {
             var underlying = new Cancelable(Sys.Scheduler);
             var linked = Cancelable.CreateLinkedCancelable(Sys.Scheduler, underlying);
@@ -136,7 +137,7 @@ namespace Akka.Tests.Actor.Cancellation
             underlying.Cancel();
             underlying.IsCancellationRequested.ShouldBeTrue();
             underlying.Token.IsCancellationRequested.ShouldBeTrue();
-            latch.Ready();
+            await latch.ReadyAsync();
 
             linked.IsCancellationRequested.ShouldBeTrue();
             linked.Token.IsCancellationRequested.ShouldBeTrue();

--- a/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
+++ b/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
@@ -288,11 +288,11 @@ namespace Akka.Tests.Actor
                 return TaskEx.FromException<Done>(new Exception("boom"));
             });
 
-            co.AddTask("a", "a2", () =>
+            co.AddTask("a", "a2", async () =>
             {
-                Task.Delay(TimeSpan.FromMilliseconds(100)).Wait();
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
                 TestActor.Tell("A");
-                return TaskEx.Completed;
+                return Done.Instance;
             });
 
             co.AddTask("b", "b1", () =>

--- a/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
@@ -240,7 +240,7 @@ namespace Akka.Tests.Actor
 
             w.Tell(new W(p.Ref));
             w.Tell(new Latches(t1, t2));
-            t1.Ready(TimeSpan.FromSeconds(3));
+            await t1.ReadyAsync(TimeSpan.FromSeconds(3));
             Watch(p.Ref);
             Sys.Stop(p.Ref);
             await ExpectTerminatedAsync(p.Ref);
@@ -385,7 +385,8 @@ namespace Akka.Tests.Actor
                 Receive<Latches>(x =>
                     {
                         x.T1.CountDown();
-                        x.T2.Ready(TimeSpan.FromSeconds(3));
+                        // Could not use ReceiveAsync here, no idea why.
+                        x.T2.ReadyAsync(TimeSpan.FromSeconds(3)).GetAwaiter().GetResult();
                     });
             }
         }

--- a/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
@@ -144,12 +144,10 @@ namespace Akka.Tests.Actor
                     new OneForOneStrategy(2, TimeSpan.FromSeconds(1), r => Directive.Restart))));
 
                 var t1 = supervisor.Ask(Props.Create(() => new EchoTestActor()));
-                await t1.AwaitWithTimeout(timeout);
-                var terminal = (LocalActorRef) t1.Result;
+                var terminal = (LocalActorRef)await t1.WaitAsync(timeout);
                 
                 var t2 = supervisor.Ask(CreateWatchAndForwarderProps(terminal, TestActor));
-                await t2.AwaitWithTimeout(timeout);
-                var monitor = (IActorRef) t2.Result;
+                var monitor = (IActorRef)await t2.WaitAsync(timeout);
 
                 terminal.Tell(Kill.Instance);
                 terminal.Tell(Kill.Instance);
@@ -386,7 +384,7 @@ namespace Akka.Tests.Actor
                     {
                         x.T1.CountDown();
                         // Could not use ReceiveAsync here, no idea why.
-                        x.T2.ReadyAsync(TimeSpan.FromSeconds(3)).GetAwaiter().GetResult();
+                        x.T2.Ready(TimeSpan.FromSeconds(3));
                     });
             }
         }

--- a/src/core/Akka.Tests/Actor/FSMActorSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMActorSpec.cs
@@ -423,7 +423,7 @@ namespace Akka.Tests.Actor
             var lockFsm = Sys.ActorOf(Props.Create(() => new Lock("33221", 1.Seconds(), latches)));
             var transitionTester = Sys.ActorOf(Props.Create(() => new TransitionTester(latches)));
             lockFsm.Tell(new SubscribeTransitionCallBack(transitionTester));
-            latches.InitialStateLatch.Ready(timeout);
+            await latches.InitialStateLatch.ReadyAsync(timeout);
 
             lockFsm.Tell('3');
             lockFsm.Tell('3');
@@ -431,24 +431,24 @@ namespace Akka.Tests.Actor
             lockFsm.Tell('2');
             lockFsm.Tell('1');
 
-            latches.UnlockedLatch.Ready(timeout);
-            latches.TransitionLatch.Ready(timeout);
-            latches.TransitionCallBackLatch.Ready(timeout);
-            latches.LockedLatch.Ready(timeout);
+            await latches.UnlockedLatch.ReadyAsync(timeout);
+            await latches.TransitionLatch.ReadyAsync(timeout);
+            await latches.TransitionCallBackLatch.ReadyAsync(timeout);
+            await latches.LockedLatch.ReadyAsync(timeout);
 
-            await EventFilter.Warning("unhandled event").ExpectOneAsync(() => {
+            await EventFilter.Warning("unhandled event").ExpectOneAsync(async () => {
                 lockFsm.Tell("not_handled");
-                latches.UnhandledLatch.Ready(timeout);
+                await latches.UnhandledLatch.ReadyAsync(timeout);
                 return Task.CompletedTask;
             });
 
             var answerLatch = new TestLatch();
             var tester = Sys.ActorOf(Props.Create(() => new AnswerTester(answerLatch, lockFsm)));
             tester.Tell(Hello.Instance);
-            answerLatch.Ready(timeout);
+            await answerLatch.ReadyAsync(timeout);
 
             tester.Tell(Bye.Instance);
-            latches.TerminatedLatch.Ready(timeout);
+            await latches.TerminatedLatch.ReadyAsync(timeout);
         }
 
         [Fact]
@@ -472,7 +472,7 @@ namespace Akka.Tests.Actor
         {
             var started = new TestLatch(1);
             var actorRef = Sys.ActorOf(Props.Create(() => new ActorStopTermination(started, TestActor)));
-            started.Ready();
+            await started.ReadyAsync();
             Sys.Stop(actorRef);
             var stopEvent = await ExpectMsgAsync<StopEvent<int, object>>(1.Seconds());
             stopEvent.Reason.Should().BeOfType<Shutdown>();

--- a/src/core/Akka.Tests/Actor/FSMActorSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMActorSpec.cs
@@ -439,7 +439,6 @@ namespace Akka.Tests.Actor
             await EventFilter.Warning("unhandled event").ExpectOneAsync(async () => {
                 lockFsm.Tell("not_handled");
                 await latches.UnhandledLatch.ReadyAsync(timeout);
-                return Task.CompletedTask;
             });
 
             var answerLatch = new TestLatch();

--- a/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
+++ b/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
@@ -55,8 +55,10 @@ namespace Akka.Tests.Actor
                     .Select(_ => Task.Run(() => Sys.ActorOf(Props.Create(() => new BlackHoleActor()), address))).ToArray();
                 // Use WhenAll with empty ContinueWith to swallow all exceptions, so we can inspect the tasks afterwards.
                 await Task.WhenAll(actors).ContinueWith(_ => { }).AwaitWithTimeout(timeout);
+#pragma warning disable xUnit1031
                 Assert.True(actors.Any(x => x.Status == TaskStatus.RanToCompletion && x.Result != null), "Failed to create any Actors");
-                Assert.True(actors.Any(x => x.Status == TaskStatus.Faulted && x.Exception.InnerException is InvalidActorNameException), "Succeeded in creating all Actors. Some should have failed.");
+#pragma warning restore xUnit1031
+                Assert.True(actors.Any(x => x.Status == TaskStatus.Faulted && x.Exception!.InnerException is InvalidActorNameException), "Succeeded in creating all Actors. Some should have failed.");
             }
         }
 

--- a/src/core/Akka.Tests/Actor/PropsSpec.cs
+++ b/src/core/Akka.Tests/Actor/PropsSpec.cs
@@ -9,6 +9,7 @@ using Akka.Actor;
 using Akka.TestKit;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Akka.Tests.Actor
@@ -32,13 +33,13 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public void Props_must_create_actor_by_producer()
+        public async Task Props_must_create_actor_by_producer()
         {
-            TestLatch latchProducer = new TestLatch();
-            TestLatch latchActor = new TestLatch();
+            var latchProducer = new TestLatch();
+            var latchActor = new TestLatch();
             var props = Props.CreateBy(new TestProducer(latchProducer, latchActor));
-            IActorRef actor = Sys.ActorOf(props);
-            latchActor.Ready(TimeSpan.FromSeconds(1));
+            var actor = Sys.ActorOf(props);
+            await latchActor.ReadyAsync(TimeSpan.FromSeconds(1));
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Actor/Setup/ActorSystemSetupSpec.cs
+++ b/src/core/Akka.Tests/Actor/Setup/ActorSystemSetupSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.TestKit;
@@ -93,7 +94,7 @@ namespace Akka.Tests.Actor.Setup
         }
 
         [Fact]
-        public void ActorSystemSettingsShouldBeAvailableFromExtendedActorSystem()
+        public async Task ActorSystemSettingsShouldBeAvailableFromExtendedActorSystem()
         {
             ActorSystem system = null;
             try
@@ -105,7 +106,8 @@ namespace Akka.Tests.Actor.Setup
             }
             finally
             {
-                system?.Terminate().Wait(TimeSpan.FromSeconds(5));
+                if(system is not null)
+                    await system.Terminate().WaitAsync(TimeSpan.FromSeconds(5));
             }
         }
 

--- a/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
+++ b/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
@@ -53,12 +53,12 @@ namespace Akka.Tests.Actor.Stash
         }
 
         [Fact]
-        public void An_actor_Must_throw_an_exception_if_the_same_message_is_stashed_twice()
+        public async Task An_actor_Must_throw_an_exception_if_the_same_message_is_stashed_twice()
         {
             _state.ExpectedException = new TestLatch();
             var stasher = ActorOf<StashingTwiceActor>("stashing-actor");
             stasher.Tell("hello");
-            _state.ExpectedException.Ready(TimeSpan.FromSeconds(3));
+            await _state.ExpectedException.ReadyAsync(TimeSpan.FromSeconds(3));
         }
 
         [Fact]
@@ -110,8 +110,8 @@ namespace Akka.Tests.Actor.Stash
 
             //During preRestart restartLatch is opened
             //After that the cell will unstash "stashme", it should be received by the slave and open hasMsgLatch
-            restartLatch.Ready(TimeSpan.FromSeconds(10));
-            hasMsgLatch.Ready(TimeSpan.FromSeconds(10));
+            await restartLatch.ReadyAsync(TimeSpan.FromSeconds(10));
+            await hasMsgLatch.ReadyAsync(TimeSpan.FromSeconds(10));
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace Akka.Tests.Actor.Stash
             //After that the cell will clear the stash
             //So when the cell tries to unstash, it will not unstash messages. If it would TestActor
             //would receive all stashme messages instead of "this should bounce back"
-            restartLatch.Ready(TimeSpan.FromSeconds(1110));
+            await restartLatch.ReadyAsync(TimeSpan.FromSeconds(1110));
             await ExpectMsgAsync("this should bounce back");
         }
 

--- a/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
@@ -227,7 +227,7 @@ namespace Akka.Tests.Actor
             {
                 c.Strategy = new OneForOneStrategy(_ =>
                 {
-                    latch.ReadyAsync(Dilated(TimeSpan.FromSeconds(4))).GetAwaiter().GetResult(); 
+                    latch.Ready(Dilated(TimeSpan.FromSeconds(4))); 
                     return Directive.Resume;
                 });
                 c.Receive<string>(s => s.StartsWith("spawn:"), (s, ctx) => ctx.Sender.Tell(ctx.ActorOf<Resumer>(s.Substring(6))));

--- a/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
@@ -225,7 +225,11 @@ namespace Akka.Tests.Actor
             var latch = CreateTestLatch();
             var slowResumer = ActorOf(c =>
             {
-                c.Strategy = new OneForOneStrategy(_ => { latch.Ready(Dilated(TimeSpan.FromSeconds(4))); return Directive.Resume; });
+                c.Strategy = new OneForOneStrategy(_ =>
+                {
+                    latch.ReadyAsync(Dilated(TimeSpan.FromSeconds(4))).GetAwaiter().GetResult(); 
+                    return Directive.Resume;
+                });
                 c.Receive<string>(s => s.StartsWith("spawn:"), (s, ctx) => ctx.Sender.Tell(ctx.ActorOf<Resumer>(s.Substring(6))));
                 c.Receive("spawn", (_, ctx) => ctx.Sender.Tell(ctx.ActorOf<Resumer>()));
             }, "slowResumer");

--- a/src/core/Akka.Tests/Actor/TimerSpec.cs
+++ b/src/core/Akka.Tests/Actor/TimerSpec.cs
@@ -411,7 +411,7 @@ namespace Akka.Tests.Actor
                         return true;
 
                     case SlowThenBump m:
-                        m.Latch.Ready(TimeSpan.FromSeconds(10));
+                        m.Latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
                         Bump();
                         return true;
 
@@ -427,7 +427,7 @@ namespace Akka.Tests.Actor
                         throw m.E;
 
                     case SlowThenThrow m:
-                        m.Latch.Ready(TimeSpan.FromSeconds(10));
+                        m.Latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
                         throw m.E;
 
                     case AutoReceive _:
@@ -505,7 +505,7 @@ namespace Akka.Tests.Actor
                             return Bump(e.StateData);
 
                         case SlowThenBump m:
-                            m.Latch.Ready(TimeSpan.FromSeconds(10));
+                            m.Latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
                             return Bump(e.StateData);
 
                         case End _:
@@ -519,7 +519,7 @@ namespace Akka.Tests.Actor
                             throw m.E;
 
                         case SlowThenThrow m:
-                            m.Latch.Ready(TimeSpan.FromSeconds(10));
+                            m.Latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
                             throw m.E;
 
                         case AutoReceive _:

--- a/src/core/Akka.Tests/Actor/TimerSpec.cs
+++ b/src/core/Akka.Tests/Actor/TimerSpec.cs
@@ -411,7 +411,7 @@ namespace Akka.Tests.Actor
                         return true;
 
                     case SlowThenBump m:
-                        m.Latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
+                        m.Latch.Ready(TimeSpan.FromSeconds(10));
                         Bump();
                         return true;
 
@@ -427,7 +427,7 @@ namespace Akka.Tests.Actor
                         throw m.E;
 
                     case SlowThenThrow m:
-                        m.Latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
+                        m.Latch.Ready(TimeSpan.FromSeconds(10));
                         throw m.E;
 
                     case AutoReceive _:
@@ -505,7 +505,7 @@ namespace Akka.Tests.Actor
                             return Bump(e.StateData);
 
                         case SlowThenBump m:
-                            m.Latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
+                            m.Latch.Ready(TimeSpan.FromSeconds(10));
                             return Bump(e.StateData);
 
                         case End _:
@@ -519,7 +519,7 @@ namespace Akka.Tests.Actor
                             throw m.E;
 
                         case SlowThenThrow m:
-                            m.Latch.ReadyAsync(TimeSpan.FromSeconds(10)).GetAwaiter().GetResult();
+                            m.Latch.Ready(TimeSpan.FromSeconds(10));
                             throw m.E;
 
                         case AutoReceive _:

--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -98,6 +98,7 @@ namespace Akka.Tests.Configuration
 #else
             // Skip this test for Linux targets
             Output.WriteLine("This test is skipped.");
+            await Task.CompletedTask;
 #endif
         }
     }

--- a/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
@@ -125,7 +125,7 @@ namespace Akka.Tests.Pattern
 
             protected override void PostStop()
             {
-                _latch.Ready(3.Seconds());
+                _latch.ReadyAsync(3.Seconds()).GetAwaiter().GetResult();
             }
 
             public static Props Props(TestLatch latch)

--- a/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
@@ -125,7 +125,7 @@ namespace Akka.Tests.Pattern
 
             protected override void PostStop()
             {
-                _latch.ReadyAsync(3.Seconds()).GetAwaiter().GetResult();
+                _latch.Ready(3.Seconds());
             }
 
             public static Props Props(TestLatch latch)

--- a/src/core/Akka.Tests/Routing/BroadcastSpec.cs
+++ b/src/core/Akka.Tests/Routing/BroadcastSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Routing;
 using Akka.TestKit;
@@ -35,7 +36,7 @@ namespace Akka.Tests.Routing
         }
 
         [Fact]
-        public void BroadcastGroup_router_must_broadcast_message_using_Tell()
+        public async Task BroadcastGroup_router_must_broadcast_message_using_Tell()
         {
             var doneLatch = new TestLatch(2);
 
@@ -50,14 +51,14 @@ namespace Akka.Tests.Routing
             routedActor.Tell(new Broadcast(1));
             routedActor.Tell(new Broadcast("end"));
 
-            doneLatch.Ready(RemainingOrDefault);
+            await doneLatch.ReadyAsync(RemainingOrDefault);
 
             counter1.Current.Should().Be(1);
             counter2.Current.Should().Be(1);
         }
 
         [Fact]
-        public void BroadcastGroup_router_must_broadcast_message_using_Ask()
+        public async Task BroadcastGroup_router_must_broadcast_message_using_Ask()
         {
             var doneLatch = new TestLatch(2);
 
@@ -72,7 +73,7 @@ namespace Akka.Tests.Routing
             routedActor.Ask(new Broadcast(1));
             routedActor.Tell(new Broadcast("end"));
 
-            doneLatch.Ready(RemainingOrDefault);
+            await doneLatch.ReadyAsync(RemainingOrDefault);
 
             counter1.Current.Should().Be(1);
             counter2.Current.Should().Be(1);

--- a/src/core/Akka.Tests/Routing/ConfiguredLocalRoutingSpec.cs
+++ b/src/core/Akka.Tests/Routing/ConfiguredLocalRoutingSpec.cs
@@ -286,7 +286,8 @@ namespace Akka.Tests.Routing
 
             var received = Enumerable.Range(1, 3).Select(_ => ExpectMsg<IActorRef>()).ToList();
             // TODO: wrong actor names
-            var expected = new List<string> { "a", "b", "c" }.Select( i => Sys.ActorSelection("/user/weird/$" + i).ResolveOne(RemainingOrDefault).Result).ToList();
+            var expected = (await Task.WhenAll(new List<string> { "a", "b", "c" }
+                .Select( i => Sys.ActorSelection("/user/weird/$" + i).ResolveOne(RemainingOrDefault)))).ToList();
 
             received.Should().BeEquivalentTo(expected);
             await ExpectNoMsgAsync(1.Seconds());

--- a/src/core/Akka.Tests/Routing/ListenerSpec.cs
+++ b/src/core/Akka.Tests/Routing/ListenerSpec.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Routing;
 using Akka.TestKit;
@@ -17,7 +18,7 @@ namespace Akka.Tests.Routing
     public class ListenerSpec : AkkaSpec
     {
         [Fact]
-        public void Listener_must_listen_in()
+        public async Task Listener_must_listen_in()
         {
             //arrange
             var fooLatch = new TestLatch(2);
@@ -41,10 +42,10 @@ namespace Akka.Tests.Routing
             broadcast.Tell("foo");
 
             //assert
-            barLatch.Ready(TestLatch.DefaultTimeout);
+            await barLatch.ReadyAsync(TestLatch.DefaultTimeout);
             Assert.Equal(2, barCount.Current);
 
-            fooLatch.Ready(TestLatch.DefaultTimeout);
+            await fooLatch.ReadyAsync(TestLatch.DefaultTimeout);
             foreach (var actor in new[] {a1, a2, a3, broadcast})
             {
                 Sys.Stop(actor);

--- a/src/core/Akka.Tests/Routing/RandomSpec.cs
+++ b/src/core/Akka.Tests/Routing/RandomSpec.cs
@@ -161,7 +161,7 @@ namespace Akka.Tests.Routing
             });
 
             Sys.Stop(actor);
-            testLatch.Ready(5.Seconds());
+            await testLatch.ReadyAsync(5.Seconds());
         }
 
         [Fact]
@@ -193,7 +193,7 @@ namespace Akka.Tests.Routing
             counter.Current.ShouldBe(connectionCount);
 
             actor.Tell(new Broadcast("end"));
-            doneLatch.Ready(TimeSpan.FromSeconds(5));
+            await doneLatch.ReadyAsync(TimeSpan.FromSeconds(5));
 
             replies.Values.ForEach(c => c.Should().BeGreaterThan(0));
             replies.Values.Any(c => c != iterationCount).ShouldBeTrue();
@@ -201,7 +201,7 @@ namespace Akka.Tests.Routing
         }
 
         [Fact]
-        public void Random_pool_must_deliver_a_broadcast_message_using_the_Tell()
+        public async Task Random_pool_must_deliver_a_broadcast_message_using_the_Tell()
         {
             const int routeeCount = 6;
             var helloLatch = new TestLatch(routeeCount);
@@ -211,10 +211,10 @@ namespace Akka.Tests.Routing
                 .Props(Props.Create(() => new RandomBroadcastActor(helloLatch, stopLatch))), "random-broadcast");
 
             actor.Tell(new Broadcast("hello"));
-            helloLatch.Ready(5.Seconds());
+            await helloLatch.ReadyAsync(5.Seconds());
 
             Sys.Stop(actor);
-            stopLatch.Ready(5.Seconds());
+            await stopLatch.ReadyAsync(5.Seconds());
         }
 
         [Fact]
@@ -267,7 +267,7 @@ namespace Akka.Tests.Routing
             }
 
             actor.Tell(new Broadcast("end"));
-            doneLatch.Ready(5.Seconds());
+            await doneLatch.ReadyAsync(5.Seconds());
 
             replies.Values.ForEach(c => c.Should().BeGreaterThan(0));
             replies.Values.Any(c => c != iterationCount).ShouldBeTrue();

--- a/src/core/Akka.Tests/Routing/ResizerSpec.cs
+++ b/src/core/Akka.Tests/Routing/ResizerSpec.cs
@@ -215,7 +215,7 @@ namespace Akka.Tests.Routing
             router.Tell(latch);
             router.Tell(latch);
 
-            latch.Ready(RemainingOrDefault);
+            await latch.ReadyAsync(RemainingOrDefault);
 
             // MessagesPerResize is 10 so there is no risk of additional resize
             (await RouteeSize(router)).Should().Be(2);
@@ -231,7 +231,7 @@ namespace Akka.Tests.Routing
             router.Tell(latch);
             router.Tell(latch);
 
-            latch.Ready(RemainingOrDefault);
+            await latch.ReadyAsync(RemainingOrDefault);
 
             (await RouteeSize(router)).Should().Be(2);
         }

--- a/src/core/Akka.Tests/Routing/RoundRobinSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoundRobinSpec.cs
@@ -147,7 +147,7 @@ namespace Akka.Tests.Routing
         }
 
         [Fact]
-        public void Round_robin_pool_must_be_able_to_shut_down_its_instance()
+        public async Task Round_robin_pool_must_be_able_to_shut_down_its_instance()
         {
             const int routeeCount = 5;
 
@@ -163,10 +163,10 @@ namespace Akka.Tests.Routing
             actor.Tell("hello", TestActor);
             actor.Tell("hello", TestActor);
 
-            helloLatch.Ready(5.Seconds());
+            await helloLatch.ReadyAsync(5.Seconds());
 
             Sys.Stop(actor);
-            stopLatch.Ready(5.Seconds());
+            await stopLatch.ReadyAsync(5.Seconds());
         }
 
         [Fact]
@@ -198,13 +198,13 @@ namespace Akka.Tests.Routing
 
             counter.Current.Should().Be(connectionCount);
             actor.Tell(new Broadcast("end"));
-            doneLatch.Ready(5.Seconds());
+            await doneLatch.ReadyAsync(5.Seconds());
 
             replies.Values.ForEach(c => c.Should().Be(iterationCount));
         }
 
         [Fact]
-        public void Round_robin_pool_must_deliver_deliver_a_broadcast_message_using_Tell()
+        public async Task Round_robin_pool_must_deliver_deliver_a_broadcast_message_using_Tell()
         {
             const int routeeCount = 5;
             var helloLatch = new TestLatch(routeeCount);
@@ -214,10 +214,10 @@ namespace Akka.Tests.Routing
                 .Props(Props.Create(() => new RoundRobinPoolBroadcastActor(helloLatch, stopLatch))), "round-robin-broadcast");
 
             actor.Tell(new Broadcast("hello"));
-            helloLatch.Ready(5.Seconds());
+            await helloLatch.ReadyAsync(5.Seconds());
 
             Sys.Stop(actor);
-            stopLatch.Ready(5.Seconds());
+            await stopLatch.ReadyAsync(5.Seconds());
         }
 
         [Fact]
@@ -270,7 +270,7 @@ namespace Akka.Tests.Routing
             }
 
             actor.Tell(new Broadcast("end"));
-            doneLatch.Ready(5.Seconds());
+            await doneLatch.ReadyAsync(5.Seconds());
 
             replies.Values.ForEach(c => c.Should().Be(iterationCount));
         }

--- a/src/core/Akka.Tests/Routing/RoutingSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoutingSpec.cs
@@ -21,18 +21,20 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
 using System.Threading.Tasks;
+using Xunit.Abstractions;
 
 namespace Akka.Tests.Routing
 {
     public class RoutingSpec : AkkaSpec
     {
-        public RoutingSpec() : base(GetConfig())
+        public RoutingSpec(ITestOutputHelper output) : base(GetConfig(), output)
         {
         }
 
         private static string GetConfig()
         {
             return @"
+                akka.loglevel = DEBUG
                 akka.actor.serialize-messages = off
                 akka.actor.deployment {
                   /router1 {
@@ -170,6 +172,7 @@ namespace Akka.Tests.Routing
 
             var c1 = await ExpectMsgAsync<IActorRef>();
             var c2 = await ExpectMsgAsync<IActorRef>();
+            c1.Should().NotBe(c2);
 
             Watch(router);
             Watch(c2);

--- a/src/core/Akka.Tests/Routing/RoutingSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoutingSpec.cs
@@ -204,7 +204,7 @@ namespace Akka.Tests.Routing
             var resizer = new TestResizer(latch);
             var router = Sys.ActorOf(new RoundRobinPool(0, resizer).Props(Props.Create<BlackHoleActor>()));
             Watch(router);
-            latch.Ready(RemainingOrDefault);
+            await latch.ReadyAsync(RemainingOrDefault);
 
             router.Tell(new GetRoutees());
             var routees = (await ExpectMsgAsync<Routees>()).Members.ToList();
@@ -242,7 +242,7 @@ namespace Akka.Tests.Routing
             var latch = new TestLatch(1);
             var resizer = new TestResizer2(latch);
             var router = Sys.ActorOf(new RoundRobinPool(0, resizer).Props(Props.Create<BlackHoleActor>()), "router3");
-            latch.Ready(RemainingOrDefault);
+            await latch.ReadyAsync(RemainingOrDefault);
             router.Tell(new GetRoutees());
             (await ExpectMsgAsync<Routees>()).Members.Count().Should().Be(3);
             Sys.Stop(router);

--- a/src/core/Akka.Tests/Routing/ScatterGatherFirstCompletedSpec.cs
+++ b/src/core/Akka.Tests/Routing/ScatterGatherFirstCompletedSpec.cs
@@ -83,7 +83,7 @@ namespace Akka.Tests.Routing
         }
 
         [Fact]
-        public void Scatter_gather_group_must_deliver_a_broadcast_message_using_tell()
+        public async Task Scatter_gather_group_must_deliver_a_broadcast_message_using_tell()
         {
             var doneLatch = new TestLatch(2);
 
@@ -98,7 +98,7 @@ namespace Akka.Tests.Routing
             routedActor.Tell(new Broadcast(1));
             routedActor.Tell(new Broadcast("end"));
 
-            doneLatch.Ready(TestKitSettings.DefaultTimeout);
+            await doneLatch.ReadyAsync(TestKitSettings.DefaultTimeout);
 
             counter1.Current.Should().Be(1);
             counter2.Current.Should().Be(1);
@@ -116,7 +116,7 @@ namespace Akka.Tests.Routing
             var routedActor = Sys.ActorOf(new ScatterGatherFirstCompletedGroup(paths, TimeSpan.FromSeconds(3)).Props());
 
             routedActor.Tell(new Broadcast(new Stop(1)));
-            shutdownLatch.Ready(TestKitSettings.DefaultTimeout);
+            await shutdownLatch.ReadyAsync(TestKitSettings.DefaultTimeout);
             var res = await routedActor.Ask<int>(0, TimeSpan.FromSeconds(10));
             res.Should().Be(14);
         }

--- a/src/core/Akka.Tests/Routing/SmallestMailboxSpec.cs
+++ b/src/core/Akka.Tests/Routing/SmallestMailboxSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Routing;
 using Akka.TestKit;
@@ -34,7 +35,7 @@ namespace Akka.Tests.Routing
                         usedActors.TryAdd(0, Self.Path.ToString());
                         Self.Tell("another in busy mailbox");
                         receivedLatch.CountDown();
-                        busy.Ready(TestLatch.DefaultTimeout);
+                        busy.ReadyAsync(TestLatch.DefaultTimeout).GetAwaiter().GetResult();
                         break;
                     
                     case (int msg, TestLatch receivedLatch) _:
@@ -49,7 +50,7 @@ namespace Akka.Tests.Routing
         }
 
         [Fact]
-        public void Smallest_mailbox_pool_must_deliver_messages_to_idle_actor()
+        public async Task Smallest_mailbox_pool_must_deliver_messages_to_idle_actor()
         {
             var usedActors = new ConcurrentDictionary<int, string>();
             var router = Sys.ActorOf(new SmallestMailboxPool(3).Props(Props.Create(() => new SmallestMailboxActor(usedActors))));
@@ -57,19 +58,19 @@ namespace Akka.Tests.Routing
             var busy = new TestLatch(1);
             var received0 = new TestLatch(1);
             router.Tell((busy, received0));
-            received0.Ready(TestKitSettings.DefaultTimeout);
+            await received0.ReadyAsync(TestKitSettings.DefaultTimeout);
 
             var received1 = new TestLatch(1);
             router.Tell((1, received1));
-            received1.Ready(TestKitSettings.DefaultTimeout);
+            await received1.ReadyAsync(TestKitSettings.DefaultTimeout);
 
             var received2 = new TestLatch(1);
             router.Tell((2, received2));
-            received2.Ready(TestKitSettings.DefaultTimeout);
+            await received2.ReadyAsync(TestKitSettings.DefaultTimeout);
 
             var received3 = new TestLatch(1);
             router.Tell((3, received3));
-            received3.Ready(TestKitSettings.DefaultTimeout);
+            await received3.ReadyAsync(TestKitSettings.DefaultTimeout);
 
             busy.CountDown();
 

--- a/src/core/Akka.Tests/Routing/SmallestMailboxSpec.cs
+++ b/src/core/Akka.Tests/Routing/SmallestMailboxSpec.cs
@@ -35,7 +35,7 @@ namespace Akka.Tests.Routing
                         usedActors.TryAdd(0, Self.Path.ToString());
                         Self.Tell("another in busy mailbox");
                         receivedLatch.CountDown();
-                        busy.ReadyAsync(TestLatch.DefaultTimeout).GetAwaiter().GetResult();
+                        busy.Ready(TestLatch.DefaultTimeout);
                         break;
                     
                     case (int msg, TestLatch receivedLatch) _:

--- a/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
+++ b/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
@@ -85,7 +85,7 @@ namespace Akka.Tests.Routing
         }
 
         [Fact]
-        public void Tail_chopping_group_router_must_deliver_a_broadcast_message_using_tell()
+        public async Task Tail_chopping_group_router_must_deliver_a_broadcast_message_using_tell()
         {
             var doneLatch = new TestLatch(2);
 
@@ -101,7 +101,7 @@ namespace Akka.Tests.Routing
             routedActor.Tell(new Broadcast(1));
             routedActor.Tell(new Broadcast("end"));
 
-            doneLatch.Ready(TestKitSettings.DefaultTimeout);
+            await doneLatch.ReadyAsync(TestKitSettings.DefaultTimeout);
 
             counter1.Current.Should().Be(1);
             counter2.Current.Should().Be(1);

--- a/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
+++ b/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
@@ -75,11 +75,29 @@ namespace Akka.Tests.Routing
             };
         }
 
+        public Func<Func<IActorRef, Task<int>>, Task<bool>> OneOfShouldEqualAsync(int what, IEnumerable<IActorRef> actors)
+        {
+            return async func =>
+            {
+                var results = await Task.WhenAll(actors.Select(func));
+                return results.Any(x => x == what);
+            };
+        }
+
         public Func<Func<IActorRef, int>, bool> AllShouldEqual(int what, IEnumerable<IActorRef> actors)
         {
             return func =>
             {
                 var results = actors.Select(func);
+                return results.All(x => x == what);
+            };
+        }
+
+        public Func<Func<IActorRef, Task<int>>, Task<bool>> AllShouldEqualAsync(int what, IEnumerable<IActorRef> actors)
+        {
+            return async func =>
+            {
+                var results = await Task.WhenAll(actors.Select(func));
                 return results.All(x => x == what);
             };
         }
@@ -121,7 +139,7 @@ namespace Akka.Tests.Routing
             await probe.ExpectMsgAsync("ack");
 
             var actorList = new List<IActorRef> { actor1, actor2 };
-            OneOfShouldEqual(1, actorList)(x => (int)x.Ask("times").Result).Should().BeTrue();
+            (await OneOfShouldEqualAsync(1, actorList)(async x => (int)await x.Ask("times"))).Should().BeTrue();
 
             routedActor.Tell(new Broadcast("stop"));
         }
@@ -142,7 +160,7 @@ namespace Akka.Tests.Routing
             failure.Cause.Should().BeOfType<AskTimeoutException>();
 
             var actorList = new List<IActorRef> { actor1, actor2 };
-            AllShouldEqual(1, actorList)(x => (int) x.Ask("times").Result).Should().BeTrue(); ;
+            (await AllShouldEqualAsync(1, actorList)(async x => (int)await x.Ask("times"))).Should().BeTrue(); ;
 
             routedActor.Tell(new Broadcast("stop"));
         }

--- a/src/core/Akka.Tests/Serialization/SerializationSetupSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSetupSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.Configuration;
@@ -16,6 +17,7 @@ using Akka.TestKit;
 using Akka.TestKit.Configs;
 using Akka.Util.Internal;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -110,7 +112,7 @@ namespace Akka.Tests.Serialization
         }
 
         [Fact]
-        public void SerializationSettingsShouldOverrideHoconSettings()
+        public async Task SerializationSettingsShouldOverrideHoconSettings()
         {
             var serializationSettings = new SerializationSetup(_ => 
                 ImmutableHashSet<SerializerDetails>.Empty
@@ -138,7 +140,7 @@ namespace Akka.Tests.Serialization
             var serializer = sys2.Serialization.FindSerializerFor(new ProgammaticDummy());
             serializer.Should().BeOfType<TestSerializer>();
 
-            sys2.Terminate().Wait();
+            await sys2.Terminate().WaitAsync(3.Seconds());
         }
     }
 }


### PR DESCRIPTION
## Changes

* Convert all unit tests to proper async
* Convert TestLatch to use `Task` instead of `Threading.CountdownEvent`
* Remove xUnit1031 error code from the "NoWarn" list