### PR TITLE
ActorGraphInterpreter Box Caching

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Streams/SelectAsyncBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Streams/SelectAsyncBenchmarks.cs
@@ -1,0 +1,119 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="SelectAsyncBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Streams;
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class SelectAsyncBenchmarks
+{
+    public readonly struct IntOrCompletion
+    {
+        public readonly int IntValue;
+        public readonly TaskCompletionSource? Completion;
+
+        public IntOrCompletion(int intValue, TaskCompletionSource? completion)
+        {
+            IntValue = intValue;
+            Completion = completion;
+        }
+    }
+    private ActorSystem system;
+    private ActorMaterializer materializer;
+
+    private IRunnableGraph<Task> simpleGraph;
+    private Task<Done> selectAsyncStub;
+    private Channel<IntOrCompletion> asyncCh;
+    private Task<Done> selectAsyncSyncStub;
+    private Channel<IntOrCompletion> asyncChSync;
+    
+    [GlobalSetup]
+    public void Setup()
+    {
+        system = ActorSystem.Create("system");
+        materializer = system.Materializer();
+        asyncCh = Channel.CreateUnbounded<IntOrCompletion>();
+            
+        asyncChSync = Channel.CreateUnbounded<IntOrCompletion>();
+            
+            
+        selectAsyncSyncStub = Source.ChannelReader(asyncChSync.Reader)
+            .SelectAsync(4, a =>
+            {
+                if (a.Completion != null)
+                {
+                    a.Completion.TrySetResult();
+                }
+                else
+                {
+                }
+
+                return Task.FromResult(NotUsed.Instance);
+            }).RunWith(Sink.Ignore<NotUsed>(), materializer);
+            
+        
+        selectAsyncStub = Source.ChannelReader(asyncCh.Reader)
+            .SelectAsync(4, async a =>
+            {
+                if (a.Completion != null)
+                {
+                    a.Completion.TrySetResult();
+                }
+                else
+                {
+                    //await Task.Yield();
+                    await Task.Delay(0);
+                }
+
+                return NotUsed.Instance;
+            }).RunWith(Sink.Ignore<NotUsed>(), materializer);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        materializer.Dispose();
+        system.Dispose();
+    }
+        
+    [Benchmark]
+    public async Task RunSelectAsync()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions
+            .RunContinuationsAsynchronously);
+        for (int i = 0; i < 100; i++)
+        {
+            asyncCh.Writer.TryWrite(new IntOrCompletion(i, null));
+        }
+
+        asyncCh.Writer.TryWrite(new IntOrCompletion(0, completion));
+        await completion.Task;
+
+    }
+        
+    [Benchmark]
+    public async Task RunSelectAsyncSync()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions
+            .RunContinuationsAsynchronously);
+        for (int i = 0; i < 100; i++)
+        {
+            asyncChSync.Writer.TryWrite(new IntOrCompletion(i, null));
+        }
+
+        asyncChSync.Writer.TryWrite(new IntOrCompletion(0, completion));
+        await completion.Task;
+
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/Streams/UnfoldAsyncBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Streams/UnfoldAsyncBenchmarks.cs
@@ -1,0 +1,122 @@
+﻿// //-----------------------------------------------------------------------
+// // <copyright file="UnfoldAsyncBenchmarks.cs" company="Akka.NET Project">
+// //     Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+// //     Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// // </copyright>
+// //-----------------------------------------------------------------------
+
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Streams;
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class UnfoldAsyncBenchmarks
+{
+    public readonly struct IntOrCompletion
+    {
+        public readonly int IntValue;
+        public readonly TaskCompletionSource? Completion;
+
+        public IntOrCompletion(int intValue, TaskCompletionSource? completion)
+        {
+            IntValue = intValue;
+            Completion = completion;
+        }
+    }
+    private ActorSystem system;
+    private ActorMaterializer materializer;
+
+    private IRunnableGraph<Task> simpleGraph;
+    private Task<Done> selectAsyncStub;
+    private Channel<IntOrCompletion> asyncNoYieldCh;
+    private Task<Done> selectValueTaskAsyncStub;
+    private Task<Done> unfoldAsyncSyncStub;
+    private Task<Done> selectAsyncValueTaskSyncStub;
+    private Channel<IntOrCompletion> asyncYieldCh;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        system = ActorSystem.Create("system");
+        materializer = system.Materializer();
+        asyncNoYieldCh = Channel.CreateUnbounded<IntOrCompletion>();
+            
+        asyncYieldCh = Channel.CreateUnbounded<IntOrCompletion>();
+            
+            
+        unfoldAsyncSyncStub = Source.UnfoldAsync<ChannelReader<IntOrCompletion>,int>(asyncYieldCh.Reader, async r =>
+            {
+                var i = await r.ReadAsync();
+                if (i.Completion != null)
+                {
+                    i.Completion.TrySetResult();
+                    return (r, -1);
+                }
+                else
+                {
+                    return (r, i.IntValue);
+                }
+            })
+            .RunWith(Sink.Ignore<int>(), materializer);
+            
+        selectAsyncStub = Source.UnfoldAsync<ChannelReader<IntOrCompletion>,int>(asyncNoYieldCh.Reader,async r =>
+        { 
+            await Task.Yield();
+            var a = await r.ReadAsync(); 
+            if (a.Completion != null)
+            {
+                a.Completion.TrySetResult();
+                return (r, -1);
+            }
+            else
+            {
+                return (r, a.IntValue);
+            }
+        }).RunWith(Sink.Ignore<int>(), materializer);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        materializer.Dispose();
+        system.Dispose();
+    }
+        
+    [Benchmark]
+    public async Task UnfoldAsyncYieldInConsume()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions
+            .RunContinuationsAsynchronously);
+        for (int i = 0; i < 100; i++)
+        {
+            asyncNoYieldCh.Writer.TryWrite(new IntOrCompletion(i, null));
+        }
+
+        asyncNoYieldCh.Writer.TryWrite(new IntOrCompletion(0, completion));
+        await completion.Task;
+
+    }
+    
+    [Benchmark]
+    public async Task UnfoldAsyncYieldInPush()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions
+            .RunContinuationsAsynchronously);
+        for (int i = 0; i < 100; i++)
+        {
+            asyncYieldCh.Writer.TryWrite(new IntOrCompletion(i, null));
+            await Task.Yield();
+        }
+
+        asyncYieldCh.Writer.TryWrite(new IntOrCompletion(0, completion));
+        await completion.Task;
+
+    }
+    
+}

