### PR TITLE
troubleshooting `ShardingRegion.StartEntity` handling changes

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowning2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowning2Spec.cs
@@ -193,10 +193,10 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(20), () =>
             {
-                StartPersistenceIfNeeded(startOn: config.First, config.First, config.Second);
+                StartPersistenceIfNeeded(startOn: Config.First, Config.First, Config.Second);
 
-                Join(config.First, config.First, onJoinedRunOnFrom: StartSharding);
-                Join(config.Second, config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
+                Join(Config.First, Config.First, onJoinedRunOnFrom: StartSharding);
+                Join(Config.Second, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
 
                 // all Up, everywhere before continuing
                 RunOn(() =>
@@ -206,7 +206,7 @@ namespace Akka.Cluster.Sharding.Tests
                         Cluster.State.Members.Count.Should().Be(2);
                         Cluster.State.Members.Should().OnlyContain(m => m.Status == MemberStatus.Up);
                     });
-                }, config.First, config.Second);
+                }, Config.First, Config.Second);
 
                 EnterBarrier("after-2");
             });
@@ -225,7 +225,7 @@ namespace Akka.Cluster.Sharding.Tests
                 }).ToImmutableDictionary();
                 shardLocations.Tell(new Locations(locations));
                 Sys.Log.Debug("Original locations: [{0}]", string.Join(", ", locations.Select(i => $"{i.Key}: {i.Value}")));
-            }, config.First);
+            }, Config.First);
             EnterBarrier("after-3");
         }
 
@@ -233,18 +233,18 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(20), () =>
             {
-                var secondAddress = GetAddress(config.Second);
+                var secondAddress = GetAddress(Config.Second);
 
                 RunOn(() =>
                 {
-                    TestConductor.Blackhole(config.First, config.Second, Direction.Both).Wait();
-                }, config.First);
+                    TestConductor.Blackhole(Config.First, Config.Second, Direction.Both).Wait();
+                }, Config.First);
 
                 Thread.Sleep(3000);
 
                 RunOn(() =>
                 {
-                    Cluster.Down(GetAddress(config.Second));
+                    Cluster.Down(GetAddress(Config.Second));
                     AwaitAssert(() =>
                     {
                         Cluster.State.Members.Count.Should().Be(1);
@@ -264,7 +264,7 @@ namespace Akka.Cluster.Sharding.Tests
                     });
                     Sys.Log.Debug("Additional locations: [{0}]", string.Join(", ", additionalLocations.Select(i => $"{i.Key}: {i.Value}")));
 
-                    Sys.ActorSelection(Node(config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
+                    Sys.ActorSelection(Node(Config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
                     var originalLocations = ExpectMsg<Locations>().Locs;
 
                     AwaitAssert(() =>
@@ -284,7 +284,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                         }
                     });
-                }, config.First);
+                }, Config.First);
             });
 
             EnterBarrier("after-4");

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowningSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowningSpec.cs
@@ -195,10 +195,10 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(20), () =>
             {
-                StartPersistenceIfNeeded(startOn: config.Controller, config.First, config.Second);
+                StartPersistenceIfNeeded(startOn: Config.Controller, Config.First, Config.Second);
 
-                Join(config.First, config.First, onJoinedRunOnFrom: StartSharding);
-                Join(config.Second, config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
+                Join(Config.First, Config.First, onJoinedRunOnFrom: StartSharding);
+                Join(Config.Second, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
 
                 // all Up, everywhere before continuing
                 RunOn(() =>
@@ -208,7 +208,7 @@ namespace Akka.Cluster.Sharding.Tests
                         Cluster.State.Members.Count.Should().Be(2);
                         Cluster.State.Members.Should().OnlyContain(m => m.Status == MemberStatus.Up);
                     });
-                }, config.First, config.Second);
+                }, Config.First, Config.Second);
 
                 EnterBarrier("after-2");
             });
@@ -228,7 +228,7 @@ namespace Akka.Cluster.Sharding.Tests
                 }).ToImmutableDictionary();
                 shardLocations.Tell(new Locations(locations));
                 Sys.Log.Debug("Original locations: [{0}]", string.Join(", ", locations.Select(i => $"{i.Key}: {i.Value}")));
-            }, config.First);
+            }, Config.First);
             EnterBarrier("after-3");
         }
 
@@ -236,22 +236,22 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(20), () =>
             {
-                var firstAddress = GetAddress(config.First);
-                Sys.ActorSelection(Node(config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
+                var firstAddress = GetAddress(Config.First);
+                Sys.ActorSelection(Node(Config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
                 var originalLocations = ExpectMsg<Locations>().Locs;
 
                 EnterBarrier("after-3-locations");
 
                 RunOn(() =>
                 {
-                    TestConductor.Blackhole(config.First, config.Second, Direction.Both).Wait();
-                }, config.Controller);
+                    TestConductor.Blackhole(Config.First, Config.Second, Direction.Both).Wait();
+                }, Config.Controller);
 
                 Thread.Sleep(3000);
 
                 RunOn(() =>
                 {
-                    Cluster.Down(GetAddress(config.First));
+                    Cluster.Down(GetAddress(Config.First));
                     AwaitAssert(() =>
                     {
                         Cluster.State.Members.Count.Should().Be(1);
@@ -288,7 +288,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                         }
                     });
-                }, config.Second);
+                }, Config.Second);
             });
 
             EnterBarrier("after-4");

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
@@ -210,9 +210,9 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(30), () =>
             {
-                StartPersistenceIfNeeded(startOn: config.First, config.First, config.Second);
+                StartPersistenceIfNeeded(startOn: Config.First, Config.First, Config.Second);
 
-                Join(config.First, config.First);
+                Join(Config.First, Config.First);
 
                 RunOn(() =>
                 {
@@ -221,30 +221,30 @@ namespace Akka.Cluster.Sharding.Tests
                     _region.Value.Tell(1);
                     ExpectMsg(1);
                     LastSender.Path.Should().Be(_region.Value.Path / "1" / "1");
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("first-started");
 
-                Join(config.Second, config.First);
+                Join(Config.Second, Config.First);
 
                 _region.Value.Tell(2);
                 ExpectMsg(2);
                 RunOn(() =>
                 {
                     LastSender.Path.Should().Be(_region.Value.Path / "2" / "2");
-                }, config.First);
+                }, Config.First);
                 RunOn(() =>
                 {
-                    LastSender.Path.Should().Be(Node(config.First) / "system" / "sharding" / "Entity" / "2" / "2");
-                }, config.Second);
+                    LastSender.Path.Should().Be(Node(Config.First) / "system" / "sharding" / "Entity" / "2" / "2");
+                }, Config.Second);
                 EnterBarrier("second-started");
 
                 RunOn(() =>
                 {
-                    Sys.ActorSelection(Node(config.Second) / "system" / "sharding" / "Entity").Tell(new Identify(null));
+                    Sys.ActorSelection(Node(Config.Second) / "system" / "sharding" / "Entity").Tell(new Identify(null));
                     var secondRegion = ExpectMsg<ActorIdentity>().Subject;
                     _allocator.Value.Tell(new UseRegion(secondRegion));
                     ExpectMsg<UseRegionAck>();
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("second-active");
 
                 _region.Value.Tell(3);
@@ -252,12 +252,12 @@ namespace Akka.Cluster.Sharding.Tests
                 RunOn(() =>
                 {
                     LastSender.Path.Should().Be(_region.Value.Path / "3" / "3");
-                }, config.Second);
+                }, Config.Second);
 
                 RunOn(() =>
                 {
-                    LastSender.Path.Should().Be(Node(config.Second) / "system" / "sharding" / "Entity" / "3" / "3");
-                }, config.First);
+                    LastSender.Path.Should().Be(Node(Config.Second) / "system" / "sharding" / "Entity" / "3" / "3");
+                }, Config.First);
 
                 EnterBarrier("after-2");
             });
@@ -278,13 +278,13 @@ namespace Akka.Cluster.Sharding.Tests
                         _region.Value.Tell(2, p.Ref);
                         p.ExpectMsg(2, TimeSpan.FromSeconds(2));
 
-                        p.LastSender.Path.Should().Be(Node(config.Second) / "system" / "sharding" / "Entity" / "2" / "2");
+                        p.LastSender.Path.Should().Be(Node(Config.Second) / "system" / "sharding" / "Entity" / "2" / "2");
                     });
 
                     _region.Value.Tell(1);
                     ExpectMsg(1);
                     LastSender.Path.Should().Be(_region.Value.Path / "1" / "1");
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("after-2");
             });
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -197,10 +197,10 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(20), () =>
             {
-                StartPersistenceIfNeeded(startOn: config.Controller, config.First, config.Second);
+                StartPersistenceIfNeeded(startOn: Config.Controller, Config.First, Config.Second);
 
-                Join(config.First, config.First);
-                Join(config.Second, config.First);
+                Join(Config.First, Config.First);
+                Join(Config.Second, Config.First);
 
                 RunOn(() =>
                 {
@@ -214,7 +214,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg<Value>(v => v.Id == "20" && v.N == 2);
                     region.Tell(new Get("21"));
                     ExpectMsg<Value>(v => v.Id == "21" && v.N == 3);
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("after-2");
             });
         }
