### PR TITLE
Add ByteString ToReadOnlySpan

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Core.verified.txt
@@ -3378,6 +3378,7 @@ namespace Akka.IO
         public Akka.IO.ByteString Slice(int index) { }
         public Akka.IO.ByteString Slice(int index, int count) { }
         public byte[] ToArray() { }
+        public System.ReadOnlySpan<byte> ToReadOnlySpan() { }
         public override string ToString() { }
         public string ToString(System.Text.Encoding encoding) { }
         public void WriteTo(System.IO.Stream stream) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3796,6 +3796,7 @@ namespace Akka.IO
         public Akka.IO.ByteString Slice(int index) { }
         public Akka.IO.ByteString Slice(int index, int count) { }
         public byte[] ToArray() { }
+        public System.ReadOnlySpan<byte> ToReadOnlySpan() { }
         public override string ToString() { }
         public string ToString(System.Text.Encoding encoding) { }
         public void WriteTo(System.IO.Stream stream) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3786,6 +3786,7 @@ namespace Akka.IO
         public Akka.IO.ByteString Slice(int index) { }
         public Akka.IO.ByteString Slice(int index, int count) { }
         public byte[] ToArray() { }
+        public System.ReadOnlySpan<byte> ToReadOnlySpan() { }
         public override string ToString() { }
         public string ToString(System.Text.Encoding encoding) { }
         public void WriteTo(System.IO.Stream stream) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.verified.txt
@@ -3341,6 +3341,7 @@ namespace Akka.IO
         public Akka.IO.ByteString Slice(int index) { }
         public Akka.IO.ByteString Slice(int index, int count) { }
         public byte[] ToArray() { }
+        public System.ReadOnlySpan<byte> ToReadOnlySpan() { }
         public override string ToString() { }
         public string ToString(System.Text.Encoding encoding) { }
         public void WriteTo(System.IO.Stream stream) { }

--- a/src/core/Akka.Tests/Util/ByteStringSpec.cs
+++ b/src/core/Akka.Tests/Util/ByteStringSpec.cs
@@ -68,7 +68,7 @@ namespace Akka.Tests.Util
             var memory = new ReadOnlyMemory<byte>(bytes);
             var spanMemory = memory.Span;
 
-            // span has memory reference to underlying byte array
+            // span has memory reference to underlying byte array 
             (aSpan == spanMemory).Should().BeTrue();
             
             // Do another ToReadOnlySpan

--- a/src/core/Akka/Util/ByteString.cs
+++ b/src/core/Akka/Util/ByteString.cs
@@ -507,6 +507,27 @@ namespace Akka.IO
             CopyTo(copy, 0, _count);
             return copy;
         }
+        
+        /// <summary>
+        /// Returns a ReadOnlySpan<byte/> over the contents of this ByteString.
+        /// This is a non-copying operation, when the ByteString is compact.
+        /// When it is not compact, the contents are copied into a new array.
+        /// </summary>
+        /// <returns>A ReadOnlySpan<byte/> over the byte data.</returns>
+        public ReadOnlySpan<byte> ToReadOnlySpan()
+        {
+            if (_count == 0)
+                return ReadOnlySpan<byte>.Empty;
+        
+            if (IsCompact)
+            {
+                // If compact, data is in a single buffer.
+                var compactBuffer = _buffers[0];
+                return new ReadOnlySpan<byte>(compactBuffer.Array, compactBuffer.Offset, compactBuffer.Count);
+            }
+           
+            return new ReadOnlySpan<byte>(ToArray());
+        }
 
         /// <summary>
         /// Appends <paramref name="other"/> <see cref="ByteString"/> at the tail


### PR DESCRIPTION
Fixes #7488 

## Changes

Add ByteString ToReadOnlySpan, which has `NO` memory copy, compared to ToArray(), when ByteString is compact.

Why?

Currently we do a lot of RabbitMQ IncomingMessage Deserialization by calling ToArray() (which does memory copying)

            var evt = JsonSerializer.Deserialize<T>(message.Message.Bytes.ToArray(), SerializerOptions);

Using ToReadOnlySpan, memory copy can be avoided, as most of our IncomingMessage is compact


## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7488 
* [x] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