--- a/src/benchmark/Akka.Benchmarks/Streams/UnfoldResourceAsyncBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Streams/UnfoldResourceAsyncBenchmarks.cs
@@ -1,0 +1,230 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="UnfoldResourceAsyncBenchmarks.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Akka.Streams.Implementation.Fusing;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Streams;
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class UnfoldResourceAsyncBenchmarks
+{
+    
+    public readonly struct IntOrCompletion
+    {
+        public readonly int IntValue;
+        public readonly TaskCompletionSource? Completion;
+
+        public IntOrCompletion(int intValue, TaskCompletionSource? completion)
+        {
+            IntValue = intValue;
+            Completion = completion;
+        }
+    }
+    private ActorSystem system;
+    private ActorMaterializer materializer;
+
+    private IRunnableGraph<Task> simpleGraph;
+    private Task<Done> selectAsyncStub;
+    private Channel<IntOrCompletion> asyncNoYieldCh;
+    private Task<Done> unfoldAsyncSyncStub;
+    private Channel<IntOrCompletion> asyncYieldCh;
+    private Channel<IntOrCompletion> straightCh;
+    private Task straightTask;
+    private CancellationTokenSource straightChTokenSource;
+    private Channel<IntOrCompletion> straightYieldCh;
+    private Task straightYieldTask;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        system = ActorSystem.Create("system");
+        materializer = system.Materializer();
+        asyncNoYieldCh = Channel.CreateUnbounded<IntOrCompletion>();
+            
+        asyncYieldCh = Channel.CreateUnbounded<IntOrCompletion>();
+            
+            
+        unfoldAsyncSyncStub = Source.UnfoldResourceAsync<int,ChannelReader<IntOrCompletion>>(()=> Task.FromResult(asyncYieldCh.Reader), async r =>
+            {
+                var i = await r.ReadAsync();
+                if (i.Completion != null)
+                {
+                    i.Completion.TrySetResult();
+                    return -1;
+                }
+                else
+                {
+                    return i.IntValue;
+                }
+            }, (r)=> Task.FromResult(Done.Instance))
+            .RunWith(Sink.Ignore<int>(), materializer);
+            
+        selectAsyncStub = Source.UnfoldResourceAsync<int,ChannelReader<IntOrCompletion>>(()=>Task.FromResult(asyncNoYieldCh.Reader),async r =>
+        { 
+            await Task.Yield();
+            var a = await r.ReadAsync(); 
+            if (a.Completion != null)
+            {
+                a.Completion.TrySetResult();
+                return -1;
+            }
+            else
+            {
+                //await Task.Yield();
+                //        await Task.Delay(0);
+                return  a.IntValue;
+            }
+        }, (r)=> Task.FromResult(Done.Instance) ).RunWith(Sink.Ignore<int>(), materializer);
+        
+        
+        straightChTokenSource = new CancellationTokenSource();
+        straightCh = Channel.CreateUnbounded<IntOrCompletion>();
+
+
+        straightTask = Task.Run(async () =>
+        {
+            static async IAsyncEnumerable<int> GetEnumerator(
+                ChannelReader<IntOrCompletion> reader, CancellationToken token)
+            {
+                while (token.IsCancellationRequested == false)
+                {
+                    await Task.Yield();
+                    var a = await reader.ReadAsync();
+                    if (a.Completion != null)
+                    {
+                        a.Completion.TrySetResult();
+                        yield return -1;
+                    }
+                    else
+                    {
+                        //await Task.Yield();
+                        //await Task.Delay(0);
+                        yield return a.IntValue;
+                    }
+                }
+            }
+            var r = straightCh.Reader;
+            await foreach (var v in GetEnumerator(r,straightChTokenSource.Token))
+            {
+                
+            }
+        });
+        
+        straightYieldCh = Channel.CreateUnbounded<IntOrCompletion>();
+
+
+        straightYieldTask = Task.Run(async () =>
+        {
+            static async IAsyncEnumerable<int> GetEnumerator(
+                ChannelReader<IntOrCompletion> reader, CancellationToken token)
+            {
+                while (token.IsCancellationRequested == false)
+                {
+                    var a = await reader.ReadAsync();
+                    if (a.Completion != null)
+                    {
+                        a.Completion.TrySetResult();
+                        yield return -1;
+                    }
+                    else
+                    {
+                        //await Task.Yield();
+                        //await Task.Delay(0);
+                        yield return a.IntValue;
+                    }
+                }
+            }
+            var r = straightYieldCh.Reader;
+            await foreach (var v in GetEnumerator(r,straightChTokenSource.Token))
+            {
+                
+            }
+        });
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        materializer.Dispose();
+        system.Dispose();
+        straightChTokenSource.Cancel();
+    }
+        
+    [Benchmark]
+    public async Task UnfoldResourceAsyncNoYield()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions
+            .RunContinuationsAsynchronously);
+        for (int i = 0; i < 100; i++)
+        {
+            asyncNoYieldCh.Writer.TryWrite(new IntOrCompletion(i, null));
+        }
+
+        asyncNoYieldCh.Writer.TryWrite(new IntOrCompletion(0, completion));
+        await completion.Task;
+
+    }
+        
+        
+    [Benchmark]
+    public async Task UnfoldResourceAsyncWithYield()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions
+            .RunContinuationsAsynchronously);
+        for (int i = 0; i < 100; i++)
+        {
+            asyncYieldCh.Writer.TryWrite(new IntOrCompletion(i, null));
+            await Task.Yield();
+        }
+
+        asyncYieldCh.Writer.TryWrite(new IntOrCompletion(0, completion));
+        await completion.Task;
+
+    }
+        
+        
+    
+    [Benchmark]
+    public async Task StraightChannelReadNoYield()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions
+            .RunContinuationsAsynchronously);
+        for (int i = 0; i < 100; i++)
+        {
+            straightCh.Writer.TryWrite(new IntOrCompletion(i, null));
+        }
+
+        straightCh.Writer.TryWrite(new IntOrCompletion(0, completion));
+        await completion.Task;
+
+    }
+    
+    [Benchmark]
+    public async Task StraightChannelReadWithYield()
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions
+            .RunContinuationsAsynchronously);
+        for (int i = 0; i < 100; i++)
+        {
+            straightYieldCh.Writer.TryWrite(new IntOrCompletion(i, null));
+            await Task.Yield();
+        }
+
+        straightYieldCh.Writer.TryWrite(new IntOrCompletion(0, completion));
+        await completion.Task;
+
+    }
+}

