### PR TITLE
Fix racy `PersistentFsmSpec`s

### DIFF
--- a/src/core/Akka.Persistence.Tests/Fsm/PersistentFSMSpec.cs
+++ b/src/core/Akka.Persistence.Tests/Fsm/PersistentFSMSpec.cs
@@ -297,27 +297,27 @@ namespace Akka.Persistence.Tests.Fsm
         }
 
         [Fact]
-        public void PersistentFSM_must_not_trigger_onTransition_for_stay()
+        public async Task PersistentFSM_must_not_trigger_onTransition_for_stay()
         {
             var probe = CreateTestProbe(Sys);
             var fsmRef = Sys.ActorOf(SimpleTransitionFSM.Props(Name, probe.Ref));
 
-            probe.ExpectMsg("LookingAround -> LookingAround", 3.Seconds()); // caused by initialize(), OK
+            await probe.ExpectMsgAsync("LookingAround -> LookingAround", 3.Seconds()); // caused by initialize(), OK
 
             fsmRef.Tell("goto(the same state)"); // causes goto()
-            probe.ExpectMsg("LookingAround -> LookingAround", 3.Seconds());
+            await probe.ExpectMsgAsync("LookingAround -> LookingAround", 3.Seconds());
 
             fsmRef.Tell("stay");
-            probe.ExpectNoMsg(3.Seconds());
+            await probe.ExpectNoMsgAsync(3.Seconds());
         }
 
         [Fact]
-        public void PersistentFSM_must_not_persist_state_change_event_when_staying_in_the_same_state()
+        public async Task PersistentFSM_must_not_persist_state_change_event_when_staying_in_the_same_state()
         {
             var dummyReportActorRef = CreateTestProbe().Ref;
 
             var fsmRef = Sys.ActorOf(WebStoreCustomerFSM.Props(Name, dummyReportActorRef));
-            Watch(fsmRef);
+            await WatchAsync(fsmRef);
 
             var shirt = new Item("1", "Shirt", 59.99F);
             var shoes = new Item("2", "Shoes", 89.99F);
@@ -331,38 +331,38 @@ namespace Akka.Persistence.Tests.Fsm
             fsmRef.Tell(new AddItem(coat));
             fsmRef.Tell(new GetCurrentCart());
 
-            ExpectMsg<EmptyShoppingCart>();
+            await ExpectMsgAsync<EmptyShoppingCart>();
 
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes, coat);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes, coat);
 
             fsmRef.Tell(PoisonPill.Instance);
-            ExpectTerminated(fsmRef);
+            await ExpectTerminatedAsync(fsmRef);
 
             var persistentEventsStreamer = Sys.ActorOf(PersistentEventsStreamer.Props(Name, TestActor));
 
-            ExpectMsg<ItemAdded>().Item.Should().Be(shirt);
-            ExpectMsg<PersistentFSM.StateChangeEvent>();
+            (await ExpectMsgAsync<ItemAdded>()).Item.Should().Be(shirt);
+            await ExpectMsgAsync<PersistentFSM.StateChangeEvent>();
 
-            ExpectMsg<ItemAdded>().Item.Should().Be(shoes);
-            ExpectMsg<PersistentFSM.StateChangeEvent>();
+            (await ExpectMsgAsync<ItemAdded>()).Item.Should().Be(shoes);
+            await ExpectMsgAsync<PersistentFSM.StateChangeEvent>();
+            
+            (await ExpectMsgAsync<ItemAdded>()).Item.Should().Be(coat);
+            await ExpectMsgAsync<PersistentFSM.StateChangeEvent>();
 
-            ExpectMsg<ItemAdded>().Item.Should().Be(coat);
-            ExpectMsg<PersistentFSM.StateChangeEvent>();
-
-            Watch(persistentEventsStreamer);
+            await WatchAsync(persistentEventsStreamer);
             persistentEventsStreamer.Tell(PoisonPill.Instance);
-            ExpectTerminated(persistentEventsStreamer);
+            await ExpectTerminatedAsync(persistentEventsStreamer);
         }
 
         [Fact]