@@ -227,14 +227,14 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     if (PersistenceIsNeeded)
                     {
-                        TestConductor.Blackhole(config.Controller, config.First, ThrottleTransportAdapter.Direction.Both).Wait();
-                        TestConductor.Blackhole(config.Controller, config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
+                        TestConductor.Blackhole(Config.Controller, Config.First, ThrottleTransportAdapter.Direction.Both).Wait();
+                        TestConductor.Blackhole(Config.Controller, Config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
                     }
                     else
                     {
-                        TestConductor.Blackhole(config.First, config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
+                        TestConductor.Blackhole(Config.First, Config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
                     }
-                }, config.Controller);
+                }, Config.Controller);
                 EnterBarrier("journal-backholded");
 
                 RunOn(() =>
@@ -245,21 +245,21 @@ namespace Akka.Cluster.Sharding.Tests
                     var probe = CreateTestProbe();
                     region.Tell(new Get("40"), probe.Ref);
                     probe.ExpectNoMsg(TimeSpan.FromSeconds(1));
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("first-delayed");
 
                 RunOn(() =>
                 {
                     if (PersistenceIsNeeded)
                     {
-                        TestConductor.PassThrough(config.Controller, config.First, ThrottleTransportAdapter.Direction.Both).Wait();
-                        TestConductor.PassThrough(config.Controller, config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
+                        TestConductor.PassThrough(Config.Controller, Config.First, ThrottleTransportAdapter.Direction.Both).Wait();
+                        TestConductor.PassThrough(Config.Controller, Config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
                     }
                     else
                     {
-                        TestConductor.PassThrough(config.First, config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
+                        TestConductor.PassThrough(Config.First, Config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
                     }
-                }, config.Controller);
+                }, Config.Controller);
                 EnterBarrier("journal-ok");
 
                 RunOn(() =>
@@ -305,7 +305,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                     region.Tell(new Get("40"));
                     ExpectMsg<Value>(v => v.Id == "40" && v.N == 4);
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("verified-first");
 
                 RunOn(() =>
@@ -323,7 +323,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg<Value>(v => v.Id == "20" && v.N == 4);
                     region.Tell(new Get("30"));
                     ExpectMsg<Value>(v => v.Id == "30" && v.N == 6);
-                }, config.Second);
+                }, Config.Second);
                 EnterBarrier("after-3");
             });
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
@@ -91,9 +91,9 @@ namespace Akka.Cluster.Sharding.Tests
 
         private void Inspecting_cluster_sharding_state_must_join_cluster()
         {
-            Join(config.Controller, config.Controller);
-            Join(config.First, config.Controller);
-            Join(config.Second, config.Controller);
+            Join(Config.Controller, Config.Controller);
+            Join(Config.First, Config.Controller);
+            Join(Config.Second, Config.Controller);
 
             // make sure all nodes are up
             AwaitAssert(() =>
@@ -110,7 +110,7 @@ namespace Akka.Cluster.Sharding.Tests
                     role: "shard",
                     extractEntityId: extractEntityId,
                     extractShardId: extractShardId);
-            }, config.Controller);
+            }, Config.Controller);
 
             RunOn(() =>
             {
@@ -118,10 +118,10 @@ namespace Akka.Cluster.Sharding.Tests
                     Sys,
                     typeName: ShardTypeName,
                     entityProps: Props.Create(() => new PingPongActor()),
-                    settings: settings.Value.WithRole("shard"),
+                    settings: Settings.Value.WithRole("shard"),
                     extractEntityId: extractEntityId,
                     extractShardId: extractShardId);
-            }, config.First, config.Second);
+            }, Config.First, Config.Second);
 
             EnterBarrier("sharding started");
         }
@@ -158,7 +158,7 @@ namespace Akka.Cluster.Sharding.Tests
                         pingProbe.ReceiveWhile(null, m => (PingPongActor.Pong)m, 4);
                     });
                 });
-            }, config.Controller);
+            }, Config.Controller);
 
             EnterBarrier("sharded actors started");
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
@@ -88,7 +88,7 @@ namespace Akka.Cluster.Sharding.Tests
                 Sys,
                 typeName: ShardTypeName,
                 entityProps: Props.Create(() => new PingPongActor()),
-                settings: settings.Value.WithRole("shard"),
+                settings: Settings.Value.WithRole("shard"),
                 extractEntityId: extractEntityId,
                 extractShardId: extractShardId);
         }
@@ -107,10 +107,10 @@ namespace Akka.Cluster.Sharding.Tests
 
         private void Inspecting_cluster_sharding_state_must_join_cluster()
         {
-            Join(config.Controller, config.Controller);
-            Join(config.First, config.Controller);
-            Join(config.Second, config.Controller);
-            Join(config.Third, config.Controller);
+            Join(Config.Controller, Config.Controller);
+            Join(Config.First, Config.Controller);
+            Join(Config.Second, Config.Controller);
+            Join(Config.Third, Config.Controller);
 
             // make sure all nodes are up
             Within(TimeSpan.FromSeconds(10), () =>
@@ -130,12 +130,12 @@ namespace Akka.Cluster.Sharding.Tests
                     extractEntityId: extractEntityId,
                     extractShardId: extractShardId);
 
-            }, config.Controller);
+            }, Config.Controller);
 
             RunOn(() =>
             {
                 StartShard();
-            }, config.First, config.Second, config.Third);
+            }, Config.First, Config.Second, Config.Third);
 
             EnterBarrier("sharding started");
         }
@@ -177,7 +177,7 @@ namespace Akka.Cluster.Sharding.Tests
                         pingProbe.ReceiveWhile(null, m => (PingPongActor.Pong)m, 4);
                     });
                 });
-            }, config.Controller);
+            }, Config.Controller);
 
             EnterBarrier("sharded actors started");
         }
@@ -206,8 +206,8 @@ namespace Akka.Cluster.Sharding.Tests
         {
             RunOn(() =>
             {
-                Cluster.Get(Sys).Leave(Node(config.Third).Address);
-            }, config.Controller);
+                Cluster.Get(Sys).Leave(Node(Config.Third).Address);
+            }, Config.Controller);
 
             RunOn(() =>
             {
@@ -218,7 +218,7 @@ namespace Akka.Cluster.Sharding.Tests
                         Cluster.Get(Sys).State.Members.Count.Should().Be(3);
                     });
                 });
-            }, config.First, config.Second);
+            }, Config.First, Config.Second);
 
             EnterBarrier("third node removed");
             Sys.Log.Info("third node removed");
@@ -238,7 +238,7 @@ namespace Akka.Cluster.Sharding.Tests
                         pingProbe.ReceiveWhile(null, m => (PingPongActor.Pong)m, 4);
                     });
                 });
-            }, config.Controller);
+            }, Config.Controller);
 
             EnterBarrier("shards revived");
 
@@ -255,7 +255,7 @@ namespace Akka.Cluster.Sharding.Tests
                         regions.Values.SelectMany(i => i.Stats.Values).Sum().Should().Be(4);
                     });
                 });
-            }, config.Controller);
+            }, Config.Controller);
 
             EnterBarrier("done");
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownOldestSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownOldestSpec.cs
@@ -207,10 +207,10 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(30), () =>
             {
-                StartPersistenceIfNeeded(startOn: config.First, config.First, config.Second);
+                StartPersistenceIfNeeded(startOn: Config.First, Config.First, Config.Second);
 
-                Join(config.First, config.First, TypeName);
-                Join(config.Second, config.First, TypeName);
+                Join(Config.First, Config.First, TypeName);
+                Join(Config.Second, Config.First, TypeName);
 
                 AwaitAssert(() =>
                 {
@@ -245,12 +245,12 @@ namespace Akka.Cluster.Sharding.Tests
                     Sys.ActorOf(TerminationOrderActor.Props(terminationProbe.Ref, coordinator, _region.Value));
 
                     // trigger graceful shutdown
-                    Cluster.Leave(GetAddress(config.First));
+                    Cluster.Leave(GetAddress(Config.First));
 
                     // region first
                     terminationProbe.ExpectMsg<TerminationOrderActor.RegionTerminated>();
                     terminationProbe.ExpectMsg<TerminationOrderActor.CoordinatorTerminated>();
-                }, config.First);
+                }, Config.First);
 
                 EnterBarrier("terminated");
 
@@ -269,7 +269,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                         responses.Count.Should().Be(100);
                     });
-                }, config.Second);
+                }, Config.Second);
                 EnterBarrier("done-o");
             });
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
@@ -122,10 +122,10 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(30), () =>
             {
-                StartPersistenceIfNeeded(startOn: config.First, config.First, config.Second);
+                StartPersistenceIfNeeded(startOn: Config.First, Config.First, Config.Second);
 
-                Join(config.First, config.First, TypeName); // oldest
-                Join(config.Second, config.First, TypeName);
+                Join(Config.First, Config.First, TypeName); // oldest
+                Join(Config.Second, Config.First, TypeName);
 
                 AwaitAssert(() =>
                 {
@@ -161,7 +161,7 @@ namespace Akka.Cluster.Sharding.Tests
                         return Done.Instance;
                     });
                     CoordinatedShutdown.Get(Sys).Run(CoordinatedShutdown.UnknownReason.Instance);
-                }, config.Second);
+                }, Config.Second);
 
                 RunOn(() =>
                 {
@@ -175,7 +175,7 @@ namespace Akka.Cluster.Sharding.Tests
                             probe.LastSender.Path.Should().Be(_region.Value.Path / i.ToString() / i.ToString());
                         }
                     });
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("handoff-completed");
 
                 // Check that the coordinator is correctly notified the region has stopped:
@@ -188,14 +188,14 @@ namespace Akka.Cluster.Sharding.Tests
                         ExpectMsg<CurrentRegions>().Regions.Count.Should().Be(1);
                     });
                     // without having to wait for the member to be entirely removed (as that would cause unnecessary latency)
