### PR TITLE
Fix missing TOC entries and page header typo

### DIFF
--- a/docs/articles/debugging/rules/AK1001.md
+++ b/docs/articles/debugging/rules/AK1001.md
@@ -3,7 +3,7 @@ uid: AK1001
 title: Akka.Analyzers Rule AK1001 - "Should always close over `Sender` when using `PipeTo`"
 ---
 
-# AK1000 - Error
+# AK1001 - Error
 
 You should always close over [`Context.Sender`](xref:Akka.Actor.IActorContext#Akka_Actor_IActorContext_Sender) when using [`PipeTo`](xref:Akka.Actor.PipeToSupport#Akka_Actor_PipeToSupport_PipeTo_System_Threading_Tasks_Task_Akka_Actor_ICanTell_Akka_Actor_IActorRef_System_Func_System_Object__System_Func_System_Exception_System_Object__)
 

--- a/docs/articles/debugging/rules/toc.yml
+++ b/docs/articles/debugging/rules/toc.yml
@@ -2,6 +2,10 @@
   href: AK1000.md
 - name: AK1001
   href: AK1001.md
+- name: AK1002
+  href: AK1002.md
+- name: AK1003
+  href: AK1003.md
 - name: AK2000
   href: AK2000.md
 - name: AK2001


### PR DESCRIPTION
## Changes

- Fix missing link in rules table of content
- Fix bug in AK1001 header