### PR TITLE
Update failure message syntax

### DIFF
--- a/docs/articles/actors/receive-actor-api.md
+++ b/docs/articles/actors/receive-actor-api.md
@@ -419,7 +419,7 @@ try
 }
 catch (Exception e)
 {
-    Sender.Tell(new Failure { Exception = e }, Self);
+    Sender.Tell(new Akka.Actor.Status.Failure(e), Self);
 }
 ```
 


### PR DESCRIPTION
Followed the docs to add a failure response for `.Ask` and saw that `new Failure {}` is deprecated. This updates the docs to use the now-recommended syntax as I understand it.

Fixes #

## Changes

Updates the section on `.Ask` failures to move to `new Akka.Actor.Status.Failure(e)`.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [x] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

N/A -- doc only

### This PR's Benchmarks

N/A -- doc only