### PR TITLE
[WIP] OpenTelemetry trace id correlation for `ILoggingAdapter`

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3311,6 +3311,7 @@ namespace Akka.Event
         public Akka.Actor.IActorRef Sender { get; }
         public override string ToString() { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class BusLogging : Akka.Event.LoggingAdapterBase
     {
         public BusLogging(Akka.Event.LoggingBus bus, string logSource, System.Type logClass, Akka.Event.ILogMessageFormatter logMessageFormatter) { }
@@ -3340,6 +3341,7 @@ namespace Akka.Event
     {
         public Debug(string logSource, System.Type logClass, object message) { }
         public Debug(System.Exception cause, string logSource, System.Type logClass, object message) { }
+        public Debug(System.Exception cause, string logSource, System.Type logClass, object message, [System.Runtime.CompilerServices.IsReadOnlyAttribute()] ref System.Diagnostics.ActivityContext context) { }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public class DefaultLogMessageFormatter : Akka.Event.ILogMessageFormatter
@@ -3367,6 +3369,7 @@ namespace Akka.Event
     public class Error : Akka.Event.LogEvent
     {
         public Error(System.Exception cause, string logSource, System.Type logClass, object message) { }
+        public Error(System.Exception cause, string logSource, System.Type logClass, object message, [System.Runtime.CompilerServices.IsReadOnlyAttribute()] ref System.Diagnostics.ActivityContext context) { }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public abstract class EventBus<TEvent, TClassifier, TSubscriber>
@@ -3425,6 +3428,7 @@ namespace Akka.Event
     {
         public Info(string logSource, System.Type logClass, object message) { }
         public Info(System.Exception cause, string logSource, System.Type logClass, object message) { }
+        public Info(System.Exception cause, string logSource, System.Type logClass, object message, [System.Runtime.CompilerServices.IsReadOnlyAttribute()] ref System.Diagnostics.ActivityContext context) { }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public class InitializeLogger : Akka.Actor.INoSerializationVerificationNeeded
@@ -3432,9 +3436,12 @@ namespace Akka.Event
         public InitializeLogger(Akka.Event.LoggingBus loggingBus) { }
         public Akka.Event.LoggingBus LoggingBus { get; }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class LogEvent : Akka.Actor.INoSerializationVerificationNeeded
     {
         protected LogEvent() { }
+        public System.Diagnostics.ActivityContext ActivityContext { get; set; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public System.Exception Cause { get; set; }
         public System.Type LogClass { get; set; }
         public string LogSource { get; set; }
@@ -3714,6 +3721,7 @@ namespace Akka.Event
     {
         public Warning(string logSource, System.Type logClass, object message) { }
         public Warning(System.Exception cause, string logSource, System.Type logClass, object message) { }
+        public Warning(System.Exception cause, string logSource, System.Type logClass, object message, [System.Runtime.CompilerServices.IsReadOnlyAttribute()] ref System.Diagnostics.ActivityContext context) { }
         public override Akka.Event.LogLevel LogLevel() { }
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3303,6 +3303,7 @@ namespace Akka.Event
         public Akka.Actor.IActorRef Sender { get; }
         public override string ToString() { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class BusLogging : Akka.Event.LoggingAdapterBase
     {
         public BusLogging(Akka.Event.LoggingBus bus, string logSource, System.Type logClass, Akka.Event.ILogMessageFormatter logMessageFormatter) { }
@@ -3332,6 +3333,7 @@ namespace Akka.Event
     {
         public Debug(string logSource, System.Type logClass, object message) { }
         public Debug(System.Exception cause, string logSource, System.Type logClass, object message) { }
+        public Debug(System.Exception cause, string logSource, System.Type logClass, object message, ref System.Diagnostics.ActivityContext context) { }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public class DefaultLogMessageFormatter : Akka.Event.ILogMessageFormatter
@@ -3359,6 +3361,7 @@ namespace Akka.Event
     public class Error : Akka.Event.LogEvent
     {
         public Error(System.Exception cause, string logSource, System.Type logClass, object message) { }
+        public Error(System.Exception cause, string logSource, System.Type logClass, object message, ref System.Diagnostics.ActivityContext context) { }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public abstract class EventBus<TEvent, TClassifier, TSubscriber>
@@ -3417,6 +3420,7 @@ namespace Akka.Event
     {
         public Info(string logSource, System.Type logClass, object message) { }
         public Info(System.Exception cause, string logSource, System.Type logClass, object message) { }
+        public Info(System.Exception cause, string logSource, System.Type logClass, object message, ref System.Diagnostics.ActivityContext context) { }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public class InitializeLogger : Akka.Actor.INoSerializationVerificationNeeded
@@ -3424,9 +3428,12 @@ namespace Akka.Event
         public InitializeLogger(Akka.Event.LoggingBus loggingBus) { }
         public Akka.Event.LoggingBus LoggingBus { get; }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class LogEvent : Akka.Actor.INoSerializationVerificationNeeded
     {
         protected LogEvent() { }
+        public System.Diagnostics.ActivityContext ActivityContext { get; set; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
         public System.Exception Cause { get; set; }
         public System.Type LogClass { get; set; }
         public string LogSource { get; set; }
@@ -3704,6 +3711,7 @@ namespace Akka.Event
     {
         public Warning(string logSource, System.Type logClass, object message) { }
         public Warning(System.Exception cause, string logSource, System.Type logClass, object message) { }
+        public Warning(System.Exception cause, string logSource, System.Type logClass, object message, ref System.Diagnostics.ActivityContext context) { }
         public override Akka.Event.LogLevel LogLevel() { }
     }
 }

--- a/src/core/Akka.API.Tests/verify/DefaultLogFormatSpec.ShouldUseDefaultLogFormatWithTraceCorrelation.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/DefaultLogFormatSpec.ShouldUseDefaultLogFormatWithTraceCorrelation.DotNet.verified.txt
@@ -1,0 +1,4 @@
+﻿[DEBUG][DateTime][Thread 0001][ActorSystem(test)][TraceId=00000000000000000000000000000000, SpanId=0000000000000000, TraceFlags=None] This is a test 1 cheese
+[INFO][DateTime][Thread 0001][ActorSystem(test)][TraceId=00000000000000000000000000000000, SpanId=0000000000000000, TraceFlags=None] This is a test 1
+[WARNING][DateTime][Thread 0001][ActorSystem(test)][TraceId=00000000000000000000000000000000, SpanId=0000000000000000, TraceFlags=None] This is a test 1
+[ERROR][DateTime][Thread 0001][ActorSystem(test)][TraceId=00000000000000000000000000000000, SpanId=0000000000000000, TraceFlags=None] This is a test 1

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Polyfill" Version="1.28.0" PrivateAssets="all" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Threading.Channels" Version="$(MicrosoftLibVersion)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftLibVersion)" />
   </ItemGroup>
   
   <ItemGroup Label="PublicAnalyzers">

--- a/src/core/Akka/Event/BusLogging.cs
+++ b/src/core/Akka/Event/BusLogging.cs
@@ -4,7 +4,7 @@
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
+#nullable enable
 using System;
 using Akka.Actor;
 
@@ -72,14 +72,16 @@ namespace Akka.Event
         /// </summary>
         public override bool IsWarningEnabled { get; }
         
-        private LogEvent CreateLogEvent(LogLevel logLevel, object message, Exception cause = null)
+        private LogEvent CreateLogEvent(LogLevel logLevel, object message, Exception? cause = null)
         {
+            var currentContext = (System.Diagnostics.Activity.Current?.Context ?? default);
+            
             return logLevel switch
             {
-                LogLevel.DebugLevel => new Debug(cause, LogSource, LogClass, message),
-                LogLevel.InfoLevel => new Info(cause, LogSource, LogClass, message),
-                LogLevel.WarningLevel => new Warning(cause, LogSource, LogClass, message),
-                LogLevel.ErrorLevel => new Error(cause, LogSource, LogClass, message),
+                LogLevel.DebugLevel => new Debug(cause, LogSource, LogClass, message, currentContext),
+                LogLevel.InfoLevel => new Info(cause, LogSource, LogClass, message, currentContext),
+                LogLevel.WarningLevel => new Warning(cause, LogSource, LogClass, message, currentContext),
+                LogLevel.ErrorLevel => new Error(cause, LogSource, LogClass, message, currentContext),
                 _ => throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null)
             };
         }

--- a/src/core/Akka/Event/Debug.cs
+++ b/src/core/Akka/Event/Debug.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 
 namespace Akka.Event
 {
@@ -32,12 +33,26 @@ namespace Akka.Event
         /// <param name="logSource">The source that generated the log event.</param>
         /// <param name="logClass">The type of logger used to log the event.</param>
         /// <param name="message">The message that is being logged.</param>
-        public Debug(Exception cause, string logSource, Type logClass, object message)
+        public Debug(Exception cause, string logSource, Type logClass, object message) 
+            : this(cause, logSource, logClass, message, default)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Debug" /> class.
+        /// </summary>
+        /// <param name="cause">The exception that generated the log event.</param>
+        /// <param name="logSource">The source that generated the log event.</param>
+        /// <param name="logClass">The type of logger used to log the event.</param>
+        /// <param name="message">The message that is being logged.</param>
+        /// <param name="context">The current <see cref="Activity"/>'s context, if one is present.</param>>
+        public Debug(Exception cause, string logSource, Type logClass, object message, in ActivityContext context)
         {
             LogSource = logSource;
             LogClass = logClass;
             Message = message;
             Cause = cause;
+            ActivityContext = context;
         }
 
         /// <summary>

--- a/src/core/Akka/Event/Error.cs
+++ b/src/core/Akka/Event/Error.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 
 namespace Akka.Event
 {
@@ -22,11 +23,25 @@ namespace Akka.Event
         /// <param name="logClass">The type of logger used to log the event.</param>
         /// <param name="message">The message that is being logged.</param>
         public Error(Exception cause, string logSource, Type logClass, object message)
+            : this(cause, logSource, logClass, message, default)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Error" /> class.
+        /// </summary>
+        /// <param name="cause">The exception that caused the log event.</param>
+        /// <param name="logSource">The source that generated the log event.</param>
+        /// <param name="logClass">The type of logger used to log the event.</param>
+        /// <param name="message">The message that is being logged.</param>
+        /// <param name="context">The current <see cref="Activity"/>'s context, if one is present.</param>
+        public Error(Exception cause, string logSource, Type logClass, object message, in ActivityContext context)
         {
             Cause = cause;
             LogSource = logSource;
             LogClass = logClass;
             Message = message;
+            ActivityContext = context;
         }
 
         /// <summary>

--- a/src/core/Akka/Event/Info.cs
+++ b/src/core/Akka/Event/Info.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 
 namespace Akka.Event
 {
@@ -32,12 +33,27 @@ namespace Akka.Event
         /// <param name="logSource">The source that generated the log event.</param>
         /// <param name="logClass">The type of logger used to log the event.</param>
         /// <param name="message">The message that is being logged.</param>
-        public Info(Exception cause, string logSource, Type logClass, object message)
+        public Info(Exception cause, string logSource, Type logClass, object message) 
+            : this(cause, logSource, logClass, message, default)
+        {
+           
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Info" /> class.
+        /// </summary>
+        /// <param name="cause">The exception that generated the log event.</param>
+        /// <param name="logSource">The source that generated the log event.</param>
+        /// <param name="logClass">The type of logger used to log the event.</param>
+        /// <param name="message">The message that is being logged.</param>
+        /// <param name="context">The current <see cref="Activity"/>'s context, if one is present.</param>
+        public Info(Exception cause, string logSource, Type logClass, object message, in ActivityContext context)
         {
             Cause = cause;
             LogSource = logSource;
             LogClass = logClass;
             Message = message;
+            ActivityContext = context;
         }
 
         /// <summary>

--- a/src/core/Akka/Event/LogEvent.cs
+++ b/src/core/Akka/Event/LogEvent.cs
@@ -4,7 +4,7 @@
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
-
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -53,7 +53,9 @@ namespace Akka.Event
         /// <summary>
         /// Initializes a new instance of the <see cref="LogEvent" /> class.
         /// </summary>
+#pragma warning disable CS8618, CS9264
         protected LogEvent()
+#pragma warning restore CS8618, CS9264
         {
             Timestamp = DateTime.UtcNow;
             Thread = Thread.CurrentThread;
@@ -62,7 +64,7 @@ namespace Akka.Event
         /// <summary>
         /// The exception that caused the log event. Can be <c>null</c>
         /// </summary>
-        public Exception Cause { get; protected set; }
+        public Exception? Cause { get; protected set; }
 
         /// <summary>
         /// The timestamp that this event occurred.

--- a/src/core/Akka/Event/Warning.cs
+++ b/src/core/Akka/Event/Warning.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 
 namespace Akka.Event
 {
@@ -33,11 +34,25 @@ namespace Akka.Event
         /// <param name="logClass">The type of logger used to log the event.</param>
         /// <param name="message">The message that is being logged.</param>
         public Warning(Exception cause, string logSource, Type logClass, object message)
+            : this(cause, logSource, logClass, message, default)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Warning" /> class.
+        /// </summary>
+        /// <param name="cause">The exception that caused the log event.</param>
+        /// <param name="logSource">The source that generated the log event.</param>
+        /// <param name="logClass">The type of logger used to log the event.</param>
+        /// <param name="message">The message that is being logged.</param>
+        /// <param name="context">The current <see cref="Activity"/>'s context, if one is present.</param>
+        public Warning(Exception cause, string logSource, Type logClass, object message, in ActivityContext context)
         {
             LogSource = logSource;
             LogClass = logClass;
             Message = message;
             Cause = cause;
+            ActivityContext = context;
         }
 
         /// <summary>


### PR DESCRIPTION
## Changes

close #6855 - has to be integrated with Akka.Hosting and Akka.Logger.Serilog before the issue is "officially" addressed though

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #6855
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.