### PR TITLE
Fixed: `IWrappedMessage` + `IDeadLetterSuppression` handling

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3686,7 +3686,7 @@ namespace Akka.Event
     }
     public sealed class SuppressedDeadLetter : Akka.Event.AllDeadLetters
     {
-        public SuppressedDeadLetter(Akka.Event.IDeadLetterSuppression message, Akka.Actor.IActorRef sender, Akka.Actor.IActorRef recipient) { }
+        public SuppressedDeadLetter(object message, Akka.Actor.IActorRef sender, Akka.Actor.IActorRef recipient) { }
     }
     public class TraceLogger : Akka.Actor.UntypedActor
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3676,7 +3676,7 @@ namespace Akka.Event
     }
     public sealed class SuppressedDeadLetter : Akka.Event.AllDeadLetters
     {
-        public SuppressedDeadLetter(Akka.Event.IDeadLetterSuppression message, Akka.Actor.IActorRef sender, Akka.Actor.IActorRef recipient) { }
+        public SuppressedDeadLetter(object message, Akka.Actor.IActorRef sender, Akka.Actor.IActorRef recipient) { }
     }
     public class TraceLogger : Akka.Actor.UntypedActor
     {

--- a/src/core/Akka.Tests/Actor/DeadLettersSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeadLettersSpec.cs
@@ -46,5 +46,24 @@ namespace Akka.Tests
             var msg = await ExpectMsgAsync<SuppressedDeadLetter>();
             msg.Message.ToString()!.Contains("SuppressedMessage").ShouldBeTrue();
         }
+        
+        [Fact]
+        public async Task ShouldLogNormalActorSelectionWrappedMessages()
+        {
+            Sys.EventStream.Subscribe(TestActor, typeof(DeadLetter));
+            var selection = Sys.ActorSelection("/user/foobar");
+            selection.Tell(new WrappedClass("chocolate-beans"));
+            await ExpectMsgAsync<DeadLetter>();
+        }
+        
+        [Fact]
+        public async Task ShouldNotLogActorSelectionWrappedMessagesWithDeadLetterSuppression()
+        {
+            Sys.EventStream.Subscribe(TestActor, typeof(AllDeadLetters));
+            var selection = Sys.ActorSelection("/user/foobar");
+            selection.Tell(new WrappedClass(new SuppressedMessage()));
+            var msg = await ExpectMsgAsync<SuppressedDeadLetter>();
+            msg.Message.ToString()!.Contains("SuppressedMessage").ShouldBeTrue();
+        }
     }
 }

--- a/src/core/Akka.Tests/Actor/DeadLettersSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeadLettersSpec.cs
@@ -35,8 +35,6 @@ namespace Akka.Tests
         {
             Sys.EventStream.Subscribe(TestActor, typeof(DeadLetter));
             Sys.DeadLetters.Tell(new WrappedClass("chocolate-beans"));
-                
-            // this is just to make the test deterministic
             await ExpectMsgAsync<DeadLetter>();
         }
         
@@ -45,8 +43,6 @@ namespace Akka.Tests
         {
             Sys.EventStream.Subscribe(TestActor, typeof(AllDeadLetters));
             Sys.DeadLetters.Tell(new WrappedClass(new SuppressedMessage()));
-                
-            // this is just to make the test deterministic
             var msg = await ExpectMsgAsync<SuppressedDeadLetter>();
             msg.Message.ToString()!.Contains("SuppressedMessage").ShouldBeTrue();
         }

--- a/src/core/Akka.Tests/Actor/WrappedMessagesSpec.cs
+++ b/src/core/Akka.Tests/Actor/WrappedMessagesSpec.cs
@@ -44,11 +44,11 @@ public class WrappedMessagesSpec
         {"chocolate-beans", false}
     };
         
