### PR TITLE
Partial fix on CVE-2018-8292

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/Akka.Cluster.Metrics.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/Akka.Cluster.Metrics.Tests.MultiNode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
+        <TargetFramework>$(NetTestVersion)</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -14,6 +14,7 @@
         <PackageReference Include="Akka.MultiNode.TestAdapter" Version="$(MultiNodeAdapterVersion)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
         <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+        <PackageReference Include="xunit" Version="$(XunitVersion)"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVersion)">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Akka.Cluster.Sharding.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Akka.Cluster.Sharding.Tests.MultiNode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,7 +15,8 @@
   <ItemGroup>
       <PackageReference Include="Akka.MultiNode.TestAdapter" Version="$(MultiNodeAdapterVersion)" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+      <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+      <PackageReference Include="xunit" Version="$(XunitVersion)"/>
       <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVersion)">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Akka.Cluster.Tools.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Akka.Cluster.Tools.Tests.MultiNode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +14,8 @@
   <ItemGroup>
       <PackageReference Include="Akka.MultiNode.TestAdapter" Version="$(MultiNodeAdapterVersion)" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+      <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+      <PackageReference Include="xunit" Version="$(XunitVersion)"/>
       <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVersion)">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/Akka.DistributedData.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.DistributedData.Tests.MultiNode/Akka.DistributedData.Tests.MultiNode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
   </PropertyGroup>
  
   <ItemGroup>
@@ -14,7 +14,8 @@
   <ItemGroup>
       <PackageReference Include="Akka.MultiNode.TestAdapter" Version="$(MultiNodeAdapterVersion)" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+      <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+      <PackageReference Include="xunit" Version="$(XunitVersion)"/>
       <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVersion)">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Akka.Persistence.Sql.Common.csproj
@@ -13,6 +13,12 @@
 
     <ItemGroup>
         <PackageReference Include="System.Data.Common" Version="4.3.0"/>
+      
+        <!--
+          This reference is added to resolve CVE-2018-8292 because System.Data.Common references the bad version
+          of this package. This can be removed if System.Data.Common ever release a clean version in the future
+        -->
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
 </Project>

--- a/src/core/Akka.Cluster.Tests.MultiNode/Akka.Cluster.Tests.MultiNode.csproj
+++ b/src/core/Akka.Cluster.Tests.MultiNode/Akka.Cluster.Tests.MultiNode.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +13,8 @@
   <ItemGroup>
       <PackageReference Include="Akka.MultiNode.TestAdapter" Version="$(MultiNodeAdapterVersion)" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+      <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+      <PackageReference Include="xunit" Version="$(XunitVersion)"/>
       <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVersion)">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/core/Akka.Remote.Tests.MultiNode/Akka.Remote.Tests.MultiNode.csproj
