### PR TITLE
ReceiveActor - Removing MatchBuilder and making use of handlers.

### DIFF
--- a/src/core/Akka.Tests/Actor/ReceiveActorHandlersTests.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorHandlersTests.cs
@@ -14,7 +14,9 @@ namespace Akka.Tests.Actor;
 public class ReceiveActorHandlersTests
 {   
     // Tests to do
-    // - Review all tests here as they were AI generated 
+    // - Review all tests here as they were AI generated
+    // - Rename the tests to be more accurate.
+    // - Add tests for the AddGenericReceiveHandler method
     // - Adding for IFoo and then sending a message of Bar : IFoo and it handled
     // - Decide if tests here should cater for adding receive handlers after "built"
     // - See if any of the Test_that_signatures_are_equal and Test_that_signatures_differs tests are applicable
@@ -76,6 +78,24 @@ public class ReceiveActorHandlersTests
 
         handlers.AddReceiveAnyHandler(_ => { });
     }
-    
-    
+
+    [Fact]
+    public void Given_a_TypedReceive_handler_with_no_predicate_has_been_added_When_adding_any_handler_Then_it_succeeds()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddTypedReceiveHandler(typeof(object), null, _ => true);
+        
+        // This should throw because the object handler is already added and would catch this before.
+        Assert.Throws<InvalidOperationException>(() => handlers.AddTypedReceiveHandler(typeof(int), _ => true, _ => true));
+    }
+
+    [Fact]
+    public void Given_a_TypedReceive_handler_with_predicate_has_been_added_When_adding_typed_handler_Then_it_succeeds()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true);
+        
+        // This should be allowed  because the object handler is already but it has a predicate that might not match.
+        handlers.AddTypedReceiveHandler(typeof(int), _ => true, _ => true);
+    }
 }

--- a/src/core/Akka.Tests/Actor/ReceiveActorHandlersTests.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorHandlersTests.cs
@@ -12,7 +12,13 @@ using Xunit;
 namespace Akka.Tests.Actor;
 
 public class ReceiveActorHandlersTests
-{
+{   
+    // Tests to do
+    // - Review all tests here as they were AI generated 
+    // - Adding for IFoo and then sending a message of Bar : IFoo and it handled
+    // - Decide if tests here should cater for adding receive handlers after "built"
+    // - See if any of the Test_that_signatures_are_equal and Test_that_signatures_differs tests are applicable
+
     [Fact]
     public void Given_a_ReceiveAny_handler_has_been_added_When_adding_handler_Then_it_fails()
     {
@@ -63,15 +69,6 @@ public class ReceiveActorHandlersTests
     }
 
     [Fact]
-    public void Given_a_TypedReceive_handler_has_been_added_When_adding_any_handler_Then_it_fails()
-    {
-        var handlers = new ReceiveActorHandlers();
-        handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true);
-
-        Assert.Throws<InvalidOperationException>(() => handlers.AddReceiveAnyHandler(_ => { }));
-    }
-
-    [Fact]
     public void Given_a_TypedReceive_handler_with_predicate_has_been_added_When_adding_any_handler_Then_it_succeeds()
     {
         var handlers = new ReceiveActorHandlers();
@@ -79,4 +76,6 @@ public class ReceiveActorHandlersTests
 
         handlers.AddReceiveAnyHandler(_ => { });
     }
+    
+    
 }

--- a/src/core/Akka.Tests/Actor/ReceiveActorHandlersTests.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorHandlersTests.cs
@@ -1,0 +1,82 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ReceiveActorHandlersTests.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2025 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Xunit;
+
+namespace Akka.Tests.Actor;
+
+public class ReceiveActorHandlersTests
+{
+    [Fact]
+    public void Given_a_ReceiveAny_handler_has_been_added_When_adding_handler_Then_it_fails()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddReceiveAnyHandler(_ => { });
+
+        // As we have added a handler that matches everything, adding another handler is pointless, so
+        // the builder should throw an exception.
+        Assert.Throws<InvalidOperationException>(() =>
+            handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true));
+    }
+
+    [Fact]
+    public void Given_a_TypedReceive_handler_has_been_added_When_adding_handler_Then_it_fails()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddTypedReceiveHandler(typeof(object), null, _ => true);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            handlers.AddTypedReceiveHandler(typeof(object), null, _ => true));
+    }
+
+    [Fact]
+    public void Given_a_TypedReceive_handler_with_predicate_has_been_added_When_adding_handler_Then_it_succeeds()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true);
+
+        handlers.AddTypedReceiveHandler(typeof(object), null, _ => true);
+    }
+
+    [Fact]
+    public void Given_a_TypedReceive_handler_for_different_type_When_adding_handler_Then_it_succeeds()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddTypedReceiveHandler(typeof(string), _ => true, _ => true);
+
+        handlers.AddTypedReceiveHandler(typeof(int), _ => true, _ => true);
+    }
+
+    [Fact]
+    public void Given_a_ReceiveAny_handler_has_been_added_When_adding_any_handler_Then_it_fails()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddReceiveAnyHandler(_ => { });
+
+        Assert.Throws<InvalidOperationException>(() => handlers.AddReceiveAnyHandler(_ => { }));
+    }
+
+    [Fact]
+    public void Given_a_TypedReceive_handler_has_been_added_When_adding_any_handler_Then_it_fails()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true);
+
+        Assert.Throws<InvalidOperationException>(() => handlers.AddReceiveAnyHandler(_ => { }));
+    }
+
+    [Fact]
+    public void Given_a_TypedReceive_handler_with_predicate_has_been_added_When_adding_any_handler_Then_it_succeeds()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true);
+
+        handlers.AddReceiveAnyHandler(_ => { });
+    }
+}

