### PR TITLE
Remove `System.ConfigurationManager` support from .NET 6+

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -2297,26 +2297,12 @@ namespace Akka.Configuration
         public static Akka.Configuration.Config FromResource(string resourceName, object instanceInAssembly) { }
         public static Akka.Configuration.Config FromResource<TAssembly>(string resourceName) { }
         public static Akka.Configuration.Config FromResource(string resourceName, System.Reflection.Assembly assembly) { }
-        public static Akka.Configuration.Config Load() { }
         public static Akka.Configuration.Config ParseString(string hocon, System.Func<string, Akka.Configuration.Hocon.HoconRoot> includeCallback) { }
         public static Akka.Configuration.Config ParseString(string hocon) { }
     }
 }
 namespace Akka.Configuration.Hocon
 {
-    public class AkkaConfigurationSection : System.Configuration.ConfigurationSection
-    {
-        public AkkaConfigurationSection() { }
-        public Akka.Configuration.Config AkkaConfig { get; }
-        [System.Configuration.ConfigurationPropertyAttribute("hocon", IsRequired=true)]
-        public Akka.Configuration.Hocon.HoconConfigurationElement Hocon { get; set; }
-    }
-    public abstract class CDataConfigurationElement : System.Configuration.ConfigurationElement
-    {
-        protected const string ContentPropertyName = "content";
-        protected CDataConfigurationElement() { }
-        protected override void DeserializeElement(System.Xml.XmlReader reader, bool serializeCollectionKey) { }
-    }
     public class HoconArray : System.Collections.Generic.List<Akka.Configuration.Hocon.HoconValue>, Akka.Configuration.Hocon.IHoconElement
     {
         public HoconArray() { }
@@ -2325,12 +2311,6 @@ namespace Akka.Configuration.Hocon
         public bool IsArray() { }
         public bool IsString() { }
         public override string ToString() { }
-    }
-    public class HoconConfigurationElement : Akka.Configuration.Hocon.CDataConfigurationElement
-    {
-        public HoconConfigurationElement() { }
-        [System.Configuration.ConfigurationPropertyAttribute("content", IsKey=true, IsRequired=true)]
-        public string Content { get; set; }
     }
     public class HoconLiteral : Akka.Configuration.Hocon.IHoconElement
     {

--- a/src/core/Akka.Cluster.Tests/ProviderSelectionSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ProviderSelectionSpec.cs
@@ -16,7 +16,7 @@ namespace Akka.Cluster.Tests
     public class ProviderSelectionSpec
     {
         public ActorSystemSetup Setup { get; } = ActorSystemSetup.Create();
-        public Config LocalConfig { get; } = ConfigurationFactory.Load();
+        public Config LocalConfig { get; } = ConfigurationFactory.Default();
 
         public Settings SettingsWith(string key)
         {

--- a/src/core/Akka.Discovery.Tests/DiscoveryConfigurationSpec.cs
+++ b/src/core/Akka.Discovery.Tests/DiscoveryConfigurationSpec.cs
@@ -47,7 +47,7 @@ namespace Akka.Discovery.Tests
                         akka-mock-inside {{
                             class = ""{className}""
                         }}
-                    }}").WithFallback(ConfigurationFactory.Load()));
+                    }}"));
 
             var discovery = Discovery.Get(sys).Default;
             discovery.Should().BeAssignableTo<FakeTestDiscovery>();
@@ -70,7 +70,7 @@ namespace Akka.Discovery.Tests
                         mock2 {{
                             class = ""{className2}""
                         }}
-                    }}").WithFallback(ConfigurationFactory.Load()));
+                    }}"));
 
             Discovery.Get(sys).Default.Should().BeAssignableTo<FakeTestDiscovery>();
             Discovery.Get(sys).LoadServiceDiscovery("mock2").Should().BeAssignableTo<FakeTestDiscovery2>();
@@ -93,7 +93,7 @@ namespace Akka.Discovery.Tests
                         mock2 {{
                             class = ""{className2}""
                         }}
-                    }}").WithFallback(ConfigurationFactory.Load()));
+                    }}"));
 
             Discovery.Get(sys).LoadServiceDiscovery("mock2").Should().BeSameAs(Discovery.Get(sys).LoadServiceDiscovery("mock2"));
             Discovery.Get(sys).Default.Should().BeSameAs(Discovery.Get(sys).LoadServiceDiscovery("mock1"));
@@ -112,7 +112,7 @@ namespace Akka.Discovery.Tests
                         mock1 {{
                             class = ""{className}""
                         }}
-                    }}").WithFallback(ConfigurationFactory.Load()));
+                    }}"));
 
             Invoking(() => _ = Discovery.Get(sys).Default)
                 .Should().Throw<TargetInvocationException>()
@@ -130,7 +130,7 @@ namespace Akka.Discovery.Tests
                 ConfigurationFactory.ParseString($@"            
                     akka.discovery {{
                         method = ""{className}""
-                    }}").WithFallback(ConfigurationFactory.Load()));
+                    }}"));
 
             Invoking(() => _ = Discovery.Get(sys).Default).Should()
                 .Throw<ArgumentException>()
