### PR TITLE
distribute Akka.Analyzers as transitive dependency through Akka

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
+#### 1.5.15 January 9th 2024 ####
+
 #### 1.5.14 September 24th 2023 ####
 
 Akka.NET v1.5.14 is a maintenance release with several bug fixes.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.14</VersionPrefix>
+    <VersionPrefix>1.5.15</VersionPrefix>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
@@ -46,29 +46,8 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Akka.NET v1.5.14 is a maintenance release with several bug fixes.
-[Streams: Ensure stream are closed on shutdown](https://github.com/akkadotnet/akka.net/pull/6935)
-[Akka: Fix PeriodicTimer HashWheelTimerScheduler deadlock during start](https://github.com/akkadotnet/akka.net/pull/6949)
-[Cluster: Old version of LeastShardAllocationStrategy is now deprecated](https://github.com/akkadotnet/akka.net/pull/6975)
-[Query: Add a more descriptive ToString() values to Offset types](https://github.com/akkadotnet/akka.net/pull/6978)
-Package dependency upgrades
-[MNTR: Bump Akka.Multinode.TestAdapter to 1.5.13](https://github.com/akkadotnet/akka.net/pull/6926)
-[Akka: Bump Polyfill to 1.28](https://github.com/akkadotnet/akka.net/pull/6936)
-[Akka: Bump Google.Protobuf to 3.24.4](https://github.com/akkadotnet/akka.net/pull/6951)
-[DData: Bump LightningDB to 0.16.0](https://github.com/akkadotnet/akka.net/pull/6960)
-[Persistence: Bump Microsoft.Data.SQLite to 7.0.13](https://github.com/akkadotnet/akka.net/pull/6969)
-If you want to see the [full set of changes made in Akka.NET v1.5.14, click here](https://github.com/akkadotnet/akka.net/milestone/96?closed=1).
-| COMMITS | LOC+ | LOC- | AUTHOR              |
-|---------|------|------|---------------------|
-| 11      | 25   | 21   | dependabot[bot]     |
-| 3       | 14   | 2    | Aaron Stannard      |
-| 3       | 114  | 369  | Simon Cropp         |
-| 2       | 36   | 31   | Gregorius Soedharmo |
-| 1       | 41   | 43   | Lehonti Ramos       |
-| 1       | 38   | 0    | Yaroslav Paslavskiy |
-| 1       | 3    | 0    | Sean Killeen        |
-| 1       | 227  | 25   | Drew                |
-| 1       | 1    | 1    | szaliszali          |</PackageReleaseNotes>
+    <PackageReleaseNotes>
+    </PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup Label="Analyzers" Condition="'$(MSBuildProjectName)' != 'Akka'">
     <PackageReference Include="Akka.Analyzers" Version="$(AkkaAnalyzerVersion)" PrivateAssets="all" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,6 +39,7 @@
     <MultiNodeAdapterVersion>1.5.13</MultiNodeAdapterVersion>
     <MicrosoftLibVersion>[6.0.*,)</MicrosoftLibVersion>
     <MsExtVersion>[6.0.*,)</MsExtVersion>
+    <AkkaAnalyzerVersion>0.2.1</AkkaAnalyzerVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>
   <PropertyGroup>
@@ -69,8 +70,8 @@ If you want to see the [full set of changes made in Akka.NET v1.5.14, click here
 | 1       | 227  | 25   | Drew                |
 | 1       | 1    | 1    | szaliszali          |</PackageReleaseNotes>
   </PropertyGroup>
-  <ItemGroup Label="Analyzers">
-    <PackageReference Include="Akka.Analyzers" Version="0.2.1" PrivateAssets="all" />
+  <ItemGroup Label="Analyzers" Condition="'$(MSBuildProjectName)' != 'Akka'">
+    <PackageReference Include="Akka.Analyzers" Version="$(AkkaAnalyzerVersion)" PrivateAssets="all" />
   </ItemGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -20,6 +20,11 @@
       <PackageReference Include="System.Collections.Immutable" Version="$(MicrosoftLibVersion)" />
       <PackageReference Include="System.Threading.Channels" Version="$(MicrosoftLibVersion)" />
       <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(ConfigurationManagerVersion)"/>
+      
+  </ItemGroup>
+  
+  <ItemGroup Label="PublicAnalyzers">
+    <PackageReference Include="Akka.Analyzers" Version="$(AkkaAnalyzerVersion)" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
## Changes

Distribute [Akka.Analyzers as a dependency to all of our downstream packages and consumers](https://github.com/akkadotnet/akka.analyzers)

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have added website documentation for this feature.
