### PR TITLE
Rollback to using 6.0 MSFT libraries

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -38,8 +38,8 @@
     <HoconVersion>2.0.3</HoconVersion>
     <ConfigurationManagerVersion>6.0.1</ConfigurationManagerVersion>
     <MultiNodeAdapterVersion>1.5.25</MultiNodeAdapterVersion>
-    <MicrosoftLibVersion>[8.0.*,)</MicrosoftLibVersion>
-    <MsExtVersion>[8.0.*,)</MsExtVersion>
+    <MicrosoftLibVersion>[6.0.*,)</MicrosoftLibVersion>
+    <MsExtVersion>[6.0.*,)</MsExtVersion>
     <AkkaAnalyzerVersion>0.3.0</AkkaAnalyzerVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>


### PR DESCRIPTION
## Changes

Upgrading to 8.x for system libraries caused some DLL hell issues on downstream dependencies that don't dual-target: https://github.com/akkadotnet/Akka.Management/issues/3079