### PR TITLE
make ActorCell.Stop(IActorRef) virtual

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -122,7 +122,7 @@ namespace Akka.Actor
         protected void SetTerminated() { }
         public virtual void Start() { }
         protected void Stash(Akka.Dispatch.SysMsg.SystemMessage msg) { }
-        public void Stop(Akka.Actor.IActorRef child) { }
+        public virtual void Stop(Akka.Actor.IActorRef child) { }
         public void Stop() { }
         protected void StopFunctionRefs() { }
         public void Suspend() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -122,7 +122,7 @@ namespace Akka.Actor
         protected void SetTerminated() { }
         public virtual void Start() { }
         protected void Stash(Akka.Dispatch.SysMsg.SystemMessage msg) { }
-        public void Stop(Akka.Actor.IActorRef child) { }
+        public virtual void Stop(Akka.Actor.IActorRef child) { }
         public void Stop() { }
         protected void StopFunctionRefs() { }
         public void Suspend() { }

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -138,13 +138,11 @@ namespace Akka.Actor
         ///     Stops the specified child.
         /// </summary>
         /// <param name="child">The child.</param>
-        public void Stop(IActorRef child)
+        public virtual void Stop(IActorRef child)
         {
-            ChildRestartStats stats;
-            if (ChildrenContainer.TryGetByRef(child, out stats))
+            if (ChildrenContainer.TryGetByRef(child, out _))
             {
-                var repointableActorRef = child as RepointableActorRef;
-                if (repointableActorRef == null || repointableActorRef.IsStarted)
+                if (child is not RepointableActorRef repointableActorRef || repointableActorRef.IsStarted)
                 {
                     while (true)
                     {


### PR DESCRIPTION
## Changes

Using this for some Phobos improvements, to make it easier to trace actor terminations. 

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Changes in public API reviewed, if any.
