### PR TITLE
Fixed: `IWrappedMessage` + `IDeadLetterSuppression` handling

### DIFF
--- a/src/core/Akka.Tests/Actor/DeadLettersSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeadLettersSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -37,15 +38,20 @@ namespace Akka.Tests
         {
             Sys.EventStream.Subscribe(TestActor, typeof(DeadLetter));
             Sys.DeadLetters.Tell(new WrappedClass("chocolate-beans"));
-            await ExpectMsgAsync<DeadLetter>(deadLetter=>deadLetter.Message.ToString()!.Contains("chocolate-beans"));
+                
+            // this is just to make the test deterministic
+            await ExpectMsgAsync<DeadLetter>();
         }
         
         [Fact]
         public async Task ShouldNotLogWrappedMessagesWithDeadLetterSuppression()
         {
-            Sys.EventStream.Subscribe(TestActor, typeof(DeadLetter));
+            Sys.EventStream.Subscribe(TestActor, typeof(AllDeadLetters));
             Sys.DeadLetters.Tell(new WrappedClass(new SuppressedMessage()));
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(50));
+                
+            // this is just to make the test deterministic
+            var msg = await ExpectMsgAsync<SuppressedDeadLetter>();
+            msg.Message.ToString()!.Contains("SuppressedMessage").ShouldBeTrue();
         }
     }
 }

--- a/src/core/Akka/Actor/BuiltInActors.cs
+++ b/src/core/Akka/Actor/BuiltInActors.cs
@@ -197,6 +197,27 @@ namespace Akka.Actor
             }
             return message;
         }
+
+        /// <summary>
+        /// Is this message marked as "suppress dead letters" anywhere in its "wrap stack"
+        /// </summary>
+        internal static bool IsDeadLetterSuppressedAnywhere(object message, out IDeadLetterSuppression? suppressed)
+        {
+            var loopMessage = message;
+            while(loopMessage is not IDeadLetterSuppression && loopMessage is IWrappedMessage wm)
+            {
+                loopMessage = wm.Message;
+            }
+            
+            if (loopMessage is IDeadLetterSuppression suppression)
+            {
+                suppressed = suppression;
+                return true;
+            }
+
+            suppressed = null;
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/core/Akka/Actor/BuiltInActors.cs
+++ b/src/core/Akka/Actor/BuiltInActors.cs
@@ -226,19 +226,20 @@ namespace Akka.Actor
         /// <exception cref="InvalidMessageException">This exception is thrown if the given <paramref name="message"/> is undefined.</exception>
         protected override void TellInternal(object message, IActorRef sender)
         {
-            if (message == null) throw new InvalidMessageException("Message is null");
-            var i = message as Identify;
-            if (i != null)
+            switch (message)
             {
-                sender.Tell(new ActorIdentity(i.MessageId, ActorRefs.Nobody));
-                return;
+                case null:
+                    throw new InvalidMessageException("Message is null");
+                case Identify i:
+                    sender.Tell(new ActorIdentity(i.MessageId, ActorRefs.Nobody));
+                    return;
+                case DeadLetter d:
+                {
+                    if (!SpecialHandle(d.Message, d.Sender)) { _eventStream.Publish(d); }
+                    return;
+                }
             }
-            var d = message as DeadLetter;
-            if (d != null)
-            {
-                if (!SpecialHandle(d.Message, d.Sender)) { _eventStream.Publish(d); }
-                return;
-            }
+
             if (!SpecialHandle(message, sender)) { _eventStream.Publish(new DeadLetter(message, sender.IsNobody() ? Provider.DeadLetters : sender, this)); }
         }
 

--- a/src/core/Akka/Actor/EmptyLocalActorRef.cs
+++ b/src/core/Akka/Actor/EmptyLocalActorRef.cs
@@ -127,14 +127,14 @@ namespace Akka.Actor
 
             if (WrappedMessage.IsDeadLetterSuppressedAnywhere(possiblyWrapped, out var suppressed))
             {
-                PublishSupressedDeadLetter(possiblyWrapped, sender);
+                PublishSupressedDeadLetter(suppressed, sender);
                 return true;
             }
 
             return false;
         }
 
-        private void PublishSupressedDeadLetter(object msg, IActorRef sender)
+        private void PublishSupressedDeadLetter(IDeadLetterSuppression msg, IActorRef sender)
         {
             _eventStream.Publish(new SuppressedDeadLetter(msg, sender.IsNobody() ? _provider.DeadLetters : sender, this));
         }

