### PR TITLE
Akka.Serialization: `INoSerializationVerificationNeeded` does not handle `IWrappedMessage` correctly

### DIFF
--- a/src/core/Akka.Tests/Serialization/SerializeAllMessagesSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializeAllMessagesSpec.cs
@@ -1,0 +1,76 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="SerializeAllMessagesSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Tests.Serialization;
+
+public class SerializeAllMessagesSpec : AkkaSpec
+{
+    public SerializeAllMessagesSpec(ITestOutputHelper output) : base("akka.actor.serialize-messages = on", output)
+    {
+    }
+    
+    private class MyMessage : INoSerializationVerificationNeeded
+    {
+        public MyMessage(Action myAction)
+        {
+            MyAction = myAction;
+        }
+
+        // add an unserializable member, such as a delegate
+        public Action MyAction { get; }
+    }
+
+    private class MyWrappedMessage : IWrappedMessage
+    {
+        public MyWrappedMessage(object message)
+        {
+            Message = message;
+        }
+
+        public object Message { get; }
+    }
+    
+    // create an actor that will process a MyWrappedMessage and invoke the delegate
+    private class MyActor : ReceiveActor
+    {
+        public MyActor()
+        {
+            Receive<MyWrappedMessage>(msg =>
+            {
+                var myMessage = (MyMessage) msg.Message;
+                myMessage.MyAction();
+            });
+        }
+    }
+    
+    [Fact]
+    public async Task Should_not_serialize_WrappedMessage_with_INoSerializationVerificationNeeded()
+    {
+        // Arrange
+        var myProbe = CreateTestProbe();
+        var action = () => { myProbe.Tell("worked"); };
+        var message = new MyMessage(action);
+        var wrappedMessage = new MyWrappedMessage(message);
+        
+        var myActor = Sys.ActorOf(Props.Create(() => new MyActor()), "wrapped-message-actor");
+
+        await EventFilter.Error().ExpectAsync(0, async () =>
+        {
+            // Act
+            myActor.Tell(wrappedMessage);
+            await myProbe.ExpectMsgAsync("worked");
+        });
+    }
+}

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -521,7 +521,7 @@ namespace Akka.Actor
             var unwrapped = envelope.Message;
             
             if(envelope.Message is IWrappedMessage wrapped)
-                unwrapped = wrapped.Message;
+                unwrapped = WrappedMessage.Unwrap(wrapped); // recursively unwraps message
 
             // don't do serialization verification if the underlying type doesn't require it
             if (unwrapped is INoSerializationVerificationNeeded)

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -519,10 +519,8 @@ namespace Akka.Actor
         #nullable enable
         private Envelope SerializeAndDeserialize(Envelope envelope)
         {
-            var deadLetter = envelope.Message as DeadLetter;
-            
-            // recursively unwraps message
-            var unwrapped = WrappedMessage.Unwrap(deadLetter is not null ? deadLetter.Message : envelope.Message);
+            // recursively unwraps message, no need to check for DeadLetter because DeadLetter inherits IWrappedMessage
+            var unwrapped = WrappedMessage.Unwrap(envelope.Message);
             
             // don't do serialization verification if the underlying type doesn't require it
             if (unwrapped is INoSerializationVerificationNeeded)
@@ -539,7 +537,7 @@ namespace Akka.Actor
             }
 
             // special case handling for DeadLetters
-            return deadLetter is not null 
+            return envelope.Message is DeadLetter deadLetter 
                 ? new Envelope(new DeadLetter(deserializedMsg, deadLetter.Sender, deadLetter.Recipient), envelope.Sender) 
                 : new Envelope(deserializedMsg, envelope.Sender);
         }

--- a/src/core/Akka/Actor/BuiltInActors.cs
+++ b/src/core/Akka/Actor/BuiltInActors.cs
@@ -191,8 +191,10 @@ namespace Akka.Actor
     {
         public static object Unwrap(object message)
         {
-            if (message is IWrappedMessage wm)
-                return Unwrap(wm.Message);
+            while (message is IWrappedMessage wm)
+            {
+                message = wm.Message;
+            }
             return message;
         }
     }


### PR DESCRIPTION
## Changes

`INoSerializationVerificationNeeded` does not handle `IWrappedMessage` correctly. We handle `DeadLetter` correctly as a special case, but not any of the other `IWrappedMessage` implementations. We should handle this generically.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
