### PR TITLE
[Akka.Streams] make default `LogSource`s actually usable

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3440,6 +3440,7 @@ namespace Akka.Event
         public System.Type Type { get; }
         public static Akka.Event.LogSource Create(object o) { }
         public static Akka.Event.LogSource Create(object o, Akka.Actor.ActorSystem system) { }
+        public static Akka.Event.LogSource Create(string source, System.Type t) { }
         public static string FromActor(Akka.Actor.IActorContext actor, Akka.Actor.ActorSystem system) { }
         public static string FromActorRef(Akka.Actor.IActorRef a, Akka.Actor.ActorSystem system) { }
         public static string FromString(string source, Akka.Actor.ActorSystem system) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3430,6 +3430,7 @@ namespace Akka.Event
         public System.Type Type { get; }
         public static Akka.Event.LogSource Create(object o) { }
         public static Akka.Event.LogSource Create(object o, Akka.Actor.ActorSystem system) { }
+        public static Akka.Event.LogSource Create(string source, System.Type t) { }
         public static string FromActor(Akka.Actor.IActorContext actor, Akka.Actor.ActorSystem system) { }
         public static string FromActorRef(Akka.Actor.IActorRef a, Akka.Actor.ActorSystem system) { }
         public static string FromString(string source, Akka.Actor.ActorSystem system) { }

--- a/src/core/Akka.Streams.Tests/AkkaStreamsLogSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/AkkaStreamsLogSourceSpec.cs
@@ -1,0 +1,122 @@
+// -----------------------------------------------------------------------
+//  <copyright file="AkkaStreamsLogSourceSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Streams.Dsl;
+using Akka.Streams.Stage;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+
+namespace Akka.Streams.Tests;
+
+public class AkkaStreamsLogSourceSpec : AkkaSpec
+{
+    public AkkaStreamsLogSourceSpec(ITestOutputHelper output) : base(output, "akka.loglevel=DEBUG")
+    {
+    }
+
+    // create a custom Flow shape graph stage
+    private class TestLogStage<T> : GraphStage<FlowShape<T, T>>
+    {
+        private readonly string _name;
+
+        public TestLogStage(string name)
+        {
+            _name = name;
+            Shape = new FlowShape<T, T>(In, Out);
+        }
+
+        public Inlet<T> In { get; } = new("LogStage.in");
+        public Outlet<T> Out { get; } = new("LogStage.out");
+
+        public override FlowShape<T, T> Shape { get; }
+
+        protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(this);
+
+        private sealed class Logic : InAndOutGraphStageLogic
+        {
+            private readonly TestLogStage<T> _stage;
+            
+            public Logic(TestLogStage<T> stage) : base(stage.Shape)
+            {
+                _stage = stage;
+                SetHandler(stage.In, this);
+                SetHandler(stage.Out, this);
+            }
+
+            public override void OnPush()
+            {
+                var element = Grab(_stage.In);
+                Log.Info($"Element: {element}");
+                Push(_stage.Out, element);
+            }
+
+            public override void OnPull()
+            {
+                Pull(_stage.In);
+            }
+        }
+    }
+    
+
+    [Fact]
+    public async Task LogStage_should_log_elements_with_coherent_actorpath()
+    {
+        var probe = CreateTestProbe();
+        var source = Source.From(Enumerable.Range(1, 5));
+        var flow = Flow.Create<int>().Log("log")
+            .To(Sink.ActorRef<int>(probe.Ref, "completed", ex => new Status.Failure(ex)));
+
+        // create a probe and subscribe it to Debug level events
+        var logProbe = CreateTestProbe();
+        Sys.EventStream.Subscribe(logProbe.Ref, typeof(Debug));
+        
+
+        source.RunWith(flow, Sys);
+
+        await probe.ExpectMsgAsync(1);
+        await probe.ExpectMsgAsync(2);
+        await probe.ExpectMsgAsync(3);
+        await probe.ExpectMsgAsync(4);
+        await probe.ExpectMsgAsync(5);
+        
+        // check just the first log message
+        var logMessage = logProbe.ExpectMsg<Debug>();
+        logMessage.LogSource.Should().Contain("StreamSupervisor");
+    }
+    
+    [Fact]
+    public async Task CustomStage_should_log_elements_with_friendly_name()
+    {
+        var probe = CreateTestProbe();
+        var source = Source.From(Enumerable.Range(1, 5));
+        var flow = Flow.Create<int>().Via(new TestLogStage<int>("custom"))
+            .To(Sink.ActorRef<int>(probe.Ref, "completed", ex => new Status.Failure(ex)));
+
+        // create a probe and subscribe it to Debug level events
+        var logProbe = CreateTestProbe();
+        Sys.EventStream.Subscribe(logProbe.Ref, typeof(Info));
+        
+
+        source.RunWith(flow, Sys);
+
+        await probe.ExpectMsgAsync(1);
+        await probe.ExpectMsgAsync(2);
+        await probe.ExpectMsgAsync(3);
+        await probe.ExpectMsgAsync(4);
+        await probe.ExpectMsgAsync(5);
+        
+        // check just the first log message
+        var logMessage = logProbe.ExpectMsg<Info>();
+        logMessage.LogSource.Should().Contain("StreamSupervisor");
+    }
+}

