### PR TITLE
Akka.Persistence.Query: include more descriptive ToString() values for all Offset types #6927

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
@@ -64,6 +64,7 @@ namespace Akka.Persistence.Query
     {
         public static Akka.Persistence.Query.NoOffset Instance { get; }
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
+        public override string ToString() { }
     }
     public abstract class Offset : System.IComparable<Akka.Persistence.Query.Offset>
     {
@@ -72,6 +73,7 @@ namespace Akka.Persistence.Query
         public static Akka.Persistence.Query.Offset NoOffset() { }
         public static Akka.Persistence.Query.Offset Sequence(long value) { }
         public static Akka.Persistence.Query.Offset TimeBasedUuid(System.Guid value) { }
+        public virtual string ToString() { }
     }
     public sealed class PersistenceQuery : Akka.Actor.IExtension
     {
@@ -100,6 +102,7 @@ namespace Akka.Persistence.Query
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
+        public override string ToString() { }
     }
     public sealed class TimeBasedUuid : Akka.Persistence.Query.Offset, System.IComparable<Akka.Persistence.Query.TimeBasedUuid>
     {
@@ -109,5 +112,6 @@ namespace Akka.Persistence.Query
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
+        public override string ToString() { }
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
@@ -64,6 +64,7 @@ namespace Akka.Persistence.Query
     {
         public static Akka.Persistence.Query.NoOffset Instance { get; }
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
+        public override string ToString() { }
     }
     public abstract class Offset : System.IComparable<Akka.Persistence.Query.Offset>
     {
@@ -72,6 +73,7 @@ namespace Akka.Persistence.Query
         public static Akka.Persistence.Query.Offset NoOffset() { }
         public static Akka.Persistence.Query.Offset Sequence(long value) { }
         public static Akka.Persistence.Query.Offset TimeBasedUuid(System.Guid value) { }
+        public virtual string ToString() { }
     }
     public sealed class PersistenceQuery : Akka.Actor.IExtension
     {
@@ -100,6 +102,7 @@ namespace Akka.Persistence.Query
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
+        public override string ToString() { }
     }
     public sealed class TimeBasedUuid : Akka.Persistence.Query.Offset, System.IComparable<Akka.Persistence.Query.TimeBasedUuid>
     {
@@ -109,5 +112,6 @@ namespace Akka.Persistence.Query
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
+        public override string ToString() { }
     }
 }

--- a/src/core/Akka.Persistence.Query.Tests/OffsetSpec.cs
+++ b/src/core/Akka.Persistence.Query.Tests/OffsetSpec.cs
@@ -38,5 +38,24 @@ namespace Akka.Persistence.Query.Tests
             var shuffledSequenceBasedList = sequenceBasedList.OrderBy(_ => Guid.NewGuid());
             shuffledSequenceBasedList.Should().BeEquivalentTo(sequenceBasedList);
         }
+
+        [Fact]
+        public void Sequence_must_log_value_correctly()
+        {
+            Assert.Equal("7", new Sequence(7).ToString());
+        }
+
+        [Fact]
+        public void TimeBasedUuid_must_log_value_correctly()
+        {
+            var timeBasedUuid = new TimeBasedUuid(new Guid("49225740-2019-11ea-a6f0-a0a60c2ef4ff"));
+            Assert.Equal("49225740-2019-11ea-a6f0-a0a60c2ef4ff", timeBasedUuid.ToString());
+        }
+
+        [Fact]
+        public void NoOffset_must_log_zero()
+        {
+            Assert.Equal("0", NoOffset.Instance.ToString());
+        }
     }
 }

--- a/src/core/Akka.Persistence.Query/Offset.cs
+++ b/src/core/Akka.Persistence.Query/Offset.cs
@@ -37,6 +37,11 @@ namespace Akka.Persistence.Query
         /// </summary>
         /// <param name="other">The other offset to compare.</param>
         public abstract int CompareTo(Offset other);
+
+        /// <summary>
+        /// Used to log offset's value
+        /// </summary>
+        public abstract override string ToString();
     }
 
     /// <summary>
@@ -83,6 +88,8 @@ namespace Akka.Persistence.Query
 
             throw new InvalidOperationException($"Can't compare offset of type {GetType()} to offset of type {other.GetType()}");
         }
+
+        public override string ToString() => Value.ToString();
     }
 
     /// <summary>
@@ -123,6 +130,8 @@ namespace Akka.Persistence.Query
                 ? CompareTo(seq)
                 : throw new InvalidOperationException($"Can't compare offset of type {GetType()} to offset of type {other.GetType()}");
         }
+
+        public override string ToString() => Value.ToString();
     }
 
     /// <summary>
@@ -145,5 +154,7 @@ namespace Akka.Persistence.Query
 
             throw new InvalidOperationException($"Can't compare offset of type {GetType()} to offset of type {other.GetType()}");
         }
+
+        public override string ToString() => "0";
     }
 }


### PR DESCRIPTION
Fixes #6927 

## Changes

Added mandatory override ToString() for Offset implementations, which displays Value. Added respective unit tests. Exposed new public API ToString().

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
