### PR TITLE
made `IActorTelemetry` events nullable

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -98,6 +98,7 @@ namespace Akka.Actor
         public void CheckReceiveTimeout(bool reschedule = True) { }
         protected void ClearActor(Akka.Actor.ActorBase actor) { }
         protected void ClearActorCell() { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         protected virtual Akka.Actor.ActorRestarted CreateActorRestartedEvent(System.Exception cause) { }
         protected virtual Akka.Actor.ActorStarted CreateActorStartedEvent() { }
         protected virtual Akka.Actor.ActorStopped CreateActorStoppedEvent() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -98,6 +98,7 @@ namespace Akka.Actor
         public void CheckReceiveTimeout(bool reschedule = True) { }
         protected void ClearActor(Akka.Actor.ActorBase actor) { }
         protected void ClearActorCell() { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         protected virtual Akka.Actor.ActorRestarted CreateActorRestartedEvent(System.Exception cause) { }
         protected virtual Akka.Actor.ActorStarted CreateActorStartedEvent() { }
         protected virtual Akka.Actor.ActorStopped CreateActorStoppedEvent() { }

--- a/src/core/Akka/Actor/ActorCell.Children.cs
+++ b/src/core/Akka/Actor/ActorCell.Children.cs
@@ -141,11 +141,9 @@ namespace Akka.Actor
         /// <param name="child">The child.</param>
         public void Stop(IActorRef child)
         {
-            ChildRestartStats stats;
-            if (ChildrenContainer.TryGetByRef(child, out stats))
+            if (ChildrenContainer.TryGetByRef(child, out _))
             {
-                var repointableActorRef = child as RepointableActorRef;
-                if (repointableActorRef == null || repointableActorRef.IsStarted)
+                if (child is not RepointableActorRef repointableActorRef || repointableActorRef.IsStarted)
                 {
                     while (true)
                     {

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -441,7 +441,7 @@ namespace Akka.Actor
         /// <summary>
         /// Overrideable in order to support issues such as https://github.com/petabridge/phobos-issues/issues/82
         /// </summary>
-        protected virtual ActorStarted CreateActorStartedEvent()
+        protected virtual ActorStarted? CreateActorStartedEvent()
         {
             return new ActorStarted(Self, Props.Type);
         }
@@ -449,7 +449,7 @@ namespace Akka.Actor
         /// <summary>
         /// Overrideable in order to support issues such as https://github.com/petabridge/phobos-issues/issues/82
         /// </summary>
-        protected virtual ActorStopped CreateActorStoppedEvent()
+        protected virtual ActorStopped? CreateActorStoppedEvent()
         {
             return new ActorStopped(Self, Props.Type);
         }
@@ -466,8 +466,13 @@ namespace Akka.Actor
                 CheckReceiveTimeout();
                 if (System.Settings.DebugLifecycle)
                     Publish(new Debug(Self.Path.ToString(), created.GetType(), "Started (" + created + ")"));
-                if(System.Settings.EmitActorTelemetry)
-                    System.EventStream.Publish(CreateActorStartedEvent());
+                if (System.Settings.EmitActorTelemetry)
+                {
+                    var actorStarted = CreateActorStartedEvent();
+                    if(actorStarted != null)
+                        System.EventStream.Publish(actorStarted);
+                }
+                   
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Changes

And don't emit these events when they are `null` - aimed at fixing https://github.com/petabridge/phobos-issues/issues/86

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue https://github.com/petabridge/phobos-issues/issues/86
* [x] Changes in public API reviewed, if any.