### PR TITLE
Use NoOffset when running query from start

### DIFF
--- a/src/core/Akka.Persistence.TCK/Query/CurrentEventsByTagSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/CurrentEventsByTagSpec.cs
@@ -212,7 +212,7 @@ namespace Akka.Persistence.TCK.Query
         }
         
         [Fact]
-        public void ReadJournal_query_CurrentEventsByTag_should_include_timestamp_in_EventEnvelope()
+        public virtual void ReadJournal_query_CurrentEventsByTag_should_include_timestamp_in_EventEnvelope()
         {
             if (ReadJournal is not ICurrentEventsByTagQuery queries)
                 throw IsTypeException.ForMismatchedType(nameof(ICurrentEventsByTagQuery), ReadJournal?.GetType().Name ?? "null");
@@ -226,7 +226,7 @@ namespace Akka.Persistence.TCK.Query
             a.Tell("a green banana");
             ExpectMsg("a green banana-done");
 
-            var greenSrc = queries.CurrentEventsByTag("green", offset: Sequence(0L));
+            var greenSrc = queries.CurrentEventsByTag("green", offset: NoOffset());
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
             probe.Request(2);
             probe.ExpectNext().Timestamp.Should().BeGreaterThan(0);


### PR DESCRIPTION
## Changes

I have a issue with a persistence plugin where the first event has the offset of 0. This test made the assumption that Sequence(0) was the same as NoOffset(). I've changed the test to use NoOffset() instead.
I also made the test virtual to follow the pattern.
