### PR TITLE
Akka.Cluster.Sharding: enable `prefer-oldest` by default on `Replicator`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
@@ -74,5 +74,21 @@ namespace Akka.Cluster.Sharding.Tests
             clusterShardingSettings.TuningParameters.CoordinatorStateReadMajorityPlus.Should().Be(5);
             clusterShardingSettings.TuningParameters.CoordinatorStateWriteMajorityPlus.Should().Be(3);
         }
+
+        [Fact]
+        public void ClusterSharding_replicator_settings_should_have_default_values()
+        {
+            ClusterSharding.Get(Sys);
+            var clusterShardingSettings = ClusterShardingSettings.Create(Sys);
+            var replicatorSettings = ClusterShardingGuardian.GetReplicatorSettings(clusterShardingSettings);
+            
+            replicatorSettings.Should().NotBeNull();
+            replicatorSettings.Role.Should().BeNullOrEmpty();
+            
+            // only populated when remember-entities is enabled
+            replicatorSettings.DurableKeys.Should().BeEmpty();
+            replicatorSettings.MaxDeltaElements.Should().Be(5);
+            replicatorSettings.PreferOldest.Should().BeTrue();
+        }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingConfigSpec.cs
@@ -9,6 +9,7 @@ using System;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
+using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests
 {
@@ -29,6 +30,8 @@ namespace Akka.Cluster.Sharding.Tests
         {
             ClusterSharding.Get(Sys);
             var config = Sys.Settings.Config.GetConfig("akka.cluster.sharding");
+
+            var clusterShardingSettings = ClusterShardingSettings.Create(Sys);
 
             Assert.False(config.IsNullOrEmpty());
             Assert.Equal("sharding", config.GetString("guardian-name"));
@@ -64,6 +67,12 @@ namespace Akka.Cluster.Sharding.Tests
             Assert.Equal(string.Empty, singletonConfig.GetString("role"));
             Assert.Equal(TimeSpan.FromSeconds(1), singletonConfig.GetTimeSpan("hand-over-retry-interval"));
             Assert.Equal(15, singletonConfig.GetInt("min-number-of-hand-over-retries"));
+            
+            // DData settings
+            var minCap = config.GetInt("distributed-data.majority-min-cap");
+            minCap.Should().Be(5);
+            clusterShardingSettings.TuningParameters.CoordinatorStateReadMajorityPlus.Should().Be(5);
+            clusterShardingSettings.TuningParameters.CoordinatorStateWriteMajorityPlus.Should().Be(3);
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -297,7 +297,7 @@ namespace Akka.Cluster.Sharding
             });
         }
 
-        private ReplicatorSettings GetReplicatorSettings(ClusterShardingSettings shardingSettings)
+        internal static ReplicatorSettings GetReplicatorSettings(ClusterShardingSettings shardingSettings)
         {
             var config = Context.System.Settings.Config.GetConfig("akka.cluster.sharding.distributed-data")
                 .WithFallback(Context.System.Settings.Config.GetConfig("akka.cluster.distributed-data"));

--- a/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/reference.conf
@@ -207,6 +207,9 @@ akka.cluster.sharding {
   distributed-data {
     # minCap parameter to MajorityWrite and MajorityRead consistency level.
     majority-min-cap = 5
+    
+    # ShardCoordinator is singleton running on oldest
+    prefer-oldest = on
 
     durable.keys = ["shard-*"]
 

--- a/src/examples/Cluster/ClusterSharding/ShoppingCart/Program.cs
+++ b/src/examples/Cluster/ClusterSharding/ShoppingCart/Program.cs
@@ -47,21 +47,18 @@ namespace ShoppingCart
             #region RoleSetup
             var role = Environment.GetEnvironmentVariable("IS_FRONTEND") == "true" 
                 ? FrontEndRole : BackEndRole;
-
+            
             var config = ConfigurationFactory.ParseString(@$"
                     # We need to tell Akka to provide us cluster enabled actors
                     akka.actor.provider = cluster
-                    akka.remote.dot-netty.tcp.port = 19912
-                    akka.remote.dot-netty.tcp.public-hostname = localhost
-                    akka.cluster.seed-nodes = [""akka.tcp://shopping-cart@localhost:19912""]
 
                     # This tells Akka which role this node belongs to
                     akka.cluster.roles=[{role}]
 
                     # This tells Akka to wait for at least 4 nodes joining the cluster 
                     # before signaling that it is up and ready
-                    #akka.cluster.min-nr-of-members = 4");
-                //.BootstrapFromDocker();
+                    akka.cluster.min-nr-of-members = 4")
+                .BootstrapFromDocker();
 
             var system = ActorSystem.Create("shopping-cart", config);
             #endregion
@@ -103,7 +100,7 @@ namespace ShoppingCart
                         // .WithRole is important because we're dedicating a specific node role for
                         // the actors to be instantiated in; in this case, we're instantiating only
                         // in the "backend" roled nodes.
-                        settings: ClusterShardingSettings.Create(system).WithRole(BackEndRole).WithStateStoreMode(StateStoreMode.DData), 
+                        settings: ClusterShardingSettings.Create(system).WithRole(BackEndRole), 
                         messageExtractor: new MessageExtractor(10));
                     // </LaunchShardRegion>
                     break;

--- a/src/examples/Cluster/ClusterSharding/ShoppingCart/Program.cs
+++ b/src/examples/Cluster/ClusterSharding/ShoppingCart/Program.cs
@@ -47,18 +47,21 @@ namespace ShoppingCart
             #region RoleSetup
             var role = Environment.GetEnvironmentVariable("IS_FRONTEND") == "true" 
                 ? FrontEndRole : BackEndRole;
-            
+
             var config = ConfigurationFactory.ParseString(@$"
                     # We need to tell Akka to provide us cluster enabled actors
                     akka.actor.provider = cluster
+                    akka.remote.dot-netty.tcp.port = 19912
+                    akka.remote.dot-netty.tcp.public-hostname = localhost
+                    akka.cluster.seed-nodes = [""akka.tcp://shopping-cart@localhost:19912""]
 
                     # This tells Akka which role this node belongs to
                     akka.cluster.roles=[{role}]
 
                     # This tells Akka to wait for at least 4 nodes joining the cluster 
                     # before signaling that it is up and ready
-                    akka.cluster.min-nr-of-members = 4")
-                .BootstrapFromDocker();
+                    #akka.cluster.min-nr-of-members = 4");
+                //.BootstrapFromDocker();
 
             var system = ActorSystem.Create("shopping-cart", config);
             #endregion
@@ -100,7 +103,7 @@ namespace ShoppingCart
                         // .WithRole is important because we're dedicating a specific node role for
                         // the actors to be instantiated in; in this case, we're instantiating only
                         // in the "backend" roled nodes.
-                        settings: ClusterShardingSettings.Create(system).WithRole(BackEndRole), 
+                        settings: ClusterShardingSettings.Create(system).WithRole(BackEndRole).WithStateStoreMode(StateStoreMode.DData), 
                         messageExtractor: new MessageExtractor(10));
                     // </LaunchShardRegion>
                     break;


### PR DESCRIPTION
## Changes

Partially resolves #6973 - this change should have been made as part of https://github.com/akkadotnet/akka.net/pull/5146 originally

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #6973, #5146
