### PR TITLE
Add note about duplicate `PeriodicTimer` messages when actors are busy

### DIFF
--- a/src/core/Akka/Actor/Scheduler/TimerScheduler.cs
+++ b/src/core/Akka/Actor/Scheduler/TimerScheduler.cs
@@ -293,6 +293,9 @@ namespace Akka.Actor.Scheduler
                 return null; // message should be ignored
             }
 
+            // N.B. - repeating timers never change their generation, so this check always passes.
+            // This means that, in theory, a repeating timer can queue up the same message many times
+            // in the actor's mailbox (i.e. when actor is busy) and there's no means of de-duplicating it.
             if (timerMsg.Generation == timer.Generation)
             {
                 // valid timer


### PR DESCRIPTION
Per a Discord issue where a user saw many periodically scheduled messages get processed all at once as a result of a single long-running operation blocking the actor for ~2 minutes or so.

We might want to put this in the user-facing docs someplace too, but for now I wanted to make sure the other maintainers were aware of it AND which callsite is responsible.