### PR TITLE
made `ActorCell` use `nullable`

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -141,7 +141,7 @@ namespace Akka.Actor
                 0,
                 1})] Akka.Util.Option<object> customMessage) { }
         public bool TryGetChildStatsByName(string name, out Akka.Actor.Internal.IChildStats child) { }
-        protected bool TryGetChildStatsByRef(Akka.Actor.IActorRef actor, out Akka.Actor.Internal.ChildRestartStats child) { }
+        protected bool TryGetChildStatsByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats child) { }
         public void UnbecomeStacked() { }
         protected void UnreserveChild(string name) { }
         public Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef subject) { }
@@ -324,6 +324,7 @@ namespace Akka.Actor
     }
     public class static ActorRefs
     {
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public static readonly Akka.Actor.IActorRef NoSender;
         public static readonly Akka.Actor.Nobody Nobody;
     }
@@ -2072,7 +2073,7 @@ namespace Akka.Actor.Internal
         public abstract Akka.Actor.Internal.IChildrenContainer Reserve(string name);
         public abstract Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor);
         public bool TryGetByName(string name, out Akka.Actor.Internal.IChildStats stats) { }
-        public bool TryGetByRef(Akka.Actor.IActorRef actor, out Akka.Actor.Internal.ChildRestartStats childRestartStats) { }
+        public bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats childRestartStats) { }
         public abstract Akka.Actor.Internal.IChildrenContainer Unreserve(string name);
     }
     public class EmptyChildrenContainer : Akka.Actor.Internal.IChildrenContainer
@@ -2106,7 +2107,7 @@ namespace Akka.Actor.Internal
         Akka.Actor.Internal.IChildrenContainer Reserve(string name);
         Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor);
         bool TryGetByName(string name, out Akka.Actor.Internal.IChildStats stats);
-        bool TryGetByRef(Akka.Actor.IActorRef actor, out Akka.Actor.Internal.ChildRestartStats stats);
+        bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats stats);
         Akka.Actor.Internal.IChildrenContainer Unreserve(string name);
     }
     public interface IInitializableActor
@@ -5653,7 +5654,9 @@ namespace Akka.Util.Internal
         public static void AddOrSet<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> hash, TKey key, TValue value) { }
         public static T AsInstanceOf<T>(this object self) { }
         public static string BetweenDoubleQuotes(this string self) { }
-        public static System.Collections.Generic.IEnumerable<T> Concat<T>(this System.Collections.Generic.IEnumerable<T> enumerable, T item) { }
+        public static System.Collections.Generic.IEnumerable<T> Concat<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})] this System.Collections.Generic.IEnumerable<T> enumerable, T item) { }
         public static System.Collections.Generic.IEnumerable<T> Drop<T>(this System.Collections.Generic.IEnumerable<T> self, int count) { }
         public static void ForEach<T>(this System.Collections.Generic.IEnumerable<T> source, System.Action<T> action) { }
         public static TValue GetOrElse<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> hash, TKey key, TValue elseValue) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -59,12 +59,14 @@ namespace Akka.Actor
         protected virtual void Unhandled(object message) { }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("{Self,nq}")]
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ActorCell : Akka.Actor.IActorContext, Akka.Actor.IActorRefFactory, Akka.Actor.ICanWatch, Akka.Actor.ICell, Akka.Actor.IUntypedActorContext
     {
         public const int UndefinedUid = 0;
         public ActorCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.IInternalActorRef self, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Actor.IInternalActorRef parent) { }
         public Akka.Actor.Internal.IChildrenContainer ChildrenContainer { get; }
         public int CurrentEnvelopeId { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public object CurrentMessage { get; }
         public Akka.Dispatch.MessageDispatcher Dispatcher { get; }
         public bool HasMessages { get; }
@@ -72,22 +74,24 @@ namespace Akka.Actor
         protected bool IsNormal { get; }
         public bool IsTerminated { get; }
         protected bool IsTerminating { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public Akka.Dispatch.Mailbox Mailbox { get; }
         public int NumberOfMessages { get; }
         public Akka.Actor.IInternalActorRef Parent { get; }
         public Akka.Actor.Props Props { get; }
         public System.Nullable<System.TimeSpan> ReceiveTimeout { get; }
         public Akka.Actor.IActorRef Self { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public Akka.Actor.IActorRef Sender { get; }
         public Akka.Actor.ActorSystem System { get; }
         public Akka.Actor.Internal.ActorSystemImpl SystemImpl { get; }
         public virtual Akka.Dispatch.ActorTaskScheduler TaskScheduler { get; }
-        public virtual Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string name = null) { }
+        public virtual Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null) { }
         public Akka.Actor.ActorSelection ActorSelection(string path) { }
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath path) { }
         protected void AddWatcher(Akka.Actor.IActorRef watchee, Akka.Actor.IActorRef watcher) { }
         protected void AddressTerminated(Akka.Actor.Address address) { }
-        public virtual Akka.Actor.IActorRef AttachChild(Akka.Actor.Props props, bool isSystemService, string name = null) { }
+        public virtual Akka.Actor.IActorRef AttachChild(Akka.Actor.Props props, bool isSystemService, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null) { }
         protected virtual void AutoReceiveMessage(Akka.Actor.Envelope envelope) { }
         public void Become(Akka.Actor.Receive receive) { }
         public void BecomeStacked(Akka.Actor.Receive receive) { }
@@ -105,6 +109,7 @@ namespace Akka.Actor
         public static Akka.Actor.IActorRef GetCurrentSenderOrNoSender() { }
         public Akka.Actor.IInternalActorRef GetSingleChild(string name) { }
         public void Init(bool sendSupervise, Akka.Dispatch.MailboxType mailboxType) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         public Akka.Actor.Internal.ChildRestartStats InitChild(Akka.Actor.IInternalActorRef actor) { }
         public void Invoke(Akka.Actor.Envelope envelope) { }
         protected virtual void PreStart() { }
@@ -113,6 +118,7 @@ namespace Akka.Actor
         public void ReceiveMessageForTest(Akka.Actor.Envelope envelope) { }
         protected void ReceivedTerminated(Akka.Actor.Terminated t) { }
         protected void RemWatcher(Akka.Actor.IActorRef watchee, Akka.Actor.IActorRef watcher) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         protected Akka.Actor.Internal.SuspendReason RemoveChildAndGetStateChange(Akka.Actor.IActorRef child) { }
         public void ReserveChild(string name) { }
         public void Restart(System.Exception cause) { }
@@ -120,7 +126,7 @@ namespace Akka.Actor
         public virtual void SendMessage(Akka.Actor.Envelope message) { }
         public virtual void SendMessage(Akka.Actor.IActorRef sender, object message) { }
         public virtual void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage systemMessage) { }
-        protected void SetActorFields(Akka.Actor.ActorBase actor) { }
+        protected static void SetActorFields(Akka.Actor.ActorBase actor) { }
         protected bool SetChildrenTerminationReason(Akka.Actor.Internal.SuspendReason reason) { }
         public void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout = null) { }
         protected void SetTerminated() { }
