### PR TITLE
Added reproduction for missing `Stash.Stash` messages in Akka.Persistence actors

### DIFF
--- a/src/core/Akka.Persistence.Tests/Bugfix7373Specs.cs
+++ b/src/core/Akka.Persistence.Tests/Bugfix7373Specs.cs
@@ -1,0 +1,81 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="Bugfix7373Specs.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Tests;
+
+public class Bugfix7373Specs : AkkaSpec
+{
+    public Bugfix7373Specs(ITestOutputHelper output) : base(output)
+    {
+    }
+    
+    /// <summary>
+    /// Reproduction for https://github.com/akkadotnet/akka.net/issues/7373 
+    /// </summary>
+    [Fact]
+    public async Task ShouldDeliverAllStashedMessages()
+    {
+        // arrange
+        var actor = Sys.ActorOf(Props.Create<MinimalStashingActor>());
+        
+        // act
+        var msg = new Msg(1);
+        actor.Tell(msg);
+        actor.Tell(msg);
+        
+        actor.Tell("Initialize");
+        
+        // assert
+        await ExpectMsgAsync($"Processed: {msg}");
+        await ExpectMsgAsync($"Processed: {msg}");
+    }
+    
+    public sealed record Msg(int Id);
+    
+    public class MinimalStashingActor : UntypedPersistentActor, IWithStash
+    {
+        public override string PersistenceId => "minimal-stashing-actor";
+
+        protected override void OnCommand(object message)
+        {
+            Sender.Tell($"Processed: {message}");
+        }
+
+        private void Ready(object message)
+        {
+            switch (message)
+            {
+                case "Initialize":
+                    Persist("init", e =>
+                    {
+                        Stash.UnstashAll(); // Unstash all stashed messages
+                        Become(OnCommand); // Transition to ready state
+                    });
+                    break;
+                default:
+                    Stash.Stash(); // Stash messages until initialized
+                    break;
+            }
+        }
+
+        protected override void OnRecover(object message)
+        {
+            switch (message)
+            {
+                case RecoveryCompleted:
+                    Become(Ready);
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes

reproduces #7373

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7373