### PR TITLE
Add GitHub Actions support to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,7 @@ updates:
   - dependency-name: FluentAssertions
     versions:
     - 5.9.0
+- package-ecosystem: github-actions
+  schedule:
+    interval: daily
+    time: "11:00"


### PR DESCRIPTION
Use Dependabot to automatically update any GitHub Actions used by Akka.NET.