-                }, config.First);
+                }, Config.First);
 
 
                 RunOn(() =>
                 {
                     Watch(_region.Value);
                     ExpectTerminated(_region.Value);
-                }, config.Second);
+                }, Config.Second);
 
                 EnterBarrier("after-3");
             });
@@ -212,7 +212,7 @@ namespace Akka.Cluster.Sharding.Tests
                     Watch(regionEmpty);
                     regionEmpty.Tell(GracefulShutdown.Instance);
                     ExpectTerminated(regionEmpty, TimeSpan.FromSeconds(5));
-                }, config.First);
+                }, Config.First);
             });
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -181,13 +181,13 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(20), () =>
             {
-                StartPersistenceIfNeeded(startOn: config.First, Roles.ToArray());
+                StartPersistenceIfNeeded(startOn: Config.First, Roles.ToArray());
 
-                Join(config.First, config.First, onJoinedRunOnFrom: StartSharding);
-                Join(config.Second, config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
-                Join(config.Third, config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
-                Join(config.Fourth, config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
-                Join(config.Fifth, config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
+                Join(Config.First, Config.First, onJoinedRunOnFrom: StartSharding);
+                Join(Config.Second, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
+                Join(Config.Third, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
+                Join(Config.Fourth, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
+                Join(Config.Fifth, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
 
                 // all Up, everywhere before continuing
                 AwaitAssert(() =>
@@ -204,7 +204,7 @@ namespace Akka.Cluster.Sharding.Tests
                         _region.Value.Tell(GetCurrentRegions.Instance);
                         ExpectMsg<CurrentRegions>().Regions.Count.Should().Be(5);
                     });
-                }, config.First);
+                }, Config.First);
 
                 EnterBarrier("after-2");
             });
@@ -224,13 +224,13 @@ namespace Akka.Cluster.Sharding.Tests
 
                 shardLocations.Tell(new Locations(locations));
                 Sys.Log.Debug("Original locations: {0}", string.Join(",", locations.Select(x => $"{x.Key}->{x.Value}")));
-            }, config.First);
+            }, Config.First);
             EnterBarrier("after-3");
         }
 
         private void Cluster_sharding_with_leaving_member_must_recover_after_leaving_coordinator_node()
         {
-            Sys.ActorSelection(Node(config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
+            Sys.ActorSelection(Node(Config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
             var originalLocations = ExpectMsg<Locations>().LocationMap;
 
             var numberOfNodesLeaving = 2;
@@ -249,7 +249,7 @@ namespace Akka.Cluster.Sharding.Tests
                 var region = _region.Value;
                 Watch(region);
                 ExpectTerminated(region, TimeSpan.FromSeconds(15));
-            }, config.First);
+            }, Config.First);
             EnterBarrier("stopped");
             
             // more stress by not having the barrier here

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
@@ -101,12 +101,12 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(30), () =>
             {
-                StartPersistenceIfNeeded(startOn: config.First, config.First, config.Second, config.Third);
+                StartPersistenceIfNeeded(startOn: Config.First, Config.First, Config.Second, Config.Third);
 
                 // the only test not asserting join status before starting to shard
-                Join(config.First, config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
-                Join(config.Second, config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
-                Join(config.Third, config.First, assertNodeUp: false);
+                Join(Config.First, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
+                Join(Config.Second, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
+                Join(Config.Third, Config.First, assertNodeUp: false);
                 // wait with starting sharding on third
                 Within(Remaining, () =>
                 {
@@ -123,13 +123,13 @@ namespace Akka.Cluster.Sharding.Tests
                     _region.Value.Tell(1);
                     // not allocated because third has not registered yet
                     ExpectNoMsg(TimeSpan.FromSeconds(2));
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("verified");
 
                 RunOn(() =>
                 {
                     StartSharding();
-                }, config.Third);
+                }, Config.Third);
 
                 RunOn(() =>
                 {
@@ -139,14 +139,14 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(2);
                     _region.Value.Tell(3);
                     ExpectMsg(3);
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("shards-allocated");
 
                 _region.Value.Tell(new GetClusterShardingStats(Remaining));
                 var stats = ExpectMsg<ClusterShardingStats>();
-                var firstAddress = Node(config.First).Address;
-                var secondAddress = Node(config.Second).Address;
-                var thirdAddress = Node(config.Third).Address;
+                var firstAddress = Node(Config.First).Address;
+                var secondAddress = Node(Config.Second).Address;
+                var thirdAddress = Node(Config.Third).Address;
 
                 stats.Regions.Keys.Should().BeEquivalentTo(firstAddress, secondAddress, thirdAddress);
                 stats.Regions[firstAddress].Stats.Values.Sum().Should().Be(1);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingQueriesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingQueriesSpec.cs
@@ -100,7 +100,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         private void Querying_cluster_sharding_must_join_cluster_initialize_sharding()
         {
-            AwaitClusterUp(config.Controller, config.Busy, config.Second, config.Third);
+            AwaitClusterUp(Config.Controller, Config.Busy, Config.Second, Config.Third);
 
             RunOn(() =>
             {
@@ -110,7 +110,7 @@ namespace Akka.Cluster.Sharding.Tests
                     role: "shard",
                     extractEntityId: extractEntityId,
                     extractShardId: extractShardId);
-            }, config.Controller);
+            }, Config.Controller);
 
             RunOn(() =>
             {
@@ -118,10 +118,10 @@ namespace Akka.Cluster.Sharding.Tests
                     Sys,
                     typeName: ShardTypeName,
                     entityProps: Props.Create(() => new PingPongActor()),
-                    settings: settings.Value.WithRole("shard"),
+                    settings: Settings.Value.WithRole("shard"),
                     extractEntityId: extractEntityId,
                     extractShardId: extractShardId);
-            }, config.Busy, config.Second, config.Third);
+            }, Config.Busy, Config.Second, Config.Third);
 
             EnterBarrier("sharding started");
         }
@@ -142,7 +142,7 @@ namespace Akka.Cluster.Sharding.Tests
                         pingProbe.ReceiveWhile(null, m => (PingPongActor.Pong)m, 20);
                     });
                 });
-            }, config.Controller);
+            }, Config.Controller);
             EnterBarrier("sharded actors started");
         }
 
@@ -161,7 +161,7 @@ namespace Akka.Cluster.Sharding.Tests
                 // within shard-region-query-timeout, which only on first is 0ms
                 regions.Values.Select(i => i.Stats.Count).Sum().Should().Be(4);
                 regions.Values.Select(i => i.Failed.Count).Sum().Should().Be(timeouts);
-            }, config.Busy, config.Second, config.Third);
+            }, Config.Busy, Config.Second, Config.Third);
             EnterBarrier("received failed stats from timed out shards vs empty");
         }
 
@@ -175,7 +175,7 @@ namespace Akka.Cluster.Sharding.Tests
                 var state = probe.ExpectMsg<CurrentShardRegionState>();
                 state.Shards.Should().BeEmpty();
                 state.Failed.Should().HaveCount(2);
-            }, config.Busy);
+            }, Config.Busy);
             EnterBarrier("query-timeout-on-busy-node");
 
             RunOn(() =>
@@ -187,7 +187,7 @@ namespace Akka.Cluster.Sharding.Tests
                 var state = probe.ExpectMsg<CurrentShardRegionState>();
                 state.Shards.Should().HaveCount(2);
                 state.Failed.Should().BeEmpty();
-            }, config.Second, config.Third);
+            }, Config.Second, Config.Third);
             EnterBarrier("done");
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
@@ -62,9 +62,9 @@ namespace Akka.Cluster.Sharding.Tests
             Within(TimeSpan.FromSeconds(30), () =>
             {
                 // second should be oldest
-                Join(config.Second, config.Second);
-                Join(config.First, config.Second);
-                Join(config.Third, config.Second);
+                Join(Config.Second, Config.Second);
+                Join(Config.First, Config.Second);
+                Join(Config.Third, Config.Second);
 
                 AwaitAssert(() =>
                 {
@@ -83,7 +83,7 @@ namespace Akka.Cluster.Sharding.Tests
                         csTaskDone.Ref.Tell(Done.Instance);
                         return Task.FromResult(Done.Instance);
                     });
-                }, config.Third);
+                }, Config.Third);
 
                 StartSharding(
                     Sys,
@@ -98,14 +98,14 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     CoordinatedShutdown.Get(Sys).Run(CoordinatedShutdown.UnknownReason.Instance);
                     AwaitCondition(() => Cluster.IsTerminated);
-                }, config.Second);
+                }, Config.Second);
 
                 RunOn(() =>
                 {
                     CoordinatedShutdown.Get(Sys).Run(CoordinatedShutdown.UnknownReason.Instance);
                     AwaitCondition(() => Cluster.IsTerminated);
                     csTaskDone.ExpectMsg<Done>();
-                }, config.Third);
+                }, Config.Third);
 
                 EnterBarrier("after-shutdown");
 
@@ -114,7 +114,7 @@ namespace Akka.Cluster.Sharding.Tests
                     _region.Value.Tell(2);
                     ExpectMsg(2);
                     LastSender.Path.Address.HasLocalScope.Should().BeTrue();
-                }, config.First);
+                }, Config.First);
 
                 EnterBarrier("after-1");
             });

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
@@ -162,7 +162,7 @@ namespace Akka.Cluster.Sharding.Tests
                 Sys,
                 typeName: TypeName,
                 entityProps: Props.Create(() => new TestEntity(null)),
