### PR TITLE
Fix sharding entity id extractor nullability

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -182,7 +182,7 @@ namespace Akka.Cluster.Sharding
             else
                 id = EntityId(message);
             
-            return id is null ? null : _cachedIds[(Math.Abs(MurmurHash.StringHash(id)) % MaxNumberOfShards)];
+            return string.IsNullOrEmpty(id) ? null : _cachedIds[(Math.Abs(MurmurHash.StringHash(id)) % MaxNumberOfShards)];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -102,9 +102,9 @@ namespace Akka.Cluster.Sharding
     {
         private sealed class Implementation : HashCodeMessageExtractor
         {
-            private readonly Func<Msg, string> _entityIdExtractor;
+            private readonly Func<Msg, string?> _entityIdExtractor;
             private readonly Func<Msg, Msg>? _messageExtractor;
-            public Implementation(int maxNumberOfShards, Func<Msg, string> entityIdExtractor, Func<Msg, Msg>? messageExtractor = null) : base(maxNumberOfShards)
+            public Implementation(int maxNumberOfShards, Func<Msg, string?> entityIdExtractor, Func<Msg, Msg>? messageExtractor = null) : base(maxNumberOfShards)
             {
                 _entityIdExtractor = entityIdExtractor ?? throw new NullReferenceException(nameof(entityIdExtractor));
                 _messageExtractor = messageExtractor;
@@ -124,7 +124,7 @@ namespace Akka.Cluster.Sharding
         /// <param name="entityIdExtractor"></param>
         /// <param name="messageExtractor"></param>
         /// <returns></returns>
-        public static HashCodeMessageExtractor Create(int maxNumberOfShards, Func<Msg, string> entityIdExtractor, Func<Msg, Msg>? messageExtractor = null)
+        public static HashCodeMessageExtractor Create(int maxNumberOfShards, Func<Msg, string?> entityIdExtractor, Func<Msg, Msg>? messageExtractor = null)
             => new Implementation(maxNumberOfShards, entityIdExtractor, messageExtractor);
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace Akka.Cluster.Sharding
         /// <param name="message">TBD</param>
         /// <returns>TBD</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [Obsolete("Use ShardId(string, object?) instead")]
+        [Obsolete("Use ShardId(string, object?) instead. Since v1.5.15")]
         public virtual ShardId? ShardId(Msg message)
         {
             EntityId? id;

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
@@ -175,7 +175,10 @@ namespace Akka.Cluster.Sharding
     {
         public readonly int MaxNumberOfShards;
         protected HashCodeMessageExtractor(int maxNumberOfShards) { }
-        public static Akka.Cluster.Sharding.HashCodeMessageExtractor Create(int maxNumberOfShards, System.Func<object, string> entityIdExtractor, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+        public static Akka.Cluster.Sharding.HashCodeMessageExtractor Create(int maxNumberOfShards, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                1,
+                1,
+                2})] System.Func<object, string> entityIdExtractor, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
                 2,
                 1,
                 1})] System.Func<object, object> messageExtractor = null) { }
@@ -183,7 +186,7 @@ namespace Akka.Cluster.Sharding
         public abstract string EntityId(object message);
         [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         public virtual object EntityMessage(object message) { }
-        [System.ObsoleteAttribute("Use ShardId(string, object?) instead")]
+        [System.ObsoleteAttribute("Use ShardId(string, object?) instead. Since v1.5.15")]
         [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         public virtual string ShardId(object message) { }
         public virtual string ShardId(string entityId, [System.Runtime.CompilerServices.NullableAttribute(2)] object messageHint = null) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
@@ -175,7 +175,10 @@ namespace Akka.Cluster.Sharding
     {
         public readonly int MaxNumberOfShards;
         protected HashCodeMessageExtractor(int maxNumberOfShards) { }
-        public static Akka.Cluster.Sharding.HashCodeMessageExtractor Create(int maxNumberOfShards, System.Func<object, string> entityIdExtractor, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+        public static Akka.Cluster.Sharding.HashCodeMessageExtractor Create(int maxNumberOfShards, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                1,
+                1,
+                2})] System.Func<object, string> entityIdExtractor, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
                 2,
                 1,
                 1})] System.Func<object, object> messageExtractor = null) { }
@@ -183,7 +186,7 @@ namespace Akka.Cluster.Sharding
         public abstract string EntityId(object message);
         [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         public virtual object EntityMessage(object message) { }
-        [System.ObsoleteAttribute("Use ShardId(string, object?) instead")]
+        [System.ObsoleteAttribute("Use ShardId(string, object?) instead. Since v1.5.15")]
         [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         public virtual string ShardId(object message) { }
         public virtual string ShardId(string entityId, [System.Runtime.CompilerServices.NullableAttribute(2)] object messageHint = null) { }


### PR DESCRIPTION
EntityId extractor should be able to return a null value.

## Changes

Make the `HashCodeMessageExtractor` `Create()` and `Implementation.ctor()` take function reference that returns a nullable string.