### PR TITLE
Akka.Cluster.Sharding: added `GenericChildPerEntityParent`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/GenericChildPerEntityParent.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/GenericChildPerEntityParent.cs
@@ -1,0 +1,44 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="GenericChildPerEntityParent.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+
+namespace Akka.Cluster.Sharding;
+
+/// <summary>
+/// A generic "child per entity" parent actor.
+/// </summary>
+/// <remarks>
+/// Intended for simplifying unit tests where we don't want to use Akka.Cluster.Sharding.
+/// </remarks>
+public sealed class GenericChildPerEntityParent : ReceiveActor
+{
+    public static Props Props(IMessageExtractor extractor, Func<string, Props> propsFactory)
+    {
+        return Akka.Actor.Props.Create(() => new GenericChildPerEntityParent(extractor, propsFactory));
+    }
+    
+    /*
+     * Re-use Akka.Cluster.Sharding's infrastructure here to keep things simple.
+     */
+    private readonly IMessageExtractor _extractor;
+    private Func<string, Props> _propsFactory;
+
+    public GenericChildPerEntityParent(IMessageExtractor extractor, Func<string, Props> propsFactory)
+    {
+        _extractor = extractor;
+        _propsFactory = propsFactory;
+        
+        ReceiveAny(o =>
+        {
+            var result = _extractor.EntityId(o);
+            if (result is null) return;
+            Context.Child(result).GetOrElse(() => Context.ActorOf(propsFactory(result), result)).Forward(_extractor.EntityMessage(o));
+        });
+    }
+}

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
@@ -136,6 +136,11 @@ namespace Akka.Cluster.Sharding
     public delegate Akka.Util.Option<System.ValueTuple<string, object>> ExtractEntityId(object message);
     [System.ObsoleteAttribute("Use HashCodeMessageExtractor or IMessageExtractor instead.")]
     public delegate string ExtractShardId(object message);
+    public sealed class GenericChildPerEntityParent : Akka.Actor.ReceiveActor
+    {
+        public GenericChildPerEntityParent(Akka.Cluster.Sharding.IMessageExtractor extractor, System.Func<string, Akka.Actor.Props> propsFactory) { }
+        public static Akka.Actor.Props Props(Akka.Cluster.Sharding.IMessageExtractor extractor, System.Func<string, Akka.Actor.Props> propsFactory) { }
+    }
     public sealed class GetClusterShardingStats : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery, System.IEquatable<Akka.Cluster.Sharding.GetClusterShardingStats>
     {
         public readonly System.TimeSpan Timeout;

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
@@ -136,6 +136,11 @@ namespace Akka.Cluster.Sharding
     public delegate Akka.Util.Option<System.ValueTuple<string, object>> ExtractEntityId(object message);
     [System.ObsoleteAttribute("Use HashCodeMessageExtractor or IMessageExtractor instead.")]
     public delegate string ExtractShardId(object message);
+    public sealed class GenericChildPerEntityParent : Akka.Actor.ReceiveActor
+    {
+        public GenericChildPerEntityParent(Akka.Cluster.Sharding.IMessageExtractor extractor, System.Func<string, Akka.Actor.Props> propsFactory) { }
+        public static Akka.Actor.Props Props(Akka.Cluster.Sharding.IMessageExtractor extractor, System.Func<string, Akka.Actor.Props> propsFactory) { }
+    }
     public sealed class GetClusterShardingStats : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery, System.IEquatable<Akka.Cluster.Sharding.GetClusterShardingStats>
     {
         public readonly System.TimeSpan Timeout;


### PR DESCRIPTION
## Changes

This is a class I've been copying and pasting into dozens of Akka.NET projects over the past several years, and I thought I would propose making it part of the Akka.Cluster.Sharding package since it inherently relies on the sharding API.

What it's truly useful for is being able to maintain sharding-like-behavior while running in a local process that doesn't have clustering enabled - this is very valuable for testing.

I often use code like this in combination with Akka.Hosting:

```csharp
public static AkkaConfigurationBuilder AddNuGetEntityActors(this AkkaConfigurationBuilder builder,
      bool isClusterEnabled = true)
{
    if (isClusterEnabled)
    {
        builder.WithShardRegion<NuGetProductActor>("nuget-product", (system, registry, resolver) =>
                    s => resolver.Props<NuGetProductActor>(s), new ProductShardMessageRouter(ShardCount),
                new ShardOptions()
                {
                    RememberEntitiesStore = RememberEntitiesStore.Eventsourced,
                    StateStoreMode = StateStoreMode.DData,
                    Role = ShardRole
                });
    }
    else
    {
        /*
         * Clustering is usually only disabled for testing purposes
         */

        builder.WithActors((system, registry, resolver) =>
            {
                var parentProps = GenericChildPerEntityParent.Props(new ProductShardMessageRouter(ShardCount),
                    s => resolver.Props<NuGetProductActor>(s));

                var parent = system.ActorOf(parentProps, "nuget-product");
                registry.Register<NuGetProductActor>(parent);
            });
    }

    return builder;
}
```

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #
* [x] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.