### PR TITLE
Add per-plugin recovery permitter actors

### DIFF
--- a/src/core/Akka.Persistence.Tests/MultipleRecoveryPermitterSpec.cs
+++ b/src/core/Akka.Persistence.Tests/MultipleRecoveryPermitterSpec.cs
@@ -1,0 +1,63 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="MultipleRecoveryPermitterSpec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2025 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Persistence.Tests;
+
+public class MultipleRecoveryPermitterSpec : PersistenceSpec
+{
+    private readonly IActorRef _permitter1;
+    private readonly IActorRef _permitter2;
+    
+    public MultipleRecoveryPermitterSpec() : base(ConfigurationFactory.ParseString($$"""
+            akka.persistence
+            {
+                # default global max recovery value
+                max-concurrent-recoveries = 3
+                
+                journal
+                {
+                    plugin = "akka.persistence.journal.inmem"
+                    inmem2 {
+                        # max recovery value override
+                        max-concurrent-recoveries = 20
+                        class = "Akka.Persistence.Journal.MemoryJournal, Akka.Persistence"
+                        plugin-dispatcher = "akka.actor.default-dispatcher"
+                    }
+                }
+                
+                # snapshot store plugin is NOT defined, things should still work
+                snapshot-store.plugin = "akka.persistence.no-snapshot-store"
+                snapshot-store.local.dir = "target/snapshots-"{{typeof(RecoveryPermitterSpec).FullName}}"}
+            """))
+    {
+        var extension = Persistence.Instance.Apply(Sys);
+        _permitter1 = extension.RecoveryPermitterFor(null);
+        _permitter2 = extension.RecoveryPermitterFor("akka.persistence.journal.inmem2");
+    }
+
+    [Fact(DisplayName = "Plugin max-concurrent-recoveries HOCON setting should override akka.persistence setting")]
+    public async Task HoconOverrideTest()
+    {
+        _permitter1.Tell(GetMaxPermits.Instance);
+        await ExpectMsgAsync(3);
+        
+        _permitter2.Tell(GetMaxPermits.Instance);
+        await ExpectMsgAsync(20);
+    }
+
+    [Fact(DisplayName = "Each plugin should have their own recovery permitter")]
+    public void MultiRecoveryPermitterActorTest()
+    {
+        _permitter1.Equals(_permitter2).Should().BeFalse();
+    }
+}

--- a/src/core/Akka.Persistence.Tests/RecoveryPermitterSpec.cs
+++ b/src/core/Akka.Persistence.Tests/RecoveryPermitterSpec.cs
@@ -75,7 +75,7 @@ namespace Akka.Persistence.Tests
             akka.persistence.snapshot-store.local.dir = ""target/snapshots-" + typeof(RecoveryPermitterSpec).FullName +
                                                                                @"/"""))
         {
-            permitter = Persistence.Instance.Apply(Sys).RecoveryPermitter();
+            permitter = Persistence.Instance.Apply(Sys).RecoveryPermitterFor(null);
         }
 
         private void RequestPermit(TestProbe probe)

--- a/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Lifecycle.cs
@@ -27,7 +27,7 @@ namespace Akka.Persistence
 
         private void RequestRecoveryPermit()
         {
-            Extension.RecoveryPermitter().Tell(Akka.Persistence.RequestRecoveryPermit.Instance, Self);
+            RecoveryPermitter.Tell(Akka.Persistence.RequestRecoveryPermit.Instance, Self);
             ChangeState(WaitingRecoveryPermit(Recovery));
         }
 
@@ -46,6 +46,7 @@ namespace Akka.Persistence
             // Fail fast on missing plugins.
             var j = Journal;
             var s = SnapshotStore;
+            var r = RecoveryPermitter;
             RequestRecoveryPermit();
             base.AroundPreStart();
         }

--- a/src/core/Akka.Persistence/Eventsourced.Recovery.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Recovery.cs
@@ -270,7 +270,7 @@ namespace Akka.Persistence
         }
 
         private void ReturnRecoveryPermit() =>
