### PR TITLE
reorganized dependencies into separate paths for .NET Standard, .NET 6/8+

### DIFF
--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -11,15 +11,19 @@
     <EmbeddedResource Include="Configuration\akka.conf" />
   </ItemGroup>
 
+  <!-- Common packages for all target frameworks -->
   <ItemGroup>
-      <PackageReference Include="Polyfill" Version="1.28.0" PrivateAssets="all" />
-      <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MsExtVersion)" />
-      <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-      <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-      <PackageReference Include="System.Collections.Immutable" Version="$(MicrosoftLibVersion)" />
-      <PackageReference Include="System.Threading.Channels" Version="$(MicrosoftLibVersion)" />
-      <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(ConfigurationManagerVersion)"/>
-      
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MsExtVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="System.Collections.Immutable" Version="$(MicrosoftLibVersion)" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="$(ConfigurationManagerVersion)"/>
+  </ItemGroup>
+
+  <!-- Packages only for NetStandard -->
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardLibVersion)'">
+    <PackageReference Include="Polyfill" Version="1.28.0" PrivateAssets="all" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageReference Include="System.Threading.Channels" Version="$(MicrosoftLibVersion)" />
   </ItemGroup>
   
   <ItemGroup Label="PublicAnalyzers">


### PR DESCRIPTION
## Changes

No material changes other than reducing the number of NuGet packages .NET 6+ users need to install.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
