### PR TITLE
Fix: swallowed exceptions in timed out `WithCircuitBreaker()`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
@@ -162,18 +162,19 @@ namespace Akka.Cluster.Sharding.Tests
         /// TBD
         /// </summary>
         /// <param name="messages">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <exception cref="TimeoutException">
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken = default)
         {
             var trueMsgs = messages.ToArray();
             
             if (_store == null)
                 return StoreNotInitialized<IImmutableList<Exception>>();
 
-            return _store.Ask<object>(sender => new WriteMessages(trueMsgs, sender, 1), Timeout, CancellationToken.None)
+            return _store.Ask<object>(sender => new WriteMessages(trueMsgs, sender, 1), Timeout, cancellationToken)
                 .ContinueWith(r =>
                 {
                     if (r.IsCanceled)
@@ -195,18 +196,19 @@ namespace Akka.Cluster.Sharding.Tests
         /// </summary>
         /// <param name="persistenceId">TBD</param>
         /// <param name="toSequenceNr">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <exception cref="TimeoutException">
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken = default)
         {
             if (_store == null)
                 return StoreNotInitialized<object>();
 
             var result = new TaskCompletionSource<object>();
 
-            _store.Ask<object>(sender => new DeleteMessagesTo(persistenceId, toSequenceNr, sender), Timeout, CancellationToken.None).ContinueWith(r =>
+            _store.Ask<object>(sender => new DeleteMessagesTo(persistenceId, toSequenceNr, sender), Timeout, cancellationToken).ContinueWith(r =>
             {
                 if (r.IsFaulted)
                     result.TrySetException(r.Exception);
@@ -250,18 +252,19 @@ namespace Akka.Cluster.Sharding.Tests
         /// </summary>
         /// <param name="persistenceId">TBD</param>
         /// <param name="fromSequenceNr">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <exception cref="TimeoutException">
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken = default)
         {
             if (_store == null)
                 return StoreNotInitialized<long>();
 
             var result = new TaskCompletionSource<long>();
 
-            _store.Ask<object>(sender => new ReplayMessages(0, 0, 0, persistenceId, sender), Timeout, CancellationToken.None)
+            _store.Ask<object>(sender => new ReplayMessages(0, 0, 0, persistenceId, sender), Timeout, cancellationToken)
                 .ContinueWith(t =>
                 {
                     if (t.IsFaulted)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/SnapshotStoreProxy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/SnapshotStoreProxy.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -89,14 +90,14 @@ namespace Akka.Cluster.Sharding.Tests
             return true;
         }
 
-        protected async override Task DeleteAsync(SnapshotMetadata metadata)
+        protected override async Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken = default)
         {
             if (_store == null)
                 throw new TimeoutException("Store not intialized.");
             var s = Sender;
             try
             {
-                var response = await _store.Ask(new DeleteSnapshot(metadata), Timeout);
+                var response = await _store.Ask(new DeleteSnapshot(metadata), Timeout, cancellationToken);
                 if (response is DeleteSnapshotFailure f)
                 {
                     ExceptionDispatchInfo.Capture(f.Cause).Throw();
@@ -108,14 +109,14 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        protected async override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             if (_store == null)
                 throw new TimeoutException("Store not intialized.");
             var s = Sender;
             try
             {
-                var response = await _store.Ask(new DeleteSnapshots(persistenceId, criteria), Timeout);
+                var response = await _store.Ask(new DeleteSnapshots(persistenceId, criteria), Timeout, cancellationToken);
                 if (response is DeleteSnapshotsFailure f)
                 {
                     ExceptionDispatchInfo.Capture(f.Cause).Throw();
@@ -127,14 +128,14 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             if (_store == null)
                 throw new TimeoutException("Store not intialized.");
             var s = Sender;
             try
             {
-                var response = await _store.Ask(new LoadSnapshot(persistenceId, criteria, criteria.MaxSequenceNr), Timeout);
+                var response = await _store.Ask(new LoadSnapshot(persistenceId, criteria, criteria.MaxSequenceNr), Timeout, cancellationToken);
                 switch (response)
                 {
                     case LoadSnapshotResult ls:
@@ -154,14 +155,14 @@ namespace Akka.Cluster.Sharding.Tests
             throw new TimeoutException();
         }
 
-        protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken = default)
         {
             if (_store == null)
                 throw new TimeoutException("Store not intialized.");
             var s = Sender;
             try
             {
-                var response = await _store.Ask(new SaveSnapshot(metadata, snapshot), Timeout);
+                var response = await _store.Ask(new SaveSnapshot(metadata, snapshot), Timeout, cancellationToken);
                 if (response is SaveSnapshotFailure f)
                 {
                     ExceptionDispatchInfo.Capture(f.Cause).Throw();

--- a/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/SqlSnapshotStore.cs
+++ b/src/contrib/persistence/Akka.Persistence.Sql.Common/Snapshot/SqlSnapshotStore.cs
@@ -167,11 +167,12 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         /// </summary>
         /// <param name="persistenceId">TBD</param>
         /// <param name="criteria">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <returns>TBD</returns>
-        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             using (var connection = CreateDbConnection())
-            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _pendingRequestsCancellation.Token))
             {
                 await connection.OpenAsync(nestedCancellationTokenSource.Token);
                 return await QueryExecutor.SelectSnapshotAsync(connection, nestedCancellationTokenSource.Token, persistenceId, criteria.MaxSequenceNr, criteria.MaxTimeStamp);
@@ -183,11 +184,12 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         /// </summary>
         /// <param name="metadata">TBD</param>
         /// <param name="snapshot">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <returns>TBD</returns>
-        protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken = default)
         {
             using (var connection = CreateDbConnection())
-            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _pendingRequestsCancellation.Token))
             {
                 await connection.OpenAsync(nestedCancellationTokenSource.Token);
                 await QueryExecutor.InsertAsync(connection, nestedCancellationTokenSource.Token, snapshot, metadata);
@@ -198,11 +200,12 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         /// TBD
         /// </summary>
         /// <param name="metadata">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <returns>TBD</returns>
-        protected override async Task DeleteAsync(SnapshotMetadata metadata)
+        protected override async Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken = default)
         {
             using (var connection = CreateDbConnection())
-            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token))    
+            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _pendingRequestsCancellation.Token))    
             {
                 await connection.OpenAsync(nestedCancellationTokenSource.Token);
                 DateTime? timestamp = metadata.Timestamp != DateTime.MinValue ? metadata.Timestamp : default(DateTime?);
@@ -215,11 +218,12 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         /// </summary>
         /// <param name="persistenceId">TBD</param>
         /// <param name="criteria">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <returns>TBD</returns>
-        protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             using (var connection = CreateDbConnection())
-            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+            using (var nestedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _pendingRequestsCancellation.Token))
             {
                 await connection.OpenAsync(nestedCancellationTokenSource.Token);
                 await QueryExecutor.DeleteBatchAsync(connection, nestedCancellationTokenSource.Token, persistenceId, criteria.MaxSequenceNr, criteria.MaxTimeStamp);

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -4495,10 +4495,18 @@ namespace Akka.Pattern
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
         public void Succeed() { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
+        public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.Tasks.Task> body) { }
+        public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
         public Akka.Pattern.CircuitBreaker WithExponentialBackoff(System.TimeSpan maxResetTimeout) { }
         public Akka.Pattern.CircuitBreaker WithRandomFactor(double randomFactor) { }
         public void WithSyncCircuitBreaker(System.Action body) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -4485,10 +4485,18 @@ namespace Akka.Pattern
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
         public void Succeed() { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
+        public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.Tasks.Task> body) { }
+        public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
         public Akka.Pattern.CircuitBreaker WithExponentialBackoff(System.TimeSpan maxResetTimeout) { }
         public Akka.Pattern.CircuitBreaker WithRandomFactor(double randomFactor) { }
         public void WithSyncCircuitBreaker(System.Action body) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -857,14 +857,14 @@ namespace Akka.Persistence.Journal
     {
         protected readonly bool CanPublish;
         protected AsyncWriteJournal() { }
-        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr);
-        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken = null);
+        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken = null);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected bool ReceiveWriteJournal(object message) { }
         public abstract System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
         protected static System.Exception TryUnwrapException(System.Exception e) { }
-        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages);
+        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken = null);
     }
     public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
@@ -873,10 +873,10 @@ namespace Akka.Persistence.Journal
         public abstract System.TimeSpan Timeout { get; }
         public override void AroundPreStart() { }
         protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken = null) { }
         public class InitTimeout
         {
             public static Akka.Persistence.Journal.AsyncWriteProxy.InitTimeout Instance { get; }
@@ -955,7 +955,7 @@ namespace Akka.Persistence.Journal
     }
     public interface IAsyncRecovery
     {
-        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
     }
     public interface IEmptyEventSequence : Akka.Persistence.Journal.IEventSequence { }
@@ -994,14 +994,14 @@ namespace Akka.Persistence.Journal
         protected virtual System.Collections.Concurrent.ConcurrentDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Messages { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
         public long HighestSequenceNr(string pid) { }
         public System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentRepresentation> Read(string pid, long fromSeqNr, long toSeqNr, long max) { }
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
         protected override bool ReceivePluginInternal(object message) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Update(string pid, long seqNr, System.Func<Akka.Persistence.IPersistentRepresentation, Akka.Persistence.IPersistentRepresentation> updater) { }
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken = null) { }
         public sealed class CurrentPersistenceIds : Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Collections.Generic.IEnumerable<string> AllPersistenceIds;
@@ -1170,14 +1170,14 @@ namespace Akka.Persistence.Snapshot
     public class LocalSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public LocalSnapshotStore() { }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
         protected System.IO.FileInfo GetSnapshotFileForWrite(Akka.Persistence.SnapshotMetadata metadata, string extension = "") { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
         protected override void PreStart() { }
         protected override bool ReceivePluginInternal(object message) { }
         protected virtual void Save(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken = null) { }
         protected void Serialize(System.IO.Stream stream, Akka.Persistence.Serialization.Snapshot snapshot) { }
         protected System.IO.FileInfo WithOutputStream(Akka.Persistence.SnapshotMetadata metadata, System.Action<System.IO.Stream> p) { }
     }
@@ -1185,18 +1185,18 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual System.Collections.Generic.List<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots { get; }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken = null) { }
     }
     public sealed class NoSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public NoSnapshotStore() { }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken = null) { }
         public class NoSnapshotStoreException : System.Exception
         {
             public NoSnapshotStoreException() { }
@@ -1217,11 +1217,11 @@ namespace Akka.Persistence.Snapshot
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {
         protected SnapshotStore() { }
-        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata);
-        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
-        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
+        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken = null);
+        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null);
+        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
-        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot);
+        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken = null);
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -857,14 +857,14 @@ namespace Akka.Persistence.Journal
     {
         protected readonly bool CanPublish;
         protected AsyncWriteJournal() { }
-        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr);
-        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken = null);
+        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken = null);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected bool ReceiveWriteJournal(object message) { }
         public abstract System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
         protected static System.Exception TryUnwrapException(System.Exception e) { }
