### PR TITLE
fix race conditions with `ReceivePersistentActorTests`

### DIFF
--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorTests.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorTests.cs
@@ -31,9 +31,9 @@ namespace Akka.Persistence.Tests
             //Given
             var pid = "p-1";
             WriteEvents(pid, 1, 2, 3);
-            var actor = Sys.ActorOf(Props.Create(() => new NoCommandActor(pid)), "no-receive-specified");
             Sys.EventStream.Subscribe(TestActor, typeof(UnhandledMessage));
-
+            var actor = Sys.ActorOf(Props.Create(() => new NoCommandActor(pid)), "no-receive-specified");
+          
             //When
             actor.Tell("Something");
 
@@ -50,8 +50,8 @@ namespace Akka.Persistence.Tests
             WriteEvents(pid, "Something");
 
             // when
-            var actor = Sys.ActorOf(Props.Create(() => new NoEventActor(pid)), "no-receive-specified");
             Sys.EventStream.Subscribe(TestActor, typeof(UnhandledMessage));
+            var actor = Sys.ActorOf(Props.Create(() => new NoEventActor(pid)), "no-receive-specified");
             
             //Then
             ExpectMsg<UnhandledMessage>(m => ((string)m.Message) == "Something" && Equals(m.Recipient, actor));


### PR DESCRIPTION
## Changes

Subscriptions to the `EventStream` need to happen _before_ the actor emitting events starts, otherwise we can end up in a scenario where everything works but the assertion fails.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