-                settings: settings.Value.WithRole("sharding"),
+                settings: Settings.Value.WithRole("sharding"),
                 extractEntityId: extractEntityId,
                 extractShardId: extractShardId1);
         }
@@ -173,7 +173,7 @@ namespace Akka.Cluster.Sharding.Tests
                 sys,
                 typeName: TypeName,
                 entityProps: Props.Create(() => new TestEntity(probe)),
-                settings: ClusterShardingSettings.Create(sys).WithRememberEntities(config.RememberEntities).WithRole("sharding"),
+                settings: ClusterShardingSettings.Create(sys).WithRememberEntities(Config.RememberEntities).WithRole("sharding"),
                 extractEntityId: extractEntityId,
                 extractShardId: extractShardId2);
         }
@@ -198,11 +198,11 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(15), () =>
             {
-                StartPersistenceIfNeeded(startOn: config.First, config.Second, config.Third);
+                StartPersistenceIfNeeded(startOn: Config.First, Config.Second, Config.Third);
 
-                Join(config.First, config.First);
-                Join(config.Second, config.First);
-                Join(config.Third, config.First);
+                Join(Config.First, Config.First);
+                Join(Config.Second, Config.First);
+                Join(Config.Third, Config.First);
 
                 RunOn(() =>
                 {
@@ -213,12 +213,12 @@ namespace Akka.Cluster.Sharding.Tests
                             Cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(3);
                         });
                     });
-                }, config.First, config.Second, config.Third);
+                }, Config.First, Config.Second, Config.Third);
 
                 RunOn(() =>
                 {
                     StartShardingWithExtractor1();
-                }, config.Second, config.Third);
+                }, Config.Second, Config.Third);
                 EnterBarrier("first-cluster-up");
 
                 RunOn(() =>
@@ -229,7 +229,7 @@ namespace Akka.Cluster.Sharding.Tests
                         Region().Tell(n);
                         ExpectMsg(n);
                     }
-                }, config.Second, config.Third);
+                }, Config.Second, Config.Third);
                 EnterBarrier("first-cluster-entities-up");
             });
         }
@@ -240,9 +240,9 @@ namespace Akka.Cluster.Sharding.Tests
             {
                 RunOn(() =>
                 {
-                    TestConductor.Exit(config.Second, 0).Wait();
-                    TestConductor.Exit(config.Third, 0).Wait();
-                }, config.First);
+                    TestConductor.Exit(Config.Second, 0).Wait();
+                    TestConductor.Exit(Config.Third, 0).Wait();
+                }, Config.First);
 
                 RunOn(() =>
                 {
@@ -253,7 +253,7 @@ namespace Akka.Cluster.Sharding.Tests
                             Cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(1);
                         });
                     });
-                }, config.First);
+                }, Config.First);
 
             });
             EnterBarrier("first-sharding-cluster-stopped");
@@ -276,7 +276,7 @@ namespace Akka.Cluster.Sharding.Tests
                         Cluster.Get(Sys).IsTerminated.Should().BeTrue();
                     });
 
-                }, config.Second, config.Third);
+                }, Config.Second, Config.Third);
                 EnterBarrier("first-cluster-terminated");
 
                 // no sharding nodes left of the original cluster, start a new nodes
@@ -287,16 +287,16 @@ namespace Akka.Cluster.Sharding.Tests
 
                     if (PersistenceIsNeeded)
                     {
-                        SetStore(sys2, storeOn: config.First);
+                        SetStore(sys2, storeOn: Config.First);
 
                         ////Persistence.Persistence.Instance.Apply(sys2);
-                        //sys2.ActorSelection(Node(config.First) / "system" / "akka.persistence.journal.sqlite").Tell(new Identify(null), probe2.Ref);
+                        //sys2.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.sqlite").Tell(new Identify(null), probe2.Ref);
                         //var sharedStore = probe2.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
                         //sharedStore.Should().NotBeNull();
                         //SqliteJournalShared.SetStore(sharedStore, sys2);
                     }
 
-                    Cluster.Get(sys2).Join(Node(config.First).Address);
+                    Cluster.Get(sys2).Join(Node(Config.First).Address);
                     StartShardingWithExtractor2(sys2, probe2.Ref);
                     probe2.ExpectMsg<Started>(TimeSpan.FromSeconds(20));
 
@@ -323,12 +323,12 @@ namespace Akka.Cluster.Sharding.Tests
 
                     EnterBarrier("verified");
                     Shutdown(sys2);
-                }, config.Second, config.Third);
+                }, Config.Second, Config.Third);
 
                 RunOn(() =>
                 {
                     EnterBarrier("verified");
-                }, config.First);
+                }, Config.First);
 
                 EnterBarrier("done");
             });

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRolePartitioningSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRolePartitioningSpec.cs
@@ -179,7 +179,7 @@ namespace Akka.Cluster.Sharding.Tests
               typeName: E1.TypeKey,
               entityProps: SimpleEchoActor.Props(),
               // nodes 1,2,3: role R1, shard region E1, proxy region E2
-              settings: settings.Value.WithRole("R1"),
+              settings: Settings.Value.WithRole("R1"),
               extractEntityId: E1.ExtractEntityId,
               extractShardId: E1.ExtractShardId);
 
@@ -189,11 +189,11 @@ namespace Akka.Cluster.Sharding.Tests
                 typeName: E2.TypeKey,
                 entityProps: SimpleEchoActor.Props(),
                 // nodes 4,5: role R2, shard region E2, proxy region E1
-                settings: settings.Value.WithRole("R2"),
+                settings: Settings.Value.WithRole("R2"),
                 extractEntityId: E2.ExtractEntityId,
                 extractShardId: E2.ExtractShardId);
 
-            AwaitClusterUp(config.First, config.Second, config.Third, config.Fourth, config.Fifth);
+            AwaitClusterUp(Config.First, Config.Second, Config.Third, Config.Fourth, Config.Fifth);
 
             RunOn(() =>
             {
@@ -210,7 +210,7 @@ namespace Akka.Cluster.Sharding.Tests
                     region.Tell(GetCurrentRegions.Instance);
                     ExpectMsg<CurrentRegions>().Regions.Count.Should().Be(2);
                 });
-            }, config.Fourth);
+            }, Config.Fourth);
 
             EnterBarrier($"{Roles.Count}-up");
         }
@@ -234,7 +234,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                 stats.Regions.Keys.Should().BeEquivalentTo(fourthAddress, fifthAddress);
                 stats.Regions.Values.SelectMany(i => i.Stats.Values).Count().Should().Be(20);