-        public void PersistentFSM_must_persist_snapshot()
+        public async Task PersistentFSM_must_persist_snapshot()
         {
             var dummyReportActorRef = CreateTestProbe().Ref;
 
             var fsmRef = Sys.ActorOf(WebStoreCustomerFSM.Props(Name, dummyReportActorRef));
-            Watch(fsmRef);
+            await WatchAsync(fsmRef);
 
             var shirt = new Item("1", "Shirt", 59.99F);
             var shoes = new Item("2", "Shoes", 89.99F);
@@ -378,37 +378,37 @@ namespace Akka.Persistence.Tests.Fsm
             fsmRef.Tell(new Buy());
             fsmRef.Tell(new GetCurrentCart());
 
-            ExpectMsg<EmptyShoppingCart>();
+            await ExpectMsgAsync<EmptyShoppingCart>();
 
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes, coat);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes, coat);
 
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes, coat);
-            ExpectNoMsg(1.Seconds());
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes, coat);
+            await ExpectNoMsgAsync(1.Seconds());
 
             fsmRef.Tell(PoisonPill.Instance);
-            ExpectTerminated(fsmRef);
+            await ExpectTerminatedAsync(fsmRef);
 
             var recoveredFsmRef = Sys.ActorOf(WebStoreCustomerFSM.Props(Name, dummyReportActorRef));
             recoveredFsmRef.Tell(new GetCurrentCart());
             ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes, coat);
 
-            Watch(recoveredFsmRef);
+            await WatchAsync(recoveredFsmRef);
             recoveredFsmRef.Tell(PoisonPill.Instance);
-            ExpectTerminated(recoveredFsmRef);
+            await ExpectTerminatedAsync(recoveredFsmRef);
 
             var persistentEventsStreamer = Sys.ActorOf(PersistentEventsStreamer.Props(Name, TestActor));
 
-            ExpectMsg<SnapshotOffer>();
+            await ExpectMsgAsync<SnapshotOffer>();
 
-            Watch(persistentEventsStreamer);
+            await WatchAsync(persistentEventsStreamer);
             persistentEventsStreamer.Tell(PoisonPill.Instance);
-            ExpectTerminated(persistentEventsStreamer);
+            await ExpectTerminatedAsync(persistentEventsStreamer);
         }
 
         [Fact]
-        public void PersistentFSM_must_allow_cancelling_stateTimeout_by_issuing_forMax_null()
+        public async Task PersistentFSM_must_allow_cancelling_stateTimeout_by_issuing_forMax_null()
         {
             var probe = CreateTestProbe();
 
@@ -416,12 +416,12 @@ namespace Akka.Persistence.Tests.Fsm
             probe.ExpectMsg<StateTimeout>();
 
             fsm.Tell(TimeoutFsm.OverrideTimeoutToInf.Instance);
-            probe.ExpectMsg<TimeoutFsm.OverrideTimeoutToInf>();
-            probe.ExpectNoMsg(1.Seconds());
+            await probe.ExpectMsgAsync<TimeoutFsm.OverrideTimeoutToInf>();
+            await probe.ExpectNoMsgAsync(1.Seconds());
         }
 
         [Fact]