@@ -2060,7 +2066,7 @@ namespace Akka.Actor.Internal
         public virtual bool IsTerminating { get; }
         public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> Stats { get; }
         public abstract Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats);
-        protected void ChildStatsAppender(System.Text.StringBuilder sb, System.Collections.Generic.KeyValuePair<string, Akka.Actor.Internal.IChildStats> kvp, int index) { }
+        protected static void ChildStatsAppender(System.Text.StringBuilder sb, System.Collections.Generic.KeyValuePair<string, Akka.Actor.Internal.IChildStats> kvp, int index) { }
         public bool Contains(Akka.Actor.IActorRef actor) { }
         public abstract Akka.Actor.Internal.IChildrenContainer Remove(Akka.Actor.IActorRef child);
         public abstract Akka.Actor.Internal.IChildrenContainer Reserve(string name);
@@ -2118,6 +2124,7 @@ namespace Akka.Actor.Internal
     {
         public static Akka.Actor.Internal.InternalActivateFsmLogging Instance { get; }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class static InternalCurrentActorCellKeeper
     {
         public static Akka.Actor.ActorCell Current { get; set; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -141,7 +141,7 @@ namespace Akka.Actor
                 0,
                 1})] Akka.Util.Option<object> customMessage) { }
         public bool TryGetChildStatsByName(string name, out Akka.Actor.Internal.IChildStats child) { }
-        protected bool TryGetChildStatsByRef(Akka.Actor.IActorRef actor, out Akka.Actor.Internal.ChildRestartStats child) { }
+        protected bool TryGetChildStatsByRef(Akka.Actor.IActorRef actor, [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats child) { }
         public void UnbecomeStacked() { }
         protected void UnreserveChild(string name) { }
         public Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef subject) { }
@@ -324,6 +324,7 @@ namespace Akka.Actor
     }
     public class static ActorRefs
     {
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public static readonly Akka.Actor.IActorRef NoSender;
         public static readonly Akka.Actor.Nobody Nobody;
     }
@@ -2070,7 +2071,7 @@ namespace Akka.Actor.Internal
         public abstract Akka.Actor.Internal.IChildrenContainer Reserve(string name);
         public abstract Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor);
         public bool TryGetByName(string name, out Akka.Actor.Internal.IChildStats stats) { }
-        public bool TryGetByRef(Akka.Actor.IActorRef actor, out Akka.Actor.Internal.ChildRestartStats childRestartStats) { }
+        public bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats childRestartStats) { }
         public abstract Akka.Actor.Internal.IChildrenContainer Unreserve(string name);
     }
     public class EmptyChildrenContainer : Akka.Actor.Internal.IChildrenContainer
@@ -2104,7 +2105,7 @@ namespace Akka.Actor.Internal
         Akka.Actor.Internal.IChildrenContainer Reserve(string name);
         Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor);
         bool TryGetByName(string name, out Akka.Actor.Internal.IChildStats stats);
-        bool TryGetByRef(Akka.Actor.IActorRef actor, out Akka.Actor.Internal.ChildRestartStats stats);
+        bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats stats);
         Akka.Actor.Internal.IChildrenContainer Unreserve(string name);
     }
     public interface IInitializableActor
@@ -5642,7 +5643,9 @@ namespace Akka.Util.Internal
         public static void AddOrSet<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> hash, TKey key, TValue value) { }
         public static T AsInstanceOf<T>(this object self) { }
         public static string BetweenDoubleQuotes(this string self) { }
-        public static System.Collections.Generic.IEnumerable<T> Concat<T>(this System.Collections.Generic.IEnumerable<T> enumerable, T item) { }
+        public static System.Collections.Generic.IEnumerable<T> Concat<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                1})] this System.Collections.Generic.IEnumerable<T> enumerable, T item) { }
         public static System.Collections.Generic.IEnumerable<T> Drop<T>(this System.Collections.Generic.IEnumerable<T> self, int count) { }
         public static void ForEach<T>(this System.Collections.Generic.IEnumerable<T> source, System.Action<T> action) { }
         public static TValue GetOrElse<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> hash, TKey key, TValue elseValue) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -59,12 +59,14 @@ namespace Akka.Actor
         protected virtual void Unhandled(object message) { }
     }
     [System.Diagnostics.DebuggerDisplayAttribute("{Self,nq}")]
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ActorCell : Akka.Actor.IActorContext, Akka.Actor.IActorRefFactory, Akka.Actor.ICanWatch, Akka.Actor.ICell, Akka.Actor.IUntypedActorContext
     {
         public const int UndefinedUid = 0;
         public ActorCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.IInternalActorRef self, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Actor.IInternalActorRef parent) { }
         public Akka.Actor.Internal.IChildrenContainer ChildrenContainer { get; }
         public int CurrentEnvelopeId { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public object CurrentMessage { get; }
         public Akka.Dispatch.MessageDispatcher Dispatcher { get; }
         public bool HasMessages { get; }
@@ -72,22 +74,24 @@ namespace Akka.Actor
         protected bool IsNormal { get; }
         public bool IsTerminated { get; }
         protected bool IsTerminating { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public Akka.Dispatch.Mailbox Mailbox { get; }
         public int NumberOfMessages { get; }
         public Akka.Actor.IInternalActorRef Parent { get; }
         public Akka.Actor.Props Props { get; }
         public System.Nullable<System.TimeSpan> ReceiveTimeout { get; }
         public Akka.Actor.IActorRef Self { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public Akka.Actor.IActorRef Sender { get; }
         public Akka.Actor.ActorSystem System { get; }
         public Akka.Actor.Internal.ActorSystemImpl SystemImpl { get; }
         public virtual Akka.Dispatch.ActorTaskScheduler TaskScheduler { get; }
-        public virtual Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string name = null) { }
+        public virtual Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null) { }
         public Akka.Actor.ActorSelection ActorSelection(string path) { }
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath path) { }
         protected void AddWatcher(Akka.Actor.IActorRef watchee, Akka.Actor.IActorRef watcher) { }
         protected void AddressTerminated(Akka.Actor.Address address) { }
-        public virtual Akka.Actor.IActorRef AttachChild(Akka.Actor.Props props, bool isSystemService, string name = null) { }
+        public virtual Akka.Actor.IActorRef AttachChild(Akka.Actor.Props props, bool isSystemService, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null) { }
         protected virtual void AutoReceiveMessage(Akka.Actor.Envelope envelope) { }
         public void Become(Akka.Actor.Receive receive) { }
         public void BecomeStacked(Akka.Actor.Receive receive) { }
@@ -105,6 +109,7 @@ namespace Akka.Actor
         public static Akka.Actor.IActorRef GetCurrentSenderOrNoSender() { }
         public Akka.Actor.IInternalActorRef GetSingleChild(string name) { }
         public void Init(bool sendSupervise, Akka.Dispatch.MailboxType mailboxType) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         public Akka.Actor.Internal.ChildRestartStats InitChild(Akka.Actor.IInternalActorRef actor) { }
         public void Invoke(Akka.Actor.Envelope envelope) { }
         protected virtual void PreStart() { }
