### PR TITLE
Akka.IO: fix `TcpListener` connection queue problem

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3988,7 +3988,7 @@ namespace Akka.IO
             public static readonly Akka.IO.Tcp.Abort Instance;
             public override Akka.IO.Tcp.ConnectionClosed Event { get; }
         }
-        public class Aborted : Akka.IO.Tcp.ConnectionClosed
+        public sealed class Aborted : Akka.IO.Tcp.ConnectionClosed
         {
             public static readonly Akka.IO.Tcp.Aborted Instance;
             public override bool IsAborted { get; }
@@ -4003,13 +4003,13 @@ namespace Akka.IO
             public bool PullMode { get; }
             public override string ToString() { }
         }
-        public class Bound : Akka.IO.Tcp.Event
+        public sealed class Bound : Akka.IO.Tcp.Event
         {
             public Bound(System.Net.EndPoint localAddress) { }
             public System.Net.EndPoint LocalAddress { get; }
             public override string ToString() { }
         }
-        public class Close : Akka.IO.Tcp.CloseCommand
+        public sealed class Close : Akka.IO.Tcp.CloseCommand
         {
             public static readonly Akka.IO.Tcp.Close Instance;
             public override Akka.IO.Tcp.ConnectionClosed Event { get; }
@@ -4019,7 +4019,7 @@ namespace Akka.IO
             protected CloseCommand() { }
             public abstract Akka.IO.Tcp.ConnectionClosed Event { get; }
         }
-        public class Closed : Akka.IO.Tcp.ConnectionClosed
+        public sealed class Closed : Akka.IO.Tcp.ConnectionClosed
         {
             public static readonly Akka.IO.Tcp.Closed Instance;
         }
@@ -4040,7 +4040,7 @@ namespace Akka.IO
             [Akka.Annotations.InternalApiAttribute()]
             public Akka.IO.Tcp.CommandFailed WithCause(System.Exception cause) { }
         }
-        public class CompoundWrite : Akka.IO.Tcp.WriteCommand, System.Collections.Generic.IEnumerable<Akka.IO.Tcp.SimpleWriteCommand>, System.Collections.IEnumerable
+        public sealed class CompoundWrite : Akka.IO.Tcp.WriteCommand, System.Collections.Generic.IEnumerable<Akka.IO.Tcp.SimpleWriteCommand>, System.Collections.IEnumerable
         {
             public CompoundWrite(Akka.IO.Tcp.SimpleWriteCommand head, Akka.IO.Tcp.WriteCommand tailCommand) { }
             public Akka.IO.Tcp.SimpleWriteCommand Head { get; }
@@ -4048,17 +4048,17 @@ namespace Akka.IO
             public System.Collections.Generic.IEnumerator<Akka.IO.Tcp.SimpleWriteCommand> GetEnumerator() { }
             public override string ToString() { }
         }
-        public class ConfirmedClose : Akka.IO.Tcp.CloseCommand
+        public sealed class ConfirmedClose : Akka.IO.Tcp.CloseCommand
         {
             public static readonly Akka.IO.Tcp.ConfirmedClose Instance;
             public override Akka.IO.Tcp.ConnectionClosed Event { get; }
         }
-        public class ConfirmedClosed : Akka.IO.Tcp.ConnectionClosed
+        public sealed class ConfirmedClosed : Akka.IO.Tcp.ConnectionClosed
         {
             public static readonly Akka.IO.Tcp.ConfirmedClosed Instance;
             public override bool IsConfirmed { get; }
         }
-        public class Connect : Akka.IO.Tcp.Command
+        public sealed class Connect : Akka.IO.Tcp.Command
         {
             public Connect(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress = null, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, System.Nullable<System.TimeSpan> timeout = null, bool pullMode = False) { }
             public System.Net.EndPoint LocalAddress { get; }
@@ -4108,7 +4108,7 @@ namespace Akka.IO
             public object Token { get; }
             public override string ToString() { }
         }
-        public class PeerClosed : Akka.IO.Tcp.ConnectionClosed
+        public sealed class PeerClosed : Akka.IO.Tcp.ConnectionClosed
         {
             public static readonly Akka.IO.Tcp.PeerClosed Instance;
             public override bool IsPeerClosed { get; }
@@ -4127,17 +4127,17 @@ namespace Akka.IO
             public bool UseResumeWriting { get; }
             public override string ToString() { }
         }
-        public class ResumeAccepting : Akka.IO.Tcp.Command
+        public sealed class ResumeAccepting : Akka.IO.Tcp.Command
         {
             public ResumeAccepting(int batchSize) { }
             public int BatchSize { get; }
             public override string ToString() { }
         }
-        public class ResumeReading : Akka.IO.Tcp.Command
+        public sealed class ResumeReading : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.ResumeReading Instance;
         }
-        public class ResumeWriting : Akka.IO.Tcp.Command
+        public sealed class ResumeWriting : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.ResumeWriting Instance;
         }
@@ -4148,7 +4148,7 @@ namespace Akka.IO
             public bool WantsAck { get; }
             public Akka.IO.Tcp.CompoundWrite Append(Akka.IO.Tcp.WriteCommand that) { }
         }
-        public class SuspendReading : Akka.IO.Tcp.Command
+        public sealed class SuspendReading : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.SuspendReading Instance;
         }
@@ -4156,11 +4156,11 @@ namespace Akka.IO
         {
             public static readonly Akka.IO.Tcp.Unbind Instance;
         }
-        public class Unbound : Akka.IO.Tcp.Event
+        public sealed class Unbound : Akka.IO.Tcp.Event
         {
             public static readonly Akka.IO.Tcp.Unbound Instance;
         }
-        public class Write : Akka.IO.Tcp.SimpleWriteCommand
+        public sealed class Write : Akka.IO.Tcp.SimpleWriteCommand
         {
             public static readonly Akka.IO.Tcp.Write Empty;
             public override Akka.IO.Tcp.Event Ack { get; }
@@ -4177,7 +4177,7 @@ namespace Akka.IO
             public Akka.IO.Tcp.CompoundWrite Prepend(Akka.IO.Tcp.SimpleWriteCommand other) { }
             public Akka.IO.Tcp.WriteCommand Prepend(System.Collections.Generic.IEnumerable<Akka.IO.Tcp.WriteCommand> writes) { }
         }
-        public class WritingResumed : Akka.IO.Tcp.Event
+        public sealed class WritingResumed : Akka.IO.Tcp.Event
         {
             public static readonly Akka.IO.Tcp.WritingResumed Instance;
         }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -4214,7 +4214,6 @@ namespace Akka.IO
     public class TcpSettings
     {
         public TcpSettings(string bufferPoolConfigPath, int initialSocketAsyncEventArgs, bool traceLogging, int batchAcceptLimit, System.Nullable<System.TimeSpan> registerTimeout, int receivedMessageSizeLimit, string managementDispatcher, string fileIoDispatcher, int transferToLimit, int finishConnectRetries, bool outgoingSocketForceIpv4, int writeCommandsQueueMaxSize) { }
-        [System.ObsoleteAttribute("This setting is deprecated and will be removed in a future version.")]
         public int BatchAcceptLimit { get; }
         public string BufferPoolConfigPath { get; }
         public string FileIODispatcher { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3977,10 +3977,9 @@ namespace Akka.IO
         protected override void PostStop() { }
         protected override bool Receive(object message) { }
     }
-    public class Tcp : Akka.Actor.ExtensionIdProvider<Akka.IO.TcpExt>
+    public sealed class Tcp : Akka.Actor.ExtensionIdProvider<Akka.IO.TcpExt>
     {
         public static readonly Akka.Actor.SupervisorStrategy ConnectionSupervisorStrategy;
-        public static readonly Akka.IO.Tcp Instance;
         public Tcp() { }
         public override Akka.IO.TcpExt CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
         public static Akka.Actor.IActorRef Manager(Akka.Actor.ActorSystem system) { }
@@ -4031,6 +4030,7 @@ namespace Akka.IO
         }
         public sealed class CommandFailed : Akka.IO.Tcp.Event
         {
+            public CommandFailed(Akka.IO.Tcp.Command cmd, Akka.Util.Option<System.Exception> ex) { }
             public CommandFailed(Akka.IO.Tcp.Command cmd) { }
             public Akka.Util.Option<System.Exception> Cause { get; }
             [Akka.Annotations.InternalApiAttribute()]
@@ -4078,6 +4078,7 @@ namespace Akka.IO
         public class ConnectionClosed : Akka.IO.Tcp.Event, Akka.Event.IDeadLetterSuppression
         {
             public ConnectionClosed() { }
+            [System.Runtime.CompilerServices.NullableAttribute(2)]
             public virtual string Cause { get; }
             public virtual bool IsAborted { get; }
             public virtual bool IsConfirmed { get; }
@@ -4087,6 +4088,7 @@ namespace Akka.IO
         public sealed class ErrorClosed : Akka.IO.Tcp.ConnectionClosed
         {
             public ErrorClosed(string cause) { }
+            [System.Runtime.CompilerServices.NullableAttribute(2)]
             public override string Cause { get; }
             public override bool IsErrorClosed { get; }
             public override string ToString() { }
@@ -4191,15 +4193,14 @@ namespace Akka.IO
     {
         public static Akka.Actor.IActorRef Tcp(this Akka.Actor.ActorSystem system) { }
     }
-    public class TcpMessage
+    public class static TcpMessage
     {
-        public TcpMessage() { }
         public static Akka.IO.Tcp.Command Abort() { }
         public static Akka.IO.Tcp.Command Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint endpoint, int backlog, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, bool pullMode) { }
         public static Akka.IO.Tcp.Command Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint endpoint, int backlog) { }
         public static Akka.IO.Tcp.Command Close() { }
         public static Akka.IO.Tcp.Command ConfirmedClose() { }
-        public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, System.Nullable<System.TimeSpan> timeout, bool pullMode) { }
+        public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress, [System.Runtime.CompilerServices.NullableAttribute(2)] System.Net.EndPoint localAddress, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, System.Nullable<System.TimeSpan> timeout, bool pullMode) { }
         public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress) { }
         public static Akka.IO.Tcp.NoAck NoAck(object token = null) { }
         public static Akka.IO.Tcp.Command Register(Akka.Actor.IActorRef handler, bool keepOpenOnPeerClosed = False, bool useResumeWriting = True) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3995,7 +3995,7 @@ namespace Akka.IO
         }
         public class Bind : Akka.IO.Tcp.Command
         {
-            public Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint localAddress, int backlog = 100, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, bool pullMode = False) { }
+            public Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint localAddress, int backlog = 1024, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, bool pullMode = False) { }
             public int Backlog { get; }
             public Akka.Actor.IActorRef Handler { get; }
             public System.Net.EndPoint LocalAddress { get; }
