### PR TITLE
Akka.Actor.Serialization: remember to serialize envelope AND underlying type when using `serialize-messages=on`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorRouterSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorRouterSpec.cs
@@ -46,7 +46,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
         public bool Equals(UnwrappedMessage other)
         {
             if (ReferenceEquals(this, other)) return true;
-            return other is not null && Message == other.Message;
+            return other is not null && Message.Equals(other.Message);
         }
 
         public override bool Equals(object obj)
@@ -72,7 +72,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             path = TestActor.Path.ToStringWithoutAddress();
         }
 
-        protected void NonUnwrappingPubSub(object msg)
+        protected void NonUnwrappingPubSub<T>(T msg)
         {
             Keep_the_RouterEnvelope_when_sending_to_local_logical_path(msg);
             Keep_the_RouterEnvelope_when_sending_to_logical_path(msg);
@@ -82,7 +82,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             Send_message_to_dead_letters_if_no_recipients_available(msg);
         }
 
-        private void Keep_the_RouterEnvelope_when_sending_to_local_logical_path(object msg)
+        private void Keep_the_RouterEnvelope_when_sending_to_local_logical_path<T>(T msg)
         {
             mediator.Tell(new Put(TestActor));
             mediator.Tell(new Send(path, msg, localAffinity: true));
@@ -90,7 +90,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             mediator.Tell(new Remove(path));
         }
 
-        private void Keep_the_RouterEnvelope_when_sending_to_logical_path(object msg)
+        private void Keep_the_RouterEnvelope_when_sending_to_logical_path<T>(T msg)
         {
             mediator.Tell(new Put(TestActor));
             mediator.Tell(new Send(path, msg, localAffinity: false));
@@ -98,7 +98,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             mediator.Tell(new Remove(path));
         }
 
-        private void Keep_the_RouterEnvelope_when_sending_to_all_actors_on_logical_path(object msg)
+        private void Keep_the_RouterEnvelope_when_sending_to_all_actors_on_logical_path<T>(T msg)
         {
             mediator.Tell(new Put(TestActor));
             mediator.Tell(new SendToAll(path, msg));
@@ -106,7 +106,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             mediator.Tell(new Remove(path));
         }
 
-        private void Keep_the_RouterEnvelope_when_sending_to_topic(object msg)
+        private void Keep_the_RouterEnvelope_when_sending_to_topic<T>(T msg)
         {
             mediator.Tell(new Subscribe("topic", TestActor));
             ExpectMsg<SubscribeAck>();
@@ -118,7 +118,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             ExpectMsg<UnsubscribeAck>();
         }
 
-        private void Keep_the_RouterEnvelope_when_sending_to_topic_for_group(object msg)
+        private void Keep_the_RouterEnvelope_when_sending_to_topic_for_group<T>(T msg)
         {
             mediator.Tell(new Subscribe("topic", TestActor, "group"));
             ExpectMsg<SubscribeAck>();
@@ -130,7 +130,7 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             ExpectMsg<UnsubscribeAck>();
         }
 
-        private void Send_message_to_dead_letters_if_no_recipients_available(object msg)
+        private void Send_message_to_dead_letters_if_no_recipients_available<T>(T msg)
         {
             var probe = CreateTestProbe();
             Sys.EventStream.Subscribe(probe.Ref, typeof(DeadLetter));

--- a/src/core/Akka.Tests/Actor/ActorCellSerializeMessagesTests.cs
+++ b/src/core/Akka.Tests/Actor/ActorCellSerializeMessagesTests.cs
@@ -1,0 +1,58 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ActorCellSerializeMessagesTests.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+
+namespace Akka.Tests.Actor;
+
+public class ActorCellSerializeMessagesTests: AkkaSpec
+{
+    private class InnerMessage
+    {
+        public InnerMessage(string payload)
+        {
+            Payload = payload;
+        }
+
+        public string Payload { get; }
+    }
+    
+    private class MessageWrapper: IWrappedMessage
+    {
+        public MessageWrapper(object message)
+        {
+            Message = message;
+        }
+
+        public object Message { get; }
+    }
+    
+    private class EchoActor: ReceiveActor
+    {
+        public EchoActor()
+        {
+            ReceiveAny(msg => Sender.Tell(msg));
+        }
+    }
+    
+    public ActorCellSerializeMessagesTests(ITestOutputHelper output) : base("akka.actor.serialize-messages=on", output)
+    {
+    }
+
+    [Fact(DisplayName = "Wrapped message should be received by actors intact")]
+    public void WrappedMessageTest()
+    {
+        var actor = Sys.ActorOf(Props.Create(() => new EchoActor()));
+        actor.Tell(new MessageWrapper(new InnerMessage("payload")));
+        var receivedMsg = ExpectMsg<MessageWrapper>();
+        receivedMsg.Message.Should().BeOfType<InnerMessage>().Which.Payload.Should().Be("payload");
+    }
+}

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -519,6 +519,10 @@ namespace Akka.Actor
         #nullable enable
         private Envelope SerializeAndDeserialize(Envelope envelope)
         {
+            // in case someone has an IWrappedMessage that ALSO implements INoSerializationVerificationNeeded
+            if(envelope.Message is INoSerializationVerificationNeeded)
+                return envelope;
+            
             // recursively unwraps message, no need to check for DeadLetter because DeadLetter inherits IWrappedMessage
             var unwrapped = WrappedMessage.Unwrap(envelope.Message);
             

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -529,7 +529,7 @@ namespace Akka.Actor
             object deserializedMsg;
             try
             {
-                deserializedMsg = SerializeAndDeserializePayload(unwrapped);
+                deserializedMsg = SerializeAndDeserializePayload(envelope.Message);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Changes

Bug: need to serialize both the envelope and the underlying type when `serialize-messages=on`

We found an issue stemming from a change I made in by https://github.com/akkadotnet/akka.net/pull/7010 where the underlying `IWrappedMessage` envelope would get discarded when  `serialize-messages=on`. The solution to this problem is to force serialization of the envelope AND the underlying type and return the product of both of those. Right now we are discarding the envelope by accident, which causes the `DistributedPubSubMediator` to be unable to process any messages when `serialize-messages=on`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).