### PR TITLE
harden `QueueSinkSpec`

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSinkSpec.cs
@@ -233,9 +233,8 @@ namespace Akka.Streams.Tests.Dsl
                 await ExpectMsgAsync(Option<int>.Create(2));
 
                 sub.SendComplete();
-                var future = queue.PullAsync();
-                future.Wait(_pause).Should().BeTrue();
-                future.Result.Should().Be(Option<int>.None);
+                var result = await queue.PullAsync();
+                result.Should().Be(Option<int>.None);
             }, _materializer);
         }
 


### PR DESCRIPTION
## Changes

No need to be so prescriptive about wait times - this spec can fail due to the very short interval given to it to succeed
