### PR TITLE
Fix LocalSnapshotStore Metadata Fetch to ensure persistenceid match.

### DIFF
--- a/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
@@ -273,6 +273,7 @@ namespace Akka.Persistence.Snapshot
             var snapshots = GetSnapshotDir()
                 .EnumerateFiles("snapshot-" + Uri.EscapeDataString(persistenceId) + "-*", SearchOption.TopDirectoryOnly)
                 .Select(ExtractSnapshotMetadata)
+                .Where(m=>m.PersistenceId == persistenceId)
                 .Where(metadata => metadata != null && criteria.IsMatch(metadata) && !_saving.Contains(metadata)).ToList();
 
             snapshots.Sort(SnapshotMetadata.Comparer);


### PR DESCRIPTION
Fixes #7009

## Changes

Adds an additional filter check to getting snapshot metadata to ensure persistenceId matches.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #
* [x] Changes in public API reviewed, if any.

#### No benchmarks:

LocalSnapshot store is not meant to be performant. That said, I think one can agree that the additional `.Where()` call is dwarfed by existing regex and IO in this operation. If we want this to be 'faster' we should consider instead unrolling the LINQ block into something less capture-y.