### PR TITLE
Resolve Akka.Delivery and Akka.Cluster.Sharding.Delivery issues

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/ReliableDeliveryShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/ReliableDeliveryShardingSpec.cs
@@ -76,7 +76,7 @@ public class ReliableDeliveryShardingSpec : TestKit.Xunit2.TestKit
             $"producer-{_idCount}");
 
         // expecting 3 end messages, one for each entity: "entity-0", "entity-1", "entity-2"
-        await consumerEndProbe.ReceiveNAsync(3, TimeSpan.FromSeconds(5)).ToListAsync();
+        await consumerEndProbe.ReceiveNAsync(3, TimeSpan.FromSeconds(10)).ToListAsync();
     }
 
     [Fact]

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/Internal/ShardingProducerControllerImpl.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/Internal/ShardingProducerControllerImpl.cs
@@ -350,9 +350,10 @@ internal sealed class ShardingProducerController<T> : ReceiveActor, IWithStash, 
             {
                 switch (c)
                 {
-                    case (_, outSeqNr, { IsEmpty: true }): // no reply
+                    
+                    case (_, _, { IsEmpty: true }): // no reply
                         break;
-                    case (_, outSeqNr, { IsEmpty: false } replyTo):
+                    case (_, var outSeqNr, { IsEmpty: false } replyTo):
                         replyTo.Value.Tell(outSeqNr);  // Send the sequence number instead of Done.Instance
                         break;
                 }
@@ -539,7 +540,7 @@ internal sealed class ShardingProducerController<T> : ReceiveActor, IWithStash, 
         var self = Self;
 
         DurableQueueRef.Value.Ask<DurableProducerQueue.StoreMessageSentAck>(Mapper,
-                askTimeout, cancellationToken: default)
+                askTimeout, cancellationToken: CancellationToken.None)
             .PipeTo(self, success: _ => new StoreMessageSentCompleted<T>(messageSent),
                 failure: _ => new StoreMessageSentFailed<T>(messageSent, attempt));
     }
@@ -559,11 +560,6 @@ internal sealed class ShardingProducerController<T> : ReceiveActor, IWithStash, 
         if (_log.IsDebugEnabled) // TODO: add trace support
             _log.Debug("Sending [{0}] to [{1}] with outSeqNr [{2}]", msg?.GetType().Name, nextTo, outSeqNr);
 
-        ProducerController.MessageWithConfirmation<T> Transform(IActorRef askTarget)
-        {
-            return new ProducerController.MessageWithConfirmation<T>(msg, askTarget);
-        }
-
         var self = Self;
         nextTo.Ask<long>(Transform, Settings.InternalAskTimeout, CancellationToken.None)
             .PipeTo(self, success: seqNr =>
@@ -573,6 +569,12 @@ internal sealed class ShardingProducerController<T> : ReceiveActor, IWithStash, 
                     return new Ack(outKey, seqNr);
                 },
                 failure: _ => new AskTimeout(outKey, outSeqNr));
+        return;
+
+        ProducerController.MessageWithConfirmation<T> Transform(IActorRef askTarget)
+        {
+            return new ProducerController.MessageWithConfirmation<T>(msg, askTarget);
+        }
     }
 
     private static Option<DurableProducerQueue.State<T>> CreateInitialState(bool hasDurableQueue)
@@ -602,12 +604,13 @@ internal sealed class ShardingProducerController<T> : ReceiveActor, IWithStash, 
         var loadTimeout = Settings.ProducerControllerSettings.DurableQueueRequestTimeout;
         durableProducerQueue.OnSuccess(@ref =>
         {
-            DurableProducerQueue.LoadState Mapper(IActorRef r) => new(r);
-
             var self = Self;
             @ref.Ask<DurableProducerQueue.State<T>>(Mapper, timeout: loadTimeout, cancellationToken: default)
                 .PipeTo(self, success: state => new LoadStateReply<T>(state),
                     failure: _ => new LoadStateFailed(attempt)); // timeout
+            return;
+
+            DurableProducerQueue.LoadState Mapper(IActorRef r) => new(r);
         });
     }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/Internal/ShardingProducerControllerImpl.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/Internal/ShardingProducerControllerImpl.cs
@@ -350,10 +350,10 @@ internal sealed class ShardingProducerController<T> : ReceiveActor, IWithStash, 
             {
                 switch (c)
                 {
-                    case (_, _, { IsEmpty: true }): // no reply
+                    case (_, outSeqNr, { IsEmpty: true }): // no reply
                         break;
-                    case (_, _, { IsEmpty: false } replyTo):
-                        replyTo.Value.Tell(Done.Instance);
+                    case (_, outSeqNr, { IsEmpty: false } replyTo):
+                        replyTo.Value.Tell(outSeqNr);  // Send the sequence number instead of Done.Instance
                         break;
                 }
             }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/ShardingProducerController.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/ShardingProducerController.cs
@@ -95,12 +95,12 @@ public static class ShardingProducerController
         /// <returns>A task that will complete once the message has been successfully persisted by the <see cref="ProducerController"/>.</returns>
         public Task<long> AskNextTo(EntityId entityId, T msg, CancellationToken cancellationToken = default)
         {
+            return AskNextToRef.Ask<long>(Wrapper, cancellationToken: cancellationToken, timeout: null);
+
             MessageWithConfirmation<T> Wrapper(IActorRef r)
             {
                 return new MessageWithConfirmation<T>(entityId, msg, r);
             }
-
-            return AskNextToRef.Ask<long>(Wrapper, cancellationToken: cancellationToken, timeout: null);
         }
 
         /// <summary>

--- a/src/core/Akka/Delivery/Internal/ConsumerControllerImpl.cs
+++ b/src/core/Akka/Delivery/Internal/ConsumerControllerImpl.cs
@@ -667,7 +667,11 @@ internal sealed class ConsumerController<T> : ReceiveActor, IWithTimers, IWithSt
             var newInterval = Interval == MaxBackoff
                 ? MaxBackoff
                 : MaxBackoff.Min(TimeSpan.FromSeconds(Interval.TotalSeconds * 1.5));
-            if (newInterval != Interval) Timers.StartPeriodicTimer(Retry.Instance, Retry.Instance, newInterval);
+            if (newInterval != Interval)
+            {
+                Interval = newInterval;  // Store the new interval
+                Timers.StartPeriodicTimer(Retry.Instance, Retry.Instance, newInterval);
+            }
         }
 
         public void Reset()


### PR DESCRIPTION
## Changes

Fix #7529, Fix #7530: Fix ShardingProducerController and RetryTimer issues

- Fix #7529: Update ShardingProducerController to return sequence numbers instead of Done.Instance in AskNextTo responses to match Task<long> return type
- Fix #7530: Properly store and increment RetryTimer interval in ScheduleNext() method to enable exponential backoff

This commit addresses two issues in the Akka.Cluster.Sharding.Delivery module:

1. Fixes type mismatch in ShardingProducerController where AskNextTo was returning Done.Instance instead of the expected sequence number
2. Fixes RetryTimer not properly incrementing intervals by storing the new interval value before starting the timer

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
