### PR TITLE
Add missing cluster singleton detection

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonProxySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonProxySpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -14,11 +15,18 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit;
 using Xunit;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.Singleton
 {
     public class ClusterSingletonProxySpec : TestKit.Xunit2.TestKit
     {
+        public ClusterSingletonProxySpec(ITestOutputHelper output): base(output: output)
+        {
+        }
+        
         [Fact]
         public void ClusterSingletonProxy_must_correctly_identify_the_singleton()
         {
@@ -67,12 +75,174 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             }
         }
 
+        [Fact(DisplayName = "ClusterSingletonProxy should detect if its associated singleton failed to start after a period")]
+        public async Task ClusterSingletonProxySingletonTimeoutTest()
+        {
+            ActorSys seed = null;
+            ActorSys testSystem = null;
+
+            try
+            {
+                seed = new ActorSys(output: Output);
+                seed.Cluster.Join(seed.Cluster.SelfAddress);
+
+                // singleton proxy is waiting for a singleton in a non-existent role
+                testSystem = new ActorSys(
+                    config: """
+                            akka.cluster.singleton-proxy {
+                                role = "non-existent"
+                                log-singleton-identification-failure = true
+                                singleton-identification-failure-period = 500ms
+                            }
+                            """,
+                    output: Output);
+
+                testSystem.Sys.EventStream.Subscribe<ClusterSingletonProxy.IdentifySingletonTimedOut>(testSystem
+                    .TestActor);
+
+                // Proxy should not try to detect missing singleton if it is not part of a cluster
+                await testSystem.ExpectNoMsgAsync(1.Seconds());
+
+                testSystem.Cluster.Join(seed.Cluster.SelfAddress);
+
+                // proxy will emit IdentifySingletonTimedOut event locally if it could not find its associated singleton
+                // within the detection period
+                var msg = await testSystem.ExpectMsgAsync<ClusterSingletonProxy.IdentifySingletonTimedOut>(3.Seconds());
+                msg.SingletonName.Should().Be("singleton");
+                msg.Role.Should().Be("non-existent");
+                msg.Duration.Should().Be(TimeSpan.FromMilliseconds(500));
+
+                // force seed to leave
+                seed.Cluster.Leave(seed.Cluster.SelfAddress);
+
+                // another event should be fired because the cluster topology changed
+                msg = await testSystem.ExpectMsgAsync<ClusterSingletonProxy.IdentifySingletonTimedOut>(3.Seconds());
+                msg.SingletonName.Should().Be("singleton");
+                msg.Role.Should().Be("non-existent");
+                msg.Duration.Should().Be(TimeSpan.FromMilliseconds(500));
+            }
+            finally
+            {
+                var tasks = new List<Task>();
+                
+                if(seed is not null)
+                    tasks.Add(seed.Sys.Terminate());
+                if(testSystem is not null)
+                    tasks.Add(testSystem.Sys.Terminate());
+                
+                if(tasks.Any())
+                    await Task.WhenAll(tasks);
+            }
+        }
+
+        [Fact(DisplayName = "ClusterSingletonProxy should not start singleton identify detection if a singleton reference already found")]
+        public async Task ClusterSingletonProxySingletonTimeoutTest2()
+        {
+            const string seedConfig = """
+                                      akka.cluster {
+                                          roles = [seed] # only start singletons on seed role
+                                          min-nr-of-members = 1
+                                          singleton.role = seed # only start singletons on seed role
+                                          singleton-proxy.role = seed # only start singletons on seed role
+                                      }
+                                      """;
+            
+            ActorSys seed = null;
+            ActorSys seed2 = null;
+            ActorSys testSystem = null;
+
+            try
+            {
+                seed = new ActorSys(config: seedConfig, output: Output);
+                seed.Cluster.Join(seed.Cluster.SelfAddress);
+
+                // need to make sure that cluster member age is correct. seed node should be oldest.
+                await AwaitConditionAsync(
+                    () => Task.FromResult(Cluster.Get(seed.Sys).State.Members.Count(m => m.Status == MemberStatus.Up) == 1),
+                    TimeSpan.FromSeconds(30));
+
+                seed2 = new ActorSys(config: seedConfig, output: Output);
+                seed2.Cluster.Join(seed.Cluster.SelfAddress);
+
+                // singleton proxy is waiting for a singleton in seed role
+                testSystem = new ActorSys(
+                    config: """
+                            akka.cluster {
+                                roles = [proxy]
+                                singleton.role = seed # only start singletons on seed role
+                                singleton-proxy {
+                                    role = seed # only start singletons on seed role
+                                    log-singleton-identification-failure = true
+                                    singleton-identification-failure-period = 1s
+                                }
+                            }
+                            """,
+                    startSingleton: false,
+                    output: Output);
+
+                testSystem.Sys.EventStream.Subscribe<ClusterSingletonProxy.IdentifySingletonTimedOut>(testSystem.TestActor);
+                testSystem.Cluster.Join(seed.Cluster.SelfAddress);
+
+                // need to make sure that cluster member age is correct. seed node should be oldest.
+                await AwaitConditionAsync(
+                    () => Task.FromResult(Cluster.Get(testSystem.Sys).State.Members.Count(m => m.Status == MemberStatus.Up) == 3),
+                    TimeSpan.FromSeconds(30));
+
+                testSystem.TestProxy("hello");
+
+                // timeout event should not fire
+                await testSystem.ExpectNoMsgAsync(1.5.Seconds());
+
+                // Second seed node left the cluster, no timeout should be fired because singleton is homed in the first seed
+                await seed2.Sys.Terminate();
+                
+                // wait until MemberRemoved is triggered
+                await AwaitConditionAsync(
+                    () => Task.FromResult(Cluster.Get(testSystem.Sys).State.Members.Count(m => m.Status == MemberStatus.Up) == 2),
+                    TimeSpan.FromSeconds(30));
+
+                // timeout event should not fire
+                await testSystem.ExpectNoMsgAsync(1.5.Seconds());
+
+                // First seed node which homed the singleton left the cluster
+                await seed.Sys.Terminate();
+                
+                // wait until MemberRemoved is triggered
+                await AwaitConditionAsync(
+                    () => Task.FromResult(Cluster.Get(testSystem.Sys).State.Members.Count(m => m.Status == MemberStatus.Up) == 1),
+                    TimeSpan.FromSeconds(30));
+
+                // Proxy will emit IdentifySingletonTimedOut event locally because it lost the singleton reference
+                // and no nodes are eligible to home the singleton
+                await testSystem.ExpectMsgAsync<ClusterSingletonProxy.IdentifySingletonTimedOut>(3.Seconds());
+            }
+            finally
+            {
+                var tasks = new List<Task>();
+                
+                if(seed is not null)
+                    tasks.Add(seed.Sys.Terminate());
+                if(seed2 is not null)
+                    tasks.Add(seed2.Sys.Terminate());
+                if(testSystem is not null)
+                    tasks.Add(testSystem.Sys.Terminate());
+                
+                if(tasks.Any())
+                    await Task.WhenAll(tasks);
+            }
+        }
+        
         private class ActorSys : TestKit.Xunit2.TestKit
         {
             public Cluster Cluster { get; }
 
-            public ActorSys(string name = "ClusterSingletonProxySystem", Address joinTo = null, int bufferSize = 1000)
-                : base(ActorSystem.Create(name, ConfigurationFactory.ParseString(_cfg).WithFallback(TestKit.Configs.TestConfigs.DefaultConfig)))
+            public ActorSys(string name = "ClusterSingletonProxySystem", Address joinTo = null, int bufferSize = 1000, string config = null, bool startSingleton = true, ITestOutputHelper output = null)
+                : base(ActorSystem.Create(
+                    name: name, 
+                    config: config is null 
+                        ? ConfigurationFactory.ParseString(_cfg).WithFallback(DefaultConfig)
+                        : ConfigurationFactory.ParseString(config).WithFallback(_cfg).WithFallback(DefaultConfig)), 
+                    output: output)
             {
                 Cluster = Cluster.Get(Sys);
                 if (joinTo != null)
@@ -80,12 +250,15 @@ namespace Akka.Cluster.Tools.Tests.Singleton
                     Cluster.Join(joinTo);
                 }
 
-                Cluster.RegisterOnMemberUp(() =>
+                if (startSingleton)
                 {
-                    Sys.ActorOf(ClusterSingletonManager.Props(Props.Create(() => new Singleton()), PoisonPill.Instance,
-                        ClusterSingletonManagerSettings.Create(Sys)
-                            .WithRemovalMargin(TimeSpan.FromSeconds(5))), "singletonmanager");
-                });
+                    Cluster.RegisterOnMemberUp(() =>
+                    {
+                        Sys.ActorOf(ClusterSingletonManager.Props(Props.Create(() => new Singleton()), PoisonPill.Instance,
+                            ClusterSingletonManagerSettings.Create(Sys)
+                                .WithRemovalMargin(TimeSpan.FromSeconds(5))), "singletonmanager");
+                    });
+                }
 
                 Proxy =
                     Sys.ActorOf(

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxy.cs
@@ -151,9 +151,7 @@ namespace Akka.Cluster.Tools.Singleton
                 if (m.Member.UniqueAddress.Equals(_cluster.SelfUniqueAddress))
                     Context.Stop(Self);
                 else
-                {
                     Remove(m.Member);
-                }
             });
             Receive<ClusterEvent.IMemberEvent>(_ =>
             {

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxySettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxySettings.cs
@@ -59,7 +59,7 @@ namespace Akka.Cluster.Tools.Singleton
                 bufferSize: config.GetInt("buffer-size", 0),
                 considerAppVersion: considerAppVersion, 
                 logSingletonIdentificationFailure: config.GetBoolean("log-singleton-identification-failure", true),
-                singletonIdentificationFailurePeriod: config.GetTimeSpan("singleton-identification-failure-period", TimeSpan.FromMinutes(5)));
+                singletonIdentificationFailurePeriod: config.GetTimeSpan("singleton-identification-failure-period", TimeSpan.FromSeconds(30)));
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace Akka.Cluster.Tools.Singleton
             TimeSpan singletonIdentificationInterval,
             int bufferSize,
             bool considerAppVersion)
