### PR TITLE
#6816 Akka.DistributedData.LightningDb: move durable folder creation outside of actor constructor

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
+++ b/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
@@ -107,10 +107,8 @@ namespace Akka.DistributedData.LightningDB
         private LightningEnvironment GetLightningEnvironment()
         {
             var t0 = Stopwatch.StartNew();      
-          if (!Directory.Exists(_dir))
-            {
+            if (!Directory.Exists(_dir))
                 Directory.CreateDirectory(_dir);
-            }
          
             var env = new LightningEnvironment(_dir)
             {

--- a/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
+++ b/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
@@ -86,11 +86,7 @@ namespace Akka.DistributedData.LightningDB
                 ? Path.GetFullPath($"{path}-{Context.System.Name}-{Self.Path.Parent.Name}-{Cluster.Cluster.Get(Context.System).SelfAddress.Port}")
                 : Path.GetFullPath(path);
 
-            if (!Directory.Exists(_dir))
-            {
-                Directory.CreateDirectory(_dir);
-            }
-            
+         
             _log.Info($"Using durable data in LMDB directory [{_dir}]");
             Init();
         }
@@ -110,7 +106,12 @@ namespace Akka.DistributedData.LightningDB
 
         private LightningEnvironment GetLightningEnvironment()
         {
-            var t0 = Stopwatch.StartNew();
+            var t0 = Stopwatch.StartNew();      
+          if (!Directory.Exists(_dir))
+            {
+                Directory.CreateDirectory(_dir);
+            }
+         
             var env = new LightningEnvironment(_dir)
             {
                 MapSize = _mapSize,
@@ -181,13 +182,6 @@ namespace Akka.DistributedData.LightningDB
         {
             Receive<LoadAll>(_ =>
             {
-                if(_dir.Length == 0 || !Directory.Exists(_dir))
-                {
-                    // no files to load
-                    Sender.Tell(LoadAllCompleted.Instance);
-                    Become(Active);
-                    return;
-                }
 
                 var t0 = Stopwatch.StartNew();
                 

--- a/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
+++ b/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
@@ -56,7 +56,8 @@ namespace Akka.DistributedData.LightningDB
         private readonly long _mapSize;
 
         private readonly TimeSpan _writeBehindInterval;
-        private readonly string _dir;
+        private readonly string _path;
+        private string _dir;
 
         private readonly Dictionary<string, DurableDataEnvelope> _pending = new();
         private readonly ILoggingAdapter _log;
@@ -81,13 +82,8 @@ namespace Akka.DistributedData.LightningDB
 
             _mapSize = _config.GetByteSize("map-size") ?? 100 * 1024 * 1024;
 
-            var path = _config.GetString("dir");
-            _dir = path.EndsWith(DatabaseName)
-                ? Path.GetFullPath($"{path}-{Context.System.Name}-{Self.Path.Parent.Name}-{Cluster.Cluster.Get(Context.System).SelfAddress.Port}")
-                : Path.GetFullPath(path);
+            _path = _config.GetString("dir");
 
-         
-            _log.Info($"Using durable data in LMDB directory [{_dir}]");
             Init();
         }
 
@@ -104,11 +100,22 @@ namespace Akka.DistributedData.LightningDB
             DoWriteBehind();
         }
 
+        protected override void PreStart()
+        {
+            base.PreStart();
+
+            _dir = _path.EndsWith(DatabaseName)
+                ? Path.GetFullPath($"{_path}-{Context.System.Name}-{Self.Path.Parent.Name}-{Cluster.Cluster.Get(Context.System).SelfAddress.Port}")
+                : Path.GetFullPath(_path);
+            if (!Directory.Exists(_dir))
+                Directory.CreateDirectory(_dir);
+            
+            _log.Info($"Using durable data in LMDB directory [{_dir}]");
+        }
+
         private LightningEnvironment GetLightningEnvironment()
         {
             var t0 = Stopwatch.StartNew();      
-            if (!Directory.Exists(_dir))
-                Directory.CreateDirectory(_dir);
          
             var env = new LightningEnvironment(_dir)
             {

--- a/src/contrib/cluster/Akka.DistributedData.Tests/LightningDb/BugFix6816.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/LightningDb/BugFix6816.cs
@@ -1,0 +1,88 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="BugFix6816.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.DistributedData.Durable;
+using Akka.DistributedData.LightningDB;
+using Akka.Event;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.DistributedData.Tests.LightningDb;
+
+[Collection("DistributedDataSpec")]
+public class BugFix6816: Akka.TestKit.Xunit2.TestKit
+{
+    private const string DDataDir = "thatdir";
+    private static readonly Config BaseConfig = ConfigurationFactory.ParseString(@"
+            akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
+            akka.remote.dot-netty.tcp.port = 0")
+        .WithFallback(DistributedData.DefaultConfig())
+        .WithFallback(TestKit.Xunit2.TestKit.DefaultConfig);
+
+    private static readonly Config LmdbDefaultConfig = ConfigurationFactory.ParseString($@"
+        lmdb {{
+            dir = {DDataDir}
+            map-size = 100 MiB
+            write-behind-interval = off
+        }}");
+
+    public BugFix6816(ITestOutputHelper output): base(BaseConfig, "LmdbDurableStoreSpec", output)
+    {
+    }
+
+    [Fact]
+    public void Lmdb_creates_directory_when_handling_first_message()
+    {
+        if (Directory.Exists(DDataDir))
+        {
+            var di = new DirectoryInfo(DDataDir);
+            di.Delete(true);
+        }
+
+        Directory.Exists(DDataDir).Should().BeFalse();
+        var lmdb = ActorOf(LmdbDurableStore.Props(LmdbDefaultConfig));
+        lmdb.Tell(LoadAll.Instance);          
+        AwaitCondition(() => HasMessages);
+        ExpectMsg<LoadAllCompleted>();
+        Directory.Exists(DDataDir).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Lmdb_logs_meaningful_error_for_invalid_dir_path()
+    {
+        var invalidName = Environment.OSVersion.Platform is PlatformID.Win32NT 
+            ? "\"invalid?directory\"" : "/dev/null/illegal";
+        
+        Directory.Exists(invalidName).Should().BeFalse();
+
+        var probe = CreateTestProbe();
+        Sys.EventStream.Subscribe(probe, typeof(Error));
+        
+        var lmdb = ActorOf(LmdbDurableStore.Props(ConfigurationFactory.ParseString($@"
+        lmdb {{
+            dir = {invalidName}
+            map-size = 100 MiB
+            write-behind-interval = off
+        }}")));
+
+        //Expect meaningful error log
+        var err =probe.ExpectMsg<Error>();
+        err.Message.ToString().Should()
+            .NotContain("Error while creating actor instance of type Akka.DistributedData.LightningDB.LmdbDurableStore");
+        err.Cause.Should().BeOfType<ActorInitializationException>();
+        err.Cause.InnerException.Should().NotBeNull();
+        (err.Cause.InnerException is IOException or DirectoryNotFoundException or ArgumentException).Should().BeTrue();
+        
+        Directory.Exists(invalidName).Should().BeFalse();
+    }
+    
+}

--- a/src/contrib/cluster/Akka.DistributedData.Tests/LightningDb/BugFix6816.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/LightningDb/BugFix6816.cs
@@ -1,9 +1,9 @@
-﻿// //-----------------------------------------------------------------------
-// // <copyright file="BugFix6816.cs" company="Akka.NET Project">
-// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
-// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
-// // </copyright>
-// //-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
+// <copyright file="BugFix6816.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
 
 using System;
 using System.IO;

--- a/src/contrib/cluster/Akka.DistributedData.Tests/LightningDb/LmdbDurableStoreSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/LightningDb/LmdbDurableStoreSpec.cs
@@ -46,6 +46,7 @@ namespace Akka.DistributedData.Tests.LightningDb
                 var di = new DirectoryInfo(DDataDir);
                 di.Delete(true);
             }
+
             Directory.CreateDirectory(DDataDir);
             var lmdb = ActorOf(LmdbDurableStore.Props(LmdbDefaultConfig));
             lmdb.Tell(LoadAll.Instance);
@@ -70,7 +71,7 @@ namespace Akka.DistributedData.Tests.LightningDb
         }
 
         [Fact]
-        public void Lmdb_logs_meaningful_error_on_invalid_path()
+        public void Lmdb_logs_meaningful_error_for_invalid_dir_path()
         {
             // Try to create a directory with a path exceeding allowed length 
             string invalidName = new string('A', 247);           

--- a/src/contrib/cluster/Akka.DistributedData.Tests/LightningDb/LmdbDurableStoreSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/LightningDb/LmdbDurableStoreSpec.cs
@@ -10,31 +10,32 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.DistributedData.Durable;
 using Akka.DistributedData.LightningDB;
+using Akka.Event;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Akka.DistributedData.Tests.LightningDb
 {
-    public class LmdbDurableStoreSpec
+    [Collection("LmdbDurableStoreSpec")]
+    public class LmdbDurableStoreSpec : Akka.TestKit.Xunit2.TestKit
     {
         private const string DDataDir = "thisdir";
-        private readonly ITestOutputHelper _output;
-        
-        private static readonly Config BaseConfig = ConfigurationFactory.ParseString($@"
-            akka.actor {{
-                provider=""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
-            }}
-            akka.remote.dot-netty.tcp.port = 0
-            akka.cluster.distributed-data.durable.lmdb {{
+        private static readonly Config BaseConfig = ConfigurationFactory.ParseString(@"
+                akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
+                akka.remote.dot-netty.tcp.port = 0")
+            .WithFallback(DistributedData.DefaultConfig())
+            .WithFallback(TestKit.Xunit2.TestKit.DefaultConfig);
+
+        private static readonly Config LmdbDefaultConfig = ConfigurationFactory.ParseString($@"
+            lmdb {{
                 dir = {DDataDir}
                 map-size = 100 MiB
                 write-behind-interval = off
-            }}").WithFallback(DistributedData.DefaultConfig())
-            .WithFallback(TestKit.Xunit2.TestKit.DefaultConfig);
+            }}");
 
-        public LmdbDurableStoreSpec(ITestOutputHelper output)
+        public LmdbDurableStoreSpec(ITestOutputHelper output): base(BaseConfig, "LmdbDurableStoreSpec", output)
         {
-            _output = output;
         }
 
         [Fact]
@@ -46,15 +47,52 @@ namespace Akka.DistributedData.Tests.LightningDb
                 di.Delete(true);
             }
             Directory.CreateDirectory(DDataDir);
+            var lmdb = ActorOf(LmdbDurableStore.Props(LmdbDefaultConfig));
+            lmdb.Tell(LoadAll.Instance);
+            ExpectMsg<LoadAllCompleted>();
+        }
 
-            var testKit = new TestKit.Xunit2.TestKit(BaseConfig, nameof(LmdbDurableStoreSpec), _output);
-            var probe = testKit.CreateTestProbe();
+        [Fact]
+        public void Lmdb_creates_directory_when_handling_first_message()
+        {
+            if (Directory.Exists(DDataDir))
+            {
+                var di = new DirectoryInfo(DDataDir);
+                di.Delete(true);
+            }
 
-            var config = testKit.Sys.Settings.Config.GetConfig("akka.cluster.distributed-data.durable");
-            var lmdb = testKit.Sys.ActorOf(LmdbDurableStore.Props(config));
-            lmdb.Tell(LoadAll.Instance, probe.Ref);
+            Directory.Exists(DDataDir).Should().BeFalse();
+            IActorRef lmdb = ActorOf(LmdbDurableStore.Props(LmdbDefaultConfig));
+            lmdb.Tell(LoadAll.Instance);          
+            AwaitCondition(() => HasMessages);
+            ExpectMsg<LoadAllCompleted>();
+            Directory.Exists(DDataDir).Should().BeTrue();
+        }
 
-            probe.ExpectMsg<LoadAllCompleted>();
+        [Fact]
+        public void Lmdb_logs_meaningful_error_on_invalid_path()
+        {
+            // Try to create a directory with a path exceeding allowed length 
+            string invalidName = new string('A', 247);           
+            Directory.Exists(invalidName).Should().BeFalse();
+            IActorRef lmdb = ActorOf(LmdbDurableStore.Props(ConfigurationFactory.ParseString($@"
+            lmdb {{
+                dir = {invalidName}
+                map-size = 100 MiB
+                write-behind-interval = off
+            }}")));
+
+            //Expect meaningful error log
+            EventFilter.Custom(logEvent => logEvent is Error 
+            && !logEvent.Message.ToString().Contains("Error while creating actor instance of type Akka.DistributedData.LightningDB.LmdbDurableStore")
+            && logEvent.Cause is LoadFailedException 
+            && logEvent.Cause.InnerException != null
+            && logEvent.Cause.InnerException is DirectoryNotFoundException).ExpectOne(() =>
+            {
+                lmdb.Tell(LoadAll.Instance);
+            });
+
+            Directory.Exists(invalidName).Should().BeFalse();
         }
     }
 }

--- a/src/contrib/cluster/Akka.DistributedData.Tests/LightningDb/LmdbDurableStoreSpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/LightningDb/LmdbDurableStoreSpec.cs
@@ -10,14 +10,12 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.DistributedData.Durable;
 using Akka.DistributedData.LightningDB;
-using Akka.Event;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Akka.DistributedData.Tests.LightningDb
 {
-    public class LmdbDurableStoreSpec : Akka.TestKit.Xunit2.TestKit
+    public class LmdbDurableStoreSpec
     {
         private const string DDataDir = "thisdir";
         private readonly ITestOutputHelper _output;
@@ -32,7 +30,7 @@ namespace Akka.DistributedData.Tests.LightningDb
             }}").WithFallback(DistributedData.DefaultConfig())
             .WithFallback(TestKit.Xunit2.TestKit.DefaultConfig);
 
-        public LmdbDurableStoreSpec(ITestOutputHelper output): base(BaseConfig, nameof(LmdbDurableStoreSpec), output)
+        public LmdbDurableStoreSpec(ITestOutputHelper output)
         {
             _output = output;
         }
@@ -45,13 +43,13 @@ namespace Akka.DistributedData.Tests.LightningDb
                 var di = new DirectoryInfo(DDataDir);
                 di.Delete(true);
             }
-
             Directory.CreateDirectory(DDataDir);
             var testKit = new TestKit.Xunit2.TestKit(BaseConfig, nameof(LmdbDurableStoreSpec), _output);
             var probe = testKit.CreateTestProbe();
             var config = testKit.Sys.Settings.Config.GetConfig("akka.cluster.distributed-data.durable");
             var lmdb = testKit.Sys.ActorOf(LmdbDurableStore.Props(config));
             lmdb.Tell(LoadAll.Instance, probe.Ref);
+            
             probe.ExpectMsg<LoadAllCompleted>();
         }
     }


### PR DESCRIPTION
#6816 Akka.DistributedData.LightningDb: move durable folder creation outside of actor constructor in order to preserve stack trace / provide clearer error messages 
Fixes #
* moved folder creation from durable store's constructor to a message handler in LmdbDurableStore.
* added unit test to verify that a new folder is created as a result of a LoadAll message handling.
* added unit test to verify that folder related error messages became clearer in logs.
* derived unit test class LmdbDurableStoreSpec  from Akka.TestKit.Xunit2.TestKit.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