--- a/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
+++ b/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
@@ -386,10 +386,18 @@ namespace Akka.Streams.Implementation
         /// <returns>The newly created logging adapter.</returns>
         public override ILoggingAdapter MakeLogger(object logSource)
         {
-            if (logSource is not LogSource s) return Logging.GetLogger(System, logSource);
-            var actorPath = $"{s.Source}({LogSource.FromActorRef(_supervisor, System)})";
-            var newLogSource = LogSource.Create(actorPath, s.Type);
-            return Logging.GetLogger(System, newLogSource);
+            string actorPath;
+            LogSource newSource;
+            if (logSource is not LogSource s)
+            {
+                actorPath = $"{s}({LogSource.FromActorRef(_supervisor, System)})";
+                newSource = LogSource.Create(actorPath, s.Type);
+                return Logging.GetLogger(System, newSource);
+            }
+            
+            actorPath = $"{s.Source}({LogSource.FromActorRef(_supervisor, System)})";
+            newSource = LogSource.Create(actorPath, s.Type);
+            return Logging.GetLogger(System, newSource);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
+++ b/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
@@ -384,7 +384,13 @@ namespace Akka.Streams.Implementation
         /// </summary>
         /// <param name="logSource">The source that produces the log events.</param>
         /// <returns>The newly created logging adapter.</returns>
-        public override ILoggingAdapter MakeLogger(object logSource) => Logging.GetLogger(System, logSource);
+        public override ILoggingAdapter MakeLogger(object logSource)
+        {
+            if (logSource is not LogSource s) return Logging.GetLogger(System, logSource);
+            var actorPath = $"{s.Source}({LogSource.FromActorRef(_supervisor, System)})";
+            var newLogSource = LogSource.Create(actorPath, s.Type);
+            return Logging.GetLogger(System, newLogSource);
+        }
 
         /// <summary>
         /// TBD
@@ -402,7 +408,7 @@ namespace Akka.Streams.Implementation
                 Supervisor.Tell(PoisonPill.Instance);
         }
 
-        private ILoggingAdapter GetLogger() => _system.Log;
+        private ILoggingAdapter GetLogger() => MakeLogger(_supervisor);
     }
 
     /// <summary>

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -2905,6 +2905,8 @@ namespace Akka.Streams.Implementation.Fusing
             private Attributes.LogLevels _logLevels;
             private ILoggingAdapter _log;
 
+            protected override object LogSource => Akka.Event.LogSource.Create(_stage._name);
+
             public Logic(Log<T> stage, Attributes inheritedAttributes) : base(stage.Shape)
             {
                 _stage = stage;
@@ -2981,17 +2983,7 @@ namespace Akka.Streams.Implementation.Fusing
                     _log = _stage._adapter;
                 else
                 {
-                    try
-                    {
-                        var materializer = ActorMaterializerHelper.Downcast(Materializer);
-                        _log = new BusLogging(materializer.System.EventStream, _stage._name, GetType(), materializer.System.Settings.LogFormatter);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new Exception(
-                            "Log stage can only provide LoggingAdapter when used with ActorMaterializer! Provide a LoggingAdapter explicitly or use the actor based flow materializer.",
-                            ex);
-                    }
+                    _log = Log;
                 }
             }
 

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -840,7 +840,7 @@ namespace Akka.Streams.Stage
         /// <param name="shape">TBD</param>
         protected GraphStageLogic(Shape shape) : this(shape.Inlets.Count(), shape.Outlets.Count())
         {
-            LogSource = Akka.Event.LogSource.Create(shape);
+            LogSource = Akka.Event.LogSource.Create(shape.ToString());
         }
 
         /// <summary>
@@ -1708,7 +1708,7 @@ namespace Akka.Streams.Stage
         /// Override and return a name to be given to the StageActor of this stage.
         /// 
         /// This method will be only invoked and used once, during the first <see cref="GetStageActor"/>
-        /// invocation whichc reates the actor, since subsequent `getStageActors` calls function
+        /// invocation which creates the actor, since subsequent `getStageActors` calls function
         /// like `become`, rather than creating new actors.
         /// 
         /// Returns an empty string by default, which means that the name will a unique generated String (e.g. "$$a").

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -47,7 +47,7 @@ namespace Akka.Event
                     return new LogSource(actorRef.Path.ToString(), SourceType(actorRef));
                 case string str:
                     return new LogSource(str, SourceType(str));
