### PR TITLE
Akka.Cluster: `ClusterMessageSerializer` benchmarks

### DIFF
--- a/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Akka.Cluster.Benchmarks.csproj
@@ -15,6 +15,9 @@
     </ItemGroup>
 
     <ItemGroup>
+      <Compile Include="..\..\core\Akka.Cluster.Tests\TestMember.cs">
+        <Link>TestMember.cs</Link>
+      </Compile>
       <Compile Include="..\Akka.Benchmarks\Configurations\Configs.cs">
         <Link>Configs.cs</Link>
       </Compile>

--- a/src/benchmark/Akka.Cluster.Benchmarks/Serialization/ClusterMessageSerializerBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Serialization/ClusterMessageSerializerBenchmarks.cs
@@ -1,0 +1,137 @@
+// -----------------------------------------------------------------------
+//  <copyright file="ClusterMessageSerializerBenchmarks.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Immutable;
+using Akka.Actor;
+using Akka.Cluster.Serialization;
+using Akka.Cluster.Tests;
+using Akka.Util;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Cluster.Benchmarks.Serialization;
+
+public sealed class ClusterMessageSerializerBenchmarks
+{
+    private ExtendedActorSystem system;
+    private ClusterMessageSerializer clusterMessageSerializer;
+
+    private static readonly Member a1 = TestMember.Create(new Address("akka.tcp", "sys", "a", 2552),
+        MemberStatus.Joining, appVersion: AppVersion.Create("1.0.0"));
+
+    private static readonly Member b1 = TestMember.Create(new Address("akka.tcp", "sys", "b", 2552), MemberStatus.Up,
+        ImmutableHashSet.Create("r1"), appVersion: AppVersion.Create("1.1.0"));
+
+    private static readonly Member c1 = TestMember.Create(new Address("akka.tcp", "sys", "c", 2552),
+        MemberStatus.Leaving, ImmutableHashSet.Create("r2"), appVersion: AppVersion.Create("1.1.0"));
+
+    private static readonly Member d1 = TestMember.Create(new Address("akka.tcp", "sys", "d", 2552),
+        MemberStatus.Exiting, ImmutableHashSet.Create("r1", "r2"));
+
+    private static readonly Member e1 = TestMember.Create(new Address("akka.tcp", "sys", "e", 2552), MemberStatus.Down,
+        ImmutableHashSet.Create("r3"));
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        system = (ExtendedActorSystem)ActorSystem.Create("system", "akka.actor.provider=cluster");
+        clusterMessageSerializer = new ClusterMessageSerializer(system);
+    }
+
+    private static readonly ClusterHeartbeatSender.Heartbeat heartbeat =
+        new ClusterHeartbeatSender.Heartbeat(a1.UniqueAddress.Address, 10, 3);
+
+    private static readonly ClusterHeartbeatSender.HeartbeatRsp heartbeatRsp =
+        new ClusterHeartbeatSender.HeartbeatRsp(b1.UniqueAddress, 10, 3);
+
+    [Benchmark]
+    public byte[] Serialize_Heartbeat()
+    {
+        return clusterMessageSerializer.ToBinary(heartbeat);
+    }
+
+    [Benchmark]
+    public object Deserialize_Heartbeat()
+    {
+        return clusterMessageSerializer.FromBinary(clusterMessageSerializer.ToBinary(heartbeat),
+            clusterMessageSerializer.Manifest(heartbeat));
+    }
+
+    [Benchmark]
+    public byte[] Serialize_HeartbeatRsp()
+    {
+        return clusterMessageSerializer.ToBinary(heartbeatRsp);
+    }
+
+    [Benchmark]
+    public object Deserialize_HeartbeatRsp()
+    {
+        return clusterMessageSerializer.FromBinary(clusterMessageSerializer.ToBinary(heartbeatRsp),
+            clusterMessageSerializer.Manifest(heartbeatRsp));
+    }
+
+    private static readonly GossipEnvelope _gossipEnvelope = new GossipEnvelope(a1.UniqueAddress, c1.UniqueAddress,
+        new Gossip(ImmutableSortedSet.Create(a1, b1, c1, d1)).Increment(new VectorClock.Node("node1"))
+            .Increment(new VectorClock.Node("node2"))
+            .Seen(a1.UniqueAddress)
+            .Seen(b1.UniqueAddress));
+    private static readonly Gossip _gossip2 = _gossipEnvelope.Gossip
+        .Increment(new VectorClock.Node("node3"))
+        .Increment(new VectorClock.Node("node4"))
+        .Seen(a1.UniqueAddress).Seen(c1.UniqueAddress);
+    private static readonly Reachability _reachability = Reachability.Empty.Unreachable(a1.UniqueAddress, e1.UniqueAddress).Unreachable(b1.UniqueAddress, e1.UniqueAddress);
+
+    private static readonly Gossip _gossip3 = _gossip2.Copy(ImmutableSortedSet.Create(a1, b1, c1, d1, e1),
+        overview: _gossip2.Overview.Copy(reachability: _reachability));
+    
+    private static readonly GossipStatus _gossipStatus = new GossipStatus(a1.UniqueAddress, _gossip3.Version);
+    private static readonly InternalClusterAction.Welcome _welcome = new InternalClusterAction.Welcome(a1.UniqueAddress, _gossip3);
+    
+    [Benchmark]
+    public byte[] Serialize_GossipEnvelope()
+    {
+        return clusterMessageSerializer.ToBinary(_gossipEnvelope);
+    }
+    
+    [Benchmark]
+    public object Deserialize_GossipEnvelope()
+    {
+        return clusterMessageSerializer.FromBinary(clusterMessageSerializer.ToBinary(_gossipEnvelope),
+            clusterMessageSerializer.Manifest(_gossipEnvelope));
+    }
+    
+    [Benchmark]
+    public byte[] Serialize_GossipStatus()
+    {
+        return clusterMessageSerializer.ToBinary(_gossipStatus);
+    }
+    
+    [Benchmark]
+    public object Deserialize_GossipStatus()
+    {
+        return clusterMessageSerializer.FromBinary(clusterMessageSerializer.ToBinary(_gossipStatus),
+            clusterMessageSerializer.Manifest(_gossipStatus));
+    }
+    
+    [Benchmark]
+    public byte[] Serialize_Welcome()
+    {
+        return clusterMessageSerializer.ToBinary(_welcome);
+    }
+    
+    [Benchmark]
+    public object Deserialize_Welcome()
+    {
+        return clusterMessageSerializer.FromBinary(clusterMessageSerializer.ToBinary(_welcome),
+            clusterMessageSerializer.Manifest(_welcome));
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        system.Dispose();
+    }
+}