@@ -113,6 +118,7 @@ namespace Akka.Actor
         public void ReceiveMessageForTest(Akka.Actor.Envelope envelope) { }
         protected void ReceivedTerminated(Akka.Actor.Terminated t) { }
         protected void RemWatcher(Akka.Actor.IActorRef watchee, Akka.Actor.IActorRef watcher) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         protected Akka.Actor.Internal.SuspendReason RemoveChildAndGetStateChange(Akka.Actor.IActorRef child) { }
         public void ReserveChild(string name) { }
         public void Restart(System.Exception cause) { }
@@ -120,7 +126,7 @@ namespace Akka.Actor
         public virtual void SendMessage(Akka.Actor.Envelope message) { }
         public virtual void SendMessage(Akka.Actor.IActorRef sender, object message) { }
         public virtual void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage systemMessage) { }
-        protected void SetActorFields(Akka.Actor.ActorBase actor) { }
+        protected static void SetActorFields(Akka.Actor.ActorBase actor) { }
         protected bool SetChildrenTerminationReason(Akka.Actor.Internal.SuspendReason reason) { }
         public void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout = null) { }
         protected void SetTerminated() { }
@@ -2058,7 +2064,7 @@ namespace Akka.Actor.Internal
         public virtual bool IsTerminating { get; }
         public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> Stats { get; }
         public abstract Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats);
-        protected void ChildStatsAppender(System.Text.StringBuilder sb, System.Collections.Generic.KeyValuePair<string, Akka.Actor.Internal.IChildStats> kvp, int index) { }
+        protected static void ChildStatsAppender(System.Text.StringBuilder sb, System.Collections.Generic.KeyValuePair<string, Akka.Actor.Internal.IChildStats> kvp, int index) { }
         public bool Contains(Akka.Actor.IActorRef actor) { }
         public abstract Akka.Actor.Internal.IChildrenContainer Remove(Akka.Actor.IActorRef child);
         public abstract Akka.Actor.Internal.IChildrenContainer Reserve(string name);
