### PR TITLE
DData: if `lmdb.dir` is null or empty, log a warning and set to default

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
+++ b/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
@@ -84,6 +84,12 @@ namespace Akka.DistributedData.LightningDB
 
             _path = _config.GetString("dir");
 
+            if (string.IsNullOrEmpty(_path))
+            {
+                _log.Warning("No directory path configured for LMDB durable store, using default path");
+                _path = DatabaseName;
+            }
+
             Init();
         }
 

--- a/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
+++ b/src/contrib/cluster/Akka.DistributedData.LightningDB/LmdbDurableStore.cs
@@ -15,7 +15,6 @@ using Akka.Configuration;
 using Akka.DistributedData.Durable;
 using Akka.Event;
 using Akka.Serialization;
-using Akka.DistributedData.Internal;
 using LightningDB;
 using System.Diagnostics;
 using System.Linq;
@@ -37,7 +36,7 @@ namespace Akka.DistributedData.LightningDB
     /// to the durable store actor, which must then reply with the <see cref="StoreReply.SuccessMessage"/> or
     /// <see cref="StoreReply.FailureMessage"/> to the <see cref="StoreReply.ReplyTo"/>.
     /// </summary>
-    public sealed class LmdbDurableStore : ReceiveActor
+    public sealed class LmdbDurableStore : ReceiveActor, IWithTimers
     {
         public static Actor.Props Props(Config config) => Actor.Props.Create(() => new LmdbDurableStore(config));
 
@@ -172,7 +171,7 @@ namespace Akka.DistributedData.LightningDB
                     else
                     {
                         if (_pending.Count > 0)
-                            Context.System.Scheduler.ScheduleTellOnce(_writeBehindInterval, Self, WriteBehind.Instance, ActorRefs.NoSender);
+                           Timers.StartSingleTimer("write-behind", WriteBehind.Instance, _writeBehindInterval);
                         _pending[store.Key] = store.Data;
                     }
 
@@ -275,5 +274,7 @@ namespace Akka.DistributedData.LightningDB
                 }
             }
         }
+
+        public ITimerScheduler Timers { get; set; }
     }
 }


### PR DESCRIPTION
## Changes

DData: if `lmdb.dir` is null or empty, log a warning and set to default. Should address some `NullReferenceException` issues that occured when the following HOCON was set:

```hocon
akka.cluster.distributed-data.durable.lmdb.dir = "shard-data"
```

Reported `Exception`:

```
[15:53:33 ERR] Stopping distributed-data Replicator due to load or startup failure in durable store, caused by: Exception during creation
[akka://cluster-system/system/sharding/replicator/durableStore#713307088]: Akka.Actor.ActorInitializationException: Exception during creation
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Akka.DistributedData.LightningDB.LmdbDurableStore.PreStart()
   at Akka.Actor.ActorBase.AroundPreStart()
   at Akka.Actor.ActorCell.<>cDisplayClass175_0.<Create>b0()
   at Akka.Actor.ActorCell.UseThreadContext(Action action)
   at Akka.Actor.ActorCell.Create(Exception failure)
   --- End of inner exception stack trace -
```

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).