### PR TITLE
Fix SnapshotMetadata.Timestamp bug

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/QueryExecutor.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/QueryExecutor.cs
@@ -651,7 +651,7 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         {
             var persistenceId = reader.GetString(0);
             var sequenceNr = reader.GetInt64(1);
-            var timestamp = reader.GetDateTime(2);
+            var timestamp = DateTime.SpecifyKind(reader.GetDateTime(2), DateTimeKind.Utc);
 
             var metadata = new SnapshotMetadata(persistenceId, sequenceNr, timestamp);
             var snapshot = GetSnapshot(reader);

--- a/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/SqliteSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sqlite/Snapshot/SqliteSnapshotStore.cs
@@ -85,7 +85,7 @@ namespace Akka.Persistence.Sqlite.Snapshot
         {
             var persistenceId = reader.GetString(0);
             var sequenceNr = reader.GetInt64(1);
-            var timestamp = new DateTime(reader.GetInt64(2));
+            var timestamp = DateTime.SpecifyKind(new DateTime(reader.GetInt64(2)), DateTimeKind.Utc);
 
             var metadata = new SnapshotMetadata(persistenceId, sequenceNr, timestamp);
             var snapshot = GetSnapshot(reader);

--- a/src/core/Akka.Persistence.TCK.Tests/LocalSnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TCK.Tests/LocalSnapshotStoreSpec.cs
@@ -42,7 +42,7 @@ namespace Akka.Persistence.TCK.Tests
         public void LocalSnapshotStore_can_snapshot_actors_with_PersistenceId_containing_invalid_path_characters()
         {
             var pid = @"p\/:*?-1";
-            SnapshotStore.Tell(new SaveSnapshot(new SnapshotMetadata(pid, 1, Sys.Scheduler.Now.DateTime), "sample data"), TestActor);
+            SnapshotStore.Tell(new SaveSnapshot(new SnapshotMetadata(pid, 1, Sys.Scheduler.Now.UtcDateTime), "sample data"), TestActor);
             ExpectMsg<SaveSnapshotSuccess>();
 
             SnapshotStore.Tell(new LoadSnapshot(pid, SnapshotSelectionCriteria.Latest, long.MaxValue), TestActor);

--- a/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
@@ -247,7 +247,7 @@ namespace Akka.Persistence.TCK.Query
                 ExpectMsg($"{persistenceId}-{i}-done");
             }
 
-            var metadata = new SnapshotMetadata(persistenceId, n + 10, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(persistenceId, n + 10, Sys.Scheduler.Now.UtcDateTime);
             SnapshotStore.Tell(new SaveSnapshot(metadata, $"s-{n}"), _senderProbe.Ref);
             _senderProbe.ExpectMsg<SaveSnapshotSuccess>();
 

--- a/src/core/Akka.Persistence.TCK/Serialization/SnapshotStoreSerializationSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Serialization/SnapshotStoreSerializationSpec.cs
@@ -69,7 +69,7 @@ akka.actor {
 
             var snapshot = new Test.MySnapshot("a");
 
-            var metadata = new SnapshotMetadata(Pid, 1, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 1, Sys.Scheduler.Now.UtcDateTime);
             SnapshotStore.Tell(new SaveSnapshot(metadata, snapshot), probe.Ref);
             probe.ExpectMsg<SaveSnapshotSuccess>();
 
@@ -85,7 +85,7 @@ akka.actor {
 
             var snapshot = new Test.MySnapshot2("a");
 
-            var metadata = new SnapshotMetadata(Pid, 1, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 1, Sys.Scheduler.Now.UtcDateTime);
             SnapshotStore.Tell(new SaveSnapshot(metadata, snapshot), probe.Ref);
             probe.ExpectMsg<SaveSnapshotSuccess>();
 
@@ -107,7 +107,7 @@ akka.actor {
             };
             var atLeastOnceDeliverySnapshot = new AtLeastOnceDeliverySnapshot(17, unconfirmed);
 
-            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.Now.UtcDateTime);
             SnapshotStore.Tell(new SaveSnapshot(metadata, atLeastOnceDeliverySnapshot), probe.Ref);
             probe.ExpectMsg<SaveSnapshotSuccess>();
 
@@ -123,7 +123,7 @@ akka.actor {
             var unconfirmed = Array.Empty<UnconfirmedDelivery>();
             var atLeastOnceDeliverySnapshot = new AtLeastOnceDeliverySnapshot(13, unconfirmed);
 
-            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.Now.UtcDateTime);
             SnapshotStore.Tell(new SaveSnapshot(metadata, atLeastOnceDeliverySnapshot), probe.Ref);
             probe.ExpectMsg<SaveSnapshotSuccess>();
 
@@ -138,7 +138,7 @@ akka.actor {
 
             var persistentFSMSnapshot = new PersistentFSM.PersistentFSMSnapshot<string>("mystate", "mydata", TimeSpan.FromDays(4));
 
-            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 2, Sys.Scheduler.Now.UtcDateTime);
             SnapshotStore.Tell(new SaveSnapshot(metadata, persistentFSMSnapshot), probe.Ref);
             probe.ExpectMsg<SaveSnapshotSuccess>();
 

--- a/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSpec.cs
@@ -102,7 +102,7 @@ namespace Akka.Persistence.TCK.Snapshot
         {
             for (int i = 1; i <= 5; i++)
             {
-                var metadata = new SnapshotMetadata(Pid, i + 10, Sys.Scheduler.Now.DateTime);
+                var metadata = new SnapshotMetadata(Pid, i + 10, Sys.Scheduler.Now.UtcDateTime);
                 SnapshotStore.Tell(new SaveSnapshot(metadata, $"s-{i}"), _senderProbe.Ref);
                 yield return _senderProbe.ExpectMsg<SaveSnapshotSuccess>().Metadata;
             }
@@ -209,7 +209,7 @@ namespace Akka.Persistence.TCK.Snapshot
         {
             var md = Metadata[2];
             // In previous incarnation, timestamp argument defaults to DateTime.MinValue
-            md = new SnapshotMetadata(md.PersistenceId, md.SequenceNr, DateTime.MinValue);
+            md = new SnapshotMetadata(md.PersistenceId, md.SequenceNr, DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc));
             var command = new DeleteSnapshot(md);
             var sub = CreateTestProbe();
 
@@ -312,7 +312,7 @@ namespace Akka.Persistence.TCK.Snapshot
         [Fact]
         public virtual void SnapshotStore_should_save_bigger_size_snapshot()
         {
-            var metadata = new SnapshotMetadata(Pid, 100, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 100, Sys.Scheduler.Now.UtcDateTime);
             var bigSnapshot = new byte[SnapshotByteSizeLimit];
             new Random().NextBytes(bigSnapshot);
             SnapshotStore.Tell(new SaveSnapshot(metadata, bigSnapshot), _senderProbe.Ref);
@@ -326,7 +326,7 @@ namespace Akka.Persistence.TCK.Snapshot
             if (!SupportsSerialization) return;
 
             var probe = CreateTestProbe();
-            var metadata = new SnapshotMetadata(Pid, 100L, Sys.Scheduler.Now.DateTime);
+            var metadata = new SnapshotMetadata(Pid, 100L, Sys.Scheduler.Now.UtcDateTime);
             var snap = new TestPayload(probe.Ref);
 
             SnapshotStore.Tell(new SaveSnapshot(metadata, snap), _senderProbe.Ref);

--- a/src/core/Akka.Persistence.TestKit.Tests/TestSnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TestKit.Tests/TestSnapshotStoreSpec.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Xunit.Abstractions;
+
 namespace Akka.Persistence.TestKit.Tests
 {
     using System;
@@ -15,7 +17,7 @@ namespace Akka.Persistence.TestKit.Tests
 
     public sealed class TestSnapshotStoreSpec : PersistenceTestKit
     {
-        public TestSnapshotStoreSpec()
+        public TestSnapshotStoreSpec(ITestOutputHelper output) : base(nameof(TestSnapshotStoreSpec), output)
         {
             _probe = CreateTestProbe();
         }

--- a/src/core/Akka.Persistence/Eventsourced.cs
+++ b/src/core/Akka.Persistence/Eventsourced.cs
@@ -218,7 +218,7 @@ namespace Akka.Persistence
         /// <param name="snapshot">TBD</param>
         public void SaveSnapshot(object snapshot)
         {
-            SnapshotStore.Tell(new SaveSnapshot(new SnapshotMetadata(SnapshotterId, SnapshotSequenceNr, Context.System.Scheduler.Now.Date), snapshot));
+            SnapshotStore.Tell(new SaveSnapshot(new SnapshotMetadata(SnapshotterId, SnapshotSequenceNr, Context.System.Scheduler.Now.UtcDateTime), snapshot));
         }
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace Akka.Persistence
         /// <param name="sequenceNr">TBD</param>
         public void DeleteSnapshot(long sequenceNr)
         {
-            SnapshotStore.Tell(new DeleteSnapshot(new SnapshotMetadata(SnapshotterId, sequenceNr, DateTime.MinValue)));
+            SnapshotStore.Tell(new DeleteSnapshot(new SnapshotMetadata(SnapshotterId, sequenceNr, DateTime.SpecifyKind(DateTime.MinValue, DateTimeKind.Utc))));
         }
 
         /// <summary>

--- a/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
@@ -292,7 +292,7 @@ namespace Akka.Persistence.Snapshot
 
                 if (long.TryParse(seqNrString, out var sequenceNr) && long.TryParse(timestampTicks, out var ticks))
                 {
-                    return new SnapshotMetadata(pid, sequenceNr, new DateTime(ticks));
+                    return new SnapshotMetadata(pid, sequenceNr, DateTime.SpecifyKind(new DateTime(ticks), DateTimeKind.Utc));
                 }
             }
 

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -99,7 +99,11 @@ namespace Akka.Persistence.Snapshot
 
         private static SelectedSnapshot ToSelectedSnapshot(SnapshotEntry entry)
         {
-            return new SelectedSnapshot(new SnapshotMetadata(entry.PersistenceId, entry.SequenceNr, new DateTime(entry.Timestamp)), entry.Snapshot);
+            return new SelectedSnapshot(metadata: new SnapshotMetadata(
+                persistenceId: entry.PersistenceId,
+                sequenceNr: entry.SequenceNr,
+                timestamp: DateTime.SpecifyKind(new DateTime(entry.Timestamp), DateTimeKind.Utc)), 
+                snapshot: entry.Snapshot);
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/akkadotnet/akka.net/blame/554086ccba07338194aca2a1eb8e0f9d801973b7/src/core/Akka.Persistence/Eventsourced.cs#L221

1. It uses DateTimeOffset.Date which strips the time portion of the DateTime struct
2. DateTimeOffset.DateTime returns a DateTime object with DateTimeKind.Unspecified and we need DateTimeKind.Utc

## Changes

Make sure that we use UTC DateTime everywhere