-    // [Theory]
-    // [MemberData(nameof(SuppressedMessages))]
-    // public void ShouldDetectIfWrappedMessageIsSuppressed(object message, bool expected)
-    // {
-    //     var isSuppressed = WrappedMessage.IsDeadLetterSuppressedAnywhere(message);
-    //     isSuppressed.ShouldBe(expected);
-    // }
+    [Theory]
+    [MemberData(nameof(SuppressedMessages))]
+    public void ShouldDetectIfWrappedMessageIsSuppressed(object message, bool shouldBeSuppressed)
+    {
+        var isSuppressed = WrappedMessage.IsDeadLetterSuppressedAnywhere(message);
+        isSuppressed.ShouldBe(shouldBeSuppressed);
+    }
 }

--- a/src/core/Akka.Tests/Actor/WrappedMessagesSpec.cs
+++ b/src/core/Akka.Tests/Actor/WrappedMessagesSpec.cs
@@ -1,0 +1,54 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="WrappedMessagesSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Event;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Tests;
+
+public class WrappedMessagesSpec
+{
+    private sealed record WrappedClass(object Message) : IWrappedMessage;
+        
+    private sealed record WrappedSuppressedClass(object Message) : IWrappedMessage, IDeadLetterSuppression;
+        
+    private sealed class SuppressedMessage : IDeadLetterSuppression
+    {
+            
+    }
+        
+        
+    [Fact]
+    public void ShouldUnwrapWrappedMessage()
+    {
+        var message = new WrappedClass("chocolate-beans");
+        var unwrapped = WrappedMessage.Unwrap(message);
+        unwrapped.ShouldBe("chocolate-beans");
+    }
+        
+    public static readonly TheoryData<object, bool> SuppressedMessages = new()
+    {
+        {new SuppressedMessage(), true},
+        {new WrappedClass(new SuppressedMessage()), true},
+        {new WrappedClass(new WrappedClass(new SuppressedMessage())), true},
+        {new WrappedClass(new WrappedClass("chocolate-beans")), false},
+        {new WrappedSuppressedClass("foo"), true},
+        {new WrappedClass(new WrappedSuppressedClass("chocolate-beans")), true},
+        {new WrappedClass("chocolate-beans"), false},
+        {"chocolate-beans", false}
+    };
+        
+    // [Theory]
+    // [MemberData(nameof(SuppressedMessages))]
+    // public void ShouldDetectIfWrappedMessageIsSuppressed(object message, bool expected)
+    // {
+    //     var isSuppressed = WrappedMessage.IsDeadLetterSuppressedAnywhere(message);
+    //     isSuppressed.ShouldBe(expected);
+    // }
+}

--- a/src/core/Akka/Actor/BuiltInActors.cs
+++ b/src/core/Akka/Actor/BuiltInActors.cs
@@ -238,19 +238,20 @@ namespace Akka.Actor
         /// <exception cref="InvalidMessageException">This exception is thrown if the given <paramref name="message"/> is undefined.</exception>
         protected override void TellInternal(object message, IActorRef sender)
         {
-            if (message == null) throw new InvalidMessageException("Message is null");
-            var i = message as Identify;
-            if (i != null)
+            switch (message)
             {
-                sender.Tell(new ActorIdentity(i.MessageId, ActorRefs.Nobody));
-                return;
+                case null:
+                    throw new InvalidMessageException("Message is null");
+                case Identify i:
+                    sender.Tell(new ActorIdentity(i.MessageId, ActorRefs.Nobody));
+                    return;
+                case DeadLetter d:
+                {
+                    if (!SpecialHandle(d.Message, d.Sender)) { _eventStream.Publish(d); }
+                    return;
+                }
             }
-            var d = message as DeadLetter;
-            if (d != null)
-            {
-                if (!SpecialHandle(d.Message, d.Sender)) { _eventStream.Publish(d); }
-                return;
-            }
+
             if (!SpecialHandle(message, sender)) { _eventStream.Publish(new DeadLetter(message, sender.IsNobody() ? Provider.DeadLetters : sender, this)); }
         }
 

--- a/src/core/Akka/Actor/BuiltInActors.cs
+++ b/src/core/Akka/Actor/BuiltInActors.cs
@@ -197,6 +197,18 @@ namespace Akka.Actor
             }
             return message;
         }
