### PR TITLE
Benchmark to measure `ShardingCoordinator.CoordinatorState` serialization over DData

### DIFF
--- a/src/benchmark/Akka.Cluster.Benchmarks/Serialization/DDataSerializationBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Serialization/DDataSerializationBenchmarks.cs
@@ -66,7 +66,7 @@ public class DDataShardCoordinatorStateSerializationBenchmarks
         int regionCount)
     {
         var shards = Enumerable.Range(0, shardCount)
-            .Select(i => new KeyValuePair<string, IActorRef>($"shard-{i}", placeholders[i]))
+            .Select(i => new KeyValuePair<string, IActorRef>($"shard-{i}", placeholders[0]))
             .ToImmutableDictionary( );
         
         // evenly allocate shards to regions

--- a/src/benchmark/Akka.Cluster.Benchmarks/Serialization/DDataSerializationBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Serialization/DDataSerializationBenchmarks.cs
@@ -1,0 +1,107 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="DDataShardCoordinatorStateSerializationBenchmarks.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2024 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2024 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Cluster.Sharding;
+using Akka.Actor.Dsl;
+using Akka.Cluster.Sharding.Serialization.Proto.Msg;
+using Akka.Cluster.Tests;
+using Akka.Configuration;
+using Akka.DistributedData;
+using Akka.DistributedData.Serialization;
+using Akka.Util;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Cluster.Benchmarks.Serialization;
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class DDataShardCoordinatorStateSerializationBenchmarks
+{
+    private static readonly Config BaseConfig = ConfigurationFactory.ParseString("""
+                akka.actor.provider=cluster
+                akka.remote.dot-netty.tcp.port = 0
+        """).WithFallback(ClusterSharding.DefaultConfig());
+    private ExtendedActorSystem _system;
+    private ReplicatedDataSerializer _replicatedDataSerializer;
+    
+    private static readonly Member FakeNode = TestMember.Create(new Address("akka.tcp", "sys", "b", 2552), MemberStatus.Up,
+        ImmutableHashSet.Create("r1"), appVersion: AppVersion.Create("1.1.0"));
+    
+    [Params(1, 20, 100, 1000)]
+    public int ShardCount { get; set; }
+    
+    [Params(1, 20, 100)]
+    public int RegionCount { get; set; }
+    
+    // Used to represent shards and regions
+    private IActorRef _placeHolder;
+    
+    private readonly LWWRegisterKey<ShardCoordinator.CoordinatorState> _coordinatorStateKey = new("CoordinatorState");
+    
+    private LWWRegister<ShardCoordinator.CoordinatorState> _coordinatorState;
+    private byte[] _seralizedCoordinatorState;
+    private string _manifest = string.Empty;
+
+    private static ShardCoordinator.CoordinatorState ComputedState(IActorRef placeholder, int shardCount,
+        int regionCount)
+    {
+        var shards = Enumerable.Range(0, shardCount)
+            .Select(i => new KeyValuePair<string, IActorRef>($"shard-{i}", placeholder))
+            .ToImmutableDictionary( );
+        
+        // evenly allocate shards to regions
+        var shardsPerRegionCount = shardCount / regionCount; // region count can't be zero
+        var shardsPerRegion = shards
+            .Chunk(shardsPerRegionCount)
+            .Select(c =>
+                new KeyValuePair<IActorRef, IImmutableList<string>>(placeholder,
+                    c.Select(d => d.Key).ToImmutableList()))
+            .ToImmutableDictionary();
+
+        var regionProxies = ImmutableHashSet<IActorRef>.Empty;
+        var unallocatedShards = ImmutableHashSet<string>.Empty;
+        
+        return new ShardCoordinator.CoordinatorState(shards, shardsPerRegion, regionProxies, unallocatedShards);
+    }
+    
+    [GlobalSetup]
+    public void Setup()
+    {
+        _system ??= (ExtendedActorSystem)ActorSystem.Create("system", BaseConfig);
+        _placeHolder ??= _system.ActorOf(ctx => { });
+        _coordinatorState = new LWWRegister<ShardCoordinator.CoordinatorState>(FakeNode.UniqueAddress, 
+            ComputedState(_placeHolder, ShardCount, RegionCount));
+        _replicatedDataSerializer = new ReplicatedDataSerializer(_system);
+        _seralizedCoordinatorState = _replicatedDataSerializer.ToBinary(_coordinatorState);
+        _manifest = _replicatedDataSerializer.Manifest(_coordinatorState);
+    }
+
+    /// <summary>
+    /// Serialize the raw LWWRegister payload
+    /// </summary>
+    [Benchmark]
+    public byte[] SerializeCoordinatorState()
+    {
+        return _replicatedDataSerializer.ToBinary(_coordinatorState);
+    }
+    
+    [Benchmark]
+    public object DeserializeCoordinatorState()
+    {
+        return _replicatedDataSerializer.FromBinary(_seralizedCoordinatorState, _manifest);
+    } 
+    
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _system.Dispose();
+    }
+}

--- a/src/benchmark/Akka.Cluster.Benchmarks/Serialization/DDataSerializationBenchmarks.cs
+++ b/src/benchmark/Akka.Cluster.Benchmarks/Serialization/DDataSerializationBenchmarks.cs
@@ -5,6 +5,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -37,9 +38,9 @@ public class DDataShardCoordinatorStateSerializationBenchmarks
     
     [Params(1, 20, 100, 1000)]
     public int ShardCount { get; set; }
