### PR TITLE
Introducing Akka.NET Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Discord](https://img.shields.io/discord/974500337396375553?style=flat&logo=discord&label=Join%20Akka.NET%20Discord)](https://discord.com/invite/GSCfPwhbWP)
 [![NuGet](https://img.shields.io/nuget/v/Akka.svg?style=flat-square)](https://www.nuget.org/packages/Akka)
 [![Nuget](https://img.shields.io/nuget/dt/Akka)](https://www.nuget.org/packages/Akka)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Akka.NET%20Guru-006BFF)](https://gurubase.io/g/akka-net)
 
 
 **[Akka.NET](https://getakka.net/)** is a .NET port of the popular [Akka project](https://akka.io/) from the Scala / Java community. We are an idiomatic [.NET implementation of the actor model](https://petabridge.com/blog/akkadotnet-what-is-an-actor/) built on top of the .NET Common Language Runtime.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Akka.NET Guru](https://gurubase.io/g/akka-net) to Gurubase. Akka.NET Guru uses the data from this repo and data from the [docs](https://getakka.net/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Akka.NET Guru", which highlights that Akka.NET now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Akka.NET Guru in Gurubase, just let me know that's totally fine.
