### PR TITLE
[Streams] Fix null exceptions being propagated on downstream completion

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
@@ -4128,6 +4128,10 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    public class DownstreamCompletedWithNoCauseException : System.Exception
+    {
+        public DownstreamCompletedWithNoCauseException() { }
+    }
     [Akka.Annotations.InternalApiAttribute()]
     public sealed class Expand<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
@@ -4102,6 +4102,10 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
+    public class DownstreamCompletedWithNoCauseException : System.Exception
+    {
+        public DownstreamCompletedWithNoCauseException() { }
+    }
     [Akka.Annotations.InternalApiAttribute()]
     public sealed class Expand<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {

--- a/src/core/Akka.Streams/Implementation/Fusing/DownstreamCompletedWithNoCauseException.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/DownstreamCompletedWithNoCauseException.cs
@@ -1,0 +1,17 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="DownstreamCompletedWithNoCauseException.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2025 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+
+namespace Akka.Streams.Implementation.Fusing;
+
+public class DownstreamCompletedWithNoCauseException: Exception
+{
+    public DownstreamCompletedWithNoCauseException() : base("Downstream stage/flow completed with no cause")
+    {
+    }
+}

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -1297,10 +1297,25 @@ namespace Akka.Streams.Stage
         {
             try
             {
-                if (cause == null)
-                    throw new ArgumentException("Cancellation cause must not be null", nameof(cause));
                 if (_lastCancellationCause != null)
                     throw new ArgumentException("OnDownstreamFinish must not be called recursively", nameof(cause));
+                
+                // Some stages might propagate null exceptions due to improper Task continuation handling
+                // (see https://github.com/akkadotnet/Akka.Persistence.Sql/issues/498)
+                // This is a stop gap solution to make sure that Akka.Streams doesn't behave improperly
+                // until we can fix all of those
+                if (cause is null)
+                {
+                    try
+                    {
+                        throw new DownstreamCompletedWithNoCauseException();
+                    }
+                    catch (DownstreamCompletedWithNoCauseException e)
+                    {
+                        cause = e;
+                    }
+                }
+                
                 _lastCancellationCause = cause;
                 CancelStage(_lastCancellationCause);
             }


### PR DESCRIPTION
Fixes https://github.com/akkadotnet/Akka.Persistence.Sql/issues/498

## Changes

Replace null `Exception` with an empty exception to prevent stages from dying from improper task continuation handling.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).