### PR TITLE
Fix `ActorMaterializerImpl` `null` `LogSource`

### DIFF
--- a/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
+++ b/src/core/Akka.Streams/Implementation/ActorMaterializerImpl.cs
@@ -390,8 +390,8 @@ namespace Akka.Streams.Implementation
             LogSource newSource;
             if (logSource is not LogSource s)
             {
-                actorPath = $"{s}({LogSource.FromActorRef(_supervisor, System)})";
-                newSource = LogSource.Create(actorPath, s.Type);
+                actorPath = $"{logSource}({LogSource.FromActorRef(_supervisor, System)})";
+                newSource = LogSource.Create(actorPath, logSource.GetType());
                 return Logging.GetLogger(System, newSource);
             }
             


### PR DESCRIPTION
## Changes

The ActorMaterializer.MakeLogger() method accesses a variable that was not initialized and most possibly be null