### PR TITLE
Partial fix for CVE-2018-8292

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,8 +18,8 @@
     <LangVersion>11.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <XunitVersion>2.5.3</XunitVersion>
-    <XunitRunnerVersion>2.5.3</XunitRunnerVersion>
+    <XunitVersion>2.8.1</XunitVersion>
+    <XunitRunnerVersion>2.8.1</XunitRunnerVersion>
     <TestSdkVersion>17.9.0</TestSdkVersion>
     <HyperionVersion>0.12.2</HyperionVersion>
     <NewtonsoftJsonVersion>[13.0.1,)</NewtonsoftJsonVersion>

--- a/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
+++ b/src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.13.12" />
     <!-- FluentAssertions is used in some benchmarks to validate internal behaviors -->
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>

--- a/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
@@ -6,7 +6,6 @@
 
     <ItemGroup>
         <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
-        <PackageReference Include="BenchmarkDotNet.Diagnostics.dotTrace" Version="0.13.12" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Sharding/ShardMessageRoutingBenchmarks.cs
@@ -14,13 +14,11 @@ using Akka.Benchmarks.Configurations;
 using Akka.Cluster.Sharding;
 using Akka.Routing;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Diagnostics.dotTrace;
 using BenchmarkDotNet.Engines;
 using static Akka.Cluster.Benchmarks.Sharding.ShardingHelper;
 
 namespace Akka.Cluster.Benchmarks.Sharding
 {
-    [DotTraceDiagnoser]
     [Config(typeof(MonitoringConfig))]
     [SimpleJob(RunStrategy.Monitoring, launchCount: 10, warmupCount: 10)]
     public class ShardMessageRoutingBenchmarks

--- a/src/core/Akka.Docs.Tests/Akka.Docs.Tests.csproj
+++ b/src/core/Akka.Docs.Tests/Akka.Docs.Tests.csproj
@@ -18,7 +18,6 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
   </ItemGroup>

--- a/src/core/Akka.Persistence.TestKit.Tests/Akka.Persistence.TestKit.Tests.csproj
+++ b/src/core/Akka.Persistence.TestKit.Tests/Akka.Persistence.TestKit.Tests.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.utility" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="TeamCity.ServiceMessages" Version="3.0.13" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />


### PR DESCRIPTION
Partially fixes #7234

## Changes

* Bump xunit to 2.8.1
* Bump xunit.runner.visualstudio to 2.8.1
* Remove reference to BenchmarkDotNet.Diagnostics.dotTrace
* Remove reference to xunit.runner.utility