### PR TITLE
Fix missing `sendOneMessageToEachGroup` property in `Publish`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
@@ -642,7 +642,10 @@ namespace Akka.Cluster.Tools.PublishSubscribe
 
         private IActorRef NewTopicActor(string encodedTopic)
         {
-            var t = Context.ActorOf(Actor.Props.Create(() => new Topic(_settings.RemovedTimeToLive, _settings.RoutingLogic, _settings.SendToDeadLettersWhenNoSubscribers)), encodedTopic);
+            var t = Context.ActorOf(
+                Actor.Props.Create(() => new Topic(_settings.RemovedTimeToLive, _settings.RoutingLogic, _settings.SendToDeadLettersWhenNoSubscribers))
+                    .WithDeploy(Deploy.Local), 
+                encodedTopic);
             HandleRegisterTopic(t);
             return t;
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
@@ -274,7 +274,10 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
 
         private IActorRef NewGroupActor(string encodedGroup)
         {
-            var g = Context.ActorOf(Props.Create(() => new Group(EmptyTimeToLive, _routingLogic, SendToDeadLettersWhenNoSubscribers)), encodedGroup);
+            var g = Context.ActorOf(
+                Props.Create(() => new Group(EmptyTimeToLive, _routingLogic, SendToDeadLettersWhenNoSubscribers))
+                    .WithDeploy(Deploy.Local),
+                encodedGroup);
             Context.Watch(g);
             Context.Parent.Tell(new RegisterTopic(g));
             return g;

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
@@ -242,13 +242,14 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
             var protoMessage = new Proto.Msg.Publish();
             protoMessage.Topic = publish.Topic;
             protoMessage.Payload = _payloadSupport.PayloadToProto(publish.Message);
+            protoMessage.SendOneMessageToEachGroup = publish.SendOneMessageToEachGroup;
             return protoMessage.ToByteArray();
         }
 
         private Publish PublishFrom(byte[] bytes)
         {
             var publishProto = Proto.Msg.Publish.Parser.ParseFrom(bytes);
-            return new Publish(publishProto.Topic, _payloadSupport.PayloadFrom(publishProto.Payload));
+            return new Publish(publishProto.Topic, _payloadSupport.PayloadFrom(publishProto.Payload), publishProto.SendOneMessageToEachGroup);
         }
 
         private byte[] SendToOneSubscriberToProto(SendToOneSubscriber sendToOneSubscriber)

--- a/src/protobuf/DistributedPubSubMessages.proto
+++ b/src/protobuf/DistributedPubSubMessages.proto
@@ -47,6 +47,7 @@ message SendToAll {
 message Publish {
   string topic = 1;
   Akka.Remote.Serialization.Proto.Msg.Payload payload = 3; 
+  bool sendOneMessageToEachGroup = 4;
 }
 
 // Send a message to only one subscriber of a group.


### PR DESCRIPTION
Part of #7201

`SendOneMessageToEachGroup` was not serialized into protobuf

## Changes

* Change protobuf wire format to include the missing `SendOneMessageToEachGroup` property