### PR TITLE
fixed all `ClusterSingletonManager.DefaultConfig()` build warnings

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingConfig.cs
@@ -81,7 +81,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ")
                     .WithFallback(Sharding.ClusterSharding.DefaultConfig())
                     .WithFallback(DistributedData.DistributedData.DefaultConfig())
-                    .WithFallback(Tools.Singleton.ClusterSingletonManager.DefaultConfig())
+                    .WithFallback(Tools.Singleton.ClusterSingleton.DefaultConfig())
                     .WithFallback(MultiNodeClusterSpec.ClusterConfig());
 
             CommonConfig = (ConfigurationFactory.ParseString(additionalConfig).WithFallback(persistenceConfig).WithFallback(Common));

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ShardedDaemonProcessSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ShardedDaemonProcessSpec.cs
@@ -42,7 +42,7 @@ namespace Akka.Cluster.Sharding.Tests.MultiNode
                     }}
                 "))
                 .WithFallback(ClusterSharding.DefaultConfig())
-                .WithFallback(ClusterSingletonManager.DefaultConfig())
+                .WithFallback(ClusterSingleton.DefaultConfig())
                 .WithFallback(MultiNodeClusterSpec.ClusterConfig());
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
@@ -48,7 +48,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                 .WithFallback(Sharding.ClusterSharding.DefaultConfig())
                 .WithFallback(DistributedData.DistributedData.DefaultConfig())
-                .WithFallback(ClusterSingletonManager.DefaultConfig());
+                .WithFallback(ClusterSingleton.DefaultConfig());
 
         ClusterSharding clusterSharding;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeaseSpec.cs
@@ -79,7 +79,7 @@ namespace Akka.Cluster.Sharding.Tests
                 }
                 ")
                 .WithFallback(ClusterSharding.DefaultConfig())
-                .WithFallback(ClusterSingletonManager.DefaultConfig())
+                .WithFallback(ClusterSingleton.DefaultConfig())
                 .WithFallback(TestLease.Configuration);
 
         TimeSpan shortDuration = TimeSpan.FromMilliseconds(200);

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingMessageSerializerSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingMessageSerializerSpec.cs
@@ -34,7 +34,7 @@ namespace Akka.Cluster.Sharding.Tests
         private IActorRef regionProxy2;
 
         private static Config SpecConfig =>
