### PR TITLE
Akka.Cluster.Sharding: added tests for DData consistency settings

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
@@ -9,6 +9,7 @@ using System;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
+using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -29,6 +30,8 @@ namespace Akka.Cluster.Sharding.Tests
         {
             ClusterSharding.Get(Sys);
             var config = Sys.Settings.Config.GetConfig("akka.cluster.sharding");
+
+            var clusterShardingSettings = ClusterShardingSettings.Create(Sys);
 
             Assert.False(config.IsNullOrEmpty());
             Assert.Equal("sharding", config.GetString("guardian-name"));
@@ -64,6 +67,12 @@ namespace Akka.Cluster.Sharding.Tests
             Assert.Equal(string.Empty, singletonConfig.GetString("role"));
             Assert.Equal(TimeSpan.FromSeconds(1), singletonConfig.GetTimeSpan("hand-over-retry-interval"));
             Assert.Equal(15, singletonConfig.GetInt("min-number-of-hand-over-retries"));
+            
+            // DData settings
+            var minCap = config.GetInt("distributed-data.majority-min-cap");
+            minCap.Should().Be(5);
+            clusterShardingSettings.TuningParameters.CoordinatorStateReadMajorityPlus.Should().Be(5);
+            clusterShardingSettings.TuningParameters.CoordinatorStateWriteMajorityPlus.Should().Be(3);
         }
     }
 }


### PR DESCRIPTION
## Changes

Part of our investigation into https://github.com/akkadotnet/akka.net/issues/6973 - getting some of our sharding settings for DData under test coverage.