### PR TITLE
Added `Serialization.DeserializeActorRef` method

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/Serialization/ClusterShardingMessageSerializer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Serialization/ClusterShardingMessageSerializer.cs
@@ -699,7 +699,7 @@ namespace Akka.Cluster.Sharding.Serialization
 
         private IActorRef ResolveActorRef(string path)
         {
-            return system.Provider.ResolveActorRef(path);
+            return system.Serialization.DeserializeActorRef(path);
         }
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -5228,6 +5228,7 @@ namespace Akka.Serialization
         public void AddSerializer(string name, Akka.Serialization.Serializer serializer) { }
         public object Deserialize(byte[] bytes, int serializerId, System.Type type) { }
         public object Deserialize(byte[] bytes, int serializerId, string manifest) { }
+        public Akka.Actor.IActorRef DeserializeActorRef(string path) { }
         public Akka.Serialization.Serializer FindSerializerFor(object obj, string defaultSerializerName = null) { }
         public Akka.Serialization.Serializer FindSerializerForType(System.Type objectType, string defaultSerializerName = null) { }
         public static Akka.Serialization.Information GetCurrentTransportInformation() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -5218,6 +5218,7 @@ namespace Akka.Serialization
         public void AddSerializer(string name, Akka.Serialization.Serializer serializer) { }
         public object Deserialize(byte[] bytes, int serializerId, System.Type type) { }
         public object Deserialize(byte[] bytes, int serializerId, string manifest) { }
+        public Akka.Actor.IActorRef DeserializeActorRef(string path) { }
         public Akka.Serialization.Serializer FindSerializerFor(object obj, string defaultSerializerName = null) { }
         public Akka.Serialization.Serializer FindSerializerForType(System.Type objectType, string defaultSerializerName = null) { }
         public static Akka.Serialization.Information GetCurrentTransportInformation() { }

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -574,6 +574,17 @@ namespace Akka.Serialization
             AddSerializationMap(type, serializer);
             return serializer;
         }
+        
+        /// <summary>
+        /// Deserializes an <see cref="IActorRef"/> from its string representation.
+        /// </summary>
+        /// <param name="path">The serialized path of the actor represented as a string.</param>
+        /// <returns>The <see cref="IActorRef"/>. If no such actor exists, it will be (equivalent to) a dead letter reference.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IActorRef DeserializeActorRef(string path)
+        {
+            return System.Provider.ResolveActorRef(path);
+        }
 
         /// <summary>
         /// The serialized path of an actorRef, based on the current transport serialization information.
@@ -589,7 +600,7 @@ namespace Akka.Serialization
         public static string SerializedActorPath(IActorRef actorRef)
         {
             if (Equals(actorRef, ActorRefs.NoSender))
-                return String.Empty;
+                return string.Empty;
 
             var path = actorRef.Path;
             ExtendedActorSystem originalSystem = null;


### PR DESCRIPTION
## Changes

Designed to give us a more aligned API for end-users that need to serialize and deserialize `IActorRef`s in their own user-defined messages.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.