-            ClusterSingletonManager.DefaultConfig().WithFallback(ClusterSharding.DefaultConfig()).WithFallback(ClusterConfigFactory.Default());
+            ClusterSingleton.DefaultConfig().WithFallback(ClusterSharding.DefaultConfig()).WithFallback(ClusterConfigFactory.Default());
 
         public ClusterShardingMessageSerializerSpec() : base(SpecConfig)
         {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingSettingsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingSettingsSpec.cs
@@ -20,7 +20,7 @@ namespace Akka.Cluster.Sharding.Tests
             ConfigurationFactory.ParseString(@"akka.actor.provider = cluster
                 akka.remote.dot-netty.tcp.port = 0")
                 .WithFallback(ClusterSharding.DefaultConfig())
-                .WithFallback(ClusterSingletonManager.DefaultConfig());
+                .WithFallback(ClusterSingleton.DefaultConfig());
 
         public ClusterShardingSettingsSpec(ITestOutputHelper helper)
             : base(SpecConfig, helper)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -63,8 +63,8 @@ namespace Akka.Cluster.Sharding.Tests
                 akka.actor.provider = cluster
                 akka.remote.dot-netty.tcp.port = 0
                 akka.cluster.sharding.verbose-debug-logging = on")
-                .WithFallback(ClusterSingletonManager.DefaultConfig()
-                .WithFallback(ClusterSharding.DefaultConfig()));
+                .WithFallback(ClusterSingleton.DefaultConfig())
+                .WithFallback(ClusterSharding.DefaultConfig());
 
         public CoordinatedShutdownShardingSpec(ITestOutputHelper helper) : base(SpecConfig, helper)
         {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/EntityTerminationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/EntityTerminationSpec.cs
@@ -104,7 +104,7 @@ namespace Akka.Cluster.Sharding.Tests
                 akka.cluster.sharding.verbose-debug-logging = on
                 akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
                 akka.cluster.sharding.entity-restart-backoff = 250ms")
-                .WithFallback(ClusterSingletonManager.DefaultConfig())
+                .WithFallback(ClusterSingleton.DefaultConfig())
                 .WithFallback(ClusterSharding.DefaultConfig());
 
         public EntityTerminationSpec(ITestOutputHelper helper) : base(SpecConfig, helper)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/External/ExternalShardAllocationStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/External/ExternalShardAllocationStrategySpec.cs
@@ -40,7 +40,7 @@ namespace Akka.Cluster.Sharding.Tests.External
                 akka.actor.provider = cluster
                 akka.remote.dot-netty.tcp.port = 0
             ")
-            .WithFallback(ClusterSingletonManager.DefaultConfig())
+            .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSharding.DefaultConfig())
             .WithFallback(DistributedData.DistributedData.DefaultConfig());
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
@@ -27,7 +27,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                 .WithFallback(Sharding.ClusterSharding.DefaultConfig())
                 .WithFallback(DistributedData.DistributedData.DefaultConfig())
-                .WithFallback(ClusterSingletonManager.DefaultConfig());
+                .WithFallback(ClusterSingleton.DefaultConfig());
 
         public GetShardTypeNamesSpec(ITestOutputHelper helper) : base(SpecConfig, helper)
         {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/InactiveEntityPassivationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/InactiveEntityPassivationSpec.cs
@@ -123,7 +123,7 @@ namespace Akka.Cluster.Sharding.Tests
                 akka.cluster.sharding.verbose-debug-logging = on
                 akka.cluster.sharding.fail-on-invalid-entity-state-transition = on")
                 .WithFallback(ClusterSharding.DefaultConfig())
-                .WithFallback(ClusterSingletonManager.DefaultConfig());
+                .WithFallback(ClusterSingleton.DefaultConfig());
 
         public AbstractInactiveEntityPassivationSpec(Config config, ITestOutputHelper helper)
             : base(config.WithFallback(SpecConfig), helper)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Internal/RememberEntitiesShardStoreSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Internal/RememberEntitiesShardStoreSpec.cs
@@ -46,7 +46,7 @@ namespace Akka.Cluster.Sharding.Tests.Internal
                 akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
                 akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
             ")
-            .WithFallback(ClusterSingletonManager.DefaultConfig())
+            .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSharding.DefaultConfig())
             .WithFallback(DistributedData.DistributedData.DefaultConfig());
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Internal/RememberEntitiesStarterSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Internal/RememberEntitiesStarterSpec.cs
@@ -44,7 +44,7 @@ namespace Akka.Cluster.Sharding.Tests.Internal
         private static Config SpecConfig =>
             ConfigurationFactory.ParseString("akka.loglevel = DEBUG")
             .WithFallback(
-                ClusterSingletonManager.DefaultConfig())
+                ClusterSingleton.DefaultConfig())
                 .WithFallback(ClusterSharding.DefaultConfig())
                 .WithFallback(DistributedData.DistributedData.DefaultConfig());
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentShardingMigrationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentShardingMigrationSpec.cs
@@ -146,7 +146,7 @@ namespace Akka.Cluster.Sharding.Tests
                 }
 
                 akka.cluster.sharding.verbose-debug-logging = on")
