### PR TITLE
Fix possible problems with ClusterClient Discovery

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClientDiscovery.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClientDiscovery.cs
@@ -14,6 +14,7 @@ using Akka.Actor;
 using Akka.Discovery;
 using Akka.Event;
 using Akka.Util;
+using Akka.Util.Internal;
 
 #nullable enable
 namespace Akka.Cluster.Tools.Client;
@@ -248,28 +249,10 @@ public class ClusterClientDiscovery: UntypedActor, IWithUnboundedStash, IWithTim
         if (fullContact.Length <= count)
             return fullContact;
         
-        Shuffle(fullContact);
+        fullContact.Shuffle();
         return fullContact.Take(count).ToArray();
     }
 
-    /// <summary>
-    /// Fisher-Yates in-place array shuffle algorithm
-    /// </summary>
-    /// <param name="array"></param>
-    /// <typeparam name="T"></typeparam>
-    private static void Shuffle<T>(T[] array)
-    {
-        var rnd = ThreadLocalRandom.Current;
-        var n = array.Length;
-        for (var i = 0; i < (n - 1); i++)
-        {
-            var r = i + rnd.Next(n - i);
-            var t = array[r];
-            array[r] = array[i];
-            array[i] = t;
-        }
-    }
-    
     private Receive Active(Contact[] contacts)
     {
         if(_verboseLogging && _log.IsDebugEnabled)

--- a/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClientDiscoverySettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClientDiscoverySettings.cs
@@ -18,9 +18,10 @@ public sealed record ClusterClientDiscoverySettings(
     string ReceptionistName,
     string? PortName,
     TimeSpan DiscoveryRetryInterval,
-    TimeSpan DiscoveryTimeout)
+    TimeSpan DiscoveryTimeout,
+    int NumberOfContacts)
 {
-    public static readonly ClusterClientDiscoverySettings Empty = new ("<method>", null, null, "receptionist", null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(60));
+    public static readonly ClusterClientDiscoverySettings Empty = new ("<method>", null, null, "receptionist", null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(60), 3);
     
     public static ClusterClientDiscoverySettings Create(Config clusterClientConfig)
     {
@@ -35,7 +36,8 @@ public sealed record ClusterClientDiscoverySettings(
             config.GetString("receptionist-name", "receptionist"),
             config.GetString("port-name"),
             config.GetTimeSpan("discovery-retry-interval", TimeSpan.FromSeconds(1)),
-            config.GetTimeSpan("discovery-timeout", TimeSpan.FromSeconds(60))
+            config.GetTimeSpan("discovery-timeout", TimeSpan.FromSeconds(60)),
+            config.GetInt("number-of-contacts", 3)
         );
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools/Client/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Client/reference.conf
@@ -102,6 +102,8 @@ akka.cluster.client {
     method = <method>
     actor-system-name = null
     receptionist-name = receptionist
+    # The contact points will be trimmed down to this number of contact points to the client
+    number-of-contacts = 3
     service-name = null
     port-name = null
     discovery-retry-interval = 1s

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -55,11 +55,12 @@ namespace Akka.Cluster.Tools.Client
     {
         [System.Runtime.CompilerServices.NullableAttribute(1)]
         public static readonly Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings Empty;
-        public ClusterClientDiscoverySettings(string DiscoveryMethod, string ActorSystemName, string ServiceName, [System.Runtime.CompilerServices.NullableAttribute(1)] string ReceptionistName, string PortName, System.TimeSpan DiscoveryRetryInterval, System.TimeSpan DiscoveryTimeout) { }
+        public ClusterClientDiscoverySettings(string DiscoveryMethod, string ActorSystemName, string ServiceName, [System.Runtime.CompilerServices.NullableAttribute(1)] string ReceptionistName, string PortName, System.TimeSpan DiscoveryRetryInterval, System.TimeSpan DiscoveryTimeout, int NumberOfContacts) { }
         public string ActorSystemName { get; set; }
         public string DiscoveryMethod { get; set; }
         public System.TimeSpan DiscoveryRetryInterval { get; set; }
         public System.TimeSpan DiscoveryTimeout { get; set; }
+        public int NumberOfContacts { get; set; }
         public string PortName { get; set; }
         [System.Runtime.CompilerServices.NullableAttribute(1)]
         public string ReceptionistName { get; set; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -55,11 +55,12 @@ namespace Akka.Cluster.Tools.Client
     {
         [System.Runtime.CompilerServices.NullableAttribute(1)]
         public static readonly Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings Empty;
-        public ClusterClientDiscoverySettings(string DiscoveryMethod, string ActorSystemName, string ServiceName, [System.Runtime.CompilerServices.NullableAttribute(1)] string ReceptionistName, string PortName, System.TimeSpan DiscoveryRetryInterval, System.TimeSpan DiscoveryTimeout) { }
+        public ClusterClientDiscoverySettings(string DiscoveryMethod, string ActorSystemName, string ServiceName, [System.Runtime.CompilerServices.NullableAttribute(1)] string ReceptionistName, string PortName, System.TimeSpan DiscoveryRetryInterval, System.TimeSpan DiscoveryTimeout, int NumberOfContacts) { }
         public string ActorSystemName { get; set; }
         public string DiscoveryMethod { get; set; }
         public System.TimeSpan DiscoveryRetryInterval { get; set; }
         public System.TimeSpan DiscoveryTimeout { get; set; }
+        public int NumberOfContacts { get; set; }
         public string PortName { get; set; }
         [System.Runtime.CompilerServices.NullableAttribute(1)]
         public string ReceptionistName { get; set; }


### PR DESCRIPTION
## Changes

* Limits the number of initial contacts being used in ClusterClient Discovery to improve lost connection detection
* Randomly choose the initial contacts to prevent thundering herd problem