### PR TITLE
Fixed: Akka.Cluster.Singleton no longer moves when node with matching role and higher `AppVersion` joins cluster

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonConfigSpec.cs
@@ -42,7 +42,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             var config = Sys.Settings.Config.GetConfig("akka.cluster.singleton");
             Assert.False(config.IsNullOrEmpty());
             config.GetInt("min-number-of-hand-over-retries", 0).ShouldBe(15);
-            clusterSingletonManagerSettings.ConsiderAppVersion.ShouldBeFalse();
+            clusterSingletonManagerSettings.ConsiderAppVersion.ShouldBeTrue();
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             clusterSingletonProxySettings.Role.ShouldBe(null);
             clusterSingletonProxySettings.SingletonIdentificationInterval.TotalSeconds.ShouldBe(1);
             clusterSingletonProxySettings.BufferSize.ShouldBe(1000);
-            clusterSingletonProxySettings.ConsiderAppVersion.ShouldBeFalse();
+            clusterSingletonProxySettings.ConsiderAppVersion.ShouldBeTrue();
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonConfigSpec.cs
@@ -42,6 +42,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             var config = Sys.Settings.Config.GetConfig("akka.cluster.singleton");
             Assert.False(config.IsNullOrEmpty());
             config.GetInt("min-number-of-hand-over-retries", 0).ShouldBe(15);
+            clusterSingletonManagerSettings.ConsiderAppVersion.ShouldBeFalse();
         }
 
         [Fact]
@@ -54,6 +55,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             clusterSingletonProxySettings.Role.ShouldBe(null);
             clusterSingletonProxySettings.SingletonIdentificationInterval.TotalSeconds.ShouldBe(1);
             clusterSingletonProxySettings.BufferSize.ShouldBe(1000);
+            clusterSingletonProxySettings.ConsiderAppVersion.ShouldBeFalse();
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
@@ -29,7 +29,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
               akka.loglevel = INFO
               akka.actor.provider = ""cluster""
               akka.cluster.roles = [singleton]
