### PR TITLE
Akka.Util: improve `Result<T>`

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -5494,26 +5494,37 @@ namespace Akka.Util
         public static Akka.Util.Option<T> op_Implicit(T value) { }
         public static bool !=(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class static Result
     {
-        public static Akka.Util.Result<T> Failure<T>(System.Exception exception) { }
-        public static Akka.Util.Result<T> From<T>(System.Func<T> func) { }
-        public static Akka.Util.Result<T> FromTask<T>(System.Threading.Tasks.Task<T> task) { }
-        public static Akka.Util.Result<T> Success<T>(T value) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                0,
+                1})]
+        public static Akka.Util.Result<T> Failure<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Exception exception) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                0,
+                1})]
+        public static Akka.Util.Result<T> From<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                0,
+                1})]
+        public static Akka.Util.Result<T> FromTask<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Threading.Tasks.Task<T> task) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                0,
+                1})]
+        public static Akka.Util.Result<T> Success<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(T value) { }
     }
-    public struct Result<T> : System.IEquatable<Akka.Util.Result<T>>
+    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
+    public struct Result<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : System.IEquatable<Akka.Util.Result<T>>
     {
-        public readonly System.Exception Exception;
-        public readonly bool IsSuccess;
-        public readonly T Value;
         public Result(T value) { }
         public Result(System.Exception exception) { }
-        public bool Equals(Akka.Util.Result<T> other) { }
-        public override bool Equals(object obj) { }
-        public override int GetHashCode() { }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public System.Exception Exception { get; }
+        public bool IsSuccess { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public T Value { get; }
         public override string ToString() { }
-        public static bool ==(Akka.Util.Result<T> left, Akka.Util.Result<T> right) { }
-        public static bool !=(Akka.Util.Result<T> left, Akka.Util.Result<T> right) { }
     }
     public class Right<T>
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -5517,13 +5517,13 @@ namespace Akka.Util
     [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
     public struct Result<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : System.IEquatable<Akka.Util.Result<T>>
     {
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public readonly System.Exception Exception;
+        public readonly bool IsSuccess;
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public readonly T Value;
         public Result(T value) { }
         public Result(System.Exception exception) { }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public System.Exception Exception { get; }
-        public bool IsSuccess { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public T Value { get; }
         public override string ToString() { }
     }
     public class Right<T>

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -5483,26 +5483,36 @@ namespace Akka.Util
         public static Akka.Util.Option<T> op_Implicit(T value) { }
         public static bool !=(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class static Result
     {
-        public static Akka.Util.Result<T> Failure<T>(System.Exception exception) { }
-        public static Akka.Util.Result<T> From<T>(System.Func<T> func) { }
-        public static Akka.Util.Result<T> FromTask<T>(System.Threading.Tasks.Task<T> task) { }
-        public static Akka.Util.Result<T> Success<T>(T value) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                0,
+                1})]
+        public static Akka.Util.Result<T> Failure<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Exception exception) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                0,
+                1})]
+        public static Akka.Util.Result<T> From<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                0,
+                1})]
+        public static Akka.Util.Result<T> FromTask<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Threading.Tasks.Task<T> task) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                0,
+                1})]
+        public static Akka.Util.Result<T> Success<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(T value) { }
     }
-    public struct Result<T> : System.IEquatable<Akka.Util.Result<T>>
+    public struct Result<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : System.IEquatable<Akka.Util.Result<T>>
     {
-        public readonly System.Exception Exception;
-        public readonly bool IsSuccess;
-        public readonly T Value;
         public Result(T value) { }
         public Result(System.Exception exception) { }
-        public bool Equals(Akka.Util.Result<T> other) { }
-        public override bool Equals(object obj) { }
-        public override int GetHashCode() { }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public System.Exception Exception { get; }
+        public bool IsSuccess { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public T Value { get; }
         public override string ToString() { }
-        public static bool ==(Akka.Util.Result<T> left, Akka.Util.Result<T> right) { }
-        public static bool !=(Akka.Util.Result<T> left, Akka.Util.Result<T> right) { }
     }
     public class Right<T>
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -5505,13 +5505,13 @@ namespace Akka.Util
     }
     public struct Result<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : System.IEquatable<Akka.Util.Result<T>>
     {
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public readonly System.Exception Exception;
+        public readonly bool IsSuccess;
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public readonly T Value;
         public Result(T value) { }
         public Result(System.Exception exception) { }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public System.Exception Exception { get; }
-        public bool IsSuccess { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public T Value { get; }
         public override string ToString() { }
     }
     public class Right<T>

--- a/src/core/Akka.Tests/Util/ResultSpec.cs
+++ b/src/core/Akka.Tests/Util/ResultSpec.cs
@@ -118,6 +118,27 @@ public class ResultSpec
             .Should().Throw<ArgumentException>().WithMessage("Task is not completed.*");
     }
     