@@ -2116,6 +2122,7 @@ namespace Akka.Actor.Internal
     {
         public static Akka.Actor.Internal.InternalActivateFsmLogging Instance { get; }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class static InternalCurrentActorCellKeeper
     {
         public static Akka.Actor.ActorCell Current { get; set; }

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Threading;
@@ -36,10 +37,10 @@ namespace Akka.Actor
         }
 
         private ImmutableDictionary<string, FunctionRef> FunctionRefs => Volatile.Read(ref _functionRefsDoNotCallMeDirectly);
-        internal bool TryGetFunctionRef(string name, out FunctionRef? functionRef) =>
+        internal bool TryGetFunctionRef(string name, [NotNullWhen(true)]out FunctionRef? functionRef) =>
             FunctionRefs.TryGetValue(name, out functionRef);
 
-        internal bool TryGetFunctionRef(string name, int uid, out FunctionRef? functionRef) =>
+        internal bool TryGetFunctionRef(string name, int uid, [NotNullWhen(true)]out FunctionRef? functionRef) =>
             FunctionRefs.TryGetValue(name, out functionRef) && (uid == ActorCell.UndefinedUid || uid == functionRef.Path.Uid);
 
         internal FunctionRef AddFunctionRef(Action<IActorRef, object> tell, string suffix = "")
@@ -318,7 +319,7 @@ namespace Akka.Actor
         /// <summary>
         /// Tries to get the stats for the child with the specified name. This ignores children for whom only names have been reserved.
         /// </summary>
-        private bool TryGetChildRestartStatsByName(string name, out ChildRestartStats? child)
+        private bool TryGetChildRestartStatsByName(string name, [NotNullWhen(true)] out ChildRestartStats? child)
         {
             if (ChildrenContainer.TryGetByName(name, out var stats))
             {
@@ -337,7 +338,7 @@ namespace Akka.Actor
         /// <param name="actor">TBD</param>
         /// <param name="child">TBD</param>
         /// <returns>TBD</returns>
-        protected bool TryGetChildStatsByRef(IActorRef actor, out ChildRestartStats child)   //This is called getChildByRef in Akka JVM
+        protected bool TryGetChildStatsByRef(IActorRef actor, [NotNullWhen(true)] out ChildRestartStats? child)   //This is called getChildByRef in Akka JVM
         {
             return ChildrenContainer.TryGetByRef(actor, out child);
         }
@@ -361,20 +362,20 @@ namespace Akka.Actor
 
                 if (TryGetFunctionRef(name, out var functionRef))
                 {
-                    return functionRef!;
+                    return functionRef;
                 }
             }
             else
             {
                 var (s, uid) = GetNameAndUid(name);
-                if (TryGetChildRestartStatsByName(s, out var stats) && (uid == UndefinedUid || uid == stats?.Uid))
+                if (TryGetChildRestartStatsByName(s, out var stats) && (uid == UndefinedUid || uid == stats.Uid))
                 {
-                    return stats!.Child;
+                    return stats.Child;
                 }
 
                 if (TryGetFunctionRef(s, uid, out var functionRef))
                 {
-                    return functionRef!;
+                    return functionRef;
                 }
             }
             return ActorRefs.Nobody;

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -4,7 +4,7 @@
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -199,7 +199,7 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="actor">TBD</param>
         /// <returns>TBD</returns>
-        public ChildRestartStats InitChild(IInternalActorRef actor)
+        public ChildRestartStats? InitChild(IInternalActorRef actor)
         {
             var name = actor.Path.Name;
             while (true)

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -424,7 +424,7 @@ namespace Akka.Actor
 
         private IInternalActorRef MakeChild(Props props, string name, bool async, bool systemService)
         {
-            if (_systemImpl.Settings.SerializeAllCreators && !systemService && !(props.Deploy.Scope is LocalScope))
+            if (SystemImpl.Settings.SerializeAllCreators && !systemService && !(props.Deploy.Scope is LocalScope))
             {
                 var oldInfo = Serialization.Serialization.CurrentTransportInformation;
                 object propArgument = null;
@@ -434,7 +434,7 @@ namespace Akka.Actor
                         Serialization.Serialization.CurrentTransportInformation =
                             SystemImpl.Provider.SerializationInformation;
 
-                    var ser = _systemImpl.Serialization;
+                    var ser = SystemImpl.Serialization;
                     if (props.Arguments != null)
                     {
                         foreach (var argument in props.Arguments)
@@ -479,7 +479,7 @@ namespace Akka.Actor
                 try
                 {
                     var childPath = new ChildActorPath(Self.Path, name, NewUid());
-                    actor = _systemImpl.Provider.ActorOf(_systemImpl, props, _self, childPath,
+                    actor = SystemImpl.Provider.ActorOf(SystemImpl, props, _self, childPath,
                         systemService: systemService, deploy: null, lookupDeploy: true, async: async);
                 }
                 catch

--- a/src/core/Akka/Actor/ActorCell.DeathWatch.cs
+++ b/src/core/Akka/Actor/ActorCell.DeathWatch.cs
@@ -195,10 +195,12 @@ namespace Akka.Actor
         }
 
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
-        /// <param name="actor">TBD</param>
-        protected void UnwatchWatchedActors(ActorBase actor)
+        /// <remarks>
+        /// Cleanup routine during actor shutdown.
+        /// </remarks>
+        protected void UnwatchWatchedActors(ActorBase? actor)
         {
             var watching = _state
                 .GetWatching()
@@ -270,7 +272,8 @@ namespace Akka.Actor
                 {
                     _state = _state.RemoveWatchedBy(watcher);
 
-                    if (System.Settings.DebugLifecycle) Publish(new Debug(Self.Path.ToString(), Actor.GetType(), string.Format("no longer watched by {0}", watcher)));
+                    if (System.Settings.DebugLifecycle) Publish(new Debug(Self.Path.ToString(), Actor?.GetType(),
+                        $"no longer watched by {watcher}"));
                 }, watcher);
             }
             else if (!watcheeSelf && watcherSelf)

--- a/src/core/Akka/Actor/ActorCell.DeathWatch.cs
+++ b/src/core/Akka/Actor/ActorCell.DeathWatch.cs
@@ -238,7 +238,8 @@ namespace Akka.Actor
                 {
                     _state = _state.AddWatchedBy(watcher);
 
-                    if (System.Settings.DebugLifecycle) Publish(new Debug(Self.Path.ToString(), Actor.GetType(), string.Format("now watched by {0}", watcher)));
+                    if (System.Settings.DebugLifecycle) Publish(new Debug(Self.Path.ToString(), Actor?.GetType(),
+                        $"now watched by {watcher}"));
                 }, watcher);
             }
             else if (!watcheeSelf && watcherSelf)
@@ -247,7 +248,7 @@ namespace Akka.Actor
             }
             else
             {
-                Publish(new Warning(Self.Path.ToString(), Actor.GetType(),
+                Publish(new Warning(Self.Path.ToString(), Actor?.GetType(),
                     $"BUG: illegal Watch({watchee},{watcher} for {Self}"));
             }
         }
@@ -278,7 +279,7 @@ namespace Akka.Actor
             }
             else
             {
-                Publish(new Warning(Self.Path.ToString(), Actor.GetType(),
+                Publish(new Warning(Self.Path.ToString(), Actor?.GetType(),
                     $"BUG: illegal Unwatch({watchee},{watcher} for {Self}"));
             }
         }

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -207,6 +207,12 @@ namespace Akka.Actor
         private int CalculateState()
         {
             if(IsWaitingForChildren) return SuspendedWaitForChildrenState;
+
+            global::System.Diagnostics.Debug.Assert(
+                condition: Mailbox != null, 
+                message: $"{nameof(Mailbox)} should never be null at this point. " +
+                         $"A null {nameof(Mailbox)} should have triggered a catastrophic actor initialization failure " +
+                         "and killed this actor before ever reaching this point.");
             if(Mailbox!.IsSuspended()) return SuspendedState;
             return DefaultState;
         }
@@ -286,6 +292,9 @@ namespace Akka.Actor
                             Supervise(s.Child, s.Async);
                             break;
                         default:
+                            global::System.Diagnostics.Debug.Assert(
+                                condition: message != null, 
+                                message: $"Something really bad happened in {nameof(SysMsgInvokeAll)}, {nameof(message)} should never be null");
                             throw new NotSupportedException($"Unknown message {message!.GetType().Name}");
                     }
                 }

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -4,7 +4,7 @@
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
+#nullable enable
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -32,8 +32,8 @@ namespace Akka.Actor
         {
             get
             {
-                if (_actor != null)
-                    return _actor.GetType();
+                if (Actor != null)
+                    return Actor.GetType();
                 return GetType();
             }
         }
@@ -41,7 +41,7 @@ namespace Akka.Actor
         private int _currentEnvelopeId;
 
         /// <summary>
-        /// TBD
+        /// INTERNAL API
         /// </summary>
         public int CurrentEnvelopeId
         {
@@ -124,7 +124,7 @@ namespace Akka.Actor
             if (message is IScheduledTellMsg scheduled)
                 message = scheduled.Message;
 
-            var actor = _actor;
+            var actor = Actor;
             var actorType = actor?.GetType();
 
             if (System.Settings.DebugAutoReceive)
@@ -182,13 +182,13 @@ namespace Akka.Actor
             if (message is IScheduledTellMsg scheduled)
                 message = scheduled.Message;
             
-            var wasHandled = _actor.AroundReceive(_state.GetCurrentBehavior(), message);
+            var wasHandled = Actor.AroundReceive(_state.GetCurrentBehavior(), message);
 
-            if (System.Settings.AddLoggingReceive && _actor is ILogReceive)
+            if (System.Settings.AddLoggingReceive && Actor is ILogReceive)
             {
                 //TODO: akka alters the receive handler for logging, but the effect is the same. keep it this way?
                 var msg = "received " + (wasHandled ? "handled" : "unhandled") + " message " + message + " from " + Sender.Path;
-                Publish(new Debug(Self.Path.ToString(), _actor.GetType(), msg));
+                Publish(new Debug(Self.Path.ToString(), Actor.GetType(), msg));
             }
         }
 
@@ -452,7 +452,7 @@ namespace Akka.Actor
             try
             {
                 var created = NewActor();
-                _actor = created;
+                Actor = created;
                 UseThreadContext(() => created.AroundPreStart());
                 CheckReceiveTimeout();
                 if (System.Settings.DebugLifecycle)
@@ -462,10 +462,10 @@ namespace Akka.Actor
             }
             catch (Exception e)
             {
-                if (_actor != null)
+                if (Actor != null)
                 {
-                    ClearActor(_actor);
-                    _actor = null; // ensure that we know that we failed during creation
+                    ClearActor(Actor);
+                    Actor = null; // ensure that we know that we failed during creation
                 }
                 throw new ActorInitializationException(_self, "Exception during creation", e);
             }
@@ -528,7 +528,7 @@ namespace Akka.Actor
             }
             catch (Exception e)
             {
-                _systemImpl.EventStream.Publish(new Error(e, _self.Parent.ToString(), ActorType, "Swallowing exception during message send"));
+                SystemImpl.EventStream.Publish(new Error(e, _self.Parent.ToString(), ActorType, "Swallowing exception during message send"));
             }
         }
 

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -182,12 +182,12 @@ namespace Akka.Actor
             if (message is IScheduledTellMsg scheduled)
                 message = scheduled.Message;
             
-            var wasHandled = Actor.AroundReceive(_state.GetCurrentBehavior(), message);
+            var wasHandled = Actor!.AroundReceive(_state.GetCurrentBehavior(), message);
 
             if (System.Settings.AddLoggingReceive && Actor is ILogReceive)
             {
                 //TODO: akka alters the receive handler for logging, but the effect is the same. keep it this way?
-                var msg = "received " + (wasHandled ? "handled" : "unhandled") + " message " + message + " from " + Sender.Path;
+                var msg = "received " + (wasHandled ? "handled" : "unhandled") + " message " + message + " from " + Sender?.Path;
                 Publish(new Debug(Self.Path.ToString(), Actor.GetType(), msg));
             }
         }