@@ -4214,6 +4214,7 @@ namespace Akka.IO
     public class TcpSettings
     {
         public TcpSettings(string bufferPoolConfigPath, int initialSocketAsyncEventArgs, bool traceLogging, int batchAcceptLimit, System.Nullable<System.TimeSpan> registerTimeout, int receivedMessageSizeLimit, string managementDispatcher, string fileIoDispatcher, int transferToLimit, int finishConnectRetries, bool outgoingSocketForceIpv4, int writeCommandsQueueMaxSize) { }
+        [System.ObsoleteAttribute("This setting is deprecated and will be removed in a future version.")]
         public int BatchAcceptLimit { get; }
         public string BufferPoolConfigPath { get; }
         public string FileIODispatcher { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -4089,7 +4089,6 @@ namespace Akka.IO
         public sealed class ErrorClosed : Akka.IO.Tcp.ConnectionClosed
         {
             public ErrorClosed(string cause) { }
-            [System.Runtime.CompilerServices.NullableAttribute(2)]
             public override string Cause { get; }
             public override bool IsErrorClosed { get; }
             public override string ToString() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -4079,7 +4079,6 @@ namespace Akka.IO
         public sealed class ErrorClosed : Akka.IO.Tcp.ConnectionClosed
         {
             public ErrorClosed(string cause) { }
-            [System.Runtime.CompilerServices.NullableAttribute(2)]
             public override string Cause { get; }
             public override bool IsErrorClosed { get; }
             public override string ToString() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3978,7 +3978,7 @@ namespace Akka.IO
             public static readonly Akka.IO.Tcp.Abort Instance;
             public override Akka.IO.Tcp.ConnectionClosed Event { get; }
         }
-        public class Aborted : Akka.IO.Tcp.ConnectionClosed
+        public sealed class Aborted : Akka.IO.Tcp.ConnectionClosed
         {
             public static readonly Akka.IO.Tcp.Aborted Instance;
             public override bool IsAborted { get; }
@@ -3993,13 +3993,13 @@ namespace Akka.IO
             public bool PullMode { get; }
             public override string ToString() { }
         }
-        public class Bound : Akka.IO.Tcp.Event
+        public sealed class Bound : Akka.IO.Tcp.Event
         {
             public Bound(System.Net.EndPoint localAddress) { }
             public System.Net.EndPoint LocalAddress { get; }
             public override string ToString() { }
         }
-        public class Close : Akka.IO.Tcp.CloseCommand
+        public sealed class Close : Akka.IO.Tcp.CloseCommand
         {
             public static readonly Akka.IO.Tcp.Close Instance;
             public override Akka.IO.Tcp.ConnectionClosed Event { get; }
@@ -4009,7 +4009,7 @@ namespace Akka.IO
             protected CloseCommand() { }
             public abstract Akka.IO.Tcp.ConnectionClosed Event { get; }
         }
-        public class Closed : Akka.IO.Tcp.ConnectionClosed
+        public sealed class Closed : Akka.IO.Tcp.ConnectionClosed
         {
             public static readonly Akka.IO.Tcp.Closed Instance;
         }
@@ -4030,7 +4030,7 @@ namespace Akka.IO
             [Akka.Annotations.InternalApiAttribute()]
             public Akka.IO.Tcp.CommandFailed WithCause(System.Exception cause) { }
         }
-        public class CompoundWrite : Akka.IO.Tcp.WriteCommand, System.Collections.Generic.IEnumerable<Akka.IO.Tcp.SimpleWriteCommand>, System.Collections.IEnumerable
+        public sealed class CompoundWrite : Akka.IO.Tcp.WriteCommand, System.Collections.Generic.IEnumerable<Akka.IO.Tcp.SimpleWriteCommand>, System.Collections.IEnumerable
         {
             public CompoundWrite(Akka.IO.Tcp.SimpleWriteCommand head, Akka.IO.Tcp.WriteCommand tailCommand) { }
             public Akka.IO.Tcp.SimpleWriteCommand Head { get; }
@@ -4038,17 +4038,17 @@ namespace Akka.IO
             public System.Collections.Generic.IEnumerator<Akka.IO.Tcp.SimpleWriteCommand> GetEnumerator() { }
             public override string ToString() { }
         }
-        public class ConfirmedClose : Akka.IO.Tcp.CloseCommand
+        public sealed class ConfirmedClose : Akka.IO.Tcp.CloseCommand
         {
             public static readonly Akka.IO.Tcp.ConfirmedClose Instance;
             public override Akka.IO.Tcp.ConnectionClosed Event { get; }
         }
-        public class ConfirmedClosed : Akka.IO.Tcp.ConnectionClosed
+        public sealed class ConfirmedClosed : Akka.IO.Tcp.ConnectionClosed
         {
             public static readonly Akka.IO.Tcp.ConfirmedClosed Instance;
             public override bool IsConfirmed { get; }
         }
-        public class Connect : Akka.IO.Tcp.Command
+        public sealed class Connect : Akka.IO.Tcp.Command
         {
             public Connect(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress = null, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, System.Nullable<System.TimeSpan> timeout = null, bool pullMode = False) { }
             public System.Net.EndPoint LocalAddress { get; }
@@ -4098,7 +4098,7 @@ namespace Akka.IO
             public object Token { get; }
             public override string ToString() { }
         }
-        public class PeerClosed : Akka.IO.Tcp.ConnectionClosed
+        public sealed class PeerClosed : Akka.IO.Tcp.ConnectionClosed
         {
             public static readonly Akka.IO.Tcp.PeerClosed Instance;
             public override bool IsPeerClosed { get; }
@@ -4117,17 +4117,17 @@ namespace Akka.IO
             public bool UseResumeWriting { get; }
             public override string ToString() { }
         }
-        public class ResumeAccepting : Akka.IO.Tcp.Command
+        public sealed class ResumeAccepting : Akka.IO.Tcp.Command
         {
             public ResumeAccepting(int batchSize) { }
             public int BatchSize { get; }
             public override string ToString() { }
         }
-        public class ResumeReading : Akka.IO.Tcp.Command
+        public sealed class ResumeReading : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.ResumeReading Instance;
         }
-        public class ResumeWriting : Akka.IO.Tcp.Command
+        public sealed class ResumeWriting : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.ResumeWriting Instance;
         }
@@ -4138,7 +4138,7 @@ namespace Akka.IO
             public bool WantsAck { get; }
             public Akka.IO.Tcp.CompoundWrite Append(Akka.IO.Tcp.WriteCommand that) { }
         }
-        public class SuspendReading : Akka.IO.Tcp.Command
+        public sealed class SuspendReading : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.SuspendReading Instance;
         }
@@ -4146,11 +4146,11 @@ namespace Akka.IO
         {
             public static readonly Akka.IO.Tcp.Unbind Instance;
         }
-        public class Unbound : Akka.IO.Tcp.Event
+        public sealed class Unbound : Akka.IO.Tcp.Event
         {
             public static readonly Akka.IO.Tcp.Unbound Instance;
         }
-        public class Write : Akka.IO.Tcp.SimpleWriteCommand
+        public sealed class Write : Akka.IO.Tcp.SimpleWriteCommand
         {
             public static readonly Akka.IO.Tcp.Write Empty;
             public override Akka.IO.Tcp.Event Ack { get; }
@@ -4167,7 +4167,7 @@ namespace Akka.IO
             public Akka.IO.Tcp.CompoundWrite Prepend(Akka.IO.Tcp.SimpleWriteCommand other) { }
             public Akka.IO.Tcp.WriteCommand Prepend(System.Collections.Generic.IEnumerable<Akka.IO.Tcp.WriteCommand> writes) { }
         }
-        public class WritingResumed : Akka.IO.Tcp.Event
+        public sealed class WritingResumed : Akka.IO.Tcp.Event
         {
             public static readonly Akka.IO.Tcp.WritingResumed Instance;
         }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3985,7 +3985,7 @@ namespace Akka.IO
         }
         public class Bind : Akka.IO.Tcp.Command
         {
-            public Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint localAddress, int backlog = 100, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, bool pullMode = False) { }
+            public Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint localAddress, int backlog = 1024, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, bool pullMode = False) { }
             public int Backlog { get; }
             public Akka.Actor.IActorRef Handler { get; }
             public System.Net.EndPoint LocalAddress { get; }
@@ -4204,6 +4204,7 @@ namespace Akka.IO
     public class TcpSettings
     {
         public TcpSettings(string bufferPoolConfigPath, int initialSocketAsyncEventArgs, bool traceLogging, int batchAcceptLimit, System.Nullable<System.TimeSpan> registerTimeout, int receivedMessageSizeLimit, string managementDispatcher, string fileIoDispatcher, int transferToLimit, int finishConnectRetries, bool outgoingSocketForceIpv4, int writeCommandsQueueMaxSize) { }
+        [System.ObsoleteAttribute("This setting is deprecated and will be removed in a future version.")]
         public int BatchAcceptLimit { get; }
         public string BufferPoolConfigPath { get; }
         public string FileIODispatcher { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3967,10 +3967,9 @@ namespace Akka.IO
         protected override void PostStop() { }
         protected override bool Receive(object message) { }
     }
-    public class Tcp : Akka.Actor.ExtensionIdProvider<Akka.IO.TcpExt>
+    public sealed class Tcp : Akka.Actor.ExtensionIdProvider<Akka.IO.TcpExt>
     {
         public static readonly Akka.Actor.SupervisorStrategy ConnectionSupervisorStrategy;
-        public static readonly Akka.IO.Tcp Instance;
         public Tcp() { }
         public override Akka.IO.TcpExt CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
         public static Akka.Actor.IActorRef Manager(Akka.Actor.ActorSystem system) { }
@@ -4021,6 +4020,7 @@ namespace Akka.IO
         }
         public sealed class CommandFailed : Akka.IO.Tcp.Event
         {
+            public CommandFailed(Akka.IO.Tcp.Command cmd, Akka.Util.Option<System.Exception> ex) { }
             public CommandFailed(Akka.IO.Tcp.Command cmd) { }
             public Akka.Util.Option<System.Exception> Cause { get; }
             [Akka.Annotations.InternalApiAttribute()]
@@ -4068,6 +4068,7 @@ namespace Akka.IO
         public class ConnectionClosed : Akka.IO.Tcp.Event, Akka.Event.IDeadLetterSuppression
         {
             public ConnectionClosed() { }
+            [System.Runtime.CompilerServices.NullableAttribute(2)]
             public virtual string Cause { get; }
             public virtual bool IsAborted { get; }
             public virtual bool IsConfirmed { get; }
@@ -4077,6 +4078,7 @@ namespace Akka.IO
         public sealed class ErrorClosed : Akka.IO.Tcp.ConnectionClosed
         {
             public ErrorClosed(string cause) { }
+            [System.Runtime.CompilerServices.NullableAttribute(2)]
             public override string Cause { get; }
             public override bool IsErrorClosed { get; }
             public override string ToString() { }
@@ -4181,15 +4183,14 @@ namespace Akka.IO
     {
         public static Akka.Actor.IActorRef Tcp(this Akka.Actor.ActorSystem system) { }
     }
-    public class TcpMessage
+    public class static TcpMessage
     {
-        public TcpMessage() { }
         public static Akka.IO.Tcp.Command Abort() { }
         public static Akka.IO.Tcp.Command Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint endpoint, int backlog, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, bool pullMode) { }
         public static Akka.IO.Tcp.Command Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint endpoint, int backlog) { }
         public static Akka.IO.Tcp.Command Close() { }
         public static Akka.IO.Tcp.Command ConfirmedClose() { }
-        public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, System.Nullable<System.TimeSpan> timeout, bool pullMode) { }
+        public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress, [System.Runtime.CompilerServices.NullableAttribute(2)] System.Net.EndPoint localAddress, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, System.Nullable<System.TimeSpan> timeout, bool pullMode) { }
         public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress) { }
         public static Akka.IO.Tcp.NoAck NoAck(object token = null) { }
         public static Akka.IO.Tcp.Command Register(Akka.Actor.IActorRef handler, bool keepOpenOnPeerClosed = False, bool useResumeWriting = True) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -4204,7 +4204,6 @@ namespace Akka.IO
     public class TcpSettings
     {
         public TcpSettings(string bufferPoolConfigPath, int initialSocketAsyncEventArgs, bool traceLogging, int batchAcceptLimit, System.Nullable<System.TimeSpan> registerTimeout, int receivedMessageSizeLimit, string managementDispatcher, string fileIoDispatcher, int transferToLimit, int finishConnectRetries, bool outgoingSocketForceIpv4, int writeCommandsQueueMaxSize) { }
-        [System.ObsoleteAttribute("This setting is deprecated and will be removed in a future version.")]
         public int BatchAcceptLimit { get; }
         public string BufferPoolConfigPath { get; }
         public string FileIODispatcher { get; }

--- a/src/core/Akka.Tests/IO/TcpListenerSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpListenerSpec.cs
@@ -75,7 +75,6 @@ namespace Akka.Tests.IO
             private readonly IActorRef _handlerRef;
             private readonly TestProbe _bindCommander;
             private readonly TestProbe _parent;
-            private readonly TestProbe _selectorRouter;
             private readonly TestActorRef<ListenerParent> _parentRef;
             
             public TestSetup(TestKitBase kit, bool pullMode)
@@ -87,7 +86,7 @@ namespace Akka.Tests.IO
                 _handlerRef = _handler.Ref;
                 _bindCommander = kit.CreateTestProbe();
                 _parent = kit.CreateTestProbe();
-                _selectorRouter = kit.CreateTestProbe();
+                SelectorRouter = kit.CreateTestProbe();
 
                 _parentRef = new TestActorRef<ListenerParent>(kit.Sys, Props.Create(() => new ListenerParent(this, pullMode)));
             }
@@ -115,10 +114,7 @@ namespace Akka.Tests.IO
 
             public IActorRef Listener { get { return _parentRef.UnderlyingActor.Listener; } }
 
-            public TestProbe SelectorRouter
-            {
-                get { return _selectorRouter; }
-            }
+            public TestProbe SelectorRouter { get; }
 
             public TestProbe BindCommander { get { return _bindCommander; } }
             public TestProbe Parent { get { return _parent; } }
@@ -128,7 +124,7 @@ namespace Akka.Tests.IO
             internal void AfterBind(Socket socket)
                 => LocalEndPoint = (IPEndPoint)socket.LocalEndPoint;
 
