### PR TITLE
Fix `IMessageExtractor` technical debts in tests

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowningSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowningSpec.cs
@@ -143,25 +143,28 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        private ExtractEntityId extractEntityId = message =>
+        private sealed class MessageExtractor: IMessageExtractor
         {
-            switch (message)
-            {
-                case Ping p:
-                    return (p.Id, message);
-            }
-            return Option<(string, object)>.None;
-        };
+            public string EntityId(object message)
+                => message switch
+                {
+                    Ping p => p.Id,
+                    _ => null
+                };
 
-        internal ExtractShardId extractShardId = message =>
-        {
-            switch (message)
-            {
-                case Ping p:
-                    return p.Id[0].ToString();
-            }
-            return null;
-        };
+            public object EntityMessage(object message)
+                => message;
+
+            public string ShardId(object message)
+                => message switch
+                {
+                    Ping p => p.Id[0].ToString(),
+                    _ => null
+                };
+
+            public string ShardId(string entityId, object messageHint = null)
+                => entityId[0].ToString();
+        }
 
         private readonly Lazy<IActorRef> _region;
 
@@ -177,8 +180,7 @@ namespace Akka.Cluster.Sharding.Tests
               Sys,
               typeName: "Entity",
               entityProps: Props.Create(() => new Entity()),
-              extractEntityId: extractEntityId,
-              extractShardId: extractShardId);
+              messageExtractor: new MessageExtractor());
         }
 
         #endregion

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingCustomShardAllocationSpec.cs
@@ -191,8 +191,6 @@ namespace Akka.Cluster.Sharding.Tests
                     Sys,
                     typeName: "Entity",
                     entityProps: SimpleEchoActor.Props(),
-                    extractEntityId: IntExtractEntityId,
-                    extractShardId: IntExtractShardId,
                     allocationStrategy: new TestAllocationStrategy(_allocator.Value))
                 );
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStateSpec.cs
@@ -48,25 +48,28 @@ namespace Akka.Cluster.Sharding.Tests
         private const int NumberOfShards = 2;
         private const string ShardTypeName = "Ping";
 
-        private ExtractEntityId extractEntityId = message =>
+        private sealed class MessageExtractor: IMessageExtractor
         {
-            switch (message)
-            {
-                case PingPongActor.Ping msg:
-                    return (msg.Id.ToString(), message);
-            }
-            return Option<(string, object)>.None;
-        };
+            public string EntityId(object message)
+                => message switch
+                {
+                    PingPongActor.Ping p => p.Id.ToString(),
+                    _ => null
+                };
 
-        private ExtractShardId extractShardId = message =>
-        {
-            switch (message)
-            {
-                case PingPongActor.Ping msg:
-                    return (msg.Id % NumberOfShards).ToString();
-            }
-            return null;
-        };
+            public object EntityMessage(object message)
+                => message;
+
+            public string ShardId(object message)
+                => message switch
+                {
+                    PingPongActor.Ping p => (p.Id % NumberOfShards).ToString(),
+                    _ => null
+                };
+
+            public string ShardId(string entityId, object messageHint = null)
+                => (int.Parse(entityId) % NumberOfShards).ToString();
+        }
 
         public ClusterShardingGetStateSpec()
             : this(new ClusterShardingGetStateSpecConfig(), typeof(ClusterShardingGetStateSpec))
@@ -108,8 +111,7 @@ namespace Akka.Cluster.Sharding.Tests
                     Sys,
                     typeName: ShardTypeName,
                     role: "shard",
-                    extractEntityId: extractEntityId,
-                    extractShardId: extractShardId);
+                    messageExtractor: new MessageExtractor());
             }, Config.Controller);
 
             RunOn(() =>
@@ -119,8 +121,7 @@ namespace Akka.Cluster.Sharding.Tests
                     typeName: ShardTypeName,
                     entityProps: Props.Create(() => new PingPongActor()),
                     settings: Settings.Value.WithRole("shard"),
-                    extractEntityId: extractEntityId,
-                    extractShardId: extractShardId);
+                    messageExtractor: new MessageExtractor());
             }, Config.First, Config.Second);
 
             EnterBarrier("sharding started");

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGetStatsSpec.cs
@@ -49,25 +49,28 @@ namespace Akka.Cluster.Sharding.Tests
         private const int NumberOfShards = 3;
         private const string ShardTypeName = "Ping";
 