-    
-    [Params(1, 20, 100)]
-    public int RegionCount { get; set; }
+
+
+    public int RegionCount => Math.Max(ShardCount / 10, 1);
     
     // Used to represent shards and regions
     private IActorRef _placeHolder;

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Properties/AssemblyInfo.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Properties/AssemblyInfo.cs
@@ -15,6 +15,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
 [assembly: InternalsVisibleTo("Akka.DistributedData.Tests")]
+[assembly: InternalsVisibleTo("Akka.Cluster.Benchmarks")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/contrib/cluster/Akka.DistributedData/Properties/AssemblyInfo.cs
+++ b/src/contrib/cluster/Akka.DistributedData/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
 [assembly: InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]
+[assembly: InternalsVisibleTo("Akka.Cluster.Benchmarks")]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
@@ -1,4 +1,5 @@
 ﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData.Tests")]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
@@ -1,4 +1,5 @@
 ﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData.Tests")]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDistributedData.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDistributedData.DotNet.verified.txt
@@ -1,4 +1,5 @@
 ﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDistributedData.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDistributedData.Net.verified.txt
@@ -1,4 +1,5 @@
 ﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]


### PR DESCRIPTION
## Changes

Measuring serialization speed for the DData replicator

### Latest `dev` Benchmarks 

```

BenchmarkDotNet v0.13.12, Pop!_OS 22.04 LTS
13th Gen Intel Core i7-1360P, 1 CPU, 16 logical and 12 physical cores
.NET SDK 9.0.100
  [Host]     : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2


```
| Method                      | ShardCount | Mean         | Error     | StdDev    | Gen0     | Gen1     | Allocated  |
|---------------------------- |----------- |-------------:|----------:|----------:|---------:|---------:|-----------:|
| **SerializeCoordinatorState**   | **1**          |     **1.690 μs** | **0.0024 μs** | **0.0021 μs** |   **0.2651** |        **-** |    **2.45 KB** |
| DeserializeCoordinatorState | 1          |     2.919 μs | 0.0093 μs | 0.0087 μs |   0.3967 |        - |    3.71 KB |
| SerializeDataEnvelope       | 1          |     2.060 μs | 0.0038 μs | 0.0034 μs |   0.3510 |        - |    3.23 KB |
| DeserializeDataEnvelope     | 1          |     4.066 μs | 0.0135 μs | 0.0113 μs |   0.5035 |        - |    4.67 KB |
| SerializeDataWrite          | 1          |     2.212 μs | 0.0101 μs | 0.0094 μs |   0.3662 |        - |    3.39 KB |
| DeserializeDataWrite        | 1          |     4.297 μs | 0.0156 μs | 0.0139 μs |   0.5341 |        - |       5 KB |
| **SerializeCoordinatorState**   | **20**         |     **5.911 μs** | **0.0183 μs** | **0.0153 μs** |   **1.0376** |   **0.0153** |    **9.58 KB** |
| DeserializeCoordinatorState | 20         |    15.726 μs | 0.0164 μs | 0.0146 μs |   1.9531 |   0.0610 |   18.33 KB |
| SerializeDataEnvelope       | 20         |     6.484 μs | 0.0450 μs | 0.0399 μs |   1.4191 |   0.0305 |   13.05 KB |
| DeserializeDataEnvelope     | 20         |    16.678 μs | 0.0315 μs | 0.0279 μs |   2.4414 |   0.0610 |   22.99 KB |
| SerializeDataWrite          | 20         |     6.683 μs | 0.0172 μs | 0.0153 μs |   1.4343 |   0.0534 |   13.21 KB |
| DeserializeDataWrite        | 20         |    12.999 μs | 0.0220 μs | 0.0184 μs |   2.5024 |   0.0610 |   23.33 KB |
| **SerializeCoordinatorState**   | **100**        |    **21.923 μs** | **0.0495 μs** | **0.0438 μs** |   **4.3945** |   **0.2747** |    **40.4 KB** |
| DeserializeCoordinatorState | 100        |    82.973 μs | 0.1359 μs | 0.1205 μs |  11.7188 |   1.4648 |  108.68 KB |
| SerializeDataEnvelope       | 100        |    23.528 μs | 0.0850 μs | 0.0754 μs |   6.0730 |   0.4272 |   55.85 KB |
| DeserializeDataEnvelope     | 100        |    71.650 μs | 0.1363 μs | 0.1208 μs |  11.2305 |   1.2207 |  103.97 KB |
| SerializeDataWrite          | 100        |    23.786 μs | 0.0631 μs | 0.0559 μs |   5.9509 |   0.7935 |   54.73 KB |
| DeserializeDataWrite        | 100        |    60.977 μs | 0.1250 μs | 0.1108 μs |  12.6953 |   1.7090 |  116.77 KB |
| **SerializeCoordinatorState**   | **1000**       |   **216.195 μs** | **0.8867 μs** | **0.7860 μs** |  **42.2363** |  **12.4512** |  **390.59 KB** |
| DeserializeCoordinatorState | 1000       | 1,052.957 μs | 0.8625 μs | 0.7646 μs | 152.3438 |  72.2656 | 1409.48 KB |
| SerializeDataEnvelope       | 1000       |   222.330 μs | 2.0858 μs | 1.9510 μs |  57.1289 |  14.1602 |   526.2 KB |
| DeserializeDataEnvelope     | 1000       | 1,041.750 μs | 3.0859 μs | 2.7356 μs | 166.0156 |  99.6094 | 1535.42 KB |
| SerializeDataWrite          | 1000       |   220.144 μs | 1.6578 μs | 1.4696 μs |  57.1289 |  28.5645 |  526.37 KB |
| DeserializeDataWrite        | 1000       |   976.237 μs | 5.3706 μs | 4.7609 μs | 167.9688 | 103.5156 | 1547.56 KB |