-            Extension.RecoveryPermitter().Tell(Akka.Persistence.ReturnRecoveryPermit.Instance, Self);
+            RecoveryPermitter.Tell(Akka.Persistence.ReturnRecoveryPermit.Instance, Self);
 
         private void TransitToProcessingState()
         {

--- a/src/core/Akka.Persistence/Eventsourced.cs
+++ b/src/core/Akka.Persistence/Eventsourced.cs
@@ -81,6 +81,7 @@ namespace Akka.Persistence
         private readonly IStash _internalStash;
         private IActorRef _snapshotStore;
         private IActorRef _journal;
+        private IActorRef _recoveryPermitter;
         private List<IPersistentEnvelope> _journalBatch = new();
         private bool _isWriteInProgress;
         private long _sequenceNr;
@@ -166,6 +167,8 @@ namespace Akka.Persistence
         /// </summary>
         public IActorRef Journal => _journal ??= Extension.JournalFor(JournalPluginId);
 
+        internal IActorRef RecoveryPermitter => _recoveryPermitter ??= Extension.RecoveryPermitterFor(JournalPluginId);
+        
         /// <summary>
         /// TBD
         /// </summary>

--- a/src/core/Akka.Persistence/Persistence.cs
+++ b/src/core/Akka.Persistence/Persistence.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using Akka.Actor;
 using Akka.Annotations;
@@ -21,11 +20,12 @@ namespace Akka.Persistence
 {
     internal struct PluginHolder
     {
-        public PluginHolder(IActorRef @ref, EventAdapters adapters, Config config)
+        public PluginHolder(IActorRef @ref, EventAdapters adapters, Config config, IActorRef recoveryPermitter)
         {
             Ref = @ref;
             Adapters = adapters;
             Config = config;
+            RecoveryPermitter = recoveryPermitter;
         }
 
         public IActorRef Ref { get; }
@@ -33,6 +33,8 @@ namespace Akka.Persistence
         public EventAdapters Adapters { get; }
 
         public Config Config { get; }
+        
+        public IActorRef RecoveryPermitter { get; }
     }
 
     /// <summary>
@@ -50,7 +52,6 @@ namespace Akka.Persistence
         private readonly Lazy<string> _defaultJournalPluginId;
         private readonly Lazy<string> _defaultSnapshotPluginId;
         private readonly Lazy<IStashOverflowStrategy> _defaultInternalStashOverflowStrategy;
-        private readonly Lazy<IActorRef> _recoveryPermitter;
 
         private readonly ConcurrentDictionary<string, Lazy<PluginHolder>> _pluginExtensionIds = new();
 
@@ -120,12 +121,6 @@ namespace Akka.Persistence
                     _log.Info("Auto-starting snapshot store `{0}`", id);
                 SnapshotStoreFor(id);
             });
-
-            _recoveryPermitter = new Lazy<IActorRef>(() =>
-            {
-                var maxPermits = _config.GetInt("max-concurrent-recoveries", 0);
-                return _system.SystemActorOf(Akka.Persistence.RecoveryPermitter.Props(maxPermits), "recoveryPermitter");
-            });
         }
 
         /// <summary>
@@ -152,9 +147,10 @@ namespace Akka.Persistence
         /// INTERNAL API: When starting many persistent actors at the same time the journal its data store is protected 
         /// from being overloaded by limiting number of recoveries that can be in progress at the same time.
         /// </summary>
-        internal IActorRef RecoveryPermitter()
+        internal IActorRef RecoveryPermitterFor(string journalPluginId)
         {
-            return _recoveryPermitter.Value;
+            var configPath = string.IsNullOrEmpty(journalPluginId) ? _defaultJournalPluginId.Value : journalPluginId;
+            return PluginHolderFor(configPath, JournalFallbackConfigPath).RecoveryPermitter;
         }
 
         /// <summary>
@@ -270,6 +266,17 @@ namespace Akka.Persistence
             return pluginContainer.Value;
         }
 
+        private static IActorRef CreateRecoveryPermitter(ExtendedActorSystem system, string configPath, Config pluginConfig)
+        {
+            // backward compatibility
+            // get the setting from the plugin path, if not found, default to the one defined in "akka.persistence"
+            var maxPermits = pluginConfig.HasPath("max-concurrent-recoveries") 
+                ? pluginConfig.GetInt("max-concurrent-recoveries")
+                : system.Settings.Config.GetInt("akka.persistence.max-concurrent-recoveries");
+
+            return system.SystemActorOf(RecoveryPermitter.Props(maxPermits), $"recoveryPermitter-{configPath}");
+        }
+
         private static IActorRef CreatePlugin(ExtendedActorSystem system, string configPath, Config pluginConfig)
         {
             var pluginActorName = configPath;
@@ -303,8 +310,9 @@ namespace Akka.Persistence
             var config = system.Settings.Config.GetConfig(configPath).WithFallback(system.Settings.Config.GetConfig(fallbackPath));
             var plugin = CreatePlugin(system, configPath, config);
             var adapters = CreateAdapters(system, configPath);
+            var recoveryPermitter = CreateRecoveryPermitter(system, configPath, config);
 
-            return new PluginHolder(plugin, adapters, config);
+            return new PluginHolder(plugin, adapters, config, recoveryPermitter);
         }
     }
 


### PR DESCRIPTION
Fixes #7447

## Changes

All changes are applied to internal APIs.

* Move recovery permitter cache from global `Persistence` extension to each `EventSourced` actors.
* `RecoveryPermitter` actor is now lazily created and stored inside persistence `PluginHolder`
* Add option to declare "max-concurrent-recoveries" HOCON setting in each persistence plugin that, if declared, will override the global "akka.persistence.max-concurrent-recoveries"

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7447