### PR TITLE
Make actor start / stop telemetry descriptors overrideable

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -94,6 +94,8 @@ namespace Akka.Actor
         public void CheckReceiveTimeout(bool reschedule = True) { }
         protected void ClearActor(Akka.Actor.ActorBase actor) { }
         protected void ClearActorCell() { }
+        protected virtual Akka.Actor.ActorStarted CreateActorStartedEvent() { }
+        protected virtual Akka.Actor.ActorStopped CreateActorStoppedEvent() { }
         protected virtual Akka.Actor.ActorBase CreateNewActorInstance() { }
         [System.ObsoleteAttribute("Use TryGetChildStatsByName [0.7.1]", true)]
         public Akka.Actor.IInternalActorRef GetChildByName(string name) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -94,6 +94,8 @@ namespace Akka.Actor
         public void CheckReceiveTimeout(bool reschedule = True) { }
         protected void ClearActor(Akka.Actor.ActorBase actor) { }
         protected void ClearActorCell() { }
+        protected virtual Akka.Actor.ActorStarted CreateActorStartedEvent() { }
+        protected virtual Akka.Actor.ActorStopped CreateActorStoppedEvent() { }
         protected virtual Akka.Actor.ActorBase CreateNewActorInstance() { }
         [System.ObsoleteAttribute("Use TryGetChildStatsByName [0.7.1]", true)]
         public Akka.Actor.IInternalActorRef GetChildByName(string name) { }

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -429,6 +429,22 @@ namespace Akka.Actor
             SendSystemMessage(new Recreate(cause));
         }
 
+        /// <summary>
+        /// Overrideable in order to support issues such as https://github.com/petabridge/phobos-issues/issues/82
+        /// </summary>
+        protected virtual ActorStarted CreateActorStartedEvent()
+        {
+            return new ActorStarted(Self, Props.Type);
+        }
+        
+        /// <summary>
+        /// Overrideable in order to support issues such as https://github.com/petabridge/phobos-issues/issues/82
+        /// </summary>
+        protected virtual ActorStopped CreateActorStoppedEvent()
+        {
+            return new ActorStopped(Self, Props.Type);
+        }
+
         private void Create(Exception failure)
         {
             if (failure != null)
@@ -442,7 +458,7 @@ namespace Akka.Actor
                 if (System.Settings.DebugLifecycle)
                     Publish(new Debug(Self.Path.ToString(), created.GetType(), "Started (" + created + ")"));
                 if(System.Settings.EmitActorTelemetry)
-                    System.EventStream.Publish(new ActorStarted(Self, Props.Type));
+                    System.EventStream.Publish(CreateActorStartedEvent());
             }
             catch (Exception e)
             {

--- a/src/core/Akka/Actor/ActorCell.FaultHandling.cs
+++ b/src/core/Akka/Actor/ActorCell.FaultHandling.cs
@@ -290,7 +290,7 @@ namespace Akka.Actor
                 }
                 
                 if(System.Settings.EmitActorTelemetry)
-                    System.EventStream.Publish(new ActorStopped(Self, Props.Type));
+                    System.EventStream.Publish(CreateActorStoppedEvent());
             }
             catch (Exception x)
             {


### PR DESCRIPTION
## Changes

Designed to support https://github.com/petabridge/phobos-issues/issues/82

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue https://github.com/petabridge/phobos-issues/issues/82
* [x] Changes in public API reviewed, if any.