-        public void PersistentFSM_must_save_periodical_snapshots_if_enablesnapshotafter()
+        public async Task PersistentFSM_must_save_periodical_snapshots_if_enablesnapshotafter()
         {
             var sys2 = ActorSystem.Create("PersistentFsmSpec2", ConfigurationFactory.ParseString(@"
                 akka.persistence.fsm.snapshot-after = 3
@@ -437,14 +437,14 @@ namespace Akka.Persistence.Tests.Fsm
                 fsmRef.Tell(3);
                 // Needs to wait with expectMsg, before sending the next message to fsmRef.
                 // Otherwise, stateData sent to this probe is already updated
-                probe.ExpectMsg("SeqNo=3, StateData=List(3, 2, 1)");
+                await probe.ExpectMsgAsync("SeqNo=3, StateData=List(3, 2, 1)");
 
                 fsmRef.Tell("4x"); //changes the state to Persist4xAtOnce, also updates SeqNo although nothing is persisted
                 fsmRef.Tell(10); //Persist4xAtOnce = persist 10, 4x times
                 // snapshot-after = 3, but the SeqNo is not multiple of 3,
                 // as saveStateSnapshot() is called at the end of persistent event "batch" = 4x of 10's.
             
-                probe.ExpectMsg("SeqNo=8, StateData=List(10, 10, 10, 10, 3, 2, 1)");
+                await probe.ExpectMsgAsync("SeqNo=8, StateData=List(10, 10, 10, 10, 3, 2, 1)");
             }
             finally
             {

--- a/src/core/Akka.Persistence.Tests/Fsm/PersistentFSMSpec.cs
+++ b/src/core/Akka.Persistence.Tests/Fsm/PersistentFSMSpec.cs
@@ -92,13 +92,11 @@ namespace Akka.Persistence.Tests.Fsm
             transition1.From.Should().Be(LookingAround.Instance);
             transition1.To.Should().Be(Shopping.Instance);
 
-            Within(TimeSpan.FromSeconds(0.9), RemainingOrDefault, () =>
-            {
-                var transition2 = ExpectMsg<Transition<IUserState>>();
-                transition2.FsmRef.Should().Be(fsmRef);
-                transition2.From.Should().Be(Shopping.Instance);
-                transition2.To.Should().Be(Inactive.Instance);
-            });
+            // Wait for the transition to Inactive state, which should happen due to timeout
+            var transition2 = ExpectMsg<Transition<IUserState>>();
+            transition2.FsmRef.Should().Be(fsmRef);
+            transition2.From.Should().Be(Shopping.Instance);
+            transition2.To.Should().Be(Inactive.Instance);
 
             ExpectTerminated(fsmRef);
         }

--- a/src/core/Akka.Persistence.Tests/Fsm/PersistentFSMSpec.cs
+++ b/src/core/Akka.Persistence.Tests/Fsm/PersistentFSMSpec.cs
@@ -25,12 +25,12 @@ namespace Akka.Persistence.Tests.Fsm
         }
 
         [Fact]
-        public void PersistentFSM_must_has_function_as_regular_fsm()
+        public async Task PersistentFSM_must_has_function_as_regular_fsm()
         {
             var dummyReportActorRef = CreateTestProbe().Ref;
             var fsmRef = Sys.ActorOf(WebStoreCustomerFSM.Props(Name, dummyReportActorRef));
 
-            Watch(fsmRef);
+            await WatchAsync(fsmRef);
             fsmRef.Tell(new SubscribeTransitionCallBack(TestActor));
 
             var shirt = new Item("1", "Shirt", 59.99F);
@@ -48,66 +48,66 @@ namespace Akka.Persistence.Tests.Fsm
             fsmRef.Tell(new GetCurrentCart());
             fsmRef.Tell(new Leave());
 
-            var userState = ExpectMsg<CurrentState<IUserState>>();
+            var userState = await ExpectMsgAsync<CurrentState<IUserState>>();
             userState.FsmRef.Should().Be(fsmRef);
             userState.State.Should().Be(LookingAround.Instance);
-            ExpectMsg<EmptyShoppingCart>();
+            await ExpectMsgAsync<EmptyShoppingCart>();
 
-            var transition1 = ExpectMsg<Transition<IUserState>>();
+            var transition1 = await ExpectMsgAsync<Transition<IUserState>>();
             transition1.FsmRef.Should().Be(fsmRef);
             transition1.From.Should().Be(LookingAround.Instance);
             transition1.To.Should().Be(Shopping.Instance);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes, coat);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes, coat);
 
-            var transition2 = ExpectMsg<Transition<IUserState>>();
+            var transition2 = await ExpectMsgAsync<Transition<IUserState>>();
             transition2.FsmRef.Should().Be(fsmRef);
             transition2.From.Should().Be(Shopping.Instance);
             transition2.To.Should().Be(Paid.Instance);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes, coat);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes, coat);
 
-            ExpectTerminated(fsmRef);
+            await ExpectTerminatedAsync(fsmRef);
         }
 
         [Fact]
-        public void PersistentFSM_must_has_function_as_regular_fsm_on_state_timeout()
+        public async Task PersistentFSM_must_has_function_as_regular_fsm_on_state_timeout()
         {
             var dummyReportActorRef = CreateTestProbe().Ref;
             var fsmRef = Sys.ActorOf(WebStoreCustomerFSM.Props(Name, dummyReportActorRef));
 
-            Watch(fsmRef);
+            await WatchAsync(fsmRef);
             fsmRef.Tell(new SubscribeTransitionCallBack(TestActor));
 
             var shirt = new Item("1", "Shirt", 59.99F);
 
             fsmRef.Tell(new AddItem(shirt));
 
-            var userState = ExpectMsg<CurrentState<IUserState>>();
+            var userState = await ExpectMsgAsync<CurrentState<IUserState>>();
             userState.FsmRef.Should().Be(fsmRef);
             userState.State.Should().Be(LookingAround.Instance);
 
-            var transition1 = ExpectMsg<Transition<IUserState>>();
+            var transition1 = await ExpectMsgAsync<Transition<IUserState>>();
             transition1.FsmRef.Should().Be(fsmRef);
             transition1.From.Should().Be(LookingAround.Instance);
             transition1.To.Should().Be(Shopping.Instance);
 
             // Wait for the transition to Inactive state, which should happen due to timeout
-            var transition2 = ExpectMsg<Transition<IUserState>>();
+            var transition2 = await ExpectMsgAsync<Transition<IUserState>>();
             transition2.FsmRef.Should().Be(fsmRef);
             transition2.From.Should().Be(Shopping.Instance);
             transition2.To.Should().Be(Inactive.Instance);
 
-            ExpectTerminated(fsmRef);
+            await ExpectTerminatedAsync(fsmRef);
         }
 
         [Fact]
