### PR TITLE
[Streams] Fix ShellRegistered message deadletter log

### DIFF
--- a/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
@@ -767,7 +767,9 @@ namespace Akka.Streams.Implementation.Fusing
             public GraphInterpreterShell Shell { get; }
         }
 
-        private class ShellRegistered
+        // This is the Resume internal API message in JVM, it is used to prevent/short circuit recursive calls
+        // inside a stream. Harmless when dead-lettered.
+        private class ShellRegistered: IDeadLetterSuppression
         {
             public static readonly ShellRegistered Instance = new();
             private ShellRegistered()


### PR DESCRIPTION
Fixes #7369

`ShellRegistered` is the same as the `Resume` internal API message in JVM, it is used to prevent/short circuit recursion inside a stream. Harmless when dead-lettered.

## Changes

* Make `ShellRegistered` inherits `IDeadLetterSuppression` marker interface.