--- a/src/core/Akka/Actor/EmptyLocalActorRef.cs
+++ b/src/core/Akka/Actor/EmptyLocalActorRef.cs
@@ -127,14 +127,14 @@ namespace Akka.Actor
 
             if (WrappedMessage.IsDeadLetterSuppressedAnywhere(possiblyWrapped, out var suppressed))
             {
-                PublishSupressedDeadLetter(suppressed, sender);
+                PublishSupressedDeadLetter(possiblyWrapped, sender);
                 return true;
             }
 
             return false;
         }
 
-        private void PublishSupressedDeadLetter(IDeadLetterSuppression msg, IActorRef sender)
+        private void PublishSupressedDeadLetter(object msg, IActorRef sender)
         {
             _eventStream.Publish(new SuppressedDeadLetter(msg, sender.IsNobody() ? _provider.DeadLetters : sender, this));
         }

--- a/src/core/Akka/Event/DeadLetter.cs
+++ b/src/core/Akka/Event/DeadLetter.cs
@@ -109,6 +109,21 @@ namespace Akka.Event
             if (sender == null) throw new ArgumentNullException(nameof(sender), "SuppressedDeadLetter sender may not be null");
             if (recipient == null) throw new ArgumentNullException(nameof(recipient), "SuppressedDeadLetter recipient may not be null");
         }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SuppressedDeadLetter"/> class.
+        /// </summary>
+        /// <param name="message">The original message that could not be delivered.</param>
+        /// <param name="sender">The actor that sent the message.</param>
+        /// <param name="recipient">The actor that was to receive the message.</param>
+        /// <exception cref="ArgumentNullException">
+        /// This exception is thrown when either the sender or the recipient is undefined.
+        /// </exception>
+        public SuppressedDeadLetter(object message, IActorRef sender, IActorRef recipient) : base(message, sender, recipient)
+        {
+            if (sender == null) throw new ArgumentNullException(nameof(sender), "SuppressedDeadLetter sender may not be null");
+            if (recipient == null) throw new ArgumentNullException(nameof(recipient), "SuppressedDeadLetter recipient may not be null");
+        }
     }
 
     /// <summary>

--- a/src/core/Akka/Event/DeadLetter.cs
+++ b/src/core/Akka/Event/DeadLetter.cs
@@ -109,21 +109,6 @@ namespace Akka.Event
             if (sender == null) throw new ArgumentNullException(nameof(sender), "SuppressedDeadLetter sender may not be null");
             if (recipient == null) throw new ArgumentNullException(nameof(recipient), "SuppressedDeadLetter recipient may not be null");
         }
-        
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SuppressedDeadLetter"/> class.
-        /// </summary>
-        /// <param name="message">The original message that could not be delivered.</param>
-        /// <param name="sender">The actor that sent the message.</param>
-        /// <param name="recipient">The actor that was to receive the message.</param>
-        /// <exception cref="ArgumentNullException">
-        /// This exception is thrown when either the sender or the recipient is undefined.
-        /// </exception>
-        public SuppressedDeadLetter(object message, IActorRef sender, IActorRef recipient) : base(message, sender, recipient)
-        {
-            if (sender == null) throw new ArgumentNullException(nameof(sender), "SuppressedDeadLetter sender may not be null");
-            if (recipient == null) throw new ArgumentNullException(nameof(recipient), "SuppressedDeadLetter recipient may not be null");
-        }
     }
 
     /// <summary>

--- a/src/core/Akka/Event/UnhandledMessage.cs
+++ b/src/core/Akka/Event/UnhandledMessage.cs
@@ -12,7 +12,7 @@ namespace Akka.Event
     /// <summary>
     /// This message is published to the EventStream whenever an Actor receives a message it doesn't understand
     /// </summary>
-    public sealed class UnhandledMessage : AllDeadLetters, IWrappedMessage
+    public sealed class UnhandledMessage : AllDeadLetters
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UnhandledMessage" /> class.


### PR DESCRIPTION
## Changes

A [Phobos](https://phobos.petabridge.com/) customer noticed many `DeadLetter` messages appearing only when Phobos was enabled, but not when it was disabled - as it turns out, this is because Phobos' payload for propagating trace information transparently through the `ActorSystem` is an `IWrappedMessage` and the dead letter logging infrastructure in Akka.NET doesn't account for that accurately.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.