### PR TITLE
Add custom log level to stream Log stage

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
@@ -172,7 +172,10 @@ namespace Akka.Streams
         public System.Collections.Generic.IEnumerable<Akka.Streams.Attributes.IAttribute> AttributeList { get; }
         public Akka.Streams.Attributes And(Akka.Streams.Attributes other) { }
         public Akka.Streams.Attributes And(Akka.Streams.Attributes.IAttribute other) { }
+        [System.ObsoleteAttribute("Use GetAttribute<TAttr>() instead")]
         public bool Contains<TAttr>(TAttr attribute)
+            where TAttr : Akka.Streams.Attributes.IAttribute { }
+        public bool Contains<TAttr>()
             where TAttr : Akka.Streams.Attributes.IAttribute { }
         public static Akka.Streams.Attributes CreateAsyncBoundary() { }
         public static Akka.Streams.Attributes CreateInputBuffer(int initial, int max) { }
@@ -1400,7 +1403,7 @@ namespace Akka.Streams.Dsl
             where TOut : TInjected { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Limit<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> LimitWeighted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, long> costFunc) { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Log<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Log<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null, Akka.Event.LogLevel logLevel = 0) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Merge<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = False)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> MergeMany<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, int breadth, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
@@ -2101,7 +2104,7 @@ namespace Akka.Streams.Dsl
             where TOut : TInjected { }
         public static Akka.Streams.Dsl.Source<T, TMat> Limit<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, long max) { }
         public static Akka.Streams.Dsl.Source<T, TMat> LimitWeighted<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, long max, System.Func<T, long> costFunc) { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> Log<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> Log<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null, Akka.Event.LogLevel logLevel = 0) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Merge<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = False)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> MergeMany<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, int breadth, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
@@ -4357,7 +4360,7 @@ namespace Akka.Streams.Implementation.Fusing
     [Akka.Annotations.InternalApiAttribute()]
     public sealed class Log<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
-        public Log(string name, System.Func<T, object> extract, Akka.Event.ILoggingAdapter adapter) { }
+        public Log(string name, System.Func<T, object> extract, Akka.Event.ILoggingAdapter adapter, Akka.Event.LogLevel defaultLogLevel) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
@@ -172,7 +172,10 @@ namespace Akka.Streams
         public System.Collections.Generic.IEnumerable<Akka.Streams.Attributes.IAttribute> AttributeList { get; }
         public Akka.Streams.Attributes And(Akka.Streams.Attributes other) { }
         public Akka.Streams.Attributes And(Akka.Streams.Attributes.IAttribute other) { }
+        [System.ObsoleteAttribute("Use GetAttribute<TAttr>() instead")]
         public bool Contains<TAttr>(TAttr attribute)
+            where TAttr : Akka.Streams.Attributes.IAttribute { }
+        public bool Contains<TAttr>()
             where TAttr : Akka.Streams.Attributes.IAttribute { }
         public static Akka.Streams.Attributes CreateAsyncBoundary() { }
         public static Akka.Streams.Attributes CreateInputBuffer(int initial, int max) { }
@@ -1399,7 +1402,7 @@ namespace Akka.Streams.Dsl
             where TOut : TInjected { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Limit<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> LimitWeighted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, long> costFunc) { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Log<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Log<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null, Akka.Event.LogLevel logLevel = 0) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Merge<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = False)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> MergeMany<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, int breadth, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
@@ -2100,7 +2103,7 @@ namespace Akka.Streams.Dsl
             where TOut : TInjected { }
         public static Akka.Streams.Dsl.Source<T, TMat> Limit<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, long max) { }
         public static Akka.Streams.Dsl.Source<T, TMat> LimitWeighted<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, long max, System.Func<T, long> costFunc) { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> Log<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> Log<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null, Akka.Event.LogLevel logLevel = 0) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Merge<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = False)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> MergeMany<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, int breadth, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
@@ -4331,7 +4334,7 @@ namespace Akka.Streams.Implementation.Fusing
     [Akka.Annotations.InternalApiAttribute()]
     public sealed class Log<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