-        private ExtractEntityId extractEntityId = message =>
+        private sealed class MessageExtractor: IMessageExtractor
         {
-            switch (message)
-            {
-                case PingPongActor.Ping msg:
-                    return (msg.Id.ToString(), message);
-            }
-            return Option<(string, object)>.None;
-        };
+            public string EntityId(object message)
+                => message switch
+                {
+                    PingPongActor.Ping p => p.Id.ToString(),
+                    _ => null
+                };
 
-        private ExtractShardId extractShardId = message =>
-        {
-            switch (message)
-            {
-                case PingPongActor.Ping msg:
-                    return (msg.Id % NumberOfShards).ToString();
-            }
-            return null;
-        };
+            public object EntityMessage(object message)
+                => message;
+
+            public string ShardId(object message)
+                => message switch
+                {
+                    PingPongActor.Ping p => (p.Id % NumberOfShards).ToString(),
+                    _ => null
+                };
+
+            public string ShardId(string entityId, object messageHint = null)
+                => (int.Parse(entityId) % NumberOfShards).ToString();
+        }
 
         private readonly Lazy<IActorRef> _region;
 
@@ -89,8 +92,7 @@ namespace Akka.Cluster.Sharding.Tests
                 typeName: ShardTypeName,
                 entityProps: Props.Create(() => new PingPongActor()),
                 settings: Settings.Value.WithRole("shard"),
-                extractEntityId: extractEntityId,
-                extractShardId: extractShardId);
+                messageExtractor: new MessageExtractor());
         }
 
         #endregion
@@ -127,8 +129,7 @@ namespace Akka.Cluster.Sharding.Tests
                     Sys,
                     typeName: ShardTypeName,
                     role: "shard",
-                    extractEntityId: extractEntityId,
-                    extractShardId: extractShardId);
+                    messageExtractor: new MessageExtractor());
 
             }, Config.Controller);
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownOldestSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownOldestSpec.cs
@@ -188,8 +188,6 @@ namespace Akka.Cluster.Sharding.Tests
                 Sys,
                 typeName,
                 entityProps: Props.Create(() => new SlowStopShardedEntity()),
-                extractEntityId: IntExtractEntityId,
-                extractShardId: IntExtractShardId,
                 allocationStrategy: ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit: 2, relativeLimit: 1.0),
                 handOffStopMessage: SlowStopShardedEntity.Stop.Instance);
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingGracefulShutdownSpec.cs
@@ -102,8 +102,6 @@ namespace Akka.Cluster.Sharding.Tests
                 Sys,
                 typeName,
                 entityProps: Props.Create(() => new ShardedEntity()),
-                extractEntityId: IntExtractEntityId,
-                extractShardId: IntExtractShardId,
                 allocationStrategy: ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit: 2, relativeLimit: 1.0),
                 handOffStopMessage: ShardedEntity.Stop.Instance);
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingMinMembersSpec.cs
@@ -83,8 +83,6 @@ namespace Akka.Cluster.Sharding.Tests
                 Sys,
                 typeName: "Entity",
                 entityProps: SimpleEchoActor.Props(),