-                case System.Type t:
+                case Type t:
                     return new LogSource(Logging.SimpleName(t), t);
                 default:
                     return new LogSource(Logging.SimpleName(o), SourceType(o));
@@ -64,8 +64,10 @@ namespace Akka.Event
                     return new LogSource(FromActorRef(actorRef, system), SourceType(actorRef));
                 case string str:
                     return new LogSource(FromString(str, system), SourceType(str));
-                case System.Type t:
+                case Type t:
                     return new LogSource(FromType(t, system), t);
+                case LogSource logSource:
+                    return logSource; // if someone's already created a LogSource, just use it
                 default:
                     return new LogSource(FromType(o.GetType(), system), SourceType(o));
             }
@@ -75,7 +77,7 @@ namespace Akka.Event
         {
             switch (o)
             {
-                case System.Type t:
+                case Type t:
                     return t;
                 case IActorContext context:
                     return context.Props.Type;

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -73,6 +73,11 @@ namespace Akka.Event
             }
         }
 
+        public static LogSource Create(string source, Type t)
+        {
+            return new LogSource(source, t);
+        }
+
         public static Type SourceType(object o)
         {
             switch (o)


### PR DESCRIPTION
## Changes

Fixes #7126 

So TL;DR;, logging from within an Akka.Streams graph stage is basically unusable and has been since the inception of Akka.Streams.

Behold, what my logs look like from my Akka.Streams-powered MQTT client library:

```text
[DEBUG][04/24/2024 00:50:51.923Z][Thread 0046][akka://test/user/turbomqtt-clients/tcp] Creating new TCP transport for [CreateTcpTransport { Options = MqttClientTcpOptions { AddressFamily = Unspecified, MaxFrameSize = 131072, Host = localhost, Port = 21883, ReconnectInterval = 00:00:05, MaxReconnectAttempts = 10 }, ProtocolVersion = V3_1_1 }]
[DEBUG][04/24/2024 00:50:51.924Z][Thread 0046][akka://test/user/turbomqtt-clients/tcp/$a] Created new TCP transport for client connecting to [localhost:21883]
[INFO][04/24/2024 00:50:51.928Z][Thread 0013][akka://test/user/turbomqtt-clients/tcp/$a] Attempting to connect to [localhost:21883]
[DEBUG][04/24/2024 00:50:51.929Z][Thread 0037][akka://test/user/turbomqtt-clients/tcp/$a] Attempting to connect to [localhost:21883] - resolved to [::1, 127.0.0.1]
[INFO][04/24/2024 00:50:51.930Z][Thread 0037][akka://test/user/turbomqtt-clients/tcp/$a] Successfully connected to [localhost:21883]
[DEBUG][04/24/2024 00:50:51.930Z][Thread 0013][LogSource (akka://test)] Encoded 1 messages using 37 bytes
[DEBUG][04/24/2024 00:50:51.930Z][Thread 0046][TcpMqtt311End2EndSpecs (akka://test)] Decoded 1 packets from transport.
[INFO][04/24/2024 00:50:51.930Z][Thread 0046][TcpMqtt311End2EndSpecs (akka://test)] Received packet of type Connect
[DEBUG][04/24/2024 00:50:51.930Z][Thread 0046][TcpMqtt311End2EndSpecs (akka://test)] Sending packet of type ConnAck using V3_1_1
[DEBUG][04/24/2024 00:50:51.932Z][Thread 0046][TcpMqtt311End2EndSpecs (akka://test)] Successfully wrote packet of type ConnAck [4 bytes] to transport.
[DEBUG][04/24/2024 00:50:51.932Z][Thread 0013][LogSource (akka://test)] Decoded [1] packets totaling [4] bytes
[DEBUG][04/24/2024 00:50:51.933Z][Thread 0013][LogSource (akka://test)] Received packet of type [ConnAck] from client.
[DEBUG][04/24/2024 00:50:51.933Z][Thread 0046][LogSource (akka://test)] Encoded 1 messages using 12 bytes
[DEBUG][04/24/2024 00:50:51.933Z][Thread 0013][TcpMqtt311End2EndSpecs (akka://test)] Decoded 1 packets from transport.
[INFO][04/24/2024 00:50:51.933Z][Thread 0013][TcpMqtt311End2EndSpecs (akka://test)] Received packet of type Subscribe
[DEBUG][04/24/2024 00:50:51.933Z][Thread 0013][TcpMqtt311End2EndSpecs (akka://test)] Sending packet of type SubAck using V3_1_1
[DEBUG][04/24/2024 00:50:51.933Z][Thread 0013][TcpMqtt311End2EndSpecs (akka://test)] Successfully wrote packet of type SubAck [5 bytes] to transport.
[DEBUG][04/24/2024 00:50:51.933Z][Thread 0032][LogSource (akka://test)] Decoded [1] packets totaling [5] bytes
[DEBUG][04/24/2024 00:50:51.933Z][Thread 0032][LogSource (akka://test)] Received packet of type [SubAck] from client.
[DEBUG][04/24/2024 00:50:51.934Z][Thread 0013][LogSource (akka://test)] Encoded 1 messages using 24 bytes
[WARNING][04/24/2024 00:50:51.934Z][Thread 0039][TcpMqtt311End2EndSpecs (akka://test)] Client test-client is being disconnected from server.
[DEBUG][04/24/2024 00:50:51.934Z][Thread 0039][TcpMqtt311End2EndSpecs (akka://test)] Sending packet of type Disconnect using V3_1_1
[ERROR][04/24/2024 00:50:51.934Z][Thread 0039][TcpMqtt311End2EndSpecs (akka://test)] Failed to write packet of type Disconnect to transport.
[ERROR][04/24/2024 00:50:51.934Z][Thread 0037][akka://test/user/turbomqtt-clients/tcp/$a] Failed to read from socket.
```

There are about 10 different stream stages in there, each of which get created twice (rebooting a failed connection) - I can't tell _any_ of them apart, and I know I have a bug in that code somewhere.

Thus, I've made this PR and now these logs will look more like this going forward:

```text
[INFO][04/24/2024 02:25:06.096Z][Thread 0016][FlowShape`2([LogStage.in] [LogStage.out])(akka://AkkaStreamsLogSourceSpec-1/user/StreamSupervisor-0)] Element: 1
[INFO][04/24/2024 02:25:06.097Z][Thread 0016][FlowShape`2([LogStage.in] [LogStage.out])(akka://AkkaStreamsLogSourceSpec-1/user/StreamSupervisor-0)] Element: 2
[INFO][04/24/2024 02:25:06.097Z][Thread 0016][FlowShape`2([LogStage.in] [LogStage.out])(akka://AkkaStreamsLogSourceSpec-1/user/StreamSupervisor-0)] Element: 3
[INFO][04/24/2024 02:25:06.098Z][Thread 0016][FlowShape`2([LogStage.in] [LogStage.out])(akka://AkkaStreamsLogSourceSpec-1/user/StreamSupervisor-0)] Element: 4
[INFO][04/24/2024 02:25:06.098Z][Thread 0016][FlowShape`2([LogStage.in] [LogStage.out])(akka://AkkaStreamsLogSourceSpec-1/user/StreamSupervisor-0)] Element: 5
[DEBUG][04/24/2024 02:25:06.119Z][Thread 0012][CoordinatedShutdown (akka://AkkaStreamsLogSourceSpec-1)] Performing phase [before-service-unbind] with [0] tasks.
[DEBUG][04/24/2024 02:25:06.119Z][Thread 0015][CoordinatedShutdown (akka://AkkaStreamsLogSourceSpec-1)] Performing phase [service-unbind] with [0] tasks.
[DEBUG][04/24/2024 02:25:06.120Z][Thread 0007][CoordinatedShutdown (akka://AkkaStreamsLogSourceSpec-1)] Performing phase [service-requests-done] with [0] tasks.
[DEBUG][04/24/2024 02:25:06.120Z][Thread 0017][CoordinatedShutdown (akka://AkkaStreamsLogSourceSpec-1)] Performing phase [service-stop] with [0] tasks.
[DEBUG][04/24/2024 02:25:06.120Z][Thread 0017][CoordinatedShutdown (akka://AkkaStreamsLogSourceSpec-1)] Performing phase [before-cluster-shutdown] with [0] tasks.
```

The default `LogSource` for any Akka.Streams stage, including built in ones is now `{shape.ToString()}({streamSupervisorActorPath})`.

The `shape.ToString()` method does the following by default:

```csharp
public sealed override string ToString() => $"{GetType().Name}([{string.Join(", ", Inlets)}] [{string.Join(", ", Outlets)}])";
```

Which will print out the type of stage and a rough description of its inputs and outputs, in accordance with the names given to those Inlet and Outlet types. That will add a small amount of overhead to each stage we create (a `.ToString()` call that iterates over some types that return hard-coded strings back) but in return you can now immediately understand:

1. Where in the actor hierarchy this stream is
2. What type of stage it is
3. What its inputs and outputs are

Moreover, if you override the `GraphStage.LogSource` with a friendlier name we will still append the `StreamSupervisor.Path` to it during logger construction, so you can still keep track of where this stream is within the actor hierarchy.

TL;DR; this is a substantial usability improvement for Akka.Streams.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7126 
* [x] Changes in public API reviewed, if any.
