### PR TITLE
Remove more F# duplicate package warnings

### DIFF
--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -26,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="$(FSharpVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />


### PR DESCRIPTION
## Changes

F# projects don't need to explicitly reference FSharp.Core

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).