### PR TITLE
`ShardedDaemonProcess` push mode

### DIFF
--- a/docs/articles/clustering/cluster-sharded-daemon-process.md
+++ b/docs/articles/clustering/cluster-sharded-daemon-process.md
@@ -32,5 +32,20 @@ when starting up:
 
 ## Scalability  
 
-This cluster tool is intended for small numbers of consumers and will not scale well to a large set. In large clusters
-it is recommended to limit the nodes the sharded daemon process will run on using a role.
+This cluster tool is intended for small numbers of consumers and will not scale well to a large set. In large clusters it is recommended to limit the nodes the sharded daemon process will run on using a role.
+
+## Push-Based Communication
+
+[`ShardedDaemonProcess`](xref:Akka.Cluster.Sharding.ShardedDaemonProcess) also supports push-based communication not too dissimilar from a round-robin `Router`:
+
+[!code-csharp[IActorRef returned by ShardedDaemonProcess](../../../src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessProxySpec.cs?name=PushDaemon)]
+
+The `ShardedDaemonProcess.Init` call returns an `IActorRef` - any messages you send to this `IActorRef` will be routed to one of the `n` worker instances you specified.
+
+## Daemon Proxies
+
+You can also interact with `ShardedDaemonProcess` on nodes that don't use the same [Akka.Cluster role](xref:member-roles) as the `ShardedDaemonProcess` host itself.
+
+[!code-csharp[IActorRef returned by ShardedDaemonProcess](../../../src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessProxySpec.cs?name=PushDaemonProxy)]
+
+Under the covers we use a [`ShardRegionProxy`](xref:Akka.Cluster.Sharding.ClusterSharding#Akka_Cluster_Sharding_ClusterSharding_StartProxy_System_String_System_String_Akka_Cluster_Sharding_IMessageExtractor_) to forward any messages you send to the `IActorRef` returned by the `ShardedDaemonProcess.InitProxy` method.

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessProxySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessProxySpec.cs
@@ -83,9 +83,9 @@ public class ShardedDaemonProcessProxySpec : AkkaSpec
         }
         
         // start the proxy on the proxy system
-        // var proxy = ShardedDaemonProcess.Get(_proxySystem).InitProxy(name, numWorkers, targetRole);
-        //
-        // // ping some of the workers via the proxy
+        var proxy = ShardedDaemonProcess.Get(_proxySystem).InitProxy(name, numWorkers, targetRole);
+        
+        // ping some of the workers via the proxy
         // for(var i = 0; i < numWorkers; i++)
         // {
         //     var result = await proxy.Ask<int>(i);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessProxySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessProxySpec.cs
