### PR TITLE
Akka.Actor: `Context.Watch` on `FutureActorRef<T>` creates memory leaks

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -926,6 +926,7 @@ namespace Akka.Actor
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
         public virtual void DeliverAsk(object message, Akka.Actor.ICanTell destination) { }
+        public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
     public class static Futures

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -924,6 +924,7 @@ namespace Akka.Actor
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
         public virtual void DeliverAsk(object message, Akka.Actor.ICanTell destination) { }
+        public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
     public class static Futures

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -54,7 +54,7 @@ namespace Akka.Tests.Actor
                             Sender.Tell(123);
                             break;
                         case "system":
-                            Sender.Tell(new DummySystemMessage());
+                            Sender.As<IInternalActorRef>().SendSystemMessage(new DummySystemMessage());
                             break;
                     }
                 

--- a/src/core/Akka.Tests/Actor/Bugfix7501Specs.cs
+++ b/src/core/Akka.Tests/Actor/Bugfix7501Specs.cs
@@ -26,24 +26,39 @@ public class Bugfix7501Specs : AkkaSpec
     public async Task FutureActorRefShouldSupportDeathWatch()
     {
         // arrange
+        var customDeathWatchProbe = CreateTestProbe();
         var watcher = Sys.ActorOf(act =>
         {
             act.Receive<string>((_, context) =>
             {
                 // complete the Ask
                 context.Sender.Tell("hi");
+
+                // DeathWatch the FutureActorRef<T> BEFORE it completes
+                context.Watch(context.Sender);
                 
                 // deliver the IActorRef of the Ask-er to TestActor
                 TestActor.Tell(context.Sender);
             });
+            
+            act.Receive<Terminated>((terminated, context) =>
+            {
+                // shut ourselves down to signal that we got our Terminated from FutureActorRef
+                context.Stop(context.Self);
+            });
         });
 
         // act
+        await customDeathWatchProbe.WatchAsync(watcher);
         await watcher.Ask<string>("boo", RemainingOrDefault);
         var futureActorRef = await ExpectMsgAsync<IActorRef>();
         await WatchAsync(futureActorRef); // Ask is finished - should immediately dead-letter
         
         // assert
         await ExpectTerminatedAsync(futureActorRef);
+        
+        // get the DeathWatch notification from the original actor
+        // this can only be received if the original actor got a Terminated message from FutureActorRef
+        await customDeathWatchProbe.ExpectTerminatedAsync(watcher);
     }
 }

--- a/src/core/Akka.Tests/Actor/Bugfix7501Specs.cs
+++ b/src/core/Akka.Tests/Actor/Bugfix7501Specs.cs
@@ -1,0 +1,49 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Bugfix7501Specs.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2025 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Dsl;
+using Akka.TestKit;
+using Akka.TestKit.TestActors;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Tests.Actor;
+
+public class Bugfix7501Specs : AkkaSpec
+{
+    public Bugfix7501Specs(ITestOutputHelper output) : base(output)
+    {
+        
+    }
+
+    [Fact]
+    public async Task FutureActorRefShouldSupportDeathWatch()
+    {
+        // arrange
+        var watcher = Sys.ActorOf(act =>
+        {
+            act.Receive<string>((_, context) =>
+            {
+                // complete the Ask
+                context.Sender.Tell("hi");
+                
+                // deliver the IActorRef of the Ask-er to TestActor
+                TestActor.Tell(context.Sender);
+            });
+        });
+
+        // act
+        await watcher.Ask<string>("boo", RemainingOrDefault);
+        var futureActorRef = await ExpectMsgAsync<IActorRef>();
+        await WatchAsync(futureActorRef); // Ask is finished - should immediately dead-letter
+        
+        // assert
+        await ExpectTerminatedAsync(futureActorRef);
+    }
+}

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -171,7 +171,10 @@ namespace Akka.Actor
             }
             else if (message is Unwatch unwatch)
             {
-                
+                // we're not going to support Unwatch - watchers
+                // already have to handle scenarios where the Unwatch arrives too late
+                // anyway, so we're just going to treat this like that in order to keep
+                // state management as simple as possible
             }
             else
             {

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -66,6 +66,23 @@ namespace Akka.Actor
     }
 
     /// <summary>
+    /// INTERNAL API - didn't want static helper methods declared inside generic class
+    /// </summary>
+    internal static class FutureActorRefDeathWatchSupport
+    {
+        internal static async Task ScheduleDeathWatch(IInternalActorRef notifier, IActorRef self, Task completionTask)
+        {
+            await completionTask;
+            notifier.SendSystemMessage(TerminatedFor(self));
+        }
+
+        internal static DeathWatchNotification TerminatedFor(IActorRef self)
+        {
+            return new DeathWatchNotification(self, true, false);
+        }
+    }
+
+    /// <summary>
     /// INTERNAL API.
     ///
     /// ActorRef implementation used for one-off tasks.
@@ -110,9 +127,6 @@ namespace Akka.Actor
             
             switch (message)
             {
-                case ISystemMessage msg:
-                    handled = _result.TrySetException(new InvalidOperationException($"system message of type '{msg.GetType().Name}' is invalid for {nameof(FutureActorRef<T>)}"));
-                    break;
                 case T t:
                     handled = _result.TrySetResult(t);
                     break;
@@ -140,7 +154,32 @@ namespace Akka.Actor
             if (!handled && !_result.Task.IsCanceled)
                 _provider.DeadLetters.Tell(message ?? default(T), this);            
         }
