### PR TITLE
harden `CircuitBreakerSpecs.cs`

### DIFF
--- a/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
@@ -90,8 +90,7 @@ namespace Akka.Tests.Pattern
             await AwaitConditionAsync(() => t.Status >= TaskStatus.Running); // need to kick off the task before we can check the latch
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             var epsilon = TimeSpan.FromMilliseconds(500); // need to pad timeouts due to non-determinism of OS scheduler
-            await WithinAsync(TimeSpan.FromMilliseconds(900) + epsilon,
-                () => AwaitConditionAsync(() => breaker.Instance.CurrentFailureCount == 1, Dilated(TimeSpan.FromMilliseconds(100)), TimeSpan.FromMilliseconds(100)));
+            await AwaitConditionAsync(() => breaker.Instance.CurrentFailureCount == 1, TimeSpan.FromMilliseconds(900) + epsilon, TimeSpan.FromMilliseconds(100));
         }
     }
 

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
@@ -85,7 +85,8 @@ namespace Akka.Tests.Pattern
             var breaker = ShortCallTimeoutCb();
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             // meant to run as detached task
-            Task.Run(() => breaker.Instance.WithSyncCircuitBreaker(() => Thread.Sleep(Dilated(TimeSpan.FromSeconds(1)))));
+            var t = Task.Run(() => breaker.Instance.WithSyncCircuitBreaker(() => Thread.Sleep(Dilated(TimeSpan.FromSeconds(1)))));
+            await AwaitConditionAsync(() => t.Status >= TaskStatus.Running); // need to kick off the task before we can check the latch
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             var epsilon = TimeSpan.FromMilliseconds(500); // need to pad timeouts due to non-determinism of OS scheduler
             await WithinAsync(TimeSpan.FromMilliseconds(900) + epsilon,


### PR DESCRIPTION
## Changes

harden `CircuitBreakerSpecs.Must_increment_failure_count_on_callTimeout_before_call_finishes`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).