### PR TITLE
upgrade MSFT.EXT and BCL libraries to 8.0+

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -28,6 +28,7 @@
     <GrpcToolsVersion>2.60.0</GrpcToolsVersion>
     <BenchmarkDotNetVersion>0.13.12</BenchmarkDotNetVersion>
     <NetTestVersion>net8.0</NetTestVersion>
+    <FsharpVersion>6.0.5</FsharpVersion>
     <NetFrameworkTestVersion>net48</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <NetLibVersion>net6.0</NetLibVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <!-- Set the language version for C# if we're not inside an F# project -->
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.8.1</XunitVersion>
@@ -28,7 +28,6 @@
     <GrpcToolsVersion>2.60.0</GrpcToolsVersion>
     <BenchmarkDotNetVersion>0.13.12</BenchmarkDotNetVersion>
     <NetTestVersion>net8.0</NetTestVersion>
-    <FsharpVersion>6.0.5</FsharpVersion>
     <NetFrameworkTestVersion>net48</NetFrameworkTestVersion>
     <NetStandardLibVersion>netstandard2.0</NetStandardLibVersion>
     <NetLibVersion>net6.0</NetLibVersion>
@@ -38,8 +37,8 @@
     <HoconVersion>2.0.3</HoconVersion>
     <ConfigurationManagerVersion>6.0.1</ConfigurationManagerVersion>
     <MultiNodeAdapterVersion>1.5.25</MultiNodeAdapterVersion>
-    <MicrosoftLibVersion>[6.0.*,)</MicrosoftLibVersion>
-    <MsExtVersion>[6.0.*,)</MsExtVersion>
+    <MicrosoftLibVersion>[8.0.*,)</MicrosoftLibVersion>
+    <MsExtVersion>[8.0.*,)</MsExtVersion>
     <AkkaAnalyzerVersion>0.3.0</AkkaAnalyzerVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <!-- Set the language version for C# if we're not inside an F# project -->
   <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
-    <LangVersion>13.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <XunitVersion>2.8.1</XunitVersion>


### PR DESCRIPTION
## Changes

time to upgrade to the next set of LTS - 8.0 is the baseline we should be using as 6.0 is all deprecated now.


## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