--- a/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
@@ -123,11 +123,11 @@ namespace Akka.Streams.Implementation.Fusing
         private readonly Shape _shape;
         private readonly ActorMaterializerSettings _settings;
 
-        private readonly ObjectPoolStuff.ObjectPoolV2<ActorGraphInterpreter.OnNext> _onNextPool =
+        private readonly ObjectPoolStuff.ObjectPoolV2<BoxedBoundaryEvent<ActorGraphInterpreter.OnNext>> _onNextPool =
             new (Environment.ProcessorCount*2);
-        private readonly ObjectPoolStuff.ObjectPoolV2<ActorGraphInterpreter.RequestMore> _requestMorePool =
+        private readonly ObjectPoolStuff.ObjectPoolV2<BoxedBoundaryEvent<ActorGraphInterpreter.RequestMore>> _requestMorePool =
             new (Environment.ProcessorCount*2);
-        private readonly ObjectPoolStuff.ObjectPoolV2<ActorGraphInterpreter.AsyncInput>
+        private readonly ObjectPoolStuff.ObjectPoolV2<BoxedBoundaryEvent<ActorGraphInterpreter.AsyncInput>>
             _asyncInputPool = new (Environment.ProcessorCount*2);
         private readonly ActorGraphInterpreter.Resume _resume;
         /// <summary>
