### PR TITLE
Backport `HashedWheelTimerFix` to .NET Standard 2.0

### DIFF
--- a/src/core/Akka/Actor/Scheduler/HashedWheelTimerScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/HashedWheelTimerScheduler.cs
@@ -248,8 +248,10 @@ namespace Akka.Actor
 
         private void Start()
         {
-            if (_workerState == WORKER_STATE_STARTED) { } // do nothing
-            else if (_workerState == WORKER_STATE_INIT)
+            // only read the worker state once so it can't be a moving target for else-branch
+            var workerStateRead = _workerState;
+            if (workerStateRead == WORKER_STATE_STARTED) { } // do nothing
+            else if (workerStateRead == WORKER_STATE_INIT)
             {
                 _worker ??= new Thread(Run) { IsBackground = true };
                 if (Interlocked.CompareExchange(ref _workerState, WORKER_STATE_STARTED, WORKER_STATE_INIT) ==
@@ -258,7 +260,7 @@ namespace Akka.Actor
                     _worker.Start();
                 }
             }
-            else if (_workerState is WORKER_STATE_SHUTDOWN)
+            else if (workerStateRead is WORKER_STATE_SHUTDOWN)
             {
                 throw new SchedulerException("cannot enqueue after timer shutdown");
             }


### PR DESCRIPTION
## Changes

Port https://github.com/akkadotnet/akka.net/pull/7174 to .NET Standard 2.0

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7174