--- a/src/benchmark/Akka.Cluster.Benchmarks/Serialization/ClusterMessageSerializerBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Serialization/ClusterMessageSerializerBenchmarks.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Immutable;
 using Akka.Actor;
+using Akka.Benchmarks.Configurations;
 using Akka.Cluster.Serialization;
 using Akka.Cluster.Tests;
 using Akka.Util;
@@ -14,7 +15,8 @@ using BenchmarkDotNet.Attributes;
 
 namespace Akka.Cluster.Benchmarks.Serialization;
 
-public sealed class ClusterMessageSerializerBenchmarks
+[Config(typeof(MicroBenchmarkConfig))]
+public class ClusterMessageSerializerBenchmarks
 {
     private ExtendedActorSystem _system;
     private ClusterMessageSerializer _clusterMessageSerializer;

--- a/src/benchmark/Akka.Cluster.Benchmarks/Serialization/ClusterMessageSerializerBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Serialization/ClusterMessageSerializerBenchmarks.cs
@@ -16,122 +16,120 @@ namespace Akka.Cluster.Benchmarks.Serialization;
 
 public sealed class ClusterMessageSerializerBenchmarks
 {
-    private ExtendedActorSystem system;
-    private ClusterMessageSerializer clusterMessageSerializer;
+    private ExtendedActorSystem _system;
+    private ClusterMessageSerializer _clusterMessageSerializer;
 
-    private static readonly Member a1 = TestMember.Create(new Address("akka.tcp", "sys", "a", 2552),
+    private static readonly Member A1 = TestMember.Create(new Address("akka.tcp", "sys", "a", 2552),
         MemberStatus.Joining, appVersion: AppVersion.Create("1.0.0"));
 
-    private static readonly Member b1 = TestMember.Create(new Address("akka.tcp", "sys", "b", 2552), MemberStatus.Up,
+    private static readonly Member B1 = TestMember.Create(new Address("akka.tcp", "sys", "b", 2552), MemberStatus.Up,
         ImmutableHashSet.Create("r1"), appVersion: AppVersion.Create("1.1.0"));
 
-    private static readonly Member c1 = TestMember.Create(new Address("akka.tcp", "sys", "c", 2552),
+    private static readonly Member C1 = TestMember.Create(new Address("akka.tcp", "sys", "c", 2552),
         MemberStatus.Leaving, ImmutableHashSet.Create("r2"), appVersion: AppVersion.Create("1.1.0"));
 
-    private static readonly Member d1 = TestMember.Create(new Address("akka.tcp", "sys", "d", 2552),
+    private static readonly Member D1 = TestMember.Create(new Address("akka.tcp", "sys", "d", 2552),
         MemberStatus.Exiting, ImmutableHashSet.Create("r1", "r2"));
 
-    private static readonly Member e1 = TestMember.Create(new Address("akka.tcp", "sys", "e", 2552), MemberStatus.Down,
+    private static readonly Member E1 = TestMember.Create(new Address("akka.tcp", "sys", "e", 2552), MemberStatus.Down,
         ImmutableHashSet.Create("r3"));
 
     [GlobalSetup]
     public void Setup()
     {
-        system = (ExtendedActorSystem)ActorSystem.Create("system", "akka.actor.provider=cluster");
-        clusterMessageSerializer = new ClusterMessageSerializer(system);
+        _system = (ExtendedActorSystem)ActorSystem.Create("system", "akka.actor.provider=cluster");
+        _clusterMessageSerializer = new ClusterMessageSerializer(_system);
     }
 
-    private static readonly ClusterHeartbeatSender.Heartbeat heartbeat =
-        new ClusterHeartbeatSender.Heartbeat(a1.UniqueAddress.Address, 10, 3);
+    private static readonly ClusterHeartbeatSender.Heartbeat Heartbeat = new(A1.UniqueAddress.Address, 10, 3);
 
-    private static readonly ClusterHeartbeatSender.HeartbeatRsp heartbeatRsp =
-        new ClusterHeartbeatSender.HeartbeatRsp(b1.UniqueAddress, 10, 3);
+    private static readonly ClusterHeartbeatSender.HeartbeatRsp HeartbeatRsp = new(B1.UniqueAddress, 10, 3);
 
     [Benchmark]
     public byte[] Serialize_Heartbeat()
     {
-        return clusterMessageSerializer.ToBinary(heartbeat);
+        return _clusterMessageSerializer.ToBinary(Heartbeat);
     }
 
     [Benchmark]
     public object Deserialize_Heartbeat()
     {
-        return clusterMessageSerializer.FromBinary(clusterMessageSerializer.ToBinary(heartbeat),
-            clusterMessageSerializer.Manifest(heartbeat));
+        return _clusterMessageSerializer.FromBinary(_clusterMessageSerializer.ToBinary(Heartbeat),
+            _clusterMessageSerializer.Manifest(Heartbeat));
     }
 
     [Benchmark]
     public byte[] Serialize_HeartbeatRsp()
     {
-        return clusterMessageSerializer.ToBinary(heartbeatRsp);
+        return _clusterMessageSerializer.ToBinary(HeartbeatRsp);
     }
 
     [Benchmark]
     public object Deserialize_HeartbeatRsp()
     {
-        return clusterMessageSerializer.FromBinary(clusterMessageSerializer.ToBinary(heartbeatRsp),
-            clusterMessageSerializer.Manifest(heartbeatRsp));
+        return _clusterMessageSerializer.FromBinary(_clusterMessageSerializer.ToBinary(HeartbeatRsp),
+            _clusterMessageSerializer.Manifest(HeartbeatRsp));
     }
 
-    private static readonly GossipEnvelope _gossipEnvelope = new GossipEnvelope(a1.UniqueAddress, c1.UniqueAddress,
-        new Gossip(ImmutableSortedSet.Create(a1, b1, c1, d1)).Increment(new VectorClock.Node("node1"))
+    private static readonly GossipEnvelope GossipEnvelope = new(A1.UniqueAddress, C1.UniqueAddress,
+        new Gossip(ImmutableSortedSet.Create(A1, B1, C1, D1)).Increment(new VectorClock.Node("node1"))
             .Increment(new VectorClock.Node("node2"))
-            .Seen(a1.UniqueAddress)
-            .Seen(b1.UniqueAddress));
-    private static readonly Gossip _gossip2 = _gossipEnvelope.Gossip
+            .Seen(A1.UniqueAddress)
+            .Seen(B1.UniqueAddress));
+    private static readonly Gossip Gossip2 = GossipEnvelope.Gossip
         .Increment(new VectorClock.Node("node3"))
         .Increment(new VectorClock.Node("node4"))
-        .Seen(a1.UniqueAddress).Seen(c1.UniqueAddress);
-    private static readonly Reachability _reachability = Reachability.Empty.Unreachable(a1.UniqueAddress, e1.UniqueAddress).Unreachable(b1.UniqueAddress, e1.UniqueAddress);
+        .Seen(A1.UniqueAddress).Seen(C1.UniqueAddress);
+    private static readonly Reachability Reachability = Reachability.Empty.Unreachable(A1.UniqueAddress, E1.UniqueAddress).Unreachable(B1.UniqueAddress, E1.UniqueAddress);
 
-    private static readonly Gossip _gossip3 = _gossip2.Copy(ImmutableSortedSet.Create(a1, b1, c1, d1, e1),
-        overview: _gossip2.Overview.Copy(reachability: _reachability));
+    private static readonly Gossip Gossip3 = Gossip2.Copy(ImmutableSortedSet.Create(A1, B1, C1, D1, E1),
+        overview: Gossip2.Overview.Copy(reachability: Reachability));
     
-    private static readonly GossipStatus _gossipStatus = new GossipStatus(a1.UniqueAddress, _gossip3.Version);
-    private static readonly InternalClusterAction.Welcome _welcome = new InternalClusterAction.Welcome(a1.UniqueAddress, _gossip3);
+    private static readonly GossipStatus GossipStatus = new(A1.UniqueAddress, Gossip3.Version);
+    private static readonly InternalClusterAction.Welcome Welcome = new(A1.UniqueAddress, Gossip3);
     
     [Benchmark]
     public byte[] Serialize_GossipEnvelope()
     {
-        return clusterMessageSerializer.ToBinary(_gossipEnvelope);
+        return _clusterMessageSerializer.ToBinary(GossipEnvelope);
     }
     
     [Benchmark]
     public object Deserialize_GossipEnvelope()
     {
-        return clusterMessageSerializer.FromBinary(clusterMessageSerializer.ToBinary(_gossipEnvelope),
-            clusterMessageSerializer.Manifest(_gossipEnvelope));
+        return _clusterMessageSerializer.FromBinary(_clusterMessageSerializer.ToBinary(GossipEnvelope),
+            _clusterMessageSerializer.Manifest(GossipEnvelope));
     }
     
     [Benchmark]
     public byte[] Serialize_GossipStatus()
     {
-        return clusterMessageSerializer.ToBinary(_gossipStatus);
+        return _clusterMessageSerializer.ToBinary(GossipStatus);
     }
     
     [Benchmark]
     public object Deserialize_GossipStatus()
     {
-        return clusterMessageSerializer.FromBinary(clusterMessageSerializer.ToBinary(_gossipStatus),
-            clusterMessageSerializer.Manifest(_gossipStatus));
+        return _clusterMessageSerializer.FromBinary(_clusterMessageSerializer.ToBinary(GossipStatus),
+            _clusterMessageSerializer.Manifest(GossipStatus));
     }
     
     [Benchmark]
     public byte[] Serialize_Welcome()
     {
-        return clusterMessageSerializer.ToBinary(_welcome);
+        return _clusterMessageSerializer.ToBinary(Welcome);
     }
     
     [Benchmark]
     public object Deserialize_Welcome()
     {
-        return clusterMessageSerializer.FromBinary(clusterMessageSerializer.ToBinary(_welcome),
-            clusterMessageSerializer.Manifest(_welcome));
+        return _clusterMessageSerializer.FromBinary(_clusterMessageSerializer.ToBinary(Welcome),
+            _clusterMessageSerializer.Manifest(Welcome));
     }
 
     [GlobalCleanup]
     public void Cleanup()
     {
-        system.Dispose();
+        _system.Dispose();
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
@@ -1,5 +1,6 @@
 ﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Metrics")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
@@ -1,5 +1,6 @@
 ﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Metrics")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]

--- a/src/core/Akka.Cluster/Member.cs
+++ b/src/core/Akka.Cluster/Member.cs
@@ -11,7 +11,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
 using Akka.Util;
-using Akka.Util.Internal;
 using Newtonsoft.Json;
 
 namespace Akka.Cluster

--- a/src/core/Akka.Cluster/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.Cluster/Properties/AssemblyInfo.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: InternalsVisibleTo("Akka.Cluster.Tests")]
+[assembly: InternalsVisibleTo("Akka.Cluster.Benchmarks")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Tests.MultiNode")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Tests.Performance")]
 [assembly: InternalsVisibleTo("Akka.Cluster.TestKit")]


### PR DESCRIPTION
## Changes

Trying to measure Akka.Cluster serialization overhead for gossip.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).