### PR TITLE
Akka.Persistence.Sql.Common: harden `SqlJournal` and `SqlSnapshotStore` against initialization failures

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -258,9 +258,8 @@ namespace Akka.Persistence.Sql.Common.Journal
                 case Status.Failure fail:
                     Log.Error(fail.Cause, "Failure during {0} initialization.", Self);
                     
-                    // trigger a restart so we have some hope of restarting in the future
+                    // trigger a restart so we have some hope of succeeding in the future even if initialization failed
                     throw new ApplicationException("Failed to initialize SQL Journal.", fail.Cause);
-                    return true;
                 default:
                     Stash.Stash();
                     return true;

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Journal/SqlJournal.cs
@@ -257,7 +257,9 @@ namespace Akka.Persistence.Sql.Common.Journal
                     return true;
                 case Status.Failure fail:
                     Log.Error(fail.Cause, "Failure during {0} initialization.", Self);
-                    Context.Stop(Self);
+                    
+                    // trigger a restart so we have some hope of restarting in the future
+                    throw new ApplicationException("Failed to initialize SQL Journal.", fail.Cause);
                     return true;
                 default:
                     Stash.Stash();

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/SqlSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/SqlSnapshotStore.cs
@@ -137,8 +137,9 @@ namespace Akka.Persistence.Sql.Common.Snapshot
                     return true;
                 case Status.Failure msg:
                     Log.Error(msg.Cause, "Error during snapshot store initialization");
-                    Context.Stop(Self);
-                    return true;
+                    
+                    // trigger a restart so we have some hope of succeeding in the future even if initialization failed
+                    throw new ApplicationException("Failed to initialize SQL SnapshotStore.", msg.Cause);
                 default:
                     Stash.Stash();
                     return true;


### PR DESCRIPTION
## Changes

I noticed this issue with Akka.Persistence.Sql and will be sending a pull request for that as well, but TL;DR; we had some DNS issues that prevented Akka.Persistence from being able to contact SQL Server initially - this was caused by Kubernetes being slow to resolve a DNS route. The current design basically just kills Akka.Persistence and disallows it from restarting, requiring a restart of the entire process. There's no good reason for this - we can just restart the journal / snapshot store actors instead and give the process a chance of succeeding without a reboot.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).