--- a/src/core/Akka.Tests/Actor/ReceiveActorHandlersTests.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorHandlersTests.cs
@@ -21,16 +21,43 @@ public class ReceiveActorHandlersTests
     // - Decide if tests here should cater for adding receive handlers after "built"
     // - See if any of the Test_that_signatures_are_equal and Test_that_signatures_differs tests are applicable
 
+
+    [Fact]
+    public void Given_a_ReceiveAny_handler_has_been_added_When_adding_any_handler_Then_it_fails()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddReceiveAnyHandler(_ => { });
+
+        // A ReceiveAny handler has been added, so adding another ReceiveAny handler should fail
+        Assert.Throws<InvalidOperationException>(() => 
+            handlers.AddReceiveAnyHandler(_ => { }));
+    }
+
     [Fact]
     public void Given_a_ReceiveAny_handler_has_been_added_When_adding_handler_Then_it_fails()
     {
         var handlers = new ReceiveActorHandlers();
         handlers.AddReceiveAnyHandler(_ => { });
 
-        // As we have added a handler that matches everything, adding another handler is pointless, so
-        // the builder should throw an exception.
+        // A ReceiveAny handler has been added, so adding a handler for object should fail
+        // because ReceiveAny and a receive handler for object are essentially the same
         Assert.Throws<InvalidOperationException>(() =>
-            handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true));
+            handlers.AddTypedReceiveHandler(typeof(object), null, _ => true));
+        Assert.Throws<InvalidOperationException>(() =>
+            handlers.AddTypedReceiveHandler(typeof(int), null, _ => true));
+        Assert.Throws<InvalidOperationException>(() =>
+            handlers.AddGenericReceiveHandler<bool>(null, _ => true));
+    }
+
+    [Fact]
+    public void Given_a_TypedReceive_handler_with_predicate_has_been_added_When_adding_any_handler_Then_it_succeeds()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true);
+
+        // As the object handler has a predicate, adding a ReceiveAny handler should be allowed 
+        // as the object handler might not handle all objects.
+        handlers.AddReceiveAnyHandler(_ => { });
     }
 
     [Fact]
@@ -39,6 +66,8 @@ public class ReceiveActorHandlersTests
         var handlers = new ReceiveActorHandlers();
         handlers.AddTypedReceiveHandler(typeof(object), null, _ => true);
 
+        // As a handler for the type of object with no predicate is added,
+        // adding another handler for the same type combination should fail with an exception
         Assert.Throws<InvalidOperationException>(() =>
             handlers.AddTypedReceiveHandler(typeof(object), null, _ => true));
     }
@@ -49,7 +78,33 @@ public class ReceiveActorHandlersTests
         var handlers = new ReceiveActorHandlers();
         handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true);
 
+        // The handler added has a predicate which makes it uncertain if it will handle the message.
+        // Adding another handler for the same type combination should be allowed.
         handlers.AddTypedReceiveHandler(typeof(object), null, _ => true);
+    }
+    
+    [Fact]
+    public void Given_a_Generic_handler_with_predicate_has_been_added_When_adding_handler_Then_it_succeeds()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddGenericReceiveHandler<int>(_ => true, _ => true);
+
+        // The handler added has a predicate which makes it uncertain if it will handle the message.
+        // Adding another handler for the same type combination should be allowed.
+        handlers.AddGenericReceiveHandler<int>(null, _ => true);
+    }
+    
+    
+    [Fact]
+    public void Given_a_Generic_handler_with_predicate_has_been_added_When_adding_handler_Then_it_succeeds1()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddGenericReceiveHandler<int>(null, _ => true);
+
+        // The handler has a handler for the type which has no predicate.
+        // Adding another handler for the same type combination should not be allowed.
+        Assert.Throws<InvalidOperationException>(() =>
+            handlers.AddGenericReceiveHandler<int>(_ => true, _ => true));
     }
 
     [Fact]
@@ -62,21 +117,12 @@ public class ReceiveActorHandlersTests
     }
 
     [Fact]
-    public void Given_a_ReceiveAny_handler_has_been_added_When_adding_any_handler_Then_it_fails()
+    public void Given_a_Generic_handler_for_different_type_When_adding_handler_Then_it_succeeds()
     {
         var handlers = new ReceiveActorHandlers();
-        handlers.AddReceiveAnyHandler(_ => { });
+        handlers.AddGenericReceiveHandler<string>(null, _ => true);
 
-        Assert.Throws<InvalidOperationException>(() => handlers.AddReceiveAnyHandler(_ => { }));
-    }
-
-    [Fact]
-    public void Given_a_TypedReceive_handler_with_predicate_has_been_added_When_adding_any_handler_Then_it_succeeds()
-    {
-        var handlers = new ReceiveActorHandlers();
-        handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true);
-
-        handlers.AddReceiveAnyHandler(_ => { });
+        handlers.AddGenericReceiveHandler<int>( _ => true, _ => true);
     }
 
     [Fact]
@@ -84,9 +130,12 @@ public class ReceiveActorHandlersTests
     {
         var handlers = new ReceiveActorHandlers();
         handlers.AddTypedReceiveHandler(typeof(object), null, _ => true);
-        
+
         // This should throw because the object handler is already added and would catch this before.
-        Assert.Throws<InvalidOperationException>(() => handlers.AddTypedReceiveHandler(typeof(int), _ => true, _ => true));
+        Assert.Throws<InvalidOperationException>(() => 
+            handlers.AddTypedReceiveHandler(typeof(int), _ => true, _ => true));
+        Assert.Throws<InvalidOperationException>(() => 
+            handlers.AddGenericReceiveHandler<bool>(_ => true, _ => true));
     }
 
     [Fact]

--- a/src/core/Akka.Tests/Actor/ReceiveActorHandlersTests.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorHandlersTests.cs
@@ -12,35 +12,16 @@ using Xunit;
 namespace Akka.Tests.Actor;
 
 public class ReceiveActorHandlersTests
