### PR TITLE
Fix Hyperion serializer config bug

### DIFF
--- a/src/contrib/serializers/Akka.Serialization.Hyperion/HyperionSerializer.cs
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/HyperionSerializer.cs
@@ -170,7 +170,8 @@ namespace Akka.Serialization
         /// <summary>
         /// Default settings used by <see cref="HyperionSerializer"/> when no config has been specified.
         /// </summary>
-        public static readonly HyperionSerializerSettings Default = Create(HyperionSerializer.DefaultConfiguration());
+        public static readonly HyperionSerializerSettings Default = Create(HyperionSerializer.DefaultConfiguration()
+            .GetConfig("akka.actor.serialization-settings.hyperion"));
 
         /// <summary>
         /// Creates a new instance of <see cref="HyperionSerializerSettings"/> using provided HOCON config.

--- a/src/contrib/serializers/Akka.Serialization.Hyperion/reference.conf
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion/reference.conf
@@ -1,80 +1,80 @@
 ﻿akka.actor {
-	serializers {
-		hyperion = "Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion"
-	}
-	serialization-settings {
-		hyperion {
-			# If true, hyperion serializer will preserve references between objects. 
-			# This is necessary to support things such as cyclic dependencies between objects.
-			preserve-object-references = true
+  serializers {
+    hyperion = "Akka.Serialization.HyperionSerializer, Akka.Serialization.Hyperion"
+  }
+  serialization-settings {
+    hyperion {
+      # If true, hyperion serializer will preserve references between objects. 
+      # This is necessary to support things such as cyclic dependencies between objects.
+      preserve-object-references = true
+    
+      # If true, hyperion serializer will append an information about serialized fields 
+      # to a type manifest. This will increase the payload size of the serialized message, 
+      # but will also allow to provide a limited tolerance to message schema changes 
+      # between actor systems using different assembly versions, making incremental 
+      # cluster updates less restrictive.
+      version-tolerance = true
+      
+      # If disallow-unsafe-type is set to true, hyperion serializer will block potentially 
+      # dangerous and unsafe types from being deserialized during run-time.
+      #
+      # Please check this link if you need to read more about this setting:
+      # https://getakka.net/articles/networking/serialization.html#danger-of-polymorphic-serializer
+      disallow-unsafe-type = true
+    
+      # A fully qualified type name with assembly to a type implementing 
+      # `Akka.Serialization.IKnownTypesProvider` interface, that can be used to supply 
+      # hyperion serializer with a list of types, that are expected to be well-known for 
+      # all communicating parties, effectively reducing a manifests size and serialization 
+      # time. No types are known by default. Implementing class must expose either a default 
+      # constructor or constructor accepting an `ExtendedActorSystem` as its only parameter.
+      known-types-provider = "Akka.Serialization.NoKnownTypes, Akka.Serialization.Hyperion"
 
-			# If true, hyperion serializer will append an information about serialized fields 
-			# to a type manifest. This will increase the payload size of the serialized message, 
-			# but will also allow to provide a limited tolerance to message schema changes 
-			# between actor systems using different assembly versions, making incremental 
-			# cluster updates less restrictive.
-			version-tolerance = true
-			
-			# If disallow-unsafe-type is set to true, hyperion serializer will block potentially 
-			# dangerous and unsafe types from being deserialized during run-time.
-			#
-			# Please check this link if you need to read more about this setting:
-			# https://getakka.net/articles/networking/serialization.html#danger-of-polymorphic-serializer
-			disallow-unsafe-type = true
+      # An array of fully qualified class names of types that are allowed to be deserialized
+      # during run-time. When left as an empty array, type filtering will be disabled.
+      allowed-types = []
 
-			# A fully qualified type name with assembly to a type implementing 
-			# `Akka.Serialization.IKnownTypesProvider` interface, that can be used to supply 
-			# hyperion serializer with a list of types, that are expected to be well-known for 
-			# all communicating parties, effectively reducing a manifests size and serialization 
-			# time. No types are known by default. Implementing class must expose either a default 
-			# constructor or constructor accepting an `ExtendedActorSystem` as its only parameter.
-			known-types-provider = "Akka.Serialization.NoKnownTypes, Akka.Serialization.Hyperion"
-
-            # An array of fully qualified class names of types that are allowed to be deserialized
-            # during run-time. When left as an empty array, type filtering will be disabled.
-            allowed-types = []
-
-            # A list of incompatible dll package name for deserializing types 
-            # between NetFx, .NET Core, and the new .NET
-            # Used to map and rename/correct different dll names between different platforms 
-            # in the .NET ecosystem.
-            #
-            # How it works is that when the serializer detects that the type name contains
-            # the fingerprint string, it will replace the string declared in the rename-from
-            # property into the string declared in the rename-to property.
-            #
-            # if(packageName.Contains(fingerprint)) packageName = packageName.Replace(rename-from, rename-to);
-            #
-            # The commented values below are the default values used in the serializer, 
-            # provided as an example on how to use this feature.
-            cross-platform-package-name-overrides = {
-                # netfx = [
-                #     {
-                #         fingerprint = "System.Private.CoreLib,%core%",
-                #         rename-from = "System.Private.CoreLib,%core%",
-                #         rename-to = "mscorlib,%core%"
-                #     }]
-                # netcore = [
-                #     {
-                #         fingerprint = "mscorlib,%core%",
-                #         rename-from = "mscorlib,%core%",
-                #         rename-to = "System.Private.CoreLib,%core%"
-                #     }]
-                # net = [
-                #     {
-                #         fingerprint = "mscorlib,%core%",
-                #         rename-from = "mscorlib,%core%",
-                #         rename-to = "System.Private.CoreLib,%core%"
-                #     }]
-            }
-            
-            # An array of fully qualified class names of classes inheriting Hyperion.Surrogate class.
-            # These classes will be used to transform one complex class into another much simpler class 
-            # that are more suitable for over the wire transport.
-            #
-            # Please refer to https://getakka.net/articles/networking/serialization.html#complex-object-serialization-using-hyperion
-            # for more information.
-            surrogates = []
-		}
-	}
+      # A list of incompatible dll package name for deserializing types 
+      # between NetFx, .NET Core, and the new .NET
+      # Used to map and rename/correct different dll names between different platforms 
+      # in the .NET ecosystem.
+      #
+      # How it works is that when the serializer detects that the type name contains
+      # the fingerprint string, it will replace the string declared in the rename-from
+      # property into the string declared in the rename-to property.
+      #
+      # if(packageName.Contains(fingerprint)) packageName = packageName.Replace(rename-from, rename-to);
+      #
+      # The commented values below are the default values used in the serializer, 
+      # provided as an example on how to use this feature.
+      cross-platform-package-name-overrides = {
+          # netfx = [
+          #     {
+          #         fingerprint = "System.Private.CoreLib,%core%",
+          #         rename-from = "System.Private.CoreLib,%core%",
+          #         rename-to = "mscorlib,%core%"
+          #     }]
+          # netcore = [
+          #     {
+          #         fingerprint = "mscorlib,%core%",
+          #         rename-from = "mscorlib,%core%",
+          #         rename-to = "System.Private.CoreLib,%core%"
+          #     }]
+          # net = [
+          #     {
+          #         fingerprint = "mscorlib,%core%",
+          #         rename-from = "mscorlib,%core%",
+          #         rename-to = "System.Private.CoreLib,%core%"
+          #     }]
+      }
+      
+      # An array of fully qualified class names of classes inheriting Hyperion.Surrogate class.
+      # These classes will be used to transform one complex class into another much simpler class 
+      # that are more suitable for over the wire transport.
+      #
+      # Please refer to https://getakka.net/articles/networking/serialization.html#complex-object-serialization-using-hyperion
+      # for more information.
+      surrogates = []
+    }
+  }
 }


### PR DESCRIPTION
The `HyperionSerializer(ExtendedActorSystem)` ctor method uses the wrong HOCON config.
`HyperionSerializerConfig.Create()` expects the config from the "akka.actor.serialization-settings.hyperion" path, but the `HyperionSerializer` ctor passes the HOCON root config to it.

Behavior change after this PR:
No known behavioral change.

## Changes

* Make sure the config being passed to the constructor is the correct config.