### PR TITLE
Throw clearer error message during `Stash()` in `null` message cases

### DIFF
--- a/src/core/Akka.Tests/Actor/Stash/Bugfix7398Specs.cs
+++ b/src/core/Akka.Tests/Actor/Stash/Bugfix7398Specs.cs
@@ -1,0 +1,47 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="Bugfix7398Specs.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Tests.Actor.Stash;
+
+public class Bugfix7398Specs : AkkaSpec
+{
+    public Bugfix7398Specs(ITestOutputHelper output)
+        : base(output)
+    {
+    }
+
+    private class IllegalStashActor : UntypedActor, IWithStash
+    {
+        protected override void OnReceive(object message)
+        {
+            
+        }
+
+        protected override void PreStart()
+        {
+            // ILLEGAL
+            Stash.Stash();
+        }
+
+        public IStash Stash { get; set; }
+    }
+    
+    [Fact]
+    public void Should_throw_exception_when_stashing_in_PreStart()
+    {
+        EventFilter.Exception<ActorInitializationException>().ExpectOne(() =>
+        {
+            var actor = Sys.ActorOf(Props.Create<IllegalStashActor>());
+            actor.Tell("hello");
+        });
+    }
+}

--- a/src/core/Akka/Actor/Stash/Internal/AbstractStash.cs
+++ b/src/core/Akka/Actor/Stash/Internal/AbstractStash.cs
@@ -74,9 +74,11 @@ namespace Akka.Actor.Internal
         {
             var currMsg = _actorCell.CurrentMessage;
             var sender = _actorCell.Sender;
-
+            
             if (_actorCell.CurrentEnvelopeId == _currentEnvelopeId)
             {
+                if(currMsg is null)
+                    throw new InvalidOperationException("There is no message to stash right now. Stash() must be called inside an actor's Receive methods.");
                 throw new IllegalActorStateException($"Can't stash the same message {currMsg} more than once");
             }
             _currentEnvelopeId = _actorCell.CurrentEnvelopeId;


### PR DESCRIPTION
## Changes

close #7398 

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7398 