-                extractEntityId: IntExtractEntityId,
-                extractShardId: IntExtractShardId,
                 allocationStrategy: ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit: 2, relativeLimit: 1.0),
                 handOffStopMessage: ShardedEntity.Stop.Instance);
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRegistrationCoordinatedShutdownSpec.cs
@@ -88,9 +88,7 @@ namespace Akka.Cluster.Sharding.Tests
                 StartSharding(
                     Sys,
                     typeName: "Entity",
-                    entityProps: Props.Create(() => new ShardedEntity()),
-                    extractEntityId: IntExtractEntityId,
-                    extractShardId: IntExtractShardId);
+                    entityProps: Props.Create(() => new ShardedEntity()));
 
                 EnterBarrier("before-shutdown");
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRolePartitioningSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRolePartitioningSpec.cs
@@ -106,50 +106,56 @@ namespace Akka.Cluster.Sharding.Tests
         {
             public const string TypeKey = "Datatype1";
 
-            public static readonly ExtractEntityId ExtractEntityId = message =>
+            public sealed class MessageExtractor: IMessageExtractor
             {
-                switch (message)
-                {
-                    case string id:
-                        return (id, id);
-                }
-                return Option<(string, object)>.None;
-            };
+                public string EntityId(object message)
+                    => message switch
+                    {
+                        string id => id,
+                        _ => null
+                    };
 
-            public static readonly ExtractShardId ExtractShardId = message =>
-            {
-                switch (message)
-                {
-                    case string id:
-                        return id;
-                }
-                return null;
-            };
+                public object EntityMessage(object message)
+                    => message;
+
+                public string ShardId(object message)
+                    => message switch
+                    {
+                        string id => id,
+                        _ => null
+                    };
+
+                public string ShardId(string entityId, object messageHint = null)
+                    => entityId;
+            }
         }
 
         private static class E2
         {
             public const string TypeKey = "Datatype2";
 
-            public static readonly ExtractEntityId ExtractEntityId = message =>
+            public sealed class MessageExtractor: IMessageExtractor
             {
-                switch (message)
-                {
-                    case int id:
-                        return (id.ToString(), id);
-                }
-                return Option<(string, object)>.None;
-            };
+                public string EntityId(object message)
+                    => message switch
+                    {
+                        int id => id.ToString(),
+                        _ => null
+                    };
 
-            public static readonly ExtractShardId ExtractShardId = message =>
-            {
-                switch (message)
-                {
-                    case int id:
-                        return id.ToString();
-                }
-                return null;
-            };
+                public object EntityMessage(object message)
+                    => message;
+
+                public string ShardId(object message)
+                    => message switch
+                    {
+                        int id => id.ToString(),
+                        _ => null
+                    };
+
+                public string ShardId(string entityId, object messageHint = null)
+                    => entityId;
+            }
         }
 
         private readonly Address fourthAddress;
@@ -180,8 +186,7 @@ namespace Akka.Cluster.Sharding.Tests
               entityProps: SimpleEchoActor.Props(),
               // nodes 1,2,3: role R1, shard region E1, proxy region E2
               settings: Settings.Value.WithRole("R1"),
-              extractEntityId: E1.ExtractEntityId,
-              extractShardId: E1.ExtractShardId);
+              messageExtractor: new E1.MessageExtractor());
 
             // when run on first, second and third (role R1) proxy region is started
             StartSharding(
@@ -190,8 +195,7 @@ namespace Akka.Cluster.Sharding.Tests
                 entityProps: SimpleEchoActor.Props(),
                 // nodes 4,5: role R2, shard region E2, proxy region E1
                 settings: Settings.Value.WithRole("R2"),
-                extractEntityId: E2.ExtractEntityId,
-                extractShardId: E2.ExtractShardId);
+                messageExtractor: new E2.MessageExtractor());
 
             AwaitClusterUp(Config.First, Config.Second, Config.Third, Config.Fourth, Config.Fifth);
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSingleShardPerEntitySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSingleShardPerEntitySpec.cs
@@ -67,9 +67,7 @@ namespace Akka.Cluster.Sharding.Tests
                 () => StartSharding(
                     Sys,
                     typeName: "Entity",
-                    entityProps: Props.Create(() => new ShardedEntity()),
-                    extractEntityId: IntExtractEntityId,
-                    extractShardId: IntExtractShardId));
+                    entityProps: Props.Create(() => new ShardedEntity())));
         }
 
         private void JoinAndAllocate(RoleName node, int entityId)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -290,7 +290,11 @@ namespace Akka.Cluster.Sharding.Tests
                 };
 
             public object EntityMessage(object message)
-                => message;
+                => message switch
+                {
+                    EntityEnvelope env => env.Payload,
+                    _ => message
+                };
 
             public string ShardId(object message)
                 => message switch

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -279,31 +279,30 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        private static readonly ExtractEntityId ExtractEntityId = message =>
+        private sealed class MessageExtractor: IMessageExtractor
         {
-            switch (message)
-            {
-                case EntityEnvelope env:
-                    return (env.Id.ToString(), env.Payload);
-                case Get msg:
-                    return (msg.CounterId.ToString(), message);
-            }
-            return Option<(string, object)>.None;
-        };
+            public string EntityId(object message)
+                => message switch
+                {
+                    EntityEnvelope env => env.Id.ToString(),
+                    Get msg => msg.CounterId.ToString(),
+                    _ => null
+                };
 
