### PR TITLE
Akka.Cluster.Tools.Tests: disable auto-downing on restart specs

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonLeaseSpec.cs
@@ -24,6 +24,7 @@ using DotNetty.Common.Concurrency;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.Singleton
 {
@@ -77,14 +78,14 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             }
         }
 
-        private Cluster cluster;
-        private TestLeaseExt testLeaseExt;
+        private readonly Cluster _cluster;
+        private readonly TestLeaseExt _testLeaseExt;
 
-        private AtomicCounter counter = new(0);
-        private TimeSpan shortDuration = TimeSpan.FromMilliseconds(50);
-        private string leaseOwner;
+        private readonly AtomicCounter _counter = new(0);
+        private readonly TimeSpan _shortDuration = TimeSpan.FromMilliseconds(50);
+        private readonly string _leaseOwner;
 
-        public ClusterSingletonLeaseSpec() : base(ConfigurationFactory.ParseString(@"
+        public ClusterSingletonLeaseSpec(ITestOutputHelper output) : base(ConfigurationFactory.ParseString(@"
               #akka.loglevel = INFO
               akka.loglevel = DEBUG
               akka.actor.provider = ""cluster""
@@ -99,22 +100,22 @@ namespace Akka.Cluster.Tools.Tests.Singleton
                   hostname = ""127.0.0.1""
                   port = 0
                 }
-              }").WithFallback(TestLease.Configuration))
+              }").WithFallback(TestLease.Configuration), output)
         {
 
-            cluster = Cluster.Get(Sys);
-            testLeaseExt = TestLeaseExt.Get(Sys);
+            _cluster = Cluster.Get(Sys);
+            _testLeaseExt = TestLeaseExt.Get(Sys);
 
-            leaseOwner = cluster.SelfMember.Address.HostPort();
+            _leaseOwner = _cluster.SelfMember.Address.HostPort();
 
-            cluster.Join(cluster.SelfAddress);
+            _cluster.Join(_cluster.SelfAddress);
             AwaitAssert(() =>
             {
-                cluster.SelfMember.Status.ShouldBe(MemberStatus.Up);
+                _cluster.SelfMember.Status.ShouldBe(MemberStatus.Up);
             });
         }
 
-        private string NextName() => $"important-{counter.GetAndIncrement()}";
+        private string NextName() => $"important-{_counter.GetAndIncrement()}";
 
         private ClusterSingletonManagerSettings NextSettings() => ClusterSingletonManagerSettings.Create(Sys).WithSingletonName(NextName());
 
@@ -133,10 +134,10 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             TestLease testLease = null;
             AwaitAssert(() =>
             {
-                testLease = testLeaseExt.GetTestLease(LeaseNameFor(settings));
+                testLease = _testLeaseExt.GetTestLease(LeaseNameFor(settings));
             }); // allow singleton manager to create the lease
 
-            probe.ExpectNoMsg(shortDuration);
+            probe.ExpectNoMsg(_shortDuration);
             testLease.InitialPromise.SetResult(true);
             probe.ExpectMsg("preStart");
         }
@@ -154,12 +155,12 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             TestLease testLease = null;
             AwaitAssert(() =>
             {
-                testLease = testLeaseExt.GetTestLease(LeaseNameFor(settings));
+                testLease = _testLeaseExt.GetTestLease(LeaseNameFor(settings));
             }); // allow singleton manager to create the lease
 
-            probe.ExpectNoMsg(shortDuration);
+            probe.ExpectNoMsg(_shortDuration);
             testLease.InitialPromise.SetResult(false);
-            probe.ExpectNoMsg(shortDuration);
+            probe.ExpectNoMsg(_shortDuration);
         }
 
         [Fact]
@@ -175,17 +176,17 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             TestLease testLease = null;
             AwaitAssert(() =>
             {
-                testLease = testLeaseExt.GetTestLease(LeaseNameFor(settings));
+                testLease = _testLeaseExt.GetTestLease(LeaseNameFor(settings));
             }); // allow singleton manager to create the lease
 
-            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(leaseOwner));
-            singletonProbe.ExpectNoMsg(shortDuration);
-            TaskCompletionSource<bool> nextResponse = new TaskCompletionSource<bool>();
+            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(_leaseOwner));
+            singletonProbe.ExpectNoMsg(_shortDuration);
+            var nextResponse = new TaskCompletionSource<bool>();
 
             testLease.SetNextAcquireResult(nextResponse.Task);
             testLease.InitialPromise.SetResult(false);
-            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(leaseOwner));
-            singletonProbe.ExpectNoMsg(shortDuration);
+            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(_leaseOwner));
+            singletonProbe.ExpectNoMsg(_shortDuration);
             nextResponse.SetResult(true);
             singletonProbe.ExpectMsg("preStart");
         }
