### PR TITLE
Migrate from `PackageLicenseUrl` to `PackageLicenseExpression`

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,7 @@
     <VersionPrefix>1.5.34</VersionPrefix>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>https://github.com/akkadotnet/akka.net</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/akkadotnet/akka.net/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <!-- 
       xUnit1031 is a temporary fix, we will need to pay this technical debt 
       and make everything fully async in the future 


### PR DESCRIPTION
## Changes

Changes to using an Apache 2.0 license expression instead of the deprecated `PackageLicenseUrl` property, which will make it clearer to browsers on NuGet / IDE integration what our license terms actually are:

![image](https://github.com/user-attachments/assets/8e3a055c-bc09-45fc-970e-5e220ba96a94)

to

![image](https://github.com/user-attachments/assets/640009d7-5edf-4d87-b97f-390cce446419)