### PR TITLE
Akka.Persistence.Query.InMemory.Tests: standardize `refresh-interval`

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
@@ -13,12 +13,8 @@ namespace Akka.Persistence.Query.InMemory.Tests
 {
     public class InMemoryAllEventsSpec : AllEventsSpec
     {
-        private static Config Config() => ConfigurationFactory.ParseString(@"
-            akka.loglevel = INFO
-            akka.persistence.query.journal.inmem.refresh-interval = 1s
-            akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
-            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""")
-            .WithFallback(InMemoryReadJournal.DefaultConfiguration());
+        private static Config Config() => ConfigurationFactory.ParseString("akka.loglevel = INFO")
+            .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryAllEventsSpec(ITestOutputHelper output) : base(Config(), nameof(InMemoryAllEventsSpec), output)
         {

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentAllEventsSpec.cs
@@ -13,12 +13,8 @@ namespace Akka.Persistence.Query.InMemory.Tests
 {
     public class InMemoryCurrentAllEventsSpec : CurrentAllEventsSpec
     {
-        private static Config Config() => ConfigurationFactory.ParseString(@"
-            akka.loglevel = INFO
-            akka.persistence.query.journal.inmem.refresh-interval = 1s
-            akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
-            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""")
-            .WithFallback(InMemoryReadJournal.DefaultConfiguration());
+        private static Config Config() => ConfigurationFactory.ParseString("akka.loglevel = INFO")
+            .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryCurrentAllEventsSpec(ITestOutputHelper output) : base(Config(), nameof(InMemoryCurrentAllEventsSpec), output)
         {

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByPersistenceIdSpec.cs
@@ -13,11 +13,8 @@ namespace Akka.Persistence.Query.InMemory.Tests
 {
     public class InMemoryCurrentEventsByPersistenceIdSpec : CurrentEventsByPersistenceIdSpec
     {
-        private static Config Config() => ConfigurationFactory.ParseString(@"
-            akka.loglevel = INFO
-            akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
-            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""")
-            .WithFallback(InMemoryReadJournal.DefaultConfiguration());
+        private static Config Config() => ConfigurationFactory.ParseString("akka.loglevel = INFO")
+            .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryCurrentEventsByPersistenceIdSpec(ITestOutputHelper output) : 
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByTagSpec.cs
@@ -15,8 +15,6 @@ namespace Akka.Persistence.Query.InMemory.Tests
     {
         private static Config Config() => ConfigurationFactory.ParseString(@"
             akka.loglevel = INFO
-            akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
-            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
             akka.persistence.journal.inmem {
                 event-adapters {
                   color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
@@ -25,7 +23,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
                   ""System.String"" = color-tagger
                 }
             }")
-            .WithFallback(InMemoryReadJournal.DefaultConfiguration());
+            .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryCurrentEventsByTagSpec(ITestOutputHelper output) : 
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentPersistenceIdsSpec.cs
@@ -13,11 +13,8 @@ namespace Akka.Persistence.Query.InMemory.Tests
 {
     public class InMemoryCurrentPersistenceIdsSpec : CurrentPersistenceIdsSpec
     {
-        private static Config Config() => ConfigurationFactory.ParseString(@"
-            akka.loglevel = INFO
-            akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
-            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""")
-            .WithFallback(InMemoryReadJournal.DefaultConfiguration());
+        private static Config Config() => ConfigurationFactory.ParseString("akka.loglevel = INFO")
+            .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryCurrentPersistenceIdsSpec(ITestOutputHelper output) : 
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByPersistenceIdSpec.cs
@@ -13,12 +13,8 @@ namespace Akka.Persistence.Query.InMemory.Tests
 {
     public class InMemoryEventsByPersistenceIdSpec : EventsByPersistenceIdSpec
     {
-        private static Config Config() => ConfigurationFactory.ParseString(@"
-            akka.loglevel = INFO
-            akka.persistence.query.journal.inmem.refresh-interval = 1s
-            akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
-            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""")
-            .WithFallback(InMemoryReadJournal.DefaultConfiguration());
+        private static Config Config() => ConfigurationFactory.ParseString("akka.loglevel = INFO")
+            .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryEventsByPersistenceIdSpec(ITestOutputHelper output) :
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
@@ -15,8 +15,6 @@ namespace Akka.Persistence.Query.InMemory.Tests
     {
         private static Config Config() => ConfigurationFactory.ParseString(@"
             akka.loglevel = INFO
-            akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
-            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
             akka.persistence.journal.inmem {
                 event-adapters {
                   color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK""
@@ -25,7 +23,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
                   ""System.String"" = color-tagger
                 }
             }")
-            .WithFallback(InMemoryReadJournal.DefaultConfiguration());
+            .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryEventsByTagSpec(ITestOutputHelper output) : 
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceIdsSpec.cs
@@ -15,11 +15,8 @@ namespace Akka.Persistence.Query.InMemory.Tests
     public class InMemoryPersistenceIdsSpec : PersistenceIdsSpec
     {
         private static Config Config() => ConfigurationFactory.ParseString(@"
-            akka.loglevel = INFO
-            akka.persistence.query.journal.inmem.refresh-interval = 1s
-            akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
-            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""")
-            .WithFallback(InMemoryReadJournal.DefaultConfiguration());
+            akka.loglevel = INFO")
+            .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
 
         public InMemoryPersistenceIdsSpec(ITestOutputHelper output) : base(Config(), nameof(InMemoryPersistenceIdsSpec), output)

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceSpecConfig.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceSpecConfig.cs
@@ -1,0 +1,24 @@
+// -----------------------------------------------------------------------
+//  <copyright file="InMemoryPersistenceSpecConfig.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2025 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using Akka.Configuration;
+
+namespace Akka.Persistence.Query.InMemory.Tests;
+
+public static class InMemoryPersistenceSpecConfig
+{
+    /// <summary>
+    /// Sets the refresh interval to 1s and uses the in-memory journal and snapshot store.
+    /// </summary>
+    public static readonly Config Config = ConfigurationFactory.ParseString("""
+                                                                            
+                                                                                        akka.persistence.query.journal.inmem.refresh-interval = 1s
+                                                                                        akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+                                                                                        akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.inmem"
+                                                                            """)
+        .WithFallback(InMemoryReadJournal.DefaultConfiguration());
+}

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory/EventsByPersistenceIdPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory/EventsByPersistenceIdPublisher.cs
@@ -73,13 +73,13 @@ namespace Akka.Persistence.Query.InMemory
         {
             switch (message)
             {
-                case EventsByPersistenceIdPublisher.Continue _:
+                case EventsByPersistenceIdPublisher.Continue:
                     // no-op
                     return true;
-                case Request _:
+                case Request:
                     Replay();
                     return true;
-                case Cancel _:
+                case Cancel:
                     Context.Stop(Self);
                     return true;
                 default:

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory/InMemoryReadJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory/InMemoryReadJournal.cs
@@ -129,8 +129,8 @@ namespace Akka.Persistence.Query.InMemory
             Sequence seq;
             switch (offset)
             {
-                case NoOffset _:
-                case Sequence s when s.Value == 0:
+                case NoOffset:
+                case Sequence { Value: 0 }:
                     seq = new Sequence(0L);
                     break;
                 case Sequence s:

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -91,13 +91,13 @@ namespace Akka.Persistence.Journal
                     var persistentRepresentation = p.WithTimestamp(DateTime.UtcNow.Ticks);
                     Add(persistentRepresentation);
                     _allMessages.AddLast(persistentRepresentation);
-                    if (!(p.Payload is Tagged tagged)) continue;
+                    if (p.Payload is not Tagged tagged) continue;
                     
                     foreach (var tag in tagged.Tags)
                     {
                         _tagsToMessagesMapping.AddOrUpdate(
                             tag,
-                            (_) => new LinkedList<IPersistentRepresentation>(new[] { persistentRepresentation }),
+                            (_) => new LinkedList<IPersistentRepresentation>([persistentRepresentation]),
                             (_, v) =>
                             {
                                 v.AddLast(persistentRepresentation);
@@ -107,7 +107,7 @@ namespace Akka.Persistence.Journal
                 }
             }
             
-            return Task.FromResult((IImmutableList<Exception>) null); // all good
+            return Task.FromResult<IImmutableList<Exception>>(null); // all good
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Akka.Persistence.Journal
         /// <returns>TBD</returns>
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
         {
-            return Task.FromResult(Math.Max(HighestSequenceNr(persistenceId), _meta.TryGetValue(persistenceId, out long metaSeqNr) ? metaSeqNr : 0L));
+            return Task.FromResult(Math.Max(HighestSequenceNr(persistenceId), _meta.GetValueOrDefault(persistenceId, 0L)));
         }
 
         /// <summary>
@@ -264,46 +264,23 @@ namespace Akka.Persistence.Journal
                 HighestOrderingNumber = highestOrderingNumber;
             }
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
+        
         [Serializable]
         public sealed class ReplayTaggedMessages : IJournalRequest
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public readonly int FromOffset;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public readonly int ToOffset;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public readonly int Max;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public readonly string Tag;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public readonly IActorRef ReplyTo;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="ReplayTaggedMessages"/> class.
             /// </summary>
-            /// <param name="fromOffset">TBD</param>
-            /// <param name="toOffset">TBD</param>
-            /// <param name="max">TBD</param>
-            /// <param name="tag">TBD</param>
-            /// <param name="replyTo">TBD</param>
             /// <exception cref="ArgumentException">
             /// This exception is thrown for a number of reasons. These include the following:
             /// <ul>
@@ -334,32 +311,17 @@ namespace Akka.Persistence.Journal
                 ReplyTo = replyTo;
             }
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
+        
         [Serializable]
         public sealed class ReplayedTaggedMessage : INoSerializationVerificationNeeded, IDeadLetterSuppression
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public readonly IPersistentRepresentation Persistent;
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public readonly string Tag;
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public readonly int Offset;
 
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="persistent">TBD</param>
-            /// <param name="tag">TBD</param>
-            /// <param name="offset">TBD</param>
+            public readonly IPersistentRepresentation Persistent;
+
+            public readonly string Tag;
+
+            public readonly int Offset;
+            
             public ReplayedTaggedMessage(IPersistentRepresentation persistent, string tag, int offset)
             {
                 Persistent = persistent;
@@ -368,36 +330,20 @@ namespace Akka.Persistence.Journal
             }
         }
         
-        /// <summary>
-        /// TBD
-        /// </summary>
         [Serializable]
         public sealed class ReplayAllEvents : IJournalRequest
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public readonly int FromOffset;
-            /// <summary>
-            /// TBD
-            /// </summary>
+
             public readonly int ToOffset;
-            /// <summary>
-            /// TBD
-            /// </summary>
+
             public readonly long Max;
-            /// <summary>
-            /// TBD
-            /// </summary>
+
             public readonly IActorRef ReplyTo;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="ReplayAllEvents"/> class.
             /// </summary>
-            /// <param name="fromOffset">TBD</param>
-            /// <param name="toOffset">TBD</param>
-            /// <param name="max">TBD</param>
-            /// <param name="replyTo">TBD</param>
             /// <exception cref="ArgumentException">
             /// This exception is thrown for a number of reasons. These include the following:
             /// <ul>
@@ -419,36 +365,22 @@ namespace Akka.Persistence.Journal
             }
         }
         
-        /// <summary>
-        /// TBD
-        /// </summary>
+
         [Serializable]
         public sealed class ReplayedEvent : INoSerializationVerificationNeeded, IDeadLetterSuppression
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public readonly IPersistentRepresentation Persistent;
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public readonly int Offset;
 
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="persistent">TBD</param>
-            /// <param name="offset">TBD</param>
+            public readonly IPersistentRepresentation Persistent;
+
+            public readonly int Offset;
+            
             public ReplayedEvent(IPersistentRepresentation persistent, int offset)
             {
                 Persistent = persistent;
                 Offset = offset;
             }
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
+        
         [Serializable]
         public sealed class ReplayTaggedMessagesSuccess
         {
@@ -463,9 +395,6 @@ namespace Akka.Persistence.Journal
             public int HighestSequenceNr { get; }
         }
         
-        /// <summary>
-        /// TBD
-        /// </summary>
         [Serializable]
         public sealed class EventReplaySuccess
         {
@@ -521,8 +450,7 @@ namespace Akka.Persistence.Journal
         
             public override bool Equals(object obj)
             {
-                if (!(obj is EventReplayFailure f)) return false;
-                return Equals(f);
+                return obj is EventReplayFailure f && Equals(f);
             }
 
         
@@ -633,17 +561,11 @@ namespace Akka.Persistence.Journal
 
         #endregion
     }
-
-    /// <summary>
-    /// TBD
-    /// </summary>
+    
     public class SharedMemoryJournal : MemoryJournal
     {
         private static readonly ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>> SharedMessages = new();
-
-        /// <summary>
-        /// TBD
-        /// </summary>
+        
         protected override ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>> Messages { get { return SharedMessages; } }
     }
 }


### PR DESCRIPTION
## Changes

This test suite can be racy because some of the specs have a `3s` refresh interval and 3s assertion times. Reduced to 1s across the board - and made all tests leverage the same configuration so it's easy to change.

Also cleaned up some `TBD` spam from the `MemoryJournal` in Akka.Persistence

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).