@@ -203,13 +204,13 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             TestLease testLease = null;
             AwaitAssert(() =>
             {
-                testLease = testLeaseExt.GetTestLease(LeaseNameFor(settings));
+                testLease = _testLeaseExt.GetTestLease(LeaseNameFor(settings));
             }); // allow singleton manager to create the lease
 
 
-            probe.ExpectNoMsg(shortDuration);
+            probe.ExpectNoMsg(_shortDuration);
             testLease.InitialPromise.SetException(new TestException("no lease for you"));
-            probe.ExpectNoMsg(shortDuration);
+            probe.ExpectNoMsg(_shortDuration);
         }
 
         [Fact]
@@ -225,16 +226,16 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             TestLease testLease = null;
             AwaitAssert(() =>
             {
-                testLease = testLeaseExt.GetTestLease(LeaseNameFor(settings));
+                testLease = _testLeaseExt.GetTestLease(LeaseNameFor(settings));
             }); // allow singleton manager to create the lease
 
-            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(leaseOwner));
-            singletonProbe.ExpectNoMsg(shortDuration);
+            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(_leaseOwner));
+            singletonProbe.ExpectNoMsg(_shortDuration);
             TaskCompletionSource<bool> nextResponse = new TaskCompletionSource<bool>();
             testLease.SetNextAcquireResult(nextResponse.Task);
             testLease.InitialPromise.SetException(new TestException("no lease for you"));
-            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(leaseOwner));
-            singletonProbe.ExpectNoMsg(shortDuration);
+            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(_leaseOwner));
+            singletonProbe.ExpectNoMsg(_shortDuration);
             nextResponse.SetResult(true);
             singletonProbe.ExpectMsg("preStart");
         }
@@ -252,19 +253,19 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             TestLease testLease = null;
             AwaitAssert(() =>
             {
-                testLease = testLeaseExt.GetTestLease(LeaseNameFor(settings));
+                testLease = _testLeaseExt.GetTestLease(LeaseNameFor(settings));
             }); // allow singleton manager to create the lease
 
-            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(leaseOwner));
+            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(_leaseOwner));
             testLease.InitialPromise.SetResult(true);
             lifecycleProbe.ExpectMsg("preStart");
             var callback = testLease.GetCurrentCallback();
             callback(null);
             lifecycleProbe.ExpectMsg("postStop");
-            testLease.Probe.ExpectMsg(new TestLease.ReleaseReq(leaseOwner));
+            testLease.Probe.ExpectMsg(new TestLease.ReleaseReq(_leaseOwner));
 
             // should try and reacquire lease
-            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(leaseOwner));
+            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(_leaseOwner));
             lifecycleProbe.ExpectMsg("preStart");
         }
 
@@ -281,15 +282,15 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             TestLease testLease = null;
             AwaitAssert(() =>
             {
-                testLease = testLeaseExt.GetTestLease(LeaseNameFor(settings));
+                testLease = _testLeaseExt.GetTestLease(LeaseNameFor(settings));
             }); // allow singleton manager to create the lease
 
-            singletonProbe.ExpectNoMsg(shortDuration);
-            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(leaseOwner));
+            singletonProbe.ExpectNoMsg(_shortDuration);
+            testLease.Probe.ExpectMsg(new TestLease.AcquireReq(_leaseOwner));
             testLease.InitialPromise.SetResult(true);
             singletonProbe.ExpectMsg("preStart");
-            cluster.Leave(cluster.SelfAddress);
-            testLease.Probe.ExpectMsg(new TestLease.ReleaseReq(leaseOwner));
+            _cluster.Leave(_cluster.SelfAddress);
+            testLease.Probe.ExpectMsg(new TestLease.ReleaseReq(_leaseOwner));
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
@@ -29,7 +29,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
               akka.loglevel = INFO
               akka.actor.provider = ""cluster""
               akka.cluster.roles = [singleton]
