### PR TITLE
Fix unit tests related to the Persistence DateTime bug

### DIFF
--- a/src/core/Akka.Persistence.TCK.Tests/LocalSnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TCK.Tests/LocalSnapshotStoreSpec.cs
@@ -42,7 +42,7 @@ namespace Akka.Persistence.TCK.Tests
         public void LocalSnapshotStore_can_snapshot_actors_with_PersistenceId_containing_invalid_path_characters()
         {
             var pid = @"p\/:*?-1";
-            SnapshotStore.Tell(new SaveSnapshot(new SnapshotMetadata(pid, 1, Sys.Scheduler.Now.DateTime), "sample data"), TestActor);
+            SnapshotStore.Tell(new SaveSnapshot(new SnapshotMetadata(pid, 1, Sys.Scheduler.DateTimeNow), "sample data"), TestActor);
             ExpectMsg<SaveSnapshotSuccess>();
 
             SnapshotStore.Tell(new LoadSnapshot(pid, SnapshotSelectionCriteria.Latest, long.MaxValue), TestActor);

--- a/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
@@ -247,7 +247,8 @@ namespace Akka.Persistence.TCK.Query
                 ExpectMsg($"{persistenceId}-{i}-done");
             }
 
-            var metadata = new SnapshotMetadata(persistenceId, n + 10, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(persistenceId, n + 10, Sys.Scheduler.DateTimeNow);
+            metadata.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
             SnapshotStore.Tell(new SaveSnapshot(metadata, $"s-{n}"), _senderProbe.Ref);
             _senderProbe.ExpectMsg<SaveSnapshotSuccess>();
 

--- a/src/core/Akka.Persistence.TCK/Serialization/SnapshotStoreSerializationSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Serialization/SnapshotStoreSerializationSpec.cs
@@ -69,7 +69,8 @@ akka.actor {
 
             var snapshot = new Test.MySnapshot("a");
 
-            var metadata = new SnapshotMetadata(Pid, 1, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 1, Sys.Scheduler.DateTimeNow);
+            metadata.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
             SnapshotStore.Tell(new SaveSnapshot(metadata, snapshot), probe.Ref);
             probe.ExpectMsg<SaveSnapshotSuccess>();
 
@@ -85,7 +86,8 @@ akka.actor {
 
             var snapshot = new Test.MySnapshot2("a");
 
-            var metadata = new SnapshotMetadata(Pid, 1, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 1, Sys.Scheduler.DateTimeNow);
+            metadata.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
             SnapshotStore.Tell(new SaveSnapshot(metadata, snapshot), probe.Ref);
             probe.ExpectMsg<SaveSnapshotSuccess>();
 
@@ -107,7 +109,8 @@ akka.actor {
             };
             var atLeastOnceDeliverySnapshot = new AtLeastOnceDeliverySnapshot(17, unconfirmed);
 
-            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.DateTimeNow);
+            metadata.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
             SnapshotStore.Tell(new SaveSnapshot(metadata, atLeastOnceDeliverySnapshot), probe.Ref);
             probe.ExpectMsg<SaveSnapshotSuccess>();
 
@@ -123,7 +126,8 @@ akka.actor {
             var unconfirmed = Array.Empty<UnconfirmedDelivery>();
             var atLeastOnceDeliverySnapshot = new AtLeastOnceDeliverySnapshot(13, unconfirmed);
 
-            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.DateTimeNow);
+            metadata.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
             SnapshotStore.Tell(new SaveSnapshot(metadata, atLeastOnceDeliverySnapshot), probe.Ref);
             probe.ExpectMsg<SaveSnapshotSuccess>();
 
@@ -138,7 +142,8 @@ akka.actor {
 
             var persistentFSMSnapshot = new PersistentFSM.PersistentFSMSnapshot<string>("mystate", "mydata", TimeSpan.FromDays(4));
 
-            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.DateTimeNow);
+            metadata.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
             SnapshotStore.Tell(new SaveSnapshot(metadata, persistentFSMSnapshot), probe.Ref);
             probe.ExpectMsg<SaveSnapshotSuccess>();
 

--- a/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSaveSnapshotSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSaveSnapshotSpec.cs
@@ -138,14 +138,16 @@ akka.actor {
         var snapshotStore = persistence.SnapshotStoreFor(null);
         var snap = new TestPayload(SenderProbe.Ref);
         
-        var metadata = new SnapshotMetadata(PersistenceId, 3, DateTime.Now);
+        var metadata = new SnapshotMetadata(PersistenceId, 3, DateTime.UtcNow);
+        metadata.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
         snapshotStore.Tell(new SaveSnapshot(metadata, snap), SenderProbe);
         var success = await SenderProbe.ExpectMsgAsync<SaveSnapshotSuccess>(10.Minutes());
         success.Metadata.PersistenceId.Should().Be(metadata.PersistenceId);
         success.Metadata.Timestamp.Should().Be(metadata.Timestamp);
         success.Metadata.SequenceNr.Should().Be(metadata.SequenceNr);
         
-        metadata = new SnapshotMetadata(PersistenceId, 3, DateTime.Now);
+        metadata = new SnapshotMetadata(PersistenceId, 3, DateTime.UtcNow);
+        metadata.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
         snapshotStore.Tell(new SaveSnapshot(metadata, 3), SenderProbe);
         success = await SenderProbe.ExpectMsgAsync<SaveSnapshotSuccess>();
         success.Metadata.PersistenceId.Should().Be(metadata.PersistenceId);

--- a/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSpec.cs
@@ -102,7 +102,8 @@ namespace Akka.Persistence.TCK.Snapshot
         {
             for (int i = 1; i <= 5; i++)
             {
-                var metadata = new SnapshotMetadata(Pid, i + 10, Sys.Scheduler.Now.DateTime);
+                var metadata = new SnapshotMetadata(Pid, i + 10, Sys.Scheduler.DateTimeNow);
+                metadata.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
                 SnapshotStore.Tell(new SaveSnapshot(metadata, $"s-{i}"), _senderProbe.Ref);
                 yield return _senderProbe.ExpectMsg<SaveSnapshotSuccess>().Metadata;
             }
@@ -312,7 +313,8 @@ namespace Akka.Persistence.TCK.Snapshot
         [Fact]
         public virtual void SnapshotStore_should_save_bigger_size_snapshot()
         {
-            var metadata = new SnapshotMetadata(Pid, 100, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 100, Sys.Scheduler.DateTimeNow);
+            metadata.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
             var bigSnapshot = new byte[SnapshotByteSizeLimit];
             new Random().NextBytes(bigSnapshot);
             SnapshotStore.Tell(new SaveSnapshot(metadata, bigSnapshot), _senderProbe.Ref);
@@ -326,7 +328,8 @@ namespace Akka.Persistence.TCK.Snapshot
             if (!SupportsSerialization) return;
 
             var probe = CreateTestProbe();
-            var metadata = new SnapshotMetadata(Pid, 100L, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 100L, Sys.Scheduler.DateTimeNow);
+            metadata.Timestamp.Kind.Should().Be(DateTimeKind.Utc);
             var snap = new TestPayload(probe.Ref);
 
             SnapshotStore.Tell(new SaveSnapshot(metadata, snap), _senderProbe.Ref);


### PR DESCRIPTION
## Changes

Refactor unit tests to not use `ActorSystem.Scheduler.Now.DateTime` which does not set DateTimeKind to UTC.