-                    .WithFallback(ClusterSingletonManager.DefaultConfig())
+                    .WithFallback(ClusterSingleton.DefaultConfig())
                     .WithFallback(ClusterSharding.DefaultConfig());
             }
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentStartEntitySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentStartEntitySpec.cs
@@ -21,7 +21,17 @@ namespace Akka.Cluster.Sharding.Tests
 {
     public class PersistentStartEntitySpec : AkkaSpec
     {
-        private static readonly Config SpecConfig;
+        private static Config SpecConfig =>
+            ConfigurationFactory.ParseString(@"
+                akka.loglevel = DEBUG
+                akka.actor.provider = cluster
+                akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
+                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+                akka.remote.dot-netty.tcp.port = 0
+                akka.cluster.sharding.verbose-debug-logging = on
+                akka.cluster.sharding.fail-on-invalid-entity-state-transition = on")
+                .WithFallback(ClusterSingleton.DefaultConfig())
+                .WithFallback(ClusterSharding.DefaultConfig());
 
         internal class EntityActor : ActorBase
         {
@@ -76,20 +86,6 @@ namespace Akka.Cluster.Sharding.Tests
 
             public string ShardId(string entityId, object messageHint = null)
                 => (int.Parse(entityId) % 10).ToString();
-        }
-
-        static PersistentStartEntitySpec()
-        {
-            SpecConfig = ConfigurationFactory.ParseString(@"
-                akka.loglevel = DEBUG
-                akka.actor.provider = cluster
-                akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
-                akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
-                akka.remote.dot-netty.tcp.port = 0
-                akka.cluster.sharding.verbose-debug-logging = on
-                akka.cluster.sharding.fail-on-invalid-entity-state-transition = on")
-                .WithFallback(ClusterSingletonManager.DefaultConfig()
-                .WithFallback(ClusterSharding.DefaultConfig()));
         }
 
         public PersistentStartEntitySpec(ITestOutputHelper helper) : base(SpecConfig, helper)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
@@ -65,7 +65,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                 .WithFallback(Sharding.ClusterSharding.DefaultConfig())
                 .WithFallback(DistributedData.DistributedData.DefaultConfig())
-                .WithFallback(ClusterSingletonManager.DefaultConfig());
+                .WithFallback(ClusterSingleton.DefaultConfig());
 
         public ProxyShardingSpec() : base(SpecConfig)
         {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesBatchedUpdatesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesBatchedUpdatesSpec.cs
@@ -137,7 +137,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                 .WithFallback(Sharding.ClusterSharding.DefaultConfig())
                 .WithFallback(DistributedData.DistributedData.DefaultConfig())
-                .WithFallback(ClusterSingletonManager.DefaultConfig());
+                .WithFallback(ClusterSingleton.DefaultConfig());
         }
 
         public RememberEntitiesBatchedUpdatesSpec(ITestOutputHelper helper) : base(GetConfig(), helper)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesShardIdExtractorChangeSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesShardIdExtractorChangeSpec.cs
@@ -116,7 +116,7 @@ namespace Akka.Cluster.Sharding.Tests
                 }
                 akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
                 akka.cluster.sharding.verbose-debug-logging = on")
-                    .WithFallback(ClusterSingletonManager.DefaultConfig())
+                    .WithFallback(ClusterSingleton.DefaultConfig())
                     .WithFallback(ClusterSharding.DefaultConfig());
             }
         }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardEntityFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardEntityFailureSpec.cs
@@ -30,7 +30,7 @@ namespace Akka.Cluster.Sharding.Tests
                 akka.actor.provider = cluster
                 akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
                 akka.remote.dot-netty.tcp.port = 0")
-            .WithFallback(ClusterSingletonManager.DefaultConfig())
+            .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSharding.DefaultConfig());
         
         private sealed class EntityEnvelope

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionQueriesHashCodeSpecs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionQueriesHashCodeSpecs.cs
@@ -78,7 +78,7 @@ namespace Akka.Cluster.Sharding.Tests
                                                      akka.cluster.roles = [shard]")
                 .WithFallback(Sharding.ClusterSharding.DefaultConfig())
                 .WithFallback(DistributedData.DistributedData.DefaultConfig())
-                .WithFallback(ClusterSingletonManager.DefaultConfig());
+                .WithFallback(ClusterSingleton.DefaultConfig());
         }
 
         [Fact]

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionQueriesSpecs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionQueriesSpecs.cs
@@ -90,7 +90,7 @@ namespace Akka.Cluster.Sharding.Tests
                                                      akka.cluster.roles = [shard]")
                 .WithFallback(Sharding.ClusterSharding.DefaultConfig())
                 .WithFallback(DistributedData.DistributedData.DefaultConfig())