-        
+
+        public override void SendSystemMessage(ISystemMessage message)
+        {
+            if (message is Watch watch)
+            {
+                if (_result.Task.IsCompleted)
+                {
+                    watch.Watcher.SendSystemMessage(FutureActorRefDeathWatchSupport.TerminatedFor(this));
+                }
+                else
+                {
+                    _ = FutureActorRefDeathWatchSupport.ScheduleDeathWatch(watch.Watcher, watch.Watchee, _result.Task);
+                }
+                    
+            }
+            else if (message is Unwatch unwatch)
+            {
+                
+            }
+            else
+            {
+                // TODO: blow up the caller here by just throwing the exception at the callsite?
+                _result.TrySetException(new InvalidOperationException($"system message of type '{message.GetType().Name}' is invalid for {nameof(FutureActorRef<T>)}"));
+            }
+        }
+
         public virtual void DeliverAsk(object message, ICanTell destination){
             destination.Tell(message, this);
         }

--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -72,8 +72,20 @@ namespace Akka.Actor
     {
         internal static async Task ScheduleDeathWatch(IInternalActorRef notifier, IActorRef self, Task completionTask)
         {
-            await completionTask;
-            notifier.SendSystemMessage(TerminatedFor(self));
+            try
+            {
+                await completionTask;
+            }
+            catch
+            {
+                // we don't do error handling for this - we do not care
+            }
+            finally
+            {
+                // regardless of whether we succeeded or failed, we notify watchers
+                notifier.SendSystemMessage(TerminatedFor(self));
+            }
+            
         }
 
         internal static DeathWatchNotification TerminatedFor(IActorRef self)


### PR DESCRIPTION
## Changes

Fixes #7501 

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7501 

### Latest `dev` Benchmarks 

```ini
BenchmarkDotNet v0.13.12, Pop!_OS 22.04 LTS
13th Gen Intel Core i7-1360P, 1 CPU, 16 logical and 12 physical cores
.NET SDK 9.0.100
  [Host]  : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2
  LongRun : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2

Job=LongRun  Affinity=1111111111111111  Concurrent=True  
Server=True  InvocationCount=1  IterationCount=50  
LaunchCount=3  RunStrategy=Monitoring  UnrollFactor=1  
WarmupCount=25  
```

| Method   | ActorCount | Mean         | Error        | StdDev       | Median       | Ratio | RatioSD | Req/sec       |
|--------- |----------- |-------------:|-------------:|-------------:|-------------:|------:|--------:|--------------:|
| PushMsgs | 1          |     94.40 ns |     2.449 ns |     8.935 ns |     93.86 ns |  1.00 |    0.00 | 10,593,716.16 |
| AskMsgs  | 1          |    355.81 ns |    17.848 ns |    65.117 ns |    340.14 ns |  3.80 |    0.77 |  2,810,481.06 |
|          |            |              |              |              |              |       |         |               |
| PushMsgs | 10         |    336.78 ns |    78.794 ns |   287.466 ns |    294.31 ns |  1.00 |    0.00 |  2,969,279.03 |
| AskMsgs  | 10         |  2,715.52 ns |    74.493 ns |   271.775 ns |  2,757.84 ns |  9.50 |    2.72 |    368,253.95 |
|          |            |              |              |              |              |       |         |               |
| PushMsgs | 100        | 10,026.03 ns |   291.156 ns | 1,062.227 ns | 10,290.13 ns |  1.00 |    0.00 |     99,740.39 |
| AskMsgs  | 100        | 16,289.24 ns | 1,615.623 ns | 5,894.292 ns | 16,497.87 ns |  1.65 |    0.67 |     61,390.22 |

### This PR's Benchmarks

```ini
BenchmarkDotNet v0.13.12, Pop!_OS 22.04 LTS
13th Gen Intel Core i7-1360P, 1 CPU, 16 logical and 12 physical cores
.NET SDK 9.0.100
  [Host]  : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2
  LongRun : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2

Job=LongRun  Affinity=1111111111111111  Concurrent=True  
Server=True  InvocationCount=1  IterationCount=50  
LaunchCount=3  RunStrategy=Monitoring  UnrollFactor=1  
WarmupCount=25  
```

| Method   | ActorCount | Mean         | Error        | StdDev       | Median       | Ratio | RatioSD | Req/sec       |
|--------- |----------- |-------------:|-------------:|-------------:|-------------:|------:|--------:|--------------:|
| PushMsgs | 1          |     99.15 ns |     2.404 ns |     8.770 ns |     97.76 ns |  1.00 |    0.00 | 10,085,925.42 |
| AskMsgs  | 1          |    341.15 ns |    15.517 ns |    56.612 ns |    328.58 ns |  3.47 |    0.67 |  2,931,294.70 |
|          |            |              |              |              |              |       |         |               |
| PushMsgs | 10         |    318.01 ns |    60.932 ns |   222.297 ns |    283.28 ns |  1.00 |    0.00 |  3,144,519.95 |
| AskMsgs  | 10         |  2,632.51 ns |    87.963 ns |   320.915 ns |  2,736.53 ns |  9.28 |    2.52 |    379,865.83 |
|          |            |              |              |              |              |       |         |               |
| PushMsgs | 100        | 10,001.31 ns |   328.178 ns | 1,197.295 ns | 10,301.67 ns |  1.00 |    0.00 |     99,986.89 |
| AskMsgs  | 100        | 17,766.91 ns | 1,471.117 ns | 5,367.088 ns | 18,377.23 ns |  1.81 |    0.62 |     56,284.41 |