-        private static readonly ExtractShardId ExtractShardId = message =>
-        {
-            switch (message)
-            {
-                case EntityEnvelope msg:
-                    return (msg.Id % NumberOfShards).ToString();
-                case Get msg:
-                    return (msg.CounterId % NumberOfShards).ToString();
-                case ShardRegion.StartEntity msg:
-                    return (long.Parse(msg.EntityId) % NumberOfShards).ToString();
-            }
-            return null;
-        };
+            public object EntityMessage(object message)
+                => message;
+
+            public string ShardId(object message)
+                => message switch
+                {
+                    EntityEnvelope env => (env.Id % NumberOfShards).ToString(),
+                    Get msg => (msg.CounterId % NumberOfShards).ToString(),
+                    _ => null
+                };
+
+            public string ShardId(string entityId, object messageHint = null)
+                => (long.Parse(entityId) % NumberOfShards).ToString();
+        }
 
         private const int NumberOfShards = 12;
 
@@ -523,7 +522,7 @@ namespace Akka.Cluster.Sharding.Tests
                     entityProps: _ => QualifiedCounter.Props(typeName),
                     settings: settings,
                     coordinatorPath: "/user/" + typeName + "Coordinator/singleton/coordinator",
-                    new DeprecatedHandlerExtractorAdapter(ExtractEntityId, ExtractShardId),
+                    new MessageExtractor(),
                     handOffStopMessage: PoisonPill.Instance,
                     rememberEntitiesProvider: rememberEntitiesProvider),
                 name: typeName + "Region");
@@ -683,7 +682,7 @@ namespace Akka.Cluster.Sharding.Tests
                         typeName: "counter",
                         settings: settings,
                         coordinatorPath: "/user/counterCoordinator/singleton/coordinator",
-                        new DeprecatedHandlerExtractorAdapter(ExtractEntityId, ExtractShardId)),
+                        new MessageExtractor()),
                         "regionProxy");
 
                     proxy.Tell(new Get(1));
@@ -899,24 +898,21 @@ namespace Akka.Cluster.Sharding.Tests
                         typeName: "Counter",
                         entityProps: Counter.Props(),
                         settings: ClusterShardingSettings.Create(Sys),
-                        extractEntityId: ExtractEntityId,
-                        extractShardId: ExtractShardId);
+                        messageExtractor: new MessageExtractor());
 
                     //#counter-start
                     ClusterSharding.Get(Sys).Start(
                         typeName: "AnotherCounter",
                         entityProps: AnotherCounter.Props(),
                         settings: ClusterShardingSettings.Create(Sys),
-                        extractEntityId: ExtractEntityId,
-                        extractShardId: ExtractShardId);
+                        messageExtractor: new MessageExtractor());
 
                     //#counter-supervisor-start
                     ClusterSharding.Get(Sys).Start(
                         typeName: "SupervisedCounter",
                         entityProps: CounterSupervisor.Props(),
                         settings: ClusterShardingSettings.Create(Sys),
-                        extractEntityId: ExtractEntityId,
-                        extractShardId: ExtractShardId);
+                        messageExtractor: new MessageExtractor());
                 }, Config.Third, Config.Fourth, Config.Fifth, Config.Sixth);
                 EnterBarrier("extension-started");
 
@@ -965,8 +961,7 @@ namespace Akka.Cluster.Sharding.Tests
                         typeName: "ApiTest",
                         entityProps: Counter.Props(),
                         settings: ClusterShardingSettings.Create(Sys),