-                .WithFallback(ClusterSingletonManager.DefaultConfig());
+                .WithFallback(ClusterSingleton.DefaultConfig());
         }
 
         /// <summary>

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionSpec.cs
@@ -72,8 +72,8 @@ namespace Akka.Cluster.Sharding.Tests
                 akka.cluster.sharding.verbose-debug-logging = on
                 akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
                 akka.cluster.sharding.distributed-data.durable.keys = []")
-                .WithFallback(ClusterSingletonManager.DefaultConfig()
-                .WithFallback(ClusterSharding.DefaultConfig()));
+                .WithFallback(ClusterSingleton.DefaultConfig())
+                .WithFallback(ClusterSharding.DefaultConfig());
 
 
         private ActorSystem sysA;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardWithLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardWithLeaseSpec.cs
@@ -140,8 +140,8 @@ namespace Akka.Cluster.Sharding.Tests
                 }
                 akka.cluster.sharding.verbose-debug-logging = on
                 akka.cluster.sharding.fail-on-invalid-entity-state-transition = on")
-                .WithFallback(ClusterSingletonManager.DefaultConfig()
-                .WithFallback(ClusterSharding.DefaultConfig()));
+                .WithFallback(ClusterSingleton.DefaultConfig())
+                .WithFallback(ClusterSharding.DefaultConfig());
 
         private TimeSpan shortDuration = TimeSpan.FromMilliseconds(100);
         private TestLeaseExt testLeaseExt;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardingQueriesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardingQueriesSpec.cs
@@ -27,7 +27,7 @@ namespace Akka.Cluster.Sharding.Tests
         private readonly TimeSpan timeout;
 
         private static Config SpecConfig =>
-            ClusterSingletonManager.DefaultConfig()
+            ClusterSingleton.DefaultConfig()
             .WithFallback(ClusterSharding.DefaultConfig());
 
         public ShardingQueriesSpec(ITestOutputHelper helper) : base(SpecConfig, helper)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/StartEntitySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/StartEntitySpec.cs
@@ -113,8 +113,8 @@ namespace Akka.Cluster.Sharding.Tests
                 akka.cluster.sharding.distributed-data.durable.keys = []
                 akka.cluster.sharding.verbose-debug-logging = on
                 akka.cluster.sharding.fail-on-invalid-entity-state-transition = on")
-                .WithFallback(ClusterSingletonManager.DefaultConfig()
-                .WithFallback(ClusterSharding.DefaultConfig()));
+                .WithFallback(ClusterSingleton.DefaultConfig())
+                .WithFallback(ClusterSharding.DefaultConfig());
 
         public StartEntitySpec(ITestOutputHelper helper) : base(SpecConfig, helper)
         {

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterSharding.cs
@@ -347,7 +347,7 @@ namespace Akka.Cluster.Sharding
         {
             _system = system;
             _system.Settings.InjectTopLevelFallback(DefaultConfig());
-            _system.Settings.InjectTopLevelFallback(ClusterSingletonManager.DefaultConfig());
+            _system.Settings.InjectTopLevelFallback(ClusterSingleton.DefaultConfig());
             _system.Settings.InjectTopLevelFallback(DistributedData.DistributedData.DefaultConfig());
             _cluster = Cluster.Get(_system);
             Settings = ClusterShardingSettings.Create(system);

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerChaosSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerChaosSpec.cs
@@ -47,7 +47,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Singleton
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = 0s
             ")
-            .WithFallback(ClusterSingletonManager.DefaultConfig())
+            .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSingletonProxy.DefaultConfig())
             .WithFallback(MultiNodeClusterSpec.ClusterConfig());
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerDownedSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerDownedSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Singleton
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = off
             ")
-            .WithFallback(ClusterSingletonManager.DefaultConfig())
+            .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSingletonProxy.DefaultConfig())
             .WithFallback(MultiNodeClusterSpec.ClusterConfig());
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerLeaseSpec.cs
@@ -57,7 +57,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Singleton
                     use-lease = ""test-lease""
                 }
             ")