-        public void PersistentFSM_must_recover_successfully_with_correct_state_data()
+        public async Task PersistentFSM_must_recover_successfully_with_correct_state_data()
         {
             var dummyReportActorRef = CreateTestProbe().Ref;
             var fsmRef = Sys.ActorOf(WebStoreCustomerFSM.Props(Name, dummyReportActorRef));
 
-            Watch(fsmRef);
+            await WatchAsync(fsmRef);
             fsmRef.Tell(new SubscribeTransitionCallBack(TestActor));
 
             var shirt = new Item("1", "Shirt", 59.99F);
@@ -120,23 +120,23 @@ namespace Akka.Persistence.Tests.Fsm
             fsmRef.Tell(new AddItem(shoes));
             fsmRef.Tell(new GetCurrentCart());
 
-            var userState1 = ExpectMsg<CurrentState<IUserState>>();
+            var userState1 = await ExpectMsgAsync<CurrentState<IUserState>>();
             userState1.FsmRef.Should().Be(fsmRef);
             userState1.State.Should().Be(LookingAround.Instance);
-            ExpectMsg<EmptyShoppingCart>();
+            await ExpectMsgAsync<EmptyShoppingCart>();
 
-            var transition1 = ExpectMsg<Transition<IUserState>>();
+            var transition1 = await ExpectMsgAsync<Transition<IUserState>>();
             transition1.FsmRef.Should().Be(fsmRef);
             transition1.From.Should().Be(LookingAround.Instance);
             transition1.To.Should().Be(Shopping.Instance);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes);
 
             fsmRef.Tell(PoisonPill.Instance);
-            ExpectTerminated(fsmRef);
+            await ExpectTerminatedAsync(fsmRef);
 
             var recoveredFsmRef = Sys.ActorOf(Props.Create(() => new WebStoreCustomerFSM(Name, dummyReportActorRef)));
-            Watch(recoveredFsmRef);
+            await WatchAsync(recoveredFsmRef);
             recoveredFsmRef.Tell(new SubscribeTransitionCallBack(TestActor));
 
             recoveredFsmRef.Tell(new GetCurrentCart());
@@ -148,29 +148,29 @@ namespace Akka.Persistence.Tests.Fsm
             recoveredFsmRef.Tell(new GetCurrentCart());
             recoveredFsmRef.Tell(new Leave());
 
-            var userState2 = ExpectMsg<CurrentState<IUserState>>();
+            var userState2 = await ExpectMsgAsync<CurrentState<IUserState>>();
             userState2.FsmRef.Should().Be(recoveredFsmRef);
             userState2.State.Should().Be(Shopping.Instance);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes);
 
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes, coat);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes, coat);
 
-            var transition2 = ExpectMsg<Transition<IUserState>>();
+            var transition2 = await ExpectMsgAsync<Transition<IUserState>>();
             transition2.FsmRef.Should().Be(recoveredFsmRef);
             transition2.From.Should().Be(Shopping.Instance);
             transition2.To.Should().Be(Paid.Instance);
-            ExpectMsg<NonEmptyShoppingCart>().Items.Should().ContainInOrder(shirt, shoes, coat);
+            (await ExpectMsgAsync<NonEmptyShoppingCart>()).Items.Should().ContainInOrder(shirt, shoes, coat);
 
-            ExpectTerminated(recoveredFsmRef);
+            await ExpectTerminatedAsync(recoveredFsmRef);
         }
 
         [Fact]
