### PR TITLE
Update ClusterSharding.Node example to use shared SQLite store

### DIFF
--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/Dockerfile
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/Dockerfile
@@ -1,3 +1,3 @@
-﻿FROM mcr.microsoft.com/dotnet/core/runtime:3.1
-COPY ["./bin/Release/netcoreapp3.1/publish", "."]
+﻿FROM mcr.microsoft.com/dotnet/runtime:8.0
+COPY ["./bin/Release/net8.0/publish", "."]
 ENTRYPOINT ["dotnet", "ClusterSharding.Node.dll"]

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/app.conf
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/app.conf
@@ -12,7 +12,7 @@ akka {
     auto-down-unreachable-after = 5s
     sharding {
       remember-entities = on
-      least-shard-allocation-strategy.rebalance-threshold = 3
+      least-shard-allocation-strategy.rebalance-absolute-limit = 3
       state-store-mode = ddata
     }
   }
@@ -20,14 +20,14 @@ akka {
     journal {
       plugin = "akka.persistence.journal.sqlite"
       sqlite {
-        connection-string = "Datasource=store.db"
+        connection-string = "Datasource=/data/store.db"
         auto-initialize = true
       }
     }
     snapshot-store {
       plugin = "akka.persistence.snapshot-store.sqlite"
       sqlite {
-        connection-string = "Datasource=store.db"
+        connection-string = "Datasource=/data/store.db"
         auto-initialize = true
       }
     }

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/docker-compose.yaml
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/docker-compose.yaml
@@ -1,32 +1,36 @@
-version: '3.7'
-
 services:
   node-1:
     image: cluster-sharding:latest
-    network_mode: host
     ports:
-      - '6055:6055'
+      - '6055'
     environment:
-      CLUSTER_IP: "localhost"
+      CLUSTER_IP: "node-1"
       CLUSTER_PORT: 6055
-      CLUSTER_SEEDS: "akka.tcp://sharded-cluster-system@localhost:6055"
+      CLUSTER_SEEDS: "akka.tcp://sharded-cluster-system@node-1:6055"
+    volumes:
+      - data:/data:rw
 
   node-2:
     image: cluster-sharding:latest
-    network_mode: host
     ports:
-      - '6056:6056'
+      - '6056'
     environment:
-      CLUSTER_IP: "localhost"
+      CLUSTER_IP: "node-2"
       CLUSTER_PORT: 6056
-      CLUSTER_SEEDS: "akka.tcp://sharded-cluster-system@localhost:6055"
+      CLUSTER_SEEDS: "akka.tcp://sharded-cluster-system@node-1:6055"
+    volumes:
+      - data:/data:rw
 
   node-3:
     image: cluster-sharding:latest
-    network_mode: host
     ports:
-      - '6057:6057'
+      - '6057'
     environment:
-      CLUSTER_IP: "localhost"
+      CLUSTER_IP: "node-3"
       CLUSTER_PORT: 6057
-      CLUSTER_SEEDS: "akka.tcp://sharded-cluster-system@localhost:6055"
+      CLUSTER_SEEDS: "akka.tcp://sharded-cluster-system@node-1:6055"
+    volumes:
+      - data:/data:rw
+
+volumes:
+  data: ~

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/start.cmd
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/start.cmd
@@ -1,3 +1,3 @@
 dotnet publish -c Release 
 docker build -t cluster-sharding:latest .
-docker-compose up
+docker compose up


### PR DESCRIPTION
Fixes #3608 

## Changes

ClusterSharding.Node example is updated with following:

- Correct Dockerfile to use net8.0 folder and net8.0 base image
- Use `least-shard-allocation-strategy.rebalance-absolute-limit` instead of `least-shard-allocation-strategy.rebalance-threshold` as the latter is deprecated
- Don't use host network in docker-compose.yaml to not mess with host machine ports
- Use shared SQLite database for all nodes (using docker volume) - this is crucial for rebalancing
- Use docker compose V2 as V1 is deprecated since mid of 2023

## Checklist

* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
