### PR TITLE
Add IWithTimers API with sender override

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -1183,8 +1183,11 @@ namespace Akka.Actor
         void CancelAll();
         bool IsTimerActive(object key);
         void StartPeriodicTimer(object key, object msg, System.TimeSpan interval);
+        void StartPeriodicTimer(object key, object msg, System.TimeSpan interval, Akka.Actor.IActorRef sender);
         void StartPeriodicTimer(object key, object msg, System.TimeSpan initialDelay, System.TimeSpan interval);
+        void StartPeriodicTimer(object key, object msg, System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.IActorRef sender);
         void StartSingleTimer(object key, object msg, System.TimeSpan timeout);
+        void StartSingleTimer(object key, object msg, System.TimeSpan timeout, Akka.Actor.IActorRef sender);
     }
     public interface IUntypedActorContext : Akka.Actor.IActorContext, Akka.Actor.IActorRefFactory, Akka.Actor.ICanWatch
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -1181,8 +1181,11 @@ namespace Akka.Actor
         void CancelAll();
         bool IsTimerActive(object key);
         void StartPeriodicTimer(object key, object msg, System.TimeSpan interval);
+        void StartPeriodicTimer(object key, object msg, System.TimeSpan interval, Akka.Actor.IActorRef sender);
         void StartPeriodicTimer(object key, object msg, System.TimeSpan initialDelay, System.TimeSpan interval);
+        void StartPeriodicTimer(object key, object msg, System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.IActorRef sender);
         void StartSingleTimer(object key, object msg, System.TimeSpan timeout);
+        void StartSingleTimer(object key, object msg, System.TimeSpan timeout, Akka.Actor.IActorRef sender);
     }
     public interface IUntypedActorContext : Akka.Actor.IActorContext, Akka.Actor.IActorRefFactory, Akka.Actor.ICanWatch
     {

--- a/src/core/Akka/Actor/Scheduler/ITimerScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/ITimerScheduler.cs
@@ -39,6 +39,21 @@ namespace Akka.Actor
         /// Start a periodic timer that will send <paramref name="msg"/> to the "Self" actor at
         /// a fixed <paramref name="interval"/>.
         ///
+        ///Each timer has a key and if a new timer with same key is started
+        /// the previous is cancelled and it's guaranteed that a message from the
+        /// previous timer is not received, even though it might already be enqueued
+        /// in the mailbox when the new timer is started.
+        /// </summary>
+        /// <param name="key">Name of timer</param>
+        /// <param name="msg">Message to schedule</param>
+        /// <param name="interval">Interval</param>
+        /// <param name="sender">The sender override for the timer message</param>
+        void StartPeriodicTimer(object key, object msg, TimeSpan interval, IActorRef sender);
+
+        /// <summary>
+        /// Start a periodic timer that will send <paramref name="msg"/> to the "Self" actor at
+        /// a fixed <paramref name="interval"/>.
+        ///
         /// Each timer has a key and if a new timer with same key is started
         /// the previous is cancelled and it's guaranteed that a message from the
         /// previous timer is not received, even though it might already be enqueued
@@ -49,6 +64,22 @@ namespace Akka.Actor
         /// <param name="initialDelay">Initial delay</param>
         /// <param name="interval">Interval</param>
         void StartPeriodicTimer(object key, object msg, TimeSpan initialDelay, TimeSpan interval);
+
+        /// <summary>
+        /// Start a periodic timer that will send <paramref name="msg"/> to the "Self" actor at
+        /// a fixed <paramref name="interval"/>.
+        /// 
+        /// Each timer has a key and if a new timer with same key is started
+        /// the previous is cancelled and it's guaranteed that a message from the
+        /// previous timer is not received, even though it might already be enqueued
+        /// in the mailbox when the new timer is started.
+        /// </summary>
+        /// <param name="key">Name of timer</param>
+        /// <param name="msg">Message to schedule</param>
+        /// <param name="initialDelay">Initial delay</param>
+        /// <param name="interval">Interval</param>
+        /// <param name="sender">The sender override for the timer message</param>
+        void StartPeriodicTimer(object key, object msg, TimeSpan initialDelay, TimeSpan interval, IActorRef sender);
 
         /// <summary>
         /// Start a timer that will send <paramref name="msg"/> once to the "Self" actor after
@@ -63,6 +94,21 @@ namespace Akka.Actor
         /// <param name="msg">Message to schedule</param>
         /// <param name="timeout">Interval</param>
         void StartSingleTimer(object key, object msg, TimeSpan timeout);
+
+        /// <summary>
+        /// Start a timer that will send <paramref name="msg"/> once to the "Self" actor after
+        /// the given <paramref name="timeout"/>.
+        ///
+        /// Each timer has a key and if a new timer with same key is started
+        /// the previous is cancelled and it's guaranteed that a message from the
+        /// previous timer is not received, even though it might already be enqueued
+        /// in the mailbox when the new timer is started.
+        /// </summary>
+        /// <param name="key">Name of timer</param>
+        /// <param name="msg">Message to schedule</param>
+        /// <param name="timeout">Interval</param>
+        /// <param name="sender">The sender override for the timer message</param>
+        void StartSingleTimer(object key, object msg, TimeSpan timeout, IActorRef sender);
 
         /// <summary>
         /// Check if a timer with a given <paramref name="key"/> is active.


### PR DESCRIPTION
`IWithTimers` always pass in `ActorRefs.Nobody` as the scheduler message sender for all timers/

## Changes

Add new API methods that allows user to specify the message sender for messages sent by the `IWithTimers.Timer`