### PR TITLE
Made `akka.cluster.sharding.verbose-debug-logging` accept a `LogLevel`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingLeavingSpec.cs
@@ -28,7 +28,7 @@ namespace Akka.Cluster.Sharding.Tests
 
         public ClusterShardingLeavingSpecConfig(StateStoreMode mode)
             : base(mode: mode, loglevel: "DEBUG", additionalConfig: @"
-            akka.cluster.sharding.verbose-debug-logging = on
+            akka.cluster.sharding.verbose-debug-logging = INFO
             akka.cluster.sharding.rebalance-interval = 1s # make rebalancing more likely to happen to test for https://github.com/akka/akka/issues/29093
             akka.cluster.sharding.distributed-data.majority-min-cap = 1
             akka.cluster.sharding.coordinator-state.write-majority-plus = 1

--- a/src/contrib/cluster/Akka.Cluster.Sharding/InternalConfigUtilities.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/InternalConfigUtilities.cs
@@ -24,7 +24,7 @@ internal static class InternalConfigUtilities
     /// <exception cref="ArgumentException"></exception>
     public static LogLevel? ParseVerboseLogSettings(Config coordinatorHocon)
     {
-        var logLevel = coordinatorHocon.GetString("akka.cluster.sharding.verbose-debug-logging");
+        var logLevel = coordinatorHocon.GetString("akka.cluster.sharding.verbose-debug-logging").ToLowerInvariant();
         return logLevel switch
         {
             "off" => null,

--- a/src/contrib/cluster/Akka.Cluster.Sharding/InternalConfigUtilities.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/InternalConfigUtilities.cs
@@ -28,7 +28,9 @@ internal static class InternalConfigUtilities
         return logLevel switch
         {
             "off" => null,
+            "false" => null,
             "on" => LogLevel.DebugLevel,
+            "true" => LogLevel.DebugLevel,
             "error" => LogLevel.ErrorLevel,
             "warning" => LogLevel.WarningLevel,
             "info" => LogLevel.InfoLevel,

--- a/src/contrib/cluster/Akka.Cluster.Sharding/InternalConfigUtilities.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/InternalConfigUtilities.cs
@@ -1,0 +1,39 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="InternalConfigUtilities.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Configuration;
+using Akka.Event;
+
+namespace Akka.Cluster.Sharding;
+
+/// <summary>
+/// INTERNAL API
+/// </summary>
+internal static class InternalConfigUtilities
+{
+    /// <summary>
+    /// Null in this case means "off"
+    /// </summary>
+    /// <param name="coordinatorHocon">The HOCON config used by a shard coordinator</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    public static LogLevel? ParseVerboseLogSettings(Config coordinatorHocon)
+    {
+        var logLevel = coordinatorHocon.GetString("akka.cluster.sharding.verbose-debug-logging");
+        return logLevel switch
+        {
+            "off" => null,
+            "on" => LogLevel.DebugLevel,
+            "error" => LogLevel.ErrorLevel,
+            "warning" => LogLevel.WarningLevel,
+            "info" => LogLevel.InfoLevel,
+            "debug" => LogLevel.DebugLevel,
+            _ => throw new ArgumentException($"Unknown log level: {logLevel}")
+        };
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
@@ -235,7 +235,9 @@ akka.cluster.sharding {
   lease-retry-interval = 5s
 
   # Provide a higher level of details in the debug logs, often per routed message. Be careful about enabling
-  # in production systems.
+  # in production systems. 
+  # Values can be `off`, `on`, or an `akka.loglevel` value such as `INFO`.
+  # When set to `on` these logs will be logged using `LogLevel.Debug`.
   verbose-debug-logging = off
 
   # Throw an exception if the internal state machine in the Shard actor does an invalid state transition.


### PR DESCRIPTION
## Changes

close #7097

For users with a large number of sharded entities, the `akka.cluster.sharding.verbose-debug-logging` HOCON setting now accepts a `LogLevel` argument. It also still supports the same boolean values as before too.

However, if you were to pass in the following HOCON:

```hocon
akka.cluster.sharding.verbose-debug-logging = INFO
```

All of the internal `ShardCoordinator` logs could now be captured at a `LogLevel.Info` level, so there wouldn't be any need to turn `LogLevel.Debug` on globally to capture these logs.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7097
