### PR TITLE
Akka.Cluster.Tools: fix mutability and oldest state bugs with `ClusterSingletonManager`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
@@ -31,7 +31,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
                                                                                            akka.loglevel = INFO
                                                                                            akka.actor.provider = "cluster"
                                                                                            akka.cluster.roles = [singleton]
-                                                                                           #akka.cluster.auto-down-unreachable-after = 2s
+                                                                                           akka.cluster.split-brain-resolver.stable-after = 2s
                                                                                            akka.cluster.singleton.min-number-of-hand-over-retries = 5
                                                                                            akka.remote {
                                                                                              dot-netty.tcp {
@@ -120,7 +120,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             await Join(_sys4, _sys3);
 
             // let it stabilize
-            //Task.Delay(TimeSpan.FromSeconds(5)).Wait();
+            await Task.Delay(TimeSpan.FromSeconds(5));
 
             await WithinAsync(TimeSpan.FromSeconds(10), () =>
             {

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
@@ -256,28 +256,26 @@ namespace Akka.Cluster.Tools.Singleton
     }
 
     /// <summary>
-    /// TBD
+    /// State when we're handing over control of the singleton to another node.
     /// </summary>
     [Serializable]
     internal sealed class HandingOverData : IClusterSingletonData
     {
 
         /// <summary>
-        /// TBD
+        /// The current singleton reference
         /// </summary>
         public IActorRef Singleton { get; }
 
         /// <summary>
-        /// TBD
+        /// The actor we're handing over to.
         /// </summary>
-        public IActorRef HandOverTo { get; }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="singleton">TBD</param>
-        /// <param name="handOverTo">TBD</param>
-        public HandingOverData(IActorRef singleton, IActorRef handOverTo)
+        /// <remarks>
+        /// Can be <c>null</c> if they haven't contacted us yet and some other edge conditions.
+        /// </remarks>
+        public IActorRef? HandOverTo { get; }
+        
+        public HandingOverData(IActorRef singleton, IActorRef? handOverTo)
         {
             Singleton = singleton;
             HandOverTo = handOverTo;
@@ -1243,7 +1241,7 @@ namespace Akka.Cluster.Tools.Singleton
                         return HandleHandOverDone(handingOverData.HandOverTo);
                     case HandOverToMe 
                     when e.StateData is HandingOverData d
-                         && d.HandOverTo.Equals(Sender):
+                         && Sender.Equals(d.HandOverTo):
                         // retry
                         Sender.Tell(HandOverInProgress.Instance);
                         return Stay();

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
@@ -1407,7 +1407,6 @@ namespace Akka.Cluster.Tools.Singleton
             {
                 Log.Debug("Schedule DelayedMemberRemoved for {0}", member.Address);
                 SetTimer("delayed-member-removed-" + member.UniqueAddress, new DelayedMemberRemoved(member), _removalMargin, repeat: false);
-                //Context.System.Scheduler.ScheduleTellOnce(_removalMargin, Self, new DelayedMemberRemoved(member), Self);
             }
             else Self.Tell(new DelayedMemberRemoved(member));
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
@@ -1056,8 +1056,7 @@ namespace Akka.Cluster.Tools.Singleton
                                         return Stay();
                                     case null:
                                         Sender.Tell(HandOverToMe.Instance);
-                                        becomingOldestData.PreviousOldest.Insert(0, senderUniqueAddress);
-                                        return Stay().Using(new BecomingOldestData(becomingOldestData.PreviousOldest));
+                                        return Stay().Using(new BecomingOldestData(ImmutableList<UniqueAddress>.Empty.Add(senderUniqueAddress).AddRange(becomingOldestData.PreviousOldest)));
                                 }
                             }
                         }

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
@@ -4,7 +4,7 @@
 //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
+#nullable enable
 using System;
 using System.Collections.Immutable;
 using System.Linq;
@@ -17,7 +17,6 @@ using Akka.Dispatch;
 using Akka.Event;
 using Akka.Remote;
 using Akka.Util.Internal;
-using DotNetty.Handlers.Logging;
 using static Akka.Cluster.ClusterEvent;
 
 namespace Akka.Cluster.Tools.Singleton
@@ -73,7 +72,6 @@ namespace Akka.Cluster.Tools.Singleton
     }
 
     /// <summary>
-    /// TBD
     /// Sent from from previous oldest to new oldest to
     /// initiate the normal hand-over process.
     /// Especially useful when new node joins and becomes
@@ -83,59 +81,36 @@ namespace Akka.Cluster.Tools.Singleton
     [Serializable]
     internal sealed class TakeOverFromMe : IClusterSingletonMessage, IDeadLetterSuppression
     {
-        /// <summary>
-        /// TBD
-        /// </summary>
         public static TakeOverFromMe Instance { get; } = new();
         private TakeOverFromMe() { }
     }
 
     /// <summary>
-    /// TBD
+    /// Scheduled task to cleanup overdue members that have been removed
     /// </summary>
     [Serializable]
     internal sealed class Cleanup
     {
-        /// <summary>
-        /// TBD
-        /// </summary>
         public static Cleanup Instance { get; } = new();
         private Cleanup() { }
     }
 
     /// <summary>
-    /// TBD
+    /// Initialize the oldest changed buffer actor.
     /// </summary>
     [Serializable]
     internal sealed class StartOldestChangedBuffer
     {
-        /// <summary>
-        /// TBD
-        /// </summary>
         public static StartOldestChangedBuffer Instance { get; } = new();
         private StartOldestChangedBuffer() { }
     }
 
     /// <summary>
-    /// TBD
+    /// Retry a failed cluster singleton handover.
     /// </summary>
+    /// <param name="Count">The number of retries</param>
     [Serializable]
-    internal sealed class HandOverRetry
-    {
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public int Count { get; }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="count">TBD</param>
-        public HandOverRetry(int count)
-        {
-            Count = count;
-        }
-    }
+    internal sealed record HandOverRetry(int Count);
 
     /// <summary>
     /// TBD
@@ -211,20 +186,16 @@ namespace Akka.Cluster.Tools.Singleton
     }
 
     /// <summary>
