### PR TITLE
Bump Akka.Analyzers to 0.2.3

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,7 +39,7 @@
     <MultiNodeAdapterVersion>1.5.13</MultiNodeAdapterVersion>
     <MicrosoftLibVersion>[6.0.*,)</MicrosoftLibVersion>
     <MsExtVersion>[6.0.*,)</MsExtVersion>
-    <AkkaAnalyzerVersion>0.2.2</AkkaAnalyzerVersion>
+    <AkkaAnalyzerVersion>0.2.3</AkkaAnalyzerVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
## Akka.Analyzers 0.2.3

* [AK1002: Fix false positive detection](https://github.com/akkadotnet/akka.analyzers/pull/72)
* [Add multi target support for Roslyn 3.11, 4.4, 4.6, and 4.8](https://github.com/akkadotnet/akka.analyzers/pull/73)
* [AK1001: Rule removed due to #65](https://github.com/akkadotnet/akka.analyzers/pull/74)