-        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages);
+        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken = null);
     }
     public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
@@ -873,10 +873,10 @@ namespace Akka.Persistence.Journal
         public abstract System.TimeSpan Timeout { get; }
         public override void AroundPreStart() { }
         protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken = null) { }
         public class InitTimeout
         {
             public static Akka.Persistence.Journal.AsyncWriteProxy.InitTimeout Instance { get; }
@@ -955,7 +955,7 @@ namespace Akka.Persistence.Journal
     }
     public interface IAsyncRecovery
     {
-        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken = null);
         System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
     }
     public interface IEmptyEventSequence : Akka.Persistence.Journal.IEventSequence { }
@@ -994,14 +994,14 @@ namespace Akka.Persistence.Journal
         protected virtual System.Collections.Concurrent.ConcurrentDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Messages { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
         public long HighestSequenceNr(string pid) { }
         public System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentRepresentation> Read(string pid, long fromSeqNr, long toSeqNr, long max) { }
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
         protected override bool ReceivePluginInternal(object message) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Update(string pid, long seqNr, System.Func<Akka.Persistence.IPersistentRepresentation, Akka.Persistence.IPersistentRepresentation> updater) { }
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken = null) { }
         public sealed class CurrentPersistenceIds : Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Collections.Generic.IEnumerable<string> AllPersistenceIds;
@@ -1168,14 +1168,14 @@ namespace Akka.Persistence.Snapshot
     public class LocalSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public LocalSnapshotStore() { }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
         protected System.IO.FileInfo GetSnapshotFileForWrite(Akka.Persistence.SnapshotMetadata metadata, string extension = "") { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
         protected override void PreStart() { }
         protected override bool ReceivePluginInternal(object message) { }
         protected virtual void Save(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken = null) { }
         protected void Serialize(System.IO.Stream stream, Akka.Persistence.Serialization.Snapshot snapshot) { }
         protected System.IO.FileInfo WithOutputStream(Akka.Persistence.SnapshotMetadata metadata, System.Action<System.IO.Stream> p) { }
     }
@@ -1183,18 +1183,18 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual System.Collections.Generic.List<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots { get; }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken = null) { }
     }
     public sealed class NoSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public NoSnapshotStore() { }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken = null) { }
         public class NoSnapshotStoreException : System.Exception
         {
             public NoSnapshotStoreException() { }
@@ -1215,11 +1215,11 @@ namespace Akka.Persistence.Snapshot
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {
         protected SnapshotStore() { }
-        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata);
-        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
-        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
+        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken = null);
+        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null);
+        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
-        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot);
+        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken = null);
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.DotNet.verified.txt
@@ -122,17 +122,17 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected void AddParameter(TCommand command, string paramName, System.Data.DbType dbType, object value) { }
         protected void BatchRequest(Akka.Persistence.IJournalRequest message) { }
         protected abstract TConnection CreateConnection(string connectionString);