-{   
-    // Tests to do
-    // - Review all tests here as they were AI generated
-    // - Rename the tests to be more accurate.
-    // - Add tests for the AddGenericReceiveHandler method
-    // - Adding for IFoo and then sending a message of Bar : IFoo and it handled
-    // - Decide if tests here should cater for adding receive handlers after "built"
-    // - See if any of the Test_that_signatures_are_equal and Test_that_signatures_differs tests are applicable
-
-
+{
     [Fact]
-    public void Given_a_ReceiveAny_handler_has_been_added_When_adding_any_handler_Then_it_fails()
+    public void Given_ReceiveAnyHandler_Added_When_Adding_Any_Other_Handler_Then_Should_Fail()
     {
         var handlers = new ReceiveActorHandlers();
         handlers.AddReceiveAnyHandler(_ => { });
 
-        // A ReceiveAny handler has been added, so adding another ReceiveAny handler should fail
-        Assert.Throws<InvalidOperationException>(() => 
+        // A ReceiveAny handler has been added, so adding any other handler should fail
+        Assert.Throws<InvalidOperationException>(() =>
             handlers.AddReceiveAnyHandler(_ => { }));
-    }
-
-    [Fact]
-    public void Given_a_ReceiveAny_handler_has_been_added_When_adding_handler_Then_it_fails()
-    {
-        var handlers = new ReceiveActorHandlers();
-        handlers.AddReceiveAnyHandler(_ => { });
-
-        // A ReceiveAny handler has been added, so adding a handler for object should fail
-        // because ReceiveAny and a receive handler for object are essentially the same
         Assert.Throws<InvalidOperationException>(() =>
             handlers.AddTypedReceiveHandler(typeof(object), null, _ => true));
         Assert.Throws<InvalidOperationException>(() =>
@@ -50,18 +31,18 @@ public class ReceiveActorHandlersTests
     }
 
     [Fact]
-    public void Given_a_TypedReceive_handler_with_predicate_has_been_added_When_adding_any_handler_Then_it_succeeds()
+    public void Given_TypedReceiveHandlerWithPredicate_When_Adding_ReceiveAnyHandler_Then_Should_Succeed()
     {
         var handlers = new ReceiveActorHandlers();
         handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true);
 
-        // As the object handler has a predicate, adding a ReceiveAny handler should be allowed 
+        // As the object handler has a predicate, adding a ReceiveAny handler should be allowed
         // as the object handler might not handle all objects.
         handlers.AddReceiveAnyHandler(_ => { });
     }
 
     [Fact]
-    public void Given_a_TypedReceive_handler_has_been_added_When_adding_handler_Then_it_fails()
+    public void Given_TypedReceiveHandler_When_Adding_SameTypedReceiveHandler_Then_Should_Fail()
     {
         var handlers = new ReceiveActorHandlers();
         handlers.AddTypedReceiveHandler(typeof(object), null, _ => true);
@@ -73,7 +54,7 @@ public class ReceiveActorHandlersTests
     }
 
     [Fact]
-    public void Given_a_TypedReceive_handler_with_predicate_has_been_added_When_adding_handler_Then_it_succeeds()
+    public void Given_TypedReceiveHandlerWithPredicate_When_Adding_SameTypedReceiveHandlerWithPredicate_Then_Should_Succeed()
     {
         var handlers = new ReceiveActorHandlers();
         handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true);
@@ -82,9 +63,35 @@ public class ReceiveActorHandlersTests
         // Adding another handler for the same type combination should be allowed.
         handlers.AddTypedReceiveHandler(typeof(object), null, _ => true);
     }
-    
+
     [Fact]
-    public void Given_a_Generic_handler_with_predicate_has_been_added_When_adding_handler_Then_it_succeeds()
+    public void Given_ObjectTypedReceiveHandlerWithNoPredicate_When_Adding_Any_Other_ReceiveHandler_Then_Should_Fail()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddTypedReceiveHandler(typeof(object), null, _ => true);
+
+        // This should throw because the object handler is already added and would catch this before.
+        Assert.Throws<InvalidOperationException>(() =>
+            handlers.AddTypedReceiveHandler(typeof(int), _ => true, _ => true));
+        Assert.Throws<InvalidOperationException>(() =>
+            handlers.AddGenericReceiveHandler<bool>(_ => true, _ => true));
+    }
+
+    // TODO Confirm use case - This is theoretically a breaking change. Conceptually it should not be because Object handler
+    // with no predicate is the same as a ReceiveAny handler.
+    [Fact]
+    public void Given_ObjectTypedReceiveHandlerWithNoPredicate_When_Adding_AnyReceiveHandler_Then_Should_Fail()
+    {
+        var handlers = new ReceiveActorHandlers();
+        handlers.AddTypedReceiveHandler(typeof(object), null, _ => true);
+
+        // This should throw because the object handler is already added and would catch this before.
+        Assert.Throws<InvalidOperationException>(() =>
+            handlers.AddReceiveAnyHandler(_ => { }));
+    }
+
+    [Fact]
+    public void Given_GenericReceiveHandlerWithPredicate_When_Adding_SameGenericReceiveHandlerWithPredicate_Then_Should_Succeed()
     {
         var handlers = new ReceiveActorHandlers();
         handlers.AddGenericReceiveHandler<int>(_ => true, _ => true);
@@ -93,22 +100,9 @@ public class ReceiveActorHandlersTests
         // Adding another handler for the same type combination should be allowed.
         handlers.AddGenericReceiveHandler<int>(null, _ => true);
     }
-    
-    
-    [Fact]
-    public void Given_a_Generic_handler_with_predicate_has_been_added_When_adding_handler_Then_it_succeeds1()
-    {
-        var handlers = new ReceiveActorHandlers();
-        handlers.AddGenericReceiveHandler<int>(null, _ => true);
-
-        // The handler has a handler for the type which has no predicate.
-        // Adding another handler for the same type combination should not be allowed.
-        Assert.Throws<InvalidOperationException>(() =>
-            handlers.AddGenericReceiveHandler<int>(_ => true, _ => true));
-    }
 
     [Fact]
-    public void Given_a_TypedReceive_handler_for_different_type_When_adding_handler_Then_it_succeeds()
+    public void Given_TypedReceiveHandler_When_Adding_DifferentTypedReceiveHandler_Then_Should_Succeed()
     {
         var handlers = new ReceiveActorHandlers();
         handlers.AddTypedReceiveHandler(typeof(string), _ => true, _ => true);
@@ -117,34 +111,30 @@ public class ReceiveActorHandlersTests
     }
 
     [Fact]
-    public void Given_a_Generic_handler_for_different_type_When_adding_handler_Then_it_succeeds()
+    public void Given_GenericReceiveHandler_When_Adding_DifferentGenericReceiveHandler_Then_Should_Succeed()
     {
         var handlers = new ReceiveActorHandlers();
         handlers.AddGenericReceiveHandler<string>(null, _ => true);
 
-        handlers.AddGenericReceiveHandler<int>( _ => true, _ => true);
+        handlers.AddGenericReceiveHandler<int>(_ => true, _ => true);
     }
 
     [Fact]
-    public void Given_a_TypedReceive_handler_with_no_predicate_has_been_added_When_adding_any_handler_Then_it_succeeds()
-    {
-        var handlers = new ReceiveActorHandlers();
-        handlers.AddTypedReceiveHandler(typeof(object), null, _ => true);
-
-        // This should throw because the object handler is already added and would catch this before.
-        Assert.Throws<InvalidOperationException>(() => 
-            handlers.AddTypedReceiveHandler(typeof(int), _ => true, _ => true));
-        Assert.Throws<InvalidOperationException>(() => 
-            handlers.AddGenericReceiveHandler<bool>(_ => true, _ => true));
-    }
-
-    [Fact]
-    public void Given_a_TypedReceive_handler_with_predicate_has_been_added_When_adding_typed_handler_Then_it_succeeds()
+    public void Given_TypedReceiveHandlerWithPredicate_When_Adding_DifferentTypedReceiveHandlerWithPredicate_Then_Should_Succeed()
     {
         var handlers = new ReceiveActorHandlers();
         handlers.AddTypedReceiveHandler(typeof(object), _ => true, _ => true);
-        
-        // This should be allowed  because the object handler is already but it has a predicate that might not match.
+
+        // This should be allowed because the object handler is already but it has a predicate that might not match.
         handlers.AddTypedReceiveHandler(typeof(int), _ => true, _ => true);
     }
+    
+    /*
+     * IFoo
+     * Bar: IFoo
+     *
+     * Receive<IFoo>
+     * Receive<Bar>
+     */
+    
 }