-        public void PersistentFSM_must_execute_the_defined_actions_following_successful_persistence_of_state_change()
+        public async Task PersistentFSM_must_execute_the_defined_actions_following_successful_persistence_of_state_change()
         {
             var reportActorProbe = CreateTestProbe(Sys);
             var fsmRef = Sys.ActorOf(WebStoreCustomerFSM.Props(Name, reportActorProbe.Ref));
 
-            Watch(fsmRef);
+            await WatchAsync(fsmRef);
             fsmRef.Tell(new SubscribeTransitionCallBack(TestActor));
 
             var shirt = new Item("1", "Shirt", 59.99F);
@@ -183,32 +183,32 @@ namespace Akka.Persistence.Tests.Fsm
             fsmRef.Tell(new Buy());
             fsmRef.Tell(new Leave());
 
-            var userState = ExpectMsg<CurrentState<IUserState>>();
+            var userState = await ExpectMsgAsync<CurrentState<IUserState>>();
             userState.FsmRef.Should().Be(fsmRef);
             userState.State.Should().Be(LookingAround.Instance);
 
-            var transition1 = ExpectMsg<Transition<IUserState>>();
+            var transition1 = await ExpectMsgAsync<Transition<IUserState>>();
             transition1.FsmRef.Should().Be(fsmRef);
             transition1.From.Should().Be(LookingAround.Instance);
             transition1.To.Should().Be(Shopping.Instance);
 
-            var transition2 = ExpectMsg<Transition<IUserState>>();
+            var transition2 = await ExpectMsgAsync<Transition<IUserState>>();
             transition2.FsmRef.Should().Be(fsmRef);
             transition2.From.Should().Be(Shopping.Instance);
             transition2.To.Should().Be(Paid.Instance);
 
-            reportActorProbe.ExpectMsg<PurchaseWasMade>().Items.Should().ContainInOrder(shirt, shoes, coat);
+            (await reportActorProbe.ExpectMsgAsync<PurchaseWasMade>()).Items.Should().ContainInOrder(shirt, shoes, coat);
 
-            ExpectTerminated(fsmRef);
+            await ExpectTerminatedAsync(fsmRef);
         }
 
         [Fact]
-        public void PersistentFSM_must_execute_the_defined_actions_following_successful_persistence_of_FSM_stop()
+        public async Task PersistentFSM_must_execute_the_defined_actions_following_successful_persistence_of_FSM_stop()
         {
             var reportActorProbe = CreateTestProbe(Sys);
             var fsmRef = Sys.ActorOf(WebStoreCustomerFSM.Props(Name, reportActorProbe.Ref));
 
-            Watch(fsmRef);
+            await WatchAsync(fsmRef);
             fsmRef.Tell(new SubscribeTransitionCallBack(TestActor));
 
             var shirt = new Item("1", "Shirt", 59.99F);
@@ -220,52 +220,52 @@ namespace Akka.Persistence.Tests.Fsm
             fsmRef.Tell(new AddItem(coat));
             fsmRef.Tell(new Leave());
 
-            var userState = ExpectMsg<CurrentState<IUserState>>();
+            var userState = await ExpectMsgAsync<CurrentState<IUserState>>();
             userState.FsmRef.Should().Be(fsmRef);
             userState.State.Should().Be(LookingAround.Instance);
 
-            var transition = ExpectMsg<Transition<IUserState>>();
+            var transition = await ExpectMsgAsync<Transition<IUserState>>();
             transition.FsmRef.Should().Be(fsmRef);
             transition.From.Should().Be(LookingAround.Instance);
             transition.To.Should().Be(Shopping.Instance);
 
-            reportActorProbe.ExpectMsg<ShoppingCardDiscarded>();
+            await reportActorProbe.ExpectMsgAsync<ShoppingCardDiscarded>();
 
-            ExpectTerminated(fsmRef);
+            await ExpectTerminatedAsync(fsmRef);
         }
 
         [Fact]
-        public void PersistentFSM_must_recover_successfully_with_correct_state_timeout()
+        public async Task PersistentFSM_must_recover_successfully_with_correct_state_timeout()
         {
             var dummyReportActorRef = CreateTestProbe().Ref;
             var fsmRef = Sys.ActorOf(WebStoreCustomerFSM.Props(Name, dummyReportActorRef));
 
-            Watch(fsmRef);
+            await WatchAsync(fsmRef);
             fsmRef.Tell(new SubscribeTransitionCallBack(TestActor));
 
             var shirt = new Item("1", "Shirt", 59.99F);
 
             fsmRef.Tell(new AddItem(shirt));
 
-            var userState1 = ExpectMsg<CurrentState<IUserState>>();
+            var userState1 = await ExpectMsgAsync<CurrentState<IUserState>>();
             userState1.FsmRef.Should().Be(fsmRef);
             userState1.State.Should().Be(LookingAround.Instance);
 
-            var transition1 = ExpectMsg<Transition<IUserState>>();
+            var transition1 = await ExpectMsgAsync<Transition<IUserState>>();
             transition1.FsmRef.Should().Be(fsmRef);
             transition1.From.Should().Be(LookingAround.Instance);
             transition1.To.Should().Be(Shopping.Instance);
 
-            ExpectNoMsg(TimeSpan.FromSeconds(0.6)); // arbitrarily chosen delay, less than the timeout, before stopping the FSM
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.6)); // arbitrarily chosen delay, less than the timeout, before stopping the FSM
             fsmRef.Tell(PoisonPill.Instance);