@@ -207,7 +207,7 @@ namespace Akka.Actor
         private int CalculateState()
         {
             if(IsWaitingForChildren) return SuspendedWaitForChildrenState;
-            if(Mailbox.IsSuspended()) return SuspendedState;
+            if(Mailbox!.IsSuspended()) return SuspendedState;
             return DefaultState;
         }
 
@@ -286,7 +286,7 @@ namespace Akka.Actor
                             Supervise(s.Child, s.Async);
                             break;
                         default:
-                            throw new NotSupportedException($"Unknown message {message.GetType().Name}");
+                            throw new NotSupportedException($"Unknown message {message!.GetType().Name}");
                     }
                 }
                 catch (Exception cause)
@@ -347,7 +347,7 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="mailbox">TBD</param>
         /// <returns>TBD</returns>
-        internal Mailbox SwapMailbox(Mailbox mailbox)
+        internal Mailbox? SwapMailbox(Mailbox mailbox)
         {
             Mailbox.DebugPrint("{0} Swapping mailbox to {1}", Self, mailbox);
             var ret = _mailboxDoNotCallMeDirectly;
@@ -445,7 +445,7 @@ namespace Akka.Actor
             return new ActorStopped(Self, Props.Type);
         }
 
-        private void Create(Exception failure)
+        private void Create(Exception? failure)
         {
             if (failure != null)
                 throw failure;

--- a/src/core/Akka/Actor/ActorCell.FaultHandling.cs
+++ b/src/core/Akka/Actor/ActorCell.FaultHandling.cs
@@ -4,7 +4,7 @@
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,7 +31,7 @@ namespace Akka.Actor
         }
 
         // ReSharper disable once InconsistentNaming