--- a/src/core/Akka.Tests/Actor/ReceiveActorTests.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorTests.cs
@@ -154,6 +154,19 @@ namespace Akka.Tests.Actor
             // Then
             Assert.True(terminated);
         }
+        
+        [Fact]
+        public async Task Actor_Can_Handle_Message_When_Base_Is_Defined_In_Receive()
+        {
+            //Given
+            var actor = Sys.ActorOf<ReceiveCanHandleBaseTypesActor>("ReceiveCanHandleBaseTypes");
+
+            //When
+            actor.Tell(new ReceiveCanHandleBaseMessage(), TestActor);
+
+            //Then
+            await ExpectMsgAsync("Handled");
+        }
 
         private class NoReceiveActor : ReceiveActor
         {
@@ -241,7 +254,6 @@ namespace Akka.Tests.Actor
             }
         }
 
-
         private class ReceiveAnyActor : ReceiveActor
         {
             public ReceiveAnyActor()
@@ -268,7 +280,18 @@ namespace Akka.Tests.Actor
                 });
             }
         }
-        
+
+        private class ReceiveCanHandleBaseTypesActor : ReceiveActor
+        {
+            public ReceiveCanHandleBaseTypesActor()
+            {
+                Receive<IReceiveCanHandleBaseMessage>(i => Sender.Tell("Handled", Self));
+            }
+        }
+
+        private record ReceiveCanHandleBaseMessage : IReceiveCanHandleBaseMessage { }
+
+        private interface IReceiveCanHandleBaseMessage { }
     }
 }
 