-            ExpectTerminated(fsmRef);
+            await ExpectTerminatedAsync(fsmRef);
 
             var recoveredFsmRef = Sys.ActorOf(Props.Create(() => new WebStoreCustomerFSM(Name, dummyReportActorRef)));
-            Watch(recoveredFsmRef);
+            await WatchAsync(recoveredFsmRef);
             recoveredFsmRef.Tell(new SubscribeTransitionCallBack(TestActor));
 
             // We should get either Shopping state (if we're fast enough) or a direct Inactive state
-            var userState2 = ExpectMsg<CurrentState<IUserState>>();
+            var userState2 = await ExpectMsgAsync<CurrentState<IUserState>>();
             userState2.FsmRef.Should().Be(recoveredFsmRef);
             
             if (userState2.State.Equals(Shopping.Instance))
@@ -282,18 +282,18 @@ namespace Akka.Persistence.Tests.Fsm
                 userState2.State.Should().Be(Inactive.Instance);
             }
 
-            ExpectNoMsg(TimeSpan.FromSeconds(0.6)); // arbitrarily chosen delay, less than the timeout, before stopping the FSM
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.6)); // arbitrarily chosen delay, less than the timeout, before stopping the FSM
             recoveredFsmRef.Tell(PoisonPill.Instance);
-            ExpectTerminated(recoveredFsmRef);
+            await ExpectTerminatedAsync(recoveredFsmRef);
 
             var recoveredFsmRef2 = Sys.ActorOf(Props.Create(() => new WebStoreCustomerFSM(Name, dummyReportActorRef)));
-            Watch(recoveredFsmRef2);
+            await WatchAsync(recoveredFsmRef2);
             recoveredFsmRef2.Tell(new SubscribeTransitionCallBack(TestActor));
 
-            var userState3 = ExpectMsg<CurrentState<IUserState>>();
+            var userState3 = await ExpectMsgAsync<CurrentState<IUserState>>();
             userState3.FsmRef.Should().Be(recoveredFsmRef2);
             userState3.State.Should().Be(Inactive.Instance);
-            ExpectTerminated(recoveredFsmRef2);
+            await ExpectTerminatedAsync(recoveredFsmRef2);
         }
 
         [Fact]

--- a/src/core/Akka.Persistence.Tests/Fsm/PersistentFSMSpec.cs
+++ b/src/core/Akka.Persistence.Tests/Fsm/PersistentFSMSpec.cs
@@ -266,17 +266,23 @@ namespace Akka.Persistence.Tests.Fsm
             Watch(recoveredFsmRef);
             recoveredFsmRef.Tell(new SubscribeTransitionCallBack(TestActor));
 
+            // We should get either Shopping state (if we're fast enough) or a direct Inactive state
             var userState2 = ExpectMsg<CurrentState<IUserState>>();
             userState2.FsmRef.Should().Be(recoveredFsmRef);
-            userState2.State.Should().Be(Shopping.Instance);
-
-            Within(TimeSpan.FromSeconds(0.9), RemainingOrDefault, () =>
+            
+            if (userState2.State.Equals(Shopping.Instance))
             {
+                // If we got Shopping state, we should see transition to Inactive
                 var transition2 = ExpectMsg<Transition<IUserState>>();
                 transition2.FsmRef.Should().Be(recoveredFsmRef);
                 transition2.From.Should().Be(Shopping.Instance);
                 transition2.To.Should().Be(Inactive.Instance);
-            });
+            }
+            else
+            {
+                // If timeout already occurred during recovery, we should be in Inactive
+                userState2.State.Should().Be(Inactive.Instance);
+            }
 
             ExpectNoMsg(TimeSpan.FromSeconds(0.6)); // arbitrarily chosen delay, less than the timeout, before stopping the FSM
             recoveredFsmRef.Tell(PoisonPill.Instance);


### PR DESCRIPTION
## Changes

Also, converted the whole test fixture to use `async` test methods

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
