### PR TITLE
WIP: Ddata serialization opts

### DIFF
--- a/src/benchmark/Akka.Benchmarks/DData/ORSetBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/DData/ORSetBenchmarks.cs
@@ -13,7 +13,9 @@ using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using Akka.Cluster;
 using Akka.DistributedData;
+using Akka.DistributedData.Serialization;
 using BenchmarkDotNet.Attributes;
+using static Akka.Benchmarks.DData.RDDBenchTypes;
 
 namespace Akka.Benchmarks.DData
 {

--- a/src/benchmark/Akka.Benchmarks/DData/RDDBenchTypes.cs
+++ b/src/benchmark/Akka.Benchmarks/DData/RDDBenchTypes.cs
@@ -1,0 +1,16 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="RDDBenchTypes.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+namespace Akka.Benchmarks.DData;
+
+public class RDDBenchTypes
+{
+        
+    public record struct TestKey(int i);
+
+    public record TestVal(string v);
+}

--- a/src/benchmark/Akka.Benchmarks/DData/SerializerLwwDictionaryBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/DData/SerializerLwwDictionaryBenchmarks.cs
@@ -1,0 +1,140 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="RDLwwDictionaryBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster;
+using Akka.Configuration;
+using Akka.DistributedData;
+using Akka.DistributedData.Serialization;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.DData;
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class SerializerLwwDictionaryBenchmarks
+{
+    [Params(typeof(RDDBenchTypes.TestKey), typeof(RDDBenchTypes.TestVal))]
+    public Type KeyType;
+
+    [Params(typeof(RDDBenchTypes.TestKey), typeof(RDDBenchTypes.TestVal))]
+    public Type ValueType;
+    
+    [Params(25)] 
+    public int NumElements;
+
+    [Params(10)]
+    public int NumNodes;
+
+    private UniqueAddress[] _nodes;
+    private object _c1;
+    private ActorSystem sys;
+    private ReplicatedDataSerializer ser;
+    private byte[] _c1Ser;
+    private string _c1Manifest;
+
+    [GlobalSetup]
+    public void SetupSystem()
+    {
+        typeof(SerializerLwwDictionaryBenchmarks).GetMethod(
+                nameof(SerializerLwwDictionaryBenchmarks.CreateItems),
+                BindingFlags.Instance | BindingFlags.NonPublic)
+            .MakeGenericMethod(new []{KeyType,ValueType})
+            .Invoke(this, new object[]{});
+        var conf = ConfigurationFactory.ParseString(@"akka.actor {
+  serializers {
+    akka-replicated-data = ""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData""
+  }
+  serialization-bindings {
+    ""Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData"" = akka-replicated-data
+  }
+  serialization-identifiers {
+	""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData"" = 11
+  }
+}");
+        sys = ActorSystem.Create("rddsb", conf);
+        ser = (ReplicatedDataSerializer)sys.Serialization.FindSerializerForType(
+            typeof(IReplicatedDataSerialization));
+        _c1Ser = ser.ToBinary(_c1);
+        _c1Manifest = ser.Manifest(_c1);
+    }
+
+    private void CreateItems<TKey,TValue>()
+    {
+        var newNodes = new List<UniqueAddress>(NumNodes);
+        foreach (var i in Enumerable.Range(0, NumNodes))
+        {
+            var address = new Address("akka.tcp", "Sys", "localhost", 2552 + i);
+            var uniqueAddress = new UniqueAddress(address, i);
+            newNodes.Add(uniqueAddress);
+        }
+
+        _nodes = newNodes.ToArray();
+        var newElements = new List<TValue>(NumNodes);
+        foreach (var i in Enumerable.Range(0, NumElements))
+        {
+            
+                newElements.Add(generate<TValue>(i));
+        }
+
+        var _c1 = LWWDictionary<TKey, List<TValue>>
+            .Empty;
+        int j = 0;
+        foreach (var node in _nodes)
+        {
+            _c1 = _c1.SetItem(node, generate<TKey>(j),
+                newElements);
+            j++;
+        }
+
+        this._c1 = _c1;
+    }
+
+    private TValue generate<TValue>(int i)
+    {
+        if (typeof(TValue) == typeof(RDDBenchTypes.TestVal))
+        {
+            return (TValue)(object)new RDDBenchTypes.TestVal(i.ToString());
+        }
+        else if (typeof(TValue) == typeof(RDDBenchTypes.TestKey))
+        {
+            return (TValue)(object)new RDDBenchTypes.TestKey(i);
+        }
+        else if (typeof(TValue) == typeof(int))
+        {
+            return (TValue)(object)i;
+        }
+        else if (typeof(TValue) == typeof(string))
+        {
+            return (TValue)(object)i.ToString();
+        }
+        else if (typeof(TValue) == typeof(long))
+        {
+            return (TValue)(object)(i);
+        }
+        else
+        {
+            return (TValue)(object)(i);
+        }
+    }
+
+    [Benchmark]
+    public void Serialize_LWWDict()
+    {
+        ser.ToBinary(_c1);
+    }
+
+    [Benchmark]
+    public void Deserialize_LWWDict()
+    {
+        ser.FromBinary(_c1Ser, _c1Manifest);
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/DData/SerializerORDictionaryBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/DData/SerializerORDictionaryBenchmarks.cs
@@ -1,0 +1,90 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="SerializerORDictionaryBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster;
+using Akka.Configuration;
+using Akka.DistributedData;
+using Akka.DistributedData.Serialization;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.DData;
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class SerializerORDictionaryBenchmarks
+{
+    [Params(25)] 
+    public int NumElements;
+
+    [Params(10)]
+    public int NumNodes;
+
+    private UniqueAddress[] _nodes;
+    private ORDictionary<RDDBenchTypes.TestKey,ORSet<RDDBenchTypes.TestVal>> _c1;
+    private ORSet<RDDBenchTypes.TestVal> _elements;
+    private ActorSystem sys;
+    private ReplicatedDataSerializer ser;
+    private byte[] _c1Ser;
+    private string _c1Manifest;
+
+    [GlobalSetup]
+    public void SetupSystem()
+    {
+        var newNodes = new List<UniqueAddress>(NumNodes);
+        foreach(var i in Enumerable.Range(0, NumNodes)){
+            var address = new Address("akka.tcp", "Sys", "localhost", 2552 + i);
+            var uniqueAddress = new UniqueAddress(address, i);
+            newNodes.Add(uniqueAddress);
+        }
+        _nodes = newNodes.ToArray();
+        var newElements = ORSet<RDDBenchTypes.TestVal>.Empty;
+        foreach(var i in Enumerable.Range(0, NumElements)){
+            newElements = newElements.Add(_nodes[0],new RDDBenchTypes.TestVal(i.ToString()));
+        }
+        _elements = newElements;
+
+        _c1 = ORDictionary<RDDBenchTypes.TestKey, ORSet<RDDBenchTypes.TestVal>>
+            .Empty;
+        int j = 0;
+        foreach(var node in _nodes)
+        {
+            _c1 = _c1.SetItem(node, new RDDBenchTypes.TestKey(j), _elements);
+            j++;
+        }
+        var conf = ConfigurationFactory.ParseString(@"akka.actor {
+  serializers {
+    akka-replicated-data = ""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData""
+  }
+  serialization-bindings {
+    ""Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData"" = akka-replicated-data
+  }
+  serialization-identifiers {
+	""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData"" = 11
+  }
+}");
+        sys = ActorSystem.Create("rddsb", conf);
+        ser = (ReplicatedDataSerializer)sys.Serialization.FindSerializerForType(
+            typeof(IReplicatedDataSerialization));
+        _c1Ser = ser.ToBinary(_c1);
+        _c1Manifest = ser.Manifest(_c1);
+    }
+        
+    [Benchmark]
+    public void Serialize_ORDictionary()
+    {
+        ser.ToBinary(_c1);
+    }
+
+    [Benchmark]
+    public void Deserialize_ORDictionary()
+    {
+        ser.FromBinary(_c1Ser, _c1Manifest);
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/DData/SerializerORSetBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/DData/SerializerORSetBenchmarks.cs
@@ -1,0 +1,90 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="SerializerORSetBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster;
+using Akka.Configuration;
+using Akka.DistributedData;
+using Akka.DistributedData.Serialization;
+using Akka.Serialization;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.DData;
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class SerializerORSetBenchmarks
+{
+    [Params(25)] 
+    public int NumElements;
+
+    [Params(10)]
+    public int NumNodes;
+        
+    private ActorSystem sys;
+    private ReplicatedDataSerializer ser;
+    private UniqueAddress[] _nodes;
+    private RDDBenchTypes.TestVal[] _elements;
+    private ORSet<List<RDDBenchTypes.TestVal>> _c1;
+    private byte[] _c1Ser;
+    private string _c1Manifest;
+
+    [GlobalSetup]
+    public void SetupSystem()
+    {
+        var newNodes = new List<UniqueAddress>(NumNodes);
+        foreach(var i in Enumerable.Range(0, NumNodes)){
+            var address = new Address("akka.tcp", "Sys", "localhost", 2552 + i);
+            var uniqueAddress = new UniqueAddress(address, i);
+            newNodes.Add(uniqueAddress);
+        }
+        _nodes = newNodes.ToArray();
+        var newElements = new List<RDDBenchTypes.TestVal>(NumNodes);
+        foreach(var i in Enumerable.Range(0, NumElements)){
+            newElements.Add(new RDDBenchTypes.TestVal(i.ToString()));
+        }
+        _elements = newElements.ToArray();
+
+        _c1 = ORSet<List<RDDBenchTypes.TestVal>>.Empty;
+        foreach(var node in _nodes){
+            _c1 = _c1.Add(node, _elements.ToList());
+        }
+
+        var conf = ConfigurationFactory.ParseString(@"akka.actor {
+  serializers {
+    akka-replicated-data = ""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData""
+  }
+  serialization-bindings {
+    ""Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData"" = akka-replicated-data
+  }
+  serialization-identifiers {
+	""Akka.DistributedData.Serialization.ReplicatedDataSerializer, Akka.DistributedData"" = 11
+  }
+}");
+        sys = ActorSystem.Create("rddsb", conf);
+        ser = (ReplicatedDataSerializer)sys.Serialization.FindSerializerForType(
+            typeof(IReplicatedDataSerialization));
+        _c1Ser = ser.ToBinary(_c1);
+        _c1Manifest = ser.Manifest(_c1);
+    }
+    [Benchmark]
+    public void Serialize_ORSet()
+    {
+        ser.ToBinary(_c1);
+    }
+
+    [Benchmark]
+    public void Deserialize_ORSet()
+    {
+        ser.FromBinary(_c1Ser, _c1Manifest);
+    }
+
+}

--- a/src/benchmark/Akka.Benchmarks/Program.cs
+++ b/src/benchmark/Akka.Benchmarks/Program.cs
@@ -5,7 +5,10 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Reflection;
+using System.Threading;
+using Akka.Benchmarks.DData;
 using BenchmarkDotNet.Running;
 
 namespace Akka.Benchmarks
@@ -14,6 +17,15 @@ namespace Akka.Benchmarks
     {
         static void Main(string[] args)
         {
+            //var w = new SerializerORDictionaryBenchmarks();
+            //w.NumElements = 25;
+            //w.NumNodes = 30;
+            //w.SetupSystem();
+            //Console.WriteLine("Running");
+            //while (true)
+            //{
+            //    w.Serialize_ORDictionary();
+            //}
             BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Tools/Akka.Cluster.Tools.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Akka.Cluster.Tools.csproj
@@ -13,5 +13,4 @@
         <ProjectReference Include="..\..\..\core\Akka.Cluster\Akka.Cluster.csproj"/>
         <ProjectReference Include="..\..\..\core\Akka.Coordination\Akka.Coordination.csproj"/>
     </ItemGroup>
-
 </Project>

--- a/src/contrib/cluster/Akka.Cluster.Tools/Akka.Cluster.Tools.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Akka.Cluster.Tools.csproj
@@ -13,4 +13,9 @@
         <ProjectReference Include="..\..\..\core\Akka.Cluster\Akka.Cluster.csproj"/>
         <ProjectReference Include="..\..\..\core\Akka.Coordination\Akka.Coordination.csproj"/>
     </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
+    </ItemGroup>
+
 </Project>

--- a/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
+++ b/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
         <PackageReference Include="Hyperion" Version="$(HyperionVersion)"/>
     </ItemGroup>
 

--- a/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
+++ b/src/contrib/cluster/Akka.DistributedData/Akka.DistributedData.csproj
@@ -16,6 +16,7 @@
     <ItemGroup>
         <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
         <PackageReference Include="Hyperion" Version="$(HyperionVersion)"/>
+        <PackageReference Include="NonBlocking" Version="2.1.2" />
     </ItemGroup>
 
 </Project>

--- a/src/contrib/cluster/Akka.DistributedData/Serialization/OtherMessageComparer.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Serialization/OtherMessageComparer.cs
@@ -12,6 +12,15 @@ using Akka.DistributedData.Serialization.Proto.Msg;
 
 namespace Akka.DistributedData.Serialization
 {
+    internal class OtherMessageAndVersionComparer : IComparer<
+        ValueTuple<OtherMessage, Proto.Msg.VersionVector>>
+    {
+        public static OtherMessageAndVersionComparer Instance { get; } = new();
+        public int Compare(ValueTuple<OtherMessage, Proto.Msg.VersionVector> x, ValueTuple<OtherMessage, Proto.Msg.VersionVector> y)
+        {
+            return OtherMessageComparer.Instance.Compare(x.Item1, y.Item1);
+        }
+    }
     internal class OtherMessageComparer : IComparer<OtherMessage>
     {
         public static OtherMessageComparer Instance { get; } = new();
@@ -32,15 +41,36 @@ namespace Akka.DistributedData.Serialization
             if (aSize < bSize) return -1;
             if (aSize > bSize) return 1;
 
-            for (var i = 0; i < aSize; i++)
-            {
-                var aByte = aByteString[i];
-                var bByte = bByteString[i];
-                if (aByte < bByte) return -1;
-                if (aByte > bByte) return 1;
-            }
+            //int j = 0;
+            return aByteString.SequenceCompareTo(bByteString); 
+            //while (j + 4 < aSize)
+            //{
+            //    if (aByteString.Slice(j, 4)
+            //            .SequenceEqual(bByteString.Slice(j, 4)) == false)
+            //    {
+            //        break;
+            //    }
+            //    else
+            //    {
+            //        j = j + 4;
+            //    }
+            //}
+            //for (; j < aSize; j++)
+            //{
+            //    var aByte = aByteString[j];
+            //    var bByte = bByteString[j];
+            //    if (aByte < bByte) return -1;
+            //    if (aByte > bByte) return 1;
+            //}
+            //for (var i = 0; i < aSize; i++)
+            //{
+            //    var aByte = aByteString[i];
+            //    var bByte = bByteString[i];
+            //    if (aByte < bByte) return -1;
+            //    if (aByte > bByte) return 1;
+            //}
 
-            return 0;
+            //return 0;
         }
     }
 }

--- a/src/contrib/cluster/Akka.DistributedData/Serialization/ReplicatedDataSerializer.GenericCache.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Serialization/ReplicatedDataSerializer.GenericCache.cs
@@ -1,0 +1,822 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="ReplicatedDataSerializer.GenericCache.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2023 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+using Akka.DistributedData.Serialization.Proto.Msg;
+using Google.Protobuf.Collections;
+
+namespace Akka.DistributedData.Serialization;
+
+public sealed partial class ReplicatedDataSerializer
+{
+    private sealed class LazyPool<T>
+    {
+        private readonly ConcurrentQueue<T> _poolItems = new();
+        private int _numItems = new();
+        private readonly int _maxItems;
+        public LazyPool(int maxItems)
+        {
+            _maxItems = maxItems;
+        }
+
+        public bool TryGetValue(out T value)
+        {
+            if (_numItems > 0)
+            {
+                if (Interlocked.Decrement(ref _numItems) < 0)
+                {
+                    Interlocked.Increment(ref _numItems);
+                }
+                else
+                {
+                    return _poolItems.TryDequeue(out value);
+                }
+            }
+            value = default;
+            return false;
+        }
+
+        public bool TryReturn(T value)
+        {
+            if (_numItems < _maxItems)
+            {
+                if (Interlocked.Increment(ref _numItems) < (_maxItems * 2))
+                {
+                    _poolItems.Enqueue(value);
+                    return true;
+                }
+                else
+                {
+                    Interlocked.Decrement(ref _numItems);
+                }
+            }
+
+            return false;
+        }
+    }
+    private static class SerDeserGenericCache
+    {
+        private readonly struct TwoTypeLookup : IEquatable<TwoTypeLookup>
+        {
+            public readonly Type Item1;
+            public readonly Type Item2;
+
+            public TwoTypeLookup(Type item1, Type item2)
+            {
+                Item1 = item1;
+                Item2 = item2;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is TwoTypeLookup other && Equals(other);
+            }
+
+            public bool Equals(TwoTypeLookup other)
+            {
+                return Item1 == other.Item1 && Item2 == other.Item2;
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (Item1.GetHashCode() * 397) ^ Item2.GetHashCode();
+                }
+            }
+
+            public static bool operator ==(TwoTypeLookup left, TwoTypeLookup right)
+            {
+                return left.Equals(right);
+            }
+
+            public static bool operator !=(TwoTypeLookup left, TwoTypeLookup right)
+            {
+                return !left.Equals(right);
+            }
+        }
+        private static readonly ConcurrentDictionary<Type,
+                Func<ReplicatedDataSerializer,Proto.Msg.ORSet, VersionVector, IORSet>>
+            toGenericOrSetCache = new();
+
+        public static IORSet ToGenericORSet(Type k,
+            ReplicatedDataSerializer serializer,
+            Proto.Msg.ORSet set, 
+            VersionVector versionVectors)
+        {
+            if (toGenericOrSetCache.TryGetValue(k,
+                    out var value) ==
+                false)
+            {
+                value = toGenericOrSetCache.GetOrAdd(k,
+                    static kc =>
+                        MakeInstanceCallOneGenericTwoArgs<
+                                Proto.Msg.ORSet, VersionVector, IORSet>(
+                                ORSetMaker, kc,true)
+                            .Compile());
+            }
+
+            return value(serializer, set, versionVectors);
+        }
+
+        private static readonly ConcurrentDictionary<Type,
+                Func<ReplicatedDataSerializer, IORSet, Proto.Msg.ORSet,
+                    Proto.Msg.ORSet>>
+            orSetUnknownToProto = new();
+
+        public static Proto.Msg.ORSet ORSetUnknownToProto(Type k,
+            ReplicatedDataSerializer serializer,
+            IORSet set, Proto.Msg.ORSet b)
+        {
+            
+               var value = orSetUnknownToProto.GetOrAdd(k,
+                    static kc =>
+                        MakeInstanceCallOneGenericTwoArgs<
+                                IORSet, Proto.Msg.ORSet, Proto.Msg.ORSet>(
+                                ORSetUnknownMaker, kc)
+                            .Compile());
+            return value(serializer, set, b);
+        }
+
+        private static readonly ConcurrentDictionary<Type,
+                Func<ImmutableArray<IReplicatedData>,
+                    ORSet.IDeltaGroupOperation>>
+            orDeltaGroupCtorCache = new();
+
+        public static ORSet.IDeltaGroupOperation CreateDeltaGroup(Type t,
+            ImmutableArray<IReplicatedData> arr)
+        {
+            if (orDeltaGroupCtorCache.TryGetValue(t, out var value) == false)
+            {
+                value = orDeltaGroupCtorCache.GetOrAdd(t, static ct =>
+                {
+                    return MakeConstructorExprForTypeWith1GenericsOneString<
+                        ImmutableArray<IReplicatedData>,
+                        ORSet.IDeltaGroupOperation>(
+                        typeof(ORSet<>.DeltaGroup), ct).Compile();
+                });
+            }
+
+            return value(arr);
+        }
+
+        private static readonly ConcurrentDictionary<Type,
+                Func<ReplicatedDataSerializer, IGSet, Proto.Msg.GSet>>
+            gSetToProtoCache = new();
+
+        public static Proto.Msg.GSet GSetToProto(Type k,
+            ReplicatedDataSerializer serializer,
+            IGSet operation)
+        {
+                var value = gSetToProtoCache.GetOrAdd(k,
+                    static kc =>
+                        MakeInstanceCallOneGenericOneArg<
+                                IGSet, Proto.Msg.GSet>(
+                                GSetUnknownToProtoMaker, kc)
+                            .Compile());
+
+            return value(serializer, operation);
+        }
+
+        private static readonly ConcurrentDictionary<Type,
+                Func<ReplicatedDataSerializer,RepeatedField<OtherMessage>, IGSet>>
+            toGenericGSetCache = new();
+
+        public static IGSet ToGenericGSet(Type k,
+            ReplicatedDataSerializer serializer,
+            RepeatedField<OtherMessage> operation)
+        {
+                var value = toGenericGSetCache.GetOrAdd(k,
+                    static kc =>
+                       MakeInstanceCallOneGenericOneArg<RepeatedField<OtherMessage>, IGSet>(
+                                GSetMaker, kc, true)
+                            .Compile());
+
+            return value(serializer,operation);
+        }
+
+        private static readonly ConcurrentDictionary<Type,
+                Func<ReplicatedDataSerializer, ILWWRegister,
+                    Proto.Msg.LWWRegister>>
+            genericLwwRegisterToProtoCache = new();
+
+        public static Proto.Msg.LWWRegister GenericLwwRegisterToProto(Type k,
+            ReplicatedDataSerializer serializer,
+            ILWWRegister operation)
+        {
+                var value = genericLwwRegisterToProtoCache.GetOrAdd(k,
+                    static kc =>
+                        MakeInstanceCallOneGenericOneArg<
+                                ILWWRegister, Proto.Msg.LWWRegister>(
+                                LWWProtoMaker, kc)
+                            .Compile());
+
+            return value(serializer, operation);
+        }
+
+        private static readonly ConcurrentDictionary<Type,
+                Func<ReplicatedDataSerializer, Proto.Msg.LWWRegister,
+                    ILWWRegister>>
+            genericLwwRegisterFromProtoCache = new();
+
+        public static ILWWRegister GenericLwwRegisterFromProto(Type k,
+            ReplicatedDataSerializer serializer,
+            Proto.Msg.LWWRegister operation)
+        {
+            var value = genericLwwRegisterFromProtoCache.GetOrAdd(k,
+                static kc =>
+                    MakeInstanceCallOneGenericOneArg<
+                            Proto.Msg.LWWRegister, ILWWRegister>(
+                            LWWRegisterMaker, kc, true)
+                        .Compile());
+
+
+            return value(serializer, operation);
+        }
+
+        private static readonly ConcurrentDictionary<TwoTypeLookup,
+                Func<ReplicatedDataSerializer, IORDictionary, Proto.Msg.ORMap>>
+            orDictionaryToProtoCache = new();
+
+        public static Proto.Msg.ORMap ORDictionaryToProto(Type k, Type v,
+            ReplicatedDataSerializer serializer,
+            IORDictionary operation)
+        {
+            
+                var value = orDictionaryToProtoCache.GetOrAdd(new(k, v),
+                    static kc =>
+                        MakeInstanceCallTwoGenericsOneArg<
+                                IORDictionary, Proto.Msg.ORMap>(
+                                ORDictProtoMaker, kc.Item1, kc.Item2)
+                            .Compile());
+            
+
+            return value(serializer, operation);
+        }
+
+        private static readonly ConcurrentDictionary<TwoTypeLookup,
+                Func<ReplicatedDataSerializer, Proto.Msg.ORMap, IORDictionary>>
+            orDictionaryFromProtoCache = new();
+
+        public static IORDictionary ORDictionaryFromProto(Type k, Type v,
+            ReplicatedDataSerializer serializer,
+            Proto.Msg.ORMap operation)
+        {
+                var value = orDictionaryFromProtoCache.GetOrAdd(new(k, v),
+                    static kc =>
+                        MakeInstanceCallTwoGenericsOneArg<
+                                Proto.Msg.ORMap, IORDictionary>(
+                                ORDictMaker, kc.Item1, kc.Item2)
+                            .Compile());
+            
+
+            return value(serializer, operation);
+        }
+
+        private static readonly ConcurrentDictionary<TwoTypeLookup,
+                Func<ReplicatedDataSerializer,
+                    List<ORDictionary.IDeltaOperation>,
+                    Proto.Msg.ORMapDeltaGroup>>
+            orDictionaryDeltasToProtoCache = new();
+
+        private static readonly ConcurrentDictionary<TwoTypeLookup,
+                Func<ReplicatedDataSerializer, Proto.Msg.ORMapDeltaGroup,
+                    ORDictionary.IDeltaGroupOp>>
+            orDictionaryDeltaGroupFromProtoCache = new();
+
+        public static Proto.Msg.ORMapDeltaGroup ORDictionaryDeltasToProto(
+            Type k, Type v,
+            ReplicatedDataSerializer serializer,
+            List<ORDictionary.IDeltaOperation> operation)
+        {
+                var value = orDictionaryDeltasToProtoCache.GetOrAdd(new(k, v),
+                    static kc =>
+                        MakeInstanceCallTwoGenericsOneArg<
+                                List<ORDictionary.IDeltaOperation>,
+                                Proto.Msg.ORMapDeltaGroup>(
+                                ORDeltaGroupProtoMaker, kc.Item1, kc.Item2)
+                            .Compile());
+
+            return value(serializer, operation);
+        }
+
+        public static ORDictionary.IDeltaGroupOp
+            ORDictionaryDeltaGroupFromProto(Type k, Type v,
+                ReplicatedDataSerializer serializer,
+                Proto.Msg.ORMapDeltaGroup operation)
+        {
+                var value = orDictionaryDeltaGroupFromProtoCache.GetOrAdd(new(k, v),
+                    static kc =>
+                        MakeInstanceCallTwoGenericsOneArg<
+                                Proto.Msg.ORMapDeltaGroup,
+                                ORDictionary.IDeltaGroupOp>(
+                                ORDeltaGroupMaker, kc.Item1, kc.Item2)
+                            .Compile());
+
+            return value(serializer, operation);
+        }
+
+        private static readonly ConcurrentDictionary<TwoTypeLookup,
+                Func<ReplicatedDataSerializer, ILWWDictionary,
+                    Proto.Msg.LWWMap>>
+            lwwDictionaryToProtoCache = new();
+
+        private static readonly ConcurrentDictionary<TwoTypeLookup,
+                Func<ReplicatedDataSerializer, Proto.Msg.LWWMap,
+                    ILWWDictionary>>
+            lwwDictionaryFromProtoCache = new();
+
+        private static readonly ConcurrentDictionary<TwoTypeLookup,
+                Func<ReplicatedDataSerializer, ORDictionary.IDeltaOperation,
+                    ILWWDictionaryDeltaOperation>>
+            lwwDictionaryDeltaFromProtoCache = new();
+
+
+        public static Proto.Msg.LWWMap
+            LWWDictionaryToProto(Type k, Type v,
+                ReplicatedDataSerializer serializer,
+                ILWWDictionary operation)
+        {
+                var value = lwwDictionaryToProtoCache.GetOrAdd(new(k, v),
+                    static kc =>
+                        MakeInstanceCallTwoGenericsOneArgOneConst<
+                                ILWWDictionary, Proto.Msg.TypeDescriptor, Proto.Msg.LWWMap>(
+                                LWWDictProtoMaker, GetTypeDescriptor(kc.Item2), kc.Item1, kc.Item2)
+                            .Compile());
+
+            return value(serializer, operation);
+        }
+
+        public static ILWWDictionary
+            LWWDictionaryFromProto(Type k, Type v,
+                ReplicatedDataSerializer serializer,
+                Proto.Msg.LWWMap operation)
+        {
+                var value = lwwDictionaryFromProtoCache.GetOrAdd(new(k, v),
+                    static kc =>
+                        MakeInstanceCallTwoGenericsOneArg<
+                                Proto.Msg.LWWMap,
+                                ILWWDictionary>(
+                                LWWDictMaker, kc.Item1, kc.Item2)
+                            .Compile());
+
+            return value(serializer, operation);
+        }
+
+        public static ILWWDictionaryDeltaOperation
+            LWWDictionaryDeltaFromProto(Type k, Type v,
+                ReplicatedDataSerializer serializer,
+                ORDictionary.IDeltaOperation operation)
+        {
+                var value = lwwDictionaryDeltaFromProtoCache.GetOrAdd(new(k, v),
+                    static kc =>
+                        MakeInstanceCallTwoGenericsOneArg<
+                                ORDictionary.IDeltaOperation,
+                                ILWWDictionaryDeltaOperation>(
+                                LWWDictionaryDeltaMaker, kc.Item1, kc.Item2)
+                            .Compile());
+            
+
+            return value(serializer, operation);
+        }
+
+
+        private static readonly ConcurrentDictionary<Type,
+                Func<ReplicatedDataSerializer, IPNCounterDictionary,
+                    PNCounterMap>>
+            pnToProtoCache = new();
+
+        private static readonly ConcurrentDictionary<Type,
+                Func<ReplicatedDataSerializer, ORDictionary.IDeltaOperation,
+                    IPNCounterDictionaryDeltaOperation>>
+            pnDictionaryDeltaCache = new();
+
+        private static readonly ConcurrentDictionary<Type,
+                Func<ReplicatedDataSerializer, PNCounterMap,
+                    IPNCounterDictionary>>
+            pnDictionaryFromProtoCache = new();
+
+        public static IPNCounterDictionary
+            PNCounterDictionaryFromProto(Type k,
+                ReplicatedDataSerializer serializer,
+                PNCounterMap op)
+        {
+            var   value = pnDictionaryFromProtoCache.GetOrAdd(k,
+                    static kc =>
+                        MakeInstanceCallOneGenericOneArg<
+                            PNCounterMap,
+                            IPNCounterDictionary>(
+                            PNCounterDictMaker, kc).Compile());
+            
+
+            return value(serializer, op);
+        }
+
+        private static readonly ConcurrentDictionary<Type,
+                Func<ReplicatedDataSerializer, Proto.Msg.PNCounterMap,
+                    IPNCounterDictionary>>
+            pnCounterDictionaryFromProtoCache = new();
+
+        public static IPNCounterDictionaryDeltaOperation
+            PnCounterDictionaryDeltaFromProto(Type k,
+                ReplicatedDataSerializer serializer,
+                ORDictionary.IDeltaOperation op)
+        {
+                var value = pnDictionaryDeltaCache.GetOrAdd(k,
+                    static kc =>
+                        MakeInstanceCallOneGenericOneArg<
+                            ORDictionary.IDeltaOperation,
+                            IPNCounterDictionaryDeltaOperation>(
+                            PNCounterDeltaMaker, kc).Compile());
+
+            return value(serializer, op);
+        }
+
+        public static PNCounterMap PNCounterDictionaryToProto(Type k,
+            ReplicatedDataSerializer serializer, IPNCounterDictionary dict)
+        {
+                var value = pnToProtoCache.GetOrAdd(k, static kc =>
+                    MakeInstanceCallOneGenericOneArg<IPNCounterDictionary,
+                            PNCounterMap>(PNCounterDictProtoMaker, kc)
+                        .Compile());
+            
+            return value(serializer, dict);
+        }
+
+        private static readonly
+            ConcurrentDictionary<TwoTypeLookup, Func<string, IKey>>
+            orMultiValueDictionaryKeyCache = new();
+
+        private static readonly
+            ConcurrentDictionary<TwoTypeLookup, Func<ReplicatedDataSerializer
+                , IORMultiValueDictionary, Proto.Msg.ORMultiMap>>
+            orMultiValueSerializerCache = new();
+
+        private static readonly
+            ConcurrentDictionary<TwoTypeLookup, Func<ReplicatedDataSerializer,
+                Proto.Msg.ORMultiMap, IORMultiValueDictionary>>
+            orMultiValueDeserializerCache = new();
+
+        private static readonly
+            ConcurrentDictionary<TwoTypeLookup, Func<ReplicatedDataSerializer
+                , ORDictionary.IDeltaOperation, bool,
+                IORMultiValueDictionaryDeltaOperation>>
+            orMultiValueDeltaOpCache = new();
+
+        private static readonly
+            ConcurrentDictionary<TwoTypeLookup, Func<string, IKey>>
+            orDictionaryKeyCache = new();
+
+        private static readonly
+            ConcurrentDictionary<TwoTypeLookup, Func<string, IKey>>
+            lwwDictionaryKeyCache = new();
+
+        private static readonly
+            ConcurrentDictionary<Type, Func<string, IKey>>
+            orSetKeyCache = new();
+
+        private static readonly
+            ConcurrentDictionary<Type, Func<string, IKey>>
+            pnCounterDictionaryKeyCache = new();
+
+        private static readonly
+            ConcurrentDictionary<Type, Func<string, IKey>>
+            lwwRegisterKeyCache = new();
+
+        private static readonly
+            ConcurrentDictionary<Type, Func<string, IKey>>
+            gsetKeyCache = new();
+
+        public static Proto.Msg.ORMultiMap
+            IORMultiValueDictionaryToProtoORMultiMap(Type tk, Type tv,
+                ReplicatedDataSerializer ser,
+                IORMultiValueDictionary dict)
+        {
+            
+                var value = orMultiValueSerializerCache.GetOrAdd(new(tk, tv),
+                    MakeInstanceCallTwoGenericsOneArg<
+                            IORMultiValueDictionary, Proto.Msg.ORMultiMap>(
+                            MultiMapProtoMaker, tk,
+                            tv)
+                        .Compile());
+
+            return value(ser, dict);
+        }
+
+        public static IORMultiValueDictionary
+            ProtoORMultiMapToIORMultiValueDictionary(Type tk, Type tv,
+                ReplicatedDataSerializer ser,
+                Proto.Msg.ORMultiMap dict)
+        {
+                var value = orMultiValueDeserializerCache.GetOrAdd(new(tk, tv),
+                    MakeInstanceCallTwoGenericsOneArg<
+                            Proto.Msg.ORMultiMap, IORMultiValueDictionary>(
+                            MultiDictMaker, tk,
+                            tv)
+                        .Compile());
+
+            return value(ser, dict);
+        }
+
+
+        public static IORMultiValueDictionaryDeltaOperation
+            ToOrMultiDictionaryDelta(Type tk, Type tv,
+                ReplicatedDataSerializer ser,
+                ORDictionary.IDeltaOperation deltaop, bool withValueDeltas)
+        {
+                var value = orMultiValueDeltaOpCache.GetOrAdd(new(tk, tv),
+                    MakeInstanceCallTwoGenericsTwoArgs<
+                            ORDictionary.IDeltaOperation, bool,
+                            IORMultiValueDictionaryDeltaOperation>(
+                            ORMultiDictionaryDeltaMaker, tk,
+                            tv)
+                        .Compile());
+
+            return value(ser, deltaop, withValueDeltas);
+        }
+
+        public static IKey GetGSetKey(Type k, string arg)
+        {
+                var value = gsetKeyCache.GetOrAdd(k,
+                    MakeConstructorExprForTypeWith1GenericsOneString<string,
+                        IKey>(
+                        typeof(GSetKey<>), k).Compile());
+
+            return value(arg);
+        }
+
+        public static IKey GetLWWRegisterKeyValue(Type k, string arg)
+        {
+            var value = lwwRegisterKeyCache.GetOrAdd(k,
+                MakeConstructorExprForTypeWith1GenericsOneString<string,
+                    IKey>(
+                    typeof(LWWRegisterKey<>), k).Compile());
+            return value(arg);
+        }
+
+        public static IKey GetPNCounterDictionaryKeyValue(Type k, string arg)
+        {
+            
+                var value = pnCounterDictionaryKeyCache.GetOrAdd(k,
+                    MakeConstructorExprForTypeWith1GenericsOneString<string,
+                        IKey>(
+                        typeof(PNCounterDictionaryKey<>), k).Compile());
+
+            return value(arg);
+        }
+
+        public static IKey GetORSetKey(Type k, string arg)
+        {
+            
+            var    value = orSetKeyCache.GetOrAdd(k,
+                    MakeConstructorExprForTypeWith1GenericsOneString<string,
+                        IKey>(typeof(
+                        ORSetKey<>), k).Compile());
+
+            return value(arg);
+        }
+
+        public static IKey GetORDictionaryKey(Type k, Type v,
+            string arg)
+        {
+                var value = orDictionaryKeyCache.GetOrAdd(new(k, v),
+                    MakeConstructorExprForTypeWith2GenericsOneString(
+                            typeof(ORDictionaryKey<,>), k, v)
+                        .Compile());
+
+            return value(arg);
+        }
+
+        public static IKey GetORMultiValueDictionaryKey(Type k, Type v,
+            string arg)
+        {
+                var value = orMultiValueDictionaryKeyCache.GetOrAdd(new(k, v),
+                    MakeConstructorExprForTypeWith2GenericsOneString(
+                            typeof(ORMultiValueDictionaryKey<,>), k, v)
+                        .Compile());
+
+            return value(arg);
+        }
+
+        public static IKey GetLWWDictionaryKey(Type k, Type v, string arg)
+        {
+                var value = lwwDictionaryKeyCache.GetOrAdd(new(k, v),
+                    MakeConstructorExprForTypeWith2GenericsOneString(
+                        typeof(LWWDictionaryKey<,>), k, v).Compile());
+
+            return value(arg);
+        }
+
+        private static
+            Expression<Func<ReplicatedDataSerializer,
+                TArg, TRet>>
+            MakeInstanceCallOneGenericOneArg<TArg, TRet>(
+                MethodInfo nonConstructedGenericMethodInfo, Type tk,
+                bool convert = false)
+        {
+            var i = Expression.Parameter(typeof(ReplicatedDataSerializer),
+                "ser");
+            var p = Expression.Parameter(typeof(TArg),
+                "multi");
+            var c = Expression.Call(i,
+                nonConstructedGenericMethodInfo.MakeGenericMethod(new[] { tk }),
+                new[] { p });
+            return Expression
+                .Lambda<
+                    Func<ReplicatedDataSerializer, TArg,
+                        TRet>>(
+                    convert ? Expression.Convert(c, typeof(TRet)) : c,
+                    false, i, p);
+        }
+        
+        private static
+            Expression<Func<TArg, TRet>>
+            MakeStaticCallOneGenericOneArg<TArg, TRet>(
+                MethodInfo nonConstructedGenericMethodInfo, Type tk,
+                bool convert = false)
+        {
+            var p = Expression.Parameter(typeof(TArg),
+                "multi");
+            var c = Expression.Call(nonConstructedGenericMethodInfo.MakeGenericMethod(new[] { tk }),
+                new[] { p });
+            return Expression
+                .Lambda<
+                    Func<TArg,
+                        TRet>>(
+                    convert ? Expression.Convert(c, typeof(TRet)) : c,
+                    false, p);
+        }
+
+        private static
+            Expression<Func<
+                TArg1, TArg2, TRet>>
+            MakeStaticCallOneGenericTwoArgs<TArg1, TArg2, TRet>(
+                MethodInfo nonConstructedGenericMethodInfo, Type tk,
+                bool convert = false)
+        {
+            var p = Expression.Parameter(typeof(TArg1),
+                "multi");
+            var p2 = Expression.Parameter(typeof(TArg2));
+            var c = Expression.Call(
+                nonConstructedGenericMethodInfo.MakeGenericMethod(new[] { tk }),
+                new[] { p,p2 });
+            return Expression
+                .Lambda<
+                    Func<TArg1, TArg2,
+                        TRet>>(
+                    convert ? Expression.Convert(c, typeof(TRet)) : c, false, p,
+                    p2);
+        }
+
+        private static Expression<Func<ReplicatedDataSerializer, TArg, TRet>>
+            MakeInstanceCallOneGenericOneIgnoredArg<TArg,TRet>(
+                MethodInfo nonConstructedGenericMethodInfo,
+                Type tk, Type targ2Ignore, bool convert = false)
+        {
+            var p2 = Expression.Constant(null, targ2Ignore);
+            var i = Expression.Parameter(typeof(ReplicatedDataSerializer),
+                "ser");
+            var p = Expression.Parameter(typeof(TArg),
+                "multi");
+            var c = Expression.Call(i,
+                nonConstructedGenericMethodInfo.MakeGenericMethod(new[] { tk }),
+                p, p2);
+            return Expression
+                .Lambda<
+                    Func<ReplicatedDataSerializer, TArg,
+                        TRet>>(
+                    convert ? Expression.Convert(c, typeof(TRet)) : c, false, i,
+                    p);
+
+        }
+        private static
+            Expression<Func<ReplicatedDataSerializer,
+                TArg1, TArg2, TRet>>
+            MakeInstanceCallOneGenericTwoArgs<TArg1, TArg2, TRet>(
+                MethodInfo nonConstructedGenericMethodInfo, Type tk,
+                bool convert = false)
+        {
+            
+            var p2 = Expression.Parameter(typeof(TArg2));
+            var i = Expression.Parameter(typeof(ReplicatedDataSerializer),
+                "ser");
+            var p = Expression.Parameter(typeof(TArg1),
+                "multi");
+            var c = Expression.Call(i,
+                nonConstructedGenericMethodInfo.MakeGenericMethod(new[] { tk }),
+                new[] { p, p2 });
+            return Expression
+                .Lambda<
+                    Func<ReplicatedDataSerializer, TArg1, TArg2,
+                        TRet>>(
+                    convert ? Expression.Convert(c, typeof(TRet)) : c, false, i,
+                    p, p2);
+        }
+
+        private static
+            Expression<Func<ReplicatedDataSerializer,
+                TArg, TRet>>
+            MakeInstanceCallTwoGenericsOneArg<TArg, TRet>(
+                MethodInfo nonConstructedGenericMethodInfo, Type tk, Type tv)
+        {
+            var i = Expression.Parameter(typeof(ReplicatedDataSerializer),
+                "ser");
+            var p = Expression.Parameter(typeof(TArg),
+                "multi");
+            var c = Expression.Call(i,
+                nonConstructedGenericMethodInfo.MakeGenericMethod(new[]
+                {
+                    tk, tv
+                }),
+                new[] { p });
+            return Expression
+                .Lambda<
+                    Func<ReplicatedDataSerializer, TArg,
+                        TRet>>(c, false, i, p);
+        }
+        
+        private static
+            Expression<Func<ReplicatedDataSerializer,
+                TArg, TRet>>
+            MakeInstanceCallTwoGenericsOneArgOneConst<TArg,TConst, TRet>(
+                MethodInfo nonConstructedGenericMethodInfo, TConst conArg, Type tk, Type tv)
+        {
+            var i = Expression.Parameter(typeof(ReplicatedDataSerializer),
+                "ser");
+            var p = Expression.Parameter(typeof(TArg),
+                "multi");
+            var pc = Expression.Constant(conArg, typeof(TConst));
+            var c = Expression.Call(i,
+                nonConstructedGenericMethodInfo.MakeGenericMethod(new[]
+                {
+                    tk, tv
+                }),
+                new Expression[] { p ,pc});
+            return Expression
+                .Lambda<
+                    Func<ReplicatedDataSerializer, TArg,
+                        TRet>>(c, false, i, p);
+        }
+
+        private static
+            Expression<Func<ReplicatedDataSerializer,
+                TArg1, TArg2, TRet>>
+            MakeInstanceCallTwoGenericsTwoArgs<TArg1, TArg2, TRet>(
+                MethodInfo nonConstructedGenericMethodInfo, Type tk, Type tv)
+        {
+            var i = Expression.Parameter(typeof(ReplicatedDataSerializer),
+                "ser");
+            var p = Expression.Parameter(typeof(TArg1),
+                "multi");
+            var p2 = Expression.Parameter(typeof(TArg2));
+            var c = Expression.Call(i,
+                nonConstructedGenericMethodInfo.MakeGenericMethod(new[]
+                {
+                    tk, tv
+                }),
+                new[] { p, p2 });
+            return Expression
+                .Lambda<
+                    Func<ReplicatedDataSerializer, TArg1, TArg2,
+                        TRet>>(c, false, i, p, p2);
+        }
+
+        private static Expression<Func<T, TOut>>
+            MakeConstructorExprForTypeWith1GenericsOneString<T, TOut>(Type t,
+                Type k)
+        {
+            var p = Expression.Parameter(typeof(T), "arg");
+            var ctor = t
+                .MakeGenericType(new[] { k })
+                .GetConstructor(new[] { typeof(T) });
+            var newExp = Expression.New(ctor, p);
+            var cast = Expression.Convert(newExp, typeof(TOut));
+            var newVal = Expression.Lambda<Func<T, TOut>>(cast, p);
+            return newVal;
+        }
+
+        private static Expression<Func<string, IKey>>
+            MakeConstructorExprForTypeWith2GenericsOneString(Type t, Type k,
+                Type v)
+        {
+            var p = Expression.Parameter(typeof(string), "key");
+            var ctor = t
+                .MakeGenericType(new[] { k, v })
+                .GetConstructor(new[] { typeof(string) });
+            var newExp = Expression.New(ctor, p);
+            var cast = Expression.Convert(newExp, typeof(IKey));
+            var newVal = Expression.Lambda<Func<string, IKey>>(cast, p);
+            return newVal;
+        }
+    }
+}

--- a/src/core/Akka.Remote/Serialization/WrappedPayloadSupport.cs
+++ b/src/core/Akka.Remote/Serialization/WrappedPayloadSupport.cs
@@ -29,7 +29,7 @@ namespace Akka.Remote.Serialization
             var payloadProto = new Proto.Msg.Payload();
             var serializer = _system.Serialization.FindSerializerFor(payload);
 
-            payloadProto.Message = ByteString.CopyFrom(serializer.ToBinary(payload));
+            payloadProto.Message = UnsafeByteOperations.UnsafeWrap(serializer.ToBinary(payload));
             payloadProto.SerializerId = serializer.Identifier;
 
             // get manifest

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -13,6 +13,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
 using Akka.Actor.Internal;
 using Akka.Actor.Scheduler;
 using Akka.Annotations;

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -149,6 +149,7 @@ namespace Akka.Actor
             }
 
             var future = provider.CreateFutureRef(result);
+            
             var path = future.Path;
 
             //The future actor needs to be unregistered in the temp container


### PR DESCRIPTION
## Changes

This is a substantial overhaul of `ReplicatedDataSerializer` to do the following:

1. Use Pools for Protobuf GZip/GUnzip. `CommunityToolKit` is used for this due to it's large range of framework support and overall stability.
2. Use Pooled lists for some intermediate builder cases
3. Cache certain type bytestrings used by `ReplicatedDataSerializer`/`SerializerSupport`
4. Use Cached compiled Expressions in place of Invoke where possible.

####Still To try/Do:

* [ ] Will using `NonBlocking.ConcurrentDictionary` be preferable for Compiled expression caches?
* [ ] Clean up Type composition
* [ ] Clean up formatting
* [ ] Update API

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

#### ORDictionary Before:

| Method                   | NumElements | NumNodes | Mean     | Error     | StdDev    | Gen0     | Gen1    | Allocated  |
|------------------------- |------------ |--------- |---------:|----------:|----------:|---------:|--------:|-----------:|
| Serialize_ORDictionary   | 25          | 10       | 1.646 ms | 0.0321 ms | 0.0357 ms | 214.8438 | 17.5781 |  987.41 KB |
| Deserialize_ORDictionary | 25          | 10       | 1.432 ms | 0.0130 ms | 0.0115 ms | 324.2188 | 64.4531 | 1498.57 KB |

#### LWWDictionary Before:

| Method              | KeyType | ValueType | NumElements | NumNodes | Mean       | Error    | StdDev   | Gen0     | Gen1    | Allocated |
|-------------------- |-------- |---------- |------------ |--------- |-----------:|---------:|---------:|---------:|--------:|----------:|
| Serialize_LWWDict   | TestKey | TestKey   | 25          | 10       | 1,387.8 us | 11.01 us |  9.19 us | 134.7656 | 15.6250 | 627.64 KB |
| Deserialize_LWWDict | TestKey | TestKey   | 25          | 10       |   915.6 us |  8.23 us |  7.30 us | 158.2031 | 26.3672 | 731.62 KB |
| Serialize_LWWDict   | TestKey | TestVal   | 25          | 10       |   670.3 us |  6.71 us |  5.24 us | 104.4922 | 11.7188 | 484.48 KB |
| Deserialize_LWWDict | TestKey | TestVal   | 25          | 10       |   594.1 us |  3.43 us |  2.86 us | 120.1172 | 20.5078 | 554.43 KB |
| Serialize_LWWDict   | TestVal | TestKey   | 25          | 10       | 1,310.7 us | 14.58 us | 13.64 us | 130.8594 | 15.6250 | 609.88 KB |
| Deserialize_LWWDict | TestVal | TestKey   | 25          | 10       |   869.9 us | 11.10 us | 10.39 us | 154.2969 | 25.3906 | 712.53 KB |
| Serialize_LWWDict   | TestVal | TestVal   | 25          | 10       |   586.3 us |  7.95 us |  7.04 us | 100.5859 | 11.7188 | 466.54 KB |
| Deserialize_LWWDict | TestVal | TestVal   | 25          | 10       |   548.5 us |  3.58 us |  3.35 us | 116.2109 | 21.4844 | 534.84 KB |

#### ORSet before:

| Method            | NumElements | NumNodes | Mean     | Error    | StdDev   | Gen0    | Gen1    | Allocated |
|------------------ |------------ |--------- |---------:|---------:|---------:|--------:|--------:|----------:|
| Serialize_ORSet   | 25          | 10       | 577.4 us | 10.80 us | 10.61 us | 87.8906 |  7.8125 | 406.94 KB |
| Deserialize_ORSet | 25          | 10       | 489.0 us |  9.27 us |  8.22 us | 94.7266 | 14.6484 |  436.8 KB |

### This PR's Benchmarks

#### ORDictionary After:

| Method                   | NumElements | NumNodes | Mean     | Error     | StdDev    | Gen0     | Gen1    | Allocated  |
|------------------------- |------------ |--------- |---------:|----------:|----------:|---------:|--------:|-----------:|
| Serialize_ORDictionary   | 25          | 10       | 1.370 ms | 0.0180 ms | 0.0159 ms | 189.4531 | 15.6250 |  873.66 KB |
| Deserialize_ORDictionary | 25          | 10       | 1.068 ms | 0.0125 ms | 0.0110 ms | 291.0156 |  3.9063 | 1342.23 KB |

#### LWWDictionary After:
| Method              | KeyType | ValueType | NumElements | NumNodes | Mean       | Error    | StdDev   | Gen0     | Gen1    | Allocated |
|-------------------- |-------- |---------- |------------ |--------- |-----------:|---------:|---------:|---------:|--------:|----------:|
| Serialize_LWWDict   | TestKey | TestKey   | 25          | 10       | 1,314.2 us | 13.60 us | 12.06 us | 128.9063 | 15.6250 | 592.43 KB |
| Deserialize_LWWDict | TestKey | TestKey   | 25          | 10       |   805.8 us |  5.30 us |  4.70 us | 137.6953 |  0.9766 | 634.77 KB |
| Serialize_LWWDict   | TestKey | TestVal   | 25          | 10       |   648.2 us | 12.36 us | 12.14 us |  97.6563 | 10.7422 | 450.66 KB |
| Deserialize_LWWDict | TestKey | TestVal   | 25          | 10       |   534.9 us |  4.17 us |  3.49 us |  99.6094 |  0.9766 | 459.15 KB |
| Serialize_LWWDict   | TestVal | TestKey   | 25          | 10       | 1,240.5 us | 21.59 us | 19.14 us | 125.0000 | 13.6719 | 574.79 KB |
| Deserialize_LWWDict | TestVal | TestKey   | 25          | 10       |   785.6 us |  4.82 us |  4.28 us | 133.7891 |  0.9766 | 615.27 KB |
| Serialize_LWWDict   | TestVal | TestVal   | 25          | 10       |   573.7 us | 10.62 us |  9.41 us |  93.7500 | 10.7422 | 432.66 KB |
| Deserialize_LWWDict | TestVal | TestVal   | 25          | 10       |   503.0 us |  9.07 us |  8.49 us |  94.7266 | 16.6016 | 439.51 KB |

#### ORSet After:

| Method            | NumElements | NumNodes | Mean     | Error   | StdDev  | Gen0    | Gen1    | Allocated |
|------------------ |------------ |--------- |---------:|--------:|--------:|--------:|--------:|----------:|
| Serialize_ORSet   | 25          | 10       | 496.4 us | 3.86 us | 3.42 us | 82.0313 |  7.8125 | 377.72 KB |
| Deserialize_ORSet | 25          | 10       | 438.0 us | 3.61 us | 3.20 us | 75.1953 | 12.2070 | 345.87 KB |