-            }, config.First);
+            }, Config.First);
             EnterBarrier("proxy-node-other-role-to-shard");
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSingleShardPerEntitySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSingleShardPerEntitySpec.cs
@@ -76,7 +76,7 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(10), () =>
             {
-                Join(node, config.First);
+                Join(node, Config.First);
                 RunOn(() =>
                 {
                     _region.Value.Tell(entityId);
@@ -100,18 +100,18 @@ namespace Akka.Cluster.Sharding.Tests
 
         private void Cluster_sharding_with_single_shard_per_entity_must_use_specified_region()
         {
-            JoinAndAllocate(config.First, 1);
-            JoinAndAllocate(config.Second, 2);
-            JoinAndAllocate(config.Third, 3);
-            JoinAndAllocate(config.Fourth, 4);
-            JoinAndAllocate(config.Fifth, 5);
+            JoinAndAllocate(Config.First, 1);
+            JoinAndAllocate(Config.Second, 2);
+            JoinAndAllocate(Config.Third, 3);
+            JoinAndAllocate(Config.Fourth, 4);
+            JoinAndAllocate(Config.Fifth, 5);
 
             RunOn(() =>
             {
                 // coordinator is on 'first', blackhole 3 other means that it can't update with WriteMajority
-                TestConductor.Blackhole(config.First, config.Third, ThrottleTransportAdapter.Direction.Both).Wait();
-                TestConductor.Blackhole(config.First, config.Fourth, ThrottleTransportAdapter.Direction.Both).Wait();
-                TestConductor.Blackhole(config.First, config.Fifth, ThrottleTransportAdapter.Direction.Both).Wait();
+                TestConductor.Blackhole(Config.First, Config.Third, ThrottleTransportAdapter.Direction.Both).Wait();
+                TestConductor.Blackhole(Config.First, Config.Fourth, ThrottleTransportAdapter.Direction.Both).Wait();
+                TestConductor.Blackhole(Config.First, Config.Fifth, ThrottleTransportAdapter.Direction.Both).Wait();
 
                 // shard 6 not allocated yet and due to the blackhole it will not be completed
                 _region.Value.Tell(6);
@@ -124,13 +124,13 @@ namespace Akka.Cluster.Sharding.Tests
                 // be able to answer GetShardHome even though previous request for shard 4 has not completed yet
                 _region.Value.Tell(2);
                 ExpectMsg(2);
-                LastSender.Path.Should().Be(Node(config.Second) / "system" / "sharding" / "Entity" / "2" / "2");
+                LastSender.Path.Should().Be(Node(Config.Second) / "system" / "sharding" / "Entity" / "2" / "2");
 
-                TestConductor.PassThrough(config.First, config.Third, ThrottleTransportAdapter.Direction.Both).Wait();
-                TestConductor.PassThrough(config.First, config.Fourth, ThrottleTransportAdapter.Direction.Both).Wait();
-                TestConductor.PassThrough(config.First, config.Fifth, ThrottleTransportAdapter.Direction.Both).Wait();
+                TestConductor.PassThrough(Config.First, Config.Third, ThrottleTransportAdapter.Direction.Both).Wait();
+                TestConductor.PassThrough(Config.First, Config.Fourth, ThrottleTransportAdapter.Direction.Both).Wait();
+                TestConductor.PassThrough(Config.First, Config.Fifth, ThrottleTransportAdapter.Direction.Both).Wait();
                 ExpectMsg(6, TimeSpan.FromSeconds(10));
-            }, config.First);
+            }, Config.First);
 
             EnterBarrier("after-1");
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -54,7 +54,7 @@ namespace Akka.Cluster.Sharding.Tests
             // because it uses a PersistentActor. So unlike all other uses of
             // `MultiNodeClusterShardingConfig`, we use `MultiNodeConfig.commonConfig` here,
             // and call `MultiNodeClusterShardingConfig.persistenceConfig` which does not check
-            // mode, then leverage the common config and fallbacks after these specific test configs:
+            // mode, then leverage the common _config and fallbacks after these specific test configs:
             CommonConfig = ConfigurationFactory.ParseString($@"
                 akka.cluster.sharding.verbose-debug-logging = on
                 #akka.loggers = [""akka.testkit.SilenceAllTestEventListener""]
@@ -417,7 +417,7 @@ namespace Akka.Cluster.Sharding.Tests
         private DDataRememberEntitiesProvider DdataRememberEntitiesProvider(string typeName)
         {
             var majorityMinCap = Sys.Settings.Config.GetInt("akka.cluster.sharding.distributed-data.majority-min-cap");
-            return new DDataRememberEntitiesProvider(typeName, settings.Value, majorityMinCap, _replicator.Value);
+            return new DDataRememberEntitiesProvider(typeName, Settings.Value, majorityMinCap, _replicator.Value);
         }
 
         private EventSourcedRememberEntitiesProvider EventSourcedRememberEntitiesProvider(string typeName, ClusterShardingSettings settings)
@@ -558,15 +558,15 @@ namespace Akka.Cluster.Sharding.Tests
 
         private void ClusterSharding_should_setup_shared_journal()
         {
-            StartPersistence(config.Controller,
-                config.First, config.Second, config.Third, config.Fourth, config.Fifth, config.Sixth);
+            StartPersistence(Config.Controller,
+                Config.First, Config.Second, Config.Third, Config.Fourth, Config.Fifth, Config.Sixth);
         }
 
         private void ClusterSharding_should_work_in_single_node_cluster()
         {
             Within(TimeSpan.FromSeconds(20), () =>
             {
-                Join(config.First, config.First);
+                Join(Config.First, Config.First);
 
                 RunOn(() =>
                 {
@@ -580,7 +580,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                     r.Tell(GetCurrentRegions.Instance);
                     ExpectMsg(new CurrentRegions(ImmutableHashSet.Create(Cluster.SelfAddress)));
-                }, config.First);
+                }, Config.First);
 
                 EnterBarrier("after-2");
             });
@@ -590,7 +590,7 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(20), () =>
             {
-                Join(config.Second, config.First);
+                Join(Config.Second, Config.First);
 
                 RunOn(() =>
                 {
@@ -608,7 +608,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(1);
                     r.Tell(new Get(12));
                     ExpectMsg(1);
-                }, config.Second);
+                }, Config.Second);
                 EnterBarrier("second-update");
 
                 RunOn(() =>
@@ -617,7 +617,7 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new EntityEnvelope(2, Increment.Instance));
                     r.Tell(new Get(2));
                     ExpectMsg(3);
-                    LastSender.Path.Should().Be(Node(config.Second) / "user" / "counterRegion" / "2" / "2");
+                    LastSender.Path.Should().Be(Node(Config.Second) / "user" / "counterRegion" / "2" / "2");
 
                     r.Tell(new Get(11));
                     ExpectMsg(1);
@@ -629,11 +629,11 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(1);
                     var path12 = LastSender.Path;
                     LastSender.Path.ToStringWithoutAddress().Should().Be((r.Path / "0" / "12").ToStringWithoutAddress());
-                    //LastSender.Path.Should().Be(Node(config.Second) / "user" / "counterRegion" / "0" / "12");
+                    //LastSender.Path.Should().Be(Node(_config.Second) / "user" / "counterRegion" / "0" / "12");
 
                     //one has to be local, the other one remote
                     (path11.Address.HasLocalScope && path12.Address.HasGlobalScope || path11.Address.HasGlobalScope && path12.Address.HasLocalScope).Should().BeTrue();
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("first-update");
 
                 RunOn(() =>
@@ -644,8 +644,8 @@ namespace Akka.Cluster.Sharding.Tests
                     LastSender.Path.Should().Be(r.Path / "2" / "2");
 
                     r.Tell(GetCurrentRegions.Instance);
-                    ExpectMsg(new CurrentRegions(ImmutableHashSet.Create(Cluster.SelfAddress, Node(config.First).Address)));
-                }, config.Second);
+                    ExpectMsg(new CurrentRegions(ImmutableHashSet.Create(Cluster.SelfAddress, Node(Config.First).Address)));
+                }, Config.Second);
                 EnterBarrier("after-3");
             });
         }
@@ -663,7 +663,7 @@ namespace Akka.Cluster.Sharding.Tests
                 r.Tell(new EntityEnvelope(2, Increment.Instance));
                 r.Tell(new Get(2));
                 ExpectMsg(4);
-            }, config.Second);
+            }, Config.Second);
             EnterBarrier("after-4");
         }
 
@@ -690,7 +690,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(2);
                     proxy.Tell(new Get(2));
                     ExpectMsg(4);
-                }, config.Second);
+                }, Config.Second);
                 EnterBarrier("after-5");
             });
         }
@@ -706,8 +706,8 @@ namespace Akka.Cluster.Sharding.Tests
 
                 RunOn(() =>
                 {
-                    TestConductor.Exit(config.Second, 0).Wait();
-                }, config.Controller);
+                    TestConductor.Exit(Config.Second, 0).Wait();
+                }, Config.Controller);
                 EnterBarrier("crash-second");
 
                 RunOn(() =>
@@ -735,7 +735,7 @@ namespace Akka.Cluster.Sharding.Tests
                             probe2.LastSender.Path.Should().Be(r.Path / "0" / "12");
                         });
                     });
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("after-6");
             });
         }
@@ -744,7 +744,7 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(15), () =>
             {
-                Join(config.Third, config.First);
+                Join(Config.Third, Config.First);
 
                 RunOn(() =>
                 {
@@ -755,10 +755,10 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Get(3));
                     ExpectMsg(10);
                     LastSender.Path.Should().Be(r.Path / "3" / "3"); // local
-                }, config.Third);
+                }, Config.Third);
                 EnterBarrier("third-update");
 
-                Join(config.Fourth, config.First);
+                Join(Config.Fourth, Config.First);
 
                 RunOn(() =>
                 {
@@ -769,7 +769,7 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Get(4));
                     ExpectMsg(20);
                     LastSender.Path.Should().Be(r.Path / "4" / "4"); // local
-                }, config.Fourth);
+                }, Config.Fourth);
                 EnterBarrier("fourth-update");
 
                 RunOn(() =>
@@ -778,13 +778,13 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new EntityEnvelope(3, Increment.Instance));
                     r.Tell(new Get(3));
                     ExpectMsg(11);
-                    LastSender.Path.Should().Be(Node(config.Third) / "user" / "counterRegion" / "3" / "3");
+                    LastSender.Path.Should().Be(Node(Config.Third) / "user" / "counterRegion" / "3" / "3");
 
                     r.Tell(new EntityEnvelope(4, Increment.Instance));
                     r.Tell(new Get(4));
                     ExpectMsg(21);
-                    LastSender.Path.Should().Be(Node(config.Fourth) / "user" / "counterRegion" / "4" / "4");
-                }, config.First);
+                    LastSender.Path.Should().Be(Node(Config.Fourth) / "user" / "counterRegion" / "4" / "4");
+                }, Config.First);
                 EnterBarrier("first-update");
 
                 RunOn(() =>
@@ -793,7 +793,7 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Get(3));
                     ExpectMsg(11);
                     LastSender.Path.Should().Be(r.Path / "3" / "3");
-                }, config.Third);
+                }, Config.Third);
 
                 RunOn(() =>
                 {
@@ -801,7 +801,7 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Get(4));
                     ExpectMsg(21);
                     LastSender.Path.Should().Be(r.Path / "4" / "4");
-                }, config.Fourth);
+                }, Config.Fourth);
                 EnterBarrier("after-7");
             });
         }
@@ -810,11 +810,11 @@ namespace Akka.Cluster.Sharding.Tests
         {
             Within(TimeSpan.FromSeconds(60), () =>
             {
-                Join(config.Fifth, config.Fourth);
+                Join(Config.Fifth, Config.Fourth);
                 RunOn(() =>
                 {
-                    TestConductor.Exit(config.First, 0).Wait();
-                }, config.Controller);
+                    TestConductor.Exit(Config.First, 0).Wait();
+                }, Config.Controller);
                 EnterBarrier("crash-first");
 
                 RunOn(() =>
@@ -826,7 +826,7 @@ namespace Akka.Cluster.Sharding.Tests
                         {
                             _region.Value.Tell(new Get(3), probe3.Ref);
                             probe3.ExpectMsg(11);
-                            probe3.LastSender.Path.Should().Be(Node(config.Third) / "user" / "counterRegion" / "3" / "3");
+                            probe3.LastSender.Path.Should().Be(Node(Config.Third) / "user" / "counterRegion" / "3" / "3");
                         });
                     });
 
