### PR TITLE
Update Akka.FSharp README Interop with Task Parallel Library Example

### DIFF
--- a/src/core/Akka.FSharp/README.md
+++ b/src/core/Akka.FSharp/README.md
@@ -245,7 +245,7 @@ Example:
         match box msg with
         | :? FileInfo as fi ->
             let reader = new StreamReader(fi.OpenRead())
-            reader.AsyncReadToEnd() |!> mailbox.Self
+            Async.AwaitTask (reader.ReadToEndAsync()) |!> mailbox.Self
         | :? string as content ->
             printfn "File content: %s" content
         | _ -> mailbox.Unhandled()


### PR DESCRIPTION
## Changes

Update Akka.FSharp README Interop with Task Parallel Library Example

- `System.IO.StreamReader` method name has changed to `ReadToEndAsync`
- `|!>` requires `System.Threading.Tasks.Task` to be wrapped by `Async.AwaitTask`

