### PR TITLE
Akka.TestKit.Tests: fix build warnings

### DIFF
--- a/src/core/Akka.TestKit.Tests/Bugfix7145Spec.cs
+++ b/src/core/Akka.TestKit.Tests/Bugfix7145Spec.cs
@@ -47,8 +47,10 @@ public class Bugfix7145Spec : AkkaSpec
         var actor = Sys.ActorOf(Props.Create(() => new BuggyActor()));
         var probe = CreateTestProbe();
         actor.Tell("hello", probe);
+#pragma warning disable xUnit1030
         var response1 = await probe.ExpectMsgAsync<string>().ConfigureAwait(false);
         var response2 = await probe.ExpectMsgAsync<string>().ConfigureAwait(false);
+#pragma warning restore xUnit1030
         response1.Should().Be("hello1");
         response2.Should().Be("hello2");
     }

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/NestingActor.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/NestingActor.cs
@@ -15,7 +15,10 @@ namespace Akka.TestKit.Tests.TestActorRefTests
 
         public NestingActor(bool createTestActorRef)
         {
+            // this is supposed to create a top-level actor, so the test is written correctly
+#pragma warning disable AK1008
             _nested = createTestActorRef ? Context.System.ActorOf<NestedActor>() : new TestActorRef<NestedActor>(Context.System, Props.Create<NestedActor>(), null, null);
+#pragma warning restore AK1008
         }
 
         protected override bool Receive(object message)


### PR DESCRIPTION
## Changes

Mostly have to ignore some xUnit and Akka.Analyzer warnings in cases where we're doing things that are intentionally a bit weird.