### PR TITLE
fix `KeyNotFoundException` in `DelegatingSupervisorStrategy`

### DIFF
--- a/src/core/Akka.TestKit/DelegatingSupervisorStrategy.cs
+++ b/src/core/Akka.TestKit/DelegatingSupervisorStrategy.cs
@@ -22,15 +22,19 @@ namespace Akka.TestKit
         
         protected override Directive Handle(IActorRef child, Exception exception)
         {
-            var childDelegate = Delegates[child];
-            var handleMethod = typeof(SupervisorStrategy).GetMethod(
-                name: "Handle", 
-                bindingAttr: BindingFlags.Instance | BindingFlags.NonPublic, 
-                binder: Type.DefaultBinder,
-                types: new[] {typeof(IActorRef), typeof(Exception)}, 
-                modifiers: null);
-            var result = (Directive) handleMethod.Invoke(childDelegate, new object[]{ child, exception });
-            return result;
+            if(Delegates.TryGetValue(child, out var childDelegate))
+            {
+                var handleMethod = typeof(SupervisorStrategy).GetMethod(
+                    name: "Handle", 
+                    bindingAttr: BindingFlags.Instance | BindingFlags.NonPublic, 
+                    binder: Type.DefaultBinder,
+                    types: new[] {typeof(IActorRef), typeof(Exception)}, 
+                    modifiers: null);
+                var result = (Directive) handleMethod.Invoke(childDelegate, new object[]{ child, exception });
+                return result;
+            }
+
+            return DefaultDecider.Decide(exception);
         }
         
         public override void ProcessFailure(IActorContext context, bool restart, IActorRef child, Exception cause, ChildRestartStats stats,


### PR DESCRIPTION
## Changes

close #7437 

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
