### PR TITLE
suppress `AK1004` warnings in Akka.Remote and Akka.Cluster

### DIFF
--- a/src/core/Akka.Cluster/Akka.Cluster.csproj
+++ b/src/core/Akka.Cluster/Akka.Cluster.csproj
@@ -1,10 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Description>Clustering support for Akka.NET actors. Used to build highly-available, distributed applications.</Description>
         <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
         <PackageTags>$(AkkaPackageTags);network;cluster</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <!-- 
+        Suppressing AK1004 warnings in Akka.Cluster because this project requires precise control over timer scheduling
+        for cluster coordination and gossip protocols. The standard IWithTimers pattern is too restrictive for the complex
+        timing requirements of cluster membership, failure detection, and leader election protocols where multiple concurrent
+        timers and explicit timer management are essential for correct distributed behavior.
+        -->
+        <NoWarn>$(NoWarn);AK1004</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -1,9 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Description>Remoting support for Akka.NET. Allows actors to communicate over the network.</Description>
         <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
         <PackageTags>$(AkkaPackageTags);network</PackageTags>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <!-- 
+        Suppressing AK1004 warnings in Akka.Remote because this project requires fine-grained control over timer scheduling
+        for network-related operations. The standard IWithTimers pattern doesn't support the advanced scheduling patterns
+        needed for reliable remote messaging, especially in cases where we need multiple concurrent timers of the same type
+        or need to manage timer cancellation explicitly for network protocol handling.
+        -->
+        <NoWarn>$(NoWarn);AK1004</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <EmbeddedResource Include="Configuration\Remote.conf" />


### PR DESCRIPTION
## Changes

These projects require fine-grained control over timer scheduling that goes beyond IWithTimers capabilities: need for multiple concurrent timers of the same type, complex timer management for network protocols and cluster coordination. Previous attempts to use IWithTimers (PR #7279) failed due to these requirements. Added XML comments in .csproj files explaining the rationale for suppression.