-        protected virtual System.Threading.Tasks.Task HandleDeleteMessagesTo(Akka.Persistence.DeleteMessagesTo req, TCommand command) { }
-        protected virtual System.Threading.Tasks.Task HandleReplayAllMessages(Akka.Persistence.Sql.Common.Journal.ReplayAllEvents req, TCommand command) { }
-        protected virtual System.Threading.Tasks.Task HandleReplayMessages(Akka.Persistence.ReplayMessages req, TCommand command, Akka.Actor.IActorContext context) { }
-        protected virtual System.Threading.Tasks.Task HandleReplayTaggedMessages(Akka.Persistence.Sql.Common.Journal.ReplayTaggedMessages req, TCommand command) { }
-        protected virtual System.Threading.Tasks.Task HandleSelectCurrentPersistenceIds(Akka.Persistence.Sql.Common.Journal.SelectCurrentPersistenceIds message, TCommand command) { }
+        protected virtual System.Threading.Tasks.Task HandleDeleteMessagesTo(Akka.Persistence.DeleteMessagesTo req, TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
+        protected virtual System.Threading.Tasks.Task HandleReplayAllMessages(Akka.Persistence.Sql.Common.Journal.ReplayAllEvents req, TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
+        protected virtual System.Threading.Tasks.Task HandleReplayMessages(Akka.Persistence.ReplayMessages req, TCommand command, Akka.Actor.IActorContext context, System.Threading.CancellationToken cancellationToken = null) { }
+        protected virtual System.Threading.Tasks.Task HandleReplayTaggedMessages(Akka.Persistence.Sql.Common.Journal.ReplayTaggedMessages req, TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
+        protected virtual System.Threading.Tasks.Task HandleSelectCurrentPersistenceIds(Akka.Persistence.Sql.Common.Journal.SelectCurrentPersistenceIds message, TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
         protected virtual void OnBufferOverflow(Akka.Persistence.IJournalMessage request) { }
         protected virtual void PreAddParameterToCommand(TCommand command, System.Data.Common.DbParameter param) { }
         protected override void PreStart() { }
         protected virtual Akka.Persistence.IPersistentRepresentation ReadEvent(System.Data.Common.DbDataReader reader) { }
-        protected virtual System.Threading.Tasks.Task<long> ReadHighestSequenceNr(string persistenceId, TCommand command) { }
-        protected virtual System.Threading.Tasks.Task<long> ReadHighestSequenceNr(TCommand command) { }
+        protected virtual System.Threading.Tasks.Task<long> ReadHighestSequenceNr(string persistenceId, TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
+        protected virtual System.Threading.Tasks.Task<long> ReadHighestSequenceNr(TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
         protected virtual bool Receive(object message) { }
         protected virtual void WriteEvent(TCommand command, Akka.Persistence.IPersistentRepresentation persistent, string tags = "") { }
     }
@@ -326,12 +326,12 @@ namespace Akka.Persistence.Sql.Common.Journal
         public Akka.Actor.IStash Stash { get; set; }
         protected abstract System.Data.Common.DbConnection CreateDbConnection(string connectionString);
         public System.Data.Common.DbConnection CreateDbConnection() { }
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
         protected virtual string GetConnectionString() { }
         protected Akka.Persistence.Sql.Common.Journal.ITimestampProvider GetTimestampProvider(string typeName) { }
         protected override void PostStop() { }
         protected override void PreStart() { }
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
         protected override bool ReceivePluginInternal(object message) { }
         protected virtual System.Threading.Tasks.Task<long> ReplayAllEventsAsync(Akka.Persistence.Sql.Common.Journal.ReplayAllEvents replay) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
@@ -341,7 +341,7 @@ namespace Akka.Persistence.Sql.Common.Journal
                 "LastOrdering"})]
         protected virtual System.Threading.Tasks.Task<System.ValueTuple<System.Collections.Generic.IEnumerable<string>, long>> SelectAllPersistenceIdsAsync(long offset) { }
         protected bool WaitingForInitialization(object message) { }
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken = null) { }
     }
     [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class SubscribeNewEvents : Akka.Persistence.Sql.Common.Journal.ISubscriptionCommand
@@ -490,12 +490,12 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         public Akka.Actor.IStash Stash { get; set; }
         protected abstract System.Data.Common.DbConnection CreateDbConnection(string connectionString);
         public System.Data.Common.DbConnection CreateDbConnection() { }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
         protected virtual string GetConnectionString() { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
         protected override void PostStop() { }
         protected override void PreStart() { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken = null) { }
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceSqlCommon.Net.verified.txt
@@ -122,17 +122,17 @@ namespace Akka.Persistence.Sql.Common.Journal
         protected void AddParameter(TCommand command, string paramName, System.Data.DbType dbType, object value) { }
         protected void BatchRequest(Akka.Persistence.IJournalRequest message) { }
         protected abstract TConnection CreateConnection(string connectionString);
-        protected virtual System.Threading.Tasks.Task HandleDeleteMessagesTo(Akka.Persistence.DeleteMessagesTo req, TCommand command) { }
-        protected virtual System.Threading.Tasks.Task HandleReplayAllMessages(Akka.Persistence.Sql.Common.Journal.ReplayAllEvents req, TCommand command) { }
-        protected virtual System.Threading.Tasks.Task HandleReplayMessages(Akka.Persistence.ReplayMessages req, TCommand command, Akka.Actor.IActorContext context) { }
-        protected virtual System.Threading.Tasks.Task HandleReplayTaggedMessages(Akka.Persistence.Sql.Common.Journal.ReplayTaggedMessages req, TCommand command) { }
-        protected virtual System.Threading.Tasks.Task HandleSelectCurrentPersistenceIds(Akka.Persistence.Sql.Common.Journal.SelectCurrentPersistenceIds message, TCommand command) { }
+        protected virtual System.Threading.Tasks.Task HandleDeleteMessagesTo(Akka.Persistence.DeleteMessagesTo req, TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
+        protected virtual System.Threading.Tasks.Task HandleReplayAllMessages(Akka.Persistence.Sql.Common.Journal.ReplayAllEvents req, TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
+        protected virtual System.Threading.Tasks.Task HandleReplayMessages(Akka.Persistence.ReplayMessages req, TCommand command, Akka.Actor.IActorContext context, System.Threading.CancellationToken cancellationToken = null) { }
+        protected virtual System.Threading.Tasks.Task HandleReplayTaggedMessages(Akka.Persistence.Sql.Common.Journal.ReplayTaggedMessages req, TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
+        protected virtual System.Threading.Tasks.Task HandleSelectCurrentPersistenceIds(Akka.Persistence.Sql.Common.Journal.SelectCurrentPersistenceIds message, TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
         protected virtual void OnBufferOverflow(Akka.Persistence.IJournalMessage request) { }
         protected virtual void PreAddParameterToCommand(TCommand command, System.Data.Common.DbParameter param) { }
         protected override void PreStart() { }
         protected virtual Akka.Persistence.IPersistentRepresentation ReadEvent(System.Data.Common.DbDataReader reader) { }
-        protected virtual System.Threading.Tasks.Task<long> ReadHighestSequenceNr(string persistenceId, TCommand command) { }
-        protected virtual System.Threading.Tasks.Task<long> ReadHighestSequenceNr(TCommand command) { }
+        protected virtual System.Threading.Tasks.Task<long> ReadHighestSequenceNr(string persistenceId, TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
+        protected virtual System.Threading.Tasks.Task<long> ReadHighestSequenceNr(TCommand command, System.Threading.CancellationToken cancellationToken = null) { }
         protected virtual bool Receive(object message) { }
         protected virtual void WriteEvent(TCommand command, Akka.Persistence.IPersistentRepresentation persistent, string tags = "") { }
     }
@@ -326,12 +326,12 @@ namespace Akka.Persistence.Sql.Common.Journal
         public Akka.Actor.IStash Stash { get; set; }
         protected abstract System.Data.Common.DbConnection CreateDbConnection(string connectionString);
         public System.Data.Common.DbConnection CreateDbConnection() { }
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
         protected virtual string GetConnectionString() { }
         protected Akka.Persistence.Sql.Common.Journal.ITimestampProvider GetTimestampProvider(string typeName) { }
         protected override void PostStop() { }
         protected override void PreStart() { }
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken = null) { }
         protected override bool ReceivePluginInternal(object message) { }
         protected virtual System.Threading.Tasks.Task<long> ReplayAllEventsAsync(Akka.Persistence.Sql.Common.Journal.ReplayAllEvents replay) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
@@ -341,7 +341,7 @@ namespace Akka.Persistence.Sql.Common.Journal
                 "LastOrdering"})]
         protected virtual System.Threading.Tasks.Task<System.ValueTuple<System.Collections.Generic.IEnumerable<string>, long>> SelectAllPersistenceIdsAsync(long offset) { }
         protected bool WaitingForInitialization(object message) { }
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken = null) { }
     }
     [System.ObsoleteAttribute("Query is not implemented.", true)]
     public sealed class SubscribeNewEvents : Akka.Persistence.Sql.Common.Journal.ISubscriptionCommand
