### PR TITLE
Fix AskTimeoutException message formatting bug

### DIFF
--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -218,7 +218,7 @@ namespace Akka.Tests.Actor
             }
             catch (AskTimeoutException e)
             {
-                Assert.Equal("Timeout after 00:00:03 seconds", e.Message);
+                Assert.Equal("Timeout after 3.00 seconds", e.Message);
             }
         }
 

--- a/src/core/Akka/Actor/Futures.cs
+++ b/src/core/Akka/Actor/Futures.cs
@@ -137,7 +137,7 @@ namespace Akka.Actor
 
                 ctr1 = timeoutCancellation.Token.Register(() =>
                 {
-                    result.TrySetException(new AskTimeoutException($"Timeout after {timeout} seconds"));
+                    result.TrySetException(new AskTimeoutException($"Timeout after {timeout.Value.TotalSeconds:F2} seconds"));
                 });
 
                 timeoutCancellation.CancelAfter(timeout.Value);


### PR DESCRIPTION
## Changes

Fix AskTimeoutException message formatting, its outputting the whole TimeSpan, not just the seconds part.