### PR TITLE
Akka.Streams: Improve logging and completion handling in `RestartWithBackoffFlow`

### DIFF
--- a/src/core/Akka.Streams/Dsl/RestartFlow.cs
+++ b/src/core/Akka.Streams/Dsl/RestartFlow.cs
@@ -304,8 +304,6 @@ namespace Akka.Streams.Dsl
             sinkIn.SetHandler(new LambdaInHandler(
                 onPush: () =>
                 {
-                    if (IsAvailable(Out))
-                        Push(Out, sinkIn.Grab());
                     Push(Out, sinkIn.Grab());
                 },
                 onUpstreamFinish: () =>
@@ -342,8 +340,6 @@ namespace Akka.Streams.Dsl
             SetHandler(Out,
                 onPull: () =>
                 {
-                    if (!sinkIn.IsClosed)
-                        sinkIn.Pull();
                     sinkIn.Pull();
                 },
                 onDownstreamFinish: cause =>

--- a/src/core/Akka.Streams/Dsl/RestartFlow.cs
+++ b/src/core/Akka.Streams/Dsl/RestartFlow.cs
@@ -306,6 +306,7 @@ namespace Akka.Streams.Dsl
                 {
                     if (IsAvailable(Out))
                         Push(Out, sinkIn.Grab());
+                    Push(Out, sinkIn.Grab());
                 },
                 onUpstreamFinish: () =>
                 {
@@ -343,6 +344,7 @@ namespace Akka.Streams.Dsl
                 {
                     if (!sinkIn.IsClosed)
                         sinkIn.Pull();
+                    sinkIn.Pull();
                 },
                 onDownstreamFinish: cause =>
                 {

--- a/src/core/Akka.Streams/Dsl/RestartFlow.cs
+++ b/src/core/Akka.Streams/Dsl/RestartFlow.cs
@@ -197,7 +197,7 @@ namespace Akka.Streams.Dsl
             private readonly RestartWithBackoffFlow<TIn, TOut, TMat> _stage;
             private readonly Attributes _inheritedAttributes;
             private Tuple<SubSourceOutlet<TIn>, SubSinkInlet<TOut>> _activeOutIn;
-            private TimeSpan _delay;
+            private readonly TimeSpan _delay;
             
             public Logic(RestartWithBackoffFlow<TIn, TOut, TMat> stage, Attributes inheritedAttributes, string name)
                 : base(name, stage.Shape, stage.In, stage.Out, stage.Settings, stage.OnlyOnFailures)
@@ -214,7 +214,7 @@ namespace Akka.Streams.Dsl
                 var sinkIn = CreateSubInlet(_stage.Out);
                 
                 var graph = Source.FromGraph(sourceOut.Source)
-                    //temp fix becaues the proper fix would be to have a concept of cause of cancellation. See https://github.com/akka/akka/pull/23909
+                    //temp fix because the proper fix would be to have a concept of cause of cancellation. See https://github.com/akka/akka/pull/23909
                     //TODO register issue to track this
                     .Via(DelayCancellation<TIn>(_delay))
                     .Via(_stage.FlowFactory())
@@ -301,25 +301,36 @@ namespace Akka.Streams.Dsl
         protected SubSinkInlet<TOut> CreateSubInlet(Outlet<TOut> outlet)
         {
             var sinkIn = new SubSinkInlet<TOut>(this, $"RestartWithBackoff{_name}.subIn");
-
             sinkIn.SetHandler(new LambdaInHandler(
-                onPush: () => Push(Out, sinkIn.Grab()),
+                onPush: () =>
+                {
+                    if (IsAvailable(Out))
+                        Push(Out, sinkIn.Grab());
+                },
                 onUpstreamFinish: () =>
                 {
-                    if (_finishing || MaxRestartsReached() || _onlyOnFailures)
+                    if (_finishing || (_onlyOnFailures && !MaxRestartsReached()))
+                    {
                         Complete(Out);
+                    }
+                    else if (MaxRestartsReached())
+                    {
+                        Log.Debug("Terminating restart flow due to max restarts being reached on upstream finish");
+                        _finishing = true;
+                        Complete(Out);
+                    }
                     else
                     {
                         ScheduleRestartTimer();
                     }
                 },
-                /*
-                 * upstream in this context is the wrapped stage
-                 */
                 onUpstreamFailure: ex =>
                 {
                     if (_finishing || MaxRestartsReached())
+                    {
+                        _finishing = true;
                         Fail(Out, ex);
+                    }
                     else
                     {
                         Log.Warning(ex, "Restarting graph due to failure.");
@@ -328,7 +339,11 @@ namespace Akka.Streams.Dsl
                 }));
 
             SetHandler(Out,
-                onPull: () => sinkIn.Pull(),
+                onPull: () =>
+                {
+                    if (!sinkIn.IsClosed)
+                        sinkIn.Pull();
+                },
                 onDownstreamFinish: cause =>
                 {
                     _finishing = true;

--- a/src/core/Akka.Streams/Dsl/RestartFlow.cs
+++ b/src/core/Akka.Streams/Dsl/RestartFlow.cs
@@ -253,7 +253,7 @@ namespace Akka.Streams.Dsl
                 }
             }
             
-            private Flow<T, T, NotUsed> DelayCancellation<T>(TimeSpan duration) => Flow.FromGraph(new DelayCancellationStage<T>(duration, null));
+            private static Flow<T, T, NotUsed> DelayCancellation<T>(TimeSpan duration) => Flow.FromGraph(new DelayCancellationStage<T>(duration, null));
         }
     }
 


### PR DESCRIPTION
## Changes

Added debug logging when `RestartWithBackoffFlow` terminates due to max restarts being reached on upstream finish (in scenarios where we are restarting in response to graceful shutdowns, which is configurable.) This helps diagnose scenarios where flows terminate unexpectedly due to reaching their restart limits.

The flow has two distinct behaviors:
1. `WithBackoff` - restarts on both completion and failures
2. `OnFailuresWithBackoff` - only restarts on failures

When using WithBackoff mode, normal completion triggers a restart (via `ScheduleRestartTimer()`) unless:

- The flow is already finishing (`_finishing = true`)
- Max restarts has been reached

When max restarts is reached during upstream finish, we now log this state transition to help diagnose completion behavior. This is particularly useful for understanding why a flow terminated when using `WithBackoff` mode with` maxRestarts` configured.

The debug level was chosen since this is expected behavior rather than an error condition.

Test: `A_restart_with_backoff_flow_should_not_restart_on_completion_when_maxRestarts_is_reached`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
