### PR TITLE
improve Akka.Cluster / Akka.Remote `DeadLetter` logging

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionSpec.cs
@@ -44,7 +44,6 @@ namespace Akka.Cluster.Sharding.Tests
                 => message switch
                 {
                     int i => (i % 10).ToString(),
-                    ShardRegion.StartEntity se => (int.Parse(se.EntityId) % numberOfShards).ToString(),
                     _ => null
                 };
 

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -476,7 +476,7 @@ namespace Akka.Cluster.Tests
                 await probe.ExpectMsgAsync<ClusterEvent.MemberLeft>();
                 // MemberExited might not be published before MemberRemoved
                 var removed = (ClusterEvent.MemberRemoved)await probe.FishForMessageAsync(m => m is ClusterEvent.MemberRemoved);
-                removed.PreviousStatus.Should().BeEquivalentTo(MemberStatus.Exiting);
+                new [] {MemberStatus.Exiting, MemberStatus.Leaving}.Should().Contain(removed.PreviousStatus);
                 
                 await task.ShouldCompleteWithin(3.Seconds());
             }

--- a/src/core/Akka.Cluster.Tests/GossipSpec.cs
+++ b/src/core/Akka.Cluster.Tests/GossipSpec.cs
@@ -257,11 +257,11 @@ namespace Akka.Cluster.Tests
             Member a8 = TestMember.Create(new Address("akka.tcp", "sys", "a8", 2552), MemberStatus.Exiting, ImmutableHashSet<string>.Empty.Add("role1"), upNumber: 8);
             Member a9 = TestMember.Create(new Address("akka.tcp", "sys", "a9", 2552), MemberStatus.Exiting, ImmutableHashSet<string>.Empty.Add("role2"), upNumber: 9);
 
-            IEnumerable<Member> theExiting = new Member[] { a5, a6 };
+            var theExiting = new Member[] { a5, a6 };
             var gossip = new Gossip(ImmutableSortedSet.Create(a1, a2, a3, a4, a5, a6, a7, a8, a9));
 
             var r = ClusterCoreDaemon.GossipTargetsForExitingMembers(gossip, theExiting);
-            r.Should().BeEquivalentTo(new[] { a1, a2, a5, a6, a9 });
+            r.Should().BeEquivalentTo(a1, a2, a5, a6, a9);
         }
     }
 }

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -1051,7 +1051,7 @@ namespace Akka.Cluster
             });
         }
 
-        private ActorSelection ClusterCore(Address address)
+        private static ActorSelection ClusterCore(Address address)
         {
             return Context.ActorSelection(new RootActorPath(address) / "system" / "cluster" / "core" / "daemon");
         }

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -2339,7 +2339,7 @@ namespace Akka.Cluster
                 }
 
                 PublishMembershipState();
-                GossipExitingMembersToOldest(changedMembers.Where(i => i.Status == MemberStatus.Exiting));
+                GossipExitingMembersToOldest(changedMembers.Where(i => i.Status == MemberStatus.Exiting).ToArray());
             }
         }
 
@@ -2347,7 +2347,7 @@ namespace Akka.Cluster
         /// Gossip the Exiting change to the two oldest nodes for quick dissemination to potential Singleton nodes
         /// </summary>
         /// <param name="exitingMembers"></param>