-                        extractEntityId: ExtractEntityId,
-                        extractShardId: ExtractShardId);
+                        messageExtractor: new MessageExtractor());
 
                     var counterRegionViaGet = ClusterSharding.Get(Sys).ShardRegion("ApiTest");
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingSpec.cs
@@ -131,24 +131,28 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        internal ExtractEntityId IntExtractEntityId = message =>
+        private sealed class IntMessageExtractor: IMessageExtractor
         {
-            if (message is int id)
-                return (id.ToString(), message);
-            return Option<(string, object)>.None;
-        };
+            public string EntityId(object message)
+                => message switch
+                {
+                    int id => id.ToString(),
+                    _ => null
+                };
 
-        internal ExtractShardId IntExtractShardId = message =>
-        {
-            switch (message)
-            {
-                case int id:
-                    return id.ToString();
-                case ShardRegion.StartEntity se:
-                    return se.EntityId;
-            }
-            return null;
-        };
+            public object EntityMessage(object message)
+                => message;
+
+            public string ShardId(object message)
+                => message switch
+                {
+                    int id => id.ToString(),
+                    _ => null
+                };
+
+            public string ShardId(string entityId, object messageHint = null)
+                => entityId;
+        }
 
         protected readonly TConfig Config;
 
@@ -240,7 +244,7 @@ namespace Akka.Cluster.Sharding.Tests
         protected IActorRef StartSharding(
             ActorSystem sys,
             string typeName,
-            IMessageExtractor messageExtractor,
+            IMessageExtractor messageExtractor = null,
             Props entityProps = null,
             ClusterShardingSettings settings = null,
             IShardAllocationStrategy allocationStrategy = null,
@@ -250,27 +254,7 @@ namespace Akka.Cluster.Sharding.Tests
                 typeName,
                 entityProps ?? SimpleEchoActor.Props(),
                 settings ?? Settings.Value,
-                messageExtractor,
-                allocationStrategy ?? _defaultShardAllocationStrategy.Value,
-                handOffStopMessage ?? PoisonPill.Instance);
-        }
-
-        protected IActorRef StartSharding(
-            ActorSystem sys,
-            string typeName,
-            Props entityProps = null,
-            ClusterShardingSettings settings = null,
-            ExtractEntityId extractEntityId = null,
-            ExtractShardId extractShardId = null,
-            IShardAllocationStrategy allocationStrategy = null,
-            object handOffStopMessage = null)
-        {
-            return ClusterSharding.Get(sys).Start(
-                typeName,
-                entityProps ?? SimpleEchoActor.Props(),
-                settings ?? this.Settings.Value,
-                extractEntityId ?? IntExtractEntityId,
-                extractShardId ?? IntExtractShardId,
+                messageExtractor ?? new IntMessageExtractor(),
                 allocationStrategy ?? _defaultShardAllocationStrategy.Value,
                 handOffStopMessage ?? PoisonPill.Instance);
         }
@@ -279,10 +263,9 @@ namespace Akka.Cluster.Sharding.Tests
             ActorSystem sys,
             string typeName,
             string role,
-            ExtractEntityId extractEntityId,
-            ExtractShardId extractShardId)
+            IMessageExtractor messageExtractor = null)
         {
-            return ClusterSharding.Get(sys).StartProxy(typeName, role, extractEntityId, extractShardId);
+            return ClusterSharding.Get(sys).StartProxy(typeName, role, messageExtractor ?? new IntMessageExtractor());
         }
 
         protected void SetStoreIfNeeded(ActorSystem sys, RoleName storeOn)

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -1819,7 +1819,9 @@ namespace Akka.Cluster.Sharding
 
         private void DeliverMessage(string entityId, object msg, IActorRef snd)
         {
-            var payload = _extractor.EntityMessage(msg)!; // payload can't be null unless dev really screwed up
+            var payload = _extractor.EntityMessage(msg); // payload can't be null unless dev really screwed up
+            if (payload is null)
+                throw new ArgumentNullException($"IMessageExtractor.EntityMessage() should never return null. Message extractor: {_extractor.GetType()}");
 
             if (payload is ShardRegion.StartEntity start)
             {


### PR DESCRIPTION
## Changes

* Convert all usage of `ExtractEntityId` and `ExtractShardId` delegates in unit tests to `IMessageExtractor` interface implementation.
* Improve NRE message caused by `IMessageExtractor.EntityMessage()` returning a null.
  * We can convert this into an Akka.Analyzer error rule.