@@ -148,7 +148,7 @@ namespace Akka.Discovery.Tests
                         akka-mock-inside {{
                             class = ""{typeof(TestDiscoveryWithOneParam).TypeQualifiedName()}""
                         }}
-                    }}").WithFallback(ConfigurationFactory.Load()));
+                    }}"));
 
             var discovery = Discovery.Get(sys).Default;
             discovery.Should().BeAssignableTo<TestDiscoveryWithOneParam>();
@@ -165,7 +165,7 @@ namespace Akka.Discovery.Tests
                         akka-mock-inside {{
                             class = ""{typeof(TestDiscoveryWithTwoParam).TypeQualifiedName()}""
                         }}
-                    }}").WithFallback(ConfigurationFactory.Load()));
+                    }}"));
 
             var discovery = Discovery.Get(sys).Default;
             discovery.Should().BeAssignableTo<TestDiscoveryWithTwoParam>();
@@ -182,7 +182,7 @@ namespace Akka.Discovery.Tests
                         akka-mock-inside {{
                             class = ""{typeof(TestDiscoveryWithIllegalParam).TypeQualifiedName()}""
                         }}
-                    }}").WithFallback(ConfigurationFactory.Load()));
+                    }}"));
 
             Invoking(() => _ = Discovery.Get(sys).Default).Should()
                 .Throw<ArgumentException>()
@@ -200,7 +200,7 @@ namespace Akka.Discovery.Tests
                         akka-mock-inside {{
                             class = ""{typeof(TestDiscoveryWithIllegalCtor).TypeQualifiedName()}""
                         }}
-                    }}").WithFallback(ConfigurationFactory.Load()));
+                    }}"));
 
             Invoking(() => _ = Discovery.Get(sys).Default).Should()
                 .Throw<ArgumentException>()

--- a/src/core/Akka.FSharp.Tests/ApiTests.fs
+++ b/src/core/Akka.FSharp.Tests/ApiTests.fs
@@ -96,19 +96,19 @@ type TestActorWithArgs(arg1, arg2, arg3) =
 
 [<Fact>]
 let ``can spawn simple actor from expression`` () =
-    let system = Configuration.load() |> System.create "test"
+    let system = Configuration.defaultConfig() |> System.create "test"
     let actor = spawnObj system "test-actor" <@ fun () -> TestActor() @>
     ()
 
 [<Fact>]
 let ``can spawn actor with constant args from expression`` () =
-    let system = Configuration.load() |> System.create "test"
+    let system = Configuration.defaultConfig() |> System.create "test"
     let actor = spawnObj system "test-actor" <@ fun () -> TestActorWithArgs(box 1, box true, box "yo") @>
     ()
 
 [<Fact>]
 let ``can spawn actor with captured args from expression`` () =
-    let system = Configuration.load() |> System.create "test"
+    let system = Configuration.defaultConfig() |> System.create "test"
     let arg1 = 1
     let arg2 = true
     let arg3 = "yo"
@@ -117,7 +117,7 @@ let ``can spawn actor with captured args from expression`` () =
 
 [<Fact>]
 let ``cannot spawn actor with simple expr args from expression`` () =
-    let system = Configuration.load() |> System.create "test"
+    let system = Configuration.defaultConfig() |> System.create "test"
     // this formulation is supported in FsApi's expression evaluator, however the checks in Props.Create
     // do not support this, so we test that we can evaluate this but not actually run it, as a proof of concept
     Assert.Throws<InvalidCastException>(fun () ->

--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -428,10 +428,6 @@ module Configuration =
 
     /// Returns default Akka configuration.
     let defaultConfig = Akka.Configuration.ConfigurationFactory.Default
-
-    /// Loads Akka configuration from the project's .config file.
-    #
-    let load = Akka.Configuration.ConfigurationFactory.Load
     
 module internal OptionHelper =
     

--- a/src/core/Akka.FSharp/FsApi.fs
+++ b/src/core/Akka.FSharp/FsApi.fs
@@ -430,6 +430,7 @@ module Configuration =
     let defaultConfig = Akka.Configuration.ConfigurationFactory.Default
 
     /// Loads Akka configuration from the project's .config file.
+    #
     let load = Akka.Configuration.ConfigurationFactory.Load
     
 module internal OptionHelper =

--- a/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
@@ -206,7 +206,7 @@ namespace Akka.Streams.Tests
                 port = {address.Port}
                 hostname = ""{address.Address}""
               }}