-        public Log(string name, System.Func<T, object> extract, Akka.Event.ILoggingAdapter adapter) { }
+        public Log(string name, System.Func<T, object> extract, Akka.Event.ILoggingAdapter adapter, Akka.Event.LogLevel defaultLogLevel) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
@@ -49,8 +49,8 @@ namespace Akka.Streams.Tests.Dsl
         public void Attributes_Contains_should_not_return_true_if_doesnt_exist()
         {
             var attributes = Attributes.CreateName("new-name");
-            var attribute = new Attributes.LogLevels(LogLevel.DebugLevel, LogLevel.DebugLevel, LogLevel.DebugLevel);
-            attributes.Contains(attribute).Should().BeFalse();
+            attributes.Contains<Attributes.LogLevels>().Should().BeFalse();
+            attributes.Contains<Attributes.Name>().Should().BeTrue();
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Akka.Event;
 using Akka.Streams.Dsl;
 using Akka.Streams.Implementation;
 using Akka.Streams.TestKit;
@@ -42,6 +43,14 @@ namespace Akka.Streams.Tests.Dsl
 
             var complete = await task.ShouldCompleteWithin(3.Seconds());
             complete.GetAttribute<Attributes.Name>().Value.Should().Contain("new-name");
+        }
+
+        [Fact]
+        public void Attributes_Contains_should_not_return_true_if_doesnt_exist()
+        {
+            var attributes = Attributes.CreateName("new-name");
+            var attribute = new Attributes.LogLevels(LogLevel.DebugLevel, LogLevel.DebugLevel, LogLevel.DebugLevel);
+            attributes.Contains(attribute).Should().BeFalse();
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
@@ -146,6 +146,16 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
+        public void A_Log_on_source_must_allow_configuring_log_levels_via_Method_argument()
+        {
+            Source.Single(42)
+                .Log("flow-6", logLevel: LogLevel.WarningLevel)
+                .RunWith(Sink.Ignore<int>(), Materializer);
+
+            LogProbe.ExpectMsg<Warning>().Message.ToString().Should().Be("[flow-6] Element: 42");
+        }
+
+        [Fact]
         public void A_Log_on_Source_must_follow_supervision_strategy_when_Exception_thrown()
         {
             var ex = new TestException("test");

--- a/src/core/Akka.Streams/Attributes.cs
+++ b/src/core/Akka.Streams/Attributes.cs
@@ -430,8 +430,11 @@ namespace Akka.Streams
         /// <typeparam name="TAttr">TBD</typeparam>
         /// <param name="attribute">TBD</param>
         /// <returns>TBD</returns>
-        public bool Contains<TAttr>(TAttr attribute) where TAttr : IAttribute => _attributes.Contains(attribute);
+        [Obsolete("Use GetAttribute<TAttr>() instead")]
+        public bool Contains<TAttr>(TAttr attribute) where TAttr : IAttribute => _attributes.Any(a => a is TAttr);
 
+        public bool Contains<TAttr>() where TAttr : IAttribute => _attributes.Any(a => a is TAttr);
+        
         /// <summary>
         /// Specifies the name of the operation.
         /// If the name is null or empty the name is ignored, i.e. <see cref="None"/> is returned.

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -2106,17 +2106,17 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        /// <typeparam name="TIn">TBD</typeparam>
-        /// <typeparam name="TOut">TBD</typeparam>
-        /// <typeparam name="TMat">TBD</typeparam>
-        /// <param name="flow">TBD</param>
-        /// <param name="name">TBD</param>
-        /// <param name="extract">TBD</param>
-        /// <param name="log">TBD</param>
-        /// <returns>TBD</returns>
-        public static Flow<TIn, TOut, TMat> Log<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, string name, Func<TOut, object> extract = null, ILoggingAdapter log = null)
+        /// <typeparam name="TIn">The input type</typeparam>
+        /// <typeparam name="TOut">The output type</typeparam>
+        /// <typeparam name="TMat">The materialized type</typeparam>
+        /// <param name="flow">The underlying graph</param>
+        /// <param name="name">The name of the <see cref="LogSource"/></param>
+        /// <param name="extract">Optional. Extract the content that will be captured by the logger</param>
+        /// <param name="log">Optional. Use an external logging adapter</param>
+        /// <param name="logLevel">Optional. The log level being logged. Defaults to <see cref="LogLevel.DebugLevel"/></param>
+        public static Flow<TIn, TOut, TMat> Log<TIn, TOut, TMat>(this Flow<TIn, TOut, TMat> flow, string name, Func<TOut, object> extract = null, ILoggingAdapter log = null, LogLevel logLevel = LogLevel.DebugLevel)
         {
-            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.Log(flow, name, extract, log);
+            return (Flow<TIn, TOut, TMat>)InternalFlowOperations.Log(flow, name, extract, log, logLevel);
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -2027,7 +2027,7 @@ namespace Akka.Streams.Dsl.Internal
         public static IFlow<T, TMat> Log<T, TMat>(this IFlow<T, TMat> flow, string name, Func<T, object> extract = null,
             ILoggingAdapter log = null, LogLevel logLevel = LogLevel.DebugLevel)
         {
-            return flow.Via(new Fusing.Log<T>(name, extract ?? Identity<T>(), log).WithAttributes(Attributes.CreateLogLevels(logLevel, logLevel)));
+            return flow.Via(new Fusing.Log<T>(name, extract ?? Identity<T>(), log, logLevel));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/Internal/InternalFlowOperations.cs
@@ -2017,17 +2017,17 @@ namespace Akka.Streams.Dsl.Internal
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        /// <typeparam name="T">TBD</typeparam>
-        /// <typeparam name="TMat">TBD</typeparam>
-        /// <param name="flow">TBD</param>
-        /// <param name="name">TBD</param>
-        /// <param name="extract">TBD</param>
-        /// <param name="log">TBD</param>
-        /// <returns>TBD</returns>
+        /// <typeparam name="T">The output type</typeparam>
+        /// <typeparam name="TMat">The materialized type</typeparam>
+        /// <param name="flow">The underlying graph</param>
+        /// <param name="name">The name of the <see cref="LogSource"/></param>
+        /// <param name="extract">Optional. Extract the content that will be captured by the logger</param>
+        /// <param name="log">Optional. Use an external logging adapter</param>
+        /// <param name="logLevel">Optional. The log level being logged. Defaults to <see cref="LogLevel.DebugLevel"/></param>
         public static IFlow<T, TMat> Log<T, TMat>(this IFlow<T, TMat> flow, string name, Func<T, object> extract = null,
-            ILoggingAdapter log = null)
+            ILoggingAdapter log = null, LogLevel logLevel = LogLevel.DebugLevel)
         {
-            return flow.Via(new Fusing.Log<T>(name, extract ?? Identity<T>(), log));
+            return flow.Via(new Fusing.Log<T>(name, extract ?? Identity<T>(), log).WithAttributes(Attributes.CreateLogLevels(logLevel, logLevel)));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -1984,18 +1984,22 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        /// <typeparam name="TOut">TBD</typeparam>
-        /// <typeparam name="TMat">TBD</typeparam>
-        /// <param name="flow">TBD</param>
-        /// <param name="name">TBD</param>
-        /// <param name="extract">TBD</param>
-        /// <param name="log">TBD</param>
-        /// <returns>TBD</returns>
-        public static Source<TOut, TMat> Log<TOut, TMat>(this Source<TOut, TMat> flow, string name, Func<TOut, object> extract = null, ILoggingAdapter log = null)
+        /// <typeparam name="TOut">The output type</typeparam>
+        /// <typeparam name="TMat">The materialized type</typeparam>
+        /// <param name="flow">The underlying graph</param>
+        /// <param name="name">The name of the <see cref="LogSource"/></param>
+        /// <param name="extract">Optional. Extract the content that will be captured by the logger</param>
+        /// <param name="log">Optional. Use an external logging adapter</param>
+        /// <param name="logLevel">Optional. The log level being logged. Defaults to <see cref="LogLevel.DebugLevel"/></param>
+        public static Source<TOut, TMat> Log<TOut, TMat>(
+            this Source<TOut, TMat> flow, 
+            string name, Func<TOut, object> extract = null, 
+            ILoggingAdapter log = null,
+            LogLevel logLevel = LogLevel.DebugLevel)
         {
-            return (Source<TOut, TMat>)InternalFlowOperations.Log(flow, name, extract, log);
+            return (Source<TOut, TMat>)InternalFlowOperations.Log(flow, name, extract, log, logLevel);
         }
-
+               
         /// <summary>
         /// Combine the elements of current flow and the given <see cref="Source{TOut,TMat}"/> into a stream of tuples.
         /// <para>

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -3000,8 +3000,14 @@ namespace Akka.Streams.Implementation.Fusing
 
             public override void PreStart()
             {
-                _inheritedAttributes.Contains(DefaultLogLevels);
-                _logLevels = _inheritedAttributes.GetAttribute(DefaultLogLevels);
+                if (_inheritedAttributes.Contains<Attributes.LogLevels>())
+                {
+                    _logLevels = _inheritedAttributes.GetAttribute(DefaultLogLevels);
+                }
+                else
+                {
+                    _logLevels = new Attributes.LogLevels(_stage._defaultLogLevel, _stage._defaultLogLevel, LogLevel.ErrorLevel);
+                }
                 if (_stage._adapter != null)
                     _log = _stage._adapter;
                 else
@@ -3018,18 +3024,14 @@ namespace Akka.Streams.Implementation.Fusing
         private readonly string _name;
         private readonly Func<T, object> _extract;
         private readonly ILoggingAdapter _adapter;
+        private readonly LogLevel _defaultLogLevel;
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="name">TBD</param>
-        /// <param name="extract">TBD</param>
-        /// <param name="adapter">TBD</param>
-        public Log(string name, Func<T, object> extract, ILoggingAdapter adapter)
+        public Log(string name, Func<T, object> extract, ILoggingAdapter adapter, LogLevel defaultLogLevel)
         {
             _name = name;
             _extract = extract;
             _adapter = adapter;
+            _defaultLogLevel = defaultLogLevel;
         }
 
         // TODO more optimisations can be done here - prepare logOnPush function etc

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -3000,6 +3000,7 @@ namespace Akka.Streams.Implementation.Fusing
 
             public override void PreStart()
             {
+                _inheritedAttributes.Contains(DefaultLogLevels);
                 _logLevels = _inheritedAttributes.GetAttribute(DefaultLogLevels);
                 if (_stage._adapter != null)
                     _log = _stage._adapter;


### PR DESCRIPTION
Fixes #7127

## Changes

Add a new argument to `Log()` stage to directly specify the log level.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7127
* [x] Changes in public API reviewed, if any.