### PR TITLE
DData Serializer Benches

### DIFF
--- a/src/benchmark/Akka.Benchmarks/DData/RDDBenchTypes.cs
+++ b/src/benchmark/Akka.Benchmarks/DData/RDDBenchTypes.cs
@@ -1,0 +1,16 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="RDDBenchTypes.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+namespace Akka.Benchmarks.DData;
+
+public class RDDBenchTypes
+{
+        
+    public record struct TestKey(int i);
+
+    public record TestVal(string v);
+}

--- a/src/benchmark/Akka.Benchmarks/DData/SerializerLwwDictionaryBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/DData/SerializerLwwDictionaryBenchmarks.cs
@@ -1,0 +1,140 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="RDLwwDictionaryBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster;
+using Akka.Configuration;
+using Akka.DistributedData;
+using Akka.DistributedData.Serialization;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.DData;
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class SerializerLwwDictionaryBenchmarks
+{
+    [Params(typeof(RDDBenchTypes.TestKey), typeof(RDDBenchTypes.TestVal))]
+    public Type KeyType;
+
+    [Params(typeof(RDDBenchTypes.TestKey), typeof(RDDBenchTypes.TestVal))]
+    public Type ValueType;
+    
+    [Params(25)] 
+    public int NumElements;
+
+    [Params(10)]
+    public int NumNodes;
+
+    private UniqueAddress[] _nodes;
+    private object _c1;
+    private ActorSystem sys;
+    private ReplicatedDataSerializer ser;
+    private byte[] _c1Ser;
+    private string _c1Manifest;
+
+    [GlobalSetup]
+    public void SetupSystem()
+    {
+        typeof(SerializerLwwDictionaryBenchmarks).GetMethod(
+                nameof(SerializerLwwDictionaryBenchmarks.CreateItems),
+                BindingFlags.Instance | BindingFlags.NonPublic)
+            .MakeGenericMethod(new []{KeyType,ValueType})
+            .Invoke(this, new object[]{});
+        var conf = ConfigurationFactory.ParseString(@"akka.actor {
+  serializers {
+    akka-replicated-data = ""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData""
+  }
+  serialization-bindings {
+    ""Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData"" = akka-replicated-data
+  }
+  serialization-identifiers {
+	""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData"" = 11
+  }
+}");
+        sys = ActorSystem.Create("rddsb", conf);
+        ser = (ReplicatedDataSerializer)sys.Serialization.FindSerializerForType(
+            typeof(IReplicatedDataSerialization));
+        _c1Ser = ser.ToBinary(_c1);
+        _c1Manifest = ser.Manifest(_c1);
+    }
+
+    private void CreateItems<TKey,TValue>()
+    {
+        var newNodes = new List<UniqueAddress>(NumNodes);
+        foreach (var i in Enumerable.Range(0, NumNodes))
+        {
+            var address = new Address("akka.tcp", "Sys", "localhost", 2552 + i);
+            var uniqueAddress = new UniqueAddress(address, i);
+            newNodes.Add(uniqueAddress);
+        }
+
+        _nodes = newNodes.ToArray();
+        var newElements = new List<TValue>(NumNodes);
+        foreach (var i in Enumerable.Range(0, NumElements))
+        {
+            
+                newElements.Add(generate<TValue>(i));
+        }
+
+        var _c1 = LWWDictionary<TKey, List<TValue>>
+            .Empty;
+        int j = 0;
+        foreach (var node in _nodes)
+        {
+            _c1 = _c1.SetItem(node, generate<TKey>(j),
+                newElements);
+            j++;
+        }
+
+        this._c1 = _c1;
+    }
+
+    private TValue generate<TValue>(int i)
+    {
+        if (typeof(TValue) == typeof(RDDBenchTypes.TestVal))
+        {
+            return (TValue)(object)new RDDBenchTypes.TestVal(i.ToString());
+        }
+        else if (typeof(TValue) == typeof(RDDBenchTypes.TestKey))
+        {
+            return (TValue)(object)new RDDBenchTypes.TestKey(i);
+        }
+        else if (typeof(TValue) == typeof(int))
+        {
+            return (TValue)(object)i;
+        }
+        else if (typeof(TValue) == typeof(string))
+        {
+            return (TValue)(object)i.ToString();
+        }
+        else if (typeof(TValue) == typeof(long))
+        {
+            return (TValue)(object)(i);
+        }
+        else
+        {
+            return (TValue)(object)(i);
+        }
+    }
+
+    [Benchmark]
+    public void Serialize_LWWDict()
+    {
+        ser.ToBinary(_c1);
+    }
+
+    [Benchmark]
+    public void Deserialize_LWWDict()
+    {
+        ser.FromBinary(_c1Ser, _c1Manifest);
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/DData/SerializerORDictionaryBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/DData/SerializerORDictionaryBenchmarks.cs
@@ -1,0 +1,90 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="SerializerORDictionaryBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster;
+using Akka.Configuration;
+using Akka.DistributedData;
+using Akka.DistributedData.Serialization;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.DData;
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class SerializerORDictionaryBenchmarks
+{
+    [Params(25)] 
+    public int NumElements;
+
+    [Params(10)]
+    public int NumNodes;
+
+    private UniqueAddress[] _nodes;
+    private ORDictionary<RDDBenchTypes.TestKey,ORSet<RDDBenchTypes.TestVal>> _c1;
+    private ORSet<RDDBenchTypes.TestVal> _elements;
+    private ActorSystem sys;
+    private ReplicatedDataSerializer ser;
+    private byte[] _c1Ser;
+    private string _c1Manifest;
+
+    [GlobalSetup]
+    public void SetupSystem()
+    {
+        var newNodes = new List<UniqueAddress>(NumNodes);
+        foreach(var i in Enumerable.Range(0, NumNodes)){
+            var address = new Address("akka.tcp", "Sys", "localhost", 2552 + i);
+            var uniqueAddress = new UniqueAddress(address, i);
+            newNodes.Add(uniqueAddress);
+        }
+        _nodes = newNodes.ToArray();
+        var newElements = ORSet<RDDBenchTypes.TestVal>.Empty;
+        foreach(var i in Enumerable.Range(0, NumElements)){
+            newElements = newElements.Add(_nodes[0],new RDDBenchTypes.TestVal(i.ToString()));
+        }
+        _elements = newElements;
+
+        _c1 = ORDictionary<RDDBenchTypes.TestKey, ORSet<RDDBenchTypes.TestVal>>
+            .Empty;
+        int j = 0;
+        foreach(var node in _nodes)
+        {
+            _c1 = _c1.SetItem(node, new RDDBenchTypes.TestKey(j), _elements);
+            j++;
+        }
+        var conf = ConfigurationFactory.ParseString(@"akka.actor {
+  serializers {
+    akka-replicated-data = ""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData""
+  }
+  serialization-bindings {
+    ""Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData"" = akka-replicated-data
+  }
+  serialization-identifiers {
+	""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData"" = 11
+  }
+}");
+        sys = ActorSystem.Create("rddsb", conf);
+        ser = (ReplicatedDataSerializer)sys.Serialization.FindSerializerForType(
+            typeof(IReplicatedDataSerialization));
+        _c1Ser = ser.ToBinary(_c1);
+        _c1Manifest = ser.Manifest(_c1);
+    }
+        
+    [Benchmark]
+    public void Serialize_ORDictionary()
+    {
+        ser.ToBinary(_c1);
+    }
+
+    [Benchmark]
+    public void Deserialize_ORDictionary()
+    {
+        ser.FromBinary(_c1Ser, _c1Manifest);
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/DData/SerializerORSetBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/DData/SerializerORSetBenchmarks.cs
@@ -1,0 +1,90 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="SerializerORSetBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster;
+using Akka.Configuration;
+using Akka.DistributedData;
+using Akka.DistributedData.Serialization;
+using Akka.Serialization;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.DData;
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class SerializerORSetBenchmarks
+{
+    [Params(25)] 
+    public int NumElements;
+
+    [Params(10)]
+    public int NumNodes;
+        
+    private ActorSystem sys;
+    private ReplicatedDataSerializer ser;
+    private UniqueAddress[] _nodes;
+    private RDDBenchTypes.TestVal[] _elements;
+    private ORSet<List<RDDBenchTypes.TestVal>> _c1;
+    private byte[] _c1Ser;
+    private string _c1Manifest;
+
+    [GlobalSetup]
+    public void SetupSystem()
+    {
+        var newNodes = new List<UniqueAddress>(NumNodes);
+        foreach(var i in Enumerable.Range(0, NumNodes)){
+            var address = new Address("akka.tcp", "Sys", "localhost", 2552 + i);
+            var uniqueAddress = new UniqueAddress(address, i);
+            newNodes.Add(uniqueAddress);
+        }
+        _nodes = newNodes.ToArray();
+        var newElements = new List<RDDBenchTypes.TestVal>(NumNodes);
+        foreach(var i in Enumerable.Range(0, NumElements)){
+            newElements.Add(new RDDBenchTypes.TestVal(i.ToString()));
+        }
+        _elements = newElements.ToArray();
+
+        _c1 = ORSet<List<RDDBenchTypes.TestVal>>.Empty;
+        foreach(var node in _nodes){
+            _c1 = _c1.Add(node, _elements.ToList());
+        }
+
+        var conf = ConfigurationFactory.ParseString(@"akka.actor {
+  serializers {
+    akka-replicated-data = ""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData""
+  }
+  serialization-bindings {
+    ""Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData"" = akka-replicated-data
+  }
+  serialization-identifiers {
+	""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData"" = 11
+  }
+}");
+        sys = ActorSystem.Create("rddsb", conf);
+        ser = (ReplicatedDataSerializer)sys.Serialization.FindSerializerForType(
+            typeof(IReplicatedDataSerialization));
+        _c1Ser = ser.ToBinary(_c1);
+        _c1Manifest = ser.Manifest(_c1);
+    }
+    [Benchmark]
+    public void Serialize_ORSet()
+    {
+        ser.ToBinary(_c1);
+    }
+
+    [Benchmark]
+    public void Deserialize_ORSet()
+    {
+        ser.FromBinary(_c1Ser, _c1Manifest);
+    }
+
+}


### PR DESCRIPTION
Fixes #

## Changes

Add Replicated Data Serializer Benchmarks for LWWDictionary, ORSet, and ORDictionary.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

Since these are new benchmarks, these will provide baselines after merge (I can run and do so as needed)

### This PR's Benchmarks

See above.