+
+        internal static bool IsDeadLetterSuppressedAnywhere(object message)
+        {
+            var isSuppressed = message is IDeadLetterSuppression;
+            while(!isSuppressed && message is IWrappedMessage wm)
+            {
+                message = wm.Message;
+                isSuppressed = message is IDeadLetterSuppression;
+            }
+            
+            return isSuppressed;
+        }
     }
 
     /// <summary>

--- a/src/core/Akka/Actor/DeadLetterMailbox.cs
+++ b/src/core/Akka/Actor/DeadLetterMailbox.cs
@@ -46,9 +46,13 @@ namespace Akka.Actor
         /// <param name="envelope">TBD</param>
         public void Enqueue(IActorRef receiver, Envelope envelope)
         {
-            if (envelope.Message is DeadLetter)
+            if (envelope.Message is AllDeadLetters)
             {
-                // actor subscribing to DeadLetter. Drop it.
+                /*  We're receiving a DeadLetter sent to us by someone else (which is not normal - usually only happens
+                 *  if we were explicitly subscribed to DeadLetters on the EventStream).
+                 *   
+                 *  Have to terminate here in order to prevent a stack overflow.
+                 */ 
                 return;
             }
 

--- a/src/core/Akka/Actor/EmptyLocalActorRef.cs
+++ b/src/core/Akka/Actor/EmptyLocalActorRef.cs
@@ -123,16 +123,16 @@ namespace Akka.Actor
                 return true;
             }
 
-            if (message is IDeadLetterSuppression deadLetterSuppression)
+            if (WrappedMessage.IsDeadLetterSuppressedAnywhere(message))
             {
-                PublishSupressedDeadLetter(deadLetterSuppression, sender);
+                PublishSupressedDeadLetter(message, sender);
                 return true;
             }
 
             return false;
         }
 
-        private void PublishSupressedDeadLetter(IDeadLetterSuppression msg, IActorRef sender)
+        private void PublishSupressedDeadLetter(object msg, IActorRef sender)
         {
             _eventStream.Publish(new SuppressedDeadLetter(msg, sender.IsNobody() ? _provider.DeadLetters : sender, this));
         }

--- a/src/core/Akka/Actor/EmptyLocalActorRef.cs
+++ b/src/core/Akka/Actor/EmptyLocalActorRef.cs
@@ -111,9 +111,9 @@ namespace Akka.Actor
                 }
                 else
                 {
-                    if (actorSelectionMessage.Message is IDeadLetterSuppression selectionDeadLetterSuppression)
+                    if (WrappedMessage.IsDeadLetterSuppressedAnywhere(actorSelectionMessage.Message))
                     {
-                        PublishSupressedDeadLetter(selectionDeadLetterSuppression, sender);
+                        PublishSupressedDeadLetter(actorSelectionMessage.Message, sender);
                     }
                     else
                     {

--- a/src/core/Akka/Event/DeadLetter.cs
+++ b/src/core/Akka/Event/DeadLetter.cs
@@ -104,7 +104,7 @@ namespace Akka.Event
         /// <exception cref="ArgumentNullException">
         /// This exception is thrown when either the sender or the recipient is undefined.
         /// </exception>
-        public SuppressedDeadLetter(IDeadLetterSuppression message, IActorRef sender, IActorRef recipient) : base(message, sender, recipient)
+        public SuppressedDeadLetter(object message, IActorRef sender, IActorRef recipient) : base(message, sender, recipient)
         {
             if (sender == null) throw new ArgumentNullException(nameof(sender), "SuppressedDeadLetter sender may not be null");
             if (recipient == null) throw new ArgumentNullException(nameof(recipient), "SuppressedDeadLetter recipient may not be null");


### PR DESCRIPTION
## Changes

A [Phobos](https://phobos.petabridge.com/) customer noticed many `DeadLetter` messages appearing only when Phobos was enabled, but not when it was disabled - as it turns out, this is because Phobos' payload for propagating trace information transparently through the `ActorSystem` is an `IWrappedMessage` and the dead letter logging infrastructure in Akka.NET doesn't account for that accurately.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).