### PR TITLE
fix a typo in SpanHacks.Parse exception message

### DIFF
--- a/src/core/Akka/Util/SpanHacks.cs
+++ b/src/core/Akka/Util/SpanHacks.cs
@@ -39,7 +39,7 @@ namespace Akka.Util
             if (int.TryParse(str, out var i))
                 return i;
 #endif
-            throw new FormatException($"[{str.ToString()}] is now a valid numeric format");
+            throw new FormatException($"[{str.ToString()}] is not a valid numeric format");
         }
         
         private const char Negative = '-';


### PR DESCRIPTION
## Changes

Fix a typo in the exception message in `SpanHacks.Parse` (... is no**w** a valid numeric -> ... is no**t** a valid numeric).

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

\- (I don't believe this qualifies as a significant change.)

### Latest `dev` Benchmarks 

\-

### This PR's Benchmarks

\-