### PR TITLE
Optimize cluster message serializer benchmarks

### DIFF
--- a/src/benchmark/Akka.Cluster.Benchmarks/Serialization/ClusterMessageSerializerBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Serialization/ClusterMessageSerializerBenchmarks.cs
@@ -5,6 +5,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Immutable;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
@@ -39,8 +40,8 @@ public class ClusterMessageSerializerBenchmarks
     [GlobalSetup]
     public void Setup()
     {
-        _system = (ExtendedActorSystem)ActorSystem.Create("system", "akka.actor.provider=cluster");
-        _clusterMessageSerializer = new ClusterMessageSerializer(_system);
+        _system ??= (ExtendedActorSystem)ActorSystem.Create("system", "akka.actor.provider=cluster");
+        _clusterMessageSerializer ??= new ClusterMessageSerializer(_system);
     }
 
     private static readonly ClusterHeartbeatSender.Heartbeat Heartbeat = new(A1.UniqueAddress.Address, 10, 3);
@@ -53,11 +54,23 @@ public class ClusterMessageSerializerBenchmarks
         return _clusterMessageSerializer.ToBinary(Heartbeat);
     }
 
+    private static byte[] _serializedHeartbeat = Array.Empty<byte>();
+    private static string _heartbeatManifest = string.Empty;
+    
+    [GlobalSetup(Target = nameof(Deserialize_Heartbeat))]
+    public void SetupSerializedHeartbeat()
+    {
+        Setup();
+        if(_serializedHeartbeat.Length == 0)
+            _serializedHeartbeat = _clusterMessageSerializer.ToBinary(Heartbeat);
+        if(string.IsNullOrEmpty(_heartbeatManifest))
+            _heartbeatManifest = _clusterMessageSerializer.Manifest(Heartbeat);
+    }
+
     [Benchmark]
     public object Deserialize_Heartbeat()
     {
-        return _clusterMessageSerializer.FromBinary(_clusterMessageSerializer.ToBinary(Heartbeat),
-            _clusterMessageSerializer.Manifest(Heartbeat));
+        return _clusterMessageSerializer.FromBinary(_serializedHeartbeat, _heartbeatManifest);
     }
 
     [Benchmark]
@@ -66,11 +79,23 @@ public class ClusterMessageSerializerBenchmarks
         return _clusterMessageSerializer.ToBinary(HeartbeatRsp);
     }
 
+    private static byte[] _serializedHeartbeatRsp = Array.Empty<byte>();
+    private static string _heartbeatRspManifest = string.Empty;
+    
+    [GlobalSetup(Target = nameof(Deserialize_HeartbeatRsp))]
+    public void SetupSerializedHeartbeatRsp()
+    {
+        Setup();
+        if(_serializedHeartbeatRsp.Length == 0)
+            _serializedHeartbeatRsp = _clusterMessageSerializer.ToBinary(HeartbeatRsp);
+        if(string.IsNullOrEmpty(_heartbeatRspManifest))
+            _heartbeatRspManifest = _clusterMessageSerializer.Manifest(HeartbeatRsp);
+    }
+    
     [Benchmark]
     public object Deserialize_HeartbeatRsp()
     {
-        return _clusterMessageSerializer.FromBinary(_clusterMessageSerializer.ToBinary(HeartbeatRsp),
-            _clusterMessageSerializer.Manifest(HeartbeatRsp));
+        return _clusterMessageSerializer.FromBinary(_serializedHeartbeatRsp, _heartbeatRspManifest);
     }
 
     private static readonly GossipEnvelope GossipEnvelope = new(A1.UniqueAddress, C1.UniqueAddress,
@@ -96,11 +121,23 @@ public class ClusterMessageSerializerBenchmarks
         return _clusterMessageSerializer.ToBinary(GossipEnvelope);
     }
     
+    private static byte[] _serializedGossipEnvelope = Array.Empty<byte>();
+    private static string _gossipEnvelopeManifest = string.Empty;
+    
+    [GlobalSetup(Target = nameof(Deserialize_GossipEnvelope))]
+    public void SetupSerializedGossipEnvelope()
+    {
+        Setup();
+        if(_serializedGossipEnvelope.Length == 0)
+            _serializedGossipEnvelope = _clusterMessageSerializer.ToBinary(GossipEnvelope);
+        if(string.IsNullOrEmpty(_gossipEnvelopeManifest))
+            _gossipEnvelopeManifest = _clusterMessageSerializer.Manifest(GossipEnvelope);
+    }
+    
     [Benchmark]
     public object Deserialize_GossipEnvelope()
     {
-        return _clusterMessageSerializer.FromBinary(_clusterMessageSerializer.ToBinary(GossipEnvelope),
-            _clusterMessageSerializer.Manifest(GossipEnvelope));
+        return _clusterMessageSerializer.FromBinary(_serializedGossipEnvelope, _gossipEnvelopeManifest);
     }
     
     [Benchmark]
@@ -109,11 +146,23 @@ public class ClusterMessageSerializerBenchmarks
         return _clusterMessageSerializer.ToBinary(GossipStatus);
     }
     
+    private static byte[] _serializedGossipStatus = Array.Empty<byte>();
+    private static string _gossipStatusManifest = string.Empty;
+    
+    [GlobalSetup(Target = nameof(Deserialize_GossipStatus))]
+    public void SetupSerializedGossipStatus()
+    {
+        Setup();
+        if(_serializedGossipStatus.Length == 0)
+            _serializedGossipStatus = _clusterMessageSerializer.ToBinary(GossipStatus);
+        if(string.IsNullOrEmpty(_gossipStatusManifest))
+            _gossipStatusManifest = _clusterMessageSerializer.Manifest(GossipStatus);
+    }
+    
     [Benchmark]
     public object Deserialize_GossipStatus()
     {
-        return _clusterMessageSerializer.FromBinary(_clusterMessageSerializer.ToBinary(GossipStatus),
-            _clusterMessageSerializer.Manifest(GossipStatus));
+        return _clusterMessageSerializer.FromBinary(_serializedGossipStatus, _gossipStatusManifest);
     }
     
     [Benchmark]
@@ -122,11 +171,23 @@ public class ClusterMessageSerializerBenchmarks
         return _clusterMessageSerializer.ToBinary(Welcome);
     }
     
+    private static byte[] _serializedWelcome = Array.Empty<byte>();
+    private static string _welcomeManifest = string.Empty;
+    
+    [GlobalSetup(Target = nameof(Deserialize_Welcome))]
+    public void SetupSerializedWelcome()
+    {
+        Setup();
+        if(_serializedWelcome.Length == 0)
+            _serializedWelcome = _clusterMessageSerializer.ToBinary(Welcome);
+        if(string.IsNullOrEmpty(_welcomeManifest))
+            _welcomeManifest = _clusterMessageSerializer.Manifest(Welcome);
+    }
+    
     [Benchmark]
     public object Deserialize_Welcome()
     {
-        return _clusterMessageSerializer.FromBinary(_clusterMessageSerializer.ToBinary(Welcome),
-            _clusterMessageSerializer.Manifest(Welcome));
+        return _clusterMessageSerializer.FromBinary(_serializedWelcome, _welcomeManifest);
     }
 
     [GlobalCleanup]


### PR DESCRIPTION
## Changes

* Cache message serialized byte array and manifest before performing deserialization benchmark