### PR TITLE
mark older LeastShardAllocationStrategy as obsolete

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -1415,10 +1415,13 @@ namespace Akka.Cluster.Sharding
             }
             else
             {
+                // TODO: remove this in v1.6 and force all users to use only the new strategy going forward
                 // old algorithm
                 var threshold = settings.TuningParameters.LeastShardAllocationRebalanceThreshold;
                 var maxSimultaneousRebalance = settings.TuningParameters.LeastShardAllocationMaxSimultaneousRebalance;
+#pragma warning disable CS0618 // Type or member is obsolete
                 return new LeastShardAllocationStrategy(threshold, maxSimultaneousRebalance);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardAllocationStrategy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardAllocationStrategy.cs
@@ -139,6 +139,7 @@ namespace Akka.Cluster.Sharding
     /// The number of ongoing rebalancing processes can be limited by `maxSimultaneousRebalance`.
     /// </summary>
     [Serializable]
+    [Obsolete("Use ShardAllocationStrategy.LeastShardAllocationStrategy instead. This will be removed in v1.6.")]
     public class LeastShardAllocationStrategy : AbstractLeastShardAllocationStrategy
     {
         private readonly int _rebalanceThreshold;

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
@@ -180,6 +180,8 @@ namespace Akka.Cluster.Sharding
     {
         void Start();
     }
+    [System.ObsoleteAttribute("Use ShardAllocationStrategy.LeastShardAllocationStrategy instead. This will be re" +
+        "moved in v1.6.")]
     public class LeastShardAllocationStrategy : Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy
     {
         public LeastShardAllocationStrategy(int rebalanceThreshold, int maxSimultaneousRebalance) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
@@ -180,6 +180,8 @@ namespace Akka.Cluster.Sharding
     {
         void Start();
     }
+    [System.ObsoleteAttribute("Use ShardAllocationStrategy.LeastShardAllocationStrategy instead. This will be re" +
+        "moved in v1.6.")]
     public class LeastShardAllocationStrategy : Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy
     {
         public LeastShardAllocationStrategy(int rebalanceThreshold, int maxSimultaneousRebalance) { }


### PR DESCRIPTION
Pertains to https://github.com/akkadotnet/akka.net/issues/5488, which we will eventually address in v1.6.

## Changes

Marks older `LeastShardAllocationStrategy` as obsolete.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #5488
* [x] Changes in public API reviewed, if any.