@@ -490,12 +490,12 @@ namespace Akka.Persistence.Sql.Common.Snapshot
         public Akka.Actor.IStash Stash { get; set; }
         protected abstract System.Data.Common.DbConnection CreateDbConnection(string connectionString);
         public System.Data.Common.DbConnection CreateDbConnection() { }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken = null) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
         protected virtual string GetConnectionString() { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken = null) { }
         protected override void PostStop() { }
         protected override void PreStart() { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken = null) { }
     }
 }

--- a/src/core/Akka.Docs.Tests/Utilities/CircuitBreakerDocSpec.cs
+++ b/src/core/Akka.Docs.Tests/Utilities/CircuitBreakerDocSpec.cs
@@ -52,7 +52,7 @@ namespace DocsExamples.Utilities.CircuitBreakers
             Receive<string>(str => str.Equals("is my middle name"), _ =>
             {
                 var sender = this.Sender;
-                breaker.WithCircuitBreaker(() => Task.FromResult(dangerousCall)).PipeTo(sender);
+                breaker.WithCircuitBreaker(cancellationToken => Task.FromResult(dangerousCall)).PipeTo(sender);
             });
 
             Receive<string>(str => str.Equals("block for me"), _ =>

--- a/src/core/Akka.Persistence.TestKit/Journal/TestJournal.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/TestJournal.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading;
+
 namespace Akka.Persistence.TestKit
 {
     using Akka.Actor;
@@ -48,7 +50,7 @@ namespace Akka.Persistence.TestKit
             }
         }
 
-        protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken = default)
         {
             await _connectionInterceptor.InterceptAsync();
             var exceptions = new List<Exception>();
@@ -103,10 +105,10 @@ namespace Akka.Persistence.TestKit
             }
         }
 
-        public override async Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        public override async Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken = default)
         {
             await _connectionInterceptor.InterceptAsync();
-            return await base.ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr);
+            return await base.ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, cancellationToken);
         }
 
         /// <summary>

--- a/src/core/Akka.Persistence.TestKit/SnapshotStore/TestSnapshotStore.cs
+++ b/src/core/Akka.Persistence.TestKit/SnapshotStore/TestSnapshotStore.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading;
+
 namespace Akka.Persistence.TestKit
 {
     using System.Threading.Tasks;
@@ -50,32 +52,32 @@ namespace Akka.Persistence.TestKit
             }
         }
 
-        protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken = default)
         {
             await _connectionInterceptor.InterceptAsync();
             await _saveInterceptor.InterceptAsync(metadata.PersistenceId, ToSelectionCriteria(metadata));
-            await base.SaveAsync(metadata, snapshot);
+            await base.SaveAsync(metadata, snapshot, cancellationToken);
         }
 
-        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             await _connectionInterceptor.InterceptAsync();
             await _loadInterceptor.InterceptAsync(persistenceId, criteria);
-            return await base.LoadAsync(persistenceId, criteria);
+            return await base.LoadAsync(persistenceId, criteria, cancellationToken);
         }
 
-        protected override async Task DeleteAsync(SnapshotMetadata metadata)
+        protected override async Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken = default)
         {
             await _connectionInterceptor.InterceptAsync();
             await _deleteInterceptor.InterceptAsync(metadata.PersistenceId, ToSelectionCriteria(metadata));
-            await base.DeleteAsync(metadata);
+            await base.DeleteAsync(metadata, cancellationToken);
         }
 
-        protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             await _connectionInterceptor.InterceptAsync();
             await _deleteInterceptor.InterceptAsync(persistenceId, criteria);
-            await base.DeleteAsync(persistenceId, criteria);
+            await base.DeleteAsync(persistenceId, criteria, cancellationToken);
         }
 
         static SnapshotSelectionCriteria ToSelectionCriteria(SnapshotMetadata metadata)

--- a/src/core/Akka.Persistence.Tests/Journal/ChaosJournal.cs
+++ b/src/core/Akka.Persistence.Tests/Journal/ChaosJournal.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Persistence.Journal;
@@ -83,7 +84,7 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
-        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken = default)
         {
             var promise = new TaskCompletionSource<long>();
             if (ChaosSupportExtensions.ShouldFail(_readHighestFailureRate))
@@ -93,7 +94,7 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken = default)
         {
             var promise =
                 new TaskCompletionSource<IImmutableList<Exception>>();
@@ -120,7 +121,7 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
-        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken = default)
         {
             TaskCompletionSource<object> promise = new TaskCompletionSource<object>();
             try

--- a/src/core/Akka.Persistence.Tests/PersistentActorDeleteFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorDeleteFailureSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -41,7 +42,7 @@ namespace Akka.Persistence.Tests
 
         public class DeleteFailingMemoryJournal : MemoryJournal
         {
-            protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+            protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken = default)
             {
                 var promise = new TaskCompletionSource<object>();
                 promise.SetException(new SimulatedException("Boom! Unable to delete events!"));

--- a/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Persistence.Journal;
@@ -49,7 +50,7 @@ namespace Akka.Persistence.Tests
         internal class FailingMemoryJournal : MemoryJournal
         {
 
-            protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+            protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken = default)
             {
                 var msgs = messages.ToList();
                 if (IsWrong(msgs))
@@ -59,7 +60,7 @@ namespace Akka.Persistence.Tests
                 {
                     return Task.FromResult(checkSerializable);
                 }
-                return base.WriteMessagesAsync(msgs);
+                return base.WriteMessagesAsync(msgs, cancellationToken);
             }
 
             public override Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr,

--- a/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -168,18 +169,18 @@ namespace Akka.Persistence.Tests
 
         internal class DeleteFailingLocalSnapshotStore : LocalSnapshotStore
         {
-            protected override Task DeleteAsync(SnapshotMetadata metadata)
+            protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken = default)
             {
-                base.DeleteAsync(metadata); // we actually delete it properly, but act as if it failed
+                base.DeleteAsync(metadata, cancellationToken); // we actually delete it properly, but act as if it failed
                 var promise = new TaskCompletionSource<object>();
                 promise.SetException(new InvalidOperationException("Failed to delete snapshot for some reason."));
                 return promise.Task;
             }
 
-            protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
             {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                base.DeleteAsync(persistenceId, criteria); // we actually delete it properly, but act as if it failed
+                base.DeleteAsync(persistenceId, criteria, cancellationToken); // we actually delete it properly, but act as if it failed
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
                 var promise = new TaskCompletionSource<object>();
                 promise.SetException(new InvalidOperationException("Failed to delete snapshot for some reason."));

--- a/src/core/Akka.Persistence/Journal/AsyncRecovery.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncRecovery.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 
@@ -62,7 +63,8 @@ namespace Akka.Persistence.Journal
         /// <param name="fromSequenceNr">Hint where to start searching for the highest sequence number.
         /// When a persistent actor is recovering this <paramref name="fromSequenceNr"/> will the sequence
         /// number of the used snapshot, or `0L` if no snapshot is used.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <returns>TBD</returns>
-        Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+        Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken = default);
     }
 }

