### PR TITLE
Tentative nullref fix for `LogSource`

### DIFF
--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -105,19 +105,8 @@ namespace Akka.Event
 
         public static string FromActorRef(IActorRef a, ActorSystem system)
         {
-            try
-            {
-                var defaultAddress = system.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
-                if (defaultAddress is null)
-                {
-                    return a.Path.ToString();
-                }
-                return a.Path.ToStringWithAddress(defaultAddress);
-            }
-            catch // can fail if the ActorSystem (remoting) is not completely started yet
-            {
-                return a.Path.ToString();
-            }
+            var defaultAddress = system.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
+            return defaultAddress is null ? a.Path.ToString() : a.Path.ToStringWithAddress(defaultAddress);
         }
     }
 

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -107,7 +107,12 @@ namespace Akka.Event
         {
             try
             {
-                return a.Path.ToStringWithAddress(system.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress);
+                var defaultAddress = system.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
+                if (defaultAddress is null)
+                {
+                    return a.Path.ToString();
+                }
+                return a.Path.ToStringWithAddress(defaultAddress);
             }
             catch // can fail if the ActorSystem (remoting) is not completely started yet
             {


### PR DESCRIPTION
Fixes #6966

## Changes

Please provide a brief description of the changes here.

As mentioned [here](https://github.com/akkadotnet/akka.net/issues/6966#issuecomment-1902333991) I'm getting this error 100% of times when starting the application that's configure to use Akka.Remoting.
Looking at the source code it seems to me that there's a race between [Remoting](https://github.com/akkadotnet/akka.net/blob/dev/src/core/Akka.Remote/Remoting.cs#L210) and the Logging configuration.

Apparently the logging always wins the race and consequently throws a nullref. This exception is swallowed but I was wondering if the suggested fix may be of any value since it's unlikely that the remoting system may successfully configure (this is an educated guess) after the introduced null check because the offending path has only:
- a method call
- a string compare
- an if statement

Before throwing the nullref, also since the fallback is exactly the same as what the null path takes in my PR, I think that removing the start-up exception may valuable, but I'm not an expert in Akka source and I may be missing out here.

@Arkatufus FYI since you responded in the aforementioned issue.