-            }}").WithFallback(ConfigurationFactory.Load());
+            }}");
         }
 
         public StreamRefsSpec(ITestOutputHelper output) : this(Config(), output: output)

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -259,8 +259,11 @@ namespace Akka.Actor
         public static ActorSystem Create(string name, ActorSystemSetup setup)
         {
             var bootstrapSetup = setup.Get<BootstrapSetup>();
-            var appConfig = bootstrapSetup.FlatSelect(_ => _.Config).GetOrElse(ConfigurationFactory.Load());
-
+            #if NETSTANDARD
+            var appConfig = bootstrapSetup.FlatSelect(s => s.Config).GetOrElse(ConfigurationFactory.Load());
+            #else
+            var appConfig = bootstrapSetup.FlatSelect(s => s.Config).GetOrElse(ConfigurationFactory.Default());
+            #endif
             return CreateAndStartSystem(name, appConfig, setup);
         }
 

--- a/src/core/Akka/Configuration/ConfigurationFactory.cs
+++ b/src/core/Akka/Configuration/ConfigurationFactory.cs
@@ -36,9 +36,9 @@ namespace Akka.Configuration
         /// <param name="hocon">A string that contains configuration options to use.</param>
         /// <param name="includeCallback">callback used to resolve includes</param>
         /// <returns>The configuration defined in the supplied HOCON string.</returns>
-        public static Config ParseString(string hocon, Func<string,HoconRoot> includeCallback)
+        public static Config ParseString(string hocon, Func<string, HoconRoot> includeCallback)
         {
-            HoconRoot res = Parser.Parse(hocon, includeCallback);
+            var res = Parser.Parse(hocon, includeCallback);
             return new Config(res);
         }
 
@@ -54,6 +54,7 @@ namespace Akka.Configuration
             return ParseString(hocon, null);
         }
 
+#if NETSTANDARD
         /// <summary>
         /// Loads a configuration defined in the current application's
         /// configuration file, e.g. app.config or web.config
@@ -61,9 +62,13 @@ namespace Akka.Configuration
         /// <returns>The configuration defined in the configuration file.</returns>
         public static Config Load()
         {
-            var section = (AkkaConfigurationSection)System.Configuration.ConfigurationManager.GetSection("akka") ?? new AkkaConfigurationSection();
+
+            var section =
+ (AkkaConfigurationSection)System.Configuration.ConfigurationManager.GetSection("akka") ?? new AkkaConfigurationSection();
             return section.AkkaConfig;
+
         }
+#endif
 
         /// <summary>
         /// Retrieves the default configuration that Akka.NET uses
@@ -123,7 +128,7 @@ namespace Akka.Configuration
         /// <returns>The configuration defined in the assembly that contains the given resource.</returns>
         public static Config FromResource(string resourceName, Assembly assembly)
         {
-            using(Stream stream = assembly.GetManifestResourceStream(resourceName))
+            using (Stream stream = assembly.GetManifestResourceStream(resourceName))
             {
                 Debug.Assert(stream != null, "stream != null");
                 using (var reader = new StreamReader(stream))
@@ -148,4 +153,3 @@ namespace Akka.Configuration
         }
     }
 }
-

--- a/src/core/Akka/Configuration/Hocon/AkkaConfigurationSection.cs
+++ b/src/core/Akka/Configuration/Hocon/AkkaConfigurationSection.cs
@@ -9,6 +9,7 @@ using System.Configuration;
 
 namespace Akka.Configuration.Hocon
 {
+#if NETSTANDARD
     /// <summary>
     /// This class represents a custom akka node within a configuration file.
     /// <code>
@@ -65,4 +66,5 @@ namespace Akka.Configuration.Hocon
             set { base[ConfigurationPropertyName] = value; }
         }
     }
+#endif
 }

--- a/src/core/Akka/Configuration/Hocon/CDataConfigurationElement.cs
+++ b/src/core/Akka/Configuration/Hocon/CDataConfigurationElement.cs
@@ -10,6 +10,7 @@ using System.Xml;
 
 namespace Akka.Configuration.Hocon
 {
+    #if NETSTANDARD
     /// <summary>
     /// This class represents the base implementation for retrieving text from
     /// an XML CDATA node within a configuration file.
@@ -62,4 +63,5 @@ namespace Akka.Configuration.Hocon
             reader.ReadEndElement();
         }
     }
+#endif
 }

--- a/src/core/Akka/Configuration/Hocon/HoconConfigurationElement.cs
+++ b/src/core/Akka/Configuration/Hocon/HoconConfigurationElement.cs
@@ -9,6 +9,7 @@ using System.Configuration;
 
 namespace Akka.Configuration.Hocon
 {
+#if NETSTANDARD
     /// <summary>
     /// This class represents a custom HOCON (Human-Optimized Config Object Notation)
     /// node within a configuration file.
@@ -40,4 +41,5 @@ namespace Akka.Configuration.Hocon
             set { base[ContentPropertyName] = value; }
         }
     }
+#endif
 }


### PR DESCRIPTION
## Changes

close https://github.com/akkadotnet/akka.net/issues/7430

System.ConfigurationManager is deprecated and legacy - it's also a major source of problems for AOT compilation.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Discussion issue: https://github.com/akkadotnet/akka.net/issues/7430
* [x] Changes in public API reviewed, if any.