### PR TITLE
[DOC] Add Akka.Analyzers AK1006 documentation

### DIFF
--- a/docs/articles/debugging/akka-analyzers.md
+++ b/docs/articles/debugging/akka-analyzers.md
@@ -11,16 +11,17 @@ Akka.Analyzer is a [Roslyn Analysis and Code Fix](https://learn.microsoft.com/en
 
 ## Supported Rules
 
-| Id                    | Title                                                                                                                    | Severity | Category     |
-|-----------------------|--------------------------------------------------------------------------------------------------------------------------|----------|--------------|
-| [AK1000](xref:AK1000) | Do not use `new` to create actors.                                                                                       | Error    | Actor Design |
-| [AK1002](xref:AK1002) | Must not await `Self.GracefulStop()` inside `ReceiveAsync<T>()` or `ReceiveAnyAsync`.                                    | Error    | Actor Design |
-| [AK1003](xref:AK1003) | `ReceiveAsync<T>()` or `ReceiveAnyAsync()` message handler without async lambda body.                                    | Warning  | Actor Design |
-| [AK1004](xref:AK1004) | `ScheduleTellOnce()` and `ScheduleTellRepeatedly()` can cause memory leak if not properly canceled                       | Warning  | Actor Design |
-| [AK1005](xref:AK1005) | Must close over `Sender` or `Self`                                                                                       | Warning  | Actor Design |
+| Id                    | Title                                                                                                                   | Severity | Category     |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------|----------|--------------|
+| [AK1000](xref:AK1000) | Do not use `new` to create actors.                                                                                      | Error    | Actor Design |
+| [AK1002](xref:AK1002) | Must not await `Self.GracefulStop()` inside `ReceiveAsync<T>()` or `ReceiveAnyAsync`.                                   | Error    | Actor Design |
+| [AK1003](xref:AK1003) | `ReceiveAsync<T>()` or `ReceiveAnyAsync()` message handler without async lambda body.                                   | Warning  | Actor Design |
+| [AK1004](xref:AK1004) | `ScheduleTellOnce()` and `ScheduleTellRepeatedly()` can cause memory leak if not properly canceled                      | Warning  | Actor Design |
+| [AK1005](xref:AK1005) | Must close over `Sender` or `Self`                                                                                      | Warning  | Actor Design |
+| [AK1006](xref:AK1006) | Should not call `Persist()` or `PersistAsync()` inside a loop                                                           | Warning  | Actor Design |
 | [AK1007](xref:AK1007) | `Timers.StartSingleTimer()` and `Timers.StartPeriodicTimer()` must not be used inside AroundPreRestart() or PreRestart() | Error    | Actor Design |
-| [AK2000](xref:AK2000) | Do not use `Ask` with `TimeSpan.Zero` for timeout.                                                                       | Error    | API Usage    |
-| [AK2001](xref:AK2001) | Do not use automatically handled messages in inside `Akka.Cluster.Sharding.IMessageExtractor`s.                          | Warning  | API Usage    |
+| [AK2000](xref:AK2000) | Do not use `Ask` with `TimeSpan.Zero` for timeout.                                                                      | Error    | API Usage    |
+| [AK2001](xref:AK2001) | Do not use automatically handled messages in inside `Akka.Cluster.Sharding.IMessageExtractor`s.                         | Warning  | API Usage    |
 
 ## Deprecated Rules
 

--- a/docs/articles/debugging/rules/AK1006.md
+++ b/docs/articles/debugging/rules/AK1006.md
@@ -1,0 +1,62 @@
+---
+uid: AK1006
+title: Akka.Analyzers Rule AK1006 - "Should not call `Persist()` or `PersistAsync()` inside a loop"
+---
+
+# AK1006 - Warning
+
+Calling `Persist()` or `PersistAsync()` inside a loop is an anti-pattern and is non-performant. Consider collecting all events in a collection and then call `PersistAll()` or `PersistAllAsync()` after the loop instead.
+
+## Cause
+
+Akka.NET persistence tries its best to batch consecutive calls to `Persist()` or `PersistAsync()` methods, but there is no guarantee that all of them will be batched properly. 
+
+For example, lets assume that for each command, you generate 10 `Persist()` operations. This can potentially create 10 asynchronous database connection to complete:
+
+```csharp
+using Akka.Persistence;
+
+public class MyActor: ReceivePersistentActor
+{
+    public override string PersistenceId { get; }
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        CommandAny(obj =>
+        {
+            for (var i=0; i<10; i++)
+            {
+                Persist(i, o => {});
+            }
+        });
+    }
+}
+```
+
+## Resolution
+
+If you know that a group of events need to be batched, it is a lot more performant to batch all `Persist()` operations into a single `PersistAll()` operation after the loop
+
+```csharp
+using Akka.Persistence;
+
+public class MyActor: ReceivePersistentActor
+{
+    public override string PersistenceId { get; }
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        CommandAny(obj =>
+        {
+            var events = new List<int>();
+            for (var i=0; i<10; i++)
+            {
+                events.Add(i);
+            }
+            PersistAll(events, o => {});
+        });
+    }
+}
+```
+
+The persist success callback will be called for each event that are successfully persisted, so you do not need to change your logic inside the callback.

--- a/docs/articles/debugging/rules/AK1006.md
+++ b/docs/articles/debugging/rules/AK1006.md
@@ -9,7 +9,7 @@ Calling `Persist()` or `PersistAsync()` inside a loop is an anti-pattern and is 
 
 ## Cause
 
-Akka.NET persistence tries its best to batch consecutive calls to `Persist()` or `PersistAsync()` methods, but there is no guarantee that all of them will be batched properly. 
+Akka.NET persistence tries its best to batch consecutive calls to `Persist()` or `PersistAsync()` methods, but there is no guarantee that all of them will be batched properly. \
 
 For example, lets assume that for each command, you generate 10 `Persist()` operations. This can potentially create 10 asynchronous database connection to complete:
 

--- a/docs/articles/debugging/rules/toc.yml
+++ b/docs/articles/debugging/rules/toc.yml
@@ -10,6 +10,8 @@
   href: AK1004.md
 - name: AK1005
   href: AK1005.md
+- name: AK1006
+  href: AK1006.md
 - name: AK1007
   href: AK1007.md
 - name: AK2000


### PR DESCRIPTION
---
uid: AK1006
title: Akka.Analyzers Rule AK1006 - "Should not call `Persist()` or `PersistAsync()` inside a loop"
---

# AK1006 - Warning

Calling `Persist()` or `PersistAsync()` inside a loop is an anti-pattern and is non-performant. Consider collecting all events in a collection and then call `PersistAll()` or `PersistAllAsync()` after the loop instead.

## Cause

Akka.NET persistence tries its best to batch consecutive calls to `Persist()` or `PersistAsync()` methods, but there is no guarantee that all of them will be batched properly. 

For example, lets assume that for each command, you generate 10 `Persist()` operations. This can potentially create 10 asynchronous database connection to complete:

```csharp
using Akka.Persistence;

public class MyActor: ReceivePersistentActor
{
    public override string PersistenceId { get; }
    public MyActor(string persistenceId)
    {
        PersistenceId = persistenceId;
        CommandAny(obj =>
        {
            for (var i=0; i<10; i++)
            {
                Persist(i, o => {});
            }
        });
    }
}
```

## Resolution

If you know that a group of events need to be batched, it is a lot more performant to batch all `Persist()` operations into a single `PersistAll()` operation after the loop

```csharp
using Akka.Persistence;

public class MyActor: ReceivePersistentActor
{
    public override string PersistenceId { get; }
    public MyActor(string persistenceId)
    {
        PersistenceId = persistenceId;
        CommandAny(obj =>
        {
            var events = new List<int>();
            for (var i=0; i<10; i++)
            {
                events.Add(i);
            }
            PersistAll(events, o => {});
        });
    }
}
```

The persist success callback will be called for each event that are successfully persisted, so you do not need to change your logic inside the callback.