-            : this(singletonName, role, singletonIdentificationInterval, bufferSize, considerAppVersion, true, TimeSpan.FromMinutes(5))
+            : this(singletonName, role, singletonIdentificationInterval, bufferSize, considerAppVersion, true, TimeSpan.FromSeconds(30))
         {
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonSettings.cs
@@ -154,7 +154,7 @@ namespace Akka.Cluster.Tools.Singleton
 
         [InternalApi]
         internal ClusterSingletonProxySettings ToProxySettings(string singletonName) =>
-            new(singletonName, Role, SingletonIdentificationInterval, BufferSize, ConsiderAppVersion);
+            new(singletonName, Role, SingletonIdentificationInterval, BufferSize, ConsiderAppVersion, true, TimeSpan.FromSeconds(30));
 
         [InternalApi]
         internal bool ShouldRunManager(Cluster cluster) => string.IsNullOrEmpty(Role) || cluster.SelfMember.Roles.Contains(Role);

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/reference.conf
@@ -65,8 +65,8 @@ akka.cluster.singleton-proxy {
   # Should the singleton proxy log a warning if no singleton actor were found after a period of time
   log-singleton-identification-failure = true
   
-  # The period the proxy will wait until it logs a missing singleton warning, defaults to 5 minutes 
-  singleton-identification-failure-period = 5m
+  # The period the proxy will wait until it logs a missing singleton warning, defaults to 30 seconds 
+  singleton-identification-failure-period = 30s
 
   # If the location of the singleton is unknown the proxy will buffer this
   # number of messages and deliver them when the singleton is identified.

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/reference.conf
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/reference.conf
@@ -61,6 +61,12 @@ akka.cluster.singleton-proxy {
 
   # Interval at which the proxy will try to resolve the singleton instance.
   singleton-identification-interval = 1s
+  
+  # Should the singleton proxy log a warning if no singleton actor were found after a period of time
+  log-singleton-identification-failure = true
+  
+  # The period the proxy will wait until it logs a missing singleton warning, defaults to 5 minutes 
+  singleton-identification-failure-period = 5m
 
   # If the location of the singleton is unknown the proxy will buffer this
   # number of messages and deliver them when the singleton is identified.

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -437,19 +437,27 @@ namespace Akka.Cluster.Tools.Singleton
         public ClusterSingletonProvider() { }
         public override Akka.Cluster.Tools.Singleton.ClusterSingleton CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
-    public sealed class ClusterSingletonProxy : Akka.Actor.ReceiveActor
+    public sealed class ClusterSingletonProxy : Akka.Actor.ReceiveActor, Akka.Actor.IWithTimers
     {
         public ClusterSingletonProxy(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
+        public Akka.Actor.ITimerScheduler Timers { get; set; }
         public static Akka.Configuration.Config DefaultConfig() { }
         protected override void PostStop() { }
         protected override void PreStart() { }
         public static Akka.Actor.Props Props(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
-        public sealed class IdentifySingletonTimedOut : Akka.Actor.INoSerializationVerificationNeeded
+        public enum IdentifyResult
         {
-            public IdentifySingletonTimedOut(string singletonName, string role, System.TimeSpan duration) { }
-            public System.TimeSpan Duration { get; }
+            Success = 0,
+            Timeout = 1,
+        }
+        public sealed class IdentifySingletonResult : Akka.Actor.INoSerializationVerificationNeeded
+        {
+            public IdentifySingletonResult(string singletonName, string role, Akka.Cluster.Tools.Singleton.ClusterSingletonProxy.IdentifyResult result) { }
+            public Akka.Cluster.Tools.Singleton.ClusterSingletonProxy.IdentifyResult Result { get; }
             public string Role { get; }
             public string SingletonName { get; }
+            public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxy.IdentifySingletonResult Success(string singletonName, string role) { }
+            public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxy.IdentifySingletonResult Timeout(string singletonName, string role) { }
         }
     }
     public sealed class ClusterSingletonProxySettings : Akka.Actor.INoSerializationVerificationNeeded

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -444,19 +444,33 @@ namespace Akka.Cluster.Tools.Singleton
         protected override void PostStop() { }
         protected override void PreStart() { }
         public static Akka.Actor.Props Props(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
+        public sealed class IdentifySingletonTimedOut : Akka.Actor.INoSerializationVerificationNeeded
+        {
+            public IdentifySingletonTimedOut(string singletonName, string role, System.TimeSpan duration) { }
+            public System.TimeSpan Duration { get; }
+            public string Role { get; }
+            public string SingletonName { get; }
+        }
     }
     public sealed class ClusterSingletonProxySettings : Akka.Actor.INoSerializationVerificationNeeded
     {
+        [System.ObsoleteAttribute("Use constructor with logSingletonIdentificationFailure and logSingletonIdentifica" +
+            "tionInterval parameter instead. Since v1.5.30")]
         public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize, bool considerAppVersion) { }
+        public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize, bool considerAppVersion, bool logSingletonIdentificationFailure, System.TimeSpan singletonIdentificationFailurePeriod) { }
         public int BufferSize { get; }
         public bool ConsiderAppVersion { get; }
+        public bool LogSingletonIdentificationFailure { get; }
         public string Role { get; }
+        public System.TimeSpan SingletonIdentificationFailurePeriod { get; }
         public System.TimeSpan SingletonIdentificationInterval { get; }
         public string SingletonName { get; }
         public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config, bool considerAppVersion) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithBufferSize(int bufferSize) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithLogSingletonIdentificationFailure(bool logSingletonIdentificationFailure) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithRole(string role) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonIdentificationFailureDuration(System.TimeSpan singletonIdentificationFailurePeriod) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonIdentificationInterval(System.TimeSpan singletonIdentificationInterval) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonName(string singletonName) { }
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -437,19 +437,27 @@ namespace Akka.Cluster.Tools.Singleton
         public ClusterSingletonProvider() { }
         public override Akka.Cluster.Tools.Singleton.ClusterSingleton CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
-    public sealed class ClusterSingletonProxy : Akka.Actor.ReceiveActor
+    public sealed class ClusterSingletonProxy : Akka.Actor.ReceiveActor, Akka.Actor.IWithTimers
     {
         public ClusterSingletonProxy(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
+        public Akka.Actor.ITimerScheduler Timers { get; set; }
         public static Akka.Configuration.Config DefaultConfig() { }
         protected override void PostStop() { }
         protected override void PreStart() { }
         public static Akka.Actor.Props Props(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
-        public sealed class IdentifySingletonTimedOut : Akka.Actor.INoSerializationVerificationNeeded
+        public enum IdentifyResult
         {
-            public IdentifySingletonTimedOut(string singletonName, string role, System.TimeSpan duration) { }
-            public System.TimeSpan Duration { get; }
+            Success = 0,
+            Timeout = 1,
+        }
+        public sealed class IdentifySingletonResult : Akka.Actor.INoSerializationVerificationNeeded
+        {
+            public IdentifySingletonResult(string singletonName, string role, Akka.Cluster.Tools.Singleton.ClusterSingletonProxy.IdentifyResult result) { }
+            public Akka.Cluster.Tools.Singleton.ClusterSingletonProxy.IdentifyResult Result { get; }
             public string Role { get; }
             public string SingletonName { get; }
+            public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxy.IdentifySingletonResult Success(string singletonName, string role) { }
+            public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxy.IdentifySingletonResult Timeout(string singletonName, string role) { }
         }
     }
     public sealed class ClusterSingletonProxySettings : Akka.Actor.INoSerializationVerificationNeeded

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -444,19 +444,33 @@ namespace Akka.Cluster.Tools.Singleton
         protected override void PostStop() { }
         protected override void PreStart() { }
         public static Akka.Actor.Props Props(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
+        public sealed class IdentifySingletonTimedOut : Akka.Actor.INoSerializationVerificationNeeded
+        {
+            public IdentifySingletonTimedOut(string singletonName, string role, System.TimeSpan duration) { }
+            public System.TimeSpan Duration { get; }
+            public string Role { get; }
+            public string SingletonName { get; }
+        }
     }
     public sealed class ClusterSingletonProxySettings : Akka.Actor.INoSerializationVerificationNeeded
     {
+        [System.ObsoleteAttribute("Use constructor with logSingletonIdentificationFailure and logSingletonIdentifica" +
+            "tionInterval parameter instead. Since v1.5.30")]
         public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize, bool considerAppVersion) { }
+        public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize, bool considerAppVersion, bool logSingletonIdentificationFailure, System.TimeSpan singletonIdentificationFailurePeriod) { }
         public int BufferSize { get; }
         public bool ConsiderAppVersion { get; }
+        public bool LogSingletonIdentificationFailure { get; }
         public string Role { get; }
+        public System.TimeSpan SingletonIdentificationFailurePeriod { get; }
         public System.TimeSpan SingletonIdentificationInterval { get; }
         public string SingletonName { get; }
         public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config, bool considerAppVersion) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithBufferSize(int bufferSize) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithLogSingletonIdentificationFailure(bool logSingletonIdentificationFailure) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithRole(string role) { }
+        public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonIdentificationFailureDuration(System.TimeSpan singletonIdentificationFailurePeriod) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonIdentificationInterval(System.TimeSpan singletonIdentificationInterval) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonName(string singletonName) { }
     }


### PR DESCRIPTION
As per user request, add missing cluster singleton detection to ClusterSingletonProxy to help debug misconfigured singleton setup

Detection timer:
* starts when the proxy actor started
* starts when the singleton actor ref is lost
* continuously emits/logs timeout event/log until singleton is found

## Changes

* Add new HOCON setting to opt-out of this feature
* Add new HOCON setting to set the detection period (defaults to 5 minutes)
* Add detection code to ClusterSingletonProxy
* Add unit test