### PR TITLE
(docs) Add note on prioritization of Ask()

### DIFF
--- a/docs/articles/actors/receive-actor-api.md
+++ b/docs/articles/actors/receive-actor-api.md
@@ -405,6 +405,9 @@ This example demonstrates `Ask` together with the `Pipe` Pattern on tasks, becau
 
 Using `Ask` will send a message to the receiving Actor as with `Tell`, and the receiving actor must reply with `Sender.Tell(reply, Self)` in order to complete the returned `Task` with a value. The `Ask` operation involves creating an internal actor for handling this reply, which needs to have a timeout after which it is destroyed in order not to leak resources; see more below.
 
+> [!NOTE]
+> While `Ask` waits for a response, that does not ensure it receives any kind of priority. Messages sent via `Ask` queue in actor mailboxes the same way that messages sent via `Tell` do. You may need to adapt your actor hierarchy if `Ask` messages might be impeded by a large mailbox size.
+
 > [!WARNING]
 > To complete the `Task` with an exception you need send a `Failure` message to the sender. This is not done automatically when an actor throws an exception while processing a message.
 

--- a/docs/articles/actors/receive-actor-api.md
+++ b/docs/articles/actors/receive-actor-api.md
@@ -406,7 +406,7 @@ This example demonstrates `Ask` together with the `Pipe` Pattern on tasks, becau
 Using `Ask` will send a message to the receiving Actor as with `Tell`, and the receiving actor must reply with `Sender.Tell(reply, Self)` in order to complete the returned `Task` with a value. The `Ask` operation involves creating an internal actor for handling this reply, which needs to have a timeout after which it is destroyed in order not to leak resources; see more below.
 
 > [!NOTE]
-> While `Ask` waits for a response, that does not ensure it receives any kind of priority. Messages sent via `Ask` queue in actor mailboxes the same way that messages sent via `Tell` do. You may need to adapt your actor hierarchy if `Ask` messages might be impeded by a large mailbox size.
+> While `Ask` waits for a response, that does not ensure it receives any kind of priority. Messages sent via `Ask` queue in actor mailboxes the same way that messages sent via `Tell` do. You may need to adapt your actor hierarchy if `Ask` messages might be impeded by a large queue in an actor's mailbox.
 
 > [!WARNING]
 > To complete the `Task` with an exception you need send a `Failure` message to the sender. This is not done automatically when an actor throws an exception while processing a message.

--- a/docs/articles/actors/receive-actor-api.md
+++ b/docs/articles/actors/receive-actor-api.md
@@ -403,10 +403,10 @@ Task.WhenAll(tasks).PipeTo(actorC, Self);
 
 This example demonstrates `Ask` together with the `Pipe` Pattern on tasks, because this is likely to be a common combination. Please note that all of the above is completely non-blocking and asynchronous: `Ask` produces a `Task`, two of which are awaited until both are completed, and when that happens, a new `Result` object is forwarded to another actor.
 
-Using `Ask` will send a message to the receiving Actor as with `Tell`, and the receiving actor must reply with `Sender.Tell(reply, Self)` in order to complete the returned `Task` with a value. The `Ask` operation involves creating an internal actor for handling this reply, which needs to have a timeout after which it is destroyed in order not to leak resources; see more below.
-
 > [!NOTE]
 > While `Ask` waits for a response, that does not ensure it receives any kind of priority. Messages sent via `Ask` queue in actor mailboxes the same way that messages sent via `Tell` do. You may need to adapt your actor hierarchy if `Ask` messages might be impeded by a large queue in an actor's mailbox.
+
+Using `Ask` will send a message to the receiving Actor as with `Tell`, and the receiving actor must reply with `Sender.Tell(reply, Self)` in order to complete the returned `Task` with a value. The `Ask` operation involves creating an internal actor for handling this reply, which needs to have a timeout after which it is destroyed in order not to leak resources; see more below.
 
 > [!WARNING]
 > To complete the `Task` with an exception you need send a `Failure` message to the sender. This is not done automatically when an actor throws an exception while processing a message.


### PR DESCRIPTION
Per https://discordapp.com/channels/974500337396375553/974500337954222133/1160953337408135231

Purely documentation. No related issue. Let me know if you'd like me to create one. I consider this a low priority PR for merge at your convenience.

## Changes

Update the documentation to add a note around `Ask` based on a question I asked in the Discord while jogging my memory. Figured it might be useful for others.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [X] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

N/A

### This PR's Benchmarks

N/A