### PR TITLE
Update RELEASE_NOTES.md for 1.5.27.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,15 @@
-#### 1.5.28 July 25th 2024 ####
+#### 1.5.27.1 July 25th 2024 ####
 
-*Placeholder for nightlies*
+Akka.NET v1.5.27.1 is a minor patch to fix a race condition between the logging and remoting system.
+
+* [Akka: Fix Remoting-Logging DefaultAddress race condition](https://github.com/akkadotnet/akka.net/pull/7305)
+
+To [see the full set of changes in Akka.NET v1.5.27.1, click here](https://github.com/akkadotnet/akka.net/milestone/110).
+
+| COMMITS | LOC+ | LOC- | AUTHOR              |
+|---------|------|------|---------------------|
+| 1       | 4    | 0    | Aaron Stannard      |
+| 1       | 10   | 3    | Gregorius Soedharmo |
 
 #### 1.5.27 July 25th 2024 ####
 

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -189,7 +189,7 @@ namespace Akka.Remote
         public Deployer Deployer { get; protected set; }
 
         /// <inheritdoc/>
-        public Address DefaultAddress { get { return Transport.DefaultAddress; } }
+        public Address DefaultAddress { get { return Transport?.DefaultAddress; } }
 
         private Information _serializationInformationCache;
 

--- a/src/core/Akka/Event/Logging.cs
+++ b/src/core/Akka/Event/Logging.cs
@@ -112,8 +112,15 @@ namespace Akka.Event
 
         public static string FromActorRef(IActorRef a, ActorSystem system)
         {
-            var defaultAddress = system.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
-            return defaultAddress is null ? a.Path.ToString() : a.Path.ToStringWithAddress(defaultAddress);
+            try
+            {
+                var defaultAddress = system.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress;
+                return defaultAddress is null ? a.Path.ToString() : a.Path.ToStringWithAddress(defaultAddress);
+            }
+            catch // can fail if the ActorSystem (remoting) is not completely started yet
+            {
+                return a.Path.ToString();
+            }
         }
     }
 


### PR DESCRIPTION
## 1.5.27.1 July 25th 2024

Akka.NET v1.5.27.1 is a minor patch to fix a race condition between the logging and remoting system.

* [Akka: Fix Remoting-Logging DefaultAddress race condition](https://github.com/akkadotnet/akka.net/pull/7305)

To [see the full set of changes in Akka.NET v1.5.27.1, click here](https://github.com/akkadotnet/akka.net/milestone/110).

| COMMITS | LOC+ | LOC- | AUTHOR              |
|---------|------|------|---------------------|
| 1       | 4    | 0    | Aaron Stannard      |
| 1       | 10   | 3    | Gregorius Soedharmo |