### PR TITLE
CodeQL: fix `net48` breakage

### DIFF
--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -65,7 +65,7 @@ akka.stream.materializer.subscription-timeout.timeout = 2s", helper)
         public async Task Outgoing_TCP_stream_must_be_able_to_write_a_sequence_of_ByteStrings()
         {
             var server = await new Server(this).InitializeAsync();
-            var testInput = Enumerable.Range(0, 256).Select(i => ByteString.FromBytes(new[] {Convert.ToByte(i)}));
+            var testInput = Enumerable.Range(0, 256).Select(i => ByteString.FromBytes(new byte[] {Convert.ToByte(i)}));
             var expectedOutput = ByteString.FromBytes(Enumerable.Range(0, 256).Select(Convert.ToByte).ToArray());
 
             Source.From(testInput)
@@ -466,7 +466,7 @@ akka.stream.materializer.subscription-timeout.timeout = 2s", helper)
                     .Run(Materializer);
 
             var result = await Source.From(Enumerable.Repeat(0, 1000)
-                .Select(i => ByteString.FromBytes(new[] {Convert.ToByte(i)})))
+                .Select(i => ByteString.FromBytes(new byte[] { Convert.ToByte(i) })))
                 .Via(Sys.TcpStream().OutgoingConnection(serverAddress, halfClose: true))
                 .RunAggregate(0, (i, s) => i + s.Count, Materializer).ShouldCompleteWithin(10.Seconds());
             
@@ -573,7 +573,7 @@ akka.stream.materializer.subscription-timeout.timeout = 2s", helper)
             var binding = await bindTask.ShouldCompleteWithin(3.Seconds());
 
             var testInput = Enumerable.Range(0, 255)
-                .Select(i => ByteString.FromBytes(new[] {Convert.ToByte(i)}))
+                .Select(i => ByteString.FromBytes(new byte[] { Convert.ToByte(i) }))
                 .ToList();
 
             var expectedOutput = testInput.Aggregate(ByteString.Empty, (agg, b) => agg.Concat(b));
@@ -603,7 +603,7 @@ akka.stream.materializer.subscription-timeout.timeout = 2s", helper)
             var echoConnection = Sys.TcpStream().OutgoingConnection(serverAddress);
 
             var testInput = Enumerable.Range(0, 255)
-                .Select(i => ByteString.FromBytes([Convert.ToByte(i)]))
+                .Select(i => ByteString.FromBytes(new byte[] { Convert.ToByte(i) }))
                 .ToList();
 
             var expectedOutput = testInput.Aggregate(ByteString.Empty, (agg, b) => agg.Concat(b));

--- a/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
@@ -341,7 +341,7 @@ namespace Akka.Tests.IO
                 var clients = indexRange.Select(i => (Index: i, Probe: CreateTestProbe($"test-client-{i}"))).ToArray();
                 Parallel.ForEach(clients, client =>
                 {
-                    var msg = ByteString.FromBytes(new byte[1]);
+                    var msg = ByteString.FromBytes(new byte[] {(byte) 0});
                     client.Probe.Send(actors.ClientConnection, Tcp.Write.Create(msg, AckWithValue.Create(client.Index)));
                 });
                 
@@ -519,7 +519,7 @@ namespace Akka.Tests.IO
 
         private async Task ChitChat(TestSetup.ConnectionDetail actors, int rounds = 100)
         {
-            var testData = ByteString.FromBytes(new[] {(byte) 0});
+            var testData = ByteString.FromBytes(new byte[] {(byte) 0});
             for (int i = 0; i < rounds; i++)
             {
                 actors.ClientHandler.Send(actors.ClientConnection, Tcp.Write.Create(testData));


### PR DESCRIPTION

## Changes

Accidentally broke CodeQL on https://github.com/akkadotnet/akka.net/pull/7539 due to a syntax change that Mono does not support.
