### PR TITLE
Fix racy `FunctionRefSpecs`

### DIFF
--- a/src/core/Akka.Tests/Actor/FunctionRefSpecs.cs
+++ b/src/core/Akka.Tests/Actor/FunctionRefSpecs.cs
@@ -130,9 +130,9 @@ namespace Akka.Tests.Actor
             akka.actor.debug.receive = on
             ");
         
-        public FunctionRefSpec(ITestOutputHelper output) : base(output, Config)
+        public FunctionRefSpec(ITestOutputHelper output) : base(output)
         {
-            Sys.Log.Info("Starting FunctionRefSpec");
+            //Sys.Log.Info("Starting FunctionRefSpec");
         }
 
         #region top level
@@ -151,13 +151,11 @@ namespace Akka.Tests.Actor
         public async Task FunctionRef_created_by_top_level_actor_must_be_watchable()
         {
             var s = SuperActor();
-            var forwarder = GetFunctionRef(s);
-
-            s.Tell(new GetForwarder(TestActor));
-            var f = await ExpectMsgAsync<FunctionRef>();
-            await WatchAsync(f);
-            s.Tell(new DropForwarder(f));
-            await ExpectTerminatedAsync(f);
+            var forwarder = await GetFunctionRef(s);
+            
+            await WatchAsync(forwarder);
+            s.Tell(new DropForwarder(forwarder));
+            await ExpectTerminatedAsync(forwarder);
         }
 
         [Fact]
@@ -179,7 +177,7 @@ namespace Akka.Tests.Actor
             var s = SuperActor();
             var forwarder = await GetFunctionRef(s);
 
-            Watch(forwarder);
+            await WatchAsync(forwarder);
             s.Tell(PoisonPill.Instance);
             await ExpectTerminatedAsync(forwarder);
         }
@@ -211,12 +209,10 @@ namespace Akka.Tests.Actor
         {
             var s = SupSuperActor();
             var forwarder = await GetFunctionRef(s);
-
-            s.Tell(new GetForwarder(TestActor));
-            var f = await ExpectMsgAsync<FunctionRef>();
-            await WatchAsync(f);
-            s.Tell(new DropForwarder(f));
-            await ExpectTerminatedAsync(f);
+            
+            await WatchAsync(forwarder);
+            s.Tell(new DropForwarder(forwarder));
+            await ExpectTerminatedAsync(forwarder);
         }
 
         [Fact]
@@ -238,7 +234,7 @@ namespace Akka.Tests.Actor
             var s = SupSuperActor();
             var forwarder = await GetFunctionRef(s);
 
-            Watch(forwarder);
+            await WatchAsync(forwarder);
             s.Tell(PoisonPill.Instance);
             await ExpectTerminatedAsync(forwarder);
         }

--- a/src/core/Akka.Tests/Actor/FunctionRefSpecs.cs
+++ b/src/core/Akka.Tests/Actor/FunctionRefSpecs.cs
@@ -9,6 +9,7 @@ using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.TestKit;
 using Xunit;
 using Xunit.Abstractions;
@@ -131,6 +132,7 @@ namespace Akka.Tests.Actor
         
         public FunctionRefSpec(ITestOutputHelper output) : base(output, Config)
         {
+            Sys.Log.Info("Starting FunctionRefSpec");
         }
 
         #region top level


### PR DESCRIPTION
## Changes

Noticed that these were failing racily on https://github.com/akkadotnet/akka.net/pull/7168 - I'm able to reproduce the failure in Rider using "run until failure" pretty easily. Working on debugging these.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