-            class ListenerParent : ActorBase
+            private class ListenerParent : ActorBase
             {
                 private readonly TestSetup _test;
                 private readonly bool _pullMode;

--- a/src/core/Akka.Tests/IO/TcpListenerSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpListenerSpec.cs
@@ -143,7 +143,7 @@ namespace Akka.Tests.IO
 
                     _listener = Context.ActorOf(Props.Create(() =>
                         new TcpListener(
-                            Tcp.Instance.Apply(Context.System),
+                            Tcp.For(Context.System),
                             test._bindCommander.Ref,
                             new Tcp.Bind(
                                 _test._handler.Ref, 

--- a/src/core/Akka.Tests/IO/TcpSettingsSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpSettingsSpec.cs
@@ -1,0 +1,42 @@
+//-----------------------------------------------------------------------
+// <copyright file="TcpSettingsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Tests.IO
+{
+    public class TcpSettingsSpec
+    {
+        [Fact]
+        public void TcpSettings_should_parse_all_akka_io_tcp_config_values_correctly()
+        {
+            // Arrange: load the default reference config
+            var config = ConfigurationFactory.Default();
+            var tcpConfig = config.GetConfig("akka.io.tcp");
+            var settings = TcpSettings.Create(tcpConfig);
+
+            // Assert: all values match akka.conf reference
+            settings.BufferPoolConfigPath.Should().Be("akka.io.tcp.disabled-buffer-pool");
+            settings.InitialSocketAsyncEventArgs.Should().Be(32);
+            settings.TraceLogging.Should().BeFalse();
+            settings.BatchAcceptLimit.Should().Be(Environment.ProcessorCount * 2);
+            settings.RegisterTimeout.Should().Be(TimeSpan.FromSeconds(5));
+            settings.ReceivedMessageSizeLimit.Should().Be(int.MaxValue);
+            settings.ManagementDispatcher.Should().Be("akka.actor.internal-dispatcher");
+            settings.FileIODispatcher.Should().Be("akka.actor.default-blocking-io-dispatcher");
+            settings.TransferToLimit.Should().Be(524288); // 512 KiB
+            settings.FinishConnectRetries.Should().Be(5);
+            settings.OutgoingSocketForceIpv4.Should().BeFalse();
+            settings.WriteCommandsQueueMaxSize.Should().Be(-1);
+        }
+    }
+} 

--- a/src/core/Akka/Configuration/akka.conf
+++ b/src/core/Akka/Configuration/akka.conf
@@ -763,8 +763,11 @@ akka {
 
       # The maximum number of connection that are accepted in one go,
       # higher numbers decrease latency, lower numbers increase fairness on
-      # the worker-dispatcher
-      batch-accept-limit = 10
+      # the worker-dispatcher.
+      #
+      # By default we scale to logical CPUs * 2, but you can set this to an
+      # integer value greater than 0.
+      batch-accept-limit = scale-to-cpus
 
       # The duration a connection actor waits for a `Register` message from
       # its commander before aborting the connection.

--- a/src/core/Akka/IO/Tcp.cs
+++ b/src/core/Akka/IO/Tcp.cs
@@ -156,12 +156,12 @@ namespace Akka.IO
             /// </summary>
             /// <param name="handler">The actor who will be handling the TCP listener.</param>
             /// <param name="localAddress">The local endpoint we are binding to.</param>
-            /// <param name="backlog">TCP backlog - the number of pending connections that the queue will hold.</param>
+            /// <param name="backlog">TCP backlog - the number of pending connections that the queue will hold. Defaults to 1024.</param>
             /// <param name="options">A set of socket options.</param>
             /// <param name="pullMode">Specifies whether we're running in "pull mode" or not.</param>
             public Bind(IActorRef handler,
                 EndPoint localAddress,
-                int backlog = 100,
+                int backlog = 1024,
                 IEnumerable<Inet.SocketOption> options = null,
                 bool pullMode = false)
             {

--- a/src/core/Akka/IO/Tcp.cs
+++ b/src/core/Akka/IO/Tcp.cs
@@ -36,7 +36,7 @@ namespace Akka.IO
             return PluginInstance.Apply(system).Manager;
         }
         
-        public static TcpExt For(ActorSystem system)
+        internal static TcpExt For(ActorSystem system)
         {
             return PluginInstance.Apply(system);
         }

--- a/src/core/Akka/IO/Tcp.cs
+++ b/src/core/Akka/IO/Tcp.cs
@@ -23,28 +23,19 @@ namespace Akka.IO
     /// <summary>
     /// The set of TCP capabilities for Akka.IO are exposed via this extension.
     /// </summary>
-    public class Tcp : ExtensionIdProvider<TcpExt>
+    public sealed class Tcp : ExtensionIdProvider<TcpExt>
     {
+        // TODO: refactor this in v1.6 to use a `.For` method with the correct ExtensionId provider setup
+        private static readonly Tcp PluginInstance = new();
+        
         /// <summary>
-        /// TBD
+        /// Fetches the TCP manager actor for the given actor system.
         /// </summary>
-        public static readonly Tcp Instance = new();
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="system">TBD</param>
-        /// <returns>TBD</returns>
         public static IActorRef Manager(ActorSystem system)
         {
-            return Instance.Apply(system).Manager;
+            return PluginInstance.Apply(system).Manager;
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="system">TBD</param>
-        /// <returns>TBD</returns>
+        
         public override TcpExt CreateExtension(ExtendedActorSystem system)
         {
             return new TcpExt(system);
@@ -82,32 +73,24 @@ namespace Akka.IO
         #endregion
 
         /// <summary>
-        /// TBD
+        /// Akka.IO Tcp messages are all derived from this class.
         /// </summary>
         public class Message : INoSerializationVerificationNeeded { }
 
         #region user commands
 
         // COMMANDS
+        
         /// <summary>
-        /// TBD
+        /// All Akka.IO.Tcp commands inherit from this class.
         /// </summary>
         public abstract class Command : Message
         {
-            private readonly CommandFailed _failureMessage;
-
             /// <summary>
-            /// TBD
+            /// A predefined failure message which can be used to indicate that a command
+            /// failed during processing.
             /// </summary>
-            protected Command()
-            {
-                _failureMessage = new CommandFailed(this);
-            }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public CommandFailed FailureMessage => _failureMessage;
+            public CommandFailed FailureMessage => new CommandFailed(this);
         }
 
         /// <summary>
@@ -134,7 +117,7 @@ namespace Akka.IO
             {
                 RemoteAddress = remoteAddress;
                 LocalAddress = localAddress;
-                Options = options ?? Enumerable.Empty<Inet.SocketOption>();
+                Options = options ?? [];
                 Timeout = timeout;
                 PullMode = pullMode;
             }
@@ -191,7 +174,7 @@ namespace Akka.IO
                 Handler = handler;
                 LocalAddress = localAddress;
                 Backlog = backlog;
-                Options = options ?? Enumerable.Empty<Inet.SocketOption>();
+                Options = options ?? [];
                 PullMode = pullMode;
             }
 
@@ -526,63 +509,7 @@ namespace Akka.IO
                 return new Write(data, ack);
             }
         }
-
-        /*
-        /// <summary>
-        /// Write `count` bytes starting at `position` from file at `filePath` to the connection.
-        /// The count must be &gt; 0. The connection actor will reply with a <see cref="CommandFailed"/>
-        /// message if the write could not be enqueued. If <see cref="SimpleWriteCommand.WantsAck"/>
-        /// returns true, the connection actor will reply with the supplied <see cref="SimpleWriteCommand.Ack"/>
-        /// token once the write has been successfully enqueued to the O/S kernel.
-        /// <b>Note that this does not in any way guarantee that the data will be
-        /// or have been sent!</b> Unfortunately there is no way to determine whether
-        /// a particular write has been sent by the O/S.
-        /// </summary>
-        public class WriteFile : SimpleWriteCommand
-        {
-            private readonly Event _ack;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="filePath">TBD</param>
-            /// <param name="position">TBD</param>
-            /// <param name="count">TBD</param>
-            /// <param name="ack">TBD</param>
-            /// <exception cref="ArgumentException">TBD</exception>
-            public WriteFile(string filePath, long position, long count, Event ack)
-            {
-                if (position < 0) throw new ArgumentException("WriteFile.position must be >= 0", nameof(position));
-                if (count <= 0) throw new ArgumentException("WriteFile.count must be > 0", nameof(count));
-
-                _ack = ack;
-                FilePath = filePath;
-                Position = position;
-                Count = count;
-            }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public string FilePath { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public long Position { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public long Count { get; }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public override Event Ack => _ack;
-
-            public override string ToString() =>
-                $"WriteFile(path: {FilePath}, position: {Position}, count: {Count}, ack: {Ack})";
-        }
-        */
+        
         /// <summary>
         /// A write command which aggregates two other write commands. Using this construct
         /// you can chain a number of <see cref="Akka.IO.Tcp.Write" /> commands together in a way
@@ -750,18 +677,11 @@ namespace Akka.IO
         /// </summary>
         public sealed class Received : Event
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="data">TBD</param>
             public Received(ByteString data)
             {
                 Data = data;
             }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public ByteString Data { get; }
 
             public override string ToString() =>
@@ -776,11 +696,6 @@ namespace Akka.IO
         /// </summary>
         public sealed class Connected : Event
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="remoteAddress">TBD</param>
-            /// <param name="localAddress">TBD</param>
             public Connected(EndPoint remoteAddress, EndPoint localAddress)
             {
                 RemoteAddress = remoteAddress;
@@ -788,11 +703,12 @@ namespace Akka.IO
             }
 
             /// <summary>
-            /// TBD
+            /// The remote endpoint of the connection.
             /// </summary>
             public EndPoint RemoteAddress { get; }
+            
             /// <summary>
-            /// TBD
+            /// The local endpoint of the connection.
             /// </summary>
             public EndPoint LocalAddress { get; }
 
@@ -806,21 +722,25 @@ namespace Akka.IO
         /// </summary>
         public sealed class CommandFailed : Event
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="cmd">TBD</param>
-            public CommandFailed(Command cmd) => Cmd = cmd;
+            public CommandFailed(Command cmd, Option<Exception> ex)
+            {
+                Cmd = cmd;
+                Cause = ex;
+            }
+
+            public CommandFailed(Command cmd) : this(cmd, Option<Exception>.None)
+            {
+            }
 
             /// <summary>
-            /// TBD
+            /// The original command which failed.
             /// </summary>
             public Command Cmd { get; }
 
             /// <summary>
             /// Optionally contains the cause why the command failed.
             /// </summary>
-            public Option<Exception> Cause { get; private set; } = Option<Exception>.None;
+            public Option<Exception> Cause { get; private set; }
 
             /// <summary>
             /// Creates a copy of this object with a new cause set.
@@ -847,9 +767,6 @@ namespace Akka.IO
         /// </summary>
         public class WritingResumed : Event
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly WritingResumed Instance = new();
 
             private WritingResumed()
@@ -905,29 +822,29 @@ namespace Akka.IO
         public class ConnectionClosed : Event, IDeadLetterSuppression
         {
             /// <summary>
-            /// TBD
+            /// Was the connection closed normally?
             /// </summary>
             public virtual bool IsAborted => false;
 
             /// <summary>
-            /// TBD
+            /// Can we confirm that the connection was open in the first place?
             /// </summary>
             public virtual bool IsConfirmed => false;
 
             /// <summary>
-            /// TBD
+            /// Is our remote peer closed too?
             /// </summary>
             public virtual bool IsPeerClosed => false;
 
             /// <summary>
-            /// TBD
+            /// Did the connection close due to an IO error?
             /// </summary>
             public virtual bool IsErrorClosed => false;
 
             /// <summary>
-            /// TBD
+            /// Was there a given cause for why the connection was closed?
             /// </summary>
-            public virtual string Cause => null;
+            public virtual string? Cause => null;
         }
 
         /// <summary>
@@ -935,9 +852,6 @@ namespace Akka.IO
         /// </summary>
         public class Closed : ConnectionClosed
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly Closed Instance = new();
 
             private Closed()
@@ -950,18 +864,12 @@ namespace Akka.IO
         /// </summary>
         public class Aborted : ConnectionClosed
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly Aborted Instance = new();
 
             private Aborted()
             {
             }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public override bool IsAborted => true;
         }
 
@@ -971,18 +879,12 @@ namespace Akka.IO
         /// </summary>
         public class ConfirmedClosed : ConnectionClosed
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly ConfirmedClosed Instance = new();
 
             private ConfirmedClosed()
             {
             }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public override bool IsConfirmed => true;
         }
 
@@ -991,18 +893,12 @@ namespace Akka.IO
         /// </summary>
         public class PeerClosed : ConnectionClosed
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly PeerClosed Instance = new();
 
             private PeerClosed()
             {
             }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public override bool IsPeerClosed => true;
         }
 
@@ -1011,25 +907,14 @@ namespace Akka.IO
         /// </summary>
         public sealed class ErrorClosed : ConnectionClosed
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="cause">TBD</param>
             public ErrorClosed(string cause)
             {
                 Cause = cause;
             }
 
-            /// <summary>
-            /// TBD
-            /// </summary>
             public override bool IsErrorClosed => true;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <returns>TBD</returns>
-            public override string Cause { get; }
+            
+            public override string? Cause { get; }
 
             public override string ToString() =>
                 $"ErrorClosed('{Cause}')";
@@ -1061,7 +946,7 @@ namespace Akka.IO
     }
 
     /// <summary>
-    /// TBD
+    /// Akka.IO TCP extension - provides an actor-based API for TCP socket communication.
     /// </summary>
     public sealed class TcpExt : IOExtension
     {
@@ -1093,7 +978,7 @@ namespace Akka.IO
         public IBufferPool BufferPool { get; }
 
         /// <summary>
-        /// TBD
+        /// The settings used by this extension.
         /// </summary>
         public TcpSettings Settings { get; }
 
@@ -1126,21 +1011,20 @@ namespace Akka.IO
     }
 
     /// <summary>
-    /// TBD
+    /// Helpers for generating TCP messages.
     /// </summary>
-    public class TcpMessage
+    public static class TcpMessage
     {
         /// <summary>
-        /// TBD
+        /// Connect to a remote TCP endpoint.
         /// </summary>
-        /// <param name="remoteAddress">TBD</param>
-        /// <param name="localAddress">TBD</param>
-        /// <param name="options">TBD</param>
-        /// <param name="timeout">TBD</param>
-        /// <param name="pullMode">TDB</param>
-        /// <returns>TBD</returns>
+        /// <param name="remoteAddress">The remote endpoint</param>
+        /// <param name="localAddress">An optional local endpoint address to bind to. Most users don't specify this.</param>
+        /// <param name="options">A set of socket options.</param>
+        /// <param name="timeout">An optional connect timeout. Will result in a <see cref="Tcp.CommandFailed"/> message being returned if we exceed this value.</param>
+        /// <param name="pullMode">Specifies whether we're running in "pull mode" or not.</param>
         public static Tcp.Command Connect(EndPoint remoteAddress,
-            EndPoint localAddress,
+            EndPoint? localAddress,
             IEnumerable<Inet.SocketOption> options,
             TimeSpan? timeout,
             bool pullMode)
@@ -1149,24 +1033,22 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// Connect to a remote TCP endpoint.
         /// </summary>
-        /// <param name="remoteAddress">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="remoteAddress">The remote endpoint</param>
         public static Tcp.Command Connect(EndPoint remoteAddress)
         {
-            return Connect(remoteAddress, null, null, null, false);
+            return Connect(remoteAddress, null, [], null, false);
         }
 
         /// <summary>
-        /// TBD
+        /// Bind a TCP listener to a local endpoint.
         /// </summary>
-        /// <param name="handler">TBD</param>
-        /// <param name="endpoint">TBD</param>
-        /// <param name="backlog">TBD</param>
-        /// <param name="options">TBD</param>
-        /// <param name="pullMode">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="handler">The actor who will be handling the TCP listener.</param>
+        /// <param name="endpoint">The local endpoint we are binding to.</param>
+        /// <param name="backlog">TCP backlog - the number of pending connections that the queue will hold.</param>
+        /// <param name="options">A set of socket options.</param>
+        /// <param name="pullMode">Specifies whether we're running in "pull mode" or not for all subsequent client connections.</param>
         public static Tcp.Command Bind(IActorRef handler,
             EndPoint endpoint,
             int backlog,
@@ -1177,24 +1059,22 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// Bind a TCP listener to a local endpoint.
         /// </summary>
-        /// <param name="handler">TBD</param>
-        /// <param name="endpoint">TBD</param>
-        /// <param name="backlog">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="handler">The actor who will be handling the TCP listener.</param>
+        /// <param name="endpoint">The local endpoint we are binding to.</param>
+        /// <param name="backlog">TCP backlog - the number of pending connections that the queue will hold.</param>
         public static Tcp.Command Bind(IActorRef handler, EndPoint endpoint, int backlog)
         {
             return new Tcp.Bind(handler, endpoint, backlog);
         }
 
         /// <summary>
-        /// TBD
+        /// Registers an actor to handle an outgoing or incoming TCP connection that has been established.
         /// </summary>
-        /// <param name="handler">TBD</param>
+        /// <param name="handler">The actor who will be handling the TCP communication.</param>
         /// <param name="keepOpenOnPeerClosed">TBD</param>
         /// <param name="useResumeWriting">TBD</param>
-        /// <returns>TBD</returns>
         public static Tcp.Command Register(IActorRef handler, bool keepOpenOnPeerClosed = false,
             bool useResumeWriting = true)
         {
@@ -1202,36 +1082,32 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// Unbinds a previously bound TCP listener.
         /// </summary>
-        /// <returns>TBD</returns>
         public static Tcp.Command Unbind()
         {
             return Tcp.Unbind.Instance;
         }
 
         /// <summary>
-        /// TBD
+        /// Closes an open TCP connection.
         /// </summary>
-        /// <returns>TBD</returns>
         public static Tcp.Command Close()
         {
             return Tcp.Close.Instance;
         }
 
         /// <summary>
-        /// TBD
+        /// Closes a confirmed-to-have-been-previously-running TCP connection.
         /// </summary>
-        /// <returns>TBD</returns>
         public static Tcp.Command ConfirmedClose()
         {
             return Tcp.ConfirmedClose.Instance;
         }
 
         /// <summary>
-        /// TBD
+        /// Aborts a TCP connection without flushing pending writes.
         /// </summary>
-        /// <returns>TBD</returns>
         public static Tcp.Command Abort()
         {
             return Tcp.Abort.Instance;
@@ -1297,15 +1173,14 @@ namespace Akka.IO
     }
 
     /// <summary>
-    /// TBD
+    /// Convenience methods for using the Akka.IO.Tcp extension.
     /// </summary>
     public static class TcpExtensions
     {
         /// <summary>
-        /// TBD
+        /// Returns the <see cref="ActorSystem"/>-specific <see cref="Tcp"/> instance for TCP connectivity.
         /// </summary>
-        /// <param name="system">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="system">The current actor system.</param>
         public static IActorRef Tcp(this ActorSystem system)
         {
             return IO.Tcp.Manager(system);

--- a/src/core/Akka/IO/Tcp.cs
+++ b/src/core/Akka/IO/Tcp.cs
@@ -104,16 +104,17 @@ namespace Akka.IO
         /// or the actor handling the new connection replies with a <see cref="Connected" />
         /// message.
         /// </summary>
-        public class Connect : Command
+        public sealed class Connect : Command
         {
+            
             /// <summary>
-            /// TBD
+            /// Connect to a remote TCP endpoint.
             /// </summary>
-            /// <param name="remoteAddress">TBD</param>
-            /// <param name="localAddress">TBD</param>
-            /// <param name="options">TBD</param>
-            /// <param name="timeout">TBD</param>
-            /// <param name="pullMode">TBD</param>
+            /// <param name="remoteAddress">The remote endpoint</param>
+            /// <param name="localAddress">An optional local endpoint address to bind to. Most users don't specify this.</param>
+            /// <param name="options">A set of socket options.</param>
+            /// <param name="timeout">An optional connect timeout. Will result in a <see cref="Tcp.CommandFailed"/> message being returned if we exceed this value.</param>
+            /// <param name="pullMode">Specifies whether we're running in "pull mode" or not.</param>
             public Connect(EndPoint remoteAddress,
                 EndPoint localAddress = null,
                 IEnumerable<Inet.SocketOption> options = null,
@@ -126,26 +127,14 @@ namespace Akka.IO
                 Timeout = timeout;
                 PullMode = pullMode;
             }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public EndPoint RemoteAddress { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public EndPoint LocalAddress { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
+    
             public IEnumerable<Inet.SocketOption> Options { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public TimeSpan? Timeout { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
             public bool PullMode { get; }
 
             public override string ToString() =>
@@ -163,13 +152,13 @@ namespace Akka.IO
         public class Bind : Command
         {
             /// <summary>
-            /// TBD
+            /// Bind a TCP listener to a local endpoint.
             /// </summary>
-            /// <param name="handler">TBD</param>
-            /// <param name="localAddress">TBD</param>
-            /// <param name="backlog">TBD</param>
-            /// <param name="options">TBD</param>
-            /// <param name="pullMode">TBD</param>
+            /// <param name="handler">The actor who will be handling the TCP listener.</param>
+            /// <param name="localAddress">The local endpoint we are binding to.</param>
+            /// <param name="backlog">TCP backlog - the number of pending connections that the queue will hold.</param>
+            /// <param name="options">A set of socket options.</param>
+            /// <param name="pullMode">Specifies whether we're running in "pull mode" or not.</param>
             public Bind(IActorRef handler,
                 EndPoint localAddress,
                 int backlog = 100,
@@ -183,25 +172,14 @@ namespace Akka.IO
                 PullMode = pullMode;
             }
 
-            /// <summary>
-            /// TBD
-            /// </summary>
             public IActorRef Handler { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
+
             public EndPoint LocalAddress { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
+
             public int Backlog { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
+
             public IEnumerable<Inet.SocketOption> Options { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
+
             public bool PullMode { get; }
 
             public override string ToString() =>
@@ -217,11 +195,11 @@ namespace Akka.IO
         public class Register : Command
         {
             /// <summary>
-            /// TBD
+            /// Registers an actor to handle an outgoing or incoming TCP connection that has been established.
             /// </summary>
-            /// <param name="handler">TBD</param>
-            /// <param name="keepOpenOnPeerClosed">TBD</param>
-            /// <param name="useResumeWriting">TBD</param>
+            /// <param name="handler">The actor who will be handling the TCP communication.</param>
+            /// <param name="keepOpenOnPeerClosed">Keep the connection open if the peer is closed</param>
+            /// <param name="useResumeWriting">Use resume / pause writing semantics once buffer gets full</param>
             public Register(IActorRef handler, bool keepOpenOnPeerClosed = false, bool useResumeWriting = true)
             {
                 Handler = handler;
@@ -229,17 +207,11 @@ namespace Akka.IO
                 UseResumeWriting = useResumeWriting;
             }
 
-            /// <summary>
-            /// TBD
-            /// </summary>
+    
             public IActorRef Handler { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
+      
             public bool KeepOpenOnPeerClosed { get; }
-            /// <summary>
-            /// TBD
-            /// </summary>
+ 
             public bool UseResumeWriting { get; }
 
             public override string ToString() =>
@@ -253,9 +225,6 @@ namespace Akka.IO
         /// </summary>
         public class Unbind : Command
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly Unbind Instance = new();
 
             private Unbind()
@@ -268,7 +237,7 @@ namespace Akka.IO
         public abstract class CloseCommand : Command, IDeadLetterSuppression
         {
             /// <summary>
-            /// TBD
+            /// The event to return in response to this command
             /// </summary>
             public abstract ConnectionClosed Event { get; }
         }
@@ -279,20 +248,14 @@ namespace Akka.IO
         /// data will both be notified once the socket is closed using a <see cref="Closed" />
         /// message.
         /// </summary>
-        public class Close : CloseCommand
+        public sealed class Close : CloseCommand
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly Close Instance = new();
 
             private Close()
             {
             }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public override ConnectionClosed Event => Closed.Instance;
         }
 
@@ -302,20 +265,14 @@ namespace Akka.IO
         /// command and the registered handler for incoming data will both be notified
         /// once the socket is closed using a <see cref="ConfirmedClosed" /> message.
         /// </summary>
-        public class ConfirmedClose : CloseCommand
+        public sealed class ConfirmedClose : CloseCommand
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly ConfirmedClose Instance = new();
 
             private ConfirmedClose()
             {
             }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public override ConnectionClosed Event => ConfirmedClosed.Instance;
         }
 
@@ -328,18 +285,12 @@ namespace Akka.IO
         /// </summary>
         public class Abort : CloseCommand
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly Abort Instance = new();
 
             private Abort()
             {
             }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
+            
             public override ConnectionClosed Event => Aborted.Instance;
         }
 
@@ -351,22 +302,15 @@ namespace Akka.IO
         /// </summary>
         public class NoAck : Event
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly NoAck Instance = new(null);
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="token">TBD</param>
+            
             public NoAck(object token)
             {
                 Token = token;
             }
 
             /// <summary>
-            /// TBD
+            /// A correlation id which can be used to identify a specific write operation.
             /// </summary>
             public object Token { get; }
 
@@ -375,56 +319,44 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// All write commands inherit from this class.
         /// </summary>
         public abstract class WriteCommand : Command
         {
             /// <summary>
-            /// TBD
+            /// Prepend another write before this one.
             /// </summary>
-            /// <param name="other">TBD</param>
-            /// <returns>TBD</returns>
+            /// <param name="other">The other write to prepend</param>
+            /// <returns>A compound write consisting of multiple byte buffers of non-contiguous memory</returns>
             public CompoundWrite Prepend(SimpleWriteCommand other)
             {
                 return new CompoundWrite(other, this);
             }
 
             /// <summary>
-            /// TBD
+            /// Prepend a group of writes before this one.
             /// </summary>
-            /// <param name="writes">TBD</param>
-            /// <returns>TBD</returns>
+            /// <param name="writes">The set of writes that will preceed this one.</param>
+            /// <returns>A compound write consisting of multiple byte buffers of non-contiguous memory</returns>
             public WriteCommand Prepend(IEnumerable<WriteCommand> writes)
             {
                 return writes.Reverse().Aggregate(this, (b, a) =>
                 {
-                    var simple = a as SimpleWriteCommand;
-                    if (simple != null)
-                        return b.Prepend(simple);
-
-                    var compound = a as CompoundWrite;
-                    if (compound != null)
-                        return b.Prepend(compound);
-
-                    throw new ArgumentException("The supplied WriteCommand is invalid. Only SimpleWriteCommand and CompoundWrite WriteCommands are supported.");
+                    return a switch
+                    {
+                        SimpleWriteCommand simple => b.Prepend(simple),
+                        CompoundWrite compound => b.Prepend(compound),
+                        _ => throw new ArgumentException(
+                            "The supplied WriteCommand is invalid. Only SimpleWriteCommand and CompoundWrite WriteCommands are supported.")
+                    };
                 });
             }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="writes">TBD</param>
-            /// <returns>TBD</returns>
+            
             public static WriteCommand Create(IEnumerable<WriteCommand> writes)
             {
                 return Write.Empty.Prepend(writes);
             }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="writes">TBD</param>
-            /// <returns>TBD</returns>
+            
             public static WriteCommand Create(params WriteCommand[] writes)
             {
                 return Create((IEnumerable<WriteCommand>)writes);
@@ -432,25 +364,25 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// A non-compounded write
         /// </summary>
         public abstract class SimpleWriteCommand : WriteCommand
         {
             /// <summary>
-            /// TBD
+            /// An optional acknowledgment event which will be sent to the sender of this command
             /// </summary>
             public abstract Event Ack { get; }
 
             /// <summary>
-            /// TBD
+            /// Indicates whether this message needs to be ACK'd to the handler.
             /// </summary>
-            public bool WantsAck => !(Ack is NoAck);
+            public bool WantsAck => Ack is not NoAck;
 
             /// <summary>
-            /// TBD
+            /// Appends a write after this one.
             /// </summary>
-            /// <param name="that">TBD</param>
-            /// <returns>TBD</returns>
+            /// <param name="that">The next write to append.</param>
+            /// <returns>A compound write of non-contiguous memory.</returns>
             public CompoundWrite Append(WriteCommand that)
             {
                 return that.Prepend(this);
@@ -467,20 +399,20 @@ namespace Akka.IO
         /// or have been sent!</b> Unfortunately there is no way to determine whether
         /// a particular write has been sent by the O/S.
         /// </summary>
-        public class Write : SimpleWriteCommand
+        public sealed class Write : SimpleWriteCommand
         {
             /// <summary>
-            /// TBD
+            /// Write with no data and <see cref="NoAck"/>
             /// </summary>
             public static readonly Write Empty = new(ByteString.Empty, NoAck.Instance);
 
             /// <summary>
-            /// TBD
+            /// The data we are going to write.
             /// </summary>
             public ByteString Data { get; }
 
             /// <summary>
-            /// TBD
+            /// The optional acknowledgment event which will be sent to the sender of this command.
             /// </summary>
             public override Event Ack { get; }
 
@@ -494,21 +426,19 @@ namespace Akka.IO
                 $"Write(bytes: {Data.Count}, ack: {Ack})";
 
             /// <summary>
-            /// TBD
+            /// Creates a write from a <see cref="ByteString"/>
             /// </summary>
-            /// <param name="data">TBD</param>
-            /// <returns>TBD</returns>
+            /// <param name="data">The data to return.</param>
             public static Write Create(ByteString data)
             {
                 return data.IsEmpty ? Empty : new Write(data, NoAck.Instance);
             }
 
             /// <summary>
-            /// TBD
+            /// Creates a write from a <see cref="ByteString"/>
             /// </summary>
-            /// <param name="data">TBD</param>
-            /// <param name="ack">TbD</param>
-            /// <returns>TBD</returns>
+            /// <param name="data">The data to return.</param>
+            /// <param name="ack">The acknowledgement message we're receive once this write is complete.</param>
             public static Write Create(ByteString data, Event ack)
             {
                 return new Write(data, ack);
@@ -523,26 +453,14 @@ namespace Akka.IO
         /// If the sub commands contain `ack` requests they will be honored as soon as the
         /// respective write has been written completely.
         /// </summary>
-        public class CompoundWrite : WriteCommand, IEnumerable<SimpleWriteCommand>
+        public sealed class CompoundWrite : WriteCommand, IEnumerable<SimpleWriteCommand>
         {
-            private readonly SimpleWriteCommand _head;
-            private readonly WriteCommand _tailCommand;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="head">TBD</param>
-            /// <param name="tailCommand">TBD</param>
             public CompoundWrite(SimpleWriteCommand head, WriteCommand tailCommand)
             {
-                _head = head;
-                _tailCommand = tailCommand;
+                Head = head;
+                TailCommand = tailCommand;
             }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <returns>TBD</returns>
+            
             public IEnumerator<SimpleWriteCommand> GetEnumerator()
             {
                 return Enumerable().GetEnumerator();
@@ -558,31 +476,21 @@ namespace Akka.IO
                 WriteCommand current = this;
                 while (current != null)
                 {
-                    var compound = current as CompoundWrite;
-                    if (compound != null)
+                    if (current is CompoundWrite compound)
                     {
                         current = compound.TailCommand;
                         yield return compound.Head;
                     }
 
-                    var simple = current as SimpleWriteCommand;
-                    if (simple != null)
-                    {
-                        current = null;
-                        yield return simple;
-                    }
+                    if (current is not SimpleWriteCommand simple) continue;
+                    current = null;
+                    yield return simple;
                 }
             }
+            
+            public SimpleWriteCommand Head { get; }
 
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public SimpleWriteCommand Head => _head;
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            public WriteCommand TailCommand => _tailCommand;
+            public WriteCommand TailCommand { get; }
 
             public override string ToString() =>
                 $"CompoundWrite({Head}, {TailCommand})";
@@ -595,11 +503,8 @@ namespace Akka.IO
         /// connection actor between the first <see cref="CommandFailed" /> and subsequent reception of
         /// this message will also be rejected with <see cref="CommandFailed" />.
         /// </summary>
-        public class ResumeWriting : Command
+        public sealed class ResumeWriting : Command
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly ResumeWriting Instance = new();
 
             private ResumeWriting()
@@ -612,11 +517,8 @@ namespace Akka.IO
         /// socket. TCP flow-control will then propagate backpressure to the sender side
         /// as buffers fill up on either end. To re-enable reading send <see cref="ResumeReading" />.
         /// </summary>
-        public class SuspendReading : Command
+        public sealed class SuspendReading : Command
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly SuspendReading Instance = new();
 
             private SuspendReading()
@@ -628,11 +530,8 @@ namespace Akka.IO
         /// This command needs to be sent to the connection actor after a <see cref="SuspendReading" />
         /// command in order to resume reading from the socket.
         /// </summary>
-        public class ResumeReading : Command
+        public sealed class ResumeReading : Command
         {
-            /// <summary>
-            /// TBD
-            /// </summary>
             public static readonly ResumeReading Instance = new();
 
             private ResumeReading()
@@ -644,24 +543,20 @@ namespace Akka.IO
         /// This message enables the accepting of the next connection if read throttling is enabled
         /// for connection actors.
         /// </summary>
-        public class ResumeAccepting : Command
+        public sealed class ResumeAccepting : Command
         {
             /// <summary>
-            /// TBD
+            /// The number of connections to accept before resuming read throttling.
             /// </summary>
             public int BatchSize { get; }
-
-            /// <summary>
-            /// TBD
-            /// </summary>
-            /// <param name="batchSize">TBD</param>
+            
             public ResumeAccepting(int batchSize)
             {
                 BatchSize = batchSize;
             }
 
             public override string ToString() =>
-                $"ResumeAccepting(batchSize: {BatchSize})";
+                $"ResumeAccepting(BatchSize: {BatchSize})";
         }
 
         #endregion
@@ -770,7 +665,7 @@ namespace Akka.IO
         /// the first <see cref="CommandFailed" /> message have been enqueued to the O/S kernel at this
         /// point.
         /// </summary>
-        public class WritingResumed : Event
+        public sealed class WritingResumed : Event
         {
             public static readonly WritingResumed Instance = new();
 
@@ -784,7 +679,7 @@ namespace Akka.IO
         /// in this form. If the bind address indicated a 0 port number, then the contained
         /// `localAddress` can be used to find out which port was automatically assigned.
         /// </summary>
-        public class Bound : Event
+        public sealed class Bound : Event
         {
             /// <summary>
             /// The local listening endpoint of the bound socket.
@@ -808,7 +703,7 @@ namespace Akka.IO
         /// The sender of an <see cref="Unbind" /> command will receive confirmation through this
         /// message once the listening socket has been closed.
         /// </summary>
-        public class Unbound : Event
+        public sealed class Unbound : Event
         {
             /// <summary>
             /// Singleton instance
@@ -855,7 +750,7 @@ namespace Akka.IO
         /// <summary>
         /// The connection has been closed normally in response to a <see cref="Close" /> command.
         /// </summary>
-        public class Closed : ConnectionClosed
+        public sealed class Closed : ConnectionClosed
         {
             public static readonly Closed Instance = new();
 
@@ -867,7 +762,7 @@ namespace Akka.IO
         /// <summary>
         /// The connection has been aborted in response to an <see cref="Abort" /> command.
         /// </summary>
-        public class Aborted : ConnectionClosed
+        public sealed class Aborted : ConnectionClosed
         {
             public static readonly Aborted Instance = new();
 
@@ -882,7 +777,7 @@ namespace Akka.IO
         /// The connection has been half-closed by us and then half-close by the peer
         /// in response to a <see cref="ConfirmedClose" /> command.
         /// </summary>
-        public class ConfirmedClosed : ConnectionClosed
+        public sealed class ConfirmedClosed : ConnectionClosed
         {
             public static readonly ConfirmedClosed Instance = new();
 
@@ -896,7 +791,7 @@ namespace Akka.IO
         /// <summary>
         /// The peer has closed its writing half of the connection.
         /// </summary>
-        public class PeerClosed : ConnectionClosed
+        public sealed class PeerClosed : ConnectionClosed
         {
             public static readonly PeerClosed Instance = new();
 
@@ -927,7 +822,7 @@ namespace Akka.IO
 
         #endregion
 
-        private class ConnectionSupervisorStrategyImp : OneForOneStrategy
+        private sealed class ConnectionSupervisorStrategyImp : OneForOneStrategy
         {
             public ConnectionSupervisorStrategyImp()
                 : base(StoppingStrategy.Decider)
@@ -1078,8 +973,8 @@ namespace Akka.IO
         /// Registers an actor to handle an outgoing or incoming TCP connection that has been established.
         /// </summary>
         /// <param name="handler">The actor who will be handling the TCP communication.</param>
-        /// <param name="keepOpenOnPeerClosed">TBD</param>
-        /// <param name="useResumeWriting">TBD</param>
+        /// <param name="keepOpenOnPeerClosed">Keep the connection open if the peer is closed</param>
+        /// <param name="useResumeWriting">Use resume / pause writing semantics once buffer gets full</param>
         public static Tcp.Command Register(IActorRef handler, bool keepOpenOnPeerClosed = false,
             bool useResumeWriting = true)
         {

--- a/src/core/Akka/IO/Tcp.cs
+++ b/src/core/Akka/IO/Tcp.cs
@@ -36,6 +36,11 @@ namespace Akka.IO
             return PluginInstance.Apply(system).Manager;
         }
         
+        public static TcpExt For(ActorSystem system)
+        {
+            return PluginInstance.Apply(system);
+        }
+        
         public override TcpExt CreateExtension(ExtendedActorSystem system)
         {
             return new TcpExt(system);

--- a/src/core/Akka/IO/TcpListener.cs
+++ b/src/core/Akka/IO/TcpListener.cs
@@ -40,18 +40,12 @@ namespace Akka.IO
     /// </summary>
     internal sealed class TcpListener : ActorBase, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
     {
-        /// <summary>
-        /// In the event that someone specified something stupid like 0 or a negative number
-        /// for the accept limit, this is a reasonable default.
-        /// </summary>
-        public static readonly int DefaultAcceptLimit = Environment.ProcessorCount * 2;
-
         private readonly TcpExt _tcp;
         private readonly IActorRef _bindCommander; // forwarded destination for Connected
         private Tcp.Bind _bind;
         private Socket _socket;
         private readonly ILoggingAdapter _log = Context.GetLogger();
-        private readonly int _acceptLimit = DefaultAcceptLimit;
+        private readonly int _acceptLimit;
         private SocketAsyncActorEventArgs[]? _acceptPool;
         private bool _binding;
         private static readonly EventHandler<SocketAsyncEventArgs> OnCompleted = OnIoCompleted;
@@ -64,6 +58,17 @@ namespace Akka.IO
             Tcp.Bind bind)
         {
             _tcp = tcp;
+            _acceptLimit = tcp.Settings.BatchAcceptLimit;
+
+            if (_acceptLimit <= 0)
+            {
+                _log.Warning("Batch accept limit is set to {0}, which is less than or equal to 0. " +
+                             "This value will HANG the listener.", _acceptLimit);;
+
+                _acceptLimit = TcpSettings.DefaultAcceptLimit;
+                _log.Warning("Using default value of {0} for batch accept limit", _acceptLimit);
+            }
+            
             _bindCommander = bindCommander;
 
             Self.Tell(bind);

--- a/src/core/Akka/IO/TcpListener.cs
+++ b/src/core/Akka/IO/TcpListener.cs
@@ -6,18 +6,33 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Net;
 using System.Net.Sockets;
 using Akka.Actor;
 using Akka.Dispatch;
 using Akka.Event;
 using Akka.Util.Internal;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Akka.IO
 {
+    /// <summary>
+    /// SocketAsyncEventArgs is a wrapper around SocketAsyncEventArgs that allows us to deliver
+    /// notifications to actors upon completion of the operation.
+    /// </summary>
+    internal sealed class SocketAsyncActorEventArgs : SocketAsyncEventArgs
+    {
+        public SocketAsyncActorEventArgs(IActorRef notifyMe, EventHandler<SocketAsyncEventArgs> onCompleted)
+        {
+            NotifyMe = notifyMe;
+            Completed += onCompleted;
+        }
+
+        /// <summary>
+        /// The actor we're going to notify once the operation is completed.
+        /// </summary>
+        public IActorRef NotifyMe { get; }
+    }
+
     /// <summary>
     /// INTERNAL API
     ///
@@ -30,26 +45,27 @@ namespace Akka.IO
         /// for the accept limit, this is a reasonable default.
         /// </summary>
         public static readonly int DefaultAcceptLimit = Environment.ProcessorCount * 2;
-        
+
         private readonly TcpExt _tcp;
-        private readonly IActorRef _bindCommander;  // forwarded destination for Connected
+        private readonly IActorRef _bindCommander; // forwarded destination for Connected
         private Tcp.Bind _bind;
         private Socket _socket;
         private readonly ILoggingAdapter _log = Context.GetLogger();
-        private int _acceptLimit;
-        private SocketAsyncEventArgs[]? _acceptPool;
+        private readonly int _acceptLimit = DefaultAcceptLimit;
+        private SocketAsyncActorEventArgs[]? _acceptPool;
         private bool _binding;
+        private static readonly EventHandler<SocketAsyncEventArgs> OnCompleted = OnIoCompleted;
 
         private sealed record AcceptCompleted(SocketAsyncEventArgs EventArgs) : INoSerializationVerificationNeeded;
 
         private sealed record RetryAccept(SocketAsyncEventArgs EventArgs) : INoSerializationVerificationNeeded;
-        
+
         public TcpListener(TcpExt tcp, IActorRef bindCommander,
             Tcp.Bind bind)
         {
             _tcp = tcp;
             _bindCommander = bindCommander;
-            
+
             Self.Tell(bind);
         }
 
@@ -60,7 +76,7 @@ namespace Akka.IO
                 case AcceptCompleted accepted:
                     HandleAccept(accepted.EventArgs);
                     return true;
-                
+
                 case RetryAccept retry:
                     StartAccept(retry.EventArgs);
                     return true;
@@ -72,6 +88,10 @@ namespace Akka.IO
                 case Tcp.Unbind:
                     Become(Unbinding(Sender));
                     UnbindAsync().PipeTo(Self);
+                    return true;
+
+                case Status.Failure failure:
+                    _log.Error(failure.Cause, "Received SocketAsyncEventArgs failure");
                     return true;
 
                 default:
@@ -88,43 +108,58 @@ namespace Akka.IO
                     _log.Debug("Unbound endpoint {0}, stopping listener", _bind.LocalAddress);
                     Context.Stop(Self);
                     return true;
-                
+
                 case Status.Failure fail:
                     _log.Error(fail.Cause, "Failed to unbind TCP listener for address [{0}]", _bind.LocalAddress);
                     Context.Stop(Self);
                     return true;
-                
+
                 default:
                     return false;
             }
         };
-        
+
         private void StartAccept(SocketAsyncEventArgs saea)
         {
-
             var pending = _socket.AcceptAsync(saea);
             if (!pending)
                 Self.Tell(new AcceptCompleted(saea), Self); // synchronous completion ➔ mailbox
         }
 
-        // closure
-        private IActorRef _safeSelf = Context.Self;
-
-        private void OnCompleted(object? sender, SocketAsyncEventArgs saea)
+        private static void OnIoCompleted(object? sender, SocketAsyncEventArgs saea)
         {
             // Marshall back into the actor context – keeps user code off the IOCP thread.
-            _safeSelf.Tell(new AcceptCompleted(saea), ActorRefs.NoSender);
+            var actorArgs = (SocketAsyncActorEventArgs)saea;
+
+            var actor = actorArgs.NotifyMe;
+            if (actorArgs.LastOperation == SocketAsyncOperation.Accept)
+            {
+                actor.Tell(new AcceptCompleted(saea), actor);
+            }
+            else // should never happen
+            {
+                // This should never happen, but just in case.
+                var ioe = new InvalidOperationException(
+                    $"SocketAsyncEventArgs last operation is not Accept: {actorArgs.LastOperation}");
+                actor.Tell(new Status.Failure(ioe), actor);
+
+                // retry the operation
+                actorArgs.AcceptSocket = null;
+                actor.Tell(new RetryAccept(actorArgs));
+            }
         }
-        
+
         private void HandleAccept(SocketAsyncEventArgs saea)
         {
             switch (saea.SocketError)
             {
                 case SocketError.Success:
                     var accepted = saea.AcceptSocket!;
-                    saea.AcceptSocket = null;          // ready for re‑use
-                    Context.ActorOf(Props.Create<TcpIncomingConnection>(_tcp, accepted, _bind.Handler, _bind.Options, _bind.PullMode).WithDeploy(Deploy.Local));
-                    StartAccept(saea);                 // keep the pool full
+                    saea.AcceptSocket = null; // ready for re‑use
+                    Context.ActorOf(Props
+                        .Create<TcpIncomingConnection>(_tcp, accepted, _bind.Handler, _bind.Options, _bind.PullMode)
+                        .WithDeploy(Deploy.Local));
+                    StartAccept(saea); // keep the pool full
                     break;
 
                 case SocketError.ConnectionReset:
@@ -156,15 +191,14 @@ namespace Akka.IO
                 _bind.Options.ForEach(x => x.BeforeServerSocketBind(_socket));
                 _socket.Bind(_bind.LocalAddress);
                 _socket.Listen(_bind.Backlog);
-                
-                _acceptPool = new SocketAsyncEventArgs[_acceptLimit];
+
+                _acceptPool = new SocketAsyncActorEventArgs[_acceptLimit];
                 for (var i = 0; i < _acceptPool.Length; i++)
                 {
-                    var saea = new SocketAsyncEventArgs();
-                    saea.Completed += OnCompleted;  // IOCP -> this actor
+                    var saea = new SocketAsyncActorEventArgs(Self, OnCompleted);
                     _acceptPool[i] = saea;
                 }
-                
+
                 // start accepting connections
                 foreach (var saea in _acceptPool)
                     StartAccept(saea);
@@ -190,7 +224,7 @@ namespace Akka.IO
                 return Task.FromException<Tcp.Unbound>(ex);
             }
         }
-        
+
         protected override SupervisorStrategy SupervisorStrategy()
         {
             return Tcp.ConnectionSupervisorStrategy;
@@ -206,52 +240,46 @@ namespace Akka.IO
                         _log.Warning("Already trying to bind to TCP channel on endpoint [{0}]", _bind.LocalAddress);
                         return true;
                     }
+
                     _binding = true;
                     _bind = bind;
-                    // not going to do pull mode
-                    _acceptLimit = _tcp.Settings.BatchAcceptLimit;
-                    if (_acceptLimit <= 0)
-                    {
-                        _log.Debug("Accept limit was set to {0}, which is unworkable. Using default value of {1} (logical CPUs * 2)", _acceptLimit, DefaultAcceptLimit);
-                        _acceptLimit = DefaultAcceptLimit;
-                    }
-                        
-                    
-                    _log.Info("Binding TCP channel on endpoint [{0}]", _bind.LocalAddress); 
-                    
+
+                    _log.Info("Binding TCP channel on endpoint [{0}]", _bind.LocalAddress);
+
                     BindAsync().PipeTo(Self);
                     return true;
-                
+
                 case Status.Failure fail:
                     _bindCommander.Tell(_bind.FailureMessage.WithCause(fail.Cause));
                     _log.Error(fail.Cause, "Bind failed for TCP channel on endpoint [{0}]", _bind.LocalAddress);
                     Context.Stop(Self);
                     _binding = false;
                     return true;
-                
+
                 case Tcp.Bound bound:
                     Context.Watch(_bind.Handler);
                     _bindCommander.Tell(bound);
                     Become(Bound());
                     _binding = false;
                     return true;
-                
+
                 default:
                     return false;
             }
         }
-        
+
         protected override void PostStop()
         {
             try
             {
-                if(_acceptPool != null)
-                    foreach(var saea in _acceptPool)
+                if (_acceptPool != null)
+                    foreach (var saea in _acceptPool)
                     {
                         // remove event handler
                         saea.Completed -= OnCompleted;
                         saea.Dispose();
                     }
+
                 _socket?.Dispose();
             }
             catch (Exception e)

--- a/src/core/Akka/IO/TcpListener.cs
+++ b/src/core/Akka/IO/TcpListener.cs
@@ -18,89 +18,58 @@ using System.Threading.Tasks;
 
 namespace Akka.IO
 {
-    class TcpListener : ActorBase, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
+    /// <summary>
+    /// INTERNAL API
+    ///
+    /// TcpListener is an internal actor that binds to a local address and listens for incoming TCP connections.
+    /// </summary>
+    internal sealed class TcpListener : ActorBase, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
     {
+        /// <summary>
+        /// In the event that someone specified something stupid like 0 or a negative number
+        /// for the accept limit, this is a reasonable default.
+        /// </summary>
+        public static readonly int DefaultAcceptLimit = Environment.ProcessorCount * 2;
+        
         private readonly TcpExt _tcp;
-        private readonly IActorRef _bindCommander;
+        private readonly IActorRef _bindCommander;  // forwarded destination for Connected
         private Tcp.Bind _bind;
         private Socket _socket;
         private readonly ILoggingAdapter _log = Context.GetLogger();
         private int _acceptLimit;
-        private SocketAsyncEventArgs[] _saeas;
+        private SocketAsyncEventArgs[]? _acceptPool;
         private bool _binding;
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="tcp">TBD</param>
-        /// <param name="bindCommander">TBD</param>
-        /// <param name="bind">TBD</param>
+        private sealed record AcceptCompleted(SocketAsyncEventArgs EventArgs) : INoSerializationVerificationNeeded;
+
+        private sealed record RetryAccept(SocketAsyncEventArgs EventArgs) : INoSerializationVerificationNeeded;
+        
         public TcpListener(TcpExt tcp, IActorRef bindCommander,
             Tcp.Bind bind)
         {
             _tcp = tcp;
             _bindCommander = bindCommander;
             
-            Become(Initializing());
             Self.Tell(bind);
         }
-
-        private Receive Initializing() => message =>
-        {
-            switch (message)
-            {
-                case Tcp.Bind bind:
-                    if (_binding)
-                    {
-                        _log.Warning("Already trying to bind to TCP channel on endpoint [{0}]", _bind.LocalAddress);
-                        return true;
-                    }
-                    _binding = true;
-                    _bind = bind;
-                    _acceptLimit = bind.PullMode ? 0 : _tcp.Settings.BatchAcceptLimit;
-                    BindAsync().PipeTo(Self);
-                    return true;
-                
-                case Status.Failure fail:
-                    _bindCommander.Tell(_bind.FailureMessage.WithCause(fail.Cause));
-                    _log.Error(fail.Cause, "Bind failed for TCP channel on endpoint [{0}]", _bind.LocalAddress);
-                    Context.Stop(Self);
-                    _binding = false;
-                    return true;
-                
-                case Tcp.Bound bound:
-                    Context.Watch(_bind.Handler);
-                    _bindCommander.Tell(bound);
-                    Become(Bound());
-                    _binding = false;
-                    return true;
-                
-                default:
-                    return false;
-            }
-        };
 
         private Receive Bound() => message =>
         {
             switch (message)
             {
-                case SocketEvent evt:
-                    var saea = evt.Args;
-                    if (saea.SocketError == SocketError.Success)
-                        Context.ActorOf(Props.Create<TcpIncomingConnection>(_tcp, saea.AcceptSocket, _bind.Handler, _bind.Options, _bind.PullMode).WithDeploy(Deploy.Local));
-                    
-                    saea.AcceptSocket = null;
-                    if (!_socket.AcceptAsync(saea))
-                        Self.Tell(new SocketEvent(saea));
+                case AcceptCompleted accepted:
+                    HandleAccept(accepted.EventArgs);
+                    return true;
+                
+                case RetryAccept retry:
+                    StartAccept(retry.EventArgs);
                     return true;
 
-                case Tcp.ResumeAccepting resumeAccepting:
-                    _acceptLimit = resumeAccepting.BatchSize;
-                    // TODO: this is dangerous, previous async args are not disposed and there's no guarantee that they're not still receiving data
-                    _saeas = Accept(_acceptLimit).ToArray();
+                case Tcp.ResumeAccepting:
+                    // NO-OP - this is obsolete
                     return true;
 
-                case Tcp.Unbind _:
+                case Tcp.Unbind:
                     Become(Unbinding(Sender));
                     UnbindAsync().PipeTo(Self);
                     return true;
@@ -130,16 +99,48 @@ namespace Akka.IO
             }
         };
         
-        private IEnumerable<SocketAsyncEventArgs> Accept(int limit)
+        private void StartAccept(SocketAsyncEventArgs saea)
         {
-            for(var i = 0; i < limit; i++)
+
+            var pending = _socket.AcceptAsync(saea);
+            if (!pending)
+                Self.Tell(new AcceptCompleted(saea), Self); // synchronous completion ➔ mailbox
+        }
+
+        // closure
+        private IActorRef _safeSelf = Context.Self;
+
+        private void OnCompleted(object? sender, SocketAsyncEventArgs saea)
+        {
+            // Marshall back into the actor context – keeps user code off the IOCP thread.
+            _safeSelf.Tell(new AcceptCompleted(saea), ActorRefs.NoSender);
+        }
+        
+        private void HandleAccept(SocketAsyncEventArgs saea)
+        {
+            switch (saea.SocketError)
             {
-                var self = Self;
-                var saea = new SocketAsyncEventArgs();
-                saea.Completed += (_, e) => self.Tell(new SocketEvent(e));
-                if (!_socket.AcceptAsync(saea))
-                    Self.Tell(new SocketEvent(saea));
-                yield return saea;
+                case SocketError.Success:
+                    var accepted = saea.AcceptSocket!;
+                    saea.AcceptSocket = null;          // ready for re‑use
+                    Context.ActorOf(Props.Create<TcpIncomingConnection>(_tcp, accepted, _bind.Handler, _bind.Options, _bind.PullMode).WithDeploy(Deploy.Local));
+                    StartAccept(saea);                 // keep the pool full
+                    break;
+
+                case SocketError.ConnectionReset:
+                case SocketError.NoBufferSpaceAvailable:
+                case SocketError.TryAgain:
+                case SocketError.TimedOut:
+                case SocketError.WouldBlock:
+                    // transient – short back‑off then retry
+                    saea.AcceptSocket = null;
+                    Context.System.Scheduler.ScheduleTellOnce(TimeSpan.FromMilliseconds(10), Self,
+                        new RetryAccept(saea), ActorRefs.NoSender);
+                    break;
+                default:
+                    _log.Error("Fatal socket error in TcpListener: {0}", saea.SocketError);
+                    Context.Stop(Self);
+                    break;
             }
         }
 
@@ -155,7 +156,18 @@ namespace Akka.IO
                 _bind.Options.ForEach(x => x.BeforeServerSocketBind(_socket));
                 _socket.Bind(_bind.LocalAddress);
                 _socket.Listen(_bind.Backlog);
-                _saeas = Accept(_acceptLimit).ToArray();
+                
+                _acceptPool = new SocketAsyncEventArgs[_acceptLimit];
+                for (var i = 0; i < _acceptPool.Length; i++)
+                {
+                    var saea = new SocketAsyncEventArgs();
+                    saea.Completed += OnCompleted;  // IOCP -> this actor
+                    _acceptPool[i] = saea;
+                }
+                
+                // start accepting connections
+                foreach (var saea in _acceptPool)
+                    StartAccept(saea);
 
                 return Task.FromResult(new Tcp.Bound(_socket.LocalEndPoint));
             }
@@ -186,32 +198,65 @@ namespace Akka.IO
 
         protected override bool Receive(object message)
         {
-            throw new NotImplementedException();
+            switch (message)
+            {
+                case Tcp.Bind bind:
+                    if (_binding)
+                    {
+                        _log.Warning("Already trying to bind to TCP channel on endpoint [{0}]", _bind.LocalAddress);
+                        return true;
+                    }
+                    _binding = true;
+                    _bind = bind;
+                    // not going to do pull mode
+                    _acceptLimit = _tcp.Settings.BatchAcceptLimit;
+                    if (_acceptLimit <= 0)
+                    {
+                        _log.Debug("Accept limit was set to {0}, which is unworkable. Using default value of {1} (logical CPUs * 2)", _acceptLimit, DefaultAcceptLimit);
+                        _acceptLimit = DefaultAcceptLimit;
+                    }
+                        
+                    
+                    _log.Info("Binding TCP channel on endpoint [{0}]", _bind.LocalAddress); 
+                    
+                    BindAsync().PipeTo(Self);
+                    return true;
+                
+                case Status.Failure fail:
+                    _bindCommander.Tell(_bind.FailureMessage.WithCause(fail.Cause));
+                    _log.Error(fail.Cause, "Bind failed for TCP channel on endpoint [{0}]", _bind.LocalAddress);
+                    Context.Stop(Self);
+                    _binding = false;
+                    return true;
+                
+                case Tcp.Bound bound:
+                    Context.Watch(_bind.Handler);
+                    _bindCommander.Tell(bound);
+                    Become(Bound());
+                    _binding = false;
+                    return true;
+                
+                default:
+                    return false;
+            }
         }
-
-        /// <summary>
-        /// TBD
-        /// </summary>
+        
         protected override void PostStop()
         {
             try
             {
+                if(_acceptPool != null)
+                    foreach(var saea in _acceptPool)
+                    {
+                        // remove event handler
+                        saea.Completed -= OnCompleted;
+                        saea.Dispose();
+                    }
                 _socket?.Dispose();
-                _saeas?.ForEach(x => x.Dispose());
             }
             catch (Exception e)
             {
                 _log.Debug("Error closing ServerSocketChannel: {0}", e);
-            }
-        }
-
-        private readonly struct SocketEvent : INoSerializationVerificationNeeded
-        {
-            public readonly SocketAsyncEventArgs Args;
-
-            public SocketEvent(SocketAsyncEventArgs args)
-            {
-                Args = args;
             }
         }
     }

--- a/src/core/Akka/IO/TcpManager.cs
+++ b/src/core/Akka/IO/TcpManager.cs
@@ -57,7 +57,6 @@ namespace Akka.IO
         public TcpManager(TcpExt tcp)
         {
             _tcp = tcp;
-            Context.System.EventStream.Subscribe(Self, typeof(DeadLetter));
         }
         
         protected override bool Receive(object message)
@@ -74,14 +73,6 @@ namespace Akka.IO
                 {
                     var commander = Sender;
                     Context.ActorOf(Props.Create<TcpListener>(_tcp, commander, b).WithDeploy(Deploy.Local));
-                    return true;
-                }
-                case DeadLetter dl:
-                {
-                    if (dl.Message is SocketCompleted completed)
-                    {
-                        //TODO: release resources?
-                    }
                     return true;
                 }
                 default:

--- a/src/core/Akka/IO/TcpManager.cs
+++ b/src/core/Akka/IO/TcpManager.cs
@@ -53,52 +53,42 @@ namespace Akka.IO
     internal sealed class TcpManager : ActorBase
     {
         private readonly TcpExt _tcp;
-
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="tcp">TBD</param>
+        
         public TcpManager(TcpExt tcp)
         {
             _tcp = tcp;
             Context.System.EventStream.Subscribe(Self, typeof(DeadLetter));
         }
         
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="message">TBD</param>
-        /// <exception cref="ArgumentException">TBD</exception>
-        /// <returns>TBD</returns>
         protected override bool Receive(object message)
         {
-            var c = message as Connect;
-            if (c != null)
+            switch (message)
             {
-                var commander = Sender;
-                Context.ActorOf(Props.Create<TcpOutgoingConnection>(_tcp, commander, c).WithDeploy(Deploy.Local));
-                return true;
-            }
-            var b = message as Bind;
-            if (b != null)
-            {
-                var commander = Sender;
-                Context.ActorOf(Props.Create<TcpListener>(_tcp, commander, b).WithDeploy(Deploy.Local));
-                return true;
-            }
-            var dl = message as DeadLetter;
-            if (dl != null)
-            {
-                var completed = dl.Message as SocketCompleted;
-                if (completed != null)
+                case Connect c:
                 {
-                    //TODO: release resources?
+                    var commander = Sender;
+                    Context.ActorOf(Props.Create<TcpOutgoingConnection>(_tcp, commander, c).WithDeploy(Deploy.Local));
+                    return true;
                 }
-                return true;
+                case Bind b:
+                {
+                    var commander = Sender;
+                    Context.ActorOf(Props.Create<TcpListener>(_tcp, commander, b).WithDeploy(Deploy.Local));
+                    return true;
+                }
+                case DeadLetter dl:
+                {
+                    if (dl.Message is SocketCompleted completed)
+                    {
+                        //TODO: release resources?
+                    }
+                    return true;
+                }
+                default:
+                    throw new ArgumentException($"The supplied message of type {message.GetType().Name} is invalid. Only Connect and Bind messages are supported. " +
+                                                $"If you are going to manage your connection state, you need to communicate with Tcp.Connected sender actor. " +
+                                                $"See more here: https://getakka.net/articles/networking/io.html", nameof(message));
             }
-            throw new ArgumentException($"The supplied message of type {message.GetType().Name} is invalid. Only Connect and Bind messages are supported. " +
-                                        $"If you are going to manage your connection state, you need to communicate with Tcp.Connected sender actor. " +
-                                        $"See more here: https://getakka.net/articles/networking/io.html", nameof(message));
         }
     }
 }

--- a/src/core/Akka/IO/TcpSettings.cs
+++ b/src/core/Akka/IO/TcpSettings.cs
@@ -25,7 +25,11 @@ namespace Akka.IO
         {
             var config = system.Settings.Config.GetConfig("akka.io.tcp");
             if (config.IsNullOrEmpty())
-                throw ConfigurationException.NullOrEmptyConfig<TcpSettings>("akka.io.tcp");//($"Failed to create {typeof(TcpSettings)}: akka.io.tcp configuration node not found");
+                throw
+                    ConfigurationException
+                        .NullOrEmptyConfig<
+                            TcpSettings>(
+                            "akka.io.tcp"); //($"Failed to create {typeof(TcpSettings)}: akka.io.tcp configuration node not found");
 
             return Create(config);
         }
@@ -44,7 +48,9 @@ namespace Akka.IO
                 bufferPoolConfigPath: config.GetString("buffer-pool", "akka.io.tcp.disabled-buffer-pool"),
                 initialSocketAsyncEventArgs: config.GetInt("nr-of-socket-async-event-args", 32),
                 traceLogging: config.GetBoolean("trace-logging", false),
-                batchAcceptLimit: config.GetInt("batch-accept-limit", 10),
+                batchAcceptLimit: config.GetString("batch-accept-limit") == "scale-to-cpus"
+                    ? DefaultAcceptLimit
+                    : config.GetInt("batch-accept-limit", DefaultAcceptLimit),
                 registerTimeout: config.GetTimeSpan("register-timeout", TimeSpan.FromSeconds(5)),
                 receivedMessageSizeLimit: config.GetString("max-received-message-size", "unlimited") == "unlimited"
                     ? int.MaxValue
@@ -59,23 +65,28 @@ namespace Akka.IO
                 writeCommandsQueueMaxSize: config.GetInt("write-commands-queue-max-size", -1));
         }
 
-        public TcpSettings( string    bufferPoolConfigPath,
-                            int       initialSocketAsyncEventArgs,
-                            bool      traceLogging,
-                            int       batchAcceptLimit,
-                            TimeSpan? registerTimeout,
-                            int       receivedMessageSizeLimit,
-                            string    managementDispatcher,
-                            string    fileIoDispatcher,
-                            int       transferToLimit,
-                            int       finishConnectRetries,
-                            bool      outgoingSocketForceIpv4,
-                            int       writeCommandsQueueMaxSize)
+        /// <summary>
+        /// Default size of the SAEA pool
+        /// </summary>
+        internal static readonly int DefaultAcceptLimit = Environment.ProcessorCount * 2;
+
+        public TcpSettings(string bufferPoolConfigPath,
+            int initialSocketAsyncEventArgs,
+            bool traceLogging,
+            int batchAcceptLimit,
+            TimeSpan? registerTimeout,
+            int receivedMessageSizeLimit,
+            string managementDispatcher,
+            string fileIoDispatcher,
+            int transferToLimit,
+            int finishConnectRetries,
+            bool outgoingSocketForceIpv4,
+            int writeCommandsQueueMaxSize)
         {
             BufferPoolConfigPath = bufferPoolConfigPath;
             InitialSocketAsyncEventArgs = initialSocketAsyncEventArgs;
             TraceLogging = traceLogging;
-            // BatchAcceptLimit = batchAcceptLimit; // not used, remove this setting in v1.6
+            BatchAcceptLimit = batchAcceptLimit;
             RegisterTimeout = registerTimeout;
             ReceivedMessageSizeLimit = receivedMessageSizeLimit;
             ManagementDispatcher = managementDispatcher;
@@ -111,9 +122,8 @@ namespace Akka.IO
         /// numbers decrease latency, lower numbers increase fairness on the 
         /// worker-dispatcher
         /// </summary>
-        [Obsolete("This setting is deprecated and will be removed in a future version.")]
         public int BatchAcceptLimit { get; }
-        
+
         /// <summary>
         /// The duration a connection actor waits for a `Register` message from 
         /// its commander before aborting the connection.
@@ -166,7 +176,7 @@ namespace Akka.IO
         /// in cases when DnsEndPoint is used to describe the remote address
         /// </summary>
         public bool OutgoingSocketForceIpv4 { get; }
-        
+
         /// <summary>
         /// Limits maximum size of internal queue, used in <see cref="TcpIncomingConnection"/> connection actor
         /// to store pending write commands.

--- a/src/core/Akka/IO/TcpSettings.cs
+++ b/src/core/Akka/IO/TcpSettings.cs
@@ -75,7 +75,7 @@ namespace Akka.IO
             BufferPoolConfigPath = bufferPoolConfigPath;
             InitialSocketAsyncEventArgs = initialSocketAsyncEventArgs;
             TraceLogging = traceLogging;
-            BatchAcceptLimit = batchAcceptLimit;
+            // BatchAcceptLimit = batchAcceptLimit; // not used, remove this setting in v1.6
             RegisterTimeout = registerTimeout;
             ReceivedMessageSizeLimit = receivedMessageSizeLimit;
             ManagementDispatcher = managementDispatcher;
@@ -111,6 +111,7 @@ namespace Akka.IO
         /// numbers decrease latency, lower numbers increase fairness on the 
         /// worker-dispatcher
         /// </summary>
+        [Obsolete("This setting is deprecated and will be removed in a future version.")]
         public int BatchAcceptLimit { get; }
         
         /// <summary>

--- a/src/core/Akka/IO/TcpSettings.cs
+++ b/src/core/Akka/IO/TcpSettings.cs
@@ -88,7 +88,7 @@ namespace Akka.IO
 
         /// <summary>
         /// A config path to the section defining which byte buffer pool to use.
-        /// Buffer pools are used to mitigate GC-pressure made by potentiall allocation
+        /// Buffer pools are used to mitigate GC-pressure made by potential allocation
         /// and deallocation of byte buffers used for writing/receiving data from sockets.
         /// </summary>
         public string BufferPoolConfigPath { get; }


### PR DESCRIPTION
## Changes

close https://github.com/akkadotnet/akka.net/issues/5988

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #5988
* [x] Changes in public API reviewed, if any.

### Latest `dev` Benchmarks 

```                                                                                                                                       
                                                                                                                                          
BenchmarkDotNet v0.13.12, Pop!_OS 22.04 LTS                                                                                               
13th Gen Intel Core i7-1360P, 1 CPU, 16 logical and 12 physical cores                                                                     
.NET SDK 8.0.404                                                                                                                          
  [Host]  : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2                                                                                 
  LongRun : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2                                                                                 
                                                                                                                                          
Job=LongRun  Concurrent=True  Server=True                                                                                                 
InvocationCount=1  IterationCount=10  LaunchCount=3                                                                                       
RunStrategy=Monitoring  UnrollFactor=1  WarmupCount=3                                                                                     
                                                                                                                                          
```                                                                                                                                       
| Method                    | MessageLength | ClientsCount | Mean      | Error     | StdDev    | Req/sec    |                             
|-------------------------- |-------------- |------------- |----------:|----------:|----------:|-----------:|                             
| **ClientServerCommunication** | **10**            | **1**            | **27.982 μs** | **1.2878 μs** | **1.9275 μs** |  **35,737.37** | 
| **ClientServerCommunication** | **10**            | **3**            | **14.090 μs** | **2.1295 μs** | **3.1874 μs** |  **70,974.46** | 
| **ClientServerCommunication** | **10**            | **5**            | **10.736 μs** | **1.0059 μs** | **1.5055 μs** |  **93,147.14** | 
| **ClientServerCommunication** | **10**            | **7**            |  **8.458 μs** | **0.6112 μs** | **0.9149 μs** | **118,237.67** | 
| **ClientServerCommunication** | **10**            | **10**           |  **6.384 μs** | **0.4887 μs** | **0.7315 μs** | **156,647.67** | 
| **ClientServerCommunication** | **10**            | **20**           |  **4.306 μs** | **0.3578 μs** | **0.5355 μs** | **232,243.96** | 
| **ClientServerCommunication** | **10**            | **30**           |  **4.177 μs** | **0.3495 μs** | **0.5231 μs** | **239,412.74** | 
| **ClientServerCommunication** | **10**            | **40**           |  **4.082 μs** | **0.3152 μs** | **0.4718 μs** | **244,954.21** | 
| **ClientServerCommunication** | **100**           | **1**            | **25.356 μs** | **1.2967 μs** | **1.9408 μs** |  **39,438.36** | 
| **ClientServerCommunication** | **100**           | **3**            | **16.853 μs** | **2.6889 μs** | **4.0247 μs** |  **59,337.20** | 
| **ClientServerCommunication** | **100**           | **5**            | **11.007 μs** | **0.5326 μs** | **0.7971 μs** |  **90,849.56** | 
| **ClientServerCommunication** | **100**           | **7**            |  **8.152 μs** | **0.4302 μs** | **0.6439 μs** | **122,671.38** | 
| **ClientServerCommunication** | **100**           | **10**           |  **6.648 μs** | **0.6572 μs** | **0.9837 μs** | **150,428.57** | 
| **ClientServerCommunication** | **100**           | **20**           |  **4.394 μs** | **0.3995 μs** | **0.5979 μs** | **227,607.99** | 
| **ClientServerCommunication** | **100**           | **30**           |  **4.541 μs** | **0.5171 μs** | **0.7740 μs** | **220,222.12** | 
| **ClientServerCommunication** | **100**           | **40**           |  **4.446 μs** | **0.4494 μs** | **0.6726 μs** | **224,926.92** | 
### This PR's Benchmarks

```                                                                                                                                                                   
                                                                                                                                                                      
BenchmarkDotNet v0.13.12, Pop!_OS 22.04 LTS                                                                                                                           
13th Gen Intel Core i7-1360P, 1 CPU, 16 logical and 12 physical cores                                                                                                 
.NET SDK 8.0.404                                                                                                                                                      
  [Host]  : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2                                                                                                             
  LongRun : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2                                                                                                             
                                                                                                                                                                      
Job=LongRun  Concurrent=True  Server=True                                                                                                                             
InvocationCount=1  IterationCount=10  LaunchCount=3                                                                                                                   
RunStrategy=Monitoring  UnrollFactor=1  WarmupCount=3                                                                                                                 
                                                                                                                                                                      
```                                                                                                                                                                   
| Method                    | MessageLength | ClientsCount | Mean      | Error     | StdDev    | Median    | Req/sec    |                                             
|-------------------------- |-------------- |------------- |----------:|----------:|----------:|----------:|-----------:|                                             
| **ClientServerCommunication** | **10**            | **1**            | **28.613 μs** | **1.0532 μs** | **1.5763 μs** | **28.204 μs** |  **34,949.41** |             
| **ClientServerCommunication** | **10**            | **3**            | **13.247 μs** | **2.0348 μs** | **3.0456 μs** | **13.202 μs** |  **75,489.21** |             
| **ClientServerCommunication** | **10**            | **5**            | **11.622 μs** | **0.9882 μs** | **1.4791 μs** | **11.611 μs** |  **86,046.57** |             
| **ClientServerCommunication** | **10**            | **7**            |  **8.414 μs** | **0.7337 μs** | **1.0982 μs** |  **8.291 μs** | **118,847.94** |             
| **ClientServerCommunication** | **10**            | **10**           |  **6.439 μs** | **0.4373 μs** | **0.6546 μs** |  **6.316 μs** | **155,312.36** |             
| **ClientServerCommunication** | **10**            | **20**           |  **4.597 μs** | **0.8180 μs** | **1.2244 μs** |  **4.230 μs** | **217,527.70** |             
| **ClientServerCommunication** | **10**            | **30**           |  **4.022 μs** | **0.2507 μs** | **0.3752 μs** |  **3.918 μs** | **248,662.30** |             
| **ClientServerCommunication** | **10**            | **40**           |  **3.911 μs** | **0.3339 μs** | **0.4998 μs** |  **3.737 μs** | **255,716.58** |             
| **ClientServerCommunication** | **100**           | **1**            | **25.943 μs** | **1.4570 μs** | **2.1808 μs** | **26.077 μs** |  **38,546.16** |             
| **ClientServerCommunication** | **100**           | **3**            | **14.730 μs** | **2.2137 μs** | **3.3134 μs** | **14.296 μs** |  **67,887.66** |             
| **ClientServerCommunication** | **100**           | **5**            | **11.184 μs** | **0.6095 μs** | **0.9122 μs** | **11.162 μs** |  **89,415.28** |             
| **ClientServerCommunication** | **100**           | **7**            |  **8.954 μs** | **0.9970 μs** | **1.4922 μs** |  **8.868 μs** | **111,677.15** |             
| **ClientServerCommunication** | **100**           | **10**           |  **6.562 μs** | **0.3587 μs** | **0.5368 μs** |  **6.450 μs** | **152,390.84** |             
| **ClientServerCommunication** | **100**           | **20**           |  **4.167 μs** | **0.3625 μs** | **0.5426 μs** |  **3.993 μs** | **239,966.16** |             
| **ClientServerCommunication** | **100**           | **30**           |  **4.250 μs** | **0.4495 μs** | **0.6729 μs** |  **3.902 μs** | **235,280.42** |             
| **ClientServerCommunication** | **100**           | **40**           |  **4.285 μs** | **0.4918 μs** | **0.7360 μs** |  **3.896 μs** | **233,382.51** |             
