### PR TITLE
Akka.Router: automatically unpack `IScheduledTellMsg` when being handled through a router

### DIFF
--- a/src/core/Akka.Tests/Actor/Scheduler/BugFix7247Spec.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/BugFix7247Spec.cs
@@ -56,9 +56,9 @@ public class BugFix7247Spec : AkkaSpec {
         
         // act
         var msg = "hit";
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5));
         Sys.Scheduler.ScheduleTellOnce(TimeSpan.FromMicroseconds(1), router, msg, ActorRefs.NoSender);
-        await tcs.Task; // will time out if we don't get our msg
+        await tcs.Task.WithCancellation(cts.Token); // will time out if we don't get our msg
         var respMsg = await tcs.Task;
         
         // assert

--- a/src/core/Akka.Tests/Actor/Scheduler/BugFix7247Spec.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/BugFix7247Spec.cs
@@ -1,0 +1,52 @@
+// -----------------------------------------------------------------------
+//  <copyright file="7247BugFixSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests.Actor.Scheduler;
+
+public class BugFix7247Spec : AkkaSpec {
+    public sealed class NoCellActorRef : MinimalActorRef
+    {
+        public NoCellActorRef(ActorPath path, TaskCompletionSource<object> firstMessage)
+        {
+            Path = path;
+            FirstMessage = firstMessage;
+        }
+
+        protected override void TellInternal(object message, IActorRef sender)
+        {
+            FirstMessage.TrySetResult(message);
+        }
+
+        public TaskCompletionSource<object> FirstMessage { get; }
+
+        public override ActorPath Path { get; }
+        public override IActorRefProvider Provider => throw new NotImplementedException();
+    }
+
+    [Fact(DisplayName = "Should not send ScheduledTellMsg envelopes to IActorRefs with no cell")]
+    public async Task ShouldNotSendScheduledTellMsgToNoCellActorRefs()
+    {
+        // arrange
+        var noCellPath = new RootActorPath(Address.AllSystems);
+        var tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var noCellRef = new NoCellActorRef(noCellPath, tcs);
+        
+        // act
+        var msg = "hit";
+        Sys.Scheduler.ScheduleTellOnce(TimeSpan.FromMicroseconds(1), noCellRef, msg, ActorRefs.NoSender);
+        var respMsg = await tcs.Task;
+        
+        // assert
+        Assert.Equal(msg, respMsg);
+    }
+}

--- a/src/core/Akka.Tests/Actor/Scheduler/BugFix7247Spec.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/BugFix7247Spec.cs
@@ -57,7 +57,7 @@ public class BugFix7247Spec : AkkaSpec {
         // act
         var msg = "hit";
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(0.5));
-        Sys.Scheduler.ScheduleTellOnce(TimeSpan.FromMicroseconds(1), router, msg, ActorRefs.NoSender);
+        Sys.Scheduler.ScheduleTellOnce(TimeSpan.FromMilliseconds(1), router, msg, ActorRefs.NoSender);
         await tcs.Task.WithCancellation(cts.Token); // will time out if we don't get our msg
         var respMsg = await tcs.Task;
         

--- a/src/core/Akka/Routing/RoutedActorCell.cs
+++ b/src/core/Akka/Routing/RoutedActorCell.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Akka.Actor;
 using Akka.Actor.Internal;
+using Akka.Actor.Scheduler;
 using Akka.Dispatch;
 using Akka.Util;
 using Akka.Util.Internal;
@@ -193,7 +194,14 @@ namespace Akka.Routing
             if (RouterConfig.IsManagementMessage(envelope.Message))
                 base.SendMessage(envelope);
             else
-                Router.Route(envelope.Message, envelope.Sender);
+            {
+                // Bugfix: https://github.com/akkadotnet/akka.net/issues/7247 
+                if(envelope.Message is IScheduledTellMsg scheduledTellMsg)
+                    Router.Route(scheduledTellMsg.Message, envelope.Sender);
+                else
+                    Router.Route(envelope.Message, envelope.Sender);
+            }
+               
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

Working on reproducing #7247

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7247