@@ -837,10 +837,10 @@ namespace Akka.Cluster.Sharding.Tests
                         {
                             _region.Value.Tell(new Get(4), probe4.Ref);
                             probe4.ExpectMsg(21);
-                            probe4.LastSender.Path.Should().Be(Node(config.Fourth) / "user" / "counterRegion" / "4" / "4");
+                            probe4.LastSender.Path.Should().Be(Node(Config.Fourth) / "user" / "counterRegion" / "4" / "4");
                         });
                     });
-                }, config.Fifth);
+                }, Config.Fifth);
                 EnterBarrier("after-8");
             });
         }
@@ -858,10 +858,10 @@ namespace Akka.Cluster.Sharding.Tests
                         rebalancingRegion.Tell(new Get(i));
                         ExpectMsg(1);
                     }
-                }, config.Fourth);
+                }, Config.Fourth);
                 EnterBarrier("rebalancing-shards-allocated");
 
-                Join(config.Sixth, config.Third);
+                Join(Config.Sixth, Config.Third);
 
                 RunOn(() =>
                 {
@@ -883,7 +883,7 @@ namespace Akka.Cluster.Sharding.Tests
                             count.Should().BeGreaterOrEqualTo(2);
                         });
                     });
-                }, config.Sixth);
+                }, Config.Sixth);
                 EnterBarrier("after-9");
             });
         }
@@ -917,7 +917,7 @@ namespace Akka.Cluster.Sharding.Tests
                         settings: ClusterShardingSettings.Create(Sys),
                         extractEntityId: ExtractEntityId,
                         extractShardId: ExtractShardId);
-                }, config.Third, config.Fourth, config.Fifth, config.Sixth);
+                }, Config.Third, Config.Fourth, Config.Fifth, Config.Sixth);
                 EnterBarrier("extension-started");
 
                 RunOn(() =>
@@ -937,7 +937,7 @@ namespace Akka.Cluster.Sharding.Tests
                     anotherCounterRegion.Tell(new EntityEnvelope(entityId, Decrement.Instance));
                     anotherCounterRegion.Tell(new Get(entityId));
                     ExpectMsg(-1);
-                }, config.Fifth);
+                }, Config.Fifth);
                 EnterBarrier("extension-used");
 
                 // sixth is a frontend node, i.e. proxy only
@@ -950,7 +950,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(1);
                     LastSender.Path.Address.Should().NotBe(Cluster.SelfAddress);
                 }
-            }, config.Sixth);
+            }, Config.Sixth);
                 EnterBarrier("after-10");
             });
         }
@@ -971,7 +971,7 @@ namespace Akka.Cluster.Sharding.Tests
                     var counterRegionViaGet = ClusterSharding.Get(Sys).ShardRegion("ApiTest");
 
                     counterRegionViaStart.Should().Be(counterRegionViaGet);
-                }, config.First);
+                }, Config.First);
                 EnterBarrier("after-11");
             });
         }
@@ -988,7 +988,7 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     _ = _persistentEntitiesRegion.Value;
                     _ = _anotherPersistentRegion.Value;
-                }, config.Third, config.Fourth, config.Fifth);
+                }, Config.Third, Config.Fourth, Config.Fifth);
                 EnterBarrier("persistent-start");
 
                 // watch-out, these two var are only init on 3rd node
@@ -1003,7 +1003,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                     shard = Sys.ActorSelection(LastSender.Path.Parent);
                     region = Sys.ActorSelection(LastSender.Path.Parent.Parent);
-                }, config.Third);
+                }, Config.Third);
                 EnterBarrier("counter-incremented");
 
 
@@ -1012,7 +1012,7 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     _persistentEntitiesRegion.Value.Tell(new BeginHandOff("1"));
                     ExpectMsg(new BeginHandOffAck("1"), TimeSpan.FromSeconds(10), "ShardStopped not received");
-                }, config.Third, config.Fourth, config.Fifth);
+                }, Config.Third, Config.Fourth, Config.Fifth);
                 EnterBarrier("everybody-hand-off-ack");
 
 
@@ -1052,7 +1052,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                     counter1.Tell(new Get(1));
                     ExpectMsg(1);
-                }, config.Third);
+                }, Config.Third);
                 EnterBarrier("after-shard-restart");
 
                 RunOn(() =>
@@ -1068,7 +1068,7 @@ namespace Akka.Cluster.Sharding.Tests
                     var secondCounter1 = Sys.ActorSelection(LastSender.Path.Parent / "1");
                     secondCounter1.Tell(new Identify(3));
                     ExpectMsg(new ActorIdentity(3, null), TimeSpan.FromSeconds(3));
-                }, config.Fourth);
+                }, Config.Fourth);
                 EnterBarrier("after-12");
             });
         }
@@ -1080,7 +1080,7 @@ namespace Akka.Cluster.Sharding.Tests
                 RunOn(() =>
                 {
                     _ = _persistentRegion.Value;
-                }, config.Third, config.Fourth, config.Fifth);
+                }, Config.Third, Config.Fourth, Config.Fifth);
                 EnterBarrier("cluster-started-12");
 
                 RunOn(() =>
@@ -1129,7 +1129,7 @@ namespace Akka.Cluster.Sharding.Tests
                         probe2.ExpectMsg(new ActorIdentity(2, null), TimeSpan.FromSeconds(1), "Shard was still around");
                     }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
 
-                }, config.Third);
+                }, Config.Third);
                 EnterBarrier("shard-shutdonw-12");
 
                 RunOn(() =>
@@ -1151,7 +1151,7 @@ namespace Akka.Cluster.Sharding.Tests
                         Sys.ActorSelection(shard / "13").Tell(new Identify(4), probe3.Ref);
                         probe3.ExpectMsg<ActorIdentity>(i => i.MessageId.Equals(4) && i.Subject != null);
                     }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
-                }, config.Fourth);
+                }, Config.Fourth);
                 EnterBarrier("after-13");
             });
         }
@@ -1163,7 +1163,7 @@ namespace Akka.Cluster.Sharding.Tests
                 RunOn(() =>
                 {
                     _ = _persistentRegion.Value;
-                }, config.Third, config.Fourth);
+                }, Config.Third, Config.Fourth);
                 EnterBarrier("cluster-started-12");
 
                 RunOn(() =>
@@ -1182,7 +1182,7 @@ namespace Akka.Cluster.Sharding.Tests
                         counter1.Tell(new Identify(1), probe.Ref);
                         probe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(1)).Subject.Should().NotBeNull();
                     }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
-                }, config.Third);
+                }, Config.Third);
                 EnterBarrier("after-14");
             });
         }
@@ -1197,7 +1197,7 @@ namespace Akka.Cluster.Sharding.Tests
                     _autoMigrateRegion.Value.Tell(new EntityEnvelope(1, Increment.Instance));
                     _autoMigrateRegion.Value.Tell(new Get(1));
                     ExpectMsg(1);
-                }, config.Third);
+                }, Config.Third);
                 EnterBarrier("shard1-region3");
 
                 //Start another region and test it talks to node 3
@@ -1207,11 +1207,11 @@ namespace Akka.Cluster.Sharding.Tests
                     _autoMigrateRegion.Value.Tell(new Get(1));
                     ExpectMsg(2);
 
-                    LastSender.Path.Should().Be(Node(config.Third) / "user" / "AutoMigrateRememberRegionTestRegion" / "1" / "1");
+                    LastSender.Path.Should().Be(Node(Config.Third) / "user" / "AutoMigrateRememberRegionTestRegion" / "1" / "1");
 
                     // kill region 3
                     Sys.ActorSelection(LastSender.Path.Parent.Parent).Tell(PoisonPill.Instance);
-                }, config.Fourth);
+                }, Config.Fourth);
                 EnterBarrier("region4-up");
 
                 // Wait for migration to happen
@@ -1228,7 +1228,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                     counter1.Tell(new Get(1));
                     ExpectMsg(2);
-                }, config.Fourth);
+                }, Config.Fourth);
                 EnterBarrier("after-15");
             });
         }
@@ -1247,13 +1247,13 @@ namespace Akka.Cluster.Sharding.Tests
                         _rebalancingPersistentRegion.Value.Tell(new Get(i));
                         ExpectMsg(1);
                     }
-                }, config.Fourth);
+                }, Config.Fourth);
                 EnterBarrier("entities-started");
 
                 RunOn(() =>
                 {
                     _ = _rebalancingPersistentRegion.Value;
-                }, config.Fifth);
+                }, Config.Fifth);
                 EnterBarrier("fifth-joined-shard");
 
                 RunOn(() =>
@@ -1273,7 +1273,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                         count.Should().BeGreaterOrEqualTo(2);
                     });
-                }, config.Fifth);
+                }, Config.Fifth);
                 EnterBarrier("after-16");
             });
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ExternalShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ExternalShardAllocationSpec.cs
@@ -146,7 +146,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         private void External_shard_allocation_must_form_cluster()
         {
-            AwaitClusterUp(config.First, config.Second, config.Third);
+            AwaitClusterUp(Config.First, Config.Second, Config.Third);
             EnterBarrier("cluster-started");
         }
 
@@ -164,7 +164,7 @@ namespace Akka.Cluster.Sharding.Tests
                 _shardRegion.Value.Tell(new GiveMeYourHome.Get(Myself.Name));
                 var actorLocation = ExpectMsg<GiveMeYourHome.Home>(TimeSpan.FromSeconds(20)).Address;
                 actorLocation.Should().Be(Cluster.Get(Sys).SelfAddress);