--- a/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using System.Runtime.Serialization;
+using System.Threading;
 
 namespace Akka.Persistence.Journal
 {
@@ -324,16 +325,17 @@ namespace Akka.Persistence.Journal
         /// TBD
         /// </summary>
         /// <param name="messages">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <exception cref="TimeoutException">
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken = default)
         {
             if (_store == null)
                 return StoreNotInitialized<IImmutableList<Exception>>();
 
-            return _store.Ask<IImmutableList<Exception>>(new AsyncWriteTarget.WriteMessages(messages), Timeout);
+            return _store.Ask<IImmutableList<Exception>>(new AsyncWriteTarget.WriteMessages(messages), Timeout, cancellationToken);
         }
 
         /// <summary>
@@ -341,16 +343,17 @@ namespace Akka.Persistence.Journal
         /// </summary>
         /// <param name="persistenceId">TBD</param>
         /// <param name="toSequenceNr">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <exception cref="TimeoutException">
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken = default)
         {
             if (_store == null)
                 return StoreNotInitialized<object>();
 
-            return _store.Ask(new AsyncWriteTarget.DeleteMessagesTo(persistenceId, toSequenceNr), Timeout);
+            return _store.Ask(new AsyncWriteTarget.DeleteMessagesTo(persistenceId, toSequenceNr), Timeout, cancellationToken);
         }
 
         /// <summary>
@@ -384,16 +387,17 @@ namespace Akka.Persistence.Journal
         /// </summary>
         /// <param name="persistenceId">TBD</param>
         /// <param name="fromSequenceNr">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <exception cref="TimeoutException">
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken = default)
         {
             if (_store == null)
                 return StoreNotInitialized<long>();
 
-            return _store.Ask<AsyncWriteTarget.ReplaySuccess>(new AsyncWriteTarget.ReplayMessages(persistenceId, 0, 0, 0), Timeout)
+            return _store.Ask<AsyncWriteTarget.ReplaySuccess>(new AsyncWriteTarget.ReplayMessages(persistenceId, 0, 0, 0), Timeout, cancellationToken)
                 .ContinueWith(t => t.Result.HighestSequenceNr, TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 

--- a/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Dispatch;
 using Akka.Event;
@@ -67,7 +68,7 @@ namespace Akka.Persistence.Snapshot
         private readonly ILoggingAdapter _log;
 
         /// <inheritdoc/>
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             //
             // Heuristics:
@@ -81,7 +82,7 @@ namespace Akka.Persistence.Snapshot
         }
 
         /// <inheritdoc/>
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken = default)
         {
             _saving.Add(metadata);
             return RunWithStreamDispatcher(() =>
@@ -92,7 +93,7 @@ namespace Akka.Persistence.Snapshot
         }
 
         /// <inheritdoc/>
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
+        protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken = default)
         {
             _saving.Remove(metadata);
             return RunWithStreamDispatcher(() =>
@@ -109,11 +110,11 @@ namespace Akka.Persistence.Snapshot
         }
 
         /// <inheritdoc/>
-        protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             foreach (var metadata in GetSnapshotMetadata(persistenceId, criteria))
             {
-                await DeleteAsync(metadata);
+                await DeleteAsync(metadata, cancellationToken);
             }
         }
 

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Util.Internal;
 
@@ -25,7 +26,7 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         protected virtual List<SnapshotEntry> Snapshots { get; } = new();
 
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
+        protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken = default)
         {
             bool Pred(SnapshotEntry x) => x.PersistenceId == metadata.PersistenceId && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
                                                                                     && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
@@ -37,7 +38,7 @@ namespace Akka.Persistence.Snapshot
             return TaskEx.Completed;
         }
 
-        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             var filter = CreateRangeFilter(persistenceId, criteria);
 
@@ -45,7 +46,7 @@ namespace Akka.Persistence.Snapshot
             return TaskEx.Completed;
         }
 
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             var filter = CreateRangeFilter(persistenceId, criteria);
 
@@ -54,7 +55,7 @@ namespace Akka.Persistence.Snapshot
             return Task.FromResult(snapshot);
         }
 
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken = default)
         {
 
             var snapshotEntry = ToSnapshotEntry(metadata, snapshot);

--- a/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Runtime.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Akka.Persistence.Snapshot
@@ -64,8 +65,9 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         /// <param name="persistenceId">TBD</param>
         /// <param name="criteria">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <returns>TBD</returns>
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             return Task.FromResult((SelectedSnapshot)null);
         }
@@ -75,11 +77,12 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         /// <param name="metadata">TBD</param>
         /// <param name="snapshot">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <exception cref="NoSnapshotStoreException">
         /// This exception is thrown when no snapshot store is configured.
         /// </exception>
         /// <returns>TBD</returns>
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken = default)
         {
             return Flop();
         }
@@ -88,11 +91,12 @@ namespace Akka.Persistence.Snapshot
         /// TBD
         /// </summary>
         /// <param name="metadata">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <exception cref="NoSnapshotStoreException">
         /// This exception is thrown when no snapshot store is configured.
         /// </exception>
         /// <returns>TBD</returns>
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
+        protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken = default)
         {
             return Flop();
         }
@@ -102,11 +106,12 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         /// <param name="persistenceId">TBD</param>
         /// <param name="criteria">TBD</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to stop async operation</param>
         /// <exception cref="NoSnapshotStoreException">
         /// This exception is thrown when no snapshot store is configured.
         /// </exception>
         /// <returns>TBD</returns>
