### PR TITLE
Add support for optional snapshots

### DIFF
--- a/docs/articles/persistence/snapshots.md
+++ b/docs/articles/persistence/snapshots.md
@@ -51,6 +51,19 @@ persistent actors should use the `deleteSnapshots` method. Depending on the jour
 best practice to do specific deletes with `deleteSnapshot` or to include a `minSequenceNr` as well as a `maxSequenceNr`
 for the `SnapshotSelectionCriteria`.
 
+## Optional snapshots
+
+By default, the persistent actor will unconditionally be stopped if the snapshot can't be loaded in the recovery.
+It is possible to make snapshot loading optional. This can be useful when it is alright to ignore snapshot in case
+of for example deserialization errors. When snapshot loading fails it will instead recover by replaying all events.
+
+Enable this feature by setting `snapshot-is-optional = true` in the snapshot store configuration.
+
+> [!WARNING]
+>Don't set `snapshot-is-optional = true` if events have been deleted because that would result in wrong recovered state if snapshot load fails.
+
+
+
 ## Snapshot Status Handling
 
 Saving or deleting snapshots can either succeed or fail – this information is reported back to the persistent actor via status messages as illustrated in the following table.

--- a/docs/articles/persistence/snapshots.md
+++ b/docs/articles/persistence/snapshots.md
@@ -62,8 +62,6 @@ Enable this feature by setting `snapshot-is-optional = true` in the snapshot sto
 > [!WARNING]
 >Don't set `snapshot-is-optional = true` if events have been deleted because that would result in wrong recovered state if snapshot load fails.
 
-
-
 ## Snapshot Status Handling
 
 Saving or deleting snapshots can either succeed or fail – this information is reported back to the persistent actor via status messages as illustrated in the following table.

--- a/docs/articles/persistence/snapshots.md
+++ b/docs/articles/persistence/snapshots.md
@@ -51,7 +51,7 @@ persistent actors should use the `deleteSnapshots` method. Depending on the jour
 best practice to do specific deletes with `deleteSnapshot` or to include a `minSequenceNr` as well as a `maxSequenceNr`
 for the `SnapshotSelectionCriteria`.
 
-## Optional snapshots
+## Optional Snapshots
 
 By default, the persistent actor will unconditionally be stopped if the snapshot can't be loaded in the recovery.
 It is possible to make snapshot loading optional. This can be useful when it is alright to ignore snapshot in case

--- a/src/core/Akka.Persistence/Persistence.cs
+++ b/src/core/Akka.Persistence/Persistence.cs
@@ -202,6 +202,22 @@ namespace Akka.Persistence
             var configPath = string.IsNullOrEmpty(journalPluginId) ? _defaultJournalPluginId.Value : journalPluginId;
             return PluginHolderFor(configPath, JournalFallbackConfigPath).Config;
         }
+        
+        /// <summary>
+        /// Returns the plugin config identified by <paramref name="snapshotPluginId"/>.
+        /// When empty, looks in `akka.persistence.snapshot-store.plugin` to find configuration entry path.
+        /// When configured, uses <paramref name="snapshotPluginId"/> as absolute path to the journal configuration entry.
+        /// </summary>
+        /// <param name="snapshotPluginId">TBD</param>
+        /// <exception cref="ArgumentException">
+        /// This exception is thrown when either the plugin class name is undefined or the configuration path is missing.
+        /// </exception>
+        /// <returns>TBD</returns>
+        internal Config SnapshotStoreConfigFor(string snapshotPluginId)
+        {
+            var configPath = string.IsNullOrEmpty(snapshotPluginId) ? _defaultSnapshotPluginId.Value : snapshotPluginId;
+            return PluginHolderFor(configPath, SnapshotStoreFallbackConfigPath).Config;
+        }
 
         /// <summary>
         /// Looks up the plugin config by plugin's ActorRef.

--- a/src/core/Akka.Persistence/persistence.conf
+++ b/src/core/Akka.Persistence/persistence.conf
@@ -181,6 +181,14 @@ akka.persistence {
             call-timeout = 20s
             reset-timeout = 60s
         }
+        
+        # Set this to true if successful loading of snapshot is not necessary.
+        # This can be useful when it is alright to ignore snapshot in case of
+        # for example deserialization errors. When snapshot loading fails it will instead
+        # recover by replaying all events.
+        # Don't set to true if events are deleted because that would
+        # result in wrong recovered state if snapshot load fails.
+        snapshot-is-optional = false
     }
 
     fsm {


### PR DESCRIPTION
This is the implementation for allowing persistence snapshots to be optional when failing (issue https://github.com/akkadotnet/akka.net/issues/7382)


## Changes

Setting snapshot-is-optional = true in the snapshot store configuration will allow Actors to continue if there is a failure loading the snapshot (https://doc.akka.io/libraries/akka-core/current//typed/persistence-snapshot.html#optional-snapshots)