@@ -1,0 +1,101 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ShardedDaemonProcessProxySpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+
+namespace Akka.Cluster.Sharding.Tests;
+
+public class ShardedDaemonProcessProxySpec : AkkaSpec
+{
+    private static Config GetConfig()
+    {
+        return ConfigurationFactory.ParseString(@"
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = 0
+                akka.remote.dot-netty.tcp.hostname = 127.0.0.1
+
+                # ping often/start fast for test
+                akka.cluster.sharded-daemon-process.keep-alive-interval = 1s
+                akka.cluster.roles = [workers]
+                akka.coordinated-shutdown.terminate-actor-system = off
+                akka.coordinated-shutdown.run-by-actor-system-terminate = off")
+            .WithFallback(ClusterSharding.DefaultConfig())
+            .WithFallback(ClusterSingletonProxy.DefaultConfig());
+    }
+
+    private readonly ActorSystem _proxySystem;
+
+    public ShardedDaemonProcessProxySpec(ITestOutputHelper output)
+        : base(GetConfig(), output: output)
+    {
+        _proxySystem = ActorSystem.Create(Sys.Name,
+            ConfigurationFactory
+                .ParseString("akka.cluster.roles=[proxy]").WithFallback(GetConfig()));
+    }
+    
+    private class EchoActor : ReceiveActor
+    {
+        public static Props EchoProps(int i) => Props.Create(() => new EchoActor());
+        
+        public EchoActor()
+        {
+            ReceiveAny(msg => Sender.Tell(msg));
+        }
+    }
+    
+    [Fact]
+    public async Task ShardedDaemonProcessProxy_must_start_daemon_process_on_proxy()
+    {
+        // form a cluster with one node
+        Cluster.Get(Sys).Join(Cluster.Get(Sys).SelfAddress);
+        Cluster.Get(_proxySystem).Join(Cluster.Get(Sys).SelfAddress);
+        
+        // validate that we have a 2 node cluster
+        await AwaitAssertAsync(() =>
+        {
+            Cluster.Get(Sys).State.Members.Count.Should().Be(2);
+            Cluster.Get(_proxySystem).State.Members.Count.Should().Be(2);
+        });
+        
+        // start the daemon process on the host
+        var name = "daemonTest";
+        var targetRole = "workers";
+        var numWorkers = 10;
+        var settings = ShardedDaemonProcessSettings.Create(Sys).WithRole(targetRole);
+        var host = ShardedDaemonProcess.Get(Sys).Init(name, numWorkers, EchoActor.EchoProps, settings);
+        
+        // ping some of the workers via the host
+        for(var i = 0; i < numWorkers; i++)
+        {
+            var result = await host.Ask<int>(i);
+            result.Should().Be(i);
+        }
+        
+        // start the proxy on the proxy system
+        // var proxy = ShardedDaemonProcess.Get(_proxySystem).InitProxy(name, numWorkers, targetRole);
+        //
+        // // ping some of the workers via the proxy
+        // for(var i = 0; i < numWorkers; i++)
+        // {
+        //     var result = await proxy.Ask<int>(i);
+        //     result.Should().Be(i);
+        // }
+    }
+
+    protected override void AfterAll()
+    {
+        Shutdown(_proxySystem);
+        base.AfterAll();
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessSpec.cs
@@ -12,6 +12,7 @@ using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit;
+using FluentAssertions;
 using Xunit;
 
 namespace Akka.Cluster.Sharding.Tests
@@ -21,7 +22,10 @@ namespace Akka.Cluster.Sharding.Tests
         private sealed class Stop
         {
             public static Stop Instance { get; } = new();
-            private Stop() { }
+
+            private Stop()
+            {
+            }
         }
 
         private sealed class Started
@@ -81,14 +85,16 @@ namespace Akka.Cluster.Sharding.Tests
 
         public ShardedDaemonProcessSpec()
             : base(GetConfig())
-        { }
+        {
+        }
 
         [Fact]
         public void ShardedDaemonProcess_must_have_a_single_node_cluster_running_first()
         {
             var probe = CreateTestProbe();
             Cluster.Get(Sys).Join(Cluster.Get(Sys).SelfAddress);
-            probe.AwaitAssert(() => Cluster.Get(Sys).SelfMember.Status.ShouldBe(MemberStatus.Up), TimeSpan.FromSeconds(3));
+            probe.AwaitAssert(() => Cluster.Get(Sys).SelfMember.Status.ShouldBe(MemberStatus.Up),
+                TimeSpan.FromSeconds(3));
         }
 
         [Fact]
@@ -126,7 +132,9 @@ namespace Akka.Cluster.Sharding.Tests
 
             var probe = CreateTestProbe();
             var settings = ShardedDaemonProcessSettings.Create(Sys).WithRole("workers");
-            ShardedDaemonProcess.Get(Sys).Init("roles", 3, id => MyActor.Props(id, probe.Ref), settings, PoisonPill.Instance);
+            var actorRef = ShardedDaemonProcess.Get(Sys).Init("roles", 3, id => MyActor.Props(id, probe.Ref), settings,
+                PoisonPill.Instance);
+            actorRef.Should().BeNull();
 
             probe.ExpectNoMsg();
         }
@@ -152,8 +160,10 @@ namespace Akka.Cluster.Sharding.Tests
         private void DocExample()
         {
             #region tag-processing
+
             var tags = new[] { "tag-1", "tag-2", "tag-3" };
             ShardedDaemonProcess.Get(Sys).Init("TagProcessors", tags.Length, id => TagProcessor.Props(tags[id]));
+
             #endregion
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardedDaemonProcess.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardedDaemonProcess.cs
@@ -211,7 +211,7 @@ namespace Akka.Cluster.Sharding
             {
                 var sharding = ClusterSharding.Get(_system);
                 var shardingRef = sharding.Start(
-                    typeName: $"sharded-daemon-process-{name}",
+                    typeName: FormatWorkerProcessName(name),
                     entityPropsFactory: entityId => propsFactory(int.Parse(entityId)),
                     settings: shardingSettings,
                     messageExtractor: new MessageExtractor(numberOfShards),
@@ -234,6 +234,8 @@ namespace Akka.Cluster.Sharding
 
             return null;
         }
+        
+        private static string FormatWorkerProcessName(string name) => $"sharded-daemon-process-{name}";
 
         /// <summary>
         /// Starts a proxy for a sharded daemon process running in a different role.
@@ -250,7 +252,7 @@ namespace Akka.Cluster.Sharding
             // create a shard region proxy so we can access daemon workers running in a different role
             var sharding = ClusterSharding.Get(_system);
             var shardingRef = sharding.StartProxy(
-                typeName: $"sharded-daemon-process-{name}",
+                typeName: FormatWorkerProcessName(name),
                 role: role,
                 messageExtractor: new MessageExtractor(numberOfInstances));
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardedDaemonProcess.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardedDaemonProcess.cs
@@ -113,7 +113,9 @@ namespace Akka.Cluster.Sharding
         protected override void OnReceive(object message)
         {
             var nextId = _entityIds[_index % _entityIds.Length];
-            _shardingRef.Tell(new ShardingEnvelope(nextId, message));
+            
+            // have to remember to always allow the sharding envelope to be forwarded
+            _shardingRef.Forward(new ShardingEnvelope(nextId, message));
             if (_index == int.MaxValue) _index = 0;
             else _index++;
         }
@@ -243,7 +245,7 @@ namespace Akka.Cluster.Sharding
         /// <param name="role">The role where the worker actors are hosted.</param>
         /// <returns>A reference to a router actor that will distribute all messages evenly across the workers
         /// using round-robin message routing.</returns>
-        IActorRef InitProxy(string name, int numberOfInstances, string role)
+        public IActorRef InitProxy(string name, int numberOfInstances, string role)
         {
             // create a shard region proxy so we can access daemon workers running in a different role
             var sharding = ClusterSharding.Get(_system);

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardedDaemonProcessSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardedDaemonProcessSettings.cs
@@ -4,7 +4,7 @@
 //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
+#nullable enable
 using System;
 using Akka.Actor;
 using Akka.Annotations;
@@ -24,12 +24,12 @@ namespace Akka.Cluster.Sharding
         /// <summary>
         /// Specify sharding settings that should be used for the sharded daemon process instead of loading from config.
         /// </summary>
-        public readonly ClusterShardingSettings ShardingSettings;
+        public readonly ClusterShardingSettings? ShardingSettings;
 
         /// <summary>
         /// Specifies that the ShardedDaemonProcess should run on nodes with a specific role.
         /// </summary>
-        public readonly string Role;
+        public readonly string? Role;
 
         /// <summary>
         /// Create default settings for system
@@ -48,14 +48,14 @@ namespace Akka.Cluster.Sharding
         /// <summary>
         /// Not for user constructions, use factory methods to instantiate.
         /// </summary>
-        private ShardedDaemonProcessSettings(TimeSpan keepAliveInterval, ClusterShardingSettings shardingSettings = null, string role = null)
+        private ShardedDaemonProcessSettings(TimeSpan keepAliveInterval, ClusterShardingSettings? shardingSettings = null, string? role = null)
         {
             KeepAliveInterval = keepAliveInterval;
             ShardingSettings = shardingSettings;
             Role = role;
         }
 
-        private ShardedDaemonProcessSettings Copy(TimeSpan? keepAliveInterval = null, ClusterShardingSettings shardingSettings = null, string role = null)
+        private ShardedDaemonProcessSettings Copy(TimeSpan? keepAliveInterval = null, ClusterShardingSettings? shardingSettings = null, string? role = null)
         {
             return new ShardedDaemonProcessSettings(keepAliveInterval ?? KeepAliveInterval, shardingSettings ?? ShardingSettings, role ?? Role);
         }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
@@ -287,14 +287,21 @@ namespace Akka.Cluster.Sharding
     }
     [Akka.Annotations.ApiMayChangeAttribute()]
     [Akka.Annotations.DoNotInheritAttribute()]
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ShardedDaemonProcess : Akka.Actor.IExtension
     {
         public ShardedDaemonProcess(Akka.Actor.ExtendedActorSystem system) { }
         public static Akka.Cluster.Sharding.ShardedDaemonProcess Get(Akka.Actor.ActorSystem system) { }
-        public void Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory) { }
-        public void Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, object stopMessage) { }
-        public void Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, Akka.Cluster.Sharding.ShardedDaemonProcessSettings settings, object stopMessage) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
+        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
+        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
+        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, Akka.Cluster.Sharding.ShardedDaemonProcessSettings settings, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+            0,
+            1})]
     public class ShardedDaemonProcessExtensionProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Sharding.ShardedDaemonProcess>
     {
         public ShardedDaemonProcessExtensionProvider() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
@@ -309,10 +309,13 @@ namespace Akka.Cluster.Sharding
         public override Akka.Cluster.Sharding.ShardedDaemonProcess CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
     [Akka.Annotations.ApiMayChangeAttribute()]
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ShardedDaemonProcessSettings
     {
         public readonly System.TimeSpan KeepAliveInterval;
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public readonly string Role;
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public readonly Akka.Cluster.Sharding.ClusterShardingSettings ShardingSettings;
         public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings FromConfig(Akka.Configuration.Config config) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
@@ -298,6 +298,7 @@ namespace Akka.Cluster.Sharding
         public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
         [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, Akka.Cluster.Sharding.ShardedDaemonProcessSettings settings, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
+        public Akka.Actor.IActorRef InitProxy(string name, int numberOfInstances, string role) { }
     }
     [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
             0,

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
@@ -287,14 +287,21 @@ namespace Akka.Cluster.Sharding
     }
     [Akka.Annotations.ApiMayChangeAttribute()]
     [Akka.Annotations.DoNotInheritAttribute()]
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ShardedDaemonProcess : Akka.Actor.IExtension
     {
         public ShardedDaemonProcess(Akka.Actor.ExtendedActorSystem system) { }
         public static Akka.Cluster.Sharding.ShardedDaemonProcess Get(Akka.Actor.ActorSystem system) { }
-        public void Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory) { }
-        public void Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, object stopMessage) { }
-        public void Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, Akka.Cluster.Sharding.ShardedDaemonProcessSettings settings, object stopMessage) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
+        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
+        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
+        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, Akka.Cluster.Sharding.ShardedDaemonProcessSettings settings, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+            0,
+            1})]
     public class ShardedDaemonProcessExtensionProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Sharding.ShardedDaemonProcess>
     {
         public ShardedDaemonProcessExtensionProvider() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
@@ -309,10 +309,13 @@ namespace Akka.Cluster.Sharding
         public override Akka.Cluster.Sharding.ShardedDaemonProcess CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
     [Akka.Annotations.ApiMayChangeAttribute()]
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ShardedDaemonProcessSettings
     {
         public readonly System.TimeSpan KeepAliveInterval;
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public readonly string Role;
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public readonly Akka.Cluster.Sharding.ClusterShardingSettings ShardingSettings;
         public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings FromConfig(Akka.Configuration.Config config) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
@@ -298,6 +298,7 @@ namespace Akka.Cluster.Sharding
         public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
         [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, Akka.Cluster.Sharding.ShardedDaemonProcessSettings settings, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
+        public Akka.Actor.IActorRef InitProxy(string name, int numberOfInstances, string role) { }
     }
     [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
             0,


### PR DESCRIPTION
## Changes

close #7195 - adds "push" mode to communicating with sharded daemon processes.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7195
* [x] Changes in public API reviewed, if any.
* [x] I have added website documentation for this feature.