@@ -291,8 +291,7 @@ namespace Akka.Streams.Implementation.Fusing
             {
                 case BoxedBoundaryEvent<ActorGraphInterpreter.OnNext> bOn:
                     var asO = bOn.Boxed;
-                    bOn.SetBox(default);
-                    _onNextPool.TryPush(bOn);
+                    _onNextPool.TryPush(bOn.SetBox(default));
                     return RunOnNextMeth(asO);
                     break;
                 // Case unused:
@@ -303,8 +302,7 @@ namespace Akka.Streams.Implementation.Fusing
                 //    return RunRequestMore(requestMore);
                 case BoxedBoundaryEvent<ActorGraphInterpreter.RequestMore> bRm:
                     var asR = bRm.Boxed;
-                    bRm.SetBox(default);
-                    _requestMorePool.TryPush(bRm);
+                    _requestMorePool.TryPush(bRm.SetBox(default));
                     return RunRequestMore(asR);
                 
                 case ActorGraphInterpreter.Resume _:
@@ -315,8 +313,7 @@ namespace Akka.Streams.Implementation.Fusing
                 
                 case BoxedBoundaryEvent<ActorGraphInterpreter.AsyncInput> bAi:
                     var asI = bAi.Boxed;
-                    bAi.SetBox(default);
-                    _asyncInputPool.TryPush(bAi);
+                    _asyncInputPool.TryPush(bAi.SetBox(default));
                     return RunAsyncInputMeth(asI); 
                 
                 //case ActorGraphInterpreter.AsyncInput asyncInput:

--- a/src/core/Akka.Streams/Implementation/Fusing/ObjectPoolStuff.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ObjectPoolStuff.cs
@@ -111,10 +111,9 @@ internal sealed class ObjectPoolStuff
 */
 
     internal sealed class ObjectPoolV2<T>
-        where T : struct, ActorGraphInterpreter.IBoundaryEvent
     {
         private readonly int _limit;
-        private readonly ConcurrentQueue<GraphInterpreterShell.BoxedBoundaryEvent<T>> _items = new();
+        private readonly ConcurrentQueue<T> _items = new();
         //private readonly decimal _softLimit = default;
         //private readonly decimal _softLimit2 = default;
         //private readonly decimal _softLimit3 = default;
@@ -129,7 +128,7 @@ internal sealed class ObjectPoolStuff
             _limit = size+3;
         }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool TryPop([NotNullWhen(true)] out GraphInterpreterShell.BoxedBoundaryEvent<T>? result)
+        public bool TryPop([NotNullWhen(true)] out T? result)
         {
             // Instead of lock, use CompareExchange gate.
             // In a worst case, missed cached object(create new one) but it's not a big deal.
@@ -143,7 +142,7 @@ internal sealed class ObjectPoolStuff
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void TryPush(GraphInterpreterShell.BoxedBoundaryEvent<T> item)
+        public void TryPush(T item)
         {
             if (Interlocked.Increment(ref _size) <= _limit)
             {

--- a/src/core/Akka.Streams/Implementation/Fusing/ObjectPoolStuff.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ObjectPoolStuff.cs
@@ -1,0 +1,224 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ObjectPoolStuff.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Akka.Annotations;
+
+namespace Akka.Streams.Implementation.Fusing;
+
+/// <remarks>
+/// This is an object pool based on 
+/// </remarks>
+[InternalApi]
+internal sealed class ObjectPoolStuff
+{
+    /*
+    internal interface IObjectPoolNode<T>
+    {
+        ref T? NextNode { get; }
+    }
+
+    internal sealed class ObjectPool
+    {
+        private static int typeId = -1; // Increment by IdentityGenerator<T>
+
+        private readonly object _gate = new object();
+        private readonly int _poolLimit;
+        private object[] _poolNodes = new object[4]; // ObjectPool<T>[]
+
+        // pool-limit per type.
+        public ObjectPool(int poolLimit)
+        {
+            _poolLimit = poolLimit;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryRent<T>([NotNullWhen(true)] out T? value)
+            where T : class, IObjectPoolNode<T>
+        {
+            // poolNodes is grow only, safe to access indexer with no-lock
+            var id = IdentityGenerator<T>.Identity;
+            if (id < _poolNodes.Length &&
+                _poolNodes[id] is ObjectPool<T> pool)
+            {
+                return pool.TryPop(out value);
+            }
+
+            Grow<T>(id);
+            value = default;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool Return<T>(T value)
+            where T : class, IObjectPoolNode<T>
+        {
+            var id = IdentityGenerator<T>.Identity;
+            if (id < _poolNodes.Length &&
+                _poolNodes[id] is ObjectPool<T> pool)
+            {
+                return pool.TryPush(value);
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Grow<T>(int id)
+            where T : class, IObjectPoolNode<T>
+        {
+            lock (_gate)
+            {
+                if (_poolNodes.Length <= id)
+                {
+                    Array.Resize(ref _poolNodes,
+                        Math.Max(_poolNodes.Length * 2, id + 1));
+                    _poolNodes[id] = new ObjectPool<T>(_poolLimit);
+                }
+                else if (_poolNodes[id] == null)
+                {
+                    _poolNodes[id] = new ObjectPool<T>(_poolLimit);
+                }
+                else
+                {
+                    // other thread already created new ObjectPool<T> so do nothing.
+                }
+            }
+        }
+
+        // avoid for Dictionary<Type, ***> lookup cost.
+        private static class IdentityGenerator<T>
+        {
+#pragma warning disable SA1401
+            public static int Identity;
+#pragma warning restore SA1401
+
+            static IdentityGenerator()
+            {
+                Identity = Interlocked.Increment(ref typeId);
+            }
+        }
+    }
+*/
+
+    internal sealed class ObjectPoolV2<T>
+        where T : struct, ActorGraphInterpreter.IBoundaryEvent
+    {
+        private readonly int _limit;
+        private readonly ConcurrentQueue<GraphInterpreterShell.BoxedBoundaryEvent<T>> _items = new();
+        //private readonly decimal _softLimit = default;
+        //private readonly decimal _softLimit2 = default;
+        //private readonly decimal _softLimit3 = default;
+        //private readonly decimal _softLimit4 = default;
+        private int _size;
+        //private readonly decimal _hardLimit1 = default;
+        //private readonly decimal _hardLimit2 = default;
+        //private readonly decimal _hardLimit3 = default;
+        //private readonly decimal _hardLimit4 = default;
+        public ObjectPoolV2(int size)
+        {
+            _limit = size+3;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryPop([NotNullWhen(true)] out GraphInterpreterShell.BoxedBoundaryEvent<T>? result)
+        {
+            // Instead of lock, use CompareExchange gate.
+            // In a worst case, missed cached object(create new one) but it's not a big deal.
+            if (_items.TryDequeue(out result))
+            {
+                Interlocked.Decrement(ref _size);
+                return true;
+            }
+
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void TryPush(GraphInterpreterShell.BoxedBoundaryEvent<T> item)
+        {
+            if (Interlocked.Increment(ref _size) <= _limit)
+            {
+                _items.Enqueue(item);
+            }
+            else
+            {
+                Interlocked.Decrement(ref _size);
+            }
+        }
+    }
+    
+    /*
+    internal sealed class ObjectPool<T>
+        where T : class, IObjectPoolNode<T>
+    {
+        private readonly int _limit;
+        private int _gate;
+        private int _size;
+        private T? _root;
+
+        public ObjectPool(int limit)
+        {
+            _limit = limit;
+        }
+
+        public int Size => _size;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryPop([NotNullWhen(true)] out T? result)
+        {
+            // Instead of lock, use CompareExchange gate.
+            // In a worst case, missed cached object(create new one) but it's not a big deal.
+            if (Interlocked.CompareExchange(ref _gate, 1, 0) == 0)
+            {
+                var v = _root;
+                if (!(v is null))
+                {
+                    ref var nextNode = ref v.NextNode;
+                    _root = nextNode;
+                    nextNode = null;
+                    _size--;
+                    result = v;
+                    Volatile.Write(ref _gate, 0);
+                    return true;
+                }
+
+                Volatile.Write(ref _gate, 0);
+            }
+
+            result = default;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryPush(T item)
+        {
+            if (Interlocked.CompareExchange(ref _gate, 1, 0) == 0)
+            {
+                if (_size < _limit)
+                {
+                    item.NextNode = _root;
+                    _root = item;
+                    _size++;
+                    Volatile.Write(ref _gate, 0);
+                    return true;
+                }
+                else
+                {
+                    Volatile.Write(ref _gate, 0);
+                }
+            }
+
+            return false;
+        }
+    }
+    */
+}


### PR DESCRIPTION
Fixes #

## Changes

Adds Box-Pools for various `struct` messages used by `ActorGraphInterpreter`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

TBD after feedback

### This PR's Benchmarks

TBD after feedback