-            .WithFallback(ClusterSingletonManager.DefaultConfig())
+            .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSingletonProxy.DefaultConfig())
             .WithFallback(MultiNodeClusterSpec.ClusterConfig());
 

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerLeave2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerLeave2Spec.cs
@@ -44,7 +44,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Singleton
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = off
             ")
-                .WithFallback(ClusterSingletonManager.DefaultConfig())
+                .WithFallback(ClusterSingleton.DefaultConfig())
                 .WithFallback(ClusterSingletonProxy.DefaultConfig())
                 .WithFallback(MultiNodeClusterSpec.ClusterConfig());
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerLeaveSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerLeaveSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Singleton
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = off
             ")
-            .WithFallback(ClusterSingletonManager.DefaultConfig())
+            .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSingletonProxy.DefaultConfig())
             .WithFallback(MultiNodeClusterSpec.ClusterConfig());
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerSpec.cs
@@ -49,7 +49,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Singleton
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = 0s
             ")
-            .WithFallback(ClusterSingletonManager.DefaultConfig())
+            .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSingletonProxy.DefaultConfig())
             .WithFallback(MultiNodeClusterSpec.ClusterConfig());
 

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerStartupSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerStartupSpec.cs
@@ -35,7 +35,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Singleton
                 akka.remote.retry-gate-closed-for = 1s #fast restart
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = 0s")
-            .WithFallback(ClusterSingletonManager.DefaultConfig())
+            .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSingletonProxy.DefaultConfig())
             .WithFallback(MultiNodeClusterSpec.ClusterConfig());
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonMessageSerializerSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonMessageSerializerSpec.cs
@@ -16,8 +16,8 @@ namespace Akka.Cluster.Tools.Tests.Singleton
     public class ClusterSingletonMessageSerializerSpec : AkkaSpec
     {
         public ClusterSingletonMessageSerializerSpec()
-            : base(ConfigurationFactory.ParseString(@"akka.actor.provider = cluster
-                                                      akka.remote.dot-netty.tcp.port = 0").WithFallback(ClusterSingletonManager.DefaultConfig()))
+            : base(ConfigurationFactory.ParseString("akka.actor.provider = cluster")
+                    .WithFallback(ClusterSingleton.DefaultConfig()))
         {
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManagerSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonManagerSettings.cs
@@ -27,7 +27,7 @@ namespace Akka.Cluster.Tools.Singleton
         /// <returns>The requested settings.</returns>
         public static ClusterSingletonManagerSettings Create(ActorSystem system)
         {
-            system.Settings.InjectTopLevelFallback(ClusterSingletonManager.DefaultConfig());
+            system.Settings.InjectTopLevelFallback(ClusterSingleton.DefaultConfig());
 
             var config = system.Settings.Config.GetConfig("akka.cluster.singleton");
             if (config.IsNullOrEmpty())

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxySettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonProxySettings.cs
@@ -27,7 +27,7 @@ namespace Akka.Cluster.Tools.Singleton
         /// <returns>TBD</returns>
         public static ClusterSingletonProxySettings Create(ActorSystem system)
         {
-            system.Settings.InjectTopLevelFallback(ClusterSingletonManager.DefaultConfig());
+            system.Settings.InjectTopLevelFallback(ClusterSingleton.DefaultConfig());
             var config = system.Settings.Config.GetConfig("akka.cluster.singleton-proxy");
             if (config.IsNullOrEmpty())
                 throw ConfigurationException.NullOrEmptyConfig<ClusterSingletonProxySettings>("akka.cluster.singleton-proxy");

--- a/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Singleton/ClusterSingletonSettings.cs
@@ -83,7 +83,7 @@ namespace Akka.Cluster.Tools.Singleton
         /// </summary>
         public static ClusterSingletonSettings Create(ActorSystem system)
         {
-            system.Settings.InjectTopLevelFallback(ClusterSingletonManager.DefaultConfig());
+            system.Settings.InjectTopLevelFallback(ClusterSingleton.DefaultConfig());
             return Create(system.Settings.Config.GetConfig("akka.cluster"));
         }
 


### PR DESCRIPTION
Major source of build warnings spread out across mostly other test assemblies
