### PR TITLE
DData: Fix BCL update causing DeltaPropagationSelector throwing IndexOutOfBoundException

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData/DeltaPropagationSelector.cs
+++ b/src/contrib/cluster/Akka.DistributedData/DeltaPropagationSelector.cs
@@ -70,7 +70,9 @@ namespace Akka.DistributedData
                 else
                 {
                     var i = (int)(_deltaNodeRoundRobinCounter % all.Length);
-                    slice = all.Slice(i, sliceSize).ToImmutableArray();
+                    var endIndex = i + sliceSize;
+                    if (endIndex > all.Length) endIndex = all.Length;
+                    slice = all[i..endIndex];
                 
                     if (slice.Length != sliceSize)
                         slice = slice.AddRange(all.Take(sliceSize - slice.Length));


### PR DESCRIPTION
BCL 8.0 does not allow slice end index to go out of bound (breaking behavior)

## Changes

Add index out of bound checking

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).