### PR TITLE
Akka.Cluster.Sharding: Don't enable durable DData for RE unless DData is storage engine

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingGuardian.cs
@@ -303,8 +303,8 @@ namespace Akka.Cluster.Sharding
                 .WithFallback(Context.System.Settings.Config.GetConfig("akka.cluster.distributed-data"));
             var configuredSettings = ReplicatorSettings.Create(config);
             var settingsWithRoles = configuredSettings.WithRole(shardingSettings.Role);
-            if (shardingSettings.RememberEntities)
-                return settingsWithRoles;
+            if (shardingSettings.RememberEntities && shardingSettings.RememberEntitiesStore == RememberEntitiesStore.DData)
+                return settingsWithRoles; // only enable durable keys when using DData for remember-entities
             else
                 return settingsWithRoles.WithDurableKeys(ImmutableHashSet<string>.Empty);
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingSettings.cs
@@ -366,14 +366,6 @@ namespace Akka.Cluster.Sharding
                 throw ConfigurationException.NullOrEmptyConfig<ClusterShardingSettings>();
 
 
-            int ConfigMajorityPlus(string p)
-            {
-                if (config.GetString(p)?.ToLowerInvariant() == "all")
-                    return int.MaxValue;
-                else
-                    return config.GetInt(p);
-            }
-
             var tuningParameters = new TuningParameters(
                 coordinatorFailureBackoff: config.GetTimeSpan("coordinator-failure-backoff"),
                 retryInterval: config.GetTimeSpan("retry-interval"),
@@ -426,6 +418,13 @@ namespace Akka.Cluster.Sharding
                 tuningParameters: tuningParameters,
                 coordinatorSingletonSettings: coordinatorSingletonSettings,
                 leaseSettings: lease);
+
+            int ConfigMajorityPlus(string p)
+            {
+                if (config.GetString(p)?.ToLowerInvariant() == "all")
+                    return int.MaxValue;
+                return config.GetInt(p);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

Partial fix for #7326

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7326