### PR TITLE
WIP: resolve .NET 8 test target issues

### DIFF
--- a/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/HyperionConfigTests.cs
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/HyperionConfigTests.cs
@@ -210,7 +210,7 @@ namespace Akka.Serialization.Hyperion.Tests
 #elif NETCOREAPP3_1
                 Assert.Equal("dff", @override("def"));
                 Assert.Equal("efg", @override("efg"));
-#elif NET7_0
+#elif NET6_0_OR_GREATER
                 Assert.Equal("gii", @override("ghi"));
                 Assert.Equal("hij", @override("hij"));
 #else


### PR DESCRIPTION
Have some tests that are not passing due to .NET 8 SDK upgrades in the test suite. Using this issue to work through those.