### PR TITLE
Akka.Event: expose the `EventStream` on `BusLogging` for extensibility purposes

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3295,10 +3295,13 @@ namespace Akka.Event
     public sealed class BusLogging : Akka.Event.LoggingAdapterBase
     {
         public BusLogging(Akka.Event.LoggingBus bus, string logSource, System.Type logClass, Akka.Event.ILogMessageFormatter logMessageFormatter) { }
+        public Akka.Event.LoggingBus Bus { get; }
         public override bool IsDebugEnabled { get; }
         public override bool IsErrorEnabled { get; }
         public override bool IsInfoEnabled { get; }
         public override bool IsWarningEnabled { get; }
+        public System.Type LogClass { get; }
+        public string LogSource { get; }
         protected override void NotifyLog(Akka.Event.LogLevel logLevel, object message, System.Exception cause = null) { }
     }
     public sealed class DeadLetter : Akka.Event.AllDeadLetters

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3287,10 +3287,13 @@ namespace Akka.Event
     public sealed class BusLogging : Akka.Event.LoggingAdapterBase
     {
         public BusLogging(Akka.Event.LoggingBus bus, string logSource, System.Type logClass, Akka.Event.ILogMessageFormatter logMessageFormatter) { }
+        public Akka.Event.LoggingBus Bus { get; }
         public override bool IsDebugEnabled { get; }
         public override bool IsErrorEnabled { get; }
         public override bool IsInfoEnabled { get; }
         public override bool IsWarningEnabled { get; }
+        public System.Type LogClass { get; }
+        public string LogSource { get; }
         protected override void NotifyLog(Akka.Event.LogLevel logLevel, object message, System.Exception cause = null) { }
     }
     public sealed class DeadLetter : Akka.Event.AllDeadLetters

--- a/src/core/Akka.Streams.Tests/FusingSpec.cs
+++ b/src/core/Akka.Streams.Tests/FusingSpec.cs
@@ -57,12 +57,6 @@ namespace Akka.Streams.Tests
         [Fact]
         public async Task A_SubFusingActorMaterializer_must_use_multiple_actors_when_there_are_asynchronous_boundaries_in_the_subflows_manual ()
         {
-            string RefFunc()
-            {
-                var bus = (BusLogging)GraphInterpreter.Current.Log;
-                return GetInstanceField(typeof(BusLogging), bus, "_logSource") as string;
-            }
-
             var async = Flow.Create<int>().Select(x =>
             {
                 TestActor.Tell(RefFunc());
@@ -84,6 +78,13 @@ namespace Akka.Streams.Tests
             var refs = await ReceiveNAsync(20).Distinct().ToListAsync();
             // main flow + 10 sub-flows
             refs.Count.Should().Be(11);
+            return;
+
+            string RefFunc()
+            {
+                var bus = (BusLogging)GraphInterpreter.Current.Log;
+                return bus.LogSource;
+            }
         }
 
         [Fact]
@@ -92,7 +93,7 @@ namespace Akka.Streams.Tests
             string RefFunc()
             {
                 var bus = (BusLogging)GraphInterpreter.Current.Log;
-                return GetInstanceField(typeof(BusLogging), bus, "_logSource") as string;
+                return bus.LogSource;
             }
 
             var flow = Flow.Create<int>().Select(x =>


### PR DESCRIPTION
## Changes

close #7209

The idea behind this feature is to make it possible to implement https://github.com/akkadotnet/Akka.Logger.Serilog/issues/284 - automatically add `Context` to an `ILoggingAdapter` by just calling `ForContext` without having to explicitly request a `SerilogLoggingAdapter` first. All that's needed to make this work is to make some of the internal data members of the `BugLogging` member public and read-only

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7209 
* [x] Changes in public API reviewed, if any.