+    [Fact]
+    public void ResultEqualitySpec()
+    {
+        var result1 = Result.Success(1);
+        var result2 = Result.Success(1);
+        var exception = new TestException("BOOM"); // equality by value does not work for exceptions
+        var result3 = Result.Failure<int>(exception);
+        var result4 = Result.Failure<int>(exception);
+        var result5 = Result.Success("foo");
+        var result6 = Result.Success("bar");
+        var result51 = Result.Success("foo");
+        
+        result1.Equals(result2).Should().BeTrue();
+        result1.Equals(result3).Should().BeFalse();
+        result3.Equals(result4).Should().BeTrue();
+        result5.Equals(result51).Should().BeTrue();
+        (result5 == result51).Should().BeTrue(); // test operator overloads
+        (result5 == result6).Should().BeFalse(); // test operator overloads
+        (result5 != result6).Should().BeTrue(); // test operator overloads
+    }
+    
     private static Task<int> CompletedTask(int n)
     {
         var tcs = new TaskCompletionSource<int>();

--- a/src/core/Akka/Util/Result.cs
+++ b/src/core/Akka/Util/Result.cs
@@ -19,27 +19,24 @@ namespace Akka.Util
         /// <summary>
         /// <c>true</c> if the result is successful, <c>false</c> otherwise.
         /// </summary>
-        public bool IsSuccess { get; }
-        
+        public readonly bool IsSuccess;
+
         /// <summary>
         /// <c>null</c> when <see cref="IsSuccess"/> is <c>false</c>.
         /// </summary>
-        public T? Value { get; }
-        
+        public readonly T? Value;
+
         /// <summary>
         /// <c>null</c> when <see cref="IsSuccess"/> is <c>true</c>.
         /// </summary>
-        public Exception? Exception { get; }
+        public readonly Exception? Exception;
         
         public Result(T value) : this()
         {
             IsSuccess = true;
             Value = value;
         }
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="exception">TBD</param>
+
         public Result(Exception exception) : this()
         {
             IsSuccess = false;

--- a/src/core/Akka/Util/Result.cs
+++ b/src/core/Akka/Util/Result.cs
@@ -7,37 +7,30 @@
 
 using System;
 using System.Threading.Tasks;
+#nullable enable
 
 namespace Akka.Util
 {
-    //A generic type can't have a explicit layout
-    //[StructLayout(LayoutKind.Explicit)]
     /// <summary>
-    /// TBD
+    /// A result type frequently used inside Akka.Streams and elsewhere.
     /// </summary>
-    /// <typeparam name="T">TBD</typeparam>
-    public struct Result<T> : IEquatable<Result<T>>
+    public readonly record struct Result<T>
     {
-        //[FieldOffset(0)]
         /// <summary>
-        /// TBD
+        /// <c>true</c> if the result is successful, <c>false</c> otherwise.
         /// </summary>
-        public readonly bool IsSuccess;
-        //[FieldOffset(1)]
+        public bool IsSuccess { get; }
+        
         /// <summary>
-        /// TBD
+        /// <c>null</c> when <see cref="IsSuccess"/> is <c>false</c>.
         /// </summary>
-        public readonly T Value;
-        //[FieldOffset(1)]
+        public T? Value { get; }
+        
         /// <summary>
-        /// TBD
+        /// <c>null</c> when <see cref="IsSuccess"/> is <c>true</c>.
         /// </summary>
-        public readonly Exception Exception;
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="value">TBD</param>
+        public Exception? Exception { get; }
+        
         public Result(T value) : this()
         {
             IsSuccess = true;
@@ -52,89 +45,25 @@ namespace Akka.Util
             IsSuccess = false;
             Exception = exception;
         }
-
         
-        public bool Equals(Result<T> other)
-        {
-            if (IsSuccess ^ other.IsSuccess) return false;
-            return IsSuccess
-                ? Equals(Value, other.Value)
-                : Equals(Exception, other.Exception);
-        }
-
-        
-        public override bool Equals(object obj)
-        {
-            if (obj is Result<T> result) return Equals(result);
-            return false;
-        }
-
-        
-        public override int GetHashCode()
-        {
-            return IsSuccess
-                ? (Value == null ? 0 : Value.GetHashCode())
-                : (Exception == null ? 0 : Exception.GetHashCode());
-        }
-
-        /// <summary>
-        /// Compares two specified <see cref="Result{T}"/> for equality.
-        /// </summary>
-        /// <param name="left">The first <see cref="Result{T}"/> used for comparison</param>
-        /// <param name="right">The second <see cref="Result{T}"/> used for comparison</param>
-        /// <returns><c>true</c> if both <see cref="Result{T}"/> are equal; otherwise <c>false</c></returns>
-        public static bool operator ==(Result<T> left, Result<T> right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Compares two specified <see cref="Result{T}"/> for inequality.
-        /// </summary>
-        /// <param name="left">The first <see cref="Result{T}"/> used for comparison</param>
-        /// <param name="right">The second <see cref="Result{T}"/> used for comparison</param>
-        /// <returns><c>true</c> if both <see cref="Result{T}"/> are not equal; otherwise <c>false</c></returns>
-        public static bool operator !=(Result<T> left, Result<T> right)
-        {
-            return !(left == right);
-        }
-
         public override string ToString() => IsSuccess ? $"Success ({Value})" : $"Failure ({Exception})";
     }
 
     /// <summary>
-    /// TBD
+    /// Helper methods for creating <see cref="Result{T}"/> instances.
     /// </summary>
     public static class Result
     {
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <typeparam name="T">TBD</typeparam>
-        /// <param name="value">TBD</param>
-        /// <returns>TBD</returns>
         public static Result<T> Success<T>(T value)
         {
             return new Result<T>(value);
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <typeparam name="T">TBD</typeparam>
-        /// <param name="exception">TBD</param>
-        /// <returns>TBD</returns>
+        
         public static Result<T> Failure<T>(Exception exception)
         {
             return new Result<T>(exception);
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <typeparam name="T">TBD</typeparam>
-        /// <param name="task">TBD</param>
-        /// <returns>TBD</returns>
+        
         public static Result<T> FromTask<T>(Task<T> task)
         {
             if(!task.IsCompleted)
@@ -143,7 +72,7 @@ namespace Akka.Util
             if(task.Exception is not null)
                 return new Result<T>(task.Exception);
             
-            if (task.IsCanceled && task.Exception is null)
+            if (task is { IsCanceled: true, Exception: null })
             {
                 try
                 {
@@ -157,18 +86,12 @@ namespace Akka.Util
                 throw new InvalidOperationException("Should never reach this line!");
             }
             
-            if(task.IsFaulted && task.Exception is null)
+            if(task is { IsFaulted: true, Exception: null })
                 throw new InvalidOperationException("Should never happen! something is wrong with .NET Task code!");
             
             return new Result<T>(task.Result);
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <typeparam name="T">TBD</typeparam>
-        /// <param name="func">TBD</param>
-        /// <returns>TBD</returns>
+        
         public static Result<T> From<T>(Func<T> func)
         {
             try
@@ -181,8 +104,5 @@ namespace Akka.Util
                 return new Result<T>(e);
             }
         }
-        
-        
-
     }
 }


### PR DESCRIPTION
## Changes

Designed to support our work on https://github.com/akkadotnet/akka.net/issues/7518

Makes the following changes to `Result<T>`:

- Enables nullability
- Converts fields to properties (should have been that way from the beginning IMHO) - this _might_ be a binary compatibility issue but I doubt it though as this is mostly used internally by Akka.Streams and other components.
- Redesigns the `struct` to be a `readonly record struct` so it an automatically benefit from equality by value and other compiler optimizations

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.
