### PR TITLE
RemotePingPong: don't let permission issues crash benchmark

### DIFF
--- a/src/benchmark/RemotePingPong/Program.cs
+++ b/src/benchmark/RemotePingPong/Program.cs
@@ -70,7 +70,14 @@ namespace RemotePingPong
 
         private static async Task Main(params string[] args)
         {
-            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.High;
+            try
+            {
+                Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.High;
+            }
+            catch (Exception ex)
+            {
+                await Console.Error.WriteLineAsync($"Attempted to elevate process priority, but failed due to {ex.Message} - carrying on at normal process priority.");
+            }
             if (args.Length == 0 || !uint.TryParse(args[0], out var timesToRun))
             {
                 timesToRun = 1u;


### PR DESCRIPTION
## Changes

While trying to run `RemotePingPong` on our Raspberry Pi units in the test lab this evening, I kept running into permissions issues due to us trying to attempt process priority elevation. Decided to do what Benchmark.NET does and just log a warning and run without elevating the priority if that's going to be an issue for the runtime.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