-        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken = default)
         {
             return Flop();
         }

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
@@ -17,6 +17,7 @@ using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
+using static FluentAssertions.FluentActions;
 
 namespace Akka.Tests.Pattern
 {
@@ -199,38 +200,45 @@ namespace Akka.Tests.Pattern
         public async Task Must_allow_calls_through()
         {
             var breaker = LongCallTimeoutCb();
-            var result = await breaker.Instance.WithCircuitBreaker(() => Task.Run(SayHi)).WaitAsync(AwaitTimeout);
-            Assert.Equal("hi", result);
+            var result = await breaker.Instance.WithCircuitBreaker(SayHiAsync).WaitAsync(AwaitTimeout);
+            result.Should().Be("hi");
         }
 
         [Fact(DisplayName = "An asynchronous circuit breaker that is closed must increment failure count on exception")]
         public async Task Must_increment_failure_count_on_exception()
         {
             var breaker = LongCallTimeoutCb();
-            await InterceptException<TestException>(() =>
-                breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException)).WaitAsync(AwaitTimeout));
-            Assert.True(CheckLatch(breaker.OpenLatch));
-            breaker.Instance.CurrentFailureCount.ShouldBe(1);
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
+
+            CheckLatch(breaker.OpenLatch).Should().BeTrue();
+            breaker.Instance.CurrentFailureCount.Should().Be(1);
         }
 
         [Fact(DisplayName = "An asynchronous circuit breaker that is closed must increment failure count on async failure")]
-        public void Must_increment_failure_count_on_async_failure()
+        public async Task Must_increment_failure_count_on_async_failure()
         {
             var breaker = LongCallTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
-            Assert.True(CheckLatch(breaker.OpenLatch));
-            breaker.Instance.CurrentFailureCount.ShouldBe(1);
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
+
+            CheckLatch(breaker.OpenLatch).Should().BeTrue();
+            breaker.Instance.CurrentFailureCount.Should().Be(1);
         }
 
         [Fact(DisplayName = "An asynchronous circuit breaker that is closed must reset failure count after success")]
         public async Task Must_reset_failure_count_after_success()
         {
             var breaker = MultiFailureCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(SayHi));
-            Enumerable.Range(1, 4).ForEach(_ => breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException)));
-            await AwaitAssertAsync(() => breaker.Instance.CurrentFailureCount.ShouldBe(4), AwaitTimeout);
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(SayHi));
-            await AwaitAssertAsync(() => breaker.Instance.CurrentFailureCount.ShouldBe(0), AwaitTimeout);
+            _ = await breaker.Instance.WithCircuitBreaker(SayHiAsync).WaitAsync(AwaitTimeout);
+
+            await Task.WhenAll(Enumerable.Range(1, 4)
+                .Select(_ 
+                    => InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync))));
+
+            breaker.Instance.CurrentFailureCount.Should().Be(4);
+            
+            var result = await breaker.Instance.WithCircuitBreaker(SayHiAsync).WaitAsync(AwaitTimeout);
+            result.Should().Be("hi");
+            breaker.Instance.CurrentFailureCount.ShouldBe(0);
         }
 
         [Fact(DisplayName = "An asynchronous circuit breaker that is closed must increment failure count on callTimeout")]
@@ -238,26 +246,40 @@ namespace Akka.Tests.Pattern
         {
             var breaker = ShortCallTimeoutCb();
 
-            var future = breaker.Instance.WithCircuitBreaker(async () =>
-            {
-                await Task.Delay(150);
-                ThrowException();
-            });
+            var innerFuture = SlowThrowing();
+            var future = breaker.Instance.WithCircuitBreaker(() => innerFuture);
 
-            Assert.True(CheckLatch(breaker.OpenLatch));
-            breaker.Instance.CurrentFailureCount.ShouldBe(1);
+            CheckLatch(breaker.OpenLatch).Should().BeTrue();
+            breaker.Instance.CurrentFailureCount.Should().Be(1);
 
             // Since the timeout should have happened before the inner code finishes
             // we expect a timeout, not TestException
-            await InterceptException<TimeoutException>(() => future.WaitAsync(AwaitTimeout));
+            await InterceptException<TimeoutException>(() => future);
+            
+            // Issue https://github.com/akkadotnet/akka.net/issues/7358
+            // The actual exception is thrown out-of-band with no handler because inner Task is detached
+            // after a timeout and NOT protected
+            
+            // In the bug, the task is still running when it should've been stopped. 
+            innerFuture.IsCompleted.Should().BeTrue();
+            innerFuture.IsFaulted.Should().BeTrue();
+            innerFuture.Exception.Should().BeOfType<TestException>();
+            
+            return;
+            
+            async Task SlowThrowing()
+            {
+                await Task.Delay(150);
+                await ThrowExceptionAsync();
+            }
         }
 
         [Fact(DisplayName = "An asynchronous circuit breaker that is closed must invoke onOpen if call fails and breaker transits to open state")]
-        public void Must_invoke_onOpen_if_call_fails_and_breaker_transits_to_open_state()
+        public async Task Must_invoke_onOpen_if_call_fails_and_breaker_transits_to_open_state()
         {
             var breaker = ShortCallTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
-            Assert.True(CheckLatch(breaker.OpenLatch));
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
+            CheckLatch(breaker.OpenLatch).Should().BeTrue();
         }
     }
 
@@ -267,35 +289,36 @@ namespace Akka.Tests.Pattern
         public async Task Must_pass_through_next_call_and_close_on_success()
         {
             var breaker = ShortResetTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
-            Assert.True(CheckLatch(breaker.HalfOpenLatch));
-            var result = await breaker.Instance.WithCircuitBreaker(() => Task.Run(SayHi)).WaitAsync(AwaitTimeout);
-            Assert.Equal("hi", result);
-            Assert.True(CheckLatch(breaker.ClosedLatch));
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
+            CheckLatch(breaker.HalfOpenLatch).Should().BeTrue();
+
+            var result = await breaker.Instance.WithCircuitBreaker(SayHiAsync).WaitAsync(AwaitTimeout);
+            result.Should().Be("hi");
+            CheckLatch(breaker.ClosedLatch).Should().BeTrue();
         }
 
         [Fact(DisplayName = "An asynchronous circuit breaker that is half open must re-open on exception in call")]
         public async Task Must_reopen_on_exception_in_call()
         {
             var breaker = ShortResetTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
-            Assert.True(CheckLatch(breaker.HalfOpenLatch));
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
+            CheckLatch(breaker.HalfOpenLatch).Should().BeTrue();
+            
             breaker.OpenLatch.Reset();
-            await InterceptException<TestException>(() =>
-                breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException)).WaitAsync(AwaitTimeout));
-            Assert.True(CheckLatch(breaker.OpenLatch));
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
+            CheckLatch(breaker.OpenLatch).Should().BeTrue();
         }
 
         [Fact(DisplayName = "An asynchronous circuit breaker that is half open must re-open on async failure")]
-        public void Must_reopen_on_async_failure()
+        public async Task Must_reopen_on_async_failure()
         {
             var breaker = ShortResetTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
-            Assert.True(CheckLatch(breaker.HalfOpenLatch));
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
+            CheckLatch(breaker.HalfOpenLatch).Should().BeTrue();
 
             breaker.OpenLatch.Reset();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
-            Assert.True(CheckLatch(breaker.OpenLatch));
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
+            CheckLatch(breaker.OpenLatch).Should().BeTrue();
         }
     }
 