-              akka.cluster.auto-down-unreachable-after = 2s
+              #akka.cluster.auto-down-unreachable-after = 2s
               akka.cluster.singleton.min-number-of-hand-over-retries = 5
               akka.remote {
                 dot-netty.tcp {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
@@ -15,6 +15,7 @@ using Akka.Configuration;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.Singleton
 {
@@ -25,18 +26,20 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         private readonly ActorSystem _sys3;
         private ActorSystem _sys4 = null;
 
-        public ClusterSingletonRestart2Spec() : base(@"
-              akka.loglevel = INFO
-              akka.actor.provider = ""cluster""
-              akka.cluster.roles = [singleton]
-              #akka.cluster.auto-down-unreachable-after = 2s
-              akka.cluster.singleton.min-number-of-hand-over-retries = 5
-              akka.remote {
-                dot-netty.tcp {
-                  hostname = ""127.0.0.1""
-                  port = 0
-                }
-              }")
+        public ClusterSingletonRestart2Spec(ITestOutputHelper output) : base("""
+                                                                             
+                                                                                           akka.loglevel = INFO
+                                                                                           akka.actor.provider = "cluster"
+                                                                                           akka.cluster.roles = [singleton]
+                                                                                           #akka.cluster.auto-down-unreachable-after = 2s
+                                                                                           akka.cluster.singleton.min-number-of-hand-over-retries = 5
+                                                                                           akka.remote {
+                                                                                             dot-netty.tcp {
+                                                                                               hostname = "127.0.0.1"
+                                                                                               port = 0
+                                                                                             }
+                                                                                           }
+                                                                             """, output)
         {
             _sys1 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
             _sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
@@ -104,14 +104,14 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             });
 
             Cluster.Get(_sys1).Leave(Cluster.Get(_sys1).SelfAddress);
-
+            
+            // ReSharper disable once PossibleInvalidOperationException
+            var sys2Port = Cluster.Get(_sys2).SelfAddress.Port.Value; // grab value before shutdown
             // at the same time, shutdown sys2, which would be the expected next singleton node
             Shutdown(_sys2);
             // it will be downed by the join attempts of the new incarnation
 
             // then restart it
-            // ReSharper disable once PossibleInvalidOperationException
-            var sys2Port = Cluster.Get(_sys2).SelfAddress.Port.Value;
             var sys4Config = ConfigurationFactory.ParseString(@"akka.remote.dot-netty.tcp.port=" + sys2Port)
                 .WithFallback(_sys1.Settings.Config);
             _sys4 = ActorSystem.Create(_sys1.Name, sys4Config);

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart3Spec.cs
@@ -29,7 +29,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
               akka.loglevel = DEBUG
               akka.actor.provider = ""cluster""
               akka.cluster.app-version = ""1.0.0""
-              akka.cluster.auto-down-unreachable-after = 2s
+              #akka.cluster.auto-down-unreachable-after = 2s
               akka.cluster.singleton.min-number-of-hand-over-retries = 5
               akka.cluster.singleton.consider-app-version = true
               akka.remote {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
@@ -16,6 +16,7 @@ using Akka.TestKit;
 using Akka.TestKit.TestActors;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.Singleton
 {
@@ -25,7 +26,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         private readonly ActorSystem _sys2;
         private ActorSystem _sys3 = null;
 
-        public ClusterSingletonRestartSpec() : base(@"
+        public ClusterSingletonRestartSpec(ITestOutputHelper output) : base(@"
               akka.loglevel = INFO
               akka.actor.provider = ""cluster""
               #akka.cluster.auto-down-unreachable-after = 2s
@@ -34,7 +35,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
                   hostname = ""127.0.0.1""
                   port = 0
                 }
-              }")
+              }", output)
         {
             _sys1 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
             _sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
@@ -28,7 +28,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
         public ClusterSingletonRestartSpec() : base(@"
               akka.loglevel = INFO
               akka.actor.provider = ""cluster""
-              akka.cluster.auto-down-unreachable-after = 2s
+              #akka.cluster.auto-down-unreachable-after = 2s
               akka.remote {
                 dot-netty.tcp {
                   hostname = ""127.0.0.1""

--- a/src/core/Akka.Coordination.Tests/TestLease.cs
+++ b/src/core/Akka.Coordination.Tests/TestLease.cs
@@ -33,27 +33,25 @@ namespace Akka.Coordination.Tests
             return system.WithExtension<TestLeaseExt, TestLeaseExtExtensionProvider>();
         }
 
-        private readonly ExtendedActorSystem _system;
-        private readonly ConcurrentDictionary<string, TestLease> testLeases = new();
+        private readonly ConcurrentDictionary<string, TestLease> _testLeases = new();
 
         public TestLeaseExt(ExtendedActorSystem system)
         {
-            _system = system;
-            _system.Settings.InjectTopLevelFallback(LeaseProvider.DefaultConfig());
+            system.Settings.InjectTopLevelFallback(LeaseProvider.DefaultConfig());
         }
 
         public TestLease GetTestLease(string name)
         {
-            if (!testLeases.TryGetValue(name, out var lease))
+            if (!_testLeases.TryGetValue(name, out var lease))
             {
-                throw new InvalidOperationException($"Test lease {name} has not been set yet. Current leases {string.Join(",", testLeases.Keys)}");
+                throw new InvalidOperationException($"Test lease {name} has not been set yet. Current leases {string.Join(",", _testLeases.Keys)}");
             }
             return lease;
         }
 
         public void SetTestLease(string name, TestLease lease)
         {
-            testLeases[name] = lease;
+            _testLeases[name] = lease;
         }
     }
 


### PR DESCRIPTION
## Changes

Cherry-picked from https://github.com/akkadotnet/akka.net/pull/7197 - fixes the worst offenders for "raciness" in the test suite

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
