### PR TITLE
remove duplicate package reference on Akka.FSharp

### DIFF
--- a/src/core/Akka.FSharp/Akka.FSharp.fsproj
+++ b/src/core/Akka.FSharp/Akka.FSharp.fsproj
@@ -21,7 +21,6 @@
     <ItemGroup>
         <PackageReference Include="FSharp.Quotations.Evaluator" Version="2.1.0"/>
         <PackageReference Include="FsPickler" Version="5.3.2"/>
-        <PackageReference Include="FSharp.Core" Version="$(FSharpVersion)"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Changes

Removed duplicate `FSharp.Core` packages - no longer needed to explicitly reference them

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).