### PR TITLE
Fix remoting logging DefaultAddress race condition

### DIFF
--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -189,7 +189,7 @@ namespace Akka.Remote
         public Deployer Deployer { get; protected set; }
 
         /// <inheritdoc/>
-        public Address DefaultAddress { get { return Transport.DefaultAddress; } }
+        public Address DefaultAddress { get { return Transport?.DefaultAddress; } }
 
         private Information _serializationInformationCache;
 

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -112,8 +112,15 @@ namespace Akka.Event
 
         public static string FromActorRef(IActorRef a, ActorSystem system)
         {
-            var defaultAddress = system.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
-            return defaultAddress is null ? a.Path.ToString() : a.Path.ToStringWithAddress(defaultAddress);
+            try
+            {
+                var defaultAddress = system.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
+                return defaultAddress is null ? a.Path.ToString() : a.Path.ToStringWithAddress(defaultAddress);
+            }
+            catch // can fail if the ActorSystem (remoting) is not completely started yet
+            {
+                return a.Path.ToString();
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #7304

https://github.com/akkadotnet/akka.net/blob/3eacb6cadbce653edb1fe4d29f68d4654f74c380/src/core/Akka/Event/Logging.cs#L115

This line can throw an NRE if remoting is not up and running yet
`ExtendedActorSystem.Provider.DefaultAddress` => `RemoteActorRefProvider.DefaultAddress` => `Transport.DefaultAddress` <-- Transport property is null

## Changes

Make sure that we catch any NRE thrown when `Logging` tries to access `ExtendedActorSystem.Provider.DefaultAddress`