-    /// TBD
+    /// State when we're transitioning to becoming the oldest singleton manager.
     /// </summary>
     [Serializable]
     internal sealed class BecomingOldestData : IClusterSingletonData
     {
         /// <summary>
-        /// TBD
+        /// The previous oldest nodes - can be empty
         /// </summary>
         public ImmutableList<UniqueAddress> PreviousOldest { get; }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="previousOldest">TBD</param>
+        
         public BecomingOldestData(ImmutableList<UniqueAddress> previousOldest)
         {
             PreviousOldest = previousOldest;
@@ -253,7 +224,7 @@ namespace Akka.Cluster.Tools.Singleton
     }
 
     /// <summary>
-    /// TBD
+    /// State we're transitioning into once we know we've started the hand-over process.
     /// </summary>
     [Serializable]
     internal sealed class WasOldestData : IClusterSingletonData
@@ -830,7 +801,7 @@ namespace Akka.Cluster.Tools.Singleton
             }
         }
 
-        private State<ClusterSingletonState, IClusterSingletonData> HandleHandOverDone(IActorRef handOverTo)
+        private State<ClusterSingletonState, IClusterSingletonData> HandleHandOverDone(IActorRef? handOverTo)
         {
             var newOldest = handOverTo?.Path.Address;
             Log.Info("Singleton terminated, hand-over done [{0} -> {1}]", _cluster.SelfAddress, newOldest);
@@ -851,7 +822,7 @@ namespace Akka.Cluster.Tools.Singleton
             }
         }
 