--- a/src/core/Akka/Actor/ReceiveActor.cs
+++ b/src/core/Akka/Actor/ReceiveActor.cs
@@ -111,17 +111,20 @@ namespace Akka.Actor
         {
             var messageType = message.GetType();
             var currentHandler = handlers;
-            if (currentHandler.TypedHandlers.TryGetValue(messageType, out var handler))
+            foreach (var (type, typedHandlers) in handlers.TypedHandlers)
             {
-                foreach (var subItem in handler)
+                if (type.IsAssignableFrom(messageType))
                 {
-                    if (subItem.ShouldHandle(message))
+                    foreach (var subItem in typedHandlers)
                     {
-                        var handled = subItem.Handle(message);
-
-                        if (handled)
+                        if (subItem.ShouldHandle(message))
                         {
-                            return;
+                            var handled = subItem.Handle(message);
+
+                            if (handled)
+                            {
+                                return;
+                            }
                         }
                     }
                 }

--- a/src/core/Akka/Actor/ReceiveActor.cs
+++ b/src/core/Akka/Actor/ReceiveActor.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Akka.Actor.Internal;
 using Akka.Dispatch;
-using Akka.Tools.MatchHandler;
 
 namespace Akka.Actor
 {

--- a/src/core/Akka/Actor/ReceiveActor.cs
+++ b/src/core/Akka/Actor/ReceiveActor.cs
@@ -67,30 +67,12 @@ namespace Akka.Actor
             ExecuteMessageHandler(message, _currentHandlers);
         }
 
-        private void ExecuteMessageHandler(object message, ReceiveActorHandlers handlers)
+        private void ExecuteMessageHandler(object message, ReceiveActorHandlers receiveActorHandlers)
         {
-            var messageType = message.GetType();
-            var currentHandler = handlers;
-            foreach (var (type, typedHandlers) in handlers.TypedHandlers)
-            {
-                // This is covering object types as well. There might be an ordering issue here
-                // but this should probably be resolved with the logic around how handlers are ordered.
-                if (type.IsAssignableFrom(messageType))
-                {
-                    if (typedHandlers.TryHandle(message))
-                    {
-                        return;
-                    }
-                }
-            }
+            var currentHandler = receiveActorHandlers;
+            var wasMessageHandled = currentHandler.TryHandle(message);
 
-            if (currentHandler.HandleAny != null)
-            {
-                currentHandler.HandleAny(message);
-                return;
-            }
-
-            if (_shouldUnhandle)
+            if (!wasMessageHandled && _shouldUnhandle)
             {
                 Unhandled(message);
             }

--- a/src/core/Akka/Actor/ReceiveActor.cs
+++ b/src/core/Akka/Actor/ReceiveActor.cs
@@ -416,6 +416,12 @@ namespace Akka.Actor
         {
             EnsureMayConfigureMessageHandlers();
             var handlers = _handlersStack.Peek();
+
+            if (handlers.HandleAny != null)
+            {
+                throw new InvalidOperationException("A handler that catches all messages has been added. No handler can be added after that.");
+            }
+
             handlers.HandleAny = handler;
         }
         

--- a/src/core/Akka/Actor/ReceiveActorHandlers.cs
+++ b/src/core/Akka/Actor/ReceiveActorHandlers.cs
@@ -1,0 +1,119 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ReceiveActorHandlers.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2025 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Akka.Actor;
+#nullable enable
+internal class ReceiveActorHandlers
+{
+    public ReceiveActorHandlers()
+    {
+        TypedHandlers = new Dictionary<Type, ITypeHandler>();
+        HandleAny = null;
+    }
+
+    public Dictionary<Type, ITypeHandler> TypedHandlers { get; }
+
+    public Action<object>? HandleAny { get; private set; }
+
+    public void AddGenericReceiveHandler<T>(Predicate<T>? shouldHandle, Func<T, bool> handler)
+    {
+        if (!TypedHandlers.TryGetValue(typeof(T), out var typeHandlerInterface))
+        {
+            typeHandlerInterface = new TypeHandler<T>();
+            TypedHandlers[typeHandlerInterface.HandlesType] = typeHandlerInterface;
+        }
+
+        var typedHandler = (TypeHandler<T>)typeHandlerInterface;
+
+        var predicateHandler = new PredicateHandler<T>() { Predicate = shouldHandle, Handler = handler };
+
+        typedHandler.Handlers.Add(predicateHandler);
+    }
+
+    public void AddTypedReceiveHandler(Type messageType, Predicate<object>? shouldHandle, Func<object, bool> handler)
+    {
+        // Need to add cases here if more than one object type is passed in
+        // More of the tests from match handler need to be replicated.
+
+        if (!TypedHandlers.TryGetValue(messageType, out var typeHandlerInterface))
+        {
+            typeHandlerInterface = new TypeHandler<object>();
+            TypedHandlers[messageType] = typeHandlerInterface;
+        }
+
+        var typedHandler = (TypeHandler<object>)typeHandlerInterface;
+
+        // Have to use object here as dont have the generic type information
+        var predicateHandler = new PredicateHandler<object>() { Predicate = shouldHandle, Handler = handler };
+
+        typedHandler.Handlers.Add(predicateHandler);
+    }
+
+    public void AddReceiveAnyHandler(Action<object> handler)
+    {
+        if (HandleAny != null)
+        {
+            throw new InvalidOperationException(
+                "A handler that catches all messages has been added. No handler can be added after that.");
+        }
+
+        HandleAny = handler;
+    }
+}
+
+internal interface ITypeHandler
+{
+    Type HandlesType { get; }
+
+    bool TryHandle(object message);
+}
+
+internal class TypeHandler<T> : ITypeHandler
+{
+    public TypeHandler()
+    {
+        HandlesType = typeof(T);
+        Handlers = new List<PredicateHandler<T>>();
+    }
+
+    public Type HandlesType { get; }
+
+    public List<PredicateHandler<T>> Handlers { get; }
+
+    public bool TryHandle(object message)
+    {
+        var typedMessage = (T)message;
+        foreach (var predicateHandler in Handlers)
+        {
+            if (predicateHandler.TryHandle(typedMessage))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+internal class PredicateHandler<T>
+{
+    public Predicate<T>? Predicate { get; init; }
+    public Func<T, bool> Handler { get; init; }
+
+    public bool TryHandle(T typedMessage)
+    {
+        if (Predicate == null || Predicate(typedMessage))
+        {
+            return Handler(typedMessage);
+        }
+
+        return false;
+    }
+}

--- a/src/core/Akka/Actor/ReceiveActorHandlers.cs
+++ b/src/core/Akka/Actor/ReceiveActorHandlers.cs
@@ -24,6 +24,11 @@ internal class ReceiveActorHandlers
 
     public void AddGenericReceiveHandler<T>(Predicate<T>? shouldHandle, Func<T, bool> handler)
     {
+        if (HandleAny != null)
+        {
+            throw new InvalidOperationException("A handler that catches all messages has been added. No handler can be added after that.");
+        }
+        
         if (!TypedHandlers.TryGetValue(typeof(T), out var typeHandlerInterface))
         {
             typeHandlerInterface = new TypeHandler<T>();
@@ -39,6 +44,11 @@ internal class ReceiveActorHandlers
 
     public void AddTypedReceiveHandler(Type messageType, Predicate<object>? shouldHandle, Func<object, bool> handler)
     {
+        if (HandleAny != null)
+        {
+            throw new InvalidOperationException("A handler that catches all messages has been added. No handler can be added after that.");
+        }
+        
         // Need to add cases here if more than one object type is passed in
         // More of the tests from match handler need to be replicated.
 

--- a/src/core/Akka/Actor/ReceiveActorHandlers.cs
+++ b/src/core/Akka/Actor/ReceiveActorHandlers.cs
@@ -76,6 +76,31 @@ internal class ReceiveActorHandlers
 
         HandleAny = handler;
     }
+
+    public bool TryHandle(object message)
+    {
+        var messageType = message.GetType();
+        foreach (var (type, typedHandlers) in TypedHandlers)
+        {
+            // This is covering object types as well. There might be an ordering issue here
+            // but this should probably be resolved with the logic around how handlers are ordered.
+            if (type.IsAssignableFrom(messageType))
+            {
+                if (typedHandlers.TryHandle(message))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (HandleAny != null)
+        {
+            HandleAny(message);
+            return true;
+        }
+
+        return false;
+    }
 }
 
 internal interface ITypeHandler

--- a/src/core/Akka/Actor/ReceiveActorHandlers.cs
+++ b/src/core/Akka/Actor/ReceiveActorHandlers.cs
@@ -12,51 +12,52 @@ namespace Akka.Actor;
 #nullable enable
 internal class ReceiveActorHandlers
 {
+    private bool _hadObjectHandlerWithNoPredicate;
+
     public ReceiveActorHandlers()
     {
         TypedHandlers = new Dictionary<Type, ITypeHandler>();
         HandleAny = null;
     }
 
-    public Dictionary<Type, ITypeHandler> TypedHandlers { get; }
+    private Dictionary<Type, ITypeHandler> TypedHandlers { get; }
 
-    public Action<object>? HandleAny { get; private set; }
+    private Action<object>? HandleAny { get; set; }
 
-    public void AddGenericReceiveHandler<T>(Predicate<T>? shouldHandle, Func<T, bool> handler)
+    private void CanAddMoreHandlers()
     {
+        if (_hadObjectHandlerWithNoPredicate)
+        {
+            throw new InvalidOperationException("A handler for object with no predicate has already been added. No more handlers can be added as they would be ignored.");
+        }
+
         if (HandleAny != null)
         {
-            throw new InvalidOperationException("A handler that catches all messages has been added. No handler can be added after that.");
+            throw new InvalidOperationException("A handler that catches all messages has been added. No more handlers can be added as they would be ignored.");
         }
-        
-        if (!TypedHandlers.TryGetValue(typeof(T), out var typeHandlerInterface))
+    }
+    
+    public void AddGenericReceiveHandler<T>(Predicate<T>? shouldHandlePredicate, Func<T, bool> handler)
+    {
+        CanAddMoreHandlers();
+
+        var genericType = typeof(T);
+        if (!TypedHandlers.TryGetValue(genericType, out var typeHandlerInterface))
         {
             typeHandlerInterface = new TypeHandler<T>();
-            TypedHandlers[typeHandlerInterface.HandlesType] = typeHandlerInterface;
+            TypedHandlers[genericType] = typeHandlerInterface;
         }
 
         var typedHandler = (TypeHandler<T>)typeHandlerInterface;
 
-        // If the last item added to the handlers has a predicate, then we can add a handler.
-        var handlerCount = typedHandler.Handlers.Count;
-        if (handlerCount > 0 && 
-            typedHandler.Handlers[handlerCount - 1].Predicate == null)
-        {
-            throw new InvalidOperationException("A handler with no predicate has already been added for this type. No more handlers can be added.");
-        }
-        
-        var predicateHandler = new PredicateHandler<T>() { Predicate = shouldHandle, Handler = handler };
+        var predicateHandler = new PredicateHandler<T>(shouldHandlePredicate, handler);
 
         typedHandler.Handlers.Add(predicateHandler);
     }
 
-    public void AddTypedReceiveHandler(Type messageType, Predicate<object>? shouldHandle, Func<object, bool> handler)
+    public void AddTypedReceiveHandler(Type messageType, Predicate<object>? shouldHandlePredicate, Func<object, bool> handler)
     {
-        if (HandleAny != null)
-        {
-            throw new InvalidOperationException("A handler that catches all messages has been added. No handler can be added after that.");
-        }
-        
+        CanAddMoreHandlers();
         if (!TypedHandlers.TryGetValue(messageType, out var typeHandlerInterface))
         {
             typeHandlerInterface = new TypeHandler<object>();
@@ -64,29 +65,22 @@ internal class ReceiveActorHandlers
         }
 
         var typedHandler = (TypeHandler<object>)typeHandlerInterface;
-        
-        // If the last item added to the handlers has a predicate, then we can add a handler.
-        var handlerCount = typedHandler.Handlers.Count;
-        if (handlerCount > 0 && 
-            typedHandler.Handlers[handlerCount - 1].Predicate == null)
-        {
-            throw new InvalidOperationException("A handler with no predicate has already been added for this type. No more handlers can be added.");
-        }
 
         // Have to use object here as dont have the generic type information
-        var predicateHandler = new PredicateHandler<object>() { Predicate = shouldHandle, Handler = handler };
-
+        var predicateHandler = new PredicateHandler<object>(shouldHandlePredicate, handler);
         typedHandler.Handlers.Add(predicateHandler);
+
+        // If the message type is object, then we need to track that we have added a handler with no predicate.
+        if (messageType == typeof(object) && 
+            shouldHandlePredicate == null)
+        {
+            _hadObjectHandlerWithNoPredicate = true;
+        }
     }
 
-    // TODO - Should receive any be treated like an object handler?
     public void AddReceiveAnyHandler(Action<object> handler)
     {
-        if (HandleAny != null)
-        {
-            throw new InvalidOperationException(
-                "A handler that catches all messages has been added. No handler can be added after that.");
-        }
+        CanAddMoreHandlers();
 
         HandleAny = handler;
     }
@@ -119,8 +113,6 @@ internal class ReceiveActorHandlers
 
 internal interface ITypeHandler
 {
-    Type HandlesType { get; }
-
     bool TryHandle(object message);
 }
 
@@ -128,11 +120,8 @@ internal class TypeHandler<T> : ITypeHandler
 {
     public TypeHandler()
     {
-        HandlesType = typeof(T);
         Handlers = new List<PredicateHandler<T>>();
     }
-
-    public Type HandlesType { get; }
 
     public List<PredicateHandler<T>> Handlers { get; }
 
@@ -153,8 +142,14 @@ internal class TypeHandler<T> : ITypeHandler
 
 internal class PredicateHandler<T>
 {
-    public Predicate<T>? Predicate { get; init; }
-    public Func<T, bool> Handler { get; init; }
+    public PredicateHandler(Predicate<T>? predicate, Func<T, bool> handler)
+    {
+        Predicate = predicate;
+        Handler = handler;
+    }
+
+    public Predicate<T>? Predicate { get; }
+    public Func<T, bool> Handler { get; }
 
     public bool TryHandle(T typedMessage)
     {

--- a/src/core/Akka/Actor/ReceiveActorHandlers.cs
+++ b/src/core/Akka/Actor/ReceiveActorHandlers.cs
@@ -37,6 +37,14 @@ internal class ReceiveActorHandlers
 
         var typedHandler = (TypeHandler<T>)typeHandlerInterface;
 
+        // If the last item added to the handlers has a predicate, then we can add a handler.
+        var handlerCount = typedHandler.Handlers.Count;
+        if (handlerCount > 0 && 
+            typedHandler.Handlers[handlerCount - 1].Predicate == null)
+        {
+            throw new InvalidOperationException("A handler with no predicate has already been added for this type. No more handlers can be added.");
+        }
+        
         var predicateHandler = new PredicateHandler<T>() { Predicate = shouldHandle, Handler = handler };
 
         typedHandler.Handlers.Add(predicateHandler);
@@ -49,9 +57,6 @@ internal class ReceiveActorHandlers
             throw new InvalidOperationException("A handler that catches all messages has been added. No handler can be added after that.");
         }
         
-        // Need to add cases here if more than one object type is passed in
-        // More of the tests from match handler need to be replicated.
-
         if (!TypedHandlers.TryGetValue(messageType, out var typeHandlerInterface))
         {
             typeHandlerInterface = new TypeHandler<object>();
@@ -59,6 +64,14 @@ internal class ReceiveActorHandlers
         }
 
         var typedHandler = (TypeHandler<object>)typeHandlerInterface;
+        
+        // If the last item added to the handlers has a predicate, then we can add a handler.
+        var handlerCount = typedHandler.Handlers.Count;
+        if (handlerCount > 0 && 
+            typedHandler.Handlers[handlerCount - 1].Predicate == null)
+        {
+            throw new InvalidOperationException("A handler with no predicate has already been added for this type. No more handlers can be added.");
+        }
 
         // Have to use object here as dont have the generic type information
         var predicateHandler = new PredicateHandler<object>() { Predicate = shouldHandle, Handler = handler };
@@ -66,6 +79,7 @@ internal class ReceiveActorHandlers
         typedHandler.Handlers.Add(predicateHandler);
     }
 
+    // TODO - Should receive any be treated like an object handler?
     public void AddReceiveAnyHandler(Action<object> handler)
     {
         if (HandleAny != null)

--- a/src/core/Akka/Actor/ReceiveActorHandlers.cs
+++ b/src/core/Akka/Actor/ReceiveActorHandlers.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="ReceiveActorHandlers.cs" company="Akka.NET Project">
 //      Copyright (C) 2009-2025 Lightbend Inc. <http://www.lightbend.com>
 //      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -51,7 +51,6 @@ internal class ReceiveActorHandlers
         var typedHandler = (TypeHandler<T>)typeHandlerInterface;
 
         var predicateHandler = new PredicateHandler<T>(shouldHandlePredicate, handler);
-
         typedHandler.Handlers.Add(predicateHandler);
     }
 
@@ -88,13 +87,13 @@ internal class ReceiveActorHandlers
     public bool TryHandle(object message)
     {
         var messageType = message.GetType();
-        foreach (var (type, typedHandlers) in TypedHandlers)
+        foreach (var kvp in TypedHandlers)
         {
             // This is covering object types as well. There might be an ordering issue here
             // but this should probably be resolved with the logic around how handlers are ordered.
-            if (type.IsAssignableFrom(messageType))
+            if (kvp.Key.IsAssignableFrom(messageType))
             {
-                if (typedHandlers.TryHandle(message))
+                if (kvp.Value.TryHandle(message))
                 {
                     return true;
                 }


### PR DESCRIPTION
Fixes # 
This is part of the changed needed to resolve https://github.com/akkadotnet/akka.net/issues/2811

## Changes
Here the changes are to not make use of the match builder and just make use of the handlers. The approach I have taken is very similar in structure to what was existing but making use of handlers for the various types. There could be merit in removing more of the logic to simplify the class more.

This approach has some internal classes (I created as internal as an initial approach I can see merit in pulling these out to be more clean within the class.

While all of these tests do pass I do think there are some edge cases that this does not cover when reading the comments in the MatchBuilder class. If the general approach of the handlers is what is wanted I will go into the comments and edge cases in more detail.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).


### Latest `dev` Benchmarks 
Note I pushed the dotnet up to 8.0 because I did not have 6.0 installed on this machine

```
BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.5371/22H2/2022Update)
Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET SDK 9.0.102
  [Host]     : .NET 8.0.12 (8.0.1224.60305), X64 RyuJIT AVX2
  Job-WBRIAI : .NET 8.0.12 (8.0.1224.60305), X64 RyuJIT AVX2

InvocationCount=1  LaunchCount=10  RunStrategy=Monitoring
UnrollFactor=1  WarmupCount=10

| Method                                | Mean     | Error   | StdDev  | Req/sec      |
|-------------------------------------- |---------:|--------:|--------:|-------------:|
| Actor_ping_pong_single_pair_in_memory | 227.4 ns | 1.37 ns | 4.04 ns | 4 397 699,09 |

Warming up...
OSVersion:              Microsoft Windows NT 10.0.19045.0
ProcessorCount:         8
ClockSpeed:             0 MHZ
Actor Count:            16
Messages sent/received: 30000000  (3e7)
Is Server GC:           True
Thread count:           26

ActorBase    first start time: 10.46 ms
ReceiveActor first start time: 16.52 ms

            ActorBase                          ReceiveActor
Throughput, Msgs/sec, Start [ms], Total [ms],  Msgs/sec, Start [ms], Total [ms]
         1, 25210000,      14.80,    1205.11,  28409000,      88.74,    1144.76
         5, 40595000,       7.58,     747.50,  39370000,       2.97,     765.10
        10, 46583000,     165.06,     809.82,  46511000,       2.32,     647.37
        15, 57142000,       2.29,     528.20,  54347000,       2.41,     555.26
        20, 52264000,     100.35,     674.69,  47021000,       3.83,     642.75
        30, 51107000,       1.41,     588.55,  49180000,      40.18,     651.06
        40, 59055000,       1.35,     509.36,  47846000,       1.41,     628.67
        50, 50847000,       1.92,     592.04,  58593000,       2.31,     514.41
        60, 55970000,       2.12,     539.09,  52447000,      19.28,     591.90
        70, 58939000,       1.37,     510.65,  54151000,       1.39,     555.68
        80, 57915000,       1.41,     519.77,  56179000,      12.66,     547.47
        90, 57251000,       1.37,     526.20,  48231000,       1.37,     623.77
       100, 64239000,       1.26,     468.96,  60000000,       1.39,     501.52
       200, 58593000,       1.47,     513.87,  52083000,       1.94,     578.61
       300, 64935000,       1.58,     464.56,  57915000,       1.56,     519.81
       400, 57251000,       4.82,     529.21,  56074000,       1.39,     536.56
       500, 63559000,       1.89,     474.61,  47694000,       1.27,     630.63
       600, 64377000,       1.29,     468.21,  60975000,       1.39,     493.41
       700, 57581000,       1.23,     522.33,  61728000,       1.27,     488.07
       800, 62630000,       1.27,     480.66,  56925000,       1.27,     528.49
       900, 62630000,       1.26,     481.06,  51724000,       1.25,     582.17
```

### This PR's Benchmarks

So as the numbers are showing the performance has gone backwards

```
BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.5371/22H2/2022Update)
Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET SDK 9.0.102
  [Host]     : .NET 8.0.12 (8.0.1224.60305), X64 RyuJIT AVX2
  Job-WLSTQM : .NET 8.0.12 (8.0.1224.60305), X64 RyuJIT AVX2

InvocationCount=1  LaunchCount=10  RunStrategy=Monitoring
UnrollFactor=1  WarmupCount=10

| Method                                | Mean     | Error   | StdDev  | Req/sec      |
|-------------------------------------- |---------:|--------:|--------:|-------------:|
| Actor_ping_pong_single_pair_in_memory | 236.5 ns | 1.77 ns | 5.22 ns | 4 228 340,67 |

Warming up...
OSVersion:              Microsoft Windows NT 10.0.19045.0
ProcessorCount:         8
ClockSpeed:             0 MHZ
Actor Count:            16
Messages sent/received: 30000000  (3e7)
Is Server GC:           True
Thread count:           26

ActorBase    first start time: 11.96 ms
ReceiveActor first start time:  5.37 ms

            ActorBase                          ReceiveActor
Throughput, Msgs/sec, Start [ms], Total [ms],  Msgs/sec, Start [ms], Total [ms]
         1, 22692000,       5.69,    1328.11,  28544000,      44.97,    1096.91
         5, 44247000,     156.34,     834.79,  39421000,       3.50,     765.35
        10, 57692000,       2.62,     523.27,  40983000,      33.38,     765.45
        15, 52356000,      12.17,     585.59,  52631000,     145.33,     716.11
        20, 62240000,       3.25,     486.14,  51282000,       4.10,     589.88
        30, 62893000,       1.72,     479.48,  44247000,       9.63,     688.59
        40, 63965000,       2.06,     471.63,  53003000,       1.58,     568.51
        50, 63424000,      18.76,     492.70,  48154000,       1.57,     625.47
        60, 67567000,       1.38,     445.43,  53571000,       1.56,     561.95
        70, 59405000,       1.42,     506.46,  54945000,       1.40,     548.33
        80, 66371000,       1.38,     454.23,  55045000,       2.75,     548.59
        90, 61983000,       1.28,     485.55,  55248000,       1.53,     544.57
       100, 65502000,       1.35,     460.24,  52356000,       1.49,     574.49
       200, 67873000,       1.93,     444.42,  55970000,       1.49,     537.89
       300, 63694000,       1.63,     472.91,  54347000,      62.60,     614.65
       400, 63965000,       1.74,     471.53,  51194000,       1.36,     587.42
       500, 68807000,       1.39,     438.34,  52447000,       1.46,     573.91
       600, 58479000,       1.29,     514.95,  54844000,       1.60,     548.89
       700, 53956000,       1.30,     557.95,  46296000,       1.85,     650.38
       800, 62111000,       2.65,     486.63,  51282000,       1.61,     587.52
       900, 65075000,       1.69,     463.57,  46224000,       1.95,     651.46
```