### PR TITLE
Fix DateTimeOffset.DateTime UTC bug

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -592,6 +592,7 @@ namespace Akka.Actor
     [System.ObsoleteAttribute("This class will be removed in Akka.NET v1.6.0 - use the IScheduler instead.")]
     public class DateTimeOffsetNowTimeProvider : Akka.Actor.IDateTimeOffsetNowTimeProvider, Akka.Actor.ITimeProvider
     {
+        public System.DateTime DateTimeNow { get; }
         public System.TimeSpan HighResMonotonicClock { get; }
         public static Akka.Actor.DateTimeOffsetNowTimeProvider Instance { get; }
         public System.TimeSpan MonotonicClock { get; }
@@ -932,6 +933,7 @@ namespace Akka.Actor
     public sealed class HashedWheelTimerScheduler : Akka.Actor.SchedulerBase, Akka.Actor.IDateTimeOffsetNowTimeProvider, Akka.Actor.ITimeProvider, System.IDisposable
     {
         public HashedWheelTimerScheduler(Akka.Configuration.Config scheduler, Akka.Event.ILoggingAdapter log) { }
+        protected override System.DateTime DateTimeNow { get; }
         public override System.TimeSpan HighResMonotonicClock { get; }
         public override System.TimeSpan MonotonicClock { get; }
         protected override System.DateTimeOffset TimeNow { get; }
@@ -1172,6 +1174,7 @@ namespace Akka.Actor
     }
     public interface ITimeProvider
     {
+        System.DateTime DateTimeNow { get; }
         System.TimeSpan HighResMonotonicClock { get; }
         System.TimeSpan MonotonicClock { get; }
         System.DateTimeOffset Now { get; }
@@ -1622,6 +1625,7 @@ namespace Akka.Actor
         protected readonly Akka.Event.ILoggingAdapter Log;
         protected readonly Akka.Configuration.Config SchedulerConfig;
         protected SchedulerBase(Akka.Configuration.Config scheduler, Akka.Event.ILoggingAdapter log) { }
+        protected abstract System.DateTime DateTimeNow { get; }
         public abstract System.TimeSpan HighResMonotonicClock { get; }
         public abstract System.TimeSpan MonotonicClock { get; }
         protected abstract System.DateTimeOffset TimeNow { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -592,6 +592,7 @@ namespace Akka.Actor
     [System.ObsoleteAttribute("This class will be removed in Akka.NET v1.6.0 - use the IScheduler instead.")]
     public class DateTimeOffsetNowTimeProvider : Akka.Actor.IDateTimeOffsetNowTimeProvider, Akka.Actor.ITimeProvider
     {
+        public System.DateTime DateTimeNow { get; }
         public System.TimeSpan HighResMonotonicClock { get; }
         public static Akka.Actor.DateTimeOffsetNowTimeProvider Instance { get; }
         public System.TimeSpan MonotonicClock { get; }
@@ -930,6 +931,7 @@ namespace Akka.Actor
     public sealed class HashedWheelTimerScheduler : Akka.Actor.SchedulerBase, Akka.Actor.IDateTimeOffsetNowTimeProvider, Akka.Actor.ITimeProvider, System.IDisposable
     {
         public HashedWheelTimerScheduler(Akka.Configuration.Config scheduler, Akka.Event.ILoggingAdapter log) { }
+        protected override System.DateTime DateTimeNow { get; }
         public override System.TimeSpan HighResMonotonicClock { get; }
         public override System.TimeSpan MonotonicClock { get; }
         protected override System.DateTimeOffset TimeNow { get; }
@@ -1170,6 +1172,7 @@ namespace Akka.Actor
     }
     public interface ITimeProvider
     {
+        System.DateTime DateTimeNow { get; }
         System.TimeSpan HighResMonotonicClock { get; }
         System.TimeSpan MonotonicClock { get; }
         System.DateTimeOffset Now { get; }
@@ -1620,6 +1623,7 @@ namespace Akka.Actor
         protected readonly Akka.Event.ILoggingAdapter Log;
         protected readonly Akka.Configuration.Config SchedulerConfig;
         protected SchedulerBase(Akka.Configuration.Config scheduler, Akka.Event.ILoggingAdapter log) { }
+        protected abstract System.DateTime DateTimeNow { get; }
         public abstract System.TimeSpan HighResMonotonicClock { get; }
         public abstract System.TimeSpan MonotonicClock { get; }
         protected abstract System.DateTimeOffset TimeNow { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
@@ -577,6 +577,7 @@ namespace Akka.TestKit
     {
         public TestScheduler(Akka.Configuration.Config schedulerConfig, Akka.Event.ILoggingAdapter log) { }
         public Akka.Actor.IAdvancedScheduler Advanced { get; }
+        public System.DateTime DateTimeNow { get; }
         public System.TimeSpan HighResMonotonicClock { get; }
         public System.TimeSpan MonotonicClock { get; }
         public System.DateTimeOffset Now { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.Net.verified.txt
@@ -577,6 +577,7 @@ namespace Akka.TestKit
     {
         public TestScheduler(Akka.Configuration.Config schedulerConfig, Akka.Event.ILoggingAdapter log) { }
         public Akka.Actor.IAdvancedScheduler Advanced { get; }
+        public System.DateTime DateTimeNow { get; }
         public System.TimeSpan HighResMonotonicClock { get; }
         public System.TimeSpan MonotonicClock { get; }
         public System.DateTimeOffset Now { get; }

--- a/src/core/Akka.Persistence/Eventsourced.cs
+++ b/src/core/Akka.Persistence/Eventsourced.cs
@@ -218,7 +218,7 @@ namespace Akka.Persistence
         /// <param name="snapshot">TBD</param>
         public void SaveSnapshot(object snapshot)
         {
-            SnapshotStore.Tell(new SaveSnapshot(new SnapshotMetadata(SnapshotterId, SnapshotSequenceNr, Context.System.Scheduler.Now.Date), snapshot));
+            SnapshotStore.Tell(new SaveSnapshot(new SnapshotMetadata(SnapshotterId, SnapshotSequenceNr, Context.System.Scheduler.DateTimeNow), snapshot));
         }
 
         /// <summary>

--- a/src/core/Akka.TestKit/TestScheduler.cs
+++ b/src/core/Akka.TestKit/TestScheduler.cs
@@ -212,6 +212,10 @@ namespace Akka.TestKit
         /// <summary>
         /// TBD
         /// </summary>
+        public DateTime DateTimeNow { get { return DateTime.SpecifyKind(_now.DateTime, DateTimeKind.Utc); } }
+        /// <summary>
+        /// TBD
+        /// </summary>
         public TimeSpan MonotonicClock { get { return Util.MonotonicClock.Elapsed; } }
         /// <summary>
         /// TBD

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -452,6 +452,7 @@ namespace Akka.Tests.Actor
         }
 
         public DateTimeOffset Now { get; private set; }
+        public DateTime DateTimeNow { get; private set; }
         public TimeSpan MonotonicClock { get; private set; }
         public TimeSpan HighResMonotonicClock { get; private set; }
         public IAdvancedScheduler Advanced { get; private set; }

--- a/src/core/Akka.Tests/Actor/Scheduler/SchedulerShutdownSpec.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/SchedulerShutdownSpec.cs
@@ -36,6 +36,7 @@ namespace Akka.Tests.Actor.Scheduler
             
 
             protected override DateTimeOffset TimeNow { get; }
+            protected override DateTime DateTimeNow { get; }
             public override TimeSpan MonotonicClock { get; }
             public override TimeSpan HighResMonotonicClock { get; }
 

--- a/src/core/Akka/Actor/Scheduler/DateTimeNowTimeProvider.cs
+++ b/src/core/Akka/Actor/Scheduler/DateTimeNowTimeProvider.cs
@@ -19,6 +19,8 @@ namespace Akka.Actor
         
         public DateTimeOffset Now { get { return DateTimeOffset.UtcNow; } }
         
+        public DateTime DateTimeNow => DateTime.UtcNow;
+        
         public TimeSpan MonotonicClock {get { return Util.MonotonicClock.Elapsed; }}
         
         public TimeSpan HighResMonotonicClock{get { return Util.MonotonicClock.ElapsedHighRes; }}

--- a/src/core/Akka/Actor/Scheduler/HashedWheelTimerScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/HashedWheelTimerScheduler.cs
@@ -399,6 +399,11 @@ namespace Akka.Actor
         /// <summary>
         /// TBD
         /// </summary>
+        protected override DateTime DateTimeNow => DateTime.UtcNow;
+
+        /// <summary>
+        /// TBD
+        /// </summary>
         public override TimeSpan MonotonicClock => Util.MonotonicClock.Elapsed;
 
         /// <summary>

--- a/src/core/Akka/Actor/Scheduler/ITimeProvider.cs
+++ b/src/core/Akka/Actor/Scheduler/ITimeProvider.cs
@@ -20,9 +20,13 @@ namespace Akka.Actor
     public interface ITimeProvider
     {
         /// <summary>
-        /// Gets the scheduler's notion of current time.
+        /// Gets the scheduler's notion of current time in <see cref="DateTimeOffset"/>.
         /// </summary>
         DateTimeOffset Now { get; }
+        /// <summary>
+        /// Gets the scheduler's notion of current time in <see cref="DateTime"/>.
+        /// </summary>
+        DateTime DateTimeNow { get; }
         /// <summary>
         /// TBD
         /// </summary>

--- a/src/core/Akka/Actor/Scheduler/SchedulerBase.cs
+++ b/src/core/Akka/Actor/Scheduler/SchedulerBase.cs
@@ -97,10 +97,17 @@ namespace Akka.Actor
         IAdvancedScheduler IScheduler.Advanced { get { return this; } }
         DateTimeOffset ITimeProvider.Now { get { return TimeNow; } }
 
+        DateTime ITimeProvider.DateTimeNow => DateTime.SpecifyKind(TimeNow.DateTime, DateTimeKind.Utc);
+        
         /// <summary>
-        /// The current time in UTC.
+        /// The current time in <see cref="DateTimeOffset"/> UTC.
         /// </summary>
         protected abstract DateTimeOffset TimeNow { get; }
+
+        /// <summary>
+        /// The current time in <see cref="DateTime"/> UTC.
+        /// </summary>
+        protected abstract DateTime DateTimeNow { get; }
 
         /// <summary>
         /// The current time since startup, as determined by the monotonic clock implementation.


### PR DESCRIPTION
Fixes https://github.com/akkadotnet/akka.net/blame/554086ccba07338194aca2a1eb8e0f9d801973b7/src/core/Akka.Persistence/Eventsourced.cs#L221

1. It uses `DateTimeOffset.Date` which strips the time portion of the `DateTime` struct
2. `DateTimeOffset.DateTime` returns a `DateTime` object with `DateTimeKind.Unspecified` and we need `DateTimeKind.Utc`

## Changes

Add a new property in `ITimeProvider` interface that returns a `DateTime.UtcNow`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).