-            }, config.First, config.Second, config.Third);
+            }, Config.First, Config.Second, Config.Third);
             EnterBarrier("local-message-sent");
         }
 
@@ -177,7 +177,7 @@ namespace Akka.Cluster.Sharding.Tests
                     .ClientFor(TypeName)
                     .UpdateShardLocation(shardToSpecifyLocation, Cluster.Get(Sys).SelfAddress)
                     .Result;
-            }, config.First);
+            }, Config.First);
             EnterBarrier("shard-location-updated");
 
             RunOn(() =>
@@ -186,35 +186,35 @@ namespace Akka.Cluster.Sharding.Tests
                 AwaitAssert(() =>
                 {
                     _shardRegion.Value.Tell(new GiveMeYourHome.Get(shardToSpecifyLocation), probe.Ref);
-                    probe.ExpectMsg<GiveMeYourHome.Home>(m => m.Address.Equals(GetAddress(config.First)));
+                    probe.ExpectMsg<GiveMeYourHome.Home>(m => m.Address.Equals(GetAddress(Config.First)));
                 }, TimeSpan.FromSeconds(10));
-            }, config.Second, config.Third);
+            }, Config.Second, Config.Third);
             EnterBarrier("shard-allocated-to-specific-node");
         }
 
         private void External_shard_allocation_must_allocate_to_a_node_that_does_not_exist_yet()
         {
             var onForthShardId = "on-forth";
-            var forthAddress = GetAddress(config.Forth);
+            var forthAddress = GetAddress(Config.Forth);
             RunOn(() =>
             {
                 Sys.Log.Info("Allocating {0} on {1}", onForthShardId, forthAddress);
                 ExternalShardAllocation.Get(Sys).ClientFor(TypeName).UpdateShardLocations(ImmutableDictionary<string, Address>.Empty.Add(onForthShardId, forthAddress));
-            }, config.Second);
+            }, Config.Second);
             EnterBarrier("allocated-to-new-node");
             RunOn(() =>
             {
-                JoinWithin(config.First, max: TimeSpan.FromSeconds(10));
-            }, config.Forth);
+                JoinWithin(Config.First, max: TimeSpan.FromSeconds(10));
+            }, Config.Forth);
             EnterBarrier("forth-node-joined");
             RunOn(() =>
             {
                 AwaitAssert(() =>
                 {
                     _shardRegion.Value.Tell(new GiveMeYourHome.Get(InitiallyOnForth));
-                    ExpectMsg<GiveMeYourHome.Home>(m => m.Address.Equals(GetAddress(config.Forth)));
+                    ExpectMsg<GiveMeYourHome.Home>(m => m.Address.Equals(GetAddress(Config.Forth)));
                 }, TimeSpan.FromSeconds(10));
-            }, config.First, config.Second, config.Third);
+            }, Config.First, Config.Second, Config.Third);
             EnterBarrier("shard-allocated-to-forth");
         }
 
@@ -222,18 +222,18 @@ namespace Akka.Cluster.Sharding.Tests
         {
             RunOn(() =>
             {
-                Sys.Log.Info("Moving shard from forth to first: {0}", GetAddress(config.First));
-                ExternalShardAllocation.Get(Sys).ClientFor(TypeName).UpdateShardLocation(InitiallyOnForth, GetAddress(config.First));
-            }, config.Third);
+                Sys.Log.Info("Moving shard from forth to first: {0}", GetAddress(Config.First));
+                ExternalShardAllocation.Get(Sys).ClientFor(TypeName).UpdateShardLocation(InitiallyOnForth, GetAddress(Config.First));
+            }, Config.Third);
             EnterBarrier("shard-moved-from-forth-to-first");
             RunOn(() =>
             {
                 AwaitAssert(() =>
                 {
                     _shardRegion.Value.Tell(new GiveMeYourHome.Get(InitiallyOnForth));
-                    ExpectMsg<GiveMeYourHome.Home>(m => m.Address.Equals(GetAddress(config.First)));
+                    ExpectMsg<GiveMeYourHome.Home>(m => m.Address.Equals(GetAddress(Config.First)));
                 }, TimeSpan.FromSeconds(10));
-            }, config.First, config.Second, config.Third, config.Forth);
+            }, Config.First, Config.Second, Config.Third, Config.Forth);
             EnterBarrier("finished");
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
@@ -38,7 +38,7 @@ namespace Akka.Cluster.Sharding.Tests
         /// </summary>
         /// <param name="mode">mode the state store mode</param>
         /// <param name="rememberEntities">rememberEntities defaults to off</param>
-        /// <param name="additionalConfig">additionalConfig additional config</param>
+        /// <param name="additionalConfig">additionalConfig additional _config</param>
         /// <param name="loglevel">loglevel defaults to INFO</param>
         protected MultiNodeClusterShardingConfig(
             StateStoreMode mode = StateStoreMode.DData,

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/RollingUpdateShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/RollingUpdateShardAllocationSpec.cs
@@ -147,7 +147,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         private void ClusterSharding_must_form_cluster()
         {
-            AwaitClusterUp(config.First, config.Second);
+            AwaitClusterUp(Config.First, Config.Second);
             EnterBarrier("cluster-started");
         }
 
@@ -173,13 +173,13 @@ namespace Akka.Cluster.Sharding.Tests
 
                 // one on each node
                 ImmutableHashSet.Create(address1, address2).Should().HaveCount(2);
-            }, config.First, config.Second);
+            }, Config.First, Config.Second);
             EnterBarrier("first-version-started");
         }
 
         private void ClusterSharding_must_start_a_rolling_upgrade()
         {
-            Join(config.Third, config.First);
+            Join(Config.Third, Config.First);
 
             RunOn(() =>
             {
@@ -195,14 +195,14 @@ namespace Akka.Cluster.Sharding.Tests
                     shardRegion.Value.Tell(GetCurrentRegions.Instance);
                     ExpectMsg<CurrentRegions>().Regions.Should().HaveCount(3);
                 });
-            }, config.First, config.Second, config.Third);
+            }, Config.First, Config.Second, Config.Third);
 
             EnterBarrier("third-region-registered");
             RunOn(() =>
             {
                 shardRegion.Value.Tell(new GiveMeYourHome.Get("id3"));
                 ExpectMsg<GiveMeYourHome.Home>();
-            }, config.First, config.Second);
+            }, Config.First, Config.Second);
             RunOn(() =>
             {
                 // now third region should be only option as the other two are old versions
@@ -214,26 +214,26 @@ namespace Akka.Cluster.Sharding.Tests
                     shardRegion.Value.Tell(new GiveMeYourHome.Get($"id{n}"));
                     ExpectMsg<GiveMeYourHome.Home>().Address.Should().Be(Cluster.Get(Sys).SelfAddress);
                 }
-            }, config.Third);
+            }, Config.Third);
             EnterBarrier("rolling-upgrade-in-progress");
         }
 
         private void ClusterSharding_must_complete_a_rolling_upgrade()
         {
-            Join(config.Fourth, config.First);
+            Join(Config.Fourth, Config.First);
 
             RunOn(() =>
             {
                 var cluster = Cluster.Get(Sys);
                 cluster.Leave(cluster.SelfAddress);
-            }, config.First);
+            }, Config.First);
             RunOn(() =>
             {
                 AwaitAssert(() =>
                 {
                     UpMembers.Count().Should().Be(3);
                 });
-            }, config.Second, config.Third, config.Fourth);
+            }, Config.Second, Config.Third, Config.Fourth);
             EnterBarrier("first-left");
 
             RunOn(() =>
@@ -244,7 +244,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg<CurrentRegions>().Regions.Should().HaveCount(3);
 
                 }, TimeSpan.FromSeconds(30));
-            }, config.Second, config.Third, config.Fourth);
+            }, Config.Second, Config.Third, Config.Fourth);
             EnterBarrier("sharding-handed-off");
 
             // trigger allocation (no verification because we don't know which id was on node 1)
@@ -258,14 +258,14 @@ namespace Akka.Cluster.Sharding.Tests
                     shardRegion.Value.Tell(new GiveMeYourHome.Get("id2"));
                     ExpectMsg<GiveMeYourHome.Home>();
                 });
-            }, config.Second, config.Third, config.Fourth);
+            }, Config.Second, Config.Third, Config.Fourth);
             EnterBarrier("first-allocated");
 
             RunOn(() =>
             {
                 var cluster = Cluster.Get(Sys);
                 cluster.Leave(cluster.SelfAddress);
-            }, config.Second);
+            }, Config.Second);
             RunOn(() =>
             {
                 // make sure coordinator has noticed there are only two regions
@@ -274,7 +274,7 @@ namespace Akka.Cluster.Sharding.Tests
                     shardRegion.Value.Tell(GetCurrentRegions.Instance);
                     ExpectMsg<CurrentRegions>().Regions.Should().HaveCount(2);
                 }, TimeSpan.FromSeconds(30));
-            }, config.Third, config.Fourth);
+            }, Config.Third, Config.Fourth);
             EnterBarrier("second-left");
 
             // trigger allocation and verify where each was started
@@ -290,7 +290,7 @@ namespace Akka.Cluster.Sharding.Tests
                     var address2 = ExpectMsg<GiveMeYourHome.Home>().Address;
                     UpMembers.Select(i => i.Address).Should().Contain(address2);
                 });