-        private IActorRef _failed_DoNotUseMeDirectly;
+        private IActorRef? _failed_DoNotUseMeDirectly;
         private bool IsFailed { get { return _failed_DoNotUseMeDirectly != null; } }
         private void SetFailed(IActorRef perpetrator)
         {
@@ -41,7 +41,7 @@ namespace Akka.Actor
         {
             _failed_DoNotUseMeDirectly = null;
         }
-        private IActorRef Perpetrator { get { return _failed_DoNotUseMeDirectly; } }
+        private IActorRef? Perpetrator { get { return _failed_DoNotUseMeDirectly; } }
 
         /// <summary>Re-create the actor in response to a failure.</summary>
         private void FaultRecreate(Exception cause)
@@ -342,7 +342,7 @@ namespace Akka.Actor
                 var freshActor = NewActor();
                 Actor = freshActor; // this must happen before postRestart has a chance to fail
                 if (ReferenceEquals(freshActor, failedActor))
-                    SetActorFields(freshActor); // If the creator returns the same instance, we need to restore our nulled out fields.
+                    ActorCell.SetActorFields(freshActor); // If the creator returns the same instance, we need to restore our nulled out fields.
 
                 UseThreadContext(() => freshActor.AroundPostRestart(cause, null));
 

--- a/src/core/Akka/Actor/ActorCell.FaultHandling.cs
+++ b/src/core/Akka/Actor/ActorCell.FaultHandling.cs
@@ -46,14 +46,14 @@ namespace Akka.Actor
         /// <summary>Re-create the actor in response to a failure.</summary>
         private void FaultRecreate(Exception cause)
         {
-            if (_actor == null)
+            if (Actor == null)
             {
-                _systemImpl.EventStream.Publish(new Error(null, _self.Path.ToString(), GetType(), "Changing Recreate into Create after " + cause));
+                SystemImpl.EventStream.Publish(new Error(null, _self.Path.ToString(), GetType(), "Changing Recreate into Create after " + cause));
                 FaultCreate();
             } 
             else if (IsNormal)
             {
-                var failedActor = _actor;
+                var failedActor = Actor;
 
                 if (System.Settings.DebugLifecycle)
                     Publish(new Debug(_self.Path.ToString(), failedActor.GetType(), "Restarting"));
@@ -65,7 +65,7 @@ namespace Akka.Actor
                     failedActor.AroundPreRestart(cause, optionalMessage);
 
                     // run actor pre-incarnation plugin pipeline
-                    var pipeline = _systemImpl.ActorPipelineResolver.ResolvePipeline(failedActor.GetType());
+                    var pipeline = SystemImpl.ActorPipelineResolver.ResolvePipeline(failedActor.GetType());
                     pipeline.BeforeActorIncarnated(failedActor, this);
                 }
                 catch (Exception e)
@@ -78,7 +78,7 @@ namespace Akka.Actor
                 }
                 finally
                 {
-                    ClearActor(_actor);
+                    ClearActor(Actor);
                 }
 
                 global::System.Diagnostics.Debug.Assert(Mailbox.IsSuspended(), "Mailbox must be suspended during restart, status=" + Mailbox.CurrentStatus());
@@ -110,9 +110,9 @@ namespace Akka.Actor
         /// which prompted this action.</param>
         private void FaultResume(Exception causedByFailure)
         {
-            if (_actor == null)
+            if (Actor == null)
             {
-                _systemImpl.EventStream.Publish(new Error(null, _self.Path.ToString(), GetType(), "Changing Resume into Create after " + causedByFailure));
+                SystemImpl.EventStream.Publish(new Error(null, _self.Path.ToString(), GetType(), "Changing Resume into Create after " + causedByFailure));
                 FaultCreate();
             }
             //Akka Jvm does the following commented section as well, but we do not store the context inside the actor so it's not applicable
@@ -184,7 +184,7 @@ namespace Akka.Actor
             CancelReceiveTimeout();
 
             // prevent Deadletter(Terminated) messages
-            UnwatchWatchedActors(_actor);
+            UnwatchWatchedActors(Actor);
 
             // stop all children, which will turn childrenRefs into TerminatingChildrenContainer (if there are children)
             StopChildren();
@@ -247,7 +247,7 @@ namespace Akka.Actor
                 {
                     HandleNonFatalOrInterruptedException(() =>
                     {
-                        Publish(new Error(e, _self.Path.ToString(), _actor.GetType(), "Emergency stop: exception in failure handling for " + cause));
+                        Publish(new Error(e, _self.Path.ToString(), Actor.GetType(), "Emergency stop: exception in failure handling for " + cause));
                         try
                         {
                             StopChildren();
@@ -277,7 +277,7 @@ namespace Akka.Actor
             // 
             // Please note that if a parent is also a watcher then ChildTerminated and Terminated must be processed in this
             // specific order.
-            var a = _actor;
+            var a = Actor;
             try
             {
                 if (a != null)
@@ -285,7 +285,7 @@ namespace Akka.Actor
                     a.AroundPostStop();
 
                     // run actor pre-incarnation plugin pipeline
-                    var pipeline = _systemImpl.ActorPipelineResolver.ResolvePipeline(a.GetType());
+                    var pipeline = SystemImpl.ActorPipelineResolver.ResolvePipeline(a.GetType());
                     pipeline.BeforeActorIncarnated(a, this);
                 }
                 
@@ -320,7 +320,7 @@ namespace Akka.Actor
                                     ClearActor(a);
                                     ClearActorCell();
 
-                                    _actor = null;
+                                    Actor = null;
 
                                 }
                             }
@@ -340,7 +340,7 @@ namespace Akka.Actor
                 finally { ClearFailed(); }  // must happen in any case, so that failure is propagated
 
                 var freshActor = NewActor();
-                _actor = freshActor; // this must happen before postRestart has a chance to fail
+                Actor = freshActor; // this must happen before postRestart has a chance to fail
                 if (ReferenceEquals(freshActor, failedActor))
                     SetActorFields(freshActor); // If the creator returns the same instance, we need to restore our nulled out fields.
 
@@ -367,7 +367,7 @@ namespace Akka.Actor
             }
             catch (Exception e)
             {
-                ClearActor(_actor); // in order to prevent preRestart() from happening again
+                ClearActor(Actor); // in order to prevent preRestart() from happening again
                 HandleInvokeFailure(new PostRestartException(_self, e, cause), survivors);
             }
 
@@ -386,7 +386,7 @@ namespace Akka.Actor
             CurrentMessage = f;
             var failedChild = f.Child;
             var failedChildIsNobody = failedChild.IsNobody();
-            Sender = failedChildIsNobody ? _systemImpl.DeadLetters : failedChild;
+            Sender = failedChildIsNobody ? SystemImpl.DeadLetters : failedChild;
             //Only act upon the failure, if it comes from a currently known child;
             //the UID protects against reception of a Failed from a child which was
             //killed in preRestart and re-created in postRestart
@@ -396,18 +396,18 @@ namespace Akka.Actor
                 var statsUid = childStats.Child.Path.Uid;
                 if (statsUid == f.Uid)
                 {
-                    var handled = _actor.SupervisorStrategyInternal.HandleFailure(this, failedChild, f.Cause, childStats, ChildrenContainer.Stats);
+                    var handled = Actor.SupervisorStrategyInternal.HandleFailure(this, failedChild, f.Cause, childStats, ChildrenContainer.Stats);
                     if (!handled)
                         ExceptionDispatchInfo.Capture(f.Cause).Throw();
                 }
                 else
                 {
-                    Publish(new Debug(_self.Path.ToString(), _actor.GetType(), "Dropping Failed(" + f.Cause + ") from old child " + f.Child + " (uid=" + statsUid + " != " + f.Uid + ")"));
+                    Publish(new Debug(_self.Path.ToString(), Actor.GetType(), "Dropping Failed(" + f.Cause + ") from old child " + f.Child + " (uid=" + statsUid + " != " + f.Uid + ")"));
                 }
             }
             else
             {
-                Publish(new Debug(_self.Path.ToString(), _actor.GetType(), "Dropping Failed(" + f.Cause + ") from unknown child " + failedChild));
+                Publish(new Debug(_self.Path.ToString(), Actor.GetType(), "Dropping Failed(" + f.Cause + ") from unknown child " + failedChild));
             }
         }
 
@@ -418,17 +418,17 @@ namespace Akka.Actor
             //If this fails, we do nothing in case of terminating/restarting state,
             //otherwise tell the supervisor etc. (in that second case, the match
             //below will hit the empty default case, too)
-            if (_actor != null)
+            if (Actor != null)
             {
                 try
                 {
-                    _actor.SupervisorStrategyInternal.HandleChildTerminated(this, child, GetChildren());
+                    Actor.SupervisorStrategyInternal.HandleChildTerminated(this, child, GetChildren());
                 }
                 catch (Exception e)
                 {
                     HandleNonFatalOrInterruptedException(() =>
                     {
-                        Publish(new Error(e, _self.Path.ToString(), _actor.GetType(), "HandleChildTerminated failed"));
+                        Publish(new Error(e, _self.Path.ToString(), Actor.GetType(), "HandleChildTerminated failed"));
                         HandleInvokeFailure(e);
                     });
                 }
@@ -439,7 +439,7 @@ namespace Akka.Actor
             // then we are continuing the previously suspended recreate/create/terminate action
             if (status is SuspendReason.Recreation recreation)
             {
-                FinishRecreate(recreation.Cause, _actor);
+                FinishRecreate(recreation.Cause, Actor);
             }
             else if (status is SuspendReason.Creation)
             {

--- a/src/core/Akka/Actor/ActorCell.FaultHandling.cs
+++ b/src/core/Akka/Actor/ActorCell.FaultHandling.cs
@@ -33,7 +33,7 @@ namespace Akka.Actor
         // ReSharper disable once InconsistentNaming
         private IActorRef? _failed_DoNotUseMeDirectly;
         private bool IsFailed { get { return _failed_DoNotUseMeDirectly != null; } }
-        private void SetFailed(IActorRef perpetrator)
+        private void SetFailed(IActorRef? perpetrator)
         {
             _failed_DoNotUseMeDirectly = perpetrator;
         }
@@ -81,7 +81,7 @@ namespace Akka.Actor
                     ClearActor(Actor);
                 }
 
-                global::System.Diagnostics.Debug.Assert(Mailbox.IsSuspended(), "Mailbox must be suspended during restart, status=" + Mailbox.CurrentStatus());
+                global::System.Diagnostics.Debug.Assert(Mailbox!.IsSuspended(), "Mailbox must be suspended during restart, status=" + Mailbox.CurrentStatus());
                 if (!SetChildrenTerminationReason(new SuspendReason.Recreation(cause)))
                 {
                     FinishRecreate(cause, failedActor);
@@ -108,7 +108,7 @@ namespace Akka.Actor
         /// </summary>
         /// <param name="causedByFailure">The exception that caused the failure. signifies if it was our own failure 
         /// which prompted this action.</param>
-        private void FaultResume(Exception causedByFailure)
+        private void FaultResume(Exception? causedByFailure)
         {
             if (Actor == null)
             {
@@ -144,7 +144,7 @@ namespace Akka.Actor
         /// </summary>
         private void FaultCreate()
         {
-            global::System.Diagnostics.Debug.Assert(Mailbox.IsSuspended(), "Mailbox must be suspended during failed creation, status=" + Mailbox.CurrentStatus());
+            global::System.Diagnostics.Debug.Assert(Mailbox!.IsSuspended(), "Mailbox must be suspended during failed creation, status=" + Mailbox.CurrentStatus());
             global::System.Diagnostics.Debug.Assert(_self.Equals(Perpetrator), "Perpetrator should be self");
 
             SetReceiveTimeout(null);
@@ -218,7 +218,7 @@ namespace Akka.Actor
             }
         }
 
-        private void HandleInvokeFailure(Exception cause, IEnumerable<IActorRef> childrenNotToSuspend = null)
+        private void HandleInvokeFailure(Exception cause, IEnumerable<IActorRef>? childrenNotToSuspend = null)
         {
             // prevent any further messages to be processed until the actor has been restarted
             if (!IsFailed)
@@ -230,7 +230,7 @@ namespace Akka.Actor
                     if (CurrentMessage is Failed)
                     {
                         var failedChild = Sender;
-                        childrenNotToSuspend = childrenNotToSuspend.Concat(failedChild); //Function handles childrenNotToSuspend being null
+                        childrenNotToSuspend = childrenNotToSuspend.Concat(failedChild)!; //Function handles childrenNotToSuspend being null
                         SetFailed(failedChild);
                     }
                     else
@@ -247,7 +247,7 @@ namespace Akka.Actor
                 {
                     HandleNonFatalOrInterruptedException(() =>
                     {
-                        Publish(new Error(e, _self.Path.ToString(), Actor.GetType(), "Emergency stop: exception in failure handling for " + cause));
+                        Publish(new Error(e, _self.Path.ToString(), Actor?.GetType(), "Emergency stop: exception in failure handling for " + cause));
                         try
                         {
                             StopChildren();
@@ -396,18 +396,18 @@ namespace Akka.Actor
                 var statsUid = childStats.Child.Path.Uid;
                 if (statsUid == f.Uid)
                 {
-                    var handled = Actor.SupervisorStrategyInternal.HandleFailure(this, failedChild, f.Cause, childStats, ChildrenContainer.Stats);
+                    var handled = Actor!.SupervisorStrategyInternal.HandleFailure(this, failedChild, f.Cause, childStats, ChildrenContainer.Stats);
                     if (!handled)
                         ExceptionDispatchInfo.Capture(f.Cause).Throw();
                 }
                 else
                 {
-                    Publish(new Debug(_self.Path.ToString(), Actor.GetType(), "Dropping Failed(" + f.Cause + ") from old child " + f.Child + " (uid=" + statsUid + " != " + f.Uid + ")"));
+                    Publish(new Debug(_self.Path.ToString(), Actor?.GetType(), "Dropping Failed(" + f.Cause + ") from old child " + f.Child + " (uid=" + statsUid + " != " + f.Uid + ")"));
                 }
             }
             else
             {
-                Publish(new Debug(_self.Path.ToString(), Actor.GetType(), "Dropping Failed(" + f.Cause + ") from unknown child " + failedChild));
+                Publish(new Debug(_self.Path.ToString(), Actor?.GetType(), "Dropping Failed(" + f.Cause + ") from unknown child " + failedChild));
             }
         }
 
@@ -439,7 +439,7 @@ namespace Akka.Actor
             // then we are continuing the previously suspended recreate/create/terminate action
             if (status is SuspendReason.Recreation recreation)
             {
-                FinishRecreate(recreation.Cause, Actor);
+                FinishRecreate(recreation.Cause, Actor!);
             }
             else if (status is SuspendReason.Creation)
             {

--- a/src/core/Akka/Actor/ActorCell.ReceiveTimeout.cs
+++ b/src/core/Akka/Actor/ActorCell.ReceiveTimeout.cs
@@ -4,7 +4,7 @@
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
+#nullable enable
 using System;
 
 namespace Akka.Actor
@@ -19,10 +19,10 @@ namespace Akka.Actor
     public partial class ActorCell
     {
         private TimeSpan? _receiveTimeoutDuration;
-        private ICancelable _pendingReceiveTimeout;
+        private ICancelable? _pendingReceiveTimeout;
 
         /// <summary>
-        /// TBD
+        /// Sets the 
         /// </summary>
         /// <param name="timeout">TBD</param>
         public void SetReceiveTimeout(TimeSpan? timeout = null)

--- a/src/core/Akka/Actor/ActorCell.ReceiveTimeout.cs
+++ b/src/core/Akka/Actor/ActorCell.ReceiveTimeout.cs
@@ -22,9 +22,12 @@ namespace Akka.Actor
         private ICancelable? _pendingReceiveTimeout;
 
         /// <summary>
-        /// Sets the 
+        /// Sets the receive timeout for this actor - which will trigger a <see cref="ReceiveTimeout"/> message
+        /// to be delivered into the actor's mailbox when time is up.
         /// </summary>
-        /// <param name="timeout">TBD</param>
+        /// <param name="timeout">The timeframe. If <c>null</c> is passed here it will cancel any pending receive
+        /// timeouts. If set to a value greater than <see cref="TimeSpan.Zero"/> then that will become the new
+        /// receive timeout value.</param>
         public void SetReceiveTimeout(TimeSpan? timeout = null)
         {
             _receiveTimeoutDuration = timeout;

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -7,6 +7,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Akka.Actor.Internal;
 using Akka.Dispatch;
@@ -112,7 +113,14 @@ namespace Akka.Actor
         /// <summary>
         /// Indicates whether the actor is currently terminated.
         /// </summary>
-        public bool IsTerminated => Mailbox!.IsClosed();
+        public bool IsTerminated
+        {
+            get
+            {
+                Assert.Assert(Mailbox != null, $"{nameof(Mailbox)} should never be null when {nameof(IsTerminated)} property is accessed");
+                return Mailbox!.IsClosed();
+            }
+        }
         
         /// <summary>
         /// A static reference to the current actor cell.
@@ -162,12 +170,24 @@ namespace Akka.Actor
         /// <summary>
         /// Will return <c>true</c> if <see cref="NumberOfMessages"/> is greater than zero.
         /// </summary>
-        public bool HasMessages { get { return Mailbox!.HasMessages; } }
+        public bool HasMessages {
+            get
+            {
+                Assert.Assert(Mailbox != null, $"{nameof(Mailbox)} should never be null when {nameof(HasMessages)} property is accessed");
+                return Mailbox!.HasMessages;
+            }
+        }
         
         /// <summary>
         /// Current message count inside the mailbox.
         /// </summary>
-        public int NumberOfMessages { get { return Mailbox!.NumberOfMessages; } }
+        public int NumberOfMessages {
+            get
+            {
+                Assert.Assert(Mailbox != null, $"{nameof(Mailbox)} should never be null when {nameof(NumberOfMessages)} property is accessed");
+                return Mailbox!.NumberOfMessages;
+            } 
+        }
         
         /// <summary>
         /// Indicates if we've been cleared after a restart.
@@ -236,6 +256,7 @@ namespace Akka.Actor
             }
 
             SwapMailbox(mailbox);
+            Assert.Assert(Mailbox != null, $"{nameof(Mailbox)} should never be null after {nameof(SwapMailbox)} has been invoked");
             Mailbox!.SetActor(this);
 
             //// ➡➡➡ NEVER SEND THE SAME SYSTEM MESSAGE OBJECT TO TWO ACTORS ⬅⬅⬅
@@ -372,7 +393,7 @@ namespace Akka.Actor
             });
 
 
-            Assert.Assert(instance != null, (string)(nameof(instance) + " != null"));
+            Assert.Assert(instance != null, $"{nameof(instance)} should never be null at this point");
             return instance!;
         }
 
@@ -534,7 +555,7 @@ namespace Akka.Actor
         /// TBD
         /// </summary>
         /// <returns>TBD</returns>
-        public static IActorRef GetCurrentSelfOrNoSender()
+        public static IActorRef? GetCurrentSelfOrNoSender()
         {
             var current = Current;
             return current != null ? current.Self : ActorRefs.NoSender;
@@ -543,7 +564,7 @@ namespace Akka.Actor
         /// <summary>
         /// Gets the current sender or <see cref="ActorRefs.NoSender"/>
         /// </summary>
-        public static IActorRef GetCurrentSenderOrNoSender()
+        public static IActorRef? GetCurrentSenderOrNoSender()
         {
             var current = Current;
             return current?.Sender ?? ActorRefs.NoSender;
@@ -570,7 +591,8 @@ namespace Akka.Actor
             }
             catch (Exception e)
             {
-                throw new SerializationException($"Failed to serialize and deserialize payload object [{unwrapped.GetType()}]. Envelope: [{envelope}], Actor type: [{Actor?.GetType()}]", e);
+                Assert.Assert(Actor != null, $"{nameof(Actor)} should never be null at this point");
+                throw new SerializationException($"Failed to serialize and deserialize payload object [{unwrapped.GetType()}]. Envelope: [{envelope}], Actor type: [{Actor!.GetType()}]", e);
             }
 
             // Check that this message was ever wrapped

--- a/src/core/Akka/Actor/ActorCell.cs
+++ b/src/core/Akka/Actor/ActorCell.cs
@@ -356,7 +356,7 @@ namespace Akka.Actor
             return uid;
         }
 
-        private ActorBase? NewActor()
+        private ActorBase NewActor()
         {
             PrepareForNewActor();
             ActorBase? instance = null;
@@ -370,7 +370,10 @@ namespace Akka.Actor
                 instance.SupervisorStrategyInternal = Props.SupervisorStrategy;
                 //defaults to null - won't affect lazy instantiation unless explicitly set in props
             });
-            return instance;
+
+
+            Assert.Assert(instance != null, (string)(nameof(instance) + " != null"));
+            return instance!;
         }
 
         /// <summary>

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -226,7 +226,9 @@ namespace Akka.Actor
         /// Use this value as an argument to <see cref="ICanTell.Tell"/> if there is not actor to
         /// reply to (e.g. when sending from non-actor code).
         /// </summary>
-        public static readonly IActorRef NoSender = null;
+        #nullable enable
+        public static readonly IActorRef? NoSender = null;
+        #nullable restore
     }
 
     /// <summary>

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainer.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainer.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Akka.Actor.Internal
 {
@@ -40,7 +41,9 @@ namespace Akka.Actor.Internal
         /// <param name="actor">TBD</param>
         /// <param name="stats">TBD</param>
         /// <returns>TBD</returns>
-        bool TryGetByRef(IActorRef actor, out ChildRestartStats stats);
+        #nullable enable
+        bool TryGetByRef(IActorRef actor, [NotNullWhen(true)] out ChildRestartStats? stats);
+        #nullable restore
         /// <summary>
         /// TBD
         /// </summary>

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
@@ -8,6 +8,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 
@@ -156,7 +157,8 @@ namespace Akka.Actor.Internal
         /// <param name="actor">TBD</param>
         /// <param name="childRestartStats">TBD</param>
         /// <returns>TBD</returns>
-        public bool TryGetByRef(IActorRef actor, out ChildRestartStats childRestartStats)
+        #nullable enable
+        public bool TryGetByRef(IActorRef actor, [NotNullWhen(true)] out ChildRestartStats? childRestartStats)
         {
             if (InternalChildren.TryGetValue(actor.Path.Name, out var stats))
             {
@@ -170,6 +172,7 @@ namespace Akka.Actor.Internal
             childRestartStats = null;
             return false;
         }
+        #nullable restore
 
         /// <summary>
         /// TBD

--- a/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
+++ b/src/core/Akka/Actor/ChildrenContainer/Internal/ChildrenContainerBase.cs
@@ -161,8 +161,7 @@ namespace Akka.Actor.Internal
             if (InternalChildren.TryGetValue(actor.Path.Name, out var stats))
             {
                 //Since the actor exists, ChildRestartStats is the only valid ChildStats.
-                var crStats = stats as ChildRestartStats;
-                if (crStats != null && actor.Equals(crStats.Child))
+                if (stats is ChildRestartStats crStats && actor.Equals(crStats.Child))
                 {
                     childRestartStats = crStats;
                     return true;
@@ -188,19 +187,18 @@ namespace Akka.Actor.Internal
         /// <param name="sb">TBD</param>
         /// <param name="kvp">TBD</param>
         /// <param name="index">TBD</param>
-        protected void ChildStatsAppender(StringBuilder sb, KeyValuePair<string, IChildStats> kvp, int index)
+        protected static void ChildStatsAppender(StringBuilder sb, KeyValuePair<string, IChildStats> kvp, int index)
         {
             sb.Append('<');
             var childStats = kvp.Value;
-            var childRestartStats = childStats as ChildRestartStats;
-            if (childRestartStats != null)
+            if (childStats is ChildRestartStats childRestartStats)
             {
                 sb.Append(childRestartStats.Child.Path.ToStringWithUid()).Append(':');
                 sb.Append(childRestartStats.MaxNrOfRetriesCount).Append(" retries>");
             }
             else
             {
-                sb.Append(kvp.Key).Append(":").Append(childStats).Append('>');
+                sb.Append(kvp.Key).Append(':').Append(childStats).Append('>');
             }
         }
     }

--- a/src/core/Akka/Actor/Internal/InternalCurrentActorCellKeeper.cs
+++ b/src/core/Akka/Actor/Internal/InternalCurrentActorCellKeeper.cs
@@ -4,21 +4,19 @@
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
+#nullable enable
 using System;
 
 namespace Akka.Actor.Internal
 {
     /// <summary>
-    /// TBD
-    /// 
-    /// INTERNAL!
-    /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
+    /// INTERNAL API
     /// </summary>
+    /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
     public static class InternalCurrentActorCellKeeper
     {
         [ThreadStatic]
-        private static ActorCell _current;
+        private static ActorCell? _current;
 
 
         /// <summary>
@@ -27,7 +25,8 @@ namespace Akka.Actor.Internal
         /// INTERNAL!
         /// <remarks>Note! Part of internal API. Breaking changes may occur without notice. Use at own risk.</remarks>
         /// </summary>
-        public static ActorCell Current { get { return _current; } set { _current = value; } }
+        // ReSharper disable once ConvertToAutoProperty
+        public static ActorCell? Current { get { return _current; } set { _current = value; } }
     }
 }
 

--- a/src/core/Akka/Util/Internal/Extensions.cs
+++ b/src/core/Akka/Util/Internal/Extensions.cs
@@ -177,13 +177,15 @@ namespace Akka.Util.Internal
         /// <param name="enumerable">TBD</param>
         /// <param name="item">TBD</param>
         /// <returns>TBD</returns>
-        public static IEnumerable<T> Concat<T>(this IEnumerable<T> enumerable, T item)
+        #nullable enable
+        public static IEnumerable<T> Concat<T>(this IEnumerable<T>? enumerable, T item)
         {
             var itemInArray = new[] {item};
             if (enumerable == null)
                 return itemInArray;
             return enumerable.Concat(itemInArray);
         }
+        #nullable restore
 
         /// <summary>
         /// Applies a delegate <paramref name="action" /> to all elements of this enumerable.


### PR DESCRIPTION
## Changes

This PR looks scarier than it is. I've implemented `nullability` on the `ActorCell`, the brains underneath each actor, in order to support some future changes we're going to make here. None of this should result in a behavior change or a breaking API change - practically speaking, given that most of these APIs are not called directly from user code.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