-              akka.cluster.auto-down-unreachable-after = 2s
+              #akka.cluster.auto-down-unreachable-after = 2s
               akka.cluster.singleton.min-number-of-hand-over-retries = 5
               akka.remote {
                 dot-netty.tcp {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
@@ -29,7 +29,6 @@ namespace Akka.Cluster.Tools.Tests.Singleton
               akka.loglevel = INFO
               akka.actor.provider = ""cluster""
               akka.cluster.roles = [singleton]
-              #akka.cluster.auto-down-unreachable-after = 2s
               akka.cluster.singleton.min-number-of-hand-over-retries = 5
               akka.remote {
                 dot-netty.tcp {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
@@ -29,7 +29,6 @@ namespace Akka.Cluster.Tools.Tests.Singleton
               akka.loglevel = DEBUG
               akka.actor.provider = ""cluster""
               akka.cluster.app-version = ""1.0.0""
-              #akka.cluster.auto-down-unreachable-after = 2s
               akka.cluster.singleton.min-number-of-hand-over-retries = 5
               akka.cluster.singleton.consider-app-version = true
               akka.remote {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
@@ -29,7 +29,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
               akka.loglevel = DEBUG
               akka.actor.provider = ""cluster""
               akka.cluster.app-version = ""1.0.0""
-              akka.cluster.auto-down-unreachable-after = 2s
+              #akka.cluster.auto-down-unreachable-after = 2s
               akka.cluster.singleton.min-number-of-hand-over-retries = 5
               akka.cluster.singleton.consider-app-version = true
               akka.remote {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
@@ -28,7 +28,6 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         public ClusterSingletonRestartSpec() : base(@"
               akka.loglevel = INFO
               akka.actor.provider = ""cluster""
-              #akka.cluster.auto-down-unreachable-after = 2s
               akka.remote {
                 dot-netty.tcp {
                   hostname = ""127.0.0.1""

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
@@ -28,7 +28,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         public ClusterSingletonRestartSpec() : base(@"
               akka.loglevel = INFO
               akka.actor.provider = ""cluster""
-              akka.cluster.auto-down-unreachable-after = 2s
+              #akka.cluster.auto-down-unreachable-after = 2s
               akka.remote {
                 dot-netty.tcp {
                   hostname = ""127.0.0.1""

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/MemberAgeOrderingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/MemberAgeOrderingSpec.cs
@@ -21,7 +21,24 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         [Fact(DisplayName = "MemberAgeOrdering should sort based on UpNumber")]
         public void SortByUpNumberTest()
         {
-            var members = new SortedSet<Member>(MemberAgeOrdering.DescendingWithAppVersion)
+            var members = new SortedSet<Member>(MemberAgeOrdering.OldestToYoungest)
+            {
+                Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 3),
+                Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1),
+                Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 9),
+            };
+
+            var seq = members.ToList();
+            seq.Count.Should().Be(3);
+            seq[0].Should().Be(Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1));
+            seq[1].Should().Be(Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 3));
+            seq[2].Should().Be(Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 9));
+        }
+        
+        [Fact(DisplayName = "MemberAgeOrdering should sort based on UpNumber and AppVersion")]
+        public void SortByUpNumberAndAppVersionTest()
+        {
+            var members = new SortedSet<Member>(MemberAgeOrdering.OldestToYoungestWithAppVersion)
             {
                 Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 3),
                 Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1),
@@ -38,7 +55,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         [Fact(DisplayName = "MemberAgeOrdering should sort based on Address if UpNumber is the same")]
         public void SortByAddressTest()
         {
-            var members = new SortedSet<Member>(MemberAgeOrdering.DescendingWithAppVersion)
+            var members = new SortedSet<Member>(MemberAgeOrdering.OldestToYoungestWithAppVersion)
             {
                 Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 1),
                 Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1),
@@ -55,7 +72,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         [Fact(DisplayName = "MemberAgeOrdering should prefer AppVersion over UpNumber")]
         public void SortByAppVersionTest()
         {
-            var members = new SortedSet<Member>(MemberAgeOrdering.DescendingWithAppVersion)
+            var members = new SortedSet<Member>(MemberAgeOrdering.OldestToYoungestWithAppVersion)
             {
                 Create(Address.Parse("akka://sys@darkstar:1112"), upNumber: 3, appVersion: AppVersion.Create("1.0.0")),
                 Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 1, appVersion: AppVersion.Create("1.0.0")),

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/OldChangedBufferSpecs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/OldChangedBufferSpecs.cs
@@ -1,0 +1,57 @@
+// -----------------------------------------------------------------------
+//  <copyright file="OldChangedBufferSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+#nullable enable
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Cluster.Tools.Tests.Singleton;
+
+/// <summary>
+/// Reproduction for https://github.com/akkadotnet/akka.net/issues/7196 - clearly, what we did
+/// </summary>
+public class OldChangedBufferSpecs : AkkaSpec
+{
+    public IActorRef CreateOldestChangedBuffer(string role, bool considerAppVersion)
+    {
+        return Sys.ActorOf(Props.Create(() => new OldestChangedBuffer(role, considerAppVersion)));
+    }
+    
+    private readonly ActorSystem _otherNodeV1;
+    private readonly ActorSystem _nonHostingNode;
+    private ActorSystem? _otherNodeV2;
+    
+    public OldChangedBufferSpecs(ITestOutputHelper output) : base("""
+                                          
+                                                        akka.loglevel = INFO
+                                                        akka.actor.provider = "cluster"
+                                                        akka.cluster.roles = [singleton]
+                                                        akka.cluster.auto-down-unreachable-after = 2s
+                                                        akka.cluster.singleton.min-number-of-hand-over-retries = 5
+                                                        akka.remote {
+                                                          dot-netty.tcp {
+                                                            hostname = "127.0.0.1"
+                                                            port = 0
+                                                          }
+                                                        }
+                                          """, output)
+    {
+        _otherNodeV1 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+        _nonHostingNode = ActorSystem.Create(Sys.Name, ConfigurationFactory.ParseString("akka.cluster.roles = [other]")
+            .WithFallback(Sys.Settings.Config));
+    }
+
+    [Fact(DisplayName = "Singletons should not move to higher AppVersion nodes until after older incarnation is downed")]
+    public async Task Bugfix7196Spec()
+    {
+        
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/OldChangedBufferSpecs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/OldChangedBufferSpecs.cs
@@ -5,53 +5,131 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 #nullable enable
-using System.Threading.Tasks;
+using System.Collections.Immutable;
+using System.Linq;
 using Akka.Actor;
 using Akka.Cluster.Tools.Singleton;
-using Akka.Configuration;
-using Akka.TestKit;
+using Akka.Util;
+using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.Singleton;
 
 /// <summary>
 /// Reproduction for https://github.com/akkadotnet/akka.net/issues/7196 - clearly, what we did
 /// </summary>
-public class OldChangedBufferSpecs : AkkaSpec
+// public class OldChangedBufferSpecs : AkkaSpec
+// {
+//     public IActorRef CreateOldestChangedBuffer(string role, bool considerAppVersion)
+//     {
+//         return Sys.ActorOf(Props.Create(() => new OldestChangedBuffer(role, considerAppVersion)));
+//     }
+//     
+//     private readonly ActorSystem _otherNodeV1;
+//     private readonly ActorSystem _nonHostingNode;
+//     private ActorSystem? _otherNodeV2;
+//     
+//     public OldChangedBufferSpecs(ITestOutputHelper output) : base("""
+//                                           
+//                                                         akka.loglevel = INFO
+//                                                         akka.actor.provider = "cluster"
+//                                                         akka.cluster.roles = [singleton]
+//                                                         akka.cluster.auto-down-unreachable-after = 2s
+//                                                         akka.cluster.singleton.min-number-of-hand-over-retries = 5
+//                                                         akka.remote {
+//                                                           dot-netty.tcp {
+//                                                             hostname = "127.0.0.1"
+//                                                             port = 0
+//                                                           }
+//                                                         }
+//                                           """, output)
+//     {
+//         _otherNodeV1 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+//         _nonHostingNode = ActorSystem.Create(Sys.Name, ConfigurationFactory.ParseString("akka.cluster.roles = [other]")
+//             .WithFallback(Sys.Settings.Config));
+//     }
+//
+//     [Fact(DisplayName = "Singletons should not move to higher AppVersion nodes until after older incarnation is downed")]
+//     public async Task Bugfix7196Spec()
+//     {
+//         
+//     }
+// }
+
+public class OldestChangedBufferStateSpecs
 {
-    public IActorRef CreateOldestChangedBuffer(string role, bool considerAppVersion)
+    [Fact]
+    public void OldestChangedBuffer_should_initially_only_consider_nodes_with_matching_role()
     {
-        return Sys.ActorOf(Props.Create(() => new OldestChangedBuffer(role, considerAppVersion)));
-    }
-    
-    private readonly ActorSystem _otherNodeV1;
-    private readonly ActorSystem _nonHostingNode;
-    private ActorSystem? _otherNodeV2;
-    
-    public OldChangedBufferSpecs(ITestOutputHelper output) : base("""
-                                          
-                                                        akka.loglevel = INFO
-                                                        akka.actor.provider = "cluster"
-                                                        akka.cluster.roles = [singleton]
-                                                        akka.cluster.auto-down-unreachable-after = 2s
-                                                        akka.cluster.singleton.min-number-of-hand-over-retries = 5
-                                                        akka.remote {
-                                                          dot-netty.tcp {
-                                                            hostname = "127.0.0.1"
-                                                            port = 0
-                                                          }
-                                                        }
-                                          """, output)
-    {
-        _otherNodeV1 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
-        _nonHostingNode = ActorSystem.Create(Sys.Name, ConfigurationFactory.ParseString("akka.cluster.roles = [other]")
-            .WithFallback(Sys.Settings.Config));
+        // Arrange
+        var targetRole = "target-role";
+        var targetRoles = ImmutableHashSet.Create("role1", "role2", targetRole);
+        var winningAddress = Address.Parse("akka://sys@darkstar:1112");
+        var nonTargetRoles = ImmutableHashSet.Create("role1", "role2");
+        var initialMembersByAge = ImmutableSortedSet<Member>.Empty
+            .Add(Create(winningAddress, roles:targetRoles, upNumber: 3))
+            .Add(Create(Address.Parse("akka://sys@darkstar:1113"), roles:nonTargetRoles, upNumber: 1))
+            .Add(Create(Address.Parse("akka://sys@darkstar:1111"), roles:targetRoles, upNumber: 9))
+            .WithComparer(MemberAgeOrdering.DescendingWithAppVersion);
+        
+        // Act
+         var state = new OldestChangedBufferState(initialMembersByAge, targetRole);
+         
+         // Assert
+         var oldest = state.CurrentOldest;
+         oldest.Should().NotBeNull();
+         oldest!.Address.Should().Be(winningAddress);
     }
 
-    [Fact(DisplayName = "Singletons should not move to higher AppVersion nodes until after older incarnation is downed")]
-    public async Task Bugfix7196Spec()
+    [Fact]
+    public void OldestChangedBuffer_should_not_change_leader_when_higher_AppVersion_added()
     {
+        // Arrange
+        var winningAddress = Address.Parse("akka://sys@darkstar:1112");
+        var appVersion1 = AppVersion.Create("1.0.0");
+        var appVersion2 = AppVersion.Create("1.0.2");
+        var initialMembersByAge = ImmutableSortedSet<Member>.Empty
+            .Add(Create(winningAddress, upNumber: 3, appVersion: appVersion1))
+            .Add(Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 9, appVersion: appVersion1))
+            .WithComparer(MemberAgeOrdering.DescendingWithAppVersion);
         
+        // Act
+        var state = new OldestChangedBufferState(initialMembersByAge, string.Empty);
+        var oldest = state.CurrentOldest;
+        
+        // higher upNumber - should not affect leader
+        var newMemberSameVersion  = Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 10, appVersion: appVersion1);
+        
+        // higher upNumber AND version - should not affect leader
+        var newMemberNewVersion = Create(Address.Parse("akka://sys@darkstar:1114"), upNumber: 11, appVersion: appVersion2);
+        
+        // Act
+        var (state1, oldestChanged1) = state.AddMember(newMemberSameVersion);
+        var (state2, oldestChanged2) = state1.AddMember(newMemberNewVersion);
+        
+        // Assert
+        oldest.Should().NotBeNull();
+        oldest!.Address.Should().Be(winningAddress);
+        
+        state1.CurrentOldest.Should().Be(oldest);
+        oldestChanged1.Should().BeFalse();
+        
+        state2.CurrentOldest.Should().Be(oldest);
+        oldestChanged2.Should().BeFalse();
+
+        // the members by age system is going to chose the appVersion over the upNumber
+        state2.MembersByAge.FirstOrDefault().Should().NotBe(oldest);
+        state2.MembersByAge.FirstOrDefault()!.AppVersion.Should().Be(appVersion2);
+    }
+    
+    public static Member Create(
+        Address address,
+        MemberStatus status = MemberStatus.Up,
+        ImmutableHashSet<string>? roles = null,
+        int uid = 0,
+        int upNumber = 0,
+        AppVersion? appVersion = null)
+    {
+        return Member.Create(new UniqueAddress(address, uid), upNumber, status, roles ?? ImmutableHashSet<string>.Empty, appVersion ?? AppVersion.Zero);
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/OldestChangedBufferStateSpecs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/OldestChangedBufferStateSpecs.cs
@@ -1,0 +1,180 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="OldestChangedBufferStateSpecs.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Actor;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Cluster.Tools.Tests.Singleton;
+
+public class OldestChangedBufferStateSpecs
+{
+    [Fact]
+    public void OldestChangedBuffer_should_initially_only_consider_nodes_with_matching_role()
+    {
+        // Arrange
+        var targetRole = "target-role";
+        var targetRoles = ImmutableHashSet.Create("role1", "role2", targetRole);
+        var winningAddress = Address.Parse("akka://sys@darkstar:1112");
+        var nonTargetRoles = ImmutableHashSet.Create("role1", "role2");
+        var initialMembersByAge = ImmutableSortedSet<Member>.Empty
+            .Add(Create(winningAddress, roles:targetRoles, upNumber: 3))
+            .Add(Create(Address.Parse("akka://sys@darkstar:1113"), roles:nonTargetRoles, upNumber: 1))
+            .Add(Create(Address.Parse("akka://sys@darkstar:1111"), roles:targetRoles, upNumber: 9))
+            .WithComparer(MemberAgeOrdering.DescendingWithAppVersion);
+        
+        // Act
+        var state = new OldestChangedBufferState(initialMembersByAge, targetRole);
+         
+        // Assert
+        var oldest = state.CurrentOldest;
+        oldest.Should().NotBeNull();
+        oldest!.Address.Should().Be(winningAddress);
+    }
+
+    [Fact]
+    public void OldestChangedBuffer_should_not_change_leader_when_higher_AppVersion_added()
+    {
+        // Arrange
+        var winningAddress = Address.Parse("akka://sys@darkstar:1112");
+        var appVersion1 = AppVersion.Create("1.0.0");
+        var appVersion2 = AppVersion.Create("1.0.2");
+        var initialMembersByAge = ImmutableSortedSet<Member>.Empty
+            .Add(Create(winningAddress, upNumber: 3, appVersion: appVersion1))
+            .Add(Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 9, appVersion: appVersion1))
+            .WithComparer(MemberAgeOrdering.DescendingWithAppVersion);
+        
+        // Act
+        var state = new OldestChangedBufferState(initialMembersByAge, string.Empty);
+        var oldest = state.CurrentOldest;
+        
+        // higher upNumber - should not affect leader
+        var newMemberSameVersion  = Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 10, appVersion: appVersion1);
+        
+        // higher upNumber AND version - should not affect leader
+        var newMemberNewVersion = Create(Address.Parse("akka://sys@darkstar:1114"), upNumber: 11, appVersion: appVersion2);
+        
+        // Act
+        var (state1, oldestChanged1) = state.AddMember(newMemberSameVersion);
+        var (state2, oldestChanged2) = state1.AddMember(newMemberNewVersion);
+        
+        // Assert
+        oldest.Should().NotBeNull();
+        oldest!.Address.Should().Be(winningAddress);
+        
+        state1.CurrentOldest.Should().Be(oldest);
+        oldestChanged1.Should().BeFalse();
+        
+        state2.CurrentOldest.Should().Be(oldest);
+        oldestChanged2.Should().BeFalse();
+
+        // the members by age system is going to chose the appVersion over the upNumber
+        state2.MembersByAge.FirstOrDefault().Should().NotBe(oldest);
+        state2.MembersByAge.FirstOrDefault()!.AppVersion.Should().Be(appVersion2);
+    }
+    
+    [Fact]
+    public void OldestChangedBuffer_should_change_Oldest_when_previous_Oldest_removed()
+    {
+        // Arrange
+        var winningAddress = Address.Parse("akka://sys@darkstar:1112");
+        var appVersion1 = AppVersion.Create("1.0.0");
+        var appVersion2 = AppVersion.Create("1.0.2");
+
+        var originalOldest = Create(winningAddress, upNumber: 3, appVersion: appVersion1);
+        
+        var initialMembersByAge = ImmutableSortedSet<Member>.Empty
+            .Add(originalOldest)
+            .Add(Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 9, appVersion: appVersion1))
+            .WithComparer(MemberAgeOrdering.DescendingWithAppVersion);
+        
+        // Act
+        var state = new OldestChangedBufferState(initialMembersByAge, string.Empty);
+        var oldest = state.CurrentOldest;
+        
+        // higher upNumber, same version - won't affect leader 
+        var newMemberSameVersion  = Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 4, appVersion: appVersion1);
+        
+        // lower upNumber AND version - won't affect the leader until it gets removed
+        var newMemberHigherVersion = Create(Address.Parse("akka://sys@darkstar:1114"), upNumber: 11, appVersion: appVersion2);
+        
+        // Act
+        var (state1, oldestChanged1) = state.AddMember(newMemberSameVersion);
+        var (state2, oldestChanged2) = state1.AddMember(newMemberHigherVersion);
+        var (state3, oldestChanged3) = state2.RemoveMember(originalOldest);
+        
+        // Assert
+        oldest.Should().NotBeNull();
+        oldest!.Address.Should().Be(winningAddress);
+        
+        state1.CurrentOldest.Should().Be(originalOldest);
+        oldestChanged1.Should().BeFalse();
+        
+        state2.CurrentOldest.Should().Be(originalOldest);
+        oldestChanged2.Should().BeFalse();
+        
+        state3.CurrentOldest.Should().Be(newMemberHigherVersion);
+        oldestChanged3.Should().BeTrue();
+    }
+    
+    [Fact]
+    public void OldestChangedBuffer_should_not_change_Oldest_when_nonOldest_node_removed()
+    {
+        // Arrange
+        var winningAddress = Address.Parse("akka://sys@darkstar:1112");
+        var appVersion1 = AppVersion.Create("1.0.0");
+        var appVersion2 = AppVersion.Create("1.0.2");
+        var initialMembersByAge = ImmutableSortedSet<Member>.Empty
+            .Add(Create(winningAddress, upNumber: 3, appVersion: appVersion1))
+            .Add(Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 9, appVersion: appVersion1))
+            .WithComparer(MemberAgeOrdering.DescendingWithAppVersion);
+        
+        // Act
+        var state = new OldestChangedBufferState(initialMembersByAge, string.Empty);
+        var oldest = state.CurrentOldest;
+        
+        // higher upNumber - should not affect leader
+        var newMemberSameVersion  = Create(Address.Parse("akka://sys@darkstar:1113"), upNumber: 10, appVersion: appVersion1);
+        
+        // higher upNumber AND version - should not affect leader
+        var newMemberNewVersion = Create(Address.Parse("akka://sys@darkstar:1114"), upNumber: 11, appVersion: appVersion2);
+        
+        // Act
+        var (state1, oldestChanged1) = state.AddMember(newMemberSameVersion);
+        var (state2, oldestChanged2) = state1.AddMember(newMemberNewVersion);
+        var (state3, oldestChanged3) = state2.RemoveMember(newMemberSameVersion);
+        
+        // Assert
+        oldest.Should().NotBeNull();
+        oldest!.Address.Should().Be(winningAddress);
+        
+        state1.CurrentOldest.Should().Be(oldest);
+        oldestChanged1.Should().BeFalse();
+        
+        state2.CurrentOldest.Should().Be(oldest);
+        oldestChanged2.Should().BeFalse();
+
+        state3.CurrentOldest.Should().Be(oldest);
+        oldestChanged3.Should().BeFalse();
+    }
+    
+    public static Member Create(
+        Address address,
+        MemberStatus status = MemberStatus.Up,
+        ImmutableHashSet<string>? roles = null,
+        int uid = 0,
+        int upNumber = 0,
+        AppVersion? appVersion = null)
+    {
+        return Member.Create(new UniqueAddress(address, uid), upNumber, status, roles ?? ImmutableHashSet<string>.Empty, appVersion ?? AppVersion.Zero);
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/OldestChangedBufferStateSpecs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/OldestChangedBufferStateSpecs.cs
@@ -30,7 +30,7 @@ public class OldestChangedBufferStateSpecs
             .Add(Create(winningAddress, roles:targetRoles, upNumber: 3))
             .Add(Create(Address.Parse("akka://sys@darkstar:1113"), roles:nonTargetRoles, upNumber: 1))
             .Add(Create(Address.Parse("akka://sys@darkstar:1111"), roles:targetRoles, upNumber: 9))
-            .WithComparer(MemberAgeOrdering.DescendingWithAppVersion);
+            .WithComparer(MemberAgeOrdering.OldestToYoungestWithAppVersion);
         
         // Act
         var state = new OldestChangedBufferState(initialMembersByAge, targetRole);
@@ -51,7 +51,7 @@ public class OldestChangedBufferStateSpecs
         var initialMembersByAge = ImmutableSortedSet<Member>.Empty
             .Add(Create(winningAddress, upNumber: 3, appVersion: appVersion1))
             .Add(Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 9, appVersion: appVersion1))
-            .WithComparer(MemberAgeOrdering.DescendingWithAppVersion);
+            .WithComparer(MemberAgeOrdering.OldestToYoungestWithAppVersion);
         
         // Act
         var state = new OldestChangedBufferState(initialMembersByAge, string.Empty);
@@ -95,7 +95,7 @@ public class OldestChangedBufferStateSpecs
         var initialMembersByAge = ImmutableSortedSet<Member>.Empty
             .Add(originalOldest)
             .Add(Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 9, appVersion: appVersion1))
-            .WithComparer(MemberAgeOrdering.DescendingWithAppVersion);
+            .WithComparer(MemberAgeOrdering.OldestToYoungestWithAppVersion);
         
         // Act
         var state = new OldestChangedBufferState(initialMembersByAge, string.Empty);
@@ -136,7 +136,7 @@ public class OldestChangedBufferStateSpecs
         var initialMembersByAge = ImmutableSortedSet<Member>.Empty
             .Add(Create(winningAddress, upNumber: 3, appVersion: appVersion1))
             .Add(Create(Address.Parse("akka://sys@darkstar:1111"), upNumber: 9, appVersion: appVersion1))
-            .WithComparer(MemberAgeOrdering.DescendingWithAppVersion);
+            .WithComparer(MemberAgeOrdering.OldestToYoungestWithAppVersion);
         
         // Act
         var state = new OldestChangedBufferState(initialMembersByAge, string.Empty);

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxy.cs
@@ -97,8 +97,8 @@ namespace Akka.Cluster.Tools.Singleton
             _identityId = CreateIdentifyId(_identityCounter);
 
             _memberAgeComparer = settings.ConsiderAppVersion
-                ? MemberAgeOrdering.DescendingWithAppVersion
-                : MemberAgeOrdering.Descending;
+                ? MemberAgeOrdering.OldestToYoungestWithAppVersion
+                : MemberAgeOrdering.OldestToYoungest;
             _state = new OldestChangedBufferState(ImmutableSortedSet<Member>.Empty.WithComparer(_memberAgeComparer),
                 settings.Role);
 

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/MemberAgeOrdering.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/MemberAgeOrdering.cs
@@ -24,8 +24,19 @@ namespace Akka.Cluster.Tools.Singleton
         }
 
         /// <inheritdoc/>
-        public int Compare(Member x, Member y)
+        public int Compare(Member? x, Member? y)
         {
+            switch (x)
+            {
+                // add null checks here
+                case null when y is null:
+                    return 0;
+                case null:
+                    return _ascending ? -1 : 1;
+            }
+
+            if (y is null) return _ascending ? 1 : -1;
+            
             if (_considerAppVersion)
             {
                 // prefer nodes with the highest app version, even if they're younger
@@ -40,12 +51,8 @@ namespace Akka.Cluster.Tools.Singleton
                 : (_ascending ? -1 : 1);
         }
         
-        public static readonly MemberAgeOrdering Ascending = new(true, false);
-
-        public static readonly MemberAgeOrdering AscendingWithAppVersion = new(true, true);
+        public static readonly MemberAgeOrdering OldestToYoungest = new(false, false);
         
-        public static readonly MemberAgeOrdering Descending = new(false, false);
-        
-        public static readonly MemberAgeOrdering DescendingWithAppVersion = new(false, true);
+        public static readonly MemberAgeOrdering OldestToYoungestWithAppVersion = new(false, true);
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/MemberAgeOrdering.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/MemberAgeOrdering.cs
@@ -4,13 +4,13 @@
 //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
+#nullable enable
 using System.Collections.Generic;
 
 namespace Akka.Cluster.Tools.Singleton
 {
     /// <summary>
-    /// TBD
+    /// Responsible for sorting members based on their age, with the option to consider the app version.
     /// </summary>
     internal sealed class MemberAgeOrdering : IComparer<Member>
     {
@@ -39,17 +39,11 @@ namespace Akka.Cluster.Tools.Singleton
                 ? (_ascending ? 1 : -1)
                 : (_ascending ? -1 : 1);
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
+        
         public static readonly MemberAgeOrdering Ascending = new(true, false);
 
         public static readonly MemberAgeOrdering AscendingWithAppVersion = new(true, true);
-
-        /// <summary>
-        /// TBD
-        /// </summary>
+        
         public static readonly MemberAgeOrdering Descending = new(false, false);
         
         public static readonly MemberAgeOrdering DescendingWithAppVersion = new(false, true);

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
@@ -93,8 +93,8 @@ namespace Akka.Cluster.Tools.Singleton
         public OldestChangedBuffer(string role, bool considerAppVersion)
         {
             _memberAgeComparer = considerAppVersion
-                ? MemberAgeOrdering.DescendingWithAppVersion
-                : MemberAgeOrdering.Descending;
+                ? MemberAgeOrdering.OldestToYoungestWithAppVersion
+                : MemberAgeOrdering.OldestToYoungest;
             var membersByAge = ImmutableSortedSet<Member>.Empty.WithComparer(_memberAgeComparer);
             
             State = new OldestChangedBufferState(membersByAge, role);

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBufferState.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBufferState.cs
@@ -1,0 +1,74 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="OldestChangedBufferState.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+#nullable enable
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Akka.Cluster.Tools.Singleton;
+
+/// <summary>
+/// Immutable data object that represents the state of the oldest changed buffer.
+/// </summary>
+internal sealed record OldestChangedBufferState
+{
+    public OldestChangedBufferState(ImmutableSortedSet<Member> initialMembersByAge, string? role)
+    {
+        MembersByAge = initialMembersByAge;
+        Role = role;
+        CurrentOldest = MembersByAge.FirstOrDefault(this.MatchingRole);
+    }
+
+    public string? Role { get; init; }
+
+    public Member? CurrentOldest { get; init; }
+
+    public ImmutableSortedSet<Member> MembersByAge { get; init; }
+}
+
+internal static class OldestChangedBufferStateExtensions
+{
+    internal static bool MatchingRole(this OldestChangedBufferState state, Member member)
+    {
+        return string.IsNullOrEmpty(state.Role) || member.HasRole(state.Role);
+    }
+
+    public static (OldestChangedBufferState newState, bool oldestChanged) AddMember(this OldestChangedBufferState state, Member member)
+    {
+        if (MatchingRole(state, member))
+        {
+            // remove then add node to replace it, as it's possible that the upNumber is changed
+            return ComputeNextOldest(state with { MembersByAge = state.MembersByAge.Remove(member).Add(member) });
+        }
+
+        return (state, false);
+    }
+
+    public static (OldestChangedBufferState newState, bool oldestChanged) RemoveMember(this OldestChangedBufferState state, Member member)
+    {
+        if (MatchingRole(state, member))
+        {
+            return ComputeNextOldest(state with { MembersByAge = state.MembersByAge.Remove(member) });
+        }
+
+        return (state, false);
+    }
+
+    public static (OldestChangedBufferState newState, bool oldestChanged) ComputeNextOldest(this OldestChangedBufferState state)
+    {
+        // if the current oldest has not been removed, then it remains the oldest
+        if(state.CurrentOldest is not null && state.MembersByAge.Contains(state.CurrentOldest))
+        {
+            return (state, false);
+        }
+        
+        // compute the next oldest
+        var nextOldest = state.MembersByAge.FirstOrDefault();
+        var oldestChanged = !Equals(nextOldest, state.CurrentOldest);
+        return (state with { CurrentOldest = nextOldest }, oldestChanged);
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/reference.conf
@@ -46,7 +46,7 @@ akka.cluster.singleton {
   # Should akka.cluster.app-version be considered when the cluster singleton instance is being moved to another node
   # When set to false, singleton instance will always be created on oldest member
   # When set to true, singleton instance will be created on the oldest node with the highest member app-version number
-  consider-app-version = false
+  consider-app-version = true
 }
 # //#singleton-config
 

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -397,6 +397,7 @@ namespace Akka.Cluster.Tools.Singleton
         public ClusterSingletonProvider() { }
         public override Akka.Cluster.Tools.Singleton.ClusterSingleton CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ClusterSingletonProxy : Akka.Actor.ReceiveActor
     {
         public ClusterSingletonProxy(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -397,6 +397,7 @@ namespace Akka.Cluster.Tools.Singleton
         public ClusterSingletonProvider() { }
         public override Akka.Cluster.Tools.Singleton.ClusterSingleton CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ClusterSingletonProxy : Akka.Actor.ReceiveActor
     {
         public ClusterSingletonProxy(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }


### PR DESCRIPTION
## Changes

Fixes #7196 - not done yet.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7196
* [x] Changes in public API reviewed, if any.