+++ b/src/core/Akka.Remote.Tests.MultiNode/Akka.Remote.Tests.MultiNode.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Akka.MultiNode.TestAdapter" Version="$(MultiNodeAdapterVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Partially Fix #7234

## Notes

The remaining CVE warning (all MultiNode tests) should disappear as soon as we reference a new release of MNTR test adapter that references this release.

## Changes

* Make sure that all MultiNode test projects references xunit package
* Make sure that Akka.Persistence.Sql.Common references a clean version of System.Text.RegularExpressions

```
PS D:\git\akkadotnet\akka.net\src> dotnet list package --vulnerable --include-transitive

The following sources were used:
   https://api.nuget.org/v3/index.json

The given project `PingPong` has no vulnerable packages given the current sources.
The given project `Akka.Remote.Tests` has no vulnerable packages given the current sources.
The given project `Akka.TestKit` has no vulnerable packages given the current sources.
The given project `Akka.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Remote` has no vulnerable packages given the current sources.
The given project `Akka` has no vulnerable packages given the current sources.
The given project `Akka.TestKit.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Tests.Shared.Internals` has no vulnerable packages given the current sources.
The given project `Akka.Cluster` has no vulnerable packages given the current sources.
The given project `Akka.Cluster.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Remote.TestKit` has no vulnerable packages given the current sources.
The given project `Akka.Remote.TestKit.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.TCK` has no vulnerable packages given the current sources.
The given project `Akka.Persistence` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.TCK.Tests` has no vulnerable packages given the current sources.
The given project `Akka.TestKit.Xunit2` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.Sql.Common` has no vulnerable packages given the current sources.
Project `Akka.Cluster.Tests.MultiNode` has the following vulnerable packages
   [net8.0]:
   Transitive Package                                   Resolved   Severity   Advisory URL                              
   > System.Net.Http                                    4.1.0      High       https://github.com/advisories/GHSA-7jgj-8wvc-jh57
   > System.Security.Cryptography.X509Certificates      4.1.0      High       https://github.com/advisories/GHSA-7mfr-774f-w5r9

Project `Akka.Remote.Tests.MultiNode` has the following vulnerable packages
   [net8.0]:
   Transitive Package                                   Resolved   Severity   Advisory URL

   > System.Net.Http                                    4.1.0      High       https://github.com/advisories/GHSA-7jgj-8wvc-jh57
   > System.Security.Cryptography.X509Certificates      4.1.0      High       https://github.com/advisories/GHSA-7mfr-774f-w5r9

The given project `Akka.Persistence.Sqlite` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.Sqlite.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Serialization.TestKit` has no vulnerable packages given the current sources.
The given project `Akka.Cluster.Sharding` has no vulnerable packages given the current sources.
The given project `Akka.Cluster.Tools` has no vulnerable packages given the current sources.
The given project `Akka.Cluster.Tools.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Cluster.Sharding.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Tests.Performance` has no vulnerable packages given the current sources.
The given project `Akka.Remote.Tests.Performance` has no vulnerable packages given the current sources.
The given project `Akka.Streams` has no vulnerable packages given the current sources.
The given project `Akka.Streams.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Streams.TestKit` has no vulnerable packages given the current sources.
The given project `Akka.API.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Streams.TestKit.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Cluster.TestKit` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.Query` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.Query.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Streams.Tests.Performance` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.Query.Sql` has no vulnerable packages given the current sources.
Project `Akka.Cluster.Tools.Tests.MultiNode` has the following vulnerable packages
   [net8.0]:
   Transitive Package                                   Resolved   Severity   Advisory URL

   > System.Net.Http                                    4.1.0      High       https://github.com/advisories/GHSA-7jgj-8wvc-jh57
   > System.Security.Cryptography.X509Certificates      4.1.0      High       https://github.com/advisories/GHSA-7mfr-774f-w5r9

The given project `Akka.Persistence.Sql.TestKit` has no vulnerable packages given the current sources.
The given project `Akka.Streams.Tests.TCK` has no vulnerable packages given the current sources.
Project `Akka.Cluster.Sharding.Tests.MultiNode` has the following vulnerable packages
   [net8.0]:
   Transitive Package                                   Resolved   Severity   Advisory URL

   > System.Net.Http                                    4.1.0      High       https://github.com/advisories/GHSA-7jgj-8wvc-jh57
   > System.Security.Cryptography.X509Certificates      4.1.0      High       https://github.com/advisories/GHSA-7mfr-774f-w5r9

The given project `Akka.DistributedData` has no vulnerable packages given the current sources.
The given project `Akka.DistributedData.Tests` has no vulnerable packages given the current sources.
Project `Akka.DistributedData.Tests.MultiNode` has the following vulnerable packages
   [net8.0]:
   Transitive Package                                   Resolved   Severity   Advisory URL

   > System.Net.Http                                    4.1.0      High       https://github.com/advisories/GHSA-7jgj-8wvc-jh57
   > System.Security.Cryptography.X509Certificates      4.1.0      High       https://github.com/advisories/GHSA-7mfr-774f-w5r9

The given project `Akka.Serialization.Hyperion` has no vulnerable packages given the current sources.
The given project `Akka.Serialization.Hyperion.Tests` has no vulnerable packages given the current sources.
The given project `Akka.TestKit.Xunit` has no vulnerable packages given the current sources.
The given project `Akka.Cluster.Tests.Performance` has no vulnerable packages given the current sources.
The given project `Akka.DistributedData.LightningDB` has no vulnerable packages given the current sources.
The given project `RemotePingPong` has no vulnerable packages given the current sources.
The given project `ClusterSharding.Node` has no vulnerable packages given the current sources.
The given project `ChatMessages` has no vulnerable packages given the current sources.
The given project `ChatServer` has no vulnerable packages given the current sources.
The given project `ChatClient` has no vulnerable packages given the current sources.
The given project `Samples.Cluster.Simple` has no vulnerable packages given the current sources.
The given project `Samples.Cluster.Transformation` has no vulnerable packages given the current sources.
The given project `Akka.FSharp` has no vulnerable packages given the current sources.
The given project `Akka.FSharp.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Benchmarks` has no vulnerable packages given the current sources.
The given project `SpawnBenchmark` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.FSharp` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.TestKit` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.TestKit.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.TestKit.Xunit2` has no vulnerable packages given the current sources.
The given project `Akka.Docs.Tests` has no vulnerable packages given the current sources.
The given project `Akka.Docs.Tutorials` has no vulnerable packages given the current sources.
The given project `Akka.Cluster.Metrics` has no vulnerable packages given the current sources.
The given project `Akka.Cluster.Metrics.Tests` has no vulnerable packages given the current sources.
Project `Akka.Cluster.Metrics.Tests.MultiNode` has the following vulnerable packages
   [net8.0]:
   Transitive Package                                   Resolved   Severity   Advisory URL

   > System.Net.Http                                    4.1.0      High       https://github.com/advisories/GHSA-7jgj-8wvc-jh57
   > System.Security.Cryptography.X509Certificates      4.1.0      High       https://github.com/advisories/GHSA-7mfr-774f-w5r9

The given project `Akka.Coordination` has no vulnerable packages given the current sources.
The given project `Akka.Coordination.Tests` has no vulnerable packages given the current sources.
The given project `TcpEchoService.Server` has no vulnerable packages given the current sources.
The given project `Akka.Discovery` has no vulnerable packages given the current sources.
The given project `Akka.Discovery.Tests` has no vulnerable packages given the current sources.
The given project `Samples.Cluster.AdaptiveGroup` has no vulnerable packages given the current sources.
The given project `Samples.Cluster.Metrics` has no vulnerable packages given the current sources.
The given project `Samples.Cluster.Metrics.Common` has no vulnerable packages given the current sources.
The given project `Akka.DependencyInjection` has no vulnerable packages given the current sources.
The given project `Akka.DependencyInjection.Tests` has no vulnerable packages given the current sources.
The given project `Samples.Akka.AspNetCore` has no vulnerable packages given the current sources.
The given project `SerializationBenchmarks` has no vulnerable packages given the current sources.
The given project `DDataStressTest` has no vulnerable packages given the current sources.
The given project `Akka.Cluster.Benchmarks` has no vulnerable packages given the current sources.
The given project `ShoppingCart` has no vulnerable packages given the current sources.
The given project `HelloWorld` has no vulnerable packages given the current sources.
The given project `Akka.AspNetCore` has no vulnerable packages given the current sources.
The given project `AkkaHeadlesssService` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.Custom` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.Custom.Tests` has no vulnerable packages given the current sources.
The given project `AkkaWindowsService` has no vulnerable packages given the current sources.
The given project `Akka.Cluster.Cpu.Benchmark` has no vulnerable packages given the current sources.
The given project `SampleSubscriber` has no vulnerable packages given the current sources.
The given project `SamplePublisher` has no vulnerable packages given the current sources.
The given project `SampleDestination` has no vulnerable packages given the current sources.
The given project `SampleSender` has no vulnerable packages given the current sources.
The given project `PersistenceExample` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.Query.InMemory` has no vulnerable packages given the current sources.
The given project `Akka.Persistence.Query.InMemory.Tests` has no vulnerable packages given the current sources.
The given project `ClusterToolsExample.Shared` has no vulnerable packages given the current sources.
The given project `ClusterToolsExample.Seed` has no vulnerable packages given the current sources.
The given project `ClusterToolsExample.Node` has no vulnerable packages given the current sources.
```