### PR TITLE
Akka.Cluster: improve gossip serialization performance

### DIFF
--- a/src/core/Akka.Cluster/Serialization/ClusterMessageSerializer.cs
+++ b/src/core/Akka.Cluster/Serialization/ClusterMessageSerializer.cs
@@ -328,6 +328,7 @@ namespace Akka.Cluster.Serialization
             // rather than call a bunch of individual LINQ operations, we're going to do it all in one go
             var allRoles = new HashSet<string>();
             var allAddresses = new List<UniqueAddress>(gossip.Members.Count);
+            var addressesToProto = new List<Proto.Msg.UniqueAddress>(gossip.Members.Count);
             var allAppVersions = new HashSet<string>();
             var addressMapping = new Dictionary<UniqueAddress, int>();
             var addrIndex = 0;
@@ -345,6 +346,7 @@ namespace Akka.Cluster.Serialization
                     addressMapping.Add(m.UniqueAddress, addrIndex);
                     addrIndex += 1;
                 }
+                addressesToProto.Add(UniqueAddressToProto(m.UniqueAddress));
                 var previousRoleCount = allRoles.Count;
                 allRoles.UnionWith(m.Roles);
                 if (allRoles.Count > previousRoleCount) // found a new role
@@ -385,7 +387,7 @@ namespace Akka.Cluster.Serialization
             overview.ObserverReachability.AddRange(reachabilityProto);
 
             var message = new Proto.Msg.Gossip();
-            message.AllAddresses.AddRange(allAddresses.Select(UniqueAddressToProto));
+            message.AllAddresses.AddRange(addressesToProto);
             message.AllRoles.AddRange(allRoles);
             message.AllHashes.AddRange(allHashes);
             message.Members.AddRange(membersProtos);

--- a/src/core/Akka.Cluster/Serialization/ClusterMessageSerializer.cs
+++ b/src/core/Akka.Cluster/Serialization/ClusterMessageSerializer.cs
@@ -327,7 +327,6 @@ namespace Akka.Cluster.Serialization
             
             // rather than call a bunch of individual LINQ operations, we're going to do it all in one go
             var allRoles = new HashSet<string>();
-            var allAddresses = new List<UniqueAddress>(gossip.Members.Count);
             var addressesToProto = new List<Proto.Msg.UniqueAddress>(gossip.Members.Count);
             var allAppVersions = new HashSet<string>();
             var addressMapping = new Dictionary<UniqueAddress, int>();
@@ -340,7 +339,6 @@ namespace Akka.Cluster.Serialization
 
             foreach (var m in allMembers)
             {
-                allAddresses.Add(m.UniqueAddress);
                 if (!addressMapping.ContainsKey(m.UniqueAddress))
                 {
                     addressMapping.Add(m.UniqueAddress, addrIndex);

--- a/src/core/Akka.Cluster/Serialization/ClusterMessageSerializer.cs
+++ b/src/core/Akka.Cluster/Serialization/ClusterMessageSerializer.cs
@@ -349,7 +349,7 @@ namespace Akka.Cluster.Serialization
                     foreach(var role in m.Roles)
                     {
                         // TODO: TryAdd would be nice here
-                        if (roleMapping.ContainsKey(role))
+                        if (!roleMapping.ContainsKey(role))
                         {
                             roleMapping.Add(role, roleIndex);
                             roleIndex += 1;


### PR DESCRIPTION
## Changes

Performance golf to attempt to improve serialization performance on `Gossip` data structures

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

```

BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.4529/22H2/2022Update)
AMD Ryzen 7 1700, 1 CPU, 16 logical and 8 physical cores
.NET SDK 8.0.303
  [Host]     : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2


```
| Method                     | Mean        | Error       | StdDev      | Gen0   | Allocated |
|--------------------------- |------------:|------------:|------------:|-------:|----------:|
| Serialize_Heartbeat        |    392.8 ns |     7.83 ns |    21.84 ns | 0.0534 |     224 B |
| Deserialize_Heartbeat      |    914.4 ns |    18.04 ns |    40.34 ns | 0.1640 |     688 B |
| Serialize_HeartbeatRsp     |    492.4 ns |     9.44 ns |    24.69 ns | 0.0629 |     264 B |
| Deserialize_HeartbeatRsp   |  1,149.8 ns |    22.99 ns |    55.51 ns | 0.1907 |     800 B |
| Serialize_GossipEnvelope   | 27,185.0 ns |   675.36 ns | 1,980.72 ns | 1.7700 |    7496 B |
| Deserialize_GossipEnvelope | 51,976.9 ns | 1,186.86 ns | 3,499.47 ns | 3.9673 |   16624 B |
| Serialize_GossipStatus     |  3,124.2 ns |    71.97 ns |   211.07 ns | 0.3929 |    1648 B |
| Deserialize_GossipStatus   |  8,466.2 ns |   196.12 ns |   559.54 ns | 0.9766 |    4096 B |
| Serialize_Welcome          | 42,868.1 ns |   989.00 ns | 2,869.27 ns | 2.2583 |    9592 B |
| Deserialize_Welcome        | 76,814.4 ns | 1,800.46 ns | 5,280.43 ns | 4.8828 |   20480 B |