-        private void GossipExitingMembersToOldest(IEnumerable<Member> exitingMembers)
+        private void GossipExitingMembersToOldest(IReadOnlyCollection<Member> exitingMembers)
         {
             var targets = GossipTargetsForExitingMembers(LatestGossip, exitingMembers);
             if (targets != null && targets.Any())
@@ -2509,9 +2509,9 @@ namespace Akka.Cluster
         /// <param name="latestGossip"></param>
         /// <param name="exitingMembers"></param>
         /// <returns></returns>
-        public static IEnumerable<Member> GossipTargetsForExitingMembers(Gossip latestGossip, IEnumerable<Member> exitingMembers)
+        public static IEnumerable<Member> GossipTargetsForExitingMembers(Gossip latestGossip, IReadOnlyCollection<Member> exitingMembers)
         {
-            if (exitingMembers.Any())
+            if (exitingMembers.Count > 0)
             {
                 var roles = exitingMembers.SelectMany(m => m.Roles);
                 var membersSortedByAge = latestGossip.Members

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -2234,8 +2234,7 @@ namespace Akka.Cluster
             var localOverview = localGossip.Overview;
             var localSeen = localOverview.Seen;
 
-            bool enoughMembers = IsMinNrOfMembersFulfilled();
-            bool IsJoiningUp(Member m) => m.Status is MemberStatus.Joining or MemberStatus.WeaklyUp && enoughMembers;
+            var enoughMembers = IsMinNrOfMembersFulfilled();
 
             var removedUnreachable =
                 localOverview.Reachability.AllUnreachableOrTerminated.Select(localGossip.GetMember)
@@ -2341,6 +2340,10 @@ namespace Akka.Cluster
                 PublishMembershipState();
                 GossipExitingMembersToOldest(changedMembers.Where(i => i.Status == MemberStatus.Exiting).ToArray());
             }
+
+            return;
+
+            bool IsJoiningUp(Member m) => m.Status is MemberStatus.Joining or MemberStatus.WeaklyUp && enoughMembers;
         }
 
         /// <summary>

--- a/src/core/Akka.Cluster/ClusterDaemon.cs
+++ b/src/core/Akka.Cluster/ClusterDaemon.cs
@@ -2509,7 +2509,7 @@ namespace Akka.Cluster
         /// <param name="latestGossip"></param>
         /// <param name="exitingMembers"></param>
         /// <returns></returns>
-        public static IEnumerable<Member> GossipTargetsForExitingMembers(Gossip latestGossip, IReadOnlyCollection<Member> exitingMembers)
+        public static IReadOnlyCollection<Member> GossipTargetsForExitingMembers(Gossip latestGossip, IReadOnlyCollection<Member> exitingMembers)
         {
             if (exitingMembers.Count > 0)
             {

--- a/src/core/Akka.Cluster/Gossip.cs
+++ b/src/core/Akka.Cluster/Gossip.cs
@@ -442,43 +442,40 @@ namespace Akka.Cluster
     /// the node with same host:port. The `uid` in the `UniqueAddress` is
     /// different in that case.
     /// </summary>
-    class GossipEnvelope : IClusterMessage
+    internal class GossipEnvelope : IClusterMessage
     {
-        readonly UniqueAddress _from;
-        readonly UniqueAddress _to;
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="from">TBD</param>
-        /// <param name="to">TBD</param>
-        /// <param name="gossip">TBD</param>
-        /// <param name="deadline">TBD</param>
-        /// <returns>TBD</returns>
         public GossipEnvelope(UniqueAddress from, UniqueAddress to, Gossip gossip, Deadline deadline = null)
         {
-            _from = from;
-            _to = to;
+            From = from;
+            To = to;
             Gossip = gossip;
             Deadline = deadline;
         }
 
         /// <summary>
-        /// TBD
+        /// The sender of the gossip.
         /// </summary>
-        public UniqueAddress From { get { return _from; } }
+        public UniqueAddress From { get; }
+
         /// <summary>
-        /// TBD
+        /// The receiver of the gossip.
         /// </summary>
-        public UniqueAddress To { get { return _to; } }
+        public UniqueAddress To { get; }
+
         /// <summary>
-        /// TBD
+        /// The gossip content itself
         /// </summary>
-        public Gossip Gossip { get; set; }
+        public Gossip Gossip { get; }
+        
         /// <summary>
-        /// TBD
+        /// The deadline for the gossip.
         /// </summary>
         public Deadline Deadline { get; set; }
+
+        public override string ToString()
+        {
+            return $"GossipEnvelope(from={From}, to={To}, gossip={Gossip}, deadline={Deadline})";
+        }
     }
 
     /// <summary>

--- a/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
+++ b/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
@@ -26,17 +26,19 @@ namespace Akka.Remote.Tests
 {
     public class ActorsLeakSpec : AkkaSpec
     {
-        private static readonly Config Config = ConfigurationFactory.ParseString(@"
-            akka.actor.provider = remote
-            akka.loglevel = INFO
-            akka.remote.dot-netty.tcp.applied-adapters = [trttl]
-            akka.remote.dot-netty.tcp.hostname = 127.0.0.1
-            akka.remote.log-lifecycle-events = on
-            akka.remote.transport-failure-detector.heartbeat-interval = 1 s
-            akka.remote.transport-failure-detector.acceptable-heartbeat-pause = 3 s
-            akka.remote.quarantine-after-silence = 3 s
-            akka.test.filter-leeway = 12 s
-        ");
+        private static readonly Config Config = ConfigurationFactory.ParseString("""
+            
+                        akka.actor.provider = remote
+                        akka.loglevel = INFO
+                        akka.remote.dot-netty.tcp.applied-adapters = [trttl]
+                        akka.remote.dot-netty.tcp.hostname = 127.0.0.1
+                        akka.remote.log-lifecycle-events = on
+                        akka.remote.transport-failure-detector.heartbeat-interval = 1 s
+                        akka.remote.transport-failure-detector.acceptable-heartbeat-pause = 3 s
+                        akka.remote.quarantine-after-silence = 3 s
+                        akka.test.filter-leeway = 12 s
+                    
+            """);
 
         public ActorsLeakSpec(ITestOutputHelper output) : base(Config, output)
         {
@@ -211,7 +213,7 @@ namespace Akka.Remote.Tests
                 // Watch a remote actor - this results in system message traffic
                 Sys.ActorSelection(new RootActorPath(idleRemoteAddress) / "user" / "stoppable").Tell(new Identify(1));
                 var remoteActor = (await ExpectMsgAsync<ActorIdentity>()).Subject;
-                Watch(remoteActor);
+                await WatchAsync(remoteActor);
                 remoteActor.Tell("stop");
                 await ExpectTerminatedAsync(remoteActor);
                 // All system messages have been acked now on this side

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -490,7 +490,7 @@ namespace Akka.Remote
         private readonly ICancelable _autoResendTimer;
 
         /// <summary>
-        /// TBD
+        /// The UID of the remote system we're communicating with.
         /// </summary>
         public int? Uid { get; set; }
 
@@ -703,7 +703,7 @@ namespace Akka.Remote
                     // remote address at the EndpointManager level stopping this actor. In case the remote system becomes reachable
                     // again it will be immediately quarantined due to out-of-sync system message buffer and becomes quarantined.
                     // In other words, this action is safe.
-                    if (_bailoutAt != null && _bailoutAt.IsOverdue)
+                    if (_bailoutAt is { IsOverdue: true })
                     {
                         throw new HopelessAssociation(_localAddress, _remoteAddress, Uid,
                             new TimeoutException("Delivery of system messages timed out and they were dropped"));

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -404,37 +404,28 @@ namespace Akka.Remote
         #region Internal message classes
 
         /// <summary>
-        /// TBD
+        /// Query if the <see cref="ReliableDeliverySupervisor"/> is idle
         /// </summary>
         public class IsIdle
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly IsIdle Instance = new();
             private IsIdle() { }
         }
 
         /// <summary>
-        /// TBD
+        /// Response to a <see cref="IsIdle"/> query
         /// </summary>
         public class Idle
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly Idle Instance = new();
             private Idle() { }
         }
 
         /// <summary>
-        /// TBD
+        /// Triggers a <see cref="HopelessAssociation"/> exception when the <see cref="ReliableDeliverySupervisor"/> has been idle for too long
         /// </summary>
         public class TooLongIdle
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly TooLongIdle Instance = new();
             private TooLongIdle() { }
         }
@@ -453,16 +444,16 @@ namespace Akka.Remote
         private readonly ConcurrentDictionary<EndpointManager.Link, EndpointManager.ResendState> _receiveBuffers;
 
         /// <summary>
-        /// TBD
+        /// Creates a new instance of the <see cref="ReliableDeliverySupervisor"/> class.
         /// </summary>
-        /// <param name="handleOrActive">TBD</param>
-        /// <param name="localAddress">TBD</param>
-        /// <param name="remoteAddress">TBD</param>
-        /// <param name="refuseUid">TBD</param>
-        /// <param name="transport">TBD</param>
-        /// <param name="settings">TBD</param>
-        /// <param name="codec">TBD</param>
-        /// <param name="receiveBuffers">TBD</param>
+        /// <param name="handleOrActive">The Akka.Remote protocol handle for sending messages</param>
+        /// <param name="localAddress">Our local address per the <see cref="transport"/></param>
+        /// <param name="remoteAddress">The remote address we're communicating with</param>
+        /// <param name="refuseUid">Optional - the quarantined UID for the <see cref="remoteAddress"/>, if we've previously quarantined it.</param>
+        /// <param name="transport">The underlying transport.</param>
+        /// <param name="settings">The general Akka.Remote transport settings.</param>
+        /// <param name="codec">The Akka.Remote protocol codec for encoding and decoding messages.</param>
+        /// <param name="receiveBuffers">The set of receive buffers for resending messages in the event that the connection to <see cref="remoteAddress"/> is disrupted.</param>
         public ReliableDeliverySupervisor(
                     AkkaProtocolHandle handleOrActive,
                     Address localAddress,
@@ -483,7 +474,7 @@ namespace Akka.Remote
             _receiveBuffers = receiveBuffers;
             Reset(); // needs to be called at startup
             _writer = CreateWriter(); // need to create writer at startup
-            Uid = handleOrActive != null ? (int?)handleOrActive.HandshakeInfo.Uid : null;
+            Uid = handleOrActive?.HandshakeInfo.Uid;
             UidConfirmed = Uid.HasValue && (Uid != _refuseUid);
 
             if (Uid.HasValue && Uid == _refuseUid)

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -1187,7 +1187,7 @@ namespace Akka.Remote
             {
                 // Assert handle == None?
                 Context.Parent.Tell(
-                    new ReliableDeliverySupervisor.GotUid((int)handle.ProtocolHandle.HandshakeInfo.Uid, RemoteAddress));
+                    new ReliableDeliverySupervisor.GotUid(handle.ProtocolHandle.HandshakeInfo.Uid, RemoteAddress));
                 _handle = handle.ProtocolHandle;
                 _reader = StartReadEndpoint(_handle);
                 EventPublisher.NotifyListeners(new AssociatedEvent(LocalAddress, RemoteAddress, Inbound));

--- a/src/core/Akka/Event/DeadLetterListener.cs
+++ b/src/core/Akka/Event/DeadLetterListener.cs
@@ -34,20 +34,14 @@ namespace Akka.Event
         protected override void PreRestart(Exception reason, object message)
         {
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
+        
         protected override void PreStart()
         {
             _eventStream.Subscribe(Self, typeof(DeadLetter));
             _eventStream.Subscribe(Self, typeof(Dropped));
             _eventStream.Subscribe(Self, typeof(UnhandledMessage));
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
+        
         protected override void PostStop()
         {
             _eventStream.Unsubscribe(Self);
@@ -65,12 +59,6 @@ namespace Akka.Event
                 _count++;
             }
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="message">TBD</param>
-        /// <returns>TBD</returns>
         protected override bool Receive(object message)
         {
             if (_isAlwaysLoggingDeadLetters)

--- a/src/examples/Cluster/ClusterSharding/ShoppingCart/MessageExtractor.cs
+++ b/src/examples/Cluster/ClusterSharding/ShoppingCart/MessageExtractor.cs
@@ -27,7 +27,6 @@ namespace ShoppingCart
         public override object EntityMessage(object message)
             => message switch
             {
-                ShardingEnvelope e => e.Message,
                 _ => message
             };
     }


### PR DESCRIPTION
## Changes

Various cleanup inside Akka.Cluster and Akka.Remote in order to make it easier to debug cluster gossip issues.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).