### PR TITLE
Akka.Streams.TestKit: remove all `ConfigureAwait(false)`

### DIFF
--- a/src/core/Akka.Streams.TestKit/PublisherFluentBuilder.cs
+++ b/src/core/Akka.Streams.TestKit/PublisherFluentBuilder.cs
@@ -44,12 +44,12 @@ namespace Akka.Streams.TestKit
             foreach (var func in _tasks)
             {
                 await func(cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
 
             if (asyncAction != null)
                 await asyncAction()
-                    .ConfigureAwait(false);
+                    ;
         }
 
         #region ManualProbe<T> wrapper
@@ -66,7 +66,7 @@ namespace Akka.Streams.TestKit
             [EnumeratorCancellation] CancellationToken cancellationToken = default) where TOther : class
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             await foreach (var item in ManualProbe<T>.ReceiveWhileTask(Probe.Probe, max, idle, filter, msgCount, cancellationToken))
             {
                 yield return item;
@@ -80,9 +80,9 @@ namespace Akka.Streams.TestKit
         public async Task<IPublisherEvent> ExpectEventAsync(CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectEventTask(Probe.Probe, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
 
         /// <summary>
@@ -113,9 +113,9 @@ namespace Akka.Streams.TestKit
             CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await Probe.WithinAsync(min, max, function, cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
 
         /// <summary>
@@ -126,9 +126,9 @@ namespace Akka.Streams.TestKit
         public async Task<TOther> WithinAsync<TOther>(TimeSpan max, Func<Task<TOther>> execute, CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await Probe.WithinAsync(max, execute, cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
         
         #endregion
@@ -252,9 +252,9 @@ namespace Akka.Streams.TestKit
             }
 
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await Probe<T>.ExpectRequestTask(probe, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
     }
 }

--- a/src/core/Akka.Streams.TestKit/StreamTestKit.cs
+++ b/src/core/Akka.Streams.TestKit/StreamTestKit.cs
@@ -81,7 +81,7 @@ namespace Akka.Streams.TestKit
             public void ExpectRequest(long n, CancellationToken cancellationToken = default)
             {
                 ExpectRequestAsync(n, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
             }
 
             public async Task ExpectRequestAsync(long n, CancellationToken cancellationToken = default)
@@ -89,13 +89,13 @@ namespace Akka.Streams.TestKit
                 await PublisherProbe.ExpectMsgAsync<TestPublisher.RequestMore>(
                     isMessage: x => x.NrOfElements == n && Equals(x.Subscription, this), 
                     cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
 
             public long ExpectRequest(CancellationToken cancellationToken = default)
             {
                 return ExpectRequestAsync(cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
             }
 
             public async Task<long> ExpectRequestAsync(CancellationToken cancellationToken = default)
@@ -103,14 +103,14 @@ namespace Akka.Streams.TestKit
                 var msg = await PublisherProbe.ExpectMsgAsync<TestPublisher.RequestMore>(
                     isMessage: x => Equals(this, x.Subscription), 
                     cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
                 return msg.NrOfElements;
             }
             
             public void ExpectCancellation(CancellationToken cancellationToken = default)
             {
                 ExpectCancellationAsync(cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
             }
 
             public async Task ExpectCancellationAsync(CancellationToken cancellationToken = default)
@@ -126,7 +126,7 @@ namespace Akka.Streams.TestKit
                         };
                     }, 
                     cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
             
             public void SendNext(T element) => Subscriber.OnNext(element);

--- a/src/core/Akka.Streams.TestKit/SubscriberFluentBuilder.cs
+++ b/src/core/Akka.Streams.TestKit/SubscriberFluentBuilder.cs
@@ -29,9 +29,9 @@ namespace Akka.Streams.TestKit
         public async Task<ISubscription> ExpectSubscriptionAsync(CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectSubscriptionTask(Probe, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
 
         /// <summary>
@@ -42,9 +42,9 @@ namespace Akka.Streams.TestKit
         public async Task<ISubscriberEvent> ExpectEventAsync(CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectEventTask(Probe.TestProbe, (TimeSpan?)null, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
         
         /// <summary>
@@ -57,9 +57,9 @@ namespace Akka.Streams.TestKit
             CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectEventTask(Probe.TestProbe, max, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
         
         /// <summary>
@@ -69,9 +69,9 @@ namespace Akka.Streams.TestKit
         public async Task<T> ExpectNextAsync(CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectNextTask(Probe.TestProbe, null, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
         
         /// <summary>
@@ -81,9 +81,9 @@ namespace Akka.Streams.TestKit
         public async Task<T> ExpectNextAsync(TimeSpan? timeout, CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectNextTask(Probe.TestProbe, timeout, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
         
         /// <summary>
@@ -96,7 +96,7 @@ namespace Akka.Streams.TestKit
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             await foreach (var item in ManualProbe<T>.ExpectNextNTask(Probe.TestProbe, n, timeout, cancellationToken))
             {
                 yield return item;
@@ -110,9 +110,9 @@ namespace Akka.Streams.TestKit
         public async Task<Exception> ExpectErrorAsync(CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectErrorTask(Probe.TestProbe, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
         
         /// <summary>
@@ -124,9 +124,9 @@ namespace Akka.Streams.TestKit
         public async Task<Exception> ExpectSubscriptionAndErrorAsync(CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectSubscriptionAndErrorTask(Probe, true, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
 
         /// <summary>
@@ -142,9 +142,9 @@ namespace Akka.Streams.TestKit
             CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectSubscriptionAndErrorTask(Probe, signalDemand, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
         
         /// <summary>
@@ -154,9 +154,9 @@ namespace Akka.Streams.TestKit
         public async Task<object> ExpectNextOrErrorAsync(CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectNextOrErrorTask(Probe.TestProbe, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
 
         /// <summary>
@@ -166,9 +166,9 @@ namespace Akka.Streams.TestKit
         public async Task<object> ExpectNextOrCompleteAsync(CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectNextOrCompleteTask(Probe.TestProbe, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
 
         /// <summary>
@@ -184,9 +184,9 @@ namespace Akka.Streams.TestKit
             CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectNextTask(Probe.TestProbe, predicate, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
 
         public async Task<TOther> ExpectEventAsync<TOther>(
@@ -194,9 +194,9 @@ namespace Akka.Streams.TestKit
             CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await ManualProbe<T>.ExpectEventTask(Probe.TestProbe, func, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace Akka.Streams.TestKit
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             await foreach (var item in Probe.TestProbe.ReceiveWhileAsync(max, idle, filter, msgs, cancellationToken))
             {
                 yield return item;
@@ -228,7 +228,7 @@ namespace Akka.Streams.TestKit
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             await foreach (var item in ManualProbe<T>.ReceiveWithinTask<TOther>(Probe.TestProbe, max, messages, cancellationToken))
             {
                 yield return item;
@@ -260,9 +260,9 @@ namespace Akka.Streams.TestKit
             CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await Probe.TestProbe.WithinAsync(min, max, asyncFunction, hint, epsilonValue, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
         
         /// <summary>
@@ -284,9 +284,9 @@ namespace Akka.Streams.TestKit
             CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             return await Probe.TestProbe.WithinAsync(max, actionAsync, epsilonValue, cancellationToken)
-                .ConfigureAwait(false);
+                ;
         }
         
         /// <summary>
@@ -298,7 +298,7 @@ namespace Akka.Streams.TestKit
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             await ExecuteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                ;
             await foreach (var item in ManualProbe<T>.ToStrictTask(Probe, atMost, cancellationToken))
             {
                 yield return item;
@@ -332,12 +332,12 @@ namespace Akka.Streams.TestKit
             foreach (var func in _tasks)
             {
                 await func(cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
 
             if (asyncAction != null)
                 await asyncAction()
-                    .ConfigureAwait(false);
+                    ;
         }
         
         #region Probe<T> wrapper

--- a/src/core/Akka.Streams.TestKit/TestPublisher.cs
+++ b/src/core/Akka.Streams.TestKit/TestPublisher.cs
@@ -105,7 +105,7 @@ namespace Akka.Streams.TestKit
             public StreamTestKit.PublisherProbeSubscription<T> ExpectSubscription(
                 CancellationToken cancellationToken = default)
                 => ExpectSubscriptionTask(Probe, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect a subscription.
@@ -113,7 +113,7 @@ namespace Akka.Streams.TestKit
             public async Task<StreamTestKit.PublisherProbeSubscription<T>> ExpectSubscriptionAsync(
                 CancellationToken cancellationToken = default)
                 => await ExpectSubscriptionTask(Probe, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Expect demand from the given subscription.
@@ -123,21 +123,21 @@ namespace Akka.Streams.TestKit
                 int nrOfElements,
                 CancellationToken cancellationToken = default)
                 => await ExpectRequestTask(Probe, subscription, nrOfElements, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Expect no messages.
             /// </summary>
             public async Task ExpectNoMsgAsync(CancellationToken cancellationToken = default)
                 => await ExpectNoMsgTask(Probe, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Expect no messages for given duration.
             /// </summary>
             public async Task ExpectNoMsgAsync(TimeSpan duration, CancellationToken cancellationToken = default)
                 => await ExpectNoMsgTask(Probe, duration, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Receive messages for a given duration or until one does not match a given partial function.
@@ -149,7 +149,7 @@ namespace Akka.Streams.TestKit
                 int msgCount = int.MaxValue,
                 CancellationToken cancellationToken = default) where TOther : class
                 => ReceiveWhileTask(Probe, max, idle, filter, msgCount, cancellationToken).ToListAsync(cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Receive messages for a given duration or until one does not match a given partial function.
@@ -167,14 +167,14 @@ namespace Akka.Streams.TestKit
             /// </summary>
             public IPublisherEvent ExpectEvent(CancellationToken cancellationToken = default)
                 => ExpectEventTask(Probe, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect a publisher event from the stream.
             /// </summary>
             public async Task<IPublisherEvent> ExpectEventAsync(CancellationToken cancellationToken = default)
                 => await ExpectEventTask(Probe, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Execute code block while bounding its execution time between <paramref name="min"/> and
@@ -206,7 +206,7 @@ namespace Akka.Streams.TestKit
                 Func<TOther> execute,
                 CancellationToken cancellationToken = default)
                 => WithinAsync(min, max, () => Task.FromResult(execute()), cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Execute code block while bounding its execution time between <paramref name="min"/> and
@@ -238,21 +238,21 @@ namespace Akka.Streams.TestKit
                 Func<Task<TOther>> actionAsync,
                 CancellationToken cancellationToken = default)
                 => await Probe.WithinAsync(min, max, actionAsync, cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Sane as calling Within(TimeSpan.Zero, max, function, cancellationToken).
             /// </summary>
             public TOther Within<TOther>(TimeSpan max, Func<TOther> execute, CancellationToken cancellationToken = default)
                 => WithinAsync(max, () => Task.FromResult(execute()), cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
             
             /// <summary>
             /// Sane as calling WithinAsync(TimeSpan.Zero, max, function, cancellationToken).
             /// </summary>
             public async Task<TOther> WithinAsync<TOther>(TimeSpan max, Func<Task<TOther>> execute, CancellationToken cancellationToken = default) 
                 => await Probe.WithinAsync(max, execute, cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
         }
 
         /// <summary>
@@ -278,39 +278,39 @@ namespace Akka.Streams.TestKit
             /// </summary>
             public void EnsureSubscription(CancellationToken cancellationToken = default)
                 => EnsureSubscriptionTask(this, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             public async Task EnsureSubscriptionAsync(CancellationToken cancellationToken = default)
                 => await EnsureSubscriptionTask(this, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             public async Task SendNextAsync(T element, CancellationToken cancellationToken = default)
                 => await SendNextTask(this, element, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             
             public async Task UnsafeSendNextAsync(T element, CancellationToken cancellationToken = default)
                 => await UnsafeSendNextTask(this, element, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             public async Task SendCompleteAsync(CancellationToken cancellationToken = default)
                 => await SendCompleteTask(this, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             public async Task SendErrorAsync(Exception e, CancellationToken cancellationToken = default)
                 => await SendErrorTask(this, e, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             public long ExpectRequest(CancellationToken cancellationToken = default)
                 => ExpectRequestTask(this, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             public async Task<long> ExpectRequestAsync(CancellationToken cancellationToken = default)
                 => await ExpectRequestTask(this, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             public async Task ExpectCancellationAsync(CancellationToken cancellationToken = default)
                 => await ExpectCancellationTask(this, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
         }
 
         internal sealed class LazyEmptyPublisher<T> : IPublisher<T>

--- a/src/core/Akka.Streams.TestKit/TestPublisher_Fluent.cs
+++ b/src/core/Akka.Streams.TestKit/TestPublisher_Fluent.cs
@@ -41,7 +41,7 @@ namespace Akka.Streams.TestKit
                 CancellationToken cancellationToken = default)
             {
                 ExpectRequestTask(Probe, subscription, nrOfElements, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -52,7 +52,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNoMsg(CancellationToken cancellationToken = default)
             {
                 ExpectNoMsgTask(Probe, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -63,7 +63,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNoMsg(TimeSpan duration, CancellationToken cancellationToken = default)
             {
                 ExpectNoMsgTask(Probe, duration, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -75,35 +75,35 @@ namespace Akka.Streams.TestKit
             public Probe<T> SendNext(T element, CancellationToken cancellationToken = default)
             {
                 SendNextTask(this, element, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
             public Probe<T> UnsafeSendNext(T element, CancellationToken cancellationToken = default)
             {
                 UnsafeSendNextTask(this, element, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
             public Probe<T> SendComplete(CancellationToken cancellationToken = default)
             {
                 SendCompleteTask(this, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
             public Probe<T> SendError(Exception e, CancellationToken cancellationToken = default)
             {
                 SendErrorTask(this, e, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
             
             public Probe<T> ExpectCancellation(CancellationToken cancellationToken = default)
             {
                 ExpectCancellationTask(this, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
             

--- a/src/core/Akka.Streams.TestKit/TestSubscriber.cs
+++ b/src/core/Akka.Streams.TestKit/TestSubscriber.cs
@@ -121,35 +121,35 @@ namespace Akka.Streams.TestKit
             /// </summary>
             public ISubscription ExpectSubscription(CancellationToken cancellationToken = default)
                 => ExpectSubscriptionTask(this, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expects and returns Reactive.Streams.ISubscription/>.
             /// </summary>
             public async Task<ISubscription> ExpectSubscriptionAsync(CancellationToken cancellationToken = default)
                 => await ExpectSubscriptionTask(this, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Expect and return <see cref="ISubscriberEvent"/> (any of: <see cref="OnSubscribe"/>, <see cref="OnNext"/>, <see cref="OnError"/> or <see cref="OnComplete"/>).
             /// </summary>
             public ISubscriberEvent ExpectEvent(CancellationToken cancellationToken = default)
                 => ExpectEventTask(TestProbe, (TimeSpan?)null, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect and return <see cref="ISubscriberEvent"/> (any of: <see cref="OnSubscribe"/>, <see cref="OnNext"/>, <see cref="OnError"/> or <see cref="OnComplete"/>).
             /// </summary>
             public async Task<ISubscriberEvent> ExpectEventAsync(CancellationToken cancellationToken = default)
                 => await ExpectEventTask(TestProbe, (TimeSpan?)null, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Expect and return <see cref="ISubscriberEvent"/> (any of: <see cref="OnSubscribe"/>, <see cref="OnNext"/>, <see cref="OnError"/> or <see cref="OnComplete"/>).
             /// </summary>
             public ISubscriberEvent ExpectEvent(TimeSpan max, CancellationToken cancellationToken = default)
                 => ExpectEventTask(TestProbe, max, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect and return <see cref="ISubscriberEvent"/> (any of: <see cref="OnSubscribe"/>, <see cref="OnNext"/>, <see cref="OnError"/> or <see cref="OnComplete"/>).
@@ -158,39 +158,39 @@ namespace Akka.Streams.TestKit
                 TimeSpan? max,
                 CancellationToken cancellationToken = default) 
                 => await ExpectEventTask(TestProbe, max, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Expect and return a stream element.
             /// </summary>
             public T ExpectNext(CancellationToken cancellationToken = default)
                 => ExpectNextTask(TestProbe, null, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect and return a stream element during specified time or timeout.
             /// </summary>
             public T ExpectNext(TimeSpan? timeout, CancellationToken cancellationToken = default)
                 => ExpectNextTask(TestProbe, timeout, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect and return a stream element.
             /// </summary>
             public async Task<T> ExpectNextAsync(CancellationToken cancellationToken = default)
                 => await ExpectNextTask(TestProbe, null, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Expect and return a stream element during specified time or timeout.
             /// </summary>
             public async Task<T> ExpectNextAsync(TimeSpan? timeout, CancellationToken cancellationToken = default)
                 => await ExpectNextTask(TestProbe, timeout, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             public async Task ExpectNextAsync(T element, CancellationToken cancellationToken = default)
                 => await ExpectNextTask(probe: TestProbe, element: element, timeout: null, cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             
             /// <summary>
             /// Expect a stream element.
@@ -198,7 +198,7 @@ namespace Akka.Streams.TestKit
             public async Task ExpectNextAsync(T element, TimeSpan timeout, CancellationToken cancellationToken = default)
             {
                 await ExpectNextTask(TestProbe, element, timeout, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
             
             /// <summary>
@@ -209,7 +209,7 @@ namespace Akka.Streams.TestKit
                 TimeSpan? timeout = null,
                 CancellationToken cancellationToken = default)
                 => ExpectNextNTask(TestProbe, n, timeout, cancellationToken)
-                    .ToListAsync(cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+                    .ToListAsync(cancellationToken).GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect and return the next <paramref name="n"/> stream elements.
@@ -226,7 +226,7 @@ namespace Akka.Streams.TestKit
             public async Task ExpectNextNAsync(IEnumerable<T> all, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
             {
                 await ExpectNextNTask(TestProbe, all, timeout, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
             
             /// <summary>
@@ -235,7 +235,7 @@ namespace Akka.Streams.TestKit
             public async Task ExpectNoMsgAsync(TimeSpan remaining, CancellationToken cancellationToken = default)
             {
                 await TestProbe.ExpectNoMsgAsync(remaining, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
             
             /// <summary>
@@ -243,14 +243,14 @@ namespace Akka.Streams.TestKit
             /// </summary>
             public Exception ExpectError(CancellationToken cancellationToken = default)
                 => ExpectErrorTask(TestProbe, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect and return the signalled System.Exception/>.
             /// </summary>
             public async Task<Exception> ExpectErrorAsync(CancellationToken cancellationToken = default)
                 => await ExpectErrorTask(TestProbe, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Expect subscription to be followed immediately by an error signal. By default single demand will be signaled in order to wake up a possibly lazy upstream. 
@@ -258,7 +258,7 @@ namespace Akka.Streams.TestKit
             /// </summary>
             public Exception ExpectSubscriptionAndError(CancellationToken cancellationToken = default) 
                 => ExpectSubscriptionAndErrorTask(this, true, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect subscription to be followed immediately by an error signal. By default single demand will be signaled in order to wake up a possibly lazy upstream. 
@@ -266,7 +266,7 @@ namespace Akka.Streams.TestKit
             /// </summary>
             public async Task<Exception> ExpectSubscriptionAndErrorAsync(CancellationToken cancellationToken = default) 
                 => await ExpectSubscriptionAndErrorTask(this, true, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Expect subscription to be followed immediately by an error signal. Depending on the `signalDemand` parameter demand may be signaled 
@@ -277,7 +277,7 @@ namespace Akka.Streams.TestKit
                 bool signalDemand,
                 CancellationToken cancellationToken = default)
                 => ExpectSubscriptionAndErrorTask(this, signalDemand, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect subscription to be followed immediately by an error signal. Depending on the `signalDemand` parameter demand may be signaled 
@@ -288,14 +288,14 @@ namespace Akka.Streams.TestKit
                 bool signalDemand,
                 CancellationToken cancellationToken = default)
                 => await ExpectSubscriptionAndErrorTask(this, signalDemand, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             public async Task ExpectSubscriptionAndCompleteAsync(
                 bool signalDemand = true,
                 CancellationToken cancellationToken = default)
             {
                 await ExpectSubscriptionAndCompleteTask(this, signalDemand, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
             
             /// <summary>
@@ -303,28 +303,28 @@ namespace Akka.Streams.TestKit
             /// </summary>
             public object ExpectNextOrError(CancellationToken cancellationToken = default)
                 => ExpectNextOrErrorTask(TestProbe, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect given next element or error signal, returning whichever was signaled.
             /// </summary>
             public async Task<object> ExpectNextOrErrorAsync(CancellationToken cancellationToken = default)
                 => await ExpectNextOrErrorTask(TestProbe, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Expect given next element or stream completion, returning whichever was signaled.
             /// </summary>
             public object ExpectNextOrComplete(CancellationToken cancellationToken = default)
                 => ExpectNextOrCompleteTask(TestProbe, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect given next element or stream completion, returning whichever was signaled.
             /// </summary>
             public async Task<object> ExpectNextOrCompleteAsync(CancellationToken cancellationToken = default)
                 => await ExpectNextOrCompleteTask(TestProbe, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Expect next element and test it with the <paramref name="predicate"/>
@@ -335,7 +335,7 @@ namespace Akka.Streams.TestKit
             /// <returns>The next element</returns>
             public TOther ExpectNext<TOther>(Predicate<TOther> predicate, CancellationToken cancellationToken = default)
                 => ExpectNextTask(TestProbe, predicate, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Expect next element and test it with the <paramref name="predicate"/>
@@ -348,19 +348,19 @@ namespace Akka.Streams.TestKit
                 Predicate<TOther> predicate,
                 CancellationToken cancellationToken = default)
                 => await ExpectNextTask(TestProbe, predicate, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             public TOther ExpectEvent<TOther>(
                 Func<ISubscriberEvent, TOther> func,
                 CancellationToken cancellationToken = default)
                 => ExpectEventTask(TestProbe, func, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             public async Task<TOther> ExpectEventAsync<TOther>(
                 Func<ISubscriberEvent, TOther> func,
                 CancellationToken cancellationToken = default)
                 => await ExpectEventTask(TestProbe, func, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Receive messages for a given duration or until one does not match a given partial function.
@@ -372,7 +372,7 @@ namespace Akka.Streams.TestKit
                 int msgs = int.MaxValue,
                 CancellationToken cancellationToken = default)
                 => ReceiveWhileAsync(max, idle, filter, msgs, cancellationToken)
-                    .ToListAsync(cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+                    .ToListAsync(cancellationToken).GetAwaiter().GetResult();
 
             /// <summary>
             /// Receive messages for a given duration or until one does not match a given partial function.
@@ -391,7 +391,7 @@ namespace Akka.Streams.TestKit
             public IEnumerable<TOther> ReceiveWithin<TOther>(TimeSpan? max, int messages = int.MaxValue,
                 CancellationToken cancellationToken = default)
                 => ReceiveWithinTask<TOther>(TestProbe, max, messages, cancellationToken)
-                    .ToListAsync(cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+                    .ToListAsync(cancellationToken).GetAwaiter().GetResult();
 
             /// <summary>
             /// Drains a given number of messages
@@ -431,7 +431,7 @@ namespace Akka.Streams.TestKit
 
             public async Task<TOther> WithinAsync<TOther>(TimeSpan min, TimeSpan max, Func<Task<TOther>> execute, CancellationToken cancellationToken = default) => 
                 await TestProbe.WithinAsync(min, max, execute, cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Sane as calling Within(TimeSpan.Zero, max, function).
@@ -444,7 +444,7 @@ namespace Akka.Streams.TestKit
             /// </summary>
             public async Task<TOther> WithinAsync<TOther>(TimeSpan max, Func<Task<TOther>> execute, CancellationToken cancellationToken = default) => 
                 await TestProbe.WithinAsync(max, execute, cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             public async Task WithinAsync(
                 TimeSpan max,
@@ -452,7 +452,7 @@ namespace Akka.Streams.TestKit
                 TimeSpan? epsilonValue = null,
                 CancellationToken cancellationToken = default)
                 => await TestProbe.WithinAsync(max, actionAsync, epsilonValue, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             /// <summary>
             /// Attempt to drain the stream into a strict collection (by requesting long.MaxValue elements).
@@ -462,7 +462,7 @@ namespace Akka.Streams.TestKit
             /// </remarks>
             public IList<T> ToStrict(TimeSpan atMost, CancellationToken cancellationToken = default)
                 => ToStrictTask(this, atMost, cancellationToken).ToListAsync(cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
 
             /// <summary>
             /// Attempt to drain the stream into a strict collection (by requesting long.MaxValue elements).
@@ -491,7 +491,7 @@ namespace Akka.Streams.TestKit
             public Probe<T> EnsureSubscription(CancellationToken cancellationToken = default)
             {
                 EnsureSubscriptionTask(this, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             } 
 
@@ -500,7 +500,7 @@ namespace Akka.Streams.TestKit
             /// </summary>
             public async Task EnsureSubscriptionAsync(CancellationToken cancellationToken = default)
                 => await EnsureSubscriptionTask(this, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             public async Task RequestAsync(long n)
             {

--- a/src/core/Akka.Streams.TestKit/TestSubscriber_Fluent.cs
+++ b/src/core/Akka.Streams.TestKit/TestSubscriber_Fluent.cs
@@ -37,7 +37,7 @@ namespace Akka.Streams.TestKit
                 CancellationToken cancellationToken = default)
             {
                 ExpectEventTask(TestProbe, e, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -47,7 +47,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNext(T element, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
             {
                 ExpectNextTask(TestProbe, element, timeout, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -58,7 +58,7 @@ namespace Akka.Streams.TestKit
             {
                 //=> new SubscriberFluentBuilder<T>(this).ExpectNext(element, timeout, cancellationToken);
                 ExpectNextTask(TestProbe, element, timeout, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -68,7 +68,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNext(params T[] elems)
             {
                 ExpectNextTask(this, null, default, elems)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -78,7 +78,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNext(CancellationToken cancellationToken, params T[] elems)
             {
                 ExpectNextTask(this, null, cancellationToken, elems)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -89,7 +89,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNext(TimeSpan? timeout, params T[] elems)
             {
                 ExpectNextTask(this, timeout, default, elems)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -99,7 +99,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNext(TimeSpan? timeout, CancellationToken cancellationToken, params T[] elems)
             {
                 ExpectNextTask(this, timeout, cancellationToken, elems)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -109,7 +109,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNextUnordered(params T[] elems)
             {
                 ExpectNextUnorderedTask(this, null, default, elems)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -119,7 +119,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNextUnordered(CancellationToken cancellationToken, params T[] elems)
             {
                 ExpectNextUnorderedTask(this, null, cancellationToken, elems)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -130,7 +130,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNextUnordered(TimeSpan? timeout, params T[] elems)
             {
                 ExpectNextUnorderedTask(this, timeout, default, elems)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -140,7 +140,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNextUnordered(TimeSpan? timeout, CancellationToken cancellationToken, params T[] elems)
             {
                 ExpectNextUnorderedTask(this, timeout, cancellationToken, elems)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -151,7 +151,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNextWithinSet(ICollection<T> elems, CancellationToken cancellationToken = default)
             {
                 ExpectNextWithinSetTask(TestProbe, elems, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -161,7 +161,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNextN(IEnumerable<T> all, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
             {
                 ExpectNextNTask(TestProbe, all, timeout, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
             
@@ -171,7 +171,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNextUnorderedN(IEnumerable<T> all, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
             {
                 ExpectNextUnorderedNTask(this, all, timeout, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -181,7 +181,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectComplete(CancellationToken cancellationToken = default)
             {
                 ExpectCompleteTask(TestProbe, null, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
             
@@ -194,7 +194,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectComplete(TimeSpan? timeout, CancellationToken cancellationToken = default)
             {
                 ExpectCompleteTask(TestProbe, timeout, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -205,7 +205,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectSubscriptionAndComplete(CancellationToken cancellationToken = default)
             {
                 ExpectSubscriptionAndCompleteTask(this, true, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -218,7 +218,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectSubscriptionAndComplete(bool signalDemand, CancellationToken cancellationToken = default)
             {
                 ExpectSubscriptionAndCompleteTask(this, signalDemand, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -228,7 +228,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNextOrError(T element, Exception cause, CancellationToken cancellationToken = default)
             {
                 ExpectNextOrErrorTask(TestProbe, element, cause, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
             
@@ -238,7 +238,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNextOrComplete(T element, CancellationToken cancellationToken = default)
             {
                 ExpectNextOrCompleteTask(TestProbe, element, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
 
@@ -248,7 +248,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNoMsg(CancellationToken cancellationToken = default)
             {
                 TestProbe.ExpectNoMsgAsync(cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;
             }
             
@@ -258,7 +258,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> ExpectNoMsg(TimeSpan remaining, CancellationToken cancellationToken = default)
             {
                 TestProbe.ExpectNoMsgAsync(remaining, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;                
             }
 
@@ -272,7 +272,7 @@ namespace Akka.Streams.TestKit
             public ManualProbe<T> MatchNext<TOther>(Predicate<TOther> predicate, CancellationToken cancellationToken = default)
             {
                 MatchNextTask(TestProbe, predicate, cancellationToken)
-                    .ConfigureAwait(false).GetAwaiter().GetResult();
+                    .GetAwaiter().GetResult();
                 return this;                
             }
         }

--- a/src/core/Akka.Streams.TestKit/TestSubscriber_Shared.cs
+++ b/src/core/Akka.Streams.TestKit/TestSubscriber_Shared.cs
@@ -50,7 +50,7 @@ namespace Akka.Streams.TestKit
                 
                 var e = await probe.ExpectNextNAsync(len, timeout, cancellationToken)
                     .ToListAsync(cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
                 AssertEquals(e.Count, len, "expected to get {0} events, but got {1}", len, e.Count);
                 for (var i = 0; i < elems.Length; i++)
                 {
@@ -62,7 +62,7 @@ namespace Akka.Streams.TestKit
             {
                 var len = elems.Length;
                 var e = await probe.ExpectNextNAsync(len, timeout, cancellationToken)
-                    .ToListAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                    .ToListAsync(cancellationToken: cancellationToken);
                 AssertEquals(e.Count, len, "expected to get {0} events, but got {1}", len, e.Count);
 
                 var expectedSet = new HashSet<T>(elems);
@@ -77,7 +77,7 @@ namespace Akka.Streams.TestKit
                 CancellationToken cancellationToken)
             {
                 var next = await probe.ExpectMsgAsync<OnNext<T>>(cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
                 if(!elems.Contains(next.Element))
                     Assert(false, "unexpected elements [{0}] found in the result", next.Element);
                 elems.Remove(next.Element);
@@ -122,13 +122,13 @@ namespace Akka.Streams.TestKit
                 CancellationToken cancellationToken)
             {
                 var sub = await probe.ExpectSubscriptionAsync(cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
                 
                 if (signalDemand)
                     sub.Request(1);
 
                 await ExpectCompleteTask(probe.TestProbe, null, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
 
             internal static async Task ExpectNextOrErrorTask(
@@ -169,7 +169,7 @@ namespace Akka.Streams.TestKit
                 CancellationToken cancellationToken = default)
             {
                 var msg = await probe.TestProbe.ExpectMsgAsync<OnSubscribe>(cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
                 probe.Subscription = msg.Subscription;
                 return msg.Subscription;
             }
@@ -179,7 +179,7 @@ namespace Akka.Streams.TestKit
                 TimeSpan? max,
                 CancellationToken cancellationToken = default) 
                 => await probe.ExpectMsgAsync<ISubscriberEvent>(max, cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
 
             internal static async Task<T> ExpectNextTask(
                 TestProbe probe,
@@ -372,7 +372,7 @@ namespace Akka.Streams.TestKit
                 CancellationToken cancellationToken = default)
             {
                 probe.Subscription ??= await ExpectSubscriptionTask(probe, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
             
             #endregion
@@ -401,7 +401,7 @@ namespace Akka.Streams.TestKit
                 CancellationToken cancellationToken = default)
             {
                 probe.Subscription ??= await ExpectSubscriptionTask(probe, cancellationToken)
-                    .ConfigureAwait(false);
+                    ;
             }
         }
     }

--- a/src/core/Akka.Streams.TestKit/Utils.cs
+++ b/src/core/Akka.Streams.TestKit/Utils.cs
@@ -37,7 +37,7 @@ namespace Akka.Streams.TestKit
                     block();
                     return Task.FromResult(NotUsed.Instance);
                 }, materializer, timeout, cancellationToken)
-                .ConfigureAwait(false).GetAwaiter().GetResult();
+                .GetAwaiter().GetResult();
 
         public static T AssertAllStagesStopped<T>(
             this TestKitBase spec,
@@ -46,7 +46,7 @@ namespace Akka.Streams.TestKit
             TimeSpan? timeout = null,
             CancellationToken cancellationToken = default)
             => AssertAllStagesStoppedAsync(spec, () => Task.FromResult(block()), materializer, timeout, cancellationToken)
-                .ConfigureAwait(false).GetAwaiter().GetResult();
+                .GetAwaiter().GetResult();
 
         public static async Task AssertAllStagesStoppedAsync(
             this TestKitBase spec,
@@ -58,8 +58,7 @@ namespace Akka.Streams.TestKit
                 {
                     await block();
                     return NotUsed.Instance;
-                }, materializer, timeout, cancellationToken)
-                .ConfigureAwait(false);
+                }, materializer, timeout, cancellationToken);
         
         public static async Task<T> AssertAllStagesStoppedAsync<T>(
             this TestKitBase spec,

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
@@ -121,8 +121,7 @@ namespace Akka.Streams.Tests.Dsl
                 (await probe.ReceiveNAsync(9).ToListAsync()).Should().BeEquivalentTo(Enumerable.Range(12, 9));
                 await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
 
-                foreach (var n in Enumerable.Range(1, 13))
-                    await c.ExpectNextAsync(n);
+                await c.ExpectNextNAsync(Enumerable.Range(1, 13));
             
                 await c.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
             }, Materializer).ShouldCompleteWithin(RemainingOrDefault);


### PR DESCRIPTION
## Changes

This is a no-no, for the reasons outlined by xUnit: https://xunit.net/xunit.analyzers/rules/xUnit1030

We have __a lot__ of timing sensitive tests inside the Akka.Streams.Tests et al - spreading the assertions and their work out across more task invocations doesn't do anything but increase the likelihood of false negatives happening.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