@@ -305,43 +328,40 @@ namespace Akka.Tests.Pattern
         public async Task Must_throw_exceptions_when_called_before_reset_timeout()
         {
             var breaker = LongResetTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
+            CheckLatch(breaker.OpenLatch).Should().BeTrue();
 
-            Assert.True(CheckLatch(breaker.OpenLatch));
-
-            await InterceptException<OpenCircuitException>(
-                () => breaker.Instance.WithCircuitBreaker(() => Task.Run(SayHi)).WaitAsync(AwaitTimeout));
+            await InterceptException<OpenCircuitException>(() => breaker.Instance.WithCircuitBreaker(SayHiAsync));
         }
 
         [Fact(DisplayName = "An asynchronous circuit breaker that is open must transition to half-open on reset timeout")]
-        public void Must_transition_to_half_open_on_reset_timeout()
+        public async Task Must_transition_to_half_open_on_reset_timeout()
         {
             var breaker = ShortResetTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
-            Assert.True(CheckLatch(breaker.HalfOpenLatch));
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
+            CheckLatch(breaker.HalfOpenLatch).Should().BeTrue();
         }
 
         [Fact(DisplayName = "An asynchronous circuit breaker that is open must increase the reset timeout after it transits to open again")]
         public async Task Must_increase_reset_timeout_after_it_transits_to_open_again()
         {
             var breaker = NonOneFactorCb();
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
             _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
-            Assert.True(CheckLatch(breaker.OpenLatch));
+            CheckLatch(breaker.OpenLatch).Should().BeTrue();
 
-            var e1 = await InterceptException<OpenCircuitException>(
-                () => breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException)));
+            var e1 = await InterceptException<OpenCircuitException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
             var shortRemainingDuration = e1.RemainingDuration;
 
             await Task.Delay(Dilated(TimeSpan.FromMilliseconds(1000)));
-            Assert.True(CheckLatch(breaker.HalfOpenLatch));
+            CheckLatch(breaker.HalfOpenLatch).Should().BeTrue();
 
             // transit to open again
             breaker.OpenLatch.Reset();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
-            Assert.True(CheckLatch(breaker.OpenLatch));
+            await InterceptException<TestException>(() => breaker.Instance.WithCircuitBreaker(ThrowExceptionAsync));
+            CheckLatch(breaker.OpenLatch).Should().BeTrue();
 
-            var e2 = await InterceptException<OpenCircuitException>(() =>
-                breaker.Instance.WithCircuitBreaker(() => Task.FromResult(SayHi())));
+            var e2 = await InterceptException<OpenCircuitException>(() => breaker.Instance.WithCircuitBreaker(SayHiAsync));
             var longRemainingDuration = e2.RemainingDuration;
 
             shortRemainingDuration.ShouldBeLessThan(longRemainingDuration);
@@ -357,15 +377,29 @@ namespace Akka.Tests.Pattern
         [DebuggerStepThrough]
         public static void ThrowException() => throw new TestException("Test Exception");
 
+        [DebuggerStepThrough]
+        public static async Task ThrowExceptionAsync()
+        {
+            await Task.Yield();
+            throw new TestException("Test Exception");
+        }
+
         public static string SayHi() => "hi";
 
-        protected T InterceptException<T>(Action actionThatThrows) where T : Exception =>
-            Intercept<T>(actionThatThrows);
+        public static async Task<string> SayHiAsync()
+        {
+            await Task.Yield();
+            return "hi";
+        }
 
-        protected static async Task<T> InterceptException<T>(Func<Task> actionThatThrows)
+        protected static T InterceptException<T>(Action actionThatThrows) where T : Exception =>
+            actionThatThrows.Should().Throw<T>().And;
+
+        protected async Task<T> InterceptException<T>(Func<Task> actionThatThrows)
             where T : Exception
         {
-            return (await actionThatThrows.Should().ThrowExactlyAsync<T>()).And;
+            return (await Awaiting(() => actionThatThrows().WaitAsync(AwaitTimeout))
+                .Should().ThrowExactlyAsync<T>()).And;
         }
 
         public TestBreaker ShortCallTimeoutCb() =>

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Pattern;
@@ -94,9 +95,9 @@ namespace Akka.Tests.Pattern
                 }
             }
 
-            private static async Task<JobDone> Job()
+            private static async Task<JobDone> Job(CancellationToken ct)
             {
-                await Task.Delay(TimeSpan.FromMilliseconds(ThreadLocalRandom.Current.Next(300)));
+                await Task.Delay(TimeSpan.FromMilliseconds(ThreadLocalRandom.Current.Next(300)), ct);
                 return JobDone.Instance;
             }
         }

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -224,9 +224,22 @@ namespace Akka.Pattern
         /// <typeparam name="T">TBD</typeparam>
         /// <param name="body">Call needing protected</param>
         /// <returns><see cref="Task"/> containing the call result</returns>