-            }, config.Third, config.Fourth);
+            }, Config.Third, Config.Fourth);
             EnterBarrier("completo");
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/AutomaticallyHandledExtractorMessagesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/AutomaticallyHandledExtractorMessagesSpec.cs
@@ -1,0 +1,99 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="AutomaticallyHandledExtractorMessagesSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+#nullable enable
+using Akka.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Cluster.Sharding.Tests;
+
+public class AutomaticallyHandledExtractorMessagesSpec
+{
+    // custom IMessageExtractor
+    public class MyMessageExtractor : IMessageExtractor
+    {
+        public string? EntityId(object message) => message switch
+        {
+            string s => s,
+            _ => null
+        };
+
+        public object? EntityMessage(object message) => message;
+
+        public string? ShardId(object message) => message switch
+        {
+            string s => s,
+            _ => null
+        };
+
+        public string ShardId(string entityId, object? messageHint = null)
+        {
+            return entityId;
+        }
+    }
+    
+#pragma warning disable CS0618 // Type or member is obsolete
+    private ExtractEntityId ExtractEntityId = message =>
+    {
+        if (message is string s)
+            return (s, s);
+        return Option<(string, object)>.None;
+    };
+
+    private ExtractShardId ExtractShardId = message =>
+    {
+        if (message is string s)
+            return s;
+        return null!;
+    };
+#pragma warning restore CS0618 // Type or member is obsolete
+
+    public static readonly TheoryData<(object shardingInput, object realMsg, string entityId, string shardId)> Messages = new()
+    {
+        // (new ShardRegion.StartEntity("foo"), new ShardRegion.StartEntity("foo"), "foo", "foo"),
+        (new ShardingEnvelope("bar", "baz"), "baz", "bar", "bar"),
+        ("bar", "bar", "bar", "bar"),
+    };
+    
+    [Theory]
+    [MemberData(nameof(Messages))]
+    public void ShouldAutomaticallyHandleMessagesInCustomIMessageExtractor((object shardingInput, object realMsg, string entityId, string shardId) data)
+    {
+        // arrange
+        var extractor = new ExtractorAdapter(new MyMessageExtractor());
+        
+        // act
+        var entityId = extractor.EntityId(data.shardingInput);
+        var entityMessage = extractor.EntityMessage(data.shardingInput);
+        var shardId = extractor.ShardId(entityId!, data.shardingInput);
+        
+        // assert
+        entityId.Should().Be(data.entityId);
+        entityMessage.Should().Be(data.realMsg);
+        shardId.Should().Be(data.shardId);
+    }
+    
+    // NOTE: so the old delegates are hopeless and will simply not work - you HAVE to handle the messages yourself there
+    // need to repeat of the previous test but using the deprecated delegate methods and the adapter
+    // [Theory]
+    // [MemberData(nameof(Messages))]
+    // public void ShouldAutomaticallyHandleMessagesInCustomIMessageExtractorUsingDelegates((object shardingInput, object realMsg, string entityId, string shardId) data)
+    // {
+    //     // arrange
+    //     var extractor = new ExtractorAdapter(new DeprecatedHandlerExtractorAdapter(ExtractEntityId, ExtractShardId));
+    //     
+    //     // act
+    //     var entityId = extractor.EntityId(data.shardingInput);
+    //     var entityMessage = extractor.EntityMessage(data.shardingInput);
+    //     var shardId = extractor.ShardId(entityId!, data.shardingInput);
+    //     
+    //     // assert
+    //     entityId.Should().Be(data.entityId);
+    //     entityMessage.Should().Be(data.realMsg);
+    //     shardId.Should().Be(data.shardId);
+    // }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesShardIdExtractorChangeSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesShardIdExtractorChangeSpec.cs
@@ -4,16 +4,15 @@
 //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
+#nullable enable
 
 using System;
-using System.IO;
 using System.Linq;
 using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
 using Akka.Persistence;
 using Akka.TestKit;
-using Akka.Util;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -52,36 +51,38 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        private ExtractEntityId extractEntityId = message =>
+        private class FirstExtractor : IMessageExtractor
         {
-            if (message is Message m)
-                return (m.Id.ToString(), m);
-            return Option<(string, object)>.None;
-        };
-
-        private ExtractShardId firstExtractShardId = message =>
-        {
-            switch (message)
+            public string? EntityId(object message)
             {
-                case Message m:
-                    return (m.Id % 10).ToString();
-                case ShardRegion.StartEntity se:
-                    return (int.Parse(se.EntityId) % 10).ToString();
+                if (message is Message m)
+                    return m.Id.ToString();
+                return null;
             }
-            return null;
-        };
 
-        private ExtractShardId secondExtractShardId = message =>
-        {
-            switch (message)
+            public object? EntityMessage(object message)
             {
-                case Message m:
-                    return (m.Id % 10 + 1).ToString();
-                case ShardRegion.StartEntity se:
-                    return (int.Parse(se.EntityId) % 10 + 1).ToString();
+                return message;
             }
-            return null;
-        };
+
+            public string ShardId(object message)
+            {
+                throw new NotImplementedException();
+            }
+
+            public virtual string ShardId(string entityId, object? messageHint = null)
+            {
+                return (int.Parse(entityId) % 10).ToString();
+            }
+        }
+
+        private class SecondExtractor : FirstExtractor
+        {
+            public override string ShardId(string entityId, object? messageHint = null)
+            {
+                return (int.Parse(entityId) % 10 + 1).ToString();
+            }
+        }
 
         private const string TypeName = "ShardIdExtractorChange";
 
@@ -132,7 +133,7 @@ namespace Akka.Cluster.Sharding.Tests
         [Fact]
         public void Sharding_with_remember_entities_enabled_should_allow_a_change_to_the_shard_id_extractor()
         {
-            WithSystem("FirstShardIdExtractor", firstExtractShardId, (system, region) =>
+            WithSystem("FirstShardIdExtractor", new FirstExtractor(), (system, region) =>
             {
                 AssertRegionRegistrationComplete(region);
                 region.Tell(new Message(1));
@@ -154,7 +155,7 @@ namespace Akka.Cluster.Sharding.Tests
                 });
             });
 
-            WithSystem("SecondShardIdExtractor", secondExtractShardId, (system, region) =>
+            WithSystem("SecondShardIdExtractor", new SecondExtractor(), (system, region) =>
             {
                 var probe = CreateTestProbe(system);
 
@@ -168,7 +169,7 @@ namespace Akka.Cluster.Sharding.Tests
                 });
             });
 
-            WithSystem("ThirdIncarnation", secondExtractShardId, (system, region) =>
+            WithSystem("ThirdIncarnation", new SecondExtractor(), (system, region) =>
             {
                 var probe = CreateTestProbe(system);
                 // Only way to verify that they were "normal"-remember-started here is to look at debug logs, will show
@@ -184,7 +185,7 @@ namespace Akka.Cluster.Sharding.Tests
             });
         }
 
-        private void WithSystem(string systemName, ExtractShardId extractShardId, Action<ActorSystem, IActorRef> f)
+        private void WithSystem(string systemName, IMessageExtractor extractor, Action<ActorSystem, IActorRef> f)
         {
             var system = ActorSystem.Create(systemName, Sys.Settings.Config);
             InitializeLogger(system, $"[{systemName}]");
@@ -192,7 +193,7 @@ namespace Akka.Cluster.Sharding.Tests
             Cluster.Get(system).Join(Cluster.Get(system).SelfAddress);
             try
             {
-                var region = ClusterSharding.Get(system).Start(TypeName, Props.Create(() => new PA()), ClusterShardingSettings.Create(system), extractEntityId, extractShardId);
+                var region = ClusterSharding.Get(system).Start(TypeName, Props.Create(() => new PA()), ClusterShardingSettings.Create(system), extractor);
                 f(system, region);
             }
             finally

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -90,7 +90,8 @@ namespace Akka.Cluster.Sharding
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ShardId(string entityId, Msg? messageHint = null)
         {
-            if (messageHint is StartEntity se) // need to handle StartEntity here
+            // BUGFIX for https://github.com/akkadotnet/akka.net/pull/7051 here
+            if (messageHint is ShardRegion.StartEntity se)
                 return _underlying.ShardId(se.EntityId); 
             return _underlying.ShardId(entityId, messageHint);
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -92,7 +92,7 @@ namespace Akka.Cluster.Sharding
         {
             // BUGFIX for https://github.com/akkadotnet/akka.net/pull/7051 here
             if (messageHint is ShardRegion.StartEntity se)
-                return _underlying.ShardId(se.EntityId); 
+                return _underlying.ShardId(se.EntityId, se); 
             return _underlying.ShardId(entityId, messageHint);
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -90,6 +90,8 @@ namespace Akka.Cluster.Sharding
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ShardId(string entityId, Msg? messageHint = null)
         {
+            if (messageHint is StartEntity se) // need to handle StartEntity here
+                return _underlying.ShardId(se.EntityId); 
             return _underlying.ShardId(entityId, messageHint);
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -717,9 +717,10 @@ namespace Akka.Cluster.Sharding
             }
         }
 
-        private void DeliverMessage(string entityId, object message, IActorRef sender)
+        private void DeliverMessage(string entityId, Msg message, IActorRef sender)
         {
             var shardId = _messageExtractor.ShardId(entityId, message);
+            
             if (_regionByShard.TryGetValue(shardId!, out var region))
             {
                 if (region.Equals(Self))


### PR DESCRIPTION
## Changes

Double checking to ensure that https://github.com/akkadotnet/akka.net/pull/6863 didn't make any false promises in regards to whether or `ShardRegion.StartEntity` is handled automatically or not.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
