### PR TITLE
`build.fsx`: change test targets from `net7.0` to `net8.0`

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -28,7 +28,7 @@ let outputMultiNode = outputTests @@ "multinode"
 let outputFailedMultiNode = outputTests @@ "multinode" @@ "FAILED_SPECS_LOGS"
 let outputBinariesNet45 = outputBinaries @@ "net45"
 let outputBinariesNetStandard = outputBinaries @@ "netstandard2.0"
-let outputBinariesNet = outputBinaries @@ "net7.0"
+let outputBinariesNet = outputBinaries @@ "net8.0"
 
 let buildNumber = environVarOrDefault "BUILD_NUMBER" "0"
 let hasTeamCity = (not (buildNumber = "0")) // check if we have the TeamCity environment variable for build # set
@@ -56,7 +56,7 @@ let incrementalistReport = output @@ "incrementalist.txt"
 
 // Configuration values for tests
 let testNetFrameworkVersion = "net471"
-let testNetVersion = "net7.0"
+let testNetVersion = "net8.0"
 
 Target "Clean" (fun _ ->
     ActivateFinalTarget "KillCreatedProcesses"


### PR DESCRIPTION
## Changes

Build system was still trying to run tests against .NET 7, even though all of them now target .NET 8.