### PR TITLE
Streams: Fix SelectAsync race condition bug

### DIFF
--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -2529,13 +2529,15 @@ namespace Akka.Streams.Implementation.Fusing
             {
                 private readonly Action<Holder<T>> _callback;
 
-                public Holder(Result<T> element, Action<Holder<T>> callback)
+                public Holder(object message, Result<T> element, Action<Holder<T>> callback)
                 {
                     _callback = callback;
+                    Message = message;
                     Element = element;
                 }
 
                 public Result<T> Element { get; private set; }
+                public object Message { get; }
 
                 public void SetElement(Result<T> result)
                 {
@@ -2575,7 +2577,7 @@ namespace Akka.Streams.Implementation.Fusing
                 try
                 {
                     var task = _stage._mapFunc(message);
-                    var holder = new Holder<TOut>(NotYetThere, _taskCallback);
+                    var holder = new Holder<TOut>(message, NotYetThere, _taskCallback);
                     _buffer.Enqueue(holder);
 
                     // We dispatch the task if it's ready to optimize away
@@ -2642,9 +2644,29 @@ namespace Akka.Streams.Implementation.Fusing
                     }
                     else
                     {
-                        var result = _buffer.Dequeue().Element;
+                        var holder = _buffer.Dequeue();
+                        var result = holder.Element;
                         if (!result.IsSuccess)
+                        {
+                            // this could happen if we are looping in PushOne and end up on a failed Task before the
+                            // HolderCompleted callback has run
+                            var strategy = _decider(result.Exception);
+                            Log.Error(result.Exception, "An exception occured inside SelectAsync while processing message [{0}]. Supervision strategy: {1}", holder.Message, strategy);
+                            switch (strategy)
+                            {
+                                case Directive.Stop:
+                                    FailStage(result.Exception);
+                                    return;
+                        
+                                case Directive.Resume:
+                                case Directive.Restart:
+                                    break;
+                        
+                                default:
+                                    throw new AggregateException($"Unknown SupervisionStrategy directive: {strategy}", result.Exception);
+                            }
                             continue;
+                        }
 
                         Push(_stage.Out, result.Value);
                         if (Todo < _stage._parallelism && !HasBeenPulled(inlet))


### PR DESCRIPTION
Fixes #7330

## Changes

* Add decider check inside the `PushOne()` loop

## Notes

Since this is a race condition bug, there is no reliable way to create a regression unit test for this bug.

This is the brute force unit test used to make sure that this fix works as intended:

```csharp
[Theory]
[Repeat(10000)]
public async Task A_Flow_with_SelectAsync_must_signal_error_at_appropriate_time_from_SelectAsync(int _)
{
    var failurePoint = ThreadLocalRandom.Current.Next(3, 50);
    var output = new List<int>();
    (await Awaiting(async () =>
        {
            await Source.From(Enumerable.Range(1, 500))
                .SelectAsync(100, n =>
                {
                    if (n % failurePoint == 0)
                        return Task.Run<int>(async () =>
                        {
                            await Task.Delay(ThreadLocalRandom.Current.Next(100, 200).Milliseconds());
                            throw new TestException("err2");
                        });

                    return Task.Run(async () =>
                    {
                        await Task.Delay(ThreadLocalRandom.Current.Next(20, 50).Milliseconds());
                        return n;
                    });
                })
                .Select(i =>
                {
                    output.Add(i);
                    return i;
                })
                .RunWith(Sink.Ignore<int>(), Materializer)
                .ShouldCompleteWithin(5.Seconds());
        }).Should().ThrowAsync<AggregateException>())
        .WithInnerExceptionExactly<TestException>()
        .WithMessage("err2");

    output.Count.Should().Be(failurePoint - 1);
}
```