-        private State<ClusterSingletonState, IClusterSingletonData> GoToHandingOver(IActorRef singleton, IActorRef handOverTo)
+        private State<ClusterSingletonState, IClusterSingletonData> GoToHandingOver(IActorRef? singleton, IActorRef? handOverTo)
         {
             if (singleton == null)
             {

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManager.cs
@@ -872,8 +872,6 @@ namespace Akka.Cluster.Tools.Singleton
                         if (oldestChanged.NewOldest != null && oldestChanged.NewOldest.Equals(_selfUniqueAddress))
                         {
                             Log.Info("Younger observed OldestChanged: [{0} -> myself]", youngerData.Oldest.Head()?.Address);
-                            Log.Info("Current state of cluster for our role type: [{0}]", _cluster.State.Members.Where(c => c.HasRole(_settings.Role)).Aggregate("", (s, u) => s + u + ", "));
-                            Log.Info("YoungerState: [{0}]", youngerData.Oldest.Aggregate("", (s, u) => s + u + ", "));
                             if (youngerData.Oldest.All(m => _removed.ContainsKey(m)))
                             {
                                 return TryGotoOldest();
@@ -893,7 +891,6 @@ namespace Akka.Cluster.Tools.Singleton
                         }
 
                         Log.Info("Younger observed OldestChanged: [{0} -> {1}]", youngerData.Oldest.Head()?.Address, oldestChanged.NewOldest?.Address);
-                        Log.Info("YoungerState: [{0}]", youngerData.Oldest.Aggregate("", (s, u) => s + u + ", "));
                         GetNextOldestChanged();
 
                         var newOldest = oldestChanged.NewOldest switch

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
@@ -50,7 +50,7 @@ namespace Akka.Cluster.Tools.Singleton
             /// <summary>
             /// The first event, corresponding to CurrentClusterState.
             /// </summary>
-            public List<UniqueAddress> Oldest { get; }
+            public ImmutableList<UniqueAddress> Oldest { get; }
 
             /// <summary>
             /// TBD
@@ -62,7 +62,7 @@ namespace Akka.Cluster.Tools.Singleton
             /// </summary>
             /// <param name="oldest">TBD</param>
             /// <param name="safeToBeOldest">TBD</param>
-            public InitialOldestState(List<UniqueAddress> oldest, bool safeToBeOldest)
+            public InitialOldestState(ImmutableList<UniqueAddress> oldest, bool safeToBeOldest)
             {
                 Oldest = oldest;
                 SafeToBeOldest = safeToBeOldest;
@@ -172,7 +172,7 @@ namespace Akka.Cluster.Tools.Singleton
 
             var oldest = _membersByAge.TakeWhile(m => m.UpNumber <= selfUpNumber).ToList();
             var safeToBeOldest = !oldest.Any(m => m.Status is MemberStatus.Down or MemberStatus.Exiting or MemberStatus.Leaving);
-            var initial = new InitialOldestState(oldest.Select(m => m.UniqueAddress).ToList(), safeToBeOldest);
+            var initial = new InitialOldestState(oldest.Select(m => m.UniqueAddress).ToImmutableList(), safeToBeOldest);
             _changes = _changes.Enqueue(initial);
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/OldestChangedBuffer.cs
@@ -4,14 +4,13 @@
 //     Copyright (C) 2013-2023 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Util.Internal;
 
 namespace Akka.Cluster.Tools.Singleton
 {
@@ -70,23 +69,28 @@ namespace Akka.Cluster.Tools.Singleton
         }
 
         /// <summary>
-        /// TBD
+        /// Message propagated once the previous oldest member is exiting / downed / removed.
         /// </summary>
         [Serializable]
         public sealed class OldestChanged
         {
             /// <summary>
-            /// TBD
+            /// The new "oldest" - this node will become the new singleton manager.
             /// </summary>
-            public UniqueAddress Oldest { get; }
+            /// <remarks>
+            /// Can be <c>null</c> if we're the last node in the cluster.
+            /// </remarks>
+            public UniqueAddress? NewOldest { get; }
 
             /// <summary>
-            /// TBD
+            /// The previous oldest - will be `null` if this is the first oldest.
             /// </summary>
-            /// <param name="oldest">TBD</param>
-            public OldestChanged(UniqueAddress oldest)
+            public UniqueAddress? PreviousOldest { get; }
+            
+            public OldestChanged(UniqueAddress? newOldest, UniqueAddress? previousOldest)
             {
-                Oldest = oldest;
+                NewOldest = newOldest;
+                PreviousOldest = previousOldest;
             }
         }
 
@@ -147,7 +151,7 @@ namespace Akka.Cluster.Tools.Singleton
             var after = _membersByAge.FirstOrDefault();
             
             if (!Equals(before, after))
-                _changes = _changes.Enqueue(new OldestChanged(after?.UniqueAddress));
+                _changes = _changes.Enqueue(new OldestChanged(after?.UniqueAddress, before?.UniqueAddress));
         }
 
         private bool MatchingRole(Member member)

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -395,6 +395,9 @@ namespace Akka.Cluster.Tools.Singleton
         public static Akka.Cluster.Tools.Singleton.ClusterSingleton Get(Akka.Actor.ActorSystem system) { }
         public Akka.Actor.IActorRef Init(Akka.Cluster.Tools.Singleton.SingletonActor singleton) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+            0,
+            1})]
     public sealed class ClusterSingletonManager : Akka.Actor.FSM<Akka.Cluster.Tools.Singleton.ClusterSingletonState, Akka.Cluster.Tools.Singleton.IClusterSingletonData>
     {
         public ClusterSingletonManager(Akka.Actor.Props singletonProps, object terminationMessage, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
@@ -404,6 +407,7 @@ namespace Akka.Cluster.Tools.Singleton
         public static Akka.Actor.Props Props(Akka.Actor.Props singletonProps, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
         public static Akka.Actor.Props Props(Akka.Actor.Props singletonProps, object terminationMessage, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ClusterSingletonManagerIsStuckException : Akka.Actor.AkkaException
     {
         public ClusterSingletonManagerIsStuckException(string message) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -395,6 +395,9 @@ namespace Akka.Cluster.Tools.Singleton
         public static Akka.Cluster.Tools.Singleton.ClusterSingleton Get(Akka.Actor.ActorSystem system) { }
         public Akka.Actor.IActorRef Init(Akka.Cluster.Tools.Singleton.SingletonActor singleton) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+            0,
+            1})]
     public sealed class ClusterSingletonManager : Akka.Actor.FSM<Akka.Cluster.Tools.Singleton.ClusterSingletonState, Akka.Cluster.Tools.Singleton.IClusterSingletonData>
     {
         public ClusterSingletonManager(Akka.Actor.Props singletonProps, object terminationMessage, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
@@ -404,6 +407,7 @@ namespace Akka.Cluster.Tools.Singleton
         public static Akka.Actor.Props Props(Akka.Actor.Props singletonProps, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
         public static Akka.Actor.Props Props(Akka.Actor.Props singletonProps, object terminationMessage, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ClusterSingletonManagerIsStuckException : Akka.Actor.AkkaException
     {
         public ClusterSingletonManagerIsStuckException(string message) { }


### PR DESCRIPTION
## Changes

Looks like the list of available nodes was getting mangled - seems like a basic mutability issue inside the `ClusterSingletonManager`.

close https://github.com/akkadotnet/akka.net/issues/6973
close https://github.com/akkadotnet/akka.net/issues/7196

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #6973 and #7196