### PR TITLE
Improve traceability of `ITimerMsg`

### DIFF
--- a/src/core/Akka/Actor/Scheduler/TimerScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/TimerScheduler.cs
@@ -41,36 +41,39 @@ namespace Akka.Actor.Scheduler
             }
         }
 
-        public interface ITimerMsg
+        public interface ITimerMsg : IWrappedMessage, INoSerializationVerificationNeeded
         {
             object Key { get; }
             int Generation { get; }
             TimerScheduler Owner { get; }
         }
 
-        private class TimerMsg : ITimerMsg, INoSerializationVerificationNeeded
+        private class TimerMsg : ITimerMsg
         {
             public object Key { get; }
             public int Generation { get; }
             public TimerScheduler Owner { get; }
 
-            public TimerMsg(object key, int generation, TimerScheduler owner)
+            public TimerMsg(object key, int generation, TimerScheduler owner, object message)
             {
-                this.Key = key;
-                this.Generation = generation;
-                this.Owner = owner;
+                Key = key;
+                Generation = generation;
+                Owner = owner;
+                Message = message;
             }
+            
+            public object Message { get; }
 
             public override string ToString()
             {
-                return $"TimerMsg(key={Key}, generation={Generation}, owner={Owner})";
+                return $"TimerMsg(key={Key}, generation={Generation}, owner={Owner}, message={Message})";
             }
         }
 
         private class TimerMsgNotInfluenceReceiveTimeout : TimerMsg, INotInfluenceReceiveTimeout
         {
-            public TimerMsgNotInfluenceReceiveTimeout(object key, int generation, TimerScheduler owner)
-                : base(key, generation, owner)
+            public TimerMsgNotInfluenceReceiveTimeout(object key, int generation, TimerScheduler owner, object message)
+                : base(key, generation, owner, message)
             {
             }
         }
@@ -196,9 +199,9 @@ namespace Akka.Actor.Scheduler
 
             ITimerMsg timerMsg;
             if (msg is INotInfluenceReceiveTimeout)
-                timerMsg = new TimerMsgNotInfluenceReceiveTimeout(key, nextGen, this);
+                timerMsg = new TimerMsgNotInfluenceReceiveTimeout(key, nextGen, this, msg);
             else
-                timerMsg = new TimerMsg(key, nextGen, this);
+                timerMsg = new TimerMsg(key, nextGen, this, msg);
 
             ICancelable task;
             if (repeat)


### PR DESCRIPTION
## Changes

This is mostly a [Phobos](https://phobos.petabridge.com/)-oriented improvement, aimed at making it easier to keep track of scheduled metrics in systems that use `IWithTimer` heavily. Specifically, we now include the content of the message being scheduled inside the payload so we can answer the question "what was scheduled?" without a lot of overhead.

This doesn't affect the public API of Akka.NET at all.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).