### PR TITLE
ensure we use correct serializer in `DistributedPubSubSerializerSpecs`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMessageSerializerSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMessageSerializerSpec.cs
@@ -10,9 +10,11 @@ using System.Collections.Immutable;
 using Akka.Actor;
 using Akka.Cluster.Tools.PublishSubscribe;
 using Akka.Cluster.Tools.PublishSubscribe.Internal;
+using Akka.Cluster.Tools.PublishSubscribe.Serialization;
 using Akka.Configuration;
 using Akka.Serialization;
 using Akka.TestKit;
+using FluentAssertions;
 using Xunit;
 
 namespace Akka.Cluster.Tools.Tests.PublishSubscribe
@@ -107,6 +109,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
         private T AssertAndReturn<T>(T message)
         {
             var serializer = (SerializerWithStringManifest)Sys.Serialization.FindSerializerFor(message);
+            serializer.Should().BeOfType<DistributedPubSubMessageSerializer>();
             var serialized = serializer.ToBinary(message);
             return (T)serializer.FromBinary(serialized, serializer.Manifest(message));
         }


### PR DESCRIPTION
## Changes

ensure we use correct serializer in `DistributedPubSubSerializerSpecs`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).