+        [Obsolete("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public Task<T> WithCircuitBreaker<T>(Func<Task<T>> body) => CurrentState.Invoke(body);
 
+        /// <summary>
+        /// Wraps invocation of asynchronous calls that need to be protected
+        /// </summary>
+        /// <typeparam name="T">TBD</typeparam>
+        /// <param name="body">Call needing protected</param>
+        /// <returns><see cref="Task"/> containing the call result</returns>
+        public Task<T> WithCircuitBreaker<T>(Func<CancellationToken, Task<T>> body) => CurrentState.Invoke(body);
+
+        [Obsolete("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public Task<T> WithCircuitBreaker<T, TState>(TState state, Func<TState, Task<T>> body) => 
+            CurrentState.InvokeState(state, body);
+
+        public Task<T> WithCircuitBreaker<T, TState>(TState state, Func<TState, CancellationToken, Task<T>> body) => 
             CurrentState.InvokeState(state, body);
 
         /// <summary>
@@ -234,9 +247,21 @@ namespace Akka.Pattern
         /// </summary>
         /// <param name="body">Call needing protected</param>
         /// <returns><see cref="Task"/></returns>
+        [Obsolete("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public Task WithCircuitBreaker(Func<Task> body) => CurrentState.Invoke(body);
 
+        /// <summary>
+        /// Wraps invocation of asynchronous calls that need to be protected
+        /// </summary>
+        /// <param name="body">Call needing protected</param>
+        /// <returns><see cref="Task"/></returns>
+        public Task WithCircuitBreaker(Func<CancellationToken, Task> body) => CurrentState.Invoke(body);
+
+        [Obsolete("Use WithCircuitBreaker that takes a cancellation token in the body instead", true)]
         public Task WithCircuitBreaker<TState>(TState state, Func<TState, Task> body) => 
+            CurrentState.InvokeState(state, body);
+
+        public Task WithCircuitBreaker<TState>(TState state, Func<TState, CancellationToken, Task> body) => 
             CurrentState.InvokeState(state, body);
 
         /// <summary>
@@ -244,7 +269,7 @@ namespace Akka.Pattern
         /// </summary>
         /// <param name="body">Call needing protected</param>
         public void WithSyncCircuitBreaker(Action body) =>
-            WithCircuitBreaker(body, b => Task.Run(b)).GetAwaiter().GetResult();
+            WithCircuitBreaker(body, (b, ct) => Task.Run(b, ct)).GetAwaiter().GetResult();
 
         /// <summary>
         /// Wraps invocations of asynchronous calls that need to be protected.
@@ -252,7 +277,7 @@ namespace Akka.Pattern
         /// <param name="body">Call needing protected</param>
         /// <returns>The result of the call</returns>
         public T WithSyncCircuitBreaker<T>(Func<T> body) =>
-            WithCircuitBreaker(body, b => Task.Run(b)).GetAwaiter().GetResult();
+            WithCircuitBreaker(body, (b, ct) => Task.Run(b, ct)).GetAwaiter().GetResult();
 
         /// <summary>
         /// Mark a successful call through CircuitBreaker. Sometimes the callee of CircuitBreaker sends back a message to the

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -252,7 +252,7 @@ namespace Akka.Pattern
         /// <param name="body">Call needing protected</param>
         /// <returns>The result of the call</returns>
         public T WithSyncCircuitBreaker<T>(Func<T> body) =>
-            WithCircuitBreaker(body, b => Task.Run(b)).Result;
+            WithCircuitBreaker(body, b => Task.Run(b)).GetAwaiter().GetResult();
 
         /// <summary>
         /// Mark a successful call through CircuitBreaker. Sometimes the callee of CircuitBreaker sends back a message to the

--- a/src/core/Akka/Util/Internal/AtomicState.cs
+++ b/src/core/Akka/Util/Internal/AtomicState.cs
@@ -80,22 +80,15 @@ namespace Akka.Util.Internal
         public async Task<T> CallThrough<T>(Func<CancellationToken, Task<T>> task)
         {
             var result = default(T);
+            using var cts = new CancellationTokenSource();
             try
             {
-                using var cts = new CancellationTokenSource();
-                try
-                {
-                    result = await task(cts.Token).WaitAsync(_callTimeout).ConfigureAwait(false);
-                    CallSucceeds();
-                }
-                catch
-                {
-                    cts.Cancel();
-                    throw;
-                }
+                result = await task(cts.Token).WaitAsync(_callTimeout).ConfigureAwait(false);
+                CallSucceeds();
             }
             catch (Exception ex)
             {
+                cts.Cancel();
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -107,24 +100,15 @@ namespace Akka.Util.Internal
         public async Task<T> CallThrough<T, TState>(TState state, Func<TState, CancellationToken, Task<T>> task)
         {
             var result = default(T);
+            using var cts = new CancellationTokenSource(_callTimeout);
             try
             {
-                using var cts = new CancellationTokenSource(_callTimeout);
-                try
-                {
-                    result = await task(state, cts.Token).WaitAsync(_callTimeout, cts.Token).ConfigureAwait(false);
-                    CallSucceeds();
-                }
-                catch (OperationCanceledException cancelled)
-                {
-                    if(cts.IsCancellationRequested)
-                        throw new TimeoutException(null, cancelled);
-                    
-                    throw;
-                }
+                result = await task(state, cts.Token).WaitAsync(_callTimeout, cts.Token).ConfigureAwait(false);
+                CallSucceeds();
             }
             catch (Exception ex)
             {
+                cts.Cancel();
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -141,22 +125,15 @@ namespace Akka.Util.Internal
         /// <returns><see cref="Task"/> containing the result of the call</returns>
         public async Task CallThrough(Func<CancellationToken, Task> task)
         {
+            using var cts = new CancellationTokenSource();
             try
             {
-                using var cts = new CancellationTokenSource();
-                try
-                {
-                    await task(cts.Token).WaitAsync(_callTimeout).ConfigureAwait(false);
-                    CallSucceeds();
-                }
-                catch
-                {
-                    cts.Cancel();
-                    throw;
-                }
+                await task(cts.Token).WaitAsync(_callTimeout).ConfigureAwait(false);
+                CallSucceeds();
             }
             catch (Exception ex)
             {
+                cts.Cancel();
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -165,22 +142,15 @@ namespace Akka.Util.Internal
 
         public async Task CallThrough<TState>(TState state, Func<TState, CancellationToken, Task> task)
         {
+            using var cts = new CancellationTokenSource();
             try
             {
-                using var cts = new CancellationTokenSource();
-                try
-                {
-                    await task(state, cts.Token).WaitAsync(_callTimeout).ConfigureAwait(false);
-                    CallSucceeds();
-                }
-                catch
-                {
-                    cts.Cancel();
-                    throw;
-                }
+                await task(state, cts.Token).WaitAsync(_callTimeout).ConfigureAwait(false);
+                CallSucceeds();
             }
             catch (Exception ex)
             {
+                cts.Cancel();
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();

--- a/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
+++ b/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
@@ -184,12 +184,13 @@ namespace Akka.Persistence.Custom.Snapshot
         //<LoadAsync>
         protected sealed override async Task<SelectedSnapshot> LoadAsync(
             string persistenceId,
-            SnapshotSelectionCriteria criteria)
+            SnapshotSelectionCriteria criteria,
+            CancellationToken cancellationToken = default)
         {
             // Create a new DbConnection instance
             using (var connection = new SqliteConnection(_connectionString))
             using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+                       .CreateLinkedTokenSource(cancellationToken, _pendingRequestsCancellation.Token))
             {
                 await connection.OpenAsync(cts.Token);
                 
@@ -234,12 +235,13 @@ namespace Akka.Persistence.Custom.Snapshot
         //<SaveAsync>
         protected sealed override async Task SaveAsync(
             SnapshotMetadata metadata,
-            object snapshot)
+            object snapshot,
+            CancellationToken cancellationToken = default)
         {
             // Create a new DbConnection instance
             using (var connection = new SqliteConnection(_connectionString))
             using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+                       .CreateLinkedTokenSource(cancellationToken, _pendingRequestsCancellation.Token))
             {
                 await connection.OpenAsync(cts.Token);
                 
@@ -302,12 +304,14 @@ namespace Akka.Persistence.Custom.Snapshot
         //</SaveAsync>
 
         //<DeleteAsync>
-        protected sealed override async Task DeleteAsync(SnapshotMetadata metadata)
+        protected sealed override async Task DeleteAsync(
+            SnapshotMetadata metadata,
+            CancellationToken cancellationToken = default)
         {
             // Create a new DbConnection instance
             using (var connection = new SqliteConnection(_connectionString))
             using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))    
+                       .CreateLinkedTokenSource(cancellationToken, _pendingRequestsCancellation.Token))    
             {
                 await connection.OpenAsync(cts.Token);
                 var timestamp = metadata.Timestamp != DateTime.MinValue 
@@ -346,12 +350,13 @@ namespace Akka.Persistence.Custom.Snapshot
         //<DeleteAsync2>
         protected sealed override async Task DeleteAsync(
             string persistenceId, 
-            SnapshotSelectionCriteria criteria)
+            SnapshotSelectionCriteria criteria,
+            CancellationToken cancellationToken = default)
         {
             // Create a new DbConnection instance
             using (var connection = new SqliteConnection(_connectionString))
             using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+                       .CreateLinkedTokenSource(cancellationToken, _pendingRequestsCancellation.Token))
             {
                 await connection.OpenAsync(cts.Token);
                 


### PR DESCRIPTION
Fixes #7358

## Changes

* Modernize unit tests
* Add unit test