### PR TITLE
Akka.Benchmarks: categorize and cleanup core `Akka` benchmarks

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Actor/ActorMemoryFootprintBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorMemoryFootprintBenchmark.cs
@@ -13,6 +13,7 @@ using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Actor
 {
@@ -42,6 +43,7 @@ namespace Akka.Benchmarks.Actor
         }
 
         [Benchmark]
+        [BenchmarkCategory(ActorSpawningBenchmark, MicroBenchmark)]
         public void SpawnActor()
         {
             for(var i = 0; i < SpawnCount; i++)

--- a/src/benchmark/Akka.Benchmarks/Actor/ActorMessagingMemoryPressureBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorMessagingMemoryPressureBenchmark.cs
@@ -12,6 +12,7 @@ using Akka.Benchmarks.Configurations;
 using Akka.Routing;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Engines;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Actor
 {
@@ -113,6 +114,7 @@ namespace Akka.Benchmarks.Actor
         }
 
         [Benchmark(Baseline = true, OperationsPerInvoke = MsgCount * 2)]
+        [BenchmarkCategory(MicroBenchmark, ActorMessagingBenchmark)]
         public Task PushMsgs()
         {
             for (var i = 0; i < MsgCount; i++)
@@ -124,6 +126,7 @@ namespace Akka.Benchmarks.Actor
         }
 
         [Benchmark(OperationsPerInvoke = MsgCount * 2)]
+        [BenchmarkCategory(MicroBenchmark, ActorMessagingBenchmark)]
         public Task AskMsgs()
         {
             for (var i = 0; i < MsgCount; i++)

--- a/src/benchmark/Akka.Benchmarks/Actor/ActorPathBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorPathBenchmarks.cs
@@ -9,6 +9,7 @@ using System;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Actor
 {
@@ -37,36 +38,42 @@ namespace Akka.Benchmarks.Actor
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public ActorPath ActorPath_Parse()
         {
             return ActorPath.Parse(_actorPathStr);
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public ActorPath ActorPath_Concat()
         {
             return x / "parent" / "child";
         }
         
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public bool ActorPath_Equals()
         {
             return x == y;
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public string ActorPath_ToString()
         {
             return _childPath.ToString();
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public string ActorPath_ToSerializationFormat()
         {
             return _childPath.ToSerializationFormat();
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public string ActorPath_ToSerializationFormatWithAddress()
         {
             return _childPath.ToSerializationFormatWithAddress(_otherAdr);

--- a/src/benchmark/Akka.Benchmarks/Actor/ActorRefBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorRefBenchmarks.cs
@@ -6,10 +6,10 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Actor
 {
@@ -33,18 +33,21 @@ namespace Akka.Benchmarks.Actor
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public int ActorRefGetHashCode()
         {
             return _echo.GetHashCode();
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public bool ActorRefEqualsSelf()
         {
             return _echo.Equals(_echo);
         }
         
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public bool ActorRefEqualsSomeoneElse()
         {
             return _echo.Equals(_echo2);

--- a/src/benchmark/Akka.Benchmarks/Actor/ActorSelectionBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorSelectionBenchmark.cs
@@ -6,14 +6,11 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Net.NetworkInformation;
-using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Engines;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Actor
 {
@@ -39,6 +36,7 @@ namespace Akka.Benchmarks.Actor
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark, ActorMessagingBenchmark)]
         public async Task RequestResponseActorSelection()
         {
             for(var i = 0; i < Iterations; i++)
@@ -46,6 +44,7 @@ namespace Akka.Benchmarks.Actor
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark, ActorMessagingBenchmark)]
         public void CreateActorSelection()
         {
             for (var i = 0; i < Iterations; i++)

--- a/src/benchmark/Akka.Benchmarks/Actor/AddressBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/AddressBenchmarks.cs
@@ -8,50 +8,56 @@
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Actor
 {
     [Config(typeof(MicroBenchmarkConfig))]
     public class AddressBenchmarks
     {
-        private Address x;
-        private Address y;
+        private Address _x;
+        private Address _y;
 
         [GlobalSetup]
         public void Setup()
         {
-            x = new Address("akka.tcp", "test-system", "10.62.0.101", 4000);
-            y = new Address("akka.tcp", "test-system", "10.62.0.101", 4123);
+            _x = new Address("akka.tcp", "test-system", "10.62.0.101", 4000);
+            _y = new Address("akka.tcp", "test-system", "10.62.0.101", 4123);
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public Address Address_Parse()
         {
             return Address.Parse("akka.tcp://test-system@10.62.0.100:5000/");
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public int Address_CompareTo()
         {
-            return x.CompareTo(y);
+            return _x.CompareTo(_y);
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public string Address_ToString()
         {
-            return x.ToString();
+            return _x.ToString();
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public bool Address_Equals()
         {
-            return x == y;
+            return _x == _y;
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public int Address_GetHashCode()
         {
-            return x.GetHashCode();
+            return _x.GetHashCode();
         }
     }
 }

--- a/src/benchmark/Akka.Benchmarks/Actor/FsmBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/FsmBenchmarks.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Actor
 {
@@ -124,6 +125,7 @@ namespace Akka.Benchmarks.Actor
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark, ActorMessagingBenchmark)]
         public async Task BenchmarkFsm()
         {
             for (var i = 0; i < MsgCount; i++)
@@ -142,6 +144,7 @@ namespace Akka.Benchmarks.Actor
         }
         
         [Benchmark(Baseline = true)]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark, ActorMessagingBenchmark)]
         public async Task BenchmarkUntyped()
         {
             for (var i = 0; i < MsgCount; i++)

--- a/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/GetChildBenchmark.cs
@@ -12,8 +12,8 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Engines;
 using FluentAssertions;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Actor
 {
@@ -93,17 +93,17 @@ namespace Akka.Benchmarks.Actor
         private ActorSystem _system;
         private IActorRef _parentActor;
 
-        private ActorWithChild.Get _getMessage = new("food");
-        private ActorWithChild.Create _createMessage = new("food");
+        private readonly ActorWithChild.Get _getMessage = new("food");
+        private readonly ActorWithChild.Create _createMessage = new("food");
 
         private IActorContext _cell;
         private RepointableActorRef _repointableActorRef;
         private LocalActorRef _localActorRef;
         private VirtualPathContainer _virtualPathContainer;
 
-        private List<string> _rpChildQueryPath = new() { "food", "ood", "od" };
-        private List<string> _lclChildQueryPath = new() { "ood", "od", "d" };
-        private List<string> _virtualPathContainerQueryPath = new() { "foo" };
+        private readonly List<string> _rpChildQueryPath = ["food", "ood", "od"];
+        private readonly List<string> _lclChildQueryPath = ["ood", "od", "d"];
+        private readonly List<string> _virtualPathContainerQueryPath = ["foo"];
         
         [GlobalSetup]
         public async Task Setup()
@@ -127,24 +127,28 @@ namespace Akka.Benchmarks.Actor
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public void ResolveChild()
         {
             _cell.Child(_getMessage.Name);
         }
         
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public void Resolve3DeepChildRepointableActorRef()
         {
             _repointableActorRef.GetChild(_rpChildQueryPath);
         }
         
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public void Resolve3DeepChildLocalActorRef()
         {
             _localActorRef.GetChild(_lclChildQueryPath);
         }
         
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public void ResolveVirtualPathContainer()
         {
             _virtualPathContainer.GetChild(_virtualPathContainerQueryPath);

--- a/src/benchmark/Akka.Benchmarks/Actor/PingPongBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/PingPongBenchmarks.cs
@@ -9,40 +9,39 @@ using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
-using Akka.Configuration;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Engines;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Actor
 {
-    [Config(typeof(MonitoringConfig))]
-    [SimpleJob(RunStrategy.Monitoring, launchCount: 10, warmupCount: 10)]
+    [Config(typeof(MacroBenchmarkConfig))]
     public class PingPongBenchmarks
     {
-        public const int Operations = 1_000_000;
-        private TimeSpan timeout;
-        private ActorSystem system;
-        private IActorRef ping;
+        private const int Operations = 1_000_000;
+        private TimeSpan _timeout;
+        private ActorSystem _system;
+        private IActorRef _ping;
 
         [IterationSetup]
         public void Setup()
         {
-            timeout = TimeSpan.FromMinutes(1);
-            system = ActorSystem.Create("system");
-            var pong = system.ActorOf(Props.Create(() => new Pong()));
-            ping = system.ActorOf(Props.Create(() => new Ping(pong)));
+            _timeout = TimeSpan.FromMinutes(1);
+            _system = ActorSystem.Create("system");
+            var pong = _system.ActorOf(Props.Create(() => new Pong()));
+            _ping = _system.ActorOf(Props.Create(() => new Ping(pong)));
         }
 
         [IterationCleanup]
         public void Cleanup()
         {
-            system.Dispose();
+            _system.Dispose();
         }
 
         [Benchmark(OperationsPerInvoke = Operations * 2)]
+        [BenchmarkCategory(MacroBenchmark, ActorMessagingBenchmark)]
         public async Task Actor_ping_pong_single_pair_in_memory()
         {
-            await ping.Ask(StartTest.Instance, timeout);
+            await _ping.Ask(StartTest.Instance, _timeout);
         }
 
         #region actors

--- a/src/benchmark/Akka.Benchmarks/Actor/SpawnActorBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/SpawnActorBenchmarks.cs
@@ -10,12 +10,11 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Engines;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Actor
 {
-    [Config(typeof(MicroBenchmarkConfig))]
-    [SimpleJob(RunStrategy.Throughput, warmupCount:5)]
+    [Config(typeof(MacroBenchmarkConfig))]
     public class SpawnActorBenchmarks
     {
         [Params(100_000)]
@@ -24,27 +23,28 @@ namespace Akka.Benchmarks.Actor
         [Params(true, false)]
         public bool EnableTelemetry { get; set; }
         
-        private ActorSystem system;
+        private ActorSystem _system;
 
         [IterationSetup]
         public void Setup()
         {
             if(EnableTelemetry) // need to measure the impact of publishing actor start / stop events
-                system = ActorSystem.Create("system", "akka.actor.telemetry.enabled = true");
+                _system = ActorSystem.Create("system", "akka.actor.telemetry.enabled = true");
             else
-                system = ActorSystem.Create("system");
+                _system = ActorSystem.Create("system");
         }
 
         [IterationCleanup]
         public void Cleanup()
         {
-           system.Terminate().Wait();
+           _system.Terminate().Wait();
         }
 
         [Benchmark]
+        [BenchmarkCategory(MacroBenchmark, ActorSpawningBenchmark)]
         public async Task Actor_spawn()
         {
-            var parent = system.ActorOf(Parent.Props);
+            var parent = _system.ActorOf(Parent.Props);
             
             // spawn a bunch of actors
             await parent.Ask<TestDone>(new StartTest(ActorCount), TimeSpan.FromMinutes(2)).ConfigureAwait(false);

--- a/src/benchmark/Akka.Benchmarks/Configurations/BenchmarkCategories.cs
+++ b/src/benchmark/Akka.Benchmarks/Configurations/BenchmarkCategories.cs
@@ -1,0 +1,23 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="BenchmarkCategories.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+namespace Akka.Benchmarks.Configurations;
+
+public static class BenchmarkCategories
+{
+    public const string MacroBenchmark = "MacroBenchmark";
+    public const string MicroBenchmark = "MicroBenchmark";
+    
+    public const string AkkaIOBenchmark = "Akka.IO";
+    public const string DispatcherBenchmark = "Akka.Dispatch";
+    public const string ActorSpawningBenchmark = "Actor-Spawning";
+    public const string ActorMessagingBenchmark = "Actor-Messaging";
+    public const string AkkaActorBenchmark = "Akka.Actor";
+    public const string AkkaEventBenchmark = "Akka.Event";
+    
+    public const string HoconBenchmark = "Akka.Configuration";
+}

--- a/src/benchmark/Akka.Benchmarks/Configurations/Configs.cs
+++ b/src/benchmark/Akka.Benchmarks/Configurations/Configs.cs
@@ -86,19 +86,21 @@ namespace Akka.Benchmarks.Configurations
     {
         public MacroBenchmarkConfig()
         {
-            int processorCount = Environment.ProcessorCount;
-            IntPtr affinityMask = (IntPtr)((1 << processorCount) - 1);
-
-            
             AddExporter(MarkdownExporter.GitHub);
             AddColumn(new RequestsPerSecondColumn());
+            AddColumn(new CategoriesColumn());
+            AddLogger(ConsoleLogger.Default);
+            
+            int processorCount = Environment.ProcessorCount;
+            IntPtr affinityMask = (IntPtr)((1 << processorCount) - 1);
+            
             AddJob(Job.LongRun
                 .WithGcMode(new GcMode { Server = true, Concurrent = true })
                 .WithWarmupCount(25)
                 .WithIterationCount(50)
                 .RunOncePerIteration()
                 .WithStrategy(RunStrategy.Monitoring)
-                .WithAffinity(affinityMask)
+                // .WithAffinity(affinityMask) // Optional
             );
         }
     }

--- a/src/benchmark/Akka.Benchmarks/EventStream/EventStreamBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/EventStream/EventStreamBenchmarks.cs
@@ -8,16 +8,16 @@
 using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.EventStream
 {
     [Config(typeof(MicroBenchmarkConfig))]
     public class EventStreamBenchmarks
     {
-                
-        public const int NumOperations = 1_000_000;
-        
-        internal sealed class FakeActor : MinimalActorRef
+        private const int NumOperations = 1_000_000;
+
+        private sealed class FakeActor : MinimalActorRef
         {
             public override ActorPath Path { get; } = new RootActorPath(new Address("akka", "test")) / "fake";
             public override IActorRefProvider Provider => throw new System.NotImplementedException();
@@ -33,7 +33,7 @@ namespace Akka.Benchmarks.EventStream
         private FakeActor _fakeActor;
         private Akka.Event.EventStream _eventStream;
 
-        private const string _msg = "foo";
+        private const string Msg = "foo";
 
         
         [IterationSetup]
@@ -45,11 +45,12 @@ namespace Akka.Benchmarks.EventStream
         }
         
         [Benchmark(OperationsPerInvoke = NumOperations)]
+        [BenchmarkCategory(MicroBenchmark, AkkaEventBenchmark)]
         public object Publish()
         {
             for (var i = 0; i < NumOperations; i++)
             {
-                _eventStream.Publish(_msg);
+                _eventStream.Publish(Msg);
             }
             return _fakeActor.LastMessage;
         }

--- a/src/benchmark/Akka.Benchmarks/Hocon/HoconBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Hocon/HoconBenchmarks.cs
@@ -10,113 +10,121 @@ using System.Collections.Generic;
 using Akka.Benchmarks.Configurations;
 using Akka.Configuration;
 using BenchmarkDotNet.Attributes;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Hocon
 {
     [Config(typeof(MicroBenchmarkConfig))]
+    [BenchmarkCategory(MicroBenchmark, HoconBenchmark)]
     public class HoconBenchmarks
     {
-        public const string hoconString = @"
-          akka {  
-            actor { 
-              provider = remote
-              deployment {
-                /remoteecho {
-                    remote = ""akka.tcp://DeployTarget@localhost:8090""
-                }
-              }              
-            }
-            remote {
-              dot-netty.tcp {
-                port = 8090
-                hostname = localhost
-              }
-            }
-            persistence {
-                journal {
-                    plugin = akka.persistence.journal.in-memory
-                }
-            }
-          }
-        ";
+        public const string HoconString = """
+                                          
+                                                    akka {  
+                                                      actor { 
+                                                        provider = remote
+                                                        deployment {
+                                                          /remoteecho {
+                                                              remote = "akka.tcp://DeployTarget@localhost:8090"
+                                                          }
+                                                        }              
+                                                      }
+                                                      remote {
+                                                        dot-netty.tcp {
+                                                          port = 8090
+                                                          hostname = localhost
+                                                        }
+                                                      }
+                                                      persistence {
+                                                          journal {
+                                                              plugin = akka.persistence.journal.in-memory
+                                                          }
+                                                      }
+                                                    }
+                                                  
+                                          """;
 
-        public Config fallback1;
-        public Config fallback2;
-        public Config fallback3;
+        private Config _fallback1;
+        private Config _fallback2;
+        private Config _fallback3;
 
         [GlobalSetup]
         public void Setup()
         {
-            fallback1 = ConfigurationFactory.ParseString(@"
-            akka.actor.ask-timeout = 60s
-            akka.actor.branch-factor = 0.25
-            akka.persistence {
-                journal.plugin = akka.persistence.journal.sql-server
-                journal.sql-server {
-                    auto-initialize = on
-                }
-            }");
-            fallback2 = ConfigurationFactory.ParseString(@"
-            akka.actor.provider = cluster
-            akka.remote.dot-netty.tcp {
-                hostname = ""127.0.0.1""
-                port = 0
-            }
-            akka.cluster {
-                seed-nodes = [ 
-                    ""akka.tcp://system@localhost:8000/"",
-                    ""akka.tcp://system@localhost:8001/""
-                ]
-            }");
-            fallback3 = Persistence.Persistence.DefaultConfig();
+            _fallback1 = ConfigurationFactory.ParseString("""
+                                                          
+                                                                      akka.actor.ask-timeout = 60s
+                                                                      akka.actor.branch-factor = 0.25
+                                                                      akka.persistence {
+                                                                          journal.plugin = akka.persistence.journal.sql-server
+                                                                          journal.sql-server {
+                                                                              auto-initialize = on
+                                                                          }
+                                                                      }
+                                                          """);
+            _fallback2 = ConfigurationFactory.ParseString("""
+                                                          
+                                                                      akka.actor.provider = cluster
+                                                                      akka.remote.dot-netty.tcp {
+                                                                          hostname = "127.0.0.1"
+                                                                          port = 0
+                                                                      }
+                                                                      akka.cluster {
+                                                                          seed-nodes = [ 
+                                                                              "akka.tcp://system@localhost:8000/",
+                                                                              "akka.tcp://system@localhost:8001/"
+                                                                          ]
+                                                                      }
+                                                          """);
+            _fallback3 = Persistence.Persistence.DefaultConfig();
         }
 
         [Benchmark]
         public string Hocon_parse_resolve_string_value()
         {
-            return fallback2.GetString("akka.actor.provider", null);
+            return _fallback2.GetString("akka.actor.provider", null);
         }
 
         [Benchmark]
         public int Hocon_parse_resolve_int_value()
         {
-            return fallback2.GetInt("akka.remote.dot-netty.tcp.port", 0);
+            return _fallback2.GetInt("akka.remote.dot-netty.tcp.port", 0);
         }
 
         [Benchmark]
         public double Hocon_parse_resolve_double_value()
         {
-            return fallback1.GetDouble("akka.actor.branch-factor", 0);
+            return _fallback1.GetDouble("akka.actor.branch-factor", 0);
         }
 
         [Benchmark]
         public bool Hocon_parse_resolve_boolean_value()
         {
-            return fallback1.GetBoolean("akka.persistence.journal.sql-server.auto-initialize", false);
+            return _fallback1.GetBoolean("akka.persistence.journal.sql-server.auto-initialize", false);
         }
 
         [Benchmark]
         public TimeSpan Hocon_parse_resolve_TimeSpan_value()
         {
-            return fallback1.GetTimeSpan("akka.actor.ask-timeout", null);
+            return _fallback1.GetTimeSpan("akka.actor.ask-timeout", null);
         }
 
         [Benchmark]
         public IEnumerable<string> Hocon_parse_resolve_string_list_value()
         {
-            return fallback1.GetStringList("akka.cluster.seed-nodes", new string[] { });
+            return _fallback1.GetStringList("akka.cluster.seed-nodes", new string[] { });
         }
 
         [Benchmark]
         public Config Hocon_parse_raw()
         {
-            return ConfigurationFactory.ParseString(hoconString);
+            return ConfigurationFactory.ParseString(HoconString);
         }
 
         [Benchmark]
         public Config Hocon_combine_fallbacks()
         {
-            return fallback1.WithFallback(fallback2).WithFallback(fallback3);
+            return _fallback1.WithFallback(_fallback2).WithFallback(_fallback3);
         }
     }
 }

--- a/src/benchmark/Akka.Benchmarks/IO/ByteStringBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/IO/ByteStringBenchmarks.cs
@@ -8,6 +8,7 @@
 using Akka.Benchmarks.Configurations;
 using Akka.IO;
 using BenchmarkDotNet.Attributes;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks
 {
@@ -42,18 +43,21 @@ namespace Akka.Benchmarks
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaIOBenchmark)]
         public ByteString ByteString_create_unsafe()
         {
             return ByteString.FromBytes(_bytes);
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaIOBenchmark)]
         public ByteString ByteString_create_copying()
         {
             return ByteString.CopyFrom(_bytes);
         }
         
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaIOBenchmark)]
         public ByteString ByteString_create_from_string()
         {
             return ByteString.FromString(_str);
@@ -61,6 +65,7 @@ namespace Akka.Benchmarks
 
         [Benchmark]
         [Arguments(10)]
+        [BenchmarkCategory(MicroBenchmark, AkkaIOBenchmark)]
         public ByteString ByteString_concatenation(int times)
         {
             var acc = ByteString.Empty;
@@ -73,12 +78,14 @@ namespace Akka.Benchmarks
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaIOBenchmark)]
         public ByteString ByteString_multipart_slice()
         {
             return _multipart.Slice(10, 40);
         }
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaIOBenchmark)]
         public ByteString ByteString_multipart_compact()
         {
             return _multipart.Compact();
@@ -86,6 +93,7 @@ namespace Akka.Benchmarks
 
 
         [Benchmark]
+        [BenchmarkCategory(MicroBenchmark, AkkaIOBenchmark)]
         public bool ByteString_multipart_has_substring()
         {
             byte[] array = { 6, 7, 8, 9 };

--- a/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
@@ -22,8 +22,7 @@ using BenchmarkDotNet.Engines;
 
 namespace Akka.Benchmarks
 {
-    [Config(typeof(MicroBenchmarkConfig))]
-    [SimpleJob(warmupCount: 1, invocationCount: 1, launchCount: 1, runStrategy: RunStrategy.Monitoring)]
+    [Config(typeof(MacroBenchmarkConfig))]
     public class TcpOperationsBenchmarks
     {
         private ActorSystem _system;

--- a/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Logging/LoggingBenchmarks.cs
@@ -6,11 +6,10 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Threading.Tasks;
-using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using Akka.Event;
 using BenchmarkDotNet.Attributes;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks
 {
@@ -71,6 +70,7 @@ namespace Akka.Benchmarks
         }
 
         [Benchmark(Baseline = true, OperationsPerInvoke = NumOperations)]
+        [BenchmarkCategory(MicroBenchmark, AkkaEventBenchmark)]
         public LogEvent[] LogInfoNoParams()
         {
             for(var i = 0; i < NumOperations; i++)
@@ -80,6 +80,7 @@ namespace Akka.Benchmarks
         }
         
         [Benchmark( OperationsPerInvoke = NumOperations)]
+        [BenchmarkCategory(MicroBenchmark, AkkaEventBenchmark)]
         public LogEvent[] LogInfo1Params()
         {
             for(var i = 0; i < NumOperations; i++)
@@ -89,6 +90,7 @@ namespace Akka.Benchmarks
         }
         
         [Benchmark(OperationsPerInvoke = NumOperations)]
+        [BenchmarkCategory(MicroBenchmark, AkkaEventBenchmark)]
         public LogEvent[] LogInfo2Params()
         {
             for(var i = 0; i < NumOperations; i++)
@@ -98,6 +100,7 @@ namespace Akka.Benchmarks
         }
         
         [Benchmark(OperationsPerInvoke = NumOperations)]
+        [BenchmarkCategory(MicroBenchmark, AkkaEventBenchmark)]
         public LogEvent[] LogInfoWithException()
         {
             var ex = new ApplicationException();
@@ -108,6 +111,7 @@ namespace Akka.Benchmarks
         }
         
         [Benchmark(OperationsPerInvoke = NumOperations)]
+        [BenchmarkCategory(MicroBenchmark, AkkaEventBenchmark)]
         public LogEvent[] LogInfoWithException1Params()
         {
             var ex = new ApplicationException();
@@ -118,6 +122,7 @@ namespace Akka.Benchmarks
         }
         
         [Benchmark(OperationsPerInvoke = NumOperations)]
+        [BenchmarkCategory(MicroBenchmark, AkkaEventBenchmark)]
         public LogEvent[] LogInfoWithException2Params()
         {
             var ex = new ApplicationException();


### PR DESCRIPTION
## Changes

Leveraging Benchmark.NET categories to make it easier to run them in groups, along with cleaning up the `MacroBenchmarkConfig` and doing some code / style cleanup.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
