### PR TITLE
Introduce CancellationToken to `WithCircuitBreaker`

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
@@ -158,22 +158,14 @@ namespace Akka.Cluster.Sharding.Tests
 
 
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="messages">TBD</param>
-        /// <exception cref="TimeoutException">
-        /// This exception is thrown when the store has not been initialized.
-        /// </exception>
-        /// <returns>TBD</returns>
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             var trueMsgs = messages.ToArray();
             
             if (_store == null)
                 return StoreNotInitialized<IImmutableList<Exception>>();
 
-            return _store.Ask<object>(sender => new WriteMessages(trueMsgs, sender, 1), Timeout, CancellationToken.None)
+            return _store.Ask<object>(sender => new WriteMessages(trueMsgs, sender, 1), Timeout, cancellationToken)
                 .ContinueWith(r =>
                 {
                     if (r.IsCanceled)
@@ -190,31 +182,23 @@ namespace Akka.Cluster.Sharding.Tests
                 }, TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="persistenceId">TBD</param>
-        /// <param name="toSequenceNr">TBD</param>
-        /// <exception cref="TimeoutException">
-        /// This exception is thrown when the store has not been initialized.
-        /// </exception>
-        /// <returns>TBD</returns>
-        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {
             if (_store == null)
                 return StoreNotInitialized<object>();
 
             var result = new TaskCompletionSource<object>();
 
-            _store.Ask<object>(sender => new DeleteMessagesTo(persistenceId, toSequenceNr, sender), Timeout, CancellationToken.None).ContinueWith(r =>
-            {
-                if (r.IsFaulted)
-                    result.TrySetException(r.Exception);
-                else if (r.IsCanceled)
-                    result.TrySetException(new TimeoutException());
-                else
-                    result.TrySetResult(true);
-            }, TaskContinuationOptions.ExecuteSynchronously);
+            _store.Ask<object>(sender => new DeleteMessagesTo(persistenceId, toSequenceNr, sender), Timeout, cancellationToken)
+                .ContinueWith(r =>
+                {
+                    if (r.IsFaulted)
+                        result.TrySetException(r.Exception);
+                    else if (r.IsCanceled)
+                        result.TrySetException(new TimeoutException());
+                    else
+                        result.TrySetResult(true);
+                }, TaskContinuationOptions.ExecuteSynchronously);
 
             return result.Task;
         }
@@ -245,23 +229,14 @@ namespace Akka.Cluster.Sharding.Tests
             return replayCompletionPromise.Task;
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="persistenceId">TBD</param>
-        /// <param name="fromSequenceNr">TBD</param>
-        /// <exception cref="TimeoutException">
-        /// This exception is thrown when the store has not been initialized.
-        /// </exception>
-        /// <returns>TBD</returns>
-        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
             if (_store == null)
                 return StoreNotInitialized<long>();
 
             var result = new TaskCompletionSource<long>();
 
-            _store.Ask<object>(sender => new ReplayMessages(0, 0, 0, persistenceId, sender), Timeout, CancellationToken.None)
+            _store.Ask<object>(sender => new ReplayMessages(0, 0, 0, persistenceId, sender), Timeout, cancellationToken)
                 .ContinueWith(t =>
                 {
                     if (t.IsFaulted)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
@@ -156,10 +156,6 @@ namespace Akka.Cluster.Sharding.Tests
             return true;
         }
 
-        [Obsolete("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
-            => WriteMessagesAsync(messages, CancellationToken.None);
-
         protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             var trueMsgs = messages.ToArray();
@@ -184,10 +180,6 @@ namespace Akka.Cluster.Sharding.Tests
                 }, TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Obsolete("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
-            => DeleteMessagesToAsync(persistenceId, toSequenceNr, CancellationToken.None);
-        
         protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {
             if (_store == null)
@@ -195,16 +187,15 @@ namespace Akka.Cluster.Sharding.Tests
 
             var result = new TaskCompletionSource<object>();
 
-            _store.Ask<object>(sender => new DeleteMessagesTo(persistenceId, toSequenceNr, sender), Timeout, cancellationToken)
-                .ContinueWith(r =>
-                {
-                    if (r.IsFaulted)
-                        result.TrySetException(r.Exception);
-                    else if (r.IsCanceled)
-                        result.TrySetException(new TimeoutException());
-                    else
-                        result.TrySetResult(true);
-                }, TaskContinuationOptions.ExecuteSynchronously);
+            _store.Ask<object>(sender => new DeleteMessagesTo(persistenceId, toSequenceNr, sender), Timeout, cancellationToken).ContinueWith(r =>
+            {
+                if (r.IsFaulted)
+                    result.TrySetException(r.Exception);
+                else if (r.IsCanceled)
+                    result.TrySetException(new TimeoutException());
+                else
+                    result.TrySetResult(true);
+            }, TaskContinuationOptions.ExecuteSynchronously);
 
             return result.Task;
         }
@@ -235,10 +226,6 @@ namespace Akka.Cluster.Sharding.Tests
             return replayCompletionPromise.Task;
         }
 
-        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
-            => ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, CancellationToken.None);
-        
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
             if (_store == null)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/AsyncWriteProxyEx.cs
@@ -156,7 +156,9 @@ namespace Akka.Cluster.Sharding.Tests
             return true;
         }
 
-
+        [Obsolete("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+            => WriteMessagesAsync(messages, CancellationToken.None);
 
         protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
@@ -182,6 +184,10 @@ namespace Akka.Cluster.Sharding.Tests
                 }, TaskContinuationOptions.ExecuteSynchronously);
         }
 
+        [Obsolete("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+            => DeleteMessagesToAsync(persistenceId, toSequenceNr, CancellationToken.None);
+        
         protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {
             if (_store == null)
@@ -229,6 +235,10 @@ namespace Akka.Cluster.Sharding.Tests
             return replayCompletionPromise.Task;
         }
 
+        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+            => ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, CancellationToken.None);
+        
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
             if (_store == null)

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/SnapshotStoreProxy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/SnapshotStoreProxy.cs
@@ -90,10 +90,6 @@ namespace Akka.Cluster.Sharding.Tests
             return true;
         }
 
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
-            => DeleteAsync(metadata, CancellationToken.None);
-        
         protected override async Task DeleteAsync(
             SnapshotMetadata metadata, 
             CancellationToken cancellationToken)
@@ -114,10 +110,6 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-            => DeleteAsync(persistenceId, criteria, CancellationToken.None);
-        
         protected override async Task DeleteAsync(
             string persistenceId, 
             SnapshotSelectionCriteria criteria, 
@@ -139,10 +131,6 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-            => LoadAsync(persistenceId, criteria, CancellationToken.None);
-        
         protected override async Task<SelectedSnapshot> LoadAsync(
             string persistenceId,
             SnapshotSelectionCriteria criteria, 
@@ -172,10 +160,6 @@ namespace Akka.Cluster.Sharding.Tests
             throw new TimeoutException();
         }
 
-        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
-            => SaveAsync(metadata, snapshot, CancellationToken.None);
-        
         protected override async Task SaveAsync(
             SnapshotMetadata metadata,
             object snapshot, 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/SnapshotStoreProxy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/SnapshotStoreProxy.cs
@@ -90,6 +90,10 @@ namespace Akka.Cluster.Sharding.Tests
             return true;
         }
 
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(SnapshotMetadata metadata)
+            => DeleteAsync(metadata, CancellationToken.None);
+        
         protected override async Task DeleteAsync(
             SnapshotMetadata metadata, 
             CancellationToken cancellationToken)
@@ -112,6 +116,10 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            => DeleteAsync(persistenceId, criteria, CancellationToken.None);
+        
         protected override async Task DeleteAsync(
             string persistenceId, 
             SnapshotSelectionCriteria criteria, 
@@ -135,6 +143,10 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
+        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            => LoadAsync(persistenceId, criteria, CancellationToken.None);
+        
         protected override async Task<SelectedSnapshot> LoadAsync(
             string persistenceId,
             SnapshotSelectionCriteria criteria, 
@@ -166,6 +178,10 @@ namespace Akka.Cluster.Sharding.Tests
             throw new TimeoutException();
         }
 
+        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+            => SaveAsync(metadata, snapshot, CancellationToken.None);
+        
         protected override async Task SaveAsync(
             SnapshotMetadata metadata,
             object snapshot, 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/SnapshotStoreProxy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/SnapshotStoreProxy.cs
@@ -102,9 +102,7 @@ namespace Akka.Cluster.Sharding.Tests
                 throw new TimeoutException("Store not initialized.");
             try
             {
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                cts.CancelAfter(Timeout);
-                var response = await _store.Ask(new DeleteSnapshot(metadata), cts.Token);
+                var response = await _store.Ask(new DeleteSnapshot(metadata), Timeout, cancellationToken);
                 if (response is DeleteSnapshotFailure f)
                 {
                     ExceptionDispatchInfo.Capture(f.Cause).Throw();
@@ -129,9 +127,7 @@ namespace Akka.Cluster.Sharding.Tests
                 throw new TimeoutException("Store not initialized.");
             try
             {
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                cts.CancelAfter(Timeout);
-                var response = await _store.Ask(new DeleteSnapshots(persistenceId, criteria), cts.Token);
+                var response = await _store.Ask(new DeleteSnapshots(persistenceId, criteria), Timeout, cancellationToken);
                 if (response is DeleteSnapshotsFailure f)
                 {
                     ExceptionDispatchInfo.Capture(f.Cause).Throw();
@@ -156,9 +152,7 @@ namespace Akka.Cluster.Sharding.Tests
                 throw new TimeoutException("Store not initialized.");
             try
             {
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                cts.CancelAfter(Timeout);
-                var response = await _store.Ask(new LoadSnapshot(persistenceId, criteria, criteria.MaxSequenceNr), cts.Token);
+                var response = await _store.Ask(new LoadSnapshot(persistenceId, criteria, criteria.MaxSequenceNr), Timeout, cancellationToken);
                 switch (response)
                 {
                     case LoadSnapshotResult ls:
@@ -191,9 +185,7 @@ namespace Akka.Cluster.Sharding.Tests
                 throw new TimeoutException("Store not initialized.");
             try
             {
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                cts.CancelAfter(Timeout);
-                var response = await _store.Ask(new SaveSnapshot(metadata, snapshot), cts.Token);
+                var response = await _store.Ask(new SaveSnapshot(metadata, snapshot), Timeout, cancellationToken);
                 if (response is SaveSnapshotFailure f)
                 {
                     ExceptionDispatchInfo.Capture(f.Cause).Throw();

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/SnapshotStoreProxy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/SnapshotStoreProxy.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -89,14 +90,17 @@ namespace Akka.Cluster.Sharding.Tests
             return true;
         }
 
-        protected async override Task DeleteAsync(SnapshotMetadata metadata)
+        protected override async Task DeleteAsync(
+            SnapshotMetadata metadata, 
+            CancellationToken cancellationToken)
         {
             if (_store == null)
-                throw new TimeoutException("Store not intialized.");
-            var s = Sender;
+                throw new TimeoutException("Store not initialized.");
             try
             {
-                var response = await _store.Ask(new DeleteSnapshot(metadata), Timeout);
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(Timeout);
+                var response = await _store.Ask(new DeleteSnapshot(metadata), cts.Token);
                 if (response is DeleteSnapshotFailure f)
                 {
                     ExceptionDispatchInfo.Capture(f.Cause).Throw();
@@ -108,14 +112,18 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        protected async override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task DeleteAsync(
+            string persistenceId, 
+            SnapshotSelectionCriteria criteria, 
+            CancellationToken cancellationToken)
         {
             if (_store == null)
-                throw new TimeoutException("Store not intialized.");
-            var s = Sender;
+                throw new TimeoutException("Store not initialized.");
             try
             {
-                var response = await _store.Ask(new DeleteSnapshots(persistenceId, criteria), Timeout);
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(Timeout);
+                var response = await _store.Ask(new DeleteSnapshots(persistenceId, criteria), cts.Token);
                 if (response is DeleteSnapshotsFailure f)
                 {
                     ExceptionDispatchInfo.Capture(f.Cause).Throw();
@@ -127,14 +135,18 @@ namespace Akka.Cluster.Sharding.Tests
             }
         }
 
-        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task<SelectedSnapshot> LoadAsync(
+            string persistenceId,
+            SnapshotSelectionCriteria criteria, 
+            CancellationToken cancellationToken)
         {
             if (_store == null)
-                throw new TimeoutException("Store not intialized.");
-            var s = Sender;
+                throw new TimeoutException("Store not initialized.");
             try
             {
-                var response = await _store.Ask(new LoadSnapshot(persistenceId, criteria, criteria.MaxSequenceNr), Timeout);
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(Timeout);
+                var response = await _store.Ask(new LoadSnapshot(persistenceId, criteria, criteria.MaxSequenceNr), cts.Token);
                 switch (response)
                 {
                     case LoadSnapshotResult ls:
@@ -154,14 +166,18 @@ namespace Akka.Cluster.Sharding.Tests
             throw new TimeoutException();
         }
 
-        protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override async Task SaveAsync(
+            SnapshotMetadata metadata,
+            object snapshot, 
+            CancellationToken cancellationToken)
         {
             if (_store == null)
-                throw new TimeoutException("Store not intialized.");
-            var s = Sender;
+                throw new TimeoutException("Store not initialized.");
             try
             {
-                var response = await _store.Ask(new SaveSnapshot(metadata, snapshot), Timeout);
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                cts.CancelAfter(Timeout);
+                var response = await _store.Ask(new SaveSnapshot(metadata, snapshot), cts.Token);
                 if (response is SaveSnapshotFailure f)
                 {
                     ExceptionDispatchInfo.Capture(f.Cause).Throw();

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Bugfix7399Specs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Bugfix7399Specs.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -150,14 +151,14 @@ akka.actor.provider = cluster";
                 recoveryCallback);
         }
 
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             if (!Working)
             {
                 throw new ApplicationException("Failed");
             }
 
-            return base.WriteMessagesAsync(messages);
+            return base.WriteMessagesAsync(messages, cancellationToken);
         }
     }
 
@@ -165,7 +166,9 @@ akka.actor.provider = cluster";
     {
         public static bool Working = false;
 
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
+        protected override Task DeleteAsync(
+            SnapshotMetadata metadata, 
+            CancellationToken cancellationToken)
         {
             if (!Working)
             {
@@ -175,7 +178,10 @@ akka.actor.provider = cluster";
             return Task.CompletedTask;
         }
 
-        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override Task DeleteAsync(
+            string persistenceId,
+            SnapshotSelectionCriteria criteria, 
+            CancellationToken cancellationToken)
         {
             if (!Working)
             {
@@ -185,8 +191,10 @@ akka.actor.provider = cluster";
             return Task.CompletedTask;
         }
 
-        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId,
-            SnapshotSelectionCriteria criteria)
+        protected override async Task<SelectedSnapshot> LoadAsync(
+            string persistenceId,
+            SnapshotSelectionCriteria criteria, 
+            CancellationToken cancellationToken)
         {
             if (!Working)
             {
@@ -196,7 +204,10 @@ akka.actor.provider = cluster";
             return null;
         }
 
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override Task SaveAsync(
+            SnapshotMetadata metadata,
+            object snapshot, 
+            CancellationToken cancellationToken)
         {
             if (!Working)
             {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Bugfix7399Specs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Bugfix7399Specs.cs
@@ -166,10 +166,6 @@ akka.actor.provider = cluster";
     {
         public static bool Working = false;
 
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
-            => DeleteAsync(metadata, CancellationToken.None);
-
         protected override Task DeleteAsync(
             SnapshotMetadata metadata, 
             CancellationToken cancellationToken)
@@ -181,10 +177,6 @@ akka.actor.provider = cluster";
 
             return Task.CompletedTask;
         }
-
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-            => DeleteAsync(persistenceId, criteria, CancellationToken.None);
 
         protected override Task DeleteAsync(
             string persistenceId,
@@ -198,10 +190,6 @@ akka.actor.provider = cluster";
 
             return Task.CompletedTask;
         }
-
-        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-            => LoadAsync(persistenceId, criteria, CancellationToken.None);
 
         protected override async Task<SelectedSnapshot> LoadAsync(
             string persistenceId,
@@ -215,10 +203,6 @@ akka.actor.provider = cluster";
 
             return null;
         }
-
-        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
-            => SaveAsync(metadata, snapshot, CancellationToken.None);
 
         protected override Task SaveAsync(
             SnapshotMetadata metadata,

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Bugfix7399Specs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Bugfix7399Specs.cs
@@ -166,6 +166,10 @@ akka.actor.provider = cluster";
     {
         public static bool Working = false;
 
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(SnapshotMetadata metadata)
+            => DeleteAsync(metadata, CancellationToken.None);
+
         protected override Task DeleteAsync(
             SnapshotMetadata metadata, 
             CancellationToken cancellationToken)
@@ -177,6 +181,10 @@ akka.actor.provider = cluster";
 
             return Task.CompletedTask;
         }
+
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            => DeleteAsync(persistenceId, criteria, CancellationToken.None);
 
         protected override Task DeleteAsync(
             string persistenceId,
@@ -190,6 +198,10 @@ akka.actor.provider = cluster";
 
             return Task.CompletedTask;
         }
+
+        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            => LoadAsync(persistenceId, criteria, CancellationToken.None);
 
         protected override async Task<SelectedSnapshot> LoadAsync(
             string persistenceId,
@@ -203,6 +215,10 @@ akka.actor.provider = cluster";
 
             return null;
         }
+
+        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+            => SaveAsync(metadata, snapshot, CancellationToken.None);
 
         protected override Task SaveAsync(
             SnapshotMetadata metadata,

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -4528,10 +4528,18 @@ namespace Akka.Pattern
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
         public void Succeed() { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
+        public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.Tasks.Task> body) { }
+        public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
         public Akka.Pattern.CircuitBreaker WithExponentialBackoff(System.TimeSpan maxResetTimeout) { }
         public Akka.Pattern.CircuitBreaker WithRandomFactor(double randomFactor) { }
         public void WithSyncCircuitBreaker(System.Action body) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -4529,16 +4529,20 @@ namespace Akka.Pattern
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
         public void Succeed() { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.Tasks.Task<T>> body) { }
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.Tasks.Task> body) { }
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
         public Akka.Pattern.CircuitBreaker WithExponentialBackoff(System.TimeSpan maxResetTimeout) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -4519,16 +4519,20 @@ namespace Akka.Pattern
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
         public void Succeed() { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.Tasks.Task<T>> body) { }
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.Tasks.Task> body) { }
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
         public Akka.Pattern.CircuitBreaker WithExponentialBackoff(System.TimeSpan maxResetTimeout) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -4518,10 +4518,18 @@ namespace Akka.Pattern
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
         public void Succeed() { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
+        public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
+        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.Tasks.Task> body) { }
+        public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
         public Akka.Pattern.CircuitBreaker WithExponentialBackoff(System.TimeSpan maxResetTimeout) { }
         public Akka.Pattern.CircuitBreaker WithRandomFactor(double randomFactor) { }
         public void WithSyncCircuitBreaker(System.Action body) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -857,14 +857,14 @@ namespace Akka.Persistence.Journal
     {
         protected readonly bool CanPublish;
         protected AsyncWriteJournal() { }
-        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr);
-        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected bool ReceiveWriteJournal(object message) { }
         public abstract System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
         protected static System.Exception TryUnwrapException(System.Exception e) { }
-        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages);
+        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken);
     }
     public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
@@ -873,10 +873,10 @@ namespace Akka.Persistence.Journal
         public abstract System.TimeSpan Timeout { get; }
         public override void AroundPreStart() { }
         protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken) { }
         public class InitTimeout
         {
             public static Akka.Persistence.Journal.AsyncWriteProxy.InitTimeout Instance { get; }
@@ -957,7 +957,7 @@ namespace Akka.Persistence.Journal
     }
     public interface IAsyncRecovery
     {
-        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
     }
     public interface IEmptyEventSequence : Akka.Persistence.Journal.IEventSequence { }
@@ -988,14 +988,14 @@ namespace Akka.Persistence.Journal
         protected virtual System.Collections.Concurrent.ConcurrentDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Messages { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public long HighestSequenceNr(string pid) { }
         public System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentRepresentation> Read(string pid, long fromSeqNr, long toSeqNr, long max) { }
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         protected override bool ReceivePluginInternal(object message) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Update(string pid, long seqNr, System.Func<Akka.Persistence.IPersistentRepresentation, Akka.Persistence.IPersistentRepresentation> updater) { }
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken) { }
         public sealed class CurrentPersistenceIds : Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Collections.Generic.IEnumerable<string> AllPersistenceIds;
@@ -1166,14 +1166,14 @@ namespace Akka.Persistence.Snapshot
     public class LocalSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public LocalSnapshotStore() { }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected System.IO.FileInfo GetSnapshotFileForWrite(Akka.Persistence.SnapshotMetadata metadata, string extension = "") { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override void PreStart() { }
         protected override bool ReceivePluginInternal(object message) { }
         protected virtual void Save(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         protected void Serialize(System.IO.Stream stream, Akka.Persistence.Serialization.Snapshot snapshot) { }
         protected System.IO.FileInfo WithOutputStream(Akka.Persistence.SnapshotMetadata metadata, System.Action<System.IO.Stream> p) { }
     }
@@ -1181,18 +1181,18 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual System.Collections.Generic.List<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots { get; }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
     }
     public sealed class NoSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public NoSnapshotStore() { }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         public class NoSnapshotStoreException : System.Exception
         {
             public NoSnapshotStoreException() { }
@@ -1213,11 +1213,11 @@ namespace Akka.Persistence.Snapshot
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {
         protected SnapshotStore() { }
-        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata);
-        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
-        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
+        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken);
+        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
+        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
-        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot);
+        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken);
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -857,22 +857,13 @@ namespace Akka.Persistence.Journal
     {
         protected readonly bool CanPublish;
         protected AsyncWriteJournal() { }
-        [System.ObsoleteAttribute("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Sinc" +
-            "e 1.5.42")]
-        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr);
         protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken);
-        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
-            " Since 1.5.42")]
-        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
         public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected bool ReceiveWriteJournal(object message) { }
         public abstract System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
         protected static System.Exception TryUnwrapException(System.Exception e) { }
-        [System.ObsoleteAttribute("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1" +
-            ".5.42")]
-        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages);
         protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken);
     }
     public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
@@ -966,9 +957,6 @@ namespace Akka.Persistence.Journal
     }
     public interface IAsyncRecovery
     {
-        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
-            " Since 1.5.42")]
-        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
         System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
     }
@@ -1000,22 +988,13 @@ namespace Akka.Persistence.Journal
         protected virtual System.Collections.Concurrent.ConcurrentDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Messages { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
-        [System.ObsoleteAttribute("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Sinc" +
-            "e 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public long HighestSequenceNr(string pid) { }
         public System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentRepresentation> Read(string pid, long fromSeqNr, long toSeqNr, long max) { }
-        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
-            " Since 1.5.42")]
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
         public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         protected override bool ReceivePluginInternal(object message) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Update(string pid, long seqNr, System.Func<Akka.Persistence.IPersistentRepresentation, Akka.Persistence.IPersistentRepresentation> updater) { }
-        [System.ObsoleteAttribute("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1" +
-            ".5.42")]
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken) { }
         public sealed class CurrentPersistenceIds : Akka.Event.IDeadLetterSuppression
         {
@@ -1187,21 +1166,13 @@ namespace Akka.Persistence.Snapshot
     public class LocalSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public LocalSnapshotStore() { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected System.IO.FileInfo GetSnapshotFileForWrite(Akka.Persistence.SnapshotMetadata metadata, string extension = "") { }
-        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override void PreStart() { }
         protected override bool ReceivePluginInternal(object message) { }
         protected virtual void Save(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
-        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         protected void Serialize(System.IO.Stream stream, Akka.Persistence.Serialization.Snapshot snapshot) { }
         protected System.IO.FileInfo WithOutputStream(Akka.Persistence.SnapshotMetadata metadata, System.Action<System.IO.Stream> p) { }
@@ -1210,33 +1181,17 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual System.Collections.Generic.List<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots { get; }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
     }
     public sealed class NoSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public NoSnapshotStore() { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         public class NoSnapshotStoreException : System.Exception
         {
@@ -1258,19 +1213,11 @@ namespace Akka.Persistence.Snapshot
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {
         protected SnapshotStore() { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata);
         protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken);
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
         protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
-        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
         protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
-        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot);
         protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken);
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -857,13 +857,22 @@ namespace Akka.Persistence.Journal
     {
         protected readonly bool CanPublish;
         protected AsyncWriteJournal() { }
+        [System.ObsoleteAttribute("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Sinc" +
+            "e 1.5.42")]
+        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr);
         protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken);
+        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
+            " Since 1.5.42")]
+        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
         public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected bool ReceiveWriteJournal(object message) { }
         public abstract System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
         protected static System.Exception TryUnwrapException(System.Exception e) { }
+        [System.ObsoleteAttribute("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1" +
+            ".5.42")]
+        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages);
         protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken);
     }
     public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
@@ -957,6 +966,9 @@ namespace Akka.Persistence.Journal
     }
     public interface IAsyncRecovery
     {
+        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
+            " Since 1.5.42")]
+        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
         System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
     }
@@ -988,13 +1000,22 @@ namespace Akka.Persistence.Journal
         protected virtual System.Collections.Concurrent.ConcurrentDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Messages { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
+        [System.ObsoleteAttribute("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Sinc" +
+            "e 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public long HighestSequenceNr(string pid) { }
         public System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentRepresentation> Read(string pid, long fromSeqNr, long toSeqNr, long max) { }
+        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
+            " Since 1.5.42")]
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
         public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         protected override bool ReceivePluginInternal(object message) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Update(string pid, long seqNr, System.Func<Akka.Persistence.IPersistentRepresentation, Akka.Persistence.IPersistentRepresentation> updater) { }
+        [System.ObsoleteAttribute("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1" +
+            ".5.42")]
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken) { }
         public sealed class CurrentPersistenceIds : Akka.Event.IDeadLetterSuppression
         {
@@ -1166,13 +1187,21 @@ namespace Akka.Persistence.Snapshot
     public class LocalSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public LocalSnapshotStore() { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected System.IO.FileInfo GetSnapshotFileForWrite(Akka.Persistence.SnapshotMetadata metadata, string extension = "") { }
+        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override void PreStart() { }
         protected override bool ReceivePluginInternal(object message) { }
         protected virtual void Save(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         protected void Serialize(System.IO.Stream stream, Akka.Persistence.Serialization.Snapshot snapshot) { }
         protected System.IO.FileInfo WithOutputStream(Akka.Persistence.SnapshotMetadata metadata, System.Action<System.IO.Stream> p) { }
@@ -1181,17 +1210,33 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual System.Collections.Generic.List<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots { get; }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
     }
     public sealed class NoSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public NoSnapshotStore() { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         public class NoSnapshotStoreException : System.Exception
         {
@@ -1213,11 +1258,19 @@ namespace Akka.Persistence.Snapshot
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {
         protected SnapshotStore() { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata);
         protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken);
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
         protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
+        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
         protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
+        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot);
         protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken);
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -857,14 +857,14 @@ namespace Akka.Persistence.Journal
     {
         protected readonly bool CanPublish;
         protected AsyncWriteJournal() { }
-        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr);
-        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected bool ReceiveWriteJournal(object message) { }
         public abstract System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
         protected static System.Exception TryUnwrapException(System.Exception e) { }
-        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages);
+        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken);
     }
     public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
@@ -873,10 +873,10 @@ namespace Akka.Persistence.Journal
         public abstract System.TimeSpan Timeout { get; }
         public override void AroundPreStart() { }
         protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken) { }
         public class InitTimeout
         {
             public static Akka.Persistence.Journal.AsyncWriteProxy.InitTimeout Instance { get; }
@@ -957,7 +957,7 @@ namespace Akka.Persistence.Journal
     }
     public interface IAsyncRecovery
     {
-        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
     }
     public interface IEmptyEventSequence : Akka.Persistence.Journal.IEventSequence { }
@@ -988,14 +988,14 @@ namespace Akka.Persistence.Journal
         protected virtual System.Collections.Concurrent.ConcurrentDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Messages { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public long HighestSequenceNr(string pid) { }
         public System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentRepresentation> Read(string pid, long fromSeqNr, long toSeqNr, long max) { }
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         protected override bool ReceivePluginInternal(object message) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Update(string pid, long seqNr, System.Func<Akka.Persistence.IPersistentRepresentation, Akka.Persistence.IPersistentRepresentation> updater) { }
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken) { }
         public sealed class CurrentPersistenceIds : Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Collections.Generic.IEnumerable<string> AllPersistenceIds;
@@ -1164,14 +1164,14 @@ namespace Akka.Persistence.Snapshot
     public class LocalSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public LocalSnapshotStore() { }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected System.IO.FileInfo GetSnapshotFileForWrite(Akka.Persistence.SnapshotMetadata metadata, string extension = "") { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override void PreStart() { }
         protected override bool ReceivePluginInternal(object message) { }
         protected virtual void Save(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         protected void Serialize(System.IO.Stream stream, Akka.Persistence.Serialization.Snapshot snapshot) { }
         protected System.IO.FileInfo WithOutputStream(Akka.Persistence.SnapshotMetadata metadata, System.Action<System.IO.Stream> p) { }
     }
@@ -1179,18 +1179,18 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual System.Collections.Generic.List<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots { get; }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
     }
     public sealed class NoSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public NoSnapshotStore() { }
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         public class NoSnapshotStoreException : System.Exception
         {
             public NoSnapshotStoreException() { }
@@ -1211,11 +1211,11 @@ namespace Akka.Persistence.Snapshot
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {
         protected SnapshotStore() { }
-        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata);
-        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
-        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
+        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken);
+        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
+        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
-        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot);
+        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken);
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -857,22 +857,13 @@ namespace Akka.Persistence.Journal
     {
         protected readonly bool CanPublish;
         protected AsyncWriteJournal() { }
-        [System.ObsoleteAttribute("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Sinc" +
-            "e 1.5.42")]
-        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr);
         protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken);
-        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
-            " Since 1.5.42")]
-        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
         public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected bool ReceiveWriteJournal(object message) { }
         public abstract System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
         protected static System.Exception TryUnwrapException(System.Exception e) { }
-        [System.ObsoleteAttribute("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1" +
-            ".5.42")]
-        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages);
         protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken);
     }
     public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
@@ -966,9 +957,6 @@ namespace Akka.Persistence.Journal
     }
     public interface IAsyncRecovery
     {
-        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
-            " Since 1.5.42")]
-        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
         System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
     }
@@ -1000,22 +988,13 @@ namespace Akka.Persistence.Journal
         protected virtual System.Collections.Concurrent.ConcurrentDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Messages { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
-        [System.ObsoleteAttribute("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Sinc" +
-            "e 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public long HighestSequenceNr(string pid) { }
         public System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentRepresentation> Read(string pid, long fromSeqNr, long toSeqNr, long max) { }
-        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
-            " Since 1.5.42")]
-        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
         public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         protected override bool ReceivePluginInternal(object message) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Update(string pid, long seqNr, System.Func<Akka.Persistence.IPersistentRepresentation, Akka.Persistence.IPersistentRepresentation> updater) { }
-        [System.ObsoleteAttribute("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1" +
-            ".5.42")]
-        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken) { }
         public sealed class CurrentPersistenceIds : Akka.Event.IDeadLetterSuppression
         {
@@ -1185,21 +1164,13 @@ namespace Akka.Persistence.Snapshot
     public class LocalSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public LocalSnapshotStore() { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected System.IO.FileInfo GetSnapshotFileForWrite(Akka.Persistence.SnapshotMetadata metadata, string extension = "") { }
-        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override void PreStart() { }
         protected override bool ReceivePluginInternal(object message) { }
         protected virtual void Save(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
-        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         protected void Serialize(System.IO.Stream stream, Akka.Persistence.Serialization.Snapshot snapshot) { }
         protected System.IO.FileInfo WithOutputStream(Akka.Persistence.SnapshotMetadata metadata, System.Action<System.IO.Stream> p) { }
@@ -1208,33 +1179,17 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual System.Collections.Generic.List<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots { get; }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
     }
     public sealed class NoSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public NoSnapshotStore() { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
-        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         public class NoSnapshotStoreException : System.Exception
         {
@@ -1256,19 +1211,11 @@ namespace Akka.Persistence.Snapshot
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {
         protected SnapshotStore() { }
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata);
         protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken);
-        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
         protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
-        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
         protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
-        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot);
         protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken);
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -857,13 +857,22 @@ namespace Akka.Persistence.Journal
     {
         protected readonly bool CanPublish;
         protected AsyncWriteJournal() { }
+        [System.ObsoleteAttribute("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Sinc" +
+            "e 1.5.42")]
+        protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr);
         protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken);
+        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
+            " Since 1.5.42")]
+        public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
         public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected bool ReceiveWriteJournal(object message) { }
         public abstract System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
         protected static System.Exception TryUnwrapException(System.Exception e) { }
+        [System.ObsoleteAttribute("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1" +
+            ".5.42")]
+        protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages);
         protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken);
     }
     public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
@@ -957,6 +966,9 @@ namespace Akka.Persistence.Journal
     }
     public interface IAsyncRecovery
     {
+        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
+            " Since 1.5.42")]
+        System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
         System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
     }
@@ -988,13 +1000,22 @@ namespace Akka.Persistence.Journal
         protected virtual System.Collections.Concurrent.ConcurrentDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Messages { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
+        [System.ObsoleteAttribute("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Sinc" +
+            "e 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr) { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public long HighestSequenceNr(string pid) { }
         public System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentRepresentation> Read(string pid, long fromSeqNr, long toSeqNr, long max) { }
+        [System.ObsoleteAttribute("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead." +
+            " Since 1.5.42")]
+        public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr) { }
         public override System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         protected override bool ReceivePluginInternal(object message) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Update(string pid, long seqNr, System.Func<Akka.Persistence.IPersistentRepresentation, Akka.Persistence.IPersistentRepresentation> updater) { }
+        [System.ObsoleteAttribute("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1" +
+            ".5.42")]
+        protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken) { }
         public sealed class CurrentPersistenceIds : Akka.Event.IDeadLetterSuppression
         {
@@ -1164,13 +1185,21 @@ namespace Akka.Persistence.Snapshot
     public class LocalSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public LocalSnapshotStore() { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected System.IO.FileInfo GetSnapshotFileForWrite(Akka.Persistence.SnapshotMetadata metadata, string extension = "") { }
+        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override void PreStart() { }
         protected override bool ReceivePluginInternal(object message) { }
         protected virtual void Save(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
+        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         protected void Serialize(System.IO.Stream stream, Akka.Persistence.Serialization.Snapshot snapshot) { }
         protected System.IO.FileInfo WithOutputStream(Akka.Persistence.SnapshotMetadata metadata, System.Action<System.IO.Stream> p) { }
@@ -1179,17 +1208,33 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual System.Collections.Generic.List<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots { get; }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
     }
     public sealed class NoSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public NoSnapshotStore() { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
+        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         public class NoSnapshotStoreException : System.Exception
         {
@@ -1211,11 +1256,19 @@ namespace Akka.Persistence.Snapshot
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {
         protected SnapshotStore() { }
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata);
         protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken);
+        [System.ObsoleteAttribute("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
         protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
+        [System.ObsoleteAttribute("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria);
         protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
         protected virtual bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
+        [System.ObsoleteAttribute("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot);
         protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken);
     }
 }

--- a/src/core/Akka.Docs.Tests/Utilities/CircuitBreakerDocSpec.cs
+++ b/src/core/Akka.Docs.Tests/Utilities/CircuitBreakerDocSpec.cs
@@ -52,7 +52,7 @@ namespace DocsExamples.Utilities.CircuitBreakers
             Receive<string>(str => str.Equals("is my middle name"), _ =>
             {
                 var sender = this.Sender;
-                breaker.WithCircuitBreaker(() => Task.FromResult(dangerousCall)).PipeTo(sender);
+                breaker.WithCircuitBreaker(_ => Task.FromResult(dangerousCall)).PipeTo(sender);
             });
 
             Receive<string>(str => str.Equals("block for me"), _ =>

--- a/src/core/Akka.Persistence.TestKit/Journal/TestJournal.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/TestJournal.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Threading;
+
 namespace Akka.Persistence.TestKit
 {
     using Akka.Actor;
@@ -48,7 +50,7 @@ namespace Akka.Persistence.TestKit
             }
         }
 
-        protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             await _connectionInterceptor.InterceptAsync();
             var exceptions = new List<Exception>();
@@ -90,10 +92,10 @@ namespace Akka.Persistence.TestKit
             }
         }
 
-        public override async Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        public override async Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
             await _connectionInterceptor.InterceptAsync();
-            return await base.ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr);
+            return await base.ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, cancellationToken);
         }
 
         /// <summary>

--- a/src/core/Akka.Persistence.TestKit/SnapshotStore/TestSnapshotStore.cs
+++ b/src/core/Akka.Persistence.TestKit/SnapshotStore/TestSnapshotStore.cs
@@ -5,6 +5,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
+using System.Threading;
+
 namespace Akka.Persistence.TestKit
 {
     using System.Threading.Tasks;
@@ -50,35 +53,36 @@ namespace Akka.Persistence.TestKit
             }
         }
 
-        protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override async Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
         {
             await _connectionInterceptor.InterceptAsync();
             await _saveInterceptor.InterceptAsync(metadata.PersistenceId, ToSelectionCriteria(metadata));
-            await base.SaveAsync(metadata, snapshot);
+            await base.SaveAsync(metadata, snapshot, cancellationToken);
         }
 
-        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             await _connectionInterceptor.InterceptAsync();
             await _loadInterceptor.InterceptAsync(persistenceId, criteria);
-            return await base.LoadAsync(persistenceId, criteria);
+            return await base.LoadAsync(persistenceId, criteria, cancellationToken);
         }
 
-        protected override async Task DeleteAsync(SnapshotMetadata metadata)
+        protected override async Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
             await _connectionInterceptor.InterceptAsync();
             await _deleteInterceptor.InterceptAsync(metadata.PersistenceId, ToSelectionCriteria(metadata));
-            await base.DeleteAsync(metadata);
+            await base.DeleteAsync(metadata, cancellationToken);
         }
 
-        protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             await _connectionInterceptor.InterceptAsync();
             await _deleteInterceptor.InterceptAsync(persistenceId, criteria);
-            await base.DeleteAsync(persistenceId, criteria);
+            await base.DeleteAsync(persistenceId, criteria, cancellationToken);
         }
 
-        static SnapshotSelectionCriteria ToSelectionCriteria(SnapshotMetadata metadata)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static SnapshotSelectionCriteria ToSelectionCriteria(SnapshotMetadata metadata)
             => new(metadata.SequenceNr, metadata.Timestamp, metadata.SequenceNr, metadata.Timestamp);
 
         /// <summary>

--- a/src/core/Akka.Persistence.Tests/Journal/ChaosJournal.cs
+++ b/src/core/Akka.Persistence.Tests/Journal/ChaosJournal.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Persistence.Journal;
@@ -83,7 +84,7 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
-        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
             var promise = new TaskCompletionSource<long>();
             if (ChaosSupportExtensions.ShouldFail(_readHighestFailureRate))
@@ -93,7 +94,7 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             var promise =
                 new TaskCompletionSource<IImmutableList<Exception>>();
@@ -120,7 +121,7 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
-        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {
             TaskCompletionSource<object> promise = new TaskCompletionSource<object>();
             try

--- a/src/core/Akka.Persistence.Tests/Journal/ChaosJournal.cs
+++ b/src/core/Akka.Persistence.Tests/Journal/ChaosJournal.cs
@@ -84,10 +84,6 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
-        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
-            => ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, CancellationToken.None);
-        
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
             var promise = new TaskCompletionSource<long>();
@@ -98,10 +94,6 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
-        [Obsolete("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
-            => WriteMessagesAsync(messages, CancellationToken.None);
-        
         protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             var promise =
@@ -129,10 +121,6 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
-        [Obsolete("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
-            => DeleteMessagesToAsync(persistenceId, toSequenceNr, CancellationToken.None);
-        
         protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {
             TaskCompletionSource<object> promise = new TaskCompletionSource<object>();

--- a/src/core/Akka.Persistence.Tests/Journal/ChaosJournal.cs
+++ b/src/core/Akka.Persistence.Tests/Journal/ChaosJournal.cs
@@ -84,6 +84,10 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
+        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+            => ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, CancellationToken.None);
+        
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
             var promise = new TaskCompletionSource<long>();
@@ -94,6 +98,10 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
+        [Obsolete("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+            => WriteMessagesAsync(messages, CancellationToken.None);
+        
         protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             var promise =
@@ -121,6 +129,10 @@ namespace Akka.Persistence.Tests.Journal
             return promise.Task;
         }
 
+        [Obsolete("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+            => DeleteMessagesToAsync(persistenceId, toSequenceNr, CancellationToken.None);
+        
         protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {
             TaskCompletionSource<object> promise = new TaskCompletionSource<object>();

--- a/src/core/Akka.Persistence.Tests/Journal/SteppingMemoryJournal.cs
+++ b/src/core/Akka.Persistence.Tests/Journal/SteppingMemoryJournal.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -110,14 +111,14 @@ akka.persistence.journal.stepping-inmem.instance-id = """ + instanceId + @"""");
             _current.TryRemove(_instanceId, out foo);
         }
 
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             var tasks = messages.Select(message =>
             {
                 return
                     WrapAndDoOrEnqueue(
                         () =>
-                            base.WriteMessagesAsync(new[] {message})
+                            base.WriteMessagesAsync(new[] {message}, cancellationToken)
                                 .ContinueWith(t => t.Result != null ? t.Result.FirstOrDefault() : null,
                                     _continuationOptions | TaskContinuationOptions.OnlyOnRanToCompletion));
             });
@@ -127,19 +128,19 @@ akka.persistence.journal.stepping-inmem.instance-id = """ + instanceId + @"""");
                     _continuationOptions | TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 
-        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {
             return
                 WrapAndDoOrEnqueue(
                     () =>
-                        base.DeleteMessagesToAsync(persistenceId, toSequenceNr)
+                        base.DeleteMessagesToAsync(persistenceId, toSequenceNr, cancellationToken)
                             .ContinueWith(_ => new object(),
                                 _continuationOptions | TaskContinuationOptions.OnlyOnRanToCompletion));
         }
 
-        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
-            return WrapAndDoOrEnqueue(() => base.ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr));
+            return WrapAndDoOrEnqueue(() => base.ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, cancellationToken));
         }
 
         public override Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max,

--- a/src/core/Akka.Persistence.Tests/PersistentActorDeleteFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorDeleteFailureSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -41,7 +42,7 @@ namespace Akka.Persistence.Tests
 
         public class DeleteFailingMemoryJournal : MemoryJournal
         {
-            protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+            protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
             {
                 var promise = new TaskCompletionSource<object>();
                 promise.SetException(new SimulatedException("Boom! Unable to delete events!"));

--- a/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Persistence.Journal;
@@ -49,7 +50,7 @@ namespace Akka.Persistence.Tests
         internal class FailingMemoryJournal : MemoryJournal
         {
 
-            protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+            protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
             {
                 var msgs = messages.ToList();
                 if (IsWrong(msgs))
@@ -59,7 +60,7 @@ namespace Akka.Persistence.Tests
                 {
                     return Task.FromResult(checkSerializable);
                 }
-                return base.WriteMessagesAsync(msgs);
+                return base.WriteMessagesAsync(msgs, cancellationToken);
             }
 
             public override Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr,

--- a/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotFailureRobustnessSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -168,22 +169,16 @@ namespace Akka.Persistence.Tests
 
         internal class DeleteFailingLocalSnapshotStore : LocalSnapshotStore
         {
-            protected override Task DeleteAsync(SnapshotMetadata metadata)
+            protected override async Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
             {
-                base.DeleteAsync(metadata); // we actually delete it properly, but act as if it failed
-                var promise = new TaskCompletionSource<object>();
-                promise.SetException(new InvalidOperationException("Failed to delete snapshot for some reason."));
-                return promise.Task;
+                await base.DeleteAsync(metadata, cancellationToken); // we actually delete it properly, but act as if it failed
+                throw new InvalidOperationException("Failed to delete snapshot for some reason.");
             }
 
-            protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
             {
-#pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                base.DeleteAsync(persistenceId, criteria); // we actually delete it properly, but act as if it failed
-#pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-                var promise = new TaskCompletionSource<object>();
-                promise.SetException(new InvalidOperationException("Failed to delete snapshot for some reason."));
-                return promise.Task;
+                await base.DeleteAsync(persistenceId, criteria, cancellationToken); // we actually delete it properly, but act as if it failed
+                throw new InvalidOperationException("Failed to delete snapshot for some reason.");
             }
         }
 

--- a/src/core/Akka.Persistence/Journal/AsyncRecovery.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncRecovery.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 
@@ -62,7 +63,8 @@ namespace Akka.Persistence.Journal
         /// <param name="fromSequenceNr">Hint where to start searching for the highest sequence number.
         /// When a persistent actor is recovering this <paramref name="fromSequenceNr"/> will the sequence
         /// number of the used snapshot, or `0L` if no snapshot is used.</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled recovery operation</param>
         /// <returns>TBD</returns>
-        Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+        Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken);
     }
 }

--- a/src/core/Akka.Persistence/Journal/AsyncRecovery.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncRecovery.cs
@@ -63,28 +63,6 @@ namespace Akka.Persistence.Journal
         /// <param name="fromSequenceNr">Hint where to start searching for the highest sequence number.
         /// When a persistent actor is recovering this <paramref name="fromSequenceNr"/> will the sequence
         /// number of the used snapshot, or `0L` if no snapshot is used.</param>
-        /// <returns>TBD</returns>
-        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
-
-        /// <summary>
-        /// Asynchronously reads the highest stored sequence number for provided <paramref name="persistenceId"/>.
-        /// The persistent actor will use the highest sequence number after recovery as the starting point when
-        /// persisting new events.
-        /// This sequence number is also used as `toSequenceNr` in subsequent calls to
-        /// <see cref="ReplayMessagesAsync"/> unless the user has specified a lower `toSequenceNr`.
-        /// Journal must maintain the highest sequence number and never decrease it.
-        /// 
-        /// This call is protected with a circuit-breaker.
-        /// 
-        /// Please also not that requests for the highest sequence number may be made concurrently
-        /// to writes executing for the same <paramref name="persistenceId"/>, in particular it is
-        /// possible that a restarting actor tries to recover before its outstanding writes have completed.
-        /// </summary>
-        /// <param name="persistenceId">Persistent actor identifier</param>
-        /// <param name="fromSequenceNr">Hint where to start searching for the highest sequence number.
-        /// When a persistent actor is recovering this <paramref name="fromSequenceNr"/> will the sequence
-        /// number of the used snapshot, or `0L` if no snapshot is used.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled recovery operation</param>
         /// <returns>TBD</returns>
         Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken);

--- a/src/core/Akka.Persistence/Journal/AsyncRecovery.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncRecovery.cs
@@ -25,7 +25,7 @@ namespace Akka.Persistence.Journal
         /// could not be replayed.
         /// 
         /// The <paramref name="toSequenceNr"/> is the lowest of what was returned by
-        /// <see cref="ReadHighestSequenceNrAsync"/> and what the user specified as recovery
+        /// <see cref="ReadHighestSequenceNrAsync(string, long, CancellationToken)"/> and what the user specified as recovery
         /// <see cref="Recovery"/> parameter.
         /// This does imply that this call is always preceded by reading the highest sequence number
         /// for the given <paramref name="persistenceId"/>.

--- a/src/core/Akka.Persistence/Journal/AsyncRecovery.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncRecovery.cs
@@ -63,6 +63,28 @@ namespace Akka.Persistence.Journal
         /// <param name="fromSequenceNr">Hint where to start searching for the highest sequence number.
         /// When a persistent actor is recovering this <paramref name="fromSequenceNr"/> will the sequence
         /// number of the used snapshot, or `0L` if no snapshot is used.</param>
+        /// <returns>TBD</returns>
+        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+
+        /// <summary>
+        /// Asynchronously reads the highest stored sequence number for provided <paramref name="persistenceId"/>.
+        /// The persistent actor will use the highest sequence number after recovery as the starting point when
+        /// persisting new events.
+        /// This sequence number is also used as `toSequenceNr` in subsequent calls to
+        /// <see cref="ReplayMessagesAsync"/> unless the user has specified a lower `toSequenceNr`.
+        /// Journal must maintain the highest sequence number and never decrease it.
+        /// 
+        /// This call is protected with a circuit-breaker.
+        /// 
+        /// Please also not that requests for the highest sequence number may be made concurrently
+        /// to writes executing for the same <paramref name="persistenceId"/>, in particular it is
+        /// possible that a restarting actor tries to recover before its outstanding writes have completed.
+        /// </summary>
+        /// <param name="persistenceId">Persistent actor identifier</param>
+        /// <param name="fromSequenceNr">Hint where to start searching for the highest sequence number.
+        /// When a persistent actor is recovering this <paramref name="fromSequenceNr"/> will the sequence
+        /// number of the used snapshot, or `0L` if no snapshot is used.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled recovery operation</param>
         /// <returns>TBD</returns>
         Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken);

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -79,8 +79,8 @@ namespace Akka.Persistence.Journal
                     throw new ConfigurationException($"Invalid replay-filter.mode [{replayFilterMode}], supported values [off, repair-by-discard-old, fail, warn]");
             }
             _isReplayFilterEnabled = _replayFilterMode != ReplayFilterMode.Disabled;
-            _replayFilterWindowSize = config.GetInt("replay-filter.window-size", 0);
-            _replayFilterMaxOldWriters = config.GetInt("replay-filter.max-old-writers", 0);
+            _replayFilterWindowSize = config.GetInt("replay-filter.window-size", 100);
+            _replayFilterMaxOldWriters = config.GetInt("replay-filter.max-old-writers", 10);
             _replayDebugEnabled = config.GetBoolean("replay-filter.debug", false);
 
             _resequencer = Context.ActorOf(Props.Create(() => new Resequencer()), "resequencer");
@@ -88,10 +88,6 @@ namespace Akka.Persistence.Journal
 
         /// <inheritdoc/>
         public abstract Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, Action<IPersistentRepresentation> recoveryCallback);
-
-        /// <inheritdoc/>
-        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        public abstract Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
 
         /// <inheritdoc/>
         public abstract Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken);
@@ -167,91 +163,8 @@ namespace Akka.Persistence.Journal
         /// This call is protected with a circuit-breaker.
         /// </summary>
         /// <param name="messages">TBD</param>
-        [Obsolete("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages);
-
-        /// <summary>
-        /// Plugin API: asynchronously writes a batch of persistent messages to the
-        /// journal.
-        /// 
-        /// The batch is only for performance reasons, i.e. all messages don't have to be written
-        /// atomically. Higher throughput can typically be achieved by using batch inserts of many
-        /// records compared to inserting records one-by-one, but this aspect depends on the
-        /// underlying data store and a journal implementation can implement it as efficient as
-        /// possible. Journals should aim to persist events in-order for a given `persistenceId`
-        /// as otherwise in case of a failure, the persistent state may be end up being inconsistent.
-        /// 
-        /// Each <see cref="AtomicWrite"/> message contains the single <see cref="Persistent"/>
-        /// that corresponds to the event that was passed to the 
-        /// <see cref="Eventsourced.Persist{TEvent}(TEvent,Action{TEvent})"/> method of the
-        /// <see cref="PersistentActor" />, or it contains several <see cref="Persistent"/>
-        /// that correspond to the events that were passed to the
-        /// <see cref="Eventsourced.PersistAll{TEvent}(IEnumerable{TEvent},Action{TEvent})"/>
-        /// method of the <see cref="PersistentActor"/>. All <see cref="Persistent"/> of the
-        /// <see cref="AtomicWrite"/> must be written to the data store atomically, i.e. all or none must
-        /// be stored. If the journal (data store) cannot support atomic writes of multiple
-        /// events it should reject such writes with a <see cref="NotSupportedException"/>
-        /// describing the issue. This limitation should also be documented by the journal plugin.
-        /// 
-        /// If there are failures when storing any of the messages in the batch the returned
-        /// <see cref="Task"/> must be completed with failure. The <see cref="Task"/> must only be completed with
-        /// success when all messages in the batch have been confirmed to be stored successfully,
-        /// i.e. they will be readable, and visible, in a subsequent replay. If there is
-        /// uncertainty about if the messages were stored or not the <see cref="Task"/> must be completed
-        /// with failure.
-        /// 
-        /// Data store connection problems must be signaled by completing the <see cref="Task"/> with
-        /// failure.
-        /// 
-        /// The journal can also signal that it rejects individual messages (<see cref="AtomicWrite"/>) by
-        /// the returned <see cref="Task"/>. It is possible but not mandatory to reduce
-        /// number of allocations by returning null for the happy path,
-        /// i.e. when no messages are rejected. Otherwise the returned list must have as many elements
-        /// as the input <paramref name="messages"/>. Each result element signals if the corresponding
-        /// <see cref="AtomicWrite"/> is rejected or not, with an exception describing the problem. Rejecting
-        /// a message means it was not stored, i.e. it must not be included in a later replay.
-        /// Rejecting a message is typically done before attempting to store it, e.g. because of
-        /// serialization error.
-        /// 
-        /// Data store connection problems must not be signaled as rejections.
-        /// 
-        /// It is possible but not mandatory to reduce number of allocations by returning
-        /// null for the happy path, i.e. when no messages are rejected.
-        /// 
-        /// Calls to this method are serialized by the enclosing journal actor. If you spawn
-        /// work in asynchronous tasks it is alright that they complete the futures in any order,
-        /// but the actual writes for a specific persistenceId should be serialized to avoid
-        /// issues such as events of a later write are visible to consumers (query side, or replay)
-        /// before the events of an earlier write are visible.
-        /// A <see cref="PersistentActor"/> will not send a new <see cref="WriteMessages"/> request before
-        /// the previous one has been completed.
-        /// 
-        /// Please not that the <see cref="IPersistentRepresentation.Sender"/> of the contained
-        /// <see cref="Persistent"/> objects has been nulled out (i.e. set to <see cref="ActorRefs.NoSender"/>
-        /// in order to not use space in the journal for a sender reference that will likely be obsolete
-        /// during replay.
-        /// 
-        /// Please also note that requests for the highest sequence number may be made concurrently
-        /// to this call executing for the same `persistenceId`, in particular it is possible that
-        /// a restarting actor tries to recover before its outstanding writes have completed.
-        /// In the latter case it is highly desirable to defer reading the highest sequence number
-        /// until all outstanding writes have completed, otherwise the <see cref="PersistentActor"/>
-        /// may reuse sequence numbers.
-        /// 
-        /// This call is protected with a circuit-breaker.
-        /// </summary>
-        /// <param name="messages">TBD</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param> 
         protected abstract Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Asynchronously deletes all persistent messages up to inclusive <paramref name="toSequenceNr"/>
-        /// bound.
-        /// </summary>
-        /// <param name="persistenceId">TBD</param>
-        /// <param name="toSequenceNr">TBD</param>
-        [Obsolete("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr);
 
         /// <summary>
         /// Asynchronously deletes all persistent messages up to inclusive <paramref name="toSequenceNr"/>
@@ -355,9 +268,7 @@ namespace Akka.Persistence.Journal
                 
                 try
                 {
-                    var highSequenceNr = await _breaker.WithCircuitBreaker(
-                        (message, readHighestSequenceNrFrom, awj: this), 
-                        (state, ct) =>
+                    var highSequenceNr = await _breaker.WithCircuitBreaker((message, readHighestSequenceNrFrom, awj: this), (state, ct) =>
                             state.awj.ReadHighestSequenceNrAsync(state.message.PersistenceId, state.readHighestSequenceNrFrom, ct));
                     var toSequenceNr = Math.Min(message.ToSequenceNr, highSequenceNr);
                     if (toSequenceNr <= 0L || message.FromSequenceNr > toSequenceNr)
@@ -380,9 +291,9 @@ namespace Akka.Persistence.Journal
                                     }
                                 }
                             });
-                    }
                     
-                    CompleteHighSeqNo(highSequenceNr);
+                        CompleteHighSeqNo(highSequenceNr);
+                    }
                 }
                 catch (OperationCanceledException cx)
                 {
@@ -474,7 +385,7 @@ namespace Akka.Persistence.Journal
                 : new WriteMessageRejected(x, exception, writeMessage.ActorInstanceId), results, resequencerCounter, writeMessage, resequencer, writeJournal);
         }
         
-        private static void Resequence(Func<IPersistentRepresentation, Exception, object> mapper,
+        private void Resequence(Func<IPersistentRepresentation, Exception, object> mapper,
             IImmutableList<Exception> results, long resequencerCounter, WriteMessages msg, IActorRef resequencer, IActorRef writeJournal)
         {
             var i = 0;

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Pattern;
@@ -54,9 +56,9 @@ namespace Akka.Persistence.Journal
             var config = extension.ConfigFor(Self);
             _breaker = new CircuitBreaker(
                 Context.System.Scheduler,
-                config.GetInt("circuit-breaker.max-failures", 0),
-                config.GetTimeSpan("circuit-breaker.call-timeout", null),
-                config.GetTimeSpan("circuit-breaker.reset-timeout", null));
+                config.GetInt("circuit-breaker.max-failures", 10),
+                config.GetTimeSpan("circuit-breaker.call-timeout", TimeSpan.FromSeconds(10)),
+                config.GetTimeSpan("circuit-breaker.reset-timeout", TimeSpan.FromSeconds(30)));
 
             var replayFilterMode = config.GetString("replay-filter.mode", "").ToLowerInvariant();
             switch (replayFilterMode)
@@ -88,7 +90,7 @@ namespace Akka.Persistence.Journal
         public abstract Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, Action<IPersistentRepresentation> recoveryCallback);
 
         /// <inheritdoc/>
-        public abstract Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+        public abstract Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken);
 
         /// <summary>
         /// Plugin API: asynchronously writes a batch of persistent messages to the
@@ -161,8 +163,8 @@ namespace Akka.Persistence.Journal
         /// This call is protected with a circuit-breaker.
         /// </summary>
         /// <param name="messages">TBD</param>
-        /// <returns>TBD</returns>
-        protected abstract Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages);
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param> 
+        protected abstract Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously deletes all persistent messages up to inclusive <paramref name="toSequenceNr"/>
@@ -170,8 +172,8 @@ namespace Akka.Persistence.Journal
         /// </summary>
         /// <param name="persistenceId">TBD</param>
         /// <param name="toSequenceNr">TBD</param>
-        /// <returns>TBD</returns>
-        protected abstract Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr);
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param> 
+        protected abstract Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken);
 
         /// <summary>
         /// Plugin API: Allows plugin implementers to use f.PipeTo(Self)
@@ -222,8 +224,8 @@ namespace Akka.Persistence.Journal
             {
                 try
                 {
-                    await _breaker.WithCircuitBreaker((message, awj: this), state =>
-                        state.awj.DeleteMessagesToAsync(state.message.PersistenceId, state.message.ToSequenceNr));
+                    await _breaker.WithCircuitBreaker((message, awj: this), (state, ct) =>
+                        state.awj.DeleteMessagesToAsync(state.message.PersistenceId, state.message.ToSequenceNr, ct));
 
                     message.PersistentActor.Tell(new DeleteMessagesSuccess(message.ToSequenceNr), self);
 
@@ -259,26 +261,14 @@ namespace Akka.Persistence.Journal
 
             async Task ExecuteHighestSequenceNr()
             {
-                void CompleteHighSeqNo(long highSeqNo)
-                {
-                    replyTo.Tell(new RecoverySuccess(highSeqNo));
-
-                    if (CanPublish)
-                    {
-                        eventStream.Publish(message);
-                    }
-                }
-                
                 try
                 {
-                    var highSequenceNr = await _breaker.WithCircuitBreaker((message, readHighestSequenceNrFrom, awj: this), state =>
-                        state.awj.ReadHighestSequenceNrAsync(state.message.PersistenceId, state.readHighestSequenceNrFrom));
+                    var highSequenceNr = await _breaker.WithCircuitBreaker(
+                        (message, readHighestSequenceNrFrom, awj: this), 
+                        (state, ct) =>
+                            state.awj.ReadHighestSequenceNrAsync(state.message.PersistenceId, state.readHighestSequenceNrFrom, ct));
                     var toSequenceNr = Math.Min(message.ToSequenceNr, highSequenceNr);
-                    if (toSequenceNr <= 0L || message.FromSequenceNr > toSequenceNr)
-                    {
-                        CompleteHighSeqNo(highSequenceNr);
-                    }
-                    else
+                    if (toSequenceNr > 0L && message.FromSequenceNr <= toSequenceNr)
                     {
                         // Send replayed messages and replay result to persistentActor directly. No need
                         // to resequence replayed messages relative to written and looped messages.
@@ -294,8 +284,13 @@ namespace Akka.Persistence.Journal
                                     }
                                 }
                             });
+                    }
+                    
+                    replyTo.Tell(new RecoverySuccess(highSequenceNr));
 
-                        CompleteHighSeqNo(highSequenceNr);
+                    if (CanPublish)
+                    {
+                        eventStream.Publish(message);
                     }
                 }
                 catch (OperationCanceledException cx)
@@ -357,7 +352,9 @@ namespace Akka.Persistence.Journal
                 try
                 {
                     var writeResult =
-                        await _breaker.WithCircuitBreaker((prepared, awj: this), state => state.awj.WriteMessagesAsync(state.prepared)).ConfigureAwait(false);
+                        await _breaker.WithCircuitBreaker(
+                            state: (prepared, awj: this), 
+                            body: (state, ct) => state.awj.WriteMessagesAsync(state.prepared, ct)).ConfigureAwait(false);
 
                     ProcessResults(writeResult, atomicWriteCount, message, _resequencer, resequencerCounter, self);
                 }
@@ -388,34 +385,51 @@ namespace Akka.Persistence.Journal
                 : new WriteMessageRejected(x, exception, writeMessage.ActorInstanceId), results, resequencerCounter, writeMessage, resequencer, writeJournal);
         }
         
-        private void Resequence(Func<IPersistentRepresentation, Exception, object> mapper,
-            IImmutableList<Exception> results, long resequencerCounter, WriteMessages msg, IActorRef resequencer, IActorRef writeJournal)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Resequence(
+            Func<IPersistentRepresentation, Exception, object> mapper,
+            IImmutableList<Exception> results,
+            long resequencerCounter,
+            WriteMessages msg,
+            IActorRef resequencer,
+            IActorRef writeJournal)
         {
             var i = 0;
             var enumerator = results?.GetEnumerator();
-            foreach (var resequencable in msg.Messages)
+            try
             {
-                if (resequencable is AtomicWrite aw)
+                foreach (var resequencable in msg.Messages)
                 {
-                    Exception exception = null;
-                    if (enumerator != null)
+                    if (resequencable is AtomicWrite aw)
                     {
-                        enumerator.MoveNext();
-                        exception = enumerator.Current;
-                    }
+                        Exception exception = null;
+                        if (enumerator != null)
+                        {
+                            enumerator.MoveNext();
+                            exception = enumerator.Current;
+                        }
 
-                    foreach (var p in (IEnumerable<IPersistentRepresentation>)aw.Payload)
+                        foreach (var p in (IEnumerable<IPersistentRepresentation>)aw.Payload)
+                        {
+                            resequencer.Tell(
+                                new Desequenced(mapper(p, exception), resequencerCounter + i + 1, msg.PersistentActor,
+                                    p.Sender), writeJournal);
+                            i++;
+                        }
+                    }
+                    else
                     {
-                        resequencer.Tell(new Desequenced(mapper(p, exception), resequencerCounter + i + 1, msg.PersistentActor, p.Sender), writeJournal);
+                        var loopMsg = new LoopMessageSuccess(resequencable.Payload, msg.ActorInstanceId);
+                        resequencer.Tell(
+                            new Desequenced(loopMsg, resequencerCounter + i + 1, msg.PersistentActor,
+                                resequencable.Sender), writeJournal);
                         i++;
                     }
                 }
-                else
-                {
-                    var loopMsg = new LoopMessageSuccess(resequencable.Payload, msg.ActorInstanceId);
-                    resequencer.Tell(new Desequenced(loopMsg, resequencerCounter + i + 1, msg.PersistentActor, resequencable.Sender), writeJournal);
-                    i++;
-                }
+            }
+            finally
+            {
+                enumerator?.Dispose();
             }
         }
 

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -343,6 +343,16 @@ namespace Akka.Persistence.Journal
 
             async Task ExecuteHighestSequenceNr()
             {
+                void CompleteHighSeqNo(long highSeqNo)
+                {
+                    replyTo.Tell(new RecoverySuccess(highSeqNo));
+
+                    if (CanPublish)
+                    {
+                        eventStream.Publish(message);
+                    }
+                }
+                
                 try
                 {
                     var highSequenceNr = await _breaker.WithCircuitBreaker(
@@ -350,7 +360,11 @@ namespace Akka.Persistence.Journal
                         (state, ct) =>
                             state.awj.ReadHighestSequenceNrAsync(state.message.PersistenceId, state.readHighestSequenceNrFrom, ct));
                     var toSequenceNr = Math.Min(message.ToSequenceNr, highSequenceNr);
-                    if (toSequenceNr > 0L && message.FromSequenceNr <= toSequenceNr)
+                    if (toSequenceNr <= 0L || message.FromSequenceNr > toSequenceNr)
+                    {
+                        CompleteHighSeqNo(highSequenceNr);
+                    }
+                    else
                     {
                         // Send replayed messages and replay result to persistentActor directly. No need
                         // to resequence replayed messages relative to written and looped messages.
@@ -368,12 +382,7 @@ namespace Akka.Persistence.Journal
                             });
                     }
                     
-                    replyTo.Tell(new RecoverySuccess(highSequenceNr));
-
-                    if (CanPublish)
-                    {
-                        eventStream.Publish(message);
-                    }
+                    CompleteHighSeqNo(highSequenceNr);
                 }
                 catch (OperationCanceledException cx)
                 {
@@ -434,9 +443,7 @@ namespace Akka.Persistence.Journal
                 try
                 {
                     var writeResult =
-                        await _breaker.WithCircuitBreaker(
-                            state: (prepared, awj: this), 
-                            body: (state, ct) => state.awj.WriteMessagesAsync(state.prepared, ct)).ConfigureAwait(false);
+                        await _breaker.WithCircuitBreaker((prepared, awj: this), (state, ct) => state.awj.WriteMessagesAsync(state.prepared, ct)).ConfigureAwait(false);
 
                     ProcessResults(writeResult, atomicWriteCount, message, _resequencer, resequencerCounter, self);
                 }
@@ -467,51 +474,34 @@ namespace Akka.Persistence.Journal
                 : new WriteMessageRejected(x, exception, writeMessage.ActorInstanceId), results, resequencerCounter, writeMessage, resequencer, writeJournal);
         }
         
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void Resequence(
-            Func<IPersistentRepresentation, Exception, object> mapper,
-            IImmutableList<Exception> results,
-            long resequencerCounter,
-            WriteMessages msg,
-            IActorRef resequencer,
-            IActorRef writeJournal)
+        private static void Resequence(Func<IPersistentRepresentation, Exception, object> mapper,
+            IImmutableList<Exception> results, long resequencerCounter, WriteMessages msg, IActorRef resequencer, IActorRef writeJournal)
         {
             var i = 0;
             var enumerator = results?.GetEnumerator();
-            try
+            foreach (var resequencable in msg.Messages)
             {
-                foreach (var resequencable in msg.Messages)
+                if (resequencable is AtomicWrite aw)
                 {
-                    if (resequencable is AtomicWrite aw)
+                    Exception exception = null;
+                    if (enumerator != null)
                     {
-                        Exception exception = null;
-                        if (enumerator != null)
-                        {
-                            enumerator.MoveNext();
-                            exception = enumerator.Current;
-                        }
-
-                        foreach (var p in (IEnumerable<IPersistentRepresentation>)aw.Payload)
-                        {
-                            resequencer.Tell(
-                                new Desequenced(mapper(p, exception), resequencerCounter + i + 1, msg.PersistentActor,
-                                    p.Sender), writeJournal);
-                            i++;
-                        }
+                        enumerator.MoveNext();
+                        exception = enumerator.Current;
                     }
-                    else
+
+                    foreach (var p in (IEnumerable<IPersistentRepresentation>)aw.Payload)
                     {
-                        var loopMsg = new LoopMessageSuccess(resequencable.Payload, msg.ActorInstanceId);
-                        resequencer.Tell(
-                            new Desequenced(loopMsg, resequencerCounter + i + 1, msg.PersistentActor,
-                                resequencable.Sender), writeJournal);
+                        resequencer.Tell(new Desequenced(mapper(p, exception), resequencerCounter + i + 1, msg.PersistentActor, p.Sender), writeJournal);
                         i++;
                     }
                 }
-            }
-            finally
-            {
-                enumerator?.Dispose();
+                else
+                {
+                    var loopMsg = new LoopMessageSuccess(resequencable.Payload, msg.ActorInstanceId);
+                    resequencer.Tell(new Desequenced(loopMsg, resequencerCounter + i + 1, msg.PersistentActor, resequencable.Sender), writeJournal);
+                    i++;
+                }
             }
         }
 

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -90,7 +90,85 @@ namespace Akka.Persistence.Journal
         public abstract Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, Action<IPersistentRepresentation> recoveryCallback);
 
         /// <inheritdoc/>
+        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        public abstract Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr);
+
+        /// <inheritdoc/>
         public abstract Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Plugin API: asynchronously writes a batch of persistent messages to the
+        /// journal.
+        /// 
+        /// The batch is only for performance reasons, i.e. all messages don't have to be written
+        /// atomically. Higher throughput can typically be achieved by using batch inserts of many
+        /// records compared to inserting records one-by-one, but this aspect depends on the
+        /// underlying data store and a journal implementation can implement it as efficient as
+        /// possible. Journals should aim to persist events in-order for a given `persistenceId`
+        /// as otherwise in case of a failure, the persistent state may be end up being inconsistent.
+        /// 
+        /// Each <see cref="AtomicWrite"/> message contains the single <see cref="Persistent"/>
+        /// that corresponds to the event that was passed to the 
+        /// <see cref="Eventsourced.Persist{TEvent}(TEvent,Action{TEvent})"/> method of the
+        /// <see cref="PersistentActor" />, or it contains several <see cref="Persistent"/>
+        /// that correspond to the events that were passed to the
+        /// <see cref="Eventsourced.PersistAll{TEvent}(IEnumerable{TEvent},Action{TEvent})"/>
+        /// method of the <see cref="PersistentActor"/>. All <see cref="Persistent"/> of the
+        /// <see cref="AtomicWrite"/> must be written to the data store atomically, i.e. all or none must
+        /// be stored. If the journal (data store) cannot support atomic writes of multiple
+        /// events it should reject such writes with a <see cref="NotSupportedException"/>
+        /// describing the issue. This limitation should also be documented by the journal plugin.
+        /// 
+        /// If there are failures when storing any of the messages in the batch the returned
+        /// <see cref="Task"/> must be completed with failure. The <see cref="Task"/> must only be completed with
+        /// success when all messages in the batch have been confirmed to be stored successfully,
+        /// i.e. they will be readable, and visible, in a subsequent replay. If there is
+        /// uncertainty about if the messages were stored or not the <see cref="Task"/> must be completed
+        /// with failure.
+        /// 
+        /// Data store connection problems must be signaled by completing the <see cref="Task"/> with
+        /// failure.
+        /// 
+        /// The journal can also signal that it rejects individual messages (<see cref="AtomicWrite"/>) by
+        /// the returned <see cref="Task"/>. It is possible but not mandatory to reduce
+        /// number of allocations by returning null for the happy path,
+        /// i.e. when no messages are rejected. Otherwise the returned list must have as many elements
+        /// as the input <paramref name="messages"/>. Each result element signals if the corresponding
+        /// <see cref="AtomicWrite"/> is rejected or not, with an exception describing the problem. Rejecting
+        /// a message means it was not stored, i.e. it must not be included in a later replay.
+        /// Rejecting a message is typically done before attempting to store it, e.g. because of
+        /// serialization error.
+        /// 
+        /// Data store connection problems must not be signaled as rejections.
+        /// 
+        /// It is possible but not mandatory to reduce number of allocations by returning
+        /// null for the happy path, i.e. when no messages are rejected.
+        /// 
+        /// Calls to this method are serialized by the enclosing journal actor. If you spawn
+        /// work in asynchronous tasks it is alright that they complete the futures in any order,
+        /// but the actual writes for a specific persistenceId should be serialized to avoid
+        /// issues such as events of a later write are visible to consumers (query side, or replay)
+        /// before the events of an earlier write are visible.
+        /// A <see cref="PersistentActor"/> will not send a new <see cref="WriteMessages"/> request before
+        /// the previous one has been completed.
+        /// 
+        /// Please not that the <see cref="IPersistentRepresentation.Sender"/> of the contained
+        /// <see cref="Persistent"/> objects has been nulled out (i.e. set to <see cref="ActorRefs.NoSender"/>
+        /// in order to not use space in the journal for a sender reference that will likely be obsolete
+        /// during replay.
+        /// 
+        /// Please also note that requests for the highest sequence number may be made concurrently
+        /// to this call executing for the same `persistenceId`, in particular it is possible that
+        /// a restarting actor tries to recover before its outstanding writes have completed.
+        /// In the latter case it is highly desirable to defer reading the highest sequence number
+        /// until all outstanding writes have completed, otherwise the <see cref="PersistentActor"/>
+        /// may reuse sequence numbers.
+        /// 
+        /// This call is protected with a circuit-breaker.
+        /// </summary>
+        /// <param name="messages">TBD</param>
+        [Obsolete("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages);
 
         /// <summary>
         /// Plugin API: asynchronously writes a batch of persistent messages to the
@@ -165,6 +243,15 @@ namespace Akka.Persistence.Journal
         /// <param name="messages">TBD</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param> 
         protected abstract Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Asynchronously deletes all persistent messages up to inclusive <paramref name="toSequenceNr"/>
+        /// bound.
+        /// </summary>
+        /// <param name="persistenceId">TBD</param>
+        /// <param name="toSequenceNr">TBD</param>
+        [Obsolete("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr);
 
         /// <summary>
         /// Asynchronously deletes all persistent messages up to inclusive <paramref name="toSequenceNr"/>

--- a/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using System.Runtime.Serialization;
+using System.Threading;
 
 namespace Akka.Persistence.Journal
 {
@@ -324,16 +325,21 @@ namespace Akka.Persistence.Journal
         /// TBD
         /// </summary>
         /// <param name="messages">TBD</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param>
         /// <exception cref="TimeoutException">
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(
+            IEnumerable<AtomicWrite> messages,
+            CancellationToken cancellationToken)
         {
             if (_store == null)
-                return StoreNotInitialized<IImmutableList<Exception>>();
+                throw new TimeoutException("Store not initialized."); 
 
-            return _store.Ask<IImmutableList<Exception>>(new AsyncWriteTarget.WriteMessages(messages), Timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(Timeout);
+            return await _store.Ask<IImmutableList<Exception>>(new AsyncWriteTarget.WriteMessages(messages), cts.Token);
         }
 
         /// <summary>
@@ -341,16 +347,22 @@ namespace Akka.Persistence.Journal
         /// </summary>
         /// <param name="persistenceId">TBD</param>
         /// <param name="toSequenceNr">TBD</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param>
         /// <exception cref="TimeoutException">
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+        protected override async Task DeleteMessagesToAsync(
+            string persistenceId,
+            long toSequenceNr,
+            CancellationToken cancellationToken)
         {
             if (_store == null)
-                return StoreNotInitialized<object>();
+                throw new TimeoutException("Store not initialized."); 
 
-            return _store.Ask(new AsyncWriteTarget.DeleteMessagesTo(persistenceId, toSequenceNr), Timeout);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(Timeout);
+            await _store.Ask(new AsyncWriteTarget.DeleteMessagesTo(persistenceId, toSequenceNr), cts.Token);
         }
 
         /// <summary>
@@ -384,17 +396,22 @@ namespace Akka.Persistence.Journal
         /// </summary>
         /// <param name="persistenceId">TBD</param>
         /// <param name="fromSequenceNr">TBD</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param>
         /// <exception cref="TimeoutException">
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        public override async Task<long> ReadHighestSequenceNrAsync(
+            string persistenceId,
+            long fromSequenceNr,
+            CancellationToken cancellationToken)
         {
             if (_store == null)
-                return StoreNotInitialized<long>();
+                throw new TimeoutException("Store not initialized."); 
 
-            return _store.Ask<AsyncWriteTarget.ReplaySuccess>(new AsyncWriteTarget.ReplayMessages(persistenceId, 0, 0, 0), Timeout)
-                .ContinueWith(t => t.Result.HighestSequenceNr, TaskContinuationOptions.OnlyOnRanToCompletion);
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(Timeout);
+            return (await _store.Ask<AsyncWriteTarget.ReplaySuccess>(new AsyncWriteTarget.ReplayMessages(persistenceId, 0, 0, 0), cts.Token)).HighestSequenceNr;
         }
 
         private Task<T> StoreNotInitialized<T>()

--- a/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteProxy.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Akka.Actor;
 using System.Runtime.Serialization;
@@ -330,16 +331,14 @@ namespace Akka.Persistence.Journal
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        protected override async Task<IImmutableList<Exception>> WriteMessagesAsync(
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(
             IEnumerable<AtomicWrite> messages,
             CancellationToken cancellationToken)
         {
             if (_store == null)
-                throw new TimeoutException("Store not initialized."); 
+                return StoreNotInitialized<IImmutableList<Exception>>(); 
 
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(Timeout);
-            return await _store.Ask<IImmutableList<Exception>>(new AsyncWriteTarget.WriteMessages(messages), cts.Token);
+            return _store.Ask<IImmutableList<Exception>>(new AsyncWriteTarget.WriteMessages(messages), Timeout, cancellationToken);
         }
 
         /// <summary>
@@ -352,17 +351,15 @@ namespace Akka.Persistence.Journal
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        protected override async Task DeleteMessagesToAsync(
+        protected override Task DeleteMessagesToAsync(
             string persistenceId,
             long toSequenceNr,
             CancellationToken cancellationToken)
         {
             if (_store == null)
-                throw new TimeoutException("Store not initialized."); 
+                return StoreNotInitialized<object>();
 
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(Timeout);
-            await _store.Ask(new AsyncWriteTarget.DeleteMessagesTo(persistenceId, toSequenceNr), cts.Token);
+            return _store.Ask(new AsyncWriteTarget.DeleteMessagesTo(persistenceId, toSequenceNr), Timeout, cancellationToken);
         }
 
         /// <summary>
@@ -401,20 +398,19 @@ namespace Akka.Persistence.Journal
         /// This exception is thrown when the store has not been initialized.
         /// </exception>
         /// <returns>TBD</returns>
-        public override async Task<long> ReadHighestSequenceNrAsync(
+        public override Task<long> ReadHighestSequenceNrAsync(
             string persistenceId,
             long fromSequenceNr,
             CancellationToken cancellationToken)
         {
             if (_store == null)
-                throw new TimeoutException("Store not initialized."); 
+                return StoreNotInitialized<long>(); 
 
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(Timeout);
-            return (await _store.Ask<AsyncWriteTarget.ReplaySuccess>(new AsyncWriteTarget.ReplayMessages(persistenceId, 0, 0, 0), cts.Token)).HighestSequenceNr;
+            return _store.Ask<AsyncWriteTarget.ReplaySuccess>(new AsyncWriteTarget.ReplayMessages(persistenceId, 0, 0, 0), Timeout, cancellationToken)
+                .ContinueWith(t => t.Result.HighestSequenceNr, TaskContinuationOptions.OnlyOnRanToCompletion);
         }
 
-        private Task<T> StoreNotInitialized<T>()
+        private static Task<T> StoreNotInitialized<T>()
         {
             var promise = new TaskCompletionSource<T>();
             promise.SetException(new TimeoutException("Store not initialized."));

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -32,10 +32,6 @@ namespace Akka.Persistence.Journal
         
         protected virtual ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>> Messages { get { return _messages; } }
         
-        [Obsolete("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
-            => WriteMessagesAsync(messages, CancellationToken.None);
-        
         protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             foreach (var w in messages)
@@ -64,10 +60,6 @@ namespace Akka.Persistence.Journal
             return Task.FromResult<IImmutableList<Exception>>(null); // all good
         }
 
-        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
-            => ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, CancellationToken.None);
-        
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
             return Task.FromResult(Math.Max(HighestSequenceNr(persistenceId), _meta.GetValueOrDefault(persistenceId, 0L)));
@@ -81,10 +73,6 @@ namespace Akka.Persistence.Journal
                 Read(persistenceId, fromSequenceNr, Math.Min(toSequenceNr, highest), max).ForEach(recoveryCallback);
             return Task.CompletedTask;
         }
-        
-        [Obsolete("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
-            => DeleteMessagesToAsync(persistenceId, toSequenceNr, CancellationToken.None);
         
         protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -32,6 +32,7 @@ namespace Akka.Persistence.Journal
         
         protected virtual ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>> Messages { get { return _messages; } }
         
+        [Obsolete("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
         protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
             => WriteMessagesAsync(messages, CancellationToken.None);
         
@@ -63,6 +64,7 @@ namespace Akka.Persistence.Journal
             return Task.FromResult<IImmutableList<Exception>>(null); // all good
         }
 
+        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
             => ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, CancellationToken.None);
         
@@ -80,6 +82,7 @@ namespace Akka.Persistence.Journal
             return Task.CompletedTask;
         }
         
+        [Obsolete("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
         protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
             => DeleteMessagesToAsync(persistenceId, toSequenceNr, CancellationToken.None);
         

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -10,6 +10,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -31,7 +32,7 @@ namespace Akka.Persistence.Journal
         
         protected virtual ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>> Messages { get { return _messages; } }
         
-        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             foreach (var w in messages)
             {
@@ -59,7 +60,7 @@ namespace Akka.Persistence.Journal
             return Task.FromResult<IImmutableList<Exception>>(null); // all good
         }
         
-        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
             return Task.FromResult(Math.Max(HighestSequenceNr(persistenceId), _meta.GetValueOrDefault(persistenceId, 0L)));
         }
@@ -73,7 +74,7 @@ namespace Akka.Persistence.Journal
             return Task.CompletedTask;
         }
         
-        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {
             var highestSeqNr = HighestSequenceNr(persistenceId);
             var toSeqNr = Math.Min(toSequenceNr, highestSeqNr);

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -32,6 +32,9 @@ namespace Akka.Persistence.Journal
         
         protected virtual ConcurrentDictionary<string, LinkedList<IPersistentRepresentation>> Messages { get { return _messages; } }
         
+        protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+            => WriteMessagesAsync(messages, CancellationToken.None);
+        
         protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             foreach (var w in messages)
@@ -59,6 +62,9 @@ namespace Akka.Persistence.Journal
             
             return Task.FromResult<IImmutableList<Exception>>(null); // all good
         }
+
+        public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+            => ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, CancellationToken.None);
         
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
@@ -73,6 +79,9 @@ namespace Akka.Persistence.Journal
                 Read(persistenceId, fromSequenceNr, Math.Min(toSequenceNr, highest), max).ForEach(recoveryCallback);
             return Task.CompletedTask;
         }
+        
+        protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+            => DeleteMessagesToAsync(persistenceId, toSequenceNr, CancellationToken.None);
         
         protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {

--- a/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
@@ -11,6 +11,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Dispatch;
 using Akka.Event;
@@ -67,7 +68,7 @@ namespace Akka.Persistence.Snapshot
         private readonly ILoggingAdapter _log;
 
         /// <inheritdoc/>
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             //
             // Heuristics:
@@ -81,7 +82,7 @@ namespace Akka.Persistence.Snapshot
         }
 
         /// <inheritdoc/>
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
         {
             _saving.Add(metadata);
             return RunWithStreamDispatcher(() =>
@@ -92,7 +93,7 @@ namespace Akka.Persistence.Snapshot
         }
 
         /// <inheritdoc/>
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
+        protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
             _saving.Remove(metadata);
             return RunWithStreamDispatcher(() =>
@@ -109,11 +110,11 @@ namespace Akka.Persistence.Snapshot
         }
 
         /// <inheritdoc/>
-        protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             foreach (var metadata in GetSnapshotMetadata(persistenceId, criteria))
             {
-                await DeleteAsync(metadata);
+                await DeleteAsync(metadata, cancellationToken);
             }
         }
 

--- a/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
@@ -67,10 +67,6 @@ namespace Akka.Persistence.Snapshot
 
         private readonly ILoggingAdapter _log;
 
-        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-            => LoadAsync(persistenceId, criteria, CancellationToken.None);
-
         /// <inheritdoc/>
         protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
@@ -85,10 +81,6 @@ namespace Akka.Persistence.Snapshot
             return RunWithStreamDispatcher(() => Load(metadata));
         }
 
-        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
-            => SaveAsync(metadata, snapshot, CancellationToken.None);
-
         /// <inheritdoc/>
         protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
         {
@@ -99,10 +91,6 @@ namespace Akka.Persistence.Snapshot
                 return new object();
             });
         }
-
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
-            => DeleteAsync(metadata, CancellationToken.None);
 
         /// <inheritdoc/>
         protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
@@ -120,10 +108,6 @@ namespace Akka.Persistence.Snapshot
                 return new object();
             });
         }
-
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-            => DeleteAsync(persistenceId, criteria, CancellationToken.None);
 
         /// <inheritdoc/>
         protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)

--- a/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/LocalSnapshotStore.cs
@@ -67,6 +67,10 @@ namespace Akka.Persistence.Snapshot
 
         private readonly ILoggingAdapter _log;
 
+        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            => LoadAsync(persistenceId, criteria, CancellationToken.None);
+
         /// <inheritdoc/>
         protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
@@ -81,6 +85,10 @@ namespace Akka.Persistence.Snapshot
             return RunWithStreamDispatcher(() => Load(metadata));
         }
 
+        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+            => SaveAsync(metadata, snapshot, CancellationToken.None);
+
         /// <inheritdoc/>
         protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
         {
@@ -91,6 +99,10 @@ namespace Akka.Persistence.Snapshot
                 return new object();
             });
         }
+
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(SnapshotMetadata metadata)
+            => DeleteAsync(metadata, CancellationToken.None);
 
         /// <inheritdoc/>
         protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
@@ -108,6 +120,10 @@ namespace Akka.Persistence.Snapshot
                 return new object();
             });
         }
+
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            => DeleteAsync(persistenceId, criteria, CancellationToken.None);
 
         /// <inheritdoc/>
         protected override async Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -27,10 +27,6 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         protected virtual List<SnapshotEntry> Snapshots { get; } = new();
 
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
-            => DeleteAsync(metadata, CancellationToken.None);
-
         protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
             bool Pred(SnapshotEntry x) => x.PersistenceId == metadata.PersistenceId && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
@@ -42,10 +38,6 @@ namespace Akka.Persistence.Snapshot
             return TaskEx.Completed;
         }
 
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-            => DeleteAsync(persistenceId, criteria, CancellationToken.None);
-
         protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             var filter = CreateRangeFilter(persistenceId, criteria);
@@ -53,10 +45,6 @@ namespace Akka.Persistence.Snapshot
             Snapshots.RemoveAll(x => filter(x));
             return TaskEx.Completed;
         }
-
-        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-            => LoadAsync(persistenceId, criteria, CancellationToken.None);
 
         protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
@@ -66,10 +54,6 @@ namespace Akka.Persistence.Snapshot
             var snapshot = Snapshots.Where(filter).OrderByDescending(x => x.SequenceNr).Take(1).Select(x => ToSelectedSnapshot(x)).FirstOrDefault();
             return Task.FromResult(snapshot);
         }
-
-        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
-            => SaveAsync(metadata, snapshot, CancellationToken.None);
 
         protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
         {

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -27,6 +27,10 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         protected virtual List<SnapshotEntry> Snapshots { get; } = new();
 
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(SnapshotMetadata metadata)
+            => DeleteAsync(metadata, CancellationToken.None);
+
         protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
             var snapshot = Snapshots.FirstOrDefault(Pred);
@@ -40,6 +44,10 @@ namespace Akka.Persistence.Snapshot
                 && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
         }
 
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            => DeleteAsync(persistenceId, criteria, CancellationToken.None);
+
         protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             var filter = CreateRangeFilter(persistenceId, criteria);
@@ -47,6 +55,10 @@ namespace Akka.Persistence.Snapshot
             Snapshots.RemoveAll(x => filter(x));
             return TaskEx.Completed;
         }
+
+        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            => LoadAsync(persistenceId, criteria, CancellationToken.None);
 
         protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
@@ -56,6 +68,10 @@ namespace Akka.Persistence.Snapshot
             var snapshot = Snapshots.Where(filter).OrderByDescending(x => x.SequenceNr).Take(1).Select(x => ToSelectedSnapshot(x)).FirstOrDefault();
             return Task.FromResult(snapshot);
         }
+
+        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+            => SaveAsync(metadata, snapshot, CancellationToken.None);
 
         protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
         {

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -8,6 +8,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Util.Internal;
 
@@ -25,19 +27,20 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         protected virtual List<SnapshotEntry> Snapshots { get; } = new();
 
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
+        protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
-            bool Pred(SnapshotEntry x) => x.PersistenceId == metadata.PersistenceId && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
-                                                                                    && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
-            
-
             var snapshot = Snapshots.FirstOrDefault(Pred);
             Snapshots.Remove(snapshot);
 
             return TaskEx.Completed;
+
+            bool Pred(SnapshotEntry x) => 
+                x.PersistenceId == metadata.PersistenceId 
+                && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
+                && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
         }
 
-        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             var filter = CreateRangeFilter(persistenceId, criteria);
 
@@ -45,7 +48,7 @@ namespace Akka.Persistence.Snapshot
             return TaskEx.Completed;
         }
 
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             var filter = CreateRangeFilter(persistenceId, criteria);
 
@@ -54,7 +57,7 @@ namespace Akka.Persistence.Snapshot
             return Task.FromResult(snapshot);
         }
 
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
         {
 
             var snapshotEntry = ToSnapshotEntry(metadata, snapshot);
@@ -78,7 +81,8 @@ namespace Akka.Persistence.Snapshot
             return x => x.Id == snapshotId;
         }
 
-        private Func<SnapshotEntry, bool> CreateRangeFilter(string persistenceId, SnapshotSelectionCriteria criteria)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Func<SnapshotEntry, bool> CreateRangeFilter(string persistenceId, SnapshotSelectionCriteria criteria)
         {
             return (x => x.PersistenceId == persistenceId &&
             (criteria.MaxSequenceNr <= 0 || criteria.MaxSequenceNr == long.MaxValue || x.SequenceNr <= criteria.MaxSequenceNr) &&

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -33,15 +33,13 @@ namespace Akka.Persistence.Snapshot
 
         protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
+            bool Pred(SnapshotEntry x) => x.PersistenceId == metadata.PersistenceId && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
+                                                                                    && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
+            
             var snapshot = Snapshots.FirstOrDefault(Pred);
             Snapshots.Remove(snapshot);
 
             return TaskEx.Completed;
-
-            bool Pred(SnapshotEntry x) => 
-                x.PersistenceId == metadata.PersistenceId 
-                && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
-                && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
         }
 
         [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]

--- a/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
@@ -6,7 +6,9 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Akka.Persistence.Snapshot
@@ -59,59 +61,37 @@ namespace Akka.Persistence.Snapshot
             }
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="persistenceId">TBD</param>
-        /// <param name="criteria">TBD</param>
-        /// <returns>TBD</returns>
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             return Task.FromResult((SelectedSnapshot)null);
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="metadata">TBD</param>
-        /// <param name="snapshot">TBD</param>
         /// <exception cref="NoSnapshotStoreException">
         /// This exception is thrown when no snapshot store is configured.
         /// </exception>
-        /// <returns>TBD</returns>
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
         {
             return Flop();
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="metadata">TBD</param>
         /// <exception cref="NoSnapshotStoreException">
         /// This exception is thrown when no snapshot store is configured.
         /// </exception>
-        /// <returns>TBD</returns>
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
+        protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
             return Flop();
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="persistenceId">TBD</param>
-        /// <param name="criteria">TBD</param>
         /// <exception cref="NoSnapshotStoreException">
         /// This exception is thrown when no snapshot store is configured.
         /// </exception>
-        /// <returns>TBD</returns>
-        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             return Flop();
         }
 
-        private Task Flop()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Task Flop()
         {
             var promise = new TaskCompletionSource<object>();
             promise.SetException(new NoSnapshotStoreException("No snapshot store configured."));

--- a/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
@@ -61,9 +61,21 @@ namespace Akka.Persistence.Snapshot
             }
         }
 
+        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+        {
+            return Task.FromResult((SelectedSnapshot)null);
+        }
+
         protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             return Task.FromResult((SelectedSnapshot)null);
+        }
+
+        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+        {
+            return Flop();
         }
 
         /// <exception cref="NoSnapshotStoreException">
@@ -74,10 +86,22 @@ namespace Akka.Persistence.Snapshot
             return Flop();
         }
 
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(SnapshotMetadata metadata)
+        {
+            return Flop();
+        }
+
         /// <exception cref="NoSnapshotStoreException">
         /// This exception is thrown when no snapshot store is configured.
         /// </exception>
         protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
+        {
+            return Flop();
+        }
+
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
         {
             return Flop();
         }

--- a/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/NoSnapshotStore.cs
@@ -61,21 +61,9 @@ namespace Akka.Persistence.Snapshot
             }
         }
 
-        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-        {
-            return Task.FromResult((SelectedSnapshot)null);
-        }
-
         protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
             return Task.FromResult((SelectedSnapshot)null);
-        }
-
-        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
-        {
-            return Flop();
         }
 
         /// <exception cref="NoSnapshotStoreException">
@@ -86,22 +74,10 @@ namespace Akka.Persistence.Snapshot
             return Flop();
         }
 
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
-        {
-            return Flop();
-        }
-
         /// <exception cref="NoSnapshotStoreException">
         /// This exception is thrown when no snapshot store is configured.
         /// </exception>
         protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
-        {
-            return Flop();
-        }
-
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
         {
             return Flop();
         }

--- a/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
@@ -238,35 +238,11 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         /// <param name="persistenceId">Id of the persistent actor.</param>
         /// <param name="criteria">Selection criteria for loading.</param>
-        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract Task<SelectedSnapshot> LoadAsync(
-            string persistenceId, 
-            SnapshotSelectionCriteria criteria);
-
-        /// <summary>
-        /// Plugin API: Asynchronously loads a snapshot.
-        /// 
-        /// This call is protected with a circuit-breaker
-        /// </summary>
-        /// <param name="persistenceId">Id of the persistent actor.</param>
-        /// <param name="criteria">Selection criteria for loading.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param>
         protected abstract Task<SelectedSnapshot> LoadAsync(
             string persistenceId, 
             SnapshotSelectionCriteria criteria,
             CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Plugin API: Asynchronously saves a snapshot.
-        /// 
-        /// This call is protected with a circuit-breaker
-        /// </summary>
-        /// <param name="metadata">Snapshot metadata.</param>
-        /// <param name="snapshot">Snapshot.</param>
-        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract Task SaveAsync(
-            SnapshotMetadata metadata,
-            object snapshot);
 
         /// <summary>
         /// Plugin API: Asynchronously saves a snapshot.
@@ -287,29 +263,8 @@ namespace Akka.Persistence.Snapshot
         /// This call is protected with a circuit-breaker
         /// </summary>
         /// <param name="metadata">Snapshot metadata.</param>
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract Task DeleteAsync(SnapshotMetadata metadata);
-
-        /// <summary>
-        /// Plugin API: Deletes the snapshot identified by <paramref name="metadata"/>.
-        /// 
-        /// This call is protected with a circuit-breaker
-        /// </summary>
-        /// <param name="metadata">Snapshot metadata.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param>
         protected abstract Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Plugin API: Deletes all snapshots matching provided <paramref name="criteria"/>.
-        /// 
-        /// This call is protected with a circuit-breaker
-        /// </summary>
-        /// <param name="persistenceId">Id of the persistent actor.</param>
-        /// <param name="criteria">Selection criteria for deleting.</param>
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected abstract Task DeleteAsync(
-            string persistenceId, 
-            SnapshotSelectionCriteria criteria);
 
         /// <summary>
         /// Plugin API: Deletes all snapshots matching provided <paramref name="criteria"/>.

--- a/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
@@ -68,26 +68,15 @@ namespace Akka.Persistence.Snapshot
                     break;
                 
                 case LoadSnapshot loadSnapshot:
-                    _breaker.WithCircuitBreaker(InvokeLoadAsync)
+                    _breaker.WithCircuitBreaker(ct => LoadAsync(loadSnapshot.PersistenceId, loadSnapshot.Criteria.Limit(loadSnapshot.ToSequenceNr), ct))
+                        .ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
+                                ? new LoadSnapshotResult(t.Result, loadSnapshot.ToSequenceNr) as ISnapshotResponse
+                                : new LoadSnapshotFailed(t.IsFaulted
+                                    ? TryUnwrapException(t.Exception)
+                                    : new OperationCanceledException("LoadAsync canceled, possibly due to timing out.")),
+                            _continuationOptions)
                         .PipeTo(senderPersistentActor);
                     break;
-
-                    async Task<ISnapshotResponse> InvokeLoadAsync(CancellationToken cancellationToken)
-                    {
-                        try
-                        {
-                            return new LoadSnapshotResult(
-                                snapshot: await LoadAsync(
-                                    persistenceId: loadSnapshot.PersistenceId, 
-                                    criteria: loadSnapshot.Criteria.Limit(loadSnapshot.ToSequenceNr),
-                                    cancellationToken: cancellationToken), 
-                                toSequenceNr: loadSnapshot.ToSequenceNr);
-                        }
-                        catch (Exception e)
-                        {
-                            return new LoadSnapshotFailed(TryUnwrapException(e));
-                        }
-                    }
                 
                 case SaveSnapshot saveSnapshot:
                     var metadata = new SnapshotMetadata(
@@ -96,24 +85,16 @@ namespace Akka.Persistence.Snapshot
                         timestamp: saveSnapshot.Metadata.Timestamp == DateTime.MinValue 
                             ? DateTime.UtcNow 
                             : saveSnapshot.Metadata.Timestamp);
-
-                    _breaker.WithCircuitBreaker(InvokeSaveAsync)
+                    _breaker.WithCircuitBreaker(ct => SaveAsync(metadata, saveSnapshot.Snapshot, ct))
+                        .ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
+                                ? new SaveSnapshotSuccess(metadata) as ISnapshotResponse
+                                : new SaveSnapshotFailure(saveSnapshot.Metadata,
+                                    t.IsFaulted
+                                        ? TryUnwrapException(t.Exception)
+                                        : new OperationCanceledException("SaveAsync canceled, possibly due to timing out.", TryUnwrapException(t.Exception))),
+                            _continuationOptions)
                         .PipeTo(self, senderPersistentActor);
-
                     break;
-
-                    async Task<ISnapshotResponse> InvokeSaveAsync(CancellationToken cancellationToken)
-                    {
-                        try
-                        {
-                            await SaveAsync(metadata, saveSnapshot.Snapshot, cancellationToken);
-                            return new SaveSnapshotSuccess(metadata);
-                        }
-                        catch (Exception e)
-                        {
-                            return new SaveSnapshotFailure(saveSnapshot.Metadata, TryUnwrapException(e));
-                        }
-                    }
                 
                 case SaveSnapshotSuccess:
                     try
@@ -124,59 +105,47 @@ namespace Akka.Persistence.Snapshot
                     {
                         senderPersistentActor.Tell(message);
                     }
-
                     break;
                 
                 case SaveSnapshotFailure saveSnapshotFailure:
                     try
                     {
                         ReceivePluginInternal(message);
-                        _breaker.WithCircuitBreaker(InvokeDeleteAsync);
-
-                        async Task InvokeDeleteAsync(CancellationToken cancellationToken)
-                        {
-                            try
+                        _breaker.WithCircuitBreaker(ct => DeleteAsync(saveSnapshotFailure.Metadata, ct))
+                            .ContinueWith(t =>
                             {
-                                await DeleteAsync(saveSnapshotFailure.Metadata, cancellationToken);
-                            }
-                            catch (Exception e)
-                            {
-                                _log.Error(TryUnwrapException(e), "DeleteAsync operation after SaveSnapshot failure failed.");
-                            }
-                        }
+                                if(t.IsFaulted)
+                                    _log.Error(t.Exception, "DeleteAsync operation after SaveSnapshot failure failed.");
+                                else if(t.IsCanceled)
+                                    _log.Error(t.Exception, t.Exception is not null
+                                        ? "DeleteAsync operation after SaveSnapshot failure canceled."
+                                        : "DeleteAsync operation after SaveSnapshot failure canceled, possibly due to timing out.");
+                            }, TaskContinuationOptions.ExecuteSynchronously);
                     }
                     finally
                     {
                         senderPersistentActor.Tell(message);
                     }
-
                     break;
                 
                 case DeleteSnapshot deleteSnapshot:
                 {
                     var eventStream = Context.System.EventStream;
-                    _breaker.WithCircuitBreaker(InvokeDeleteAsync)
+                    _breaker.WithCircuitBreaker(ct => DeleteAsync(deleteSnapshot.Metadata, ct))
+                        .ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
+                                ? new DeleteSnapshotSuccess(deleteSnapshot.Metadata) as ISnapshotResponse
+                                : new DeleteSnapshotFailure(deleteSnapshot.Metadata,
+                                    t.IsFaulted
+                                        ? TryUnwrapException(t.Exception)
+                                        : new OperationCanceledException("DeleteAsync canceled, possibly due to timing out.")),
+                            _continuationOptions)
                         .PipeTo(self, senderPersistentActor)
                         .ContinueWith(_ =>
                         {
                             if (_publish)
                                 eventStream.Publish(message);
                         }, _continuationOptions);
-
                     break;
-
-                    async Task<ISnapshotResponse> InvokeDeleteAsync(CancellationToken cancellationToken)
-                    {
-                        try
-                        {
-                            await DeleteAsync(deleteSnapshot.Metadata, cancellationToken);
-                            return new DeleteSnapshotSuccess(deleteSnapshot.Metadata);
-                        }
-                        catch (Exception e)
-                        {
-                            return new DeleteSnapshotFailure(deleteSnapshot.Metadata, TryUnwrapException(e));
-                        }
-                    }
                 }
                 
                 case DeleteSnapshotSuccess:
@@ -188,7 +157,6 @@ namespace Akka.Persistence.Snapshot
                     {
                         senderPersistentActor.Tell(message);
                     }
-
                     break;
                 
                 case DeleteSnapshotFailure:
@@ -200,13 +168,19 @@ namespace Akka.Persistence.Snapshot
                     {
                         senderPersistentActor.Tell(message);
                     }
-
                     break;
                 
                 case DeleteSnapshots deleteSnapshots:
                 {
                     var eventStream = Context.System.EventStream;
-                    _breaker.WithCircuitBreaker(InvokeDeleteAsync)
+                    _breaker.WithCircuitBreaker(ct => DeleteAsync(deleteSnapshots.PersistenceId, deleteSnapshots.Criteria, ct))
+                        .ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
+                                ? new DeleteSnapshotsSuccess(deleteSnapshots.Criteria) as ISnapshotResponse
+                                : new DeleteSnapshotsFailure(deleteSnapshots.Criteria,
+                                    t.IsFaulted
+                                        ? TryUnwrapException(t.Exception)
+                                        : new OperationCanceledException("DeleteAsync canceled, possibly due to timing out.")),
+                            _continuationOptions)
                         .PipeTo(self, senderPersistentActor)
                         .ContinueWith(_ =>
                         {
@@ -214,19 +188,6 @@ namespace Akka.Persistence.Snapshot
                                 eventStream.Publish(message);
                         }, _continuationOptions);
                     break;
-
-                    async Task<ISnapshotResponse> InvokeDeleteAsync(CancellationToken cancellationToken)
-                    {
-                        try
-                        {
-                            await DeleteAsync(deleteSnapshots.PersistenceId, deleteSnapshots.Criteria, cancellationToken);
-                            return new DeleteSnapshotsSuccess(deleteSnapshots.Criteria);
-                        }
-                        catch (Exception e)
-                        {
-                            return new DeleteSnapshotsFailure(deleteSnapshots.Criteria, TryUnwrapException(e));
-                        }
-                    }
                 }
                 
                 case DeleteSnapshotsSuccess:
@@ -238,7 +199,6 @@ namespace Akka.Persistence.Snapshot
                     {
                         senderPersistentActor.Tell(message);
                     }
-
                     break;
                 
                 case DeleteSnapshotsFailure:

--- a/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
@@ -6,6 +6,8 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -59,155 +61,206 @@ namespace Akka.Persistence.Snapshot
             var senderPersistentActor = Sender; // Sender is PersistentActor
             var self = Self; //Self MUST BE CLOSED OVER here, or the code below will be subject to race conditions
 
-            if (message is LoadSnapshot loadSnapshot)
+            switch (message)
             {
-                if (loadSnapshot.Criteria == SnapshotSelectionCriteria.None)
-                {
+                case LoadSnapshot loadSnapshot when loadSnapshot.Criteria.Equals(SnapshotSelectionCriteria.None):
                     senderPersistentActor.Tell(new LoadSnapshotResult(null, loadSnapshot.ToSequenceNr));
-                }
-                else
-                {
-                    _breaker.WithCircuitBreaker(() => LoadAsync(loadSnapshot.PersistenceId, loadSnapshot.Criteria.Limit(loadSnapshot.ToSequenceNr)))
-                        .ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
-                            ? new LoadSnapshotResult(t.Result, loadSnapshot.ToSequenceNr) as ISnapshotResponse
-                            : new LoadSnapshotFailed(t.IsFaulted
-                                    ? TryUnwrapException(t.Exception)
-                                    : new OperationCanceledException("LoadAsync canceled, possibly due to timing out.")),
-                            _continuationOptions)
+                    break;
+                
+                case LoadSnapshot loadSnapshot:
+                    _breaker.WithCircuitBreaker(InvokeLoadAsync)
                         .PipeTo(senderPersistentActor);
-                }
-            }
-            else if (message is SaveSnapshot saveSnapshot)
-            {
-                var metadata = new SnapshotMetadata(saveSnapshot.Metadata.PersistenceId, saveSnapshot.Metadata.SequenceNr, saveSnapshot.Metadata.Timestamp == DateTime.MinValue ? DateTime.UtcNow : saveSnapshot.Metadata.Timestamp);
+                    break;
 
-                _breaker.WithCircuitBreaker(() => SaveAsync(metadata, saveSnapshot.Snapshot))
-                    .ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
-                        ? new SaveSnapshotSuccess(metadata) as ISnapshotResponse
-                        : new SaveSnapshotFailure(saveSnapshot.Metadata,
-                            t.IsFaulted
-                                ? TryUnwrapException(t.Exception)
-                                : new OperationCanceledException("SaveAsync canceled, possibly due to timing out.", TryUnwrapException(t.Exception))),
-                        _continuationOptions)
-                    .PipeTo(self, senderPersistentActor);
-            }
-            else if (message is SaveSnapshotSuccess)
-            {
-                try
-                {
-                    ReceivePluginInternal(message);
-                }
-                finally
-                {
-                    senderPersistentActor.Tell(message);
-                }
-            }
-            else if (message is SaveSnapshotFailure saveSnapshotFailure)
-            {
-                try
-                {
-                    ReceivePluginInternal(message);
-                    _breaker.WithCircuitBreaker(() => DeleteAsync(saveSnapshotFailure.Metadata))
-                        .ContinueWith(t =>
+                    async Task<ISnapshotResponse> InvokeLoadAsync(CancellationToken cancellationToken)
+                    {
+                        try
                         {
-                            if(t.IsFaulted)
-                                _log.Error(t.Exception, "DeleteAsync operation after SaveSnapshot failure failed.");
-                            else if(t.IsCanceled)
-                                _log.Error(t.Exception, t.Exception is not null
-                                    ? "DeleteAsync operation after SaveSnapshot failure canceled."
-                                    : "DeleteAsync operation after SaveSnapshot failure canceled, possibly due to timing out.");
-                        }, TaskContinuationOptions.ExecuteSynchronously);
-                }
-                finally
-                {
-                    senderPersistentActor.Tell(message);
-                }
-            }
-            else if (message is DeleteSnapshot deleteSnapshot)
-            {
-                var eventStream = Context.System.EventStream;
-                _breaker.WithCircuitBreaker(() => DeleteAsync(deleteSnapshot.Metadata))
-                    .ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
-                                ? new DeleteSnapshotSuccess(deleteSnapshot.Metadata) as ISnapshotResponse
-                                : new DeleteSnapshotFailure(deleteSnapshot.Metadata,
-                                    t.IsFaulted
-                                        ? TryUnwrapException(t.Exception)
-                                        : new OperationCanceledException("DeleteAsync canceled, possibly due to timing out.")),
-                                _continuationOptions)
-                    .PipeTo(self, senderPersistentActor)
-                    .ContinueWith(_ =>
+                            return new LoadSnapshotResult(
+                                snapshot: await LoadAsync(
+                                    persistenceId: loadSnapshot.PersistenceId, 
+                                    criteria: loadSnapshot.Criteria.Limit(loadSnapshot.ToSequenceNr),
+                                    cancellationToken: cancellationToken), 
+                                toSequenceNr: loadSnapshot.ToSequenceNr);
+                        }
+                        catch (Exception e)
+                        {
+                            return new LoadSnapshotFailed(TryUnwrapException(e));
+                        }
+                    }
+                
+                case SaveSnapshot saveSnapshot:
+                    var metadata = new SnapshotMetadata(
+                        persistenceId: saveSnapshot.Metadata.PersistenceId,
+                        sequenceNr: saveSnapshot.Metadata.SequenceNr,
+                        timestamp: saveSnapshot.Metadata.Timestamp == DateTime.MinValue 
+                            ? DateTime.UtcNow 
+                            : saveSnapshot.Metadata.Timestamp);
+
+                    _breaker.WithCircuitBreaker(InvokeSaveAsync)
+                        .PipeTo(self, senderPersistentActor);
+
+                    break;
+
+                    async Task<ISnapshotResponse> InvokeSaveAsync(CancellationToken cancellationToken)
                     {
-                        if (_publish)
-                            eventStream.Publish(message);
-                    }, _continuationOptions);
-            }
-            else if (message is DeleteSnapshotSuccess)
-            {
-                try
-                {
-                    ReceivePluginInternal(message);
-                }
-                finally
-                {
-                    senderPersistentActor.Tell(message);
-                }
-            }
-            else if (message is DeleteSnapshotFailure)
-            {
-                try
-                {
-                    ReceivePluginInternal(message);
-                }
-                finally
-                {
-                    senderPersistentActor.Tell(message);
-                }
-            }
-            else if (message is DeleteSnapshots deleteSnapshots)
-            {
-                var eventStream = Context.System.EventStream;
-                _breaker.WithCircuitBreaker(() => DeleteAsync(deleteSnapshots.PersistenceId, deleteSnapshots.Criteria))
-                    .ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
-                                ? new DeleteSnapshotsSuccess(deleteSnapshots.Criteria) as ISnapshotResponse
-                                : new DeleteSnapshotsFailure(deleteSnapshots.Criteria,
-                                    t.IsFaulted
-                                        ? TryUnwrapException(t.Exception)
-                                        : new OperationCanceledException("DeleteAsync canceled, possibly due to timing out.")),
-                                _continuationOptions)
-                    .PipeTo(self, senderPersistentActor)
-                    .ContinueWith(_ =>
+                        try
+                        {
+                            await SaveAsync(metadata, saveSnapshot.Snapshot, cancellationToken);
+                            return new SaveSnapshotSuccess(metadata);
+                        }
+                        catch (Exception e)
+                        {
+                            return new SaveSnapshotFailure(saveSnapshot.Metadata, TryUnwrapException(e));
+                        }
+                    }
+                
+                case SaveSnapshotSuccess:
+                    try
                     {
-                        if (_publish)
-                            eventStream.Publish(message);
-                    }, _continuationOptions);
+                        ReceivePluginInternal(message);
+                    }
+                    finally
+                    {
+                        senderPersistentActor.Tell(message);
+                    }
+
+                    break;
+                
+                case SaveSnapshotFailure saveSnapshotFailure:
+                    try
+                    {
+                        ReceivePluginInternal(message);
+                        _breaker.WithCircuitBreaker(InvokeDeleteAsync);
+
+                        async Task InvokeDeleteAsync(CancellationToken cancellationToken)
+                        {
+                            try
+                            {
+                                await DeleteAsync(saveSnapshotFailure.Metadata, cancellationToken);
+                            }
+                            catch (Exception e)
+                            {
+                                _log.Error(TryUnwrapException(e), "DeleteAsync operation after SaveSnapshot failure failed.");
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        senderPersistentActor.Tell(message);
+                    }
+
+                    break;
+                
+                case DeleteSnapshot deleteSnapshot:
+                {
+                    var eventStream = Context.System.EventStream;
+                    _breaker.WithCircuitBreaker(InvokeDeleteAsync)
+                        .PipeTo(self, senderPersistentActor)
+                        .ContinueWith(_ =>
+                        {
+                            if (_publish)
+                                eventStream.Publish(message);
+                        }, _continuationOptions);
+
+                    break;
+
+                    async Task<ISnapshotResponse> InvokeDeleteAsync(CancellationToken cancellationToken)
+                    {
+                        try
+                        {
+                            await DeleteAsync(deleteSnapshot.Metadata, cancellationToken);
+                            return new DeleteSnapshotSuccess(deleteSnapshot.Metadata);
+                        }
+                        catch (Exception e)
+                        {
+                            return new DeleteSnapshotFailure(deleteSnapshot.Metadata, TryUnwrapException(e));
+                        }
+                    }
+                }
+                
+                case DeleteSnapshotSuccess:
+                    try
+                    {
+                        ReceivePluginInternal(message);
+                    }
+                    finally
+                    {
+                        senderPersistentActor.Tell(message);
+                    }
+
+                    break;
+                
+                case DeleteSnapshotFailure:
+                    try
+                    {
+                        ReceivePluginInternal(message);
+                    }
+                    finally
+                    {
+                        senderPersistentActor.Tell(message);
+                    }
+
+                    break;
+                
+                case DeleteSnapshots deleteSnapshots:
+                {
+                    var eventStream = Context.System.EventStream;
+                    _breaker.WithCircuitBreaker(InvokeDeleteAsync)
+                        .PipeTo(self, senderPersistentActor)
+                        .ContinueWith(_ =>
+                        {
+                            if (_publish)
+                                eventStream.Publish(message);
+                        }, _continuationOptions);
+                    break;
+
+                    async Task<ISnapshotResponse> InvokeDeleteAsync(CancellationToken cancellationToken)
+                    {
+                        try
+                        {
+                            await DeleteAsync(deleteSnapshots.PersistenceId, deleteSnapshots.Criteria, cancellationToken);
+                            return new DeleteSnapshotsSuccess(deleteSnapshots.Criteria);
+                        }
+                        catch (Exception e)
+                        {
+                            return new DeleteSnapshotsFailure(deleteSnapshots.Criteria, TryUnwrapException(e));
+                        }
+                    }
+                }
+                
+                case DeleteSnapshotsSuccess:
+                    try
+                    {
+                        ReceivePluginInternal(message);
+                    }
+                    finally
+                    {
+                        senderPersistentActor.Tell(message);
+                    }
+
+                    break;
+                
+                case DeleteSnapshotsFailure:
+                    try
+                    {
+                        ReceivePluginInternal(message);
+                    }
+                    finally
+                    {
+                        senderPersistentActor.Tell(message);
+                    }
+
+                    break;
+                
+                default:
+                    return false;
             }
-            else if (message is DeleteSnapshotsSuccess)
-            {
-                try
-                {
-                    ReceivePluginInternal(message);
-                }
-                finally
-                {
-                    senderPersistentActor.Tell(message);
-                }
-            }
-            else if (message is DeleteSnapshotsFailure)
-            {
-                try
-                {
-                    ReceivePluginInternal(message);
-                }
-                finally
-                {
-                    senderPersistentActor.Tell(message);
-                }
-            }
-            else return false;
             return true;
         }
 
-        private Exception TryUnwrapException(Exception e)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Exception TryUnwrapException(Exception e)
         {
             if (e is AggregateException aggregateException)
             {
@@ -225,8 +278,11 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         /// <param name="persistenceId">Id of the persistent actor.</param>
         /// <param name="criteria">Selection criteria for loading.</param>
-        /// <returns>TBD</returns>
-        protected abstract Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria);
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param>
+        protected abstract Task<SelectedSnapshot> LoadAsync(
+            string persistenceId, 
+            SnapshotSelectionCriteria criteria,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Plugin API: Asynchronously saves a snapshot.
@@ -235,8 +291,11 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         /// <param name="metadata">Snapshot metadata.</param>
         /// <param name="snapshot">Snapshot.</param>
-        /// <returns>TBD</returns>
-        protected abstract Task SaveAsync(SnapshotMetadata metadata, object snapshot);
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param>
+        protected abstract Task SaveAsync(
+            SnapshotMetadata metadata,
+            object snapshot,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Plugin API: Deletes the snapshot identified by <paramref name="metadata"/>.
@@ -244,8 +303,8 @@ namespace Akka.Persistence.Snapshot
         /// This call is protected with a circuit-breaker
         /// </summary>
         /// <param name="metadata">Snapshot metadata.</param>
-        /// <returns>TBD</returns>
-        protected abstract Task DeleteAsync(SnapshotMetadata metadata);
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param>
+        protected abstract Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken);
 
         /// <summary>
         /// Plugin API: Deletes all snapshots matching provided <paramref name="criteria"/>.
@@ -254,8 +313,11 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         /// <param name="persistenceId">Id of the persistent actor.</param>
         /// <param name="criteria">Selection criteria for deleting.</param>
-        /// <returns>TBD</returns>
-        protected abstract Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria);
+        /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param>
+        protected abstract Task DeleteAsync(
+            string persistenceId, 
+            SnapshotSelectionCriteria criteria,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Plugin API: Allows plugin implementers to use f.PipeTo(Self)

--- a/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
@@ -278,11 +278,35 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         /// <param name="persistenceId">Id of the persistent actor.</param>
         /// <param name="criteria">Selection criteria for loading.</param>
+        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract Task<SelectedSnapshot> LoadAsync(
+            string persistenceId, 
+            SnapshotSelectionCriteria criteria);
+
+        /// <summary>
+        /// Plugin API: Asynchronously loads a snapshot.
+        /// 
+        /// This call is protected with a circuit-breaker
+        /// </summary>
+        /// <param name="persistenceId">Id of the persistent actor.</param>
+        /// <param name="criteria">Selection criteria for loading.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param>
         protected abstract Task<SelectedSnapshot> LoadAsync(
             string persistenceId, 
             SnapshotSelectionCriteria criteria,
             CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Plugin API: Asynchronously saves a snapshot.
+        /// 
+        /// This call is protected with a circuit-breaker
+        /// </summary>
+        /// <param name="metadata">Snapshot metadata.</param>
+        /// <param name="snapshot">Snapshot.</param>
+        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract Task SaveAsync(
+            SnapshotMetadata metadata,
+            object snapshot);
 
         /// <summary>
         /// Plugin API: Asynchronously saves a snapshot.
@@ -303,8 +327,29 @@ namespace Akka.Persistence.Snapshot
         /// This call is protected with a circuit-breaker
         /// </summary>
         /// <param name="metadata">Snapshot metadata.</param>
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract Task DeleteAsync(SnapshotMetadata metadata);
+
+        /// <summary>
+        /// Plugin API: Deletes the snapshot identified by <paramref name="metadata"/>.
+        /// 
+        /// This call is protected with a circuit-breaker
+        /// </summary>
+        /// <param name="metadata">Snapshot metadata.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> used to signal cancelled snapshot operation</param>
         protected abstract Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Plugin API: Deletes all snapshots matching provided <paramref name="criteria"/>.
+        /// 
+        /// This call is protected with a circuit-breaker
+        /// </summary>
+        /// <param name="persistenceId">Id of the persistent actor.</param>
+        /// <param name="criteria">Selection criteria for deleting.</param>
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected abstract Task DeleteAsync(
+            string persistenceId, 
+            SnapshotSelectionCriteria criteria);
 
         /// <summary>
         /// Plugin API: Deletes all snapshots matching provided <paramref name="criteria"/>.

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
@@ -200,7 +200,7 @@ namespace Akka.Tests.Pattern
         public async Task Must_allow_calls_through()
         {
             var breaker = LongCallTimeoutCb();
-            var result = await breaker.Instance.WithCircuitBreaker(() => Task.Run(SayHi)).WaitAsync(AwaitTimeout);
+            var result = await breaker.Instance.WithCircuitBreaker(ct => Task.Run(SayHi, ct)).WaitAsync(AwaitTimeout);
             Assert.Equal("hi", result);
         }
 
@@ -209,7 +209,7 @@ namespace Akka.Tests.Pattern
         {
             var breaker = LongCallTimeoutCb();
             await InterceptException<TestException>(() =>
-                breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException)).WaitAsync(AwaitTimeout));
+                breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct)).WaitAsync(AwaitTimeout));
             Assert.True(CheckLatch(breaker.OpenLatch));
             breaker.Instance.CurrentFailureCount.ShouldBe(1);
         }
@@ -218,7 +218,7 @@ namespace Akka.Tests.Pattern
         public void Must_increment_failure_count_on_async_failure()
         {
             var breaker = LongCallTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
+            _ = breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct));
             Assert.True(CheckLatch(breaker.OpenLatch));
             breaker.Instance.CurrentFailureCount.ShouldBe(1);
         }
@@ -227,10 +227,10 @@ namespace Akka.Tests.Pattern
         public async Task Must_reset_failure_count_after_success()
         {
             var breaker = MultiFailureCb();
-            await WaitForTaskToBeScheduled(breaker.Instance.WithCircuitBreaker(() => Task.Run(SayHi)));
-            await WaitForTaskToBeScheduled(Enumerable.Range(1, 4).Select(_ => breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException))).ToList());
+            await WaitForTaskToBeScheduled(breaker.Instance.WithCircuitBreaker(ct => Task.Run(SayHi, ct)));
+            await WaitForTaskToBeScheduled(Enumerable.Range(1, 4).Select(_ => breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct))).ToList());
             await AwaitAssertAsync(() => breaker.Instance.CurrentFailureCount.ShouldBe(4), AwaitTimeout);
-            await WaitForTaskToBeScheduled(breaker.Instance.WithCircuitBreaker(() => Task.Run(SayHi)));
+            await WaitForTaskToBeScheduled(breaker.Instance.WithCircuitBreaker(ct => Task.Run(SayHi, ct)));
             await AwaitAssertAsync(() => breaker.Instance.CurrentFailureCount.ShouldBe(0), AwaitTimeout);
         }
 
@@ -239,9 +239,9 @@ namespace Akka.Tests.Pattern
         {
             var breaker = ShortCallTimeoutCb();
 
-            var future = breaker.Instance.WithCircuitBreaker(async () =>
+            var future = breaker.Instance.WithCircuitBreaker(async ct =>
             {
-                await Task.Delay(150);
+                await Task.Delay(150, ct);
                 ThrowException();
             });
 
@@ -257,7 +257,7 @@ namespace Akka.Tests.Pattern
         public void Must_invoke_onOpen_if_call_fails_and_breaker_transits_to_open_state()
         {
             var breaker = ShortCallTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
+            _ = breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct));
             Assert.True(CheckLatch(breaker.OpenLatch));
         }
     }
@@ -268,9 +268,9 @@ namespace Akka.Tests.Pattern
         public async Task Must_pass_through_next_call_and_close_on_success()
         {
             var breaker = ShortResetTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
+            _ = breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct));
             Assert.True(CheckLatch(breaker.HalfOpenLatch));
-            var result = await breaker.Instance.WithCircuitBreaker(() => Task.Run(SayHi)).WaitAsync(AwaitTimeout);
+            var result = await breaker.Instance.WithCircuitBreaker(ct => Task.Run(SayHi, ct)).WaitAsync(AwaitTimeout);
             Assert.Equal("hi", result);
             Assert.True(CheckLatch(breaker.ClosedLatch));
         }
@@ -279,11 +279,11 @@ namespace Akka.Tests.Pattern
         public async Task Must_reopen_on_exception_in_call()
         {
             var breaker = ShortResetTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
+            _ = breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct));
             Assert.True(CheckLatch(breaker.HalfOpenLatch));
             breaker.OpenLatch.Reset();
             await InterceptException<TestException>(() =>
-                breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException)).WaitAsync(AwaitTimeout));
+                breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct)).WaitAsync(AwaitTimeout));
             Assert.True(CheckLatch(breaker.OpenLatch));
         }
 
@@ -291,11 +291,11 @@ namespace Akka.Tests.Pattern
         public void Must_reopen_on_async_failure()
         {
             var breaker = ShortResetTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
+            _ = breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct));
             Assert.True(CheckLatch(breaker.HalfOpenLatch));
 
             breaker.OpenLatch.Reset();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
+            _ = breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct));
             Assert.True(CheckLatch(breaker.OpenLatch));
         }
     }
@@ -306,19 +306,19 @@ namespace Akka.Tests.Pattern
         public async Task Must_throw_exceptions_when_called_before_reset_timeout()
         {
             var breaker = LongResetTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
+            _ = breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct));
 
             Assert.True(CheckLatch(breaker.OpenLatch));
 
             await InterceptException<OpenCircuitException>(
-                () => breaker.Instance.WithCircuitBreaker(() => Task.Run(SayHi)).WaitAsync(AwaitTimeout));
+                () => breaker.Instance.WithCircuitBreaker(ct => Task.Run(SayHi, ct)).WaitAsync(AwaitTimeout));
         }
 
         [Fact(DisplayName = "An asynchronous circuit breaker that is open must transition to half-open on reset timeout")]
         public void Must_transition_to_half_open_on_reset_timeout()
         {
             var breaker = ShortResetTimeoutCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
+            _ = breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct));
             Assert.True(CheckLatch(breaker.HalfOpenLatch));
         }
 
@@ -326,11 +326,11 @@ namespace Akka.Tests.Pattern
         public async Task Must_increase_reset_timeout_after_it_transits_to_open_again()
         {
             var breaker = NonOneFactorCb();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
+            _ = breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct));
             Assert.True(CheckLatch(breaker.OpenLatch));
 
             var e1 = await InterceptException<OpenCircuitException>(
-                () => breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException)));
+                () => breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct)));
             var shortRemainingDuration = e1.RemainingDuration;
 
             await Task.Delay(Dilated(TimeSpan.FromMilliseconds(1000)));
@@ -338,11 +338,11 @@ namespace Akka.Tests.Pattern
 
             // transit to open again
             breaker.OpenLatch.Reset();
-            _ = breaker.Instance.WithCircuitBreaker(() => Task.Run(ThrowException));
+            _ = breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct));
             Assert.True(CheckLatch(breaker.OpenLatch));
 
             var e2 = await InterceptException<OpenCircuitException>(() =>
-                breaker.Instance.WithCircuitBreaker(() => Task.FromResult(SayHi())));
+                breaker.Instance.WithCircuitBreaker(_ => Task.FromResult(SayHi())));
             var longRemainingDuration = e2.RemainingDuration;
 
             shortRemainingDuration.ShouldBeLessThan(longRemainingDuration);

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Pattern;
@@ -73,11 +74,11 @@ namespace Akka.Tests.Pattern
                     case JobDone _:
                         _doneCount++;
                         break;
-                    case Status.Failure { Cause: OpenCircuitException _ }:
+                    case Status.Failure { Cause: OpenCircuitException }:
                         _circCount++;
                         _breaker.WithCircuitBreaker(Job).PipeTo(Self);
                         break;
-                    case Status.Failure { Cause: TimeoutException _ }:
+                    case Status.Failure { Cause: TimeoutException }:
                         _timeoutCount++;
                         _breaker.WithCircuitBreaker(Job).PipeTo(Self);
                         break;
@@ -94,9 +95,9 @@ namespace Akka.Tests.Pattern
                 }
             }
 
-            private static async Task<JobDone> Job()
+            private static async Task<JobDone> Job(CancellationToken ct)
             {
-                await Task.Delay(TimeSpan.FromMilliseconds(ThreadLocalRandom.Current.Next(300)));
+                await Task.Delay(TimeSpan.FromMilliseconds(ThreadLocalRandom.Current.Next(300)), ct);
                 return JobDone.Instance;
             }
         }

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
@@ -125,10 +125,10 @@ namespace Akka.Tests.Pattern
             {
                 stressActor.Tell(GetResult.Instance);
                 var result = ExpectMsg<Result>();
-                result.FailCount.ShouldBe(0);
-
                 Output.WriteLine("FailCount:{0}, DoneCount:{1}, CircCount:{2}, TimeoutCount:{3}", 
                     result.FailCount, result.DoneCount, result.CircCount, result.TimeoutCount);
+                
+                result.FailCount.ShouldBe(0);
             }
         }
     }

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -223,7 +223,7 @@ namespace Akka.Pattern
         /// <typeparam name="T">The <see cref="Type"/> returned by the protected function</typeparam>
         /// <param name="body">Call needing protected</param>
         /// <returns><see cref="Task"/> containing the call result</returns>
-        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public Task<T> WithCircuitBreaker<T>(Func<Task<T>> body) => CurrentState.Invoke(body);
 
         /// <summary>
@@ -242,7 +242,7 @@ namespace Akka.Pattern
         /// <param name="state">The state object will be passed into the protected function during invocation</param>
         /// <param name="body">Call needing protected</param>
         /// <returns><see cref="Task"/> containing the call result</returns>
-        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public Task<T> WithCircuitBreaker<T, TState>(TState state, Func<TState, Task<T>> body) => 
             CurrentState.InvokeState(state, body);
 
@@ -262,7 +262,7 @@ namespace Akka.Pattern
         /// </summary>
         /// <param name="body">Call needing protected</param>
         /// <returns><see cref="Task"/> containing the call result</returns>
-        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public Task WithCircuitBreaker(Func<Task> body) => CurrentState.Invoke(body);
 
         /// <summary>
@@ -279,7 +279,7 @@ namespace Akka.Pattern
         /// <param name="state">The state object will be passed into the protected function during invocation</param>
         /// <param name="body">Call needing protected</param>
         /// <returns><see cref="Task"/> containing the call result</returns>
-        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
+        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public Task WithCircuitBreaker<TState>(TState state, Func<TState, Task> body) => 
             CurrentState.InvokeState(state, body);
 

--- a/src/core/Akka/Pattern/CircuitBreaker.cs
+++ b/src/core/Akka/Pattern/CircuitBreaker.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -221,22 +220,77 @@ namespace Akka.Pattern
         /// <summary>
         /// Wraps invocation of asynchronous calls that need to be protected
         /// </summary>
-        /// <typeparam name="T">TBD</typeparam>
+        /// <typeparam name="T">The <see cref="Type"/> returned by the protected function</typeparam>
         /// <param name="body">Call needing protected</param>
         /// <returns><see cref="Task"/> containing the call result</returns>
+        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public Task<T> WithCircuitBreaker<T>(Func<Task<T>> body) => CurrentState.Invoke(body);
 
+        /// <summary>
+        /// Wraps invocation of asynchronous calls that need to be protected
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> returned by the protected function</typeparam>
+        /// <param name="body">Call needing protected</param>
+        /// <returns><see cref="Task"/> containing the call result</returns>
+        public Task<T> WithCircuitBreaker<T>(Func<CancellationToken, Task<T>> body) => CurrentState.Invoke(body);
+
+        /// <summary>
+        /// Wraps invocation of asynchronous calls that need to be protected
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> returned by the protected function</typeparam>
+        /// <typeparam name="TState">The <see cref="Type"/> of the state object passed into the protected function</typeparam>
+        /// <param name="state">The state object will be passed into the protected function during invocation</param>
+        /// <param name="body">Call needing protected</param>
+        /// <returns><see cref="Task"/> containing the call result</returns>
+        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public Task<T> WithCircuitBreaker<T, TState>(TState state, Func<TState, Task<T>> body) => 
             CurrentState.InvokeState(state, body);
 
         /// <summary>
         /// Wraps invocation of asynchronous calls that need to be protected
         /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> returned by the protected function</typeparam>
+        /// <typeparam name="TState">The <see cref="Type"/> of the state object passed into the protected function</typeparam>
+        /// <param name="state">The state object will be passed into the protected function during invocation</param>
         /// <param name="body">Call needing protected</param>
-        /// <returns><see cref="Task"/></returns>
+        /// <returns><see cref="Task"/> containing the call result</returns>
+        public Task<T> WithCircuitBreaker<T, TState>(TState state, Func<TState, CancellationToken, Task<T>> body) => 
+            CurrentState.InvokeState(state, body);
+
+        /// <summary>
+        /// Wraps invocation of asynchronous calls that need to be protected
+        /// </summary>
+        /// <param name="body">Call needing protected</param>
+        /// <returns><see cref="Task"/> containing the call result</returns>
+        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public Task WithCircuitBreaker(Func<Task> body) => CurrentState.Invoke(body);
 
+        /// <summary>
+        /// Wraps invocation of asynchronous calls that need to be protected
+        /// </summary>
+        /// <param name="body">Call needing protected</param>
+        /// <returns><see cref="Task"/> containing the call result</returns>
+        public Task WithCircuitBreaker(Func<CancellationToken, Task> body) => CurrentState.Invoke(body);
+
+        /// <summary>
+        /// Wraps invocation of asynchronous calls that need to be protected
+        /// </summary>
+        /// <typeparam name="TState">The <see cref="Type"/> of the state object passed into the protected function</typeparam>
+        /// <param name="state">The state object will be passed into the protected function during invocation</param>
+        /// <param name="body">Call needing protected</param>
+        /// <returns><see cref="Task"/> containing the call result</returns>
+        [Obsolete(message:"Use WithCircuitBreaker() that accepts functions with CancellationToken parameter")]
         public Task WithCircuitBreaker<TState>(TState state, Func<TState, Task> body) => 
+            CurrentState.InvokeState(state, body);
+
+        /// <summary>
+        /// Wraps invocation of asynchronous calls that need to be protected
+        /// </summary>
+        /// <typeparam name="TState">The <see cref="Type"/> of the state object passed into the protected function</typeparam>
+        /// <param name="state">The state object will be passed into the protected function during invocation</param>
+        /// <param name="body">Call needing protected</param>
+        /// <returns><see cref="Task"/> containing the call result</returns>
+        public Task WithCircuitBreaker<TState>(TState state, Func<TState, CancellationToken, Task> body) => 
             CurrentState.InvokeState(state, body);
 
         /// <summary>
@@ -244,20 +298,21 @@ namespace Akka.Pattern
         /// </summary>
         /// <param name="body">Call needing protected</param>
         public void WithSyncCircuitBreaker(Action body) =>
-            WithCircuitBreaker(body, b => Task.Run(b)).GetAwaiter().GetResult();
+            WithCircuitBreaker(body, (b, ct) => Task.Run(b, ct)).GetAwaiter().GetResult();
 
         /// <summary>
         /// Wraps invocations of asynchronous calls that need to be protected.
         /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> returned by the protected function</typeparam>
         /// <param name="body">Call needing protected</param>
         /// <returns>The result of the call</returns>
         public T WithSyncCircuitBreaker<T>(Func<T> body) =>
-            WithCircuitBreaker(body, b => Task.Run(b)).Result;
+            WithCircuitBreaker(body, (b, ct) => Task.Run(b, ct)).GetAwaiter().GetResult();
 
         /// <summary>
         /// Mark a successful call through CircuitBreaker. Sometimes the callee of CircuitBreaker sends back a message to the
         /// caller Actor. In such a case, it is convenient to mark a successful call instead of using Future
-        /// via <see cref="WithCircuitBreaker"/>
+        /// via <see cref="WithCircuitBreaker(Func{CancellationToken, Task})"/> or <see cref="WithCircuitBreaker{T}(Func{CancellationToken, Task{T}})"/>
         /// </summary>
         public void Succeed() => _currentState.CallSucceeds();
 
@@ -266,7 +321,7 @@ namespace Akka.Pattern
         /// <summary>
         /// Mark a failed call through CircuitBreaker. Sometimes the callee of CircuitBreaker sends back a message to the
         /// caller Actor. In such a case, it is convenient to mark a failed call instead of using Future
-        /// via <see cref="WithCircuitBreaker"/>
+        /// via <see cref="WithCircuitBreaker(Func{CancellationToken, Task})"/> or <see cref="WithCircuitBreaker{T}(Func{CancellationToken, Task{T}})"/>
         /// </summary>
         public void Fail() => _currentState.CallFails(new UserCalledFailException());
 
@@ -274,7 +329,7 @@ namespace Akka.Pattern
 
         /// <summary>
         /// Return true if the internal state is Closed. WARNING: It is a "power API" call which you should use with care.
-        /// Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in <see cref="WithCircuitBreaker"/>.
+        /// Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in <see cref="WithCircuitBreaker(Func{CancellationToken, Task})"/>.
         /// So, if you check the state by yourself, and make a remote call outside CircuitBreaker, you should
         /// manage the state yourself.
         /// </summary>
@@ -282,7 +337,7 @@ namespace Akka.Pattern
 
         /// <summary>
         /// Return true if the internal state is Open. WARNING: It is a "power API" call which you should use with care.
-        /// Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in <see cref="WithCircuitBreaker"/>.
+        /// Ordinal use cases of CircuitBreaker expects a remote call to return Future, as in <see cref="WithCircuitBreaker(Func{CancellationToken, Task})"/>.
         /// So, if you check the state by yourself, and make a remote call outside CircuitBreaker, you should
         /// manage the state yourself.
         /// </summary>

--- a/src/core/Akka/Pattern/CircuitBreakerState.cs
+++ b/src/core/Akka/Pattern/CircuitBreakerState.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Util;
 using Akka.Util.Internal;
@@ -45,29 +46,51 @@ namespace Akka.Pattern
         /// <summary>
         /// Fail-fast on any invocation
         /// </summary>
-        /// <typeparam name="T">N/A</typeparam>
+        /// <typeparam name="T">The return value <see cref="Type"/> of the invoked function</typeparam>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
         public override Task<T> Invoke<T>(Func<Task<T>> body) => 
             Task.FromException<T>(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
 
-        public override Task
-            InvokeState<TState>(TState state, Func<TState, Task> body) =>
-            Task.FromException(
-                new OpenCircuitException(_breaker.LastCaughtException,
-                    RemainingDuration()));
+        /// <summary>
+        /// Fail-fast on any invocation
+        /// </summary>
+        /// <typeparam name="T">The return value <see cref="Type"/> of the invoked function</typeparam>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override Task<T> Invoke<T>(Func<CancellationToken, Task<T>> body) => 
+            Task.FromException<T>(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
 
-        public override Task<T> InvokeState<T, TState>(TState state,
-            Func<TState, Task<T>> body) => Task.FromException<T>(
-            new OpenCircuitException(_breaker.LastCaughtException,
-                RemainingDuration()));
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
+        public override Task InvokeState<TState>(TState state, Func<TState, Task> body) =>
+            Task.FromException(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
+
+        public override Task InvokeState<TState>(TState state, Func<TState, CancellationToken, Task> body) =>
+            Task.FromException(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
+
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
+        public override Task<T> InvokeState<T, TState>(TState state, Func<TState, Task<T>> body) => 
+            Task.FromException<T>(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
+
+        public override Task<T> InvokeState<T, TState>(TState state, Func<TState, CancellationToken, Task<T>> body) => 
+            Task.FromException<T>(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
 
         /// <summary>
         /// Fail-fast on any invocation
         /// </summary>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
         public override Task Invoke(Func<Task> body) => 
+            Task.FromException(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
+
+        /// <summary>
+        /// Fail-fast on any invocation
+        /// </summary>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override Task Invoke(Func<CancellationToken, Task> body) => 
             Task.FromException(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
 
         /// <summary>
@@ -144,19 +167,40 @@ namespace Akka.Pattern
         /// Allows a single call through, during which all other callers fail-fast. If the call fails, the breaker reopens.
         /// If the call succeeds, the breaker closes.
         /// </summary>
-        /// <typeparam name="T">TBD</typeparam>
+        /// <typeparam name="T">The return value <see cref="Type"/> of the invoked function</typeparam>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
         public override Task<T> Invoke<T>(Func<Task<T>> body)
         {
             CheckState();
             return CallThrough(body);
         }
         
+        /// <summary>
+        /// Allows a single call through, during which all other callers fail-fast. If the call fails, the breaker reopens.
+        /// If the call succeeds, the breaker closes.
+        /// </summary>
+        /// <typeparam name="T">The return value <see cref="Type"/> of the invoked function</typeparam>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override Task<T> Invoke<T>(Func<CancellationToken, Task<T>> body)
+        {
+            CheckState();
+            return CallThrough(body);
+        }
+
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
         public override Task<T> InvokeState<T,TState>(TState state, Func<TState, Task<T>> body)
         {
             CheckState();
-            return CallThrough(state,body);
+            return CallThrough(state, body);
+        }
+
+        public override Task<T> InvokeState<T, TState>(TState state, Func<TState, CancellationToken, Task<T>> body)
+        {
+            CheckState();
+            return CallThrough(state, body);
         }
 
         /// <summary>
@@ -165,17 +209,37 @@ namespace Akka.Pattern
         /// </summary>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        public override async Task Invoke(Func<Task> body)
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
+        public override Task Invoke(Func<Task> body)
         {
             CheckState();
-            await CallThrough(body);
+            return CallThrough(body);
         }
 
-        public override async Task InvokeState<TState>(TState state,
+        /// <summary>
+        /// Allows a single call through, during which all other callers fail-fast. If the call fails, the breaker reopens.
+        /// If the call succeeds, the breaker closes.
+        /// </summary>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override Task Invoke(Func<CancellationToken, Task> body)
+        {
+            CheckState();
+            return CallThrough(body);
+        }
+
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
+        public override Task InvokeState<TState>(TState state,
             Func<TState, Task> body)
         {
             CheckState();
-            await CallThrough(state,body);
+            return CallThrough(state, body);
+        }
+
+        public override Task InvokeState<TState>(TState state, Func<TState, CancellationToken, Task> body)
+        {
+            CheckState();
+            return CallThrough(state, body);
         }
 
         /// <summary>
@@ -210,7 +274,7 @@ namespace Akka.Pattern
         /// <returns>TBD</returns>
         public override string ToString()
         {
-            return string.Format(CultureInfo.InvariantCulture, "Half-Open currently testing call for success = {0}", (_lock.Value == true));
+            return $"Half-Open currently testing call for success = {_lock.Value}";
         }
     }
 
@@ -234,15 +298,33 @@ namespace Akka.Pattern
         /// <summary>
         /// Implementation of invoke, which simply attempts the call
         /// </summary>
-        /// <typeparam name="T">TBD</typeparam>
+        /// <typeparam name="T">The return value <see cref="Type"/> of the invoked function</typeparam>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
         public override Task<T> Invoke<T>(Func<Task<T>> body)
         {
             return CallThrough(body);
         }
 
+        /// <summary>
+        /// Implementation of invoke, which simply attempts the call
+        /// </summary>
+        /// <typeparam name="T">The return value <see cref="Type"/> of the invoked function</typeparam>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override Task<T> Invoke<T>(Func<CancellationToken, Task<T>> body)
+        {
+            return CallThrough(body);
+        }
+
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
         public override Task<T> InvokeState<T, TState>(TState state, Func<TState, Task<T>> body)
+        {
+            return CallThrough(state, body);
+        }
+
+        public override Task<T> InvokeState<T, TState>(TState state, Func<TState, CancellationToken, Task<T>> body)
         {
             return CallThrough(state, body);
         }
@@ -252,12 +334,29 @@ namespace Akka.Pattern
         /// </summary>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
         public override Task Invoke(Func<Task> body)
         {
             return CallThrough(body);
         }
 
+        /// <summary>
+        /// Implementation of invoke, which simply attempts the call
+        /// </summary>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public override Task Invoke(Func<CancellationToken, Task> body)
+        {
+            return CallThrough(body);
+        }
+
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
         public override Task InvokeState<TState>(TState state, Func<TState, Task> body)
+        {
+            return CallThrough(state, body);
+        }
+
+        public override Task InvokeState<TState>(TState state, Func<TState, CancellationToken, Task> body)
         {
             return CallThrough(state, body);
         }

--- a/src/core/Akka/Pattern/CircuitBreakerState.cs
+++ b/src/core/Akka/Pattern/CircuitBreakerState.cs
@@ -49,7 +49,7 @@ namespace Akka.Pattern
         /// <typeparam name="T">The return value <see cref="Type"/> of the invoked function</typeparam>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task<T> Invoke<T>(Func<Task<T>> body) => 
             Task.FromException<T>(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
 
@@ -62,14 +62,14 @@ namespace Akka.Pattern
         public override Task<T> Invoke<T>(Func<CancellationToken, Task<T>> body) => 
             Task.FromException<T>(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
 
-        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task InvokeState<TState>(TState state, Func<TState, Task> body) =>
             Task.FromException(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
 
         public override Task InvokeState<TState>(TState state, Func<TState, CancellationToken, Task> body) =>
             Task.FromException(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
 
-        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task<T> InvokeState<T, TState>(TState state, Func<TState, Task<T>> body) => 
             Task.FromException<T>(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
 
@@ -81,7 +81,7 @@ namespace Akka.Pattern
         /// </summary>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task Invoke(Func<Task> body) => 
             Task.FromException(new OpenCircuitException(_breaker.LastCaughtException, RemainingDuration()));
 
@@ -170,7 +170,7 @@ namespace Akka.Pattern
         /// <typeparam name="T">The return value <see cref="Type"/> of the invoked function</typeparam>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task<T> Invoke<T>(Func<Task<T>> body)
         {
             CheckState();
@@ -190,7 +190,7 @@ namespace Akka.Pattern
             return CallThrough(body);
         }
 
-        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task<T> InvokeState<T,TState>(TState state, Func<TState, Task<T>> body)
         {
             CheckState();
@@ -209,7 +209,7 @@ namespace Akka.Pattern
         /// </summary>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task Invoke(Func<Task> body)
         {
             CheckState();
@@ -228,7 +228,7 @@ namespace Akka.Pattern
             return CallThrough(body);
         }
 
-        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task InvokeState<TState>(TState state,
             Func<TState, Task> body)
         {
@@ -301,7 +301,7 @@ namespace Akka.Pattern
         /// <typeparam name="T">The return value <see cref="Type"/> of the invoked function</typeparam>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task<T> Invoke<T>(Func<Task<T>> body)
         {
             return CallThrough(body);
@@ -318,7 +318,7 @@ namespace Akka.Pattern
             return CallThrough(body);
         }
 
-        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task<T> InvokeState<T, TState>(TState state, Func<TState, Task<T>> body)
         {
             return CallThrough(state, body);
@@ -334,7 +334,7 @@ namespace Akka.Pattern
         /// </summary>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use Invoke() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task Invoke(Func<Task> body)
         {
             return CallThrough(body);
@@ -350,7 +350,7 @@ namespace Akka.Pattern
             return CallThrough(body);
         }
 
-        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter")]
+        [Obsolete("Use InvokeState() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public override Task InvokeState<TState>(TState state, Func<TState, Task> body)
         {
             return CallThrough(state, body);

--- a/src/core/Akka/Util/Internal/AtomicState.cs
+++ b/src/core/Akka/Util/Internal/AtomicState.cs
@@ -87,6 +87,8 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
+                if (ex is TaskCanceledException)
+                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -112,6 +114,8 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
+                if (ex is TaskCanceledException)
+                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -130,6 +134,8 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
+                if (ex is TaskCanceledException)
+                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -149,6 +155,8 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
+                if (ex is TaskCanceledException)
+                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -172,6 +180,8 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
+                if (ex is TaskCanceledException)
+                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -194,6 +204,8 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
+                if (ex is TaskCanceledException)
+                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -209,6 +221,8 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
+                if (ex is TaskCanceledException)
+                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -225,6 +239,8 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
+                if (ex is TaskCanceledException)
+                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();

--- a/src/core/Akka/Util/Internal/AtomicState.cs
+++ b/src/core/Akka/Util/Internal/AtomicState.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Akka.Util.Internal
@@ -94,6 +95,31 @@ namespace Akka.Util.Internal
             return result;
         }
 
+        /// <summary>
+        /// Shared implementation of call across all states.  Thrown exception or execution of the call beyond the allowed
+        /// call timeout is counted as a failed call, otherwise a successful call
+        /// </summary>
+        /// <param name="task"><see cref="Task"/> Implementation of the call</param>
+        /// <returns><see cref="Task"/> containing the result of the call</returns>
+        public async Task<T> CallThrough<T>(Func<CancellationToken, Task<T>> task)
+        {
+            var result = default(T);
+            try
+            {
+                using(var cts = new CancellationTokenSource(_callTimeout))
+                    result = await task(cts.Token).WaitAsync(cts.Token).ConfigureAwait(false);
+                CallSucceeds();
+            }
+            catch (Exception ex)
+            {
+                var capturedException = ExceptionDispatchInfo.Capture(ex);
+                CallFails(capturedException.SourceException);
+                capturedException.Throw();
+            }
+
+            return result;
+        }
+
         public async Task<T> CallThrough<T, TState>(TState state, Func<TState, Task<T>> task)
         {
             var result = default(T);
@@ -112,8 +138,27 @@ namespace Akka.Util.Internal
             return result;
         }
 
+        public async Task<T> CallThrough<T, TState>(TState state, Func<TState, CancellationToken, Task<T>> task)
+        {
+            var result = default(T);
+            try
+            {
+                using(var cts = new CancellationTokenSource(_callTimeout))
+                    result = await task(state, cts.Token).WaitAsync(cts.Token).ConfigureAwait(false);
+                CallSucceeds();
+            }
+            catch (Exception ex)
+            {
+                var capturedException = ExceptionDispatchInfo.Capture(ex);
+                CallFails(capturedException.SourceException);
+                capturedException.Throw();
+            }
+
+            return result;
+        }
+
         /// <summary>
-        /// Shared implementation of call across all states.  Thrown exception or execution of the call beyond the allowed
+        /// Shared implementation of call across all states. Thrown exception or execution of the call beyond the allowed
         /// call timeout is counted as a failed call, otherwise a successful call
         /// </summary>
         /// <param name="task"><see cref="Task"/> Implementation of the call</param>
@@ -123,6 +168,28 @@ namespace Akka.Util.Internal
             try
             {
                 await task().WaitAsync(_callTimeout).ConfigureAwait(false);
+                CallSucceeds();
+            }
+            catch (Exception ex)
+            {
+                var capturedException = ExceptionDispatchInfo.Capture(ex);
+                CallFails(capturedException.SourceException);
+                capturedException.Throw();
+            }
+        }
+
+        /// <summary>
+        /// Shared implementation of call across all states. Thrown exception or execution of the call beyond the allowed
+        /// call timeout is counted as a failed call, otherwise a successful call
+        /// </summary>
+        /// <param name="task"><see cref="Task"/> Implementation of the call</param>
+        /// <returns><see cref="Task"/> containing the result of the call</returns>
+        public async Task CallThrough(Func<CancellationToken, Task> task)
+        {
+            try
+            {
+                using(var cts = new CancellationTokenSource(_callTimeout))
+                    await task(cts.Token).WaitAsync(cts.Token).ConfigureAwait(false);
                 CallSucceeds();
             }
             catch (Exception ex)
@@ -148,24 +215,93 @@ namespace Akka.Util.Internal
             }
         }
 
+        public async Task CallThrough<TState>(TState state, Func<TState, CancellationToken, Task> task)
+        {
+            try
+            {
+                using(var cts = new CancellationTokenSource(_callTimeout))
+                    await task(state, cts.Token).WaitAsync(cts.Token).ConfigureAwait(false);
+                CallSucceeds();
+            }
+            catch (Exception ex)
+            {
+                var capturedException = ExceptionDispatchInfo.Capture(ex);
+                CallFails(capturedException.SourceException);
+                capturedException.Throw();
+            }
+        }
+
         /// <summary>
         /// Abstract entry point for all states
         /// </summary>
-        /// <typeparam name="T">TBD</typeparam>
+        /// <typeparam name="T">The <see cref="Type"/> returned by the invoked function</typeparam>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
+        [Obsolete(message:"Use Invoke() that accepts functions with CancellationToken parameter")]
         public abstract Task<T> Invoke<T>(Func<Task<T>> body);
 
+        /// <summary>
+        /// Abstract entry point for all states
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> returned by the invoked function</typeparam>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public abstract Task<T> Invoke<T>(Func<CancellationToken, Task<T>> body);
+
+        /// <summary>
+        /// Abstract entry point for all states
+        /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> returned by the invoked function</typeparam>
+        /// <typeparam name="TState">The <see cref="Type"/> of the state object passed into the protected function</typeparam> 
+        /// <param name="state">The state object will be passed into the protected function during invocation</param>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        [Obsolete(message:"Use InvokeState() that accepts functions with CancellationToken parameter")]
         public abstract Task<T> InvokeState<T, TState>(TState state, Func<TState, Task<T>> body);
 
         /// <summary>
         /// Abstract entry point for all states
         /// </summary>
+        /// <typeparam name="T">The <see cref="Type"/> returned by the invoked function</typeparam>
+        /// <typeparam name="TState">The <see cref="Type"/> of the state object passed into the protected function</typeparam> 
+        /// <param name="state">The state object will be passed into the protected function during invocation</param>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public abstract Task<T> InvokeState<T, TState>(TState state, Func<TState, CancellationToken, Task<T>> body);
+
+        /// <summary>
+        /// Abstract entry point for all states
+        /// </summary>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        [Obsolete(message:"Use Invoke() that accepts functions with CancellationToken parameter")]
         public abstract Task Invoke(Func<Task> body);
 
+        /// <summary>
+        /// Abstract entry point for all states
+        /// </summary>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public abstract Task Invoke(Func<CancellationToken, Task> body);
+
+        /// <summary>
+        /// Abstract entry point for all states
+        /// </summary>
+        /// <typeparam name="TState">The <see cref="Type"/> of the state object passed into the protected function</typeparam> 
+        /// <param name="state">The state object will be passed into the protected function during invocation</param>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        [Obsolete(message:"Use InvokeState() that accepts functions with CancellationToken parameter")]
         public abstract Task InvokeState<TState>(TState state, Func<TState, Task> body);
+
+        /// <summary>
+        /// Abstract entry point for all states
+        /// </summary>
+        /// <typeparam name="TState">The <see cref="Type"/> of the state object passed into the protected function</typeparam> 
+        /// <param name="state">The state object will be passed into the protected function during invocation</param>
+        /// <param name="body">Implementation of the call that needs protected</param>
+        /// <returns><see cref="Task"/> containing result of protected call</returns>
+        public abstract Task InvokeState<TState>(TState state, Func<TState, CancellationToken, Task> body);
 
         /// <summary>
         /// Invoked when call fails

--- a/src/core/Akka/Util/Internal/AtomicState.cs
+++ b/src/core/Akka/Util/Internal/AtomicState.cs
@@ -77,23 +77,9 @@ namespace Akka.Util.Internal
         /// </summary>
         /// <param name="task"><see cref="Task"/> Implementation of the call</param>
         /// <returns><see cref="Task"/> containing the result of the call</returns>
-        public async Task<T> CallThrough<T>(Func<Task<T>> task)
-        {
-            var result = default(T);
-            try
-            {
-                result = await task().WaitAsync(_callTimeout).ConfigureAwait(false);
-                CallSucceeds();
-            }
-            catch (Exception ex)
-            {
-                var capturedException = ExceptionDispatchInfo.Capture(ex);
-                CallFails(capturedException.SourceException);
-                capturedException.Throw();
-            }
-
-            return result;
-        }
+        [Obsolete("Use CallThrough that accepts delegate function with CancellationToken argument. Since 1.5.42")]
+        public Task<T> CallThrough<T>(Func<Task<T>> task)
+            => CallThrough(_ => task());
 
         /// <summary>
         /// Shared implementation of call across all states.  Thrown exception or execution of the call beyond the allowed
@@ -104,54 +90,50 @@ namespace Akka.Util.Internal
         public async Task<T> CallThrough<T>(Func<CancellationToken, Task<T>> task)
         {
             var result = default(T);
+            var cts = new CancellationTokenSource();
             try
             {
-                using(var cts = new CancellationTokenSource(_callTimeout))
-                    result = await task(cts.Token).WaitAsync(cts.Token).ConfigureAwait(false);
+                result = await task(cts.Token).WaitAsync(_callTimeout).ConfigureAwait(false);
                 CallSucceeds();
             }
             catch (Exception ex)
             {
+                cts.Cancel(); // Signal the protected delegate that operation has been canceled
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
+            }
+            finally
+            {
+                cts.Dispose();
             }
 
             return result;
         }
 
-        public async Task<T> CallThrough<T, TState>(TState state, Func<TState, Task<T>> task)
-        {
-            var result = default(T);
-            try
-            {
-                result = await task(state).WaitAsync(_callTimeout).ConfigureAwait(false);
-                CallSucceeds();
-            }
-            catch (Exception ex)
-            {
-                var capturedException = ExceptionDispatchInfo.Capture(ex);
-                CallFails(capturedException.SourceException);
-                capturedException.Throw();
-            }
-
-            return result;
-        }
+        [Obsolete("Use CallThrough that accepts delegate function with CancellationToken argument. Since 1.5.42")]
+        public Task<T> CallThrough<T, TState>(TState state, Func<TState, Task<T>> task)
+            => CallThrough(state, (s, _) => task(s));
 
         public async Task<T> CallThrough<T, TState>(TState state, Func<TState, CancellationToken, Task<T>> task)
         {
             var result = default(T);
+            var cts = new CancellationTokenSource();
             try
             {
-                using(var cts = new CancellationTokenSource(_callTimeout))
-                    result = await task(state, cts.Token).WaitAsync(cts.Token).ConfigureAwait(false);
+                result = await task(state, cts.Token).WaitAsync(_callTimeout).ConfigureAwait(false);
                 CallSucceeds();
             }
             catch (Exception ex)
             {
+                cts.Cancel(); // Signal the protected delegate that operation has been canceled
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
+            }
+            finally
+            {
+                cts.Dispose();
             }
 
             return result;
@@ -163,20 +145,9 @@ namespace Akka.Util.Internal
         /// </summary>
         /// <param name="task"><see cref="Task"/> Implementation of the call</param>
         /// <returns><see cref="Task"/> containing the result of the call</returns>
-        public async Task CallThrough(Func<Task> task)
-        {
-            try
-            {
-                await task().WaitAsync(_callTimeout).ConfigureAwait(false);
-                CallSucceeds();
-            }
-            catch (Exception ex)
-            {
-                var capturedException = ExceptionDispatchInfo.Capture(ex);
-                CallFails(capturedException.SourceException);
-                capturedException.Throw();
-            }
-        }
+        [Obsolete("Use CallThrough that accepts delegate function with CancellationToken argument. Since 1.5.42")]
+        public Task CallThrough(Func<Task> task)
+            => CallThrough(_ => task());
 
         /// <summary>
         /// Shared implementation of call across all states. Thrown exception or execution of the call beyond the allowed
@@ -186,48 +157,47 @@ namespace Akka.Util.Internal
         /// <returns><see cref="Task"/> containing the result of the call</returns>
         public async Task CallThrough(Func<CancellationToken, Task> task)
         {
+            var cts = new CancellationTokenSource();
             try
             {
-                using(var cts = new CancellationTokenSource(_callTimeout))
-                    await task(cts.Token).WaitAsync(cts.Token).ConfigureAwait(false);
+                await task(cts.Token).WaitAsync(_callTimeout).ConfigureAwait(false);
                 CallSucceeds();
             }
             catch (Exception ex)
             {
+                cts.Cancel(); // Signal the protected delegate that operation has been canceled
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
+            }
+            finally
+            {
+                cts.Dispose();
             }
         }
 
-        public async Task CallThrough<TState>(TState state, Func<TState, Task> task)
-        {
-            try
-            {
-                await task(state).WaitAsync(_callTimeout).ConfigureAwait(false);
-                CallSucceeds();
-            }
-            catch (Exception ex)
-            {
-                var capturedException = ExceptionDispatchInfo.Capture(ex);
-                CallFails(capturedException.SourceException);
-                capturedException.Throw();
-            }
-        }
+        [Obsolete("Use CallThrough that accepts delegate function with CancellationToken argument. Since 1.5.42")]
+        public Task CallThrough<TState>(TState state, Func<TState, Task> task)
+            => CallThrough(state, (s, _) => task(s));
 
         public async Task CallThrough<TState>(TState state, Func<TState, CancellationToken, Task> task)
         {
+            var cts = new CancellationTokenSource();
             try
             {
-                using(var cts = new CancellationTokenSource(_callTimeout))
-                    await task(state, cts.Token).WaitAsync(cts.Token).ConfigureAwait(false);
+                await task(state, cts.Token).WaitAsync(_callTimeout).ConfigureAwait(false);
                 CallSucceeds();
             }
             catch (Exception ex)
             {
+                cts.Cancel(); // Signal the protected delegate that operation has been canceled
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
+            }
+            finally
+            {
+                cts.Dispose();
             }
         }
 

--- a/src/core/Akka/Util/Internal/AtomicState.cs
+++ b/src/core/Akka/Util/Internal/AtomicState.cs
@@ -87,8 +87,6 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
-                if (ex is TaskCanceledException)
-                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -114,8 +112,6 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
-                if (ex is TaskCanceledException)
-                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -134,8 +130,6 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
-                if (ex is TaskCanceledException)
-                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -155,8 +149,6 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
-                if (ex is TaskCanceledException)
-                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -180,8 +172,6 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
-                if (ex is TaskCanceledException)
-                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -204,8 +194,6 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
-                if (ex is TaskCanceledException)
-                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -221,8 +209,6 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
-                if (ex is TaskCanceledException)
-                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();
@@ -239,8 +225,6 @@ namespace Akka.Util.Internal
             }
             catch (Exception ex)
             {
-                if (ex is TaskCanceledException)
-                    ex = new TimeoutException("Task was cancelled, probably because of a timeout", ex);
                 var capturedException = ExceptionDispatchInfo.Capture(ex);
                 CallFails(capturedException.SourceException);
                 capturedException.Throw();

--- a/src/core/Akka/Util/Internal/AtomicState.cs
+++ b/src/core/Akka/Util/Internal/AtomicState.cs
@@ -253,7 +253,7 @@ namespace Akka.Util.Internal
         /// <typeparam name="T">The <see cref="Type"/> returned by the invoked function</typeparam>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        [Obsolete(message:"Use Invoke() that accepts functions with CancellationToken parameter")]
+        [Obsolete(message:"Use Invoke() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public abstract Task<T> Invoke<T>(Func<Task<T>> body);
 
         /// <summary>
@@ -272,7 +272,7 @@ namespace Akka.Util.Internal
         /// <param name="state">The state object will be passed into the protected function during invocation</param>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        [Obsolete(message:"Use InvokeState() that accepts functions with CancellationToken parameter")]
+        [Obsolete(message:"Use InvokeState() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public abstract Task<T> InvokeState<T, TState>(TState state, Func<TState, Task<T>> body);
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace Akka.Util.Internal
         /// </summary>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        [Obsolete(message:"Use Invoke() that accepts functions with CancellationToken parameter")]
+        [Obsolete(message:"Use Invoke() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public abstract Task Invoke(Func<Task> body);
 
         /// <summary>
@@ -307,7 +307,7 @@ namespace Akka.Util.Internal
         /// <param name="state">The state object will be passed into the protected function during invocation</param>
         /// <param name="body">Implementation of the call that needs protected</param>
         /// <returns><see cref="Task"/> containing result of protected call</returns>
-        [Obsolete(message:"Use InvokeState() that accepts functions with CancellationToken parameter")]
+        [Obsolete(message:"Use InvokeState() that accepts functions with CancellationToken parameter. Since 1.5.42")]
         public abstract Task InvokeState<TState>(TState state, Func<TState, Task> body);
 
         /// <summary>

--- a/src/examples/Akka.Persistence.Custom/Journal/SqliteJournal.cs
+++ b/src/examples/Akka.Persistence.Custom/Journal/SqliteJournal.cs
@@ -273,12 +273,13 @@ namespace Akka.Persistence.Custom.Journal
         // <ReadHighestSequenceNrAsync>
         public sealed override async Task<long> ReadHighestSequenceNrAsync(
             string persistenceId,
-            long fromSequenceNr)
+            long fromSequenceNr,
+            CancellationToken cancellationToken)
         {
             // Create a new DbConnection instance
             using (var connection = new SqliteConnection(_connectionString))
             using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token, cancellationToken))
             {
                 await connection.OpenAsync(cts.Token);
                 // Create new DbCommand instance
@@ -299,7 +300,7 @@ namespace Akka.Persistence.Custom.Journal
 
         // <WriteMessagesAsync>
         protected sealed override async Task<IImmutableList<Exception>> WriteMessagesAsync(
-            IEnumerable<AtomicWrite> messages)
+            IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
             // For each of the atomic write request, create an async Task 
             var writeTasks = messages.Select(async message =>
@@ -307,7 +308,7 @@ namespace Akka.Persistence.Custom.Journal
                 // Create a new DbConnection instance
                 using (var connection = new SqliteConnection(_connectionString))
                 using (var cts = CancellationTokenSource
-                           .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+                           .CreateLinkedTokenSource(_pendingRequestsCancellation.Token, cancellationToken))
                 {
                     await connection.OpenAsync(cts.Token);
                     
@@ -384,7 +385,7 @@ namespace Akka.Persistence.Custom.Journal
                 .ContinueWhenAll(writeTasks,
                     tasks => tasks.Select(t => t.IsFaulted 
                         ? TryUnwrapException(t.Exception) 
-                        : null).ToImmutableList());
+                        : null).ToImmutableList(), cancellationToken);
 
             return result;
         }
@@ -393,15 +394,16 @@ namespace Akka.Persistence.Custom.Journal
         //<DeleteMessagesToAsync>
         protected sealed override async Task DeleteMessagesToAsync(
             string persistenceId,
-            long toSequenceNr)
+            long toSequenceNr,
+            CancellationToken cancellationToken)
         {
             // Create a new DbConnection instance
             using (var connection = new SqliteConnection(_connectionString))
             {
-                await connection.OpenAsync();
+                await connection.OpenAsync(cancellationToken);
                 
                 using (var cts = CancellationTokenSource
-                           .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+                           .CreateLinkedTokenSource(_pendingRequestsCancellation.Token, cancellationToken))
                 {
                     // We will be using two DbCommands to complete this process
                     using (var deleteCommand = GetCommand(connection, DeleteBatchSql, _timeout))

--- a/src/examples/Akka.Persistence.Custom/Journal/SqliteJournal.cs
+++ b/src/examples/Akka.Persistence.Custom/Journal/SqliteJournal.cs
@@ -270,6 +270,10 @@ namespace Akka.Persistence.Custom.Journal
         }
         // </ReplayMessagesAsync>
 
+        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        public sealed override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
+            => ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, CancellationToken.None);
+        
         // <ReadHighestSequenceNrAsync>
         public sealed override async Task<long> ReadHighestSequenceNrAsync(
             string persistenceId,
@@ -298,6 +302,10 @@ namespace Akka.Persistence.Custom.Journal
         }
         // </ReadHighestSequenceNrAsync>
 
+        [Obsolete("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected sealed override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
+            => await WriteMessagesAsync(messages, CancellationToken.None);
+        
         // <WriteMessagesAsync>
         protected sealed override async Task<IImmutableList<Exception>> WriteMessagesAsync(
             IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
@@ -391,6 +399,10 @@ namespace Akka.Persistence.Custom.Journal
         }
         // </WriteMessagesAsync>
 
+        [Obsolete("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected sealed override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
+            => DeleteMessagesToAsync(persistenceId, toSequenceNr, CancellationToken.None);
+        
         //<DeleteMessagesToAsync>
         protected sealed override async Task DeleteMessagesToAsync(
             string persistenceId,

--- a/src/examples/Akka.Persistence.Custom/Journal/SqliteJournal.cs
+++ b/src/examples/Akka.Persistence.Custom/Journal/SqliteJournal.cs
@@ -270,10 +270,6 @@ namespace Akka.Persistence.Custom.Journal
         }
         // </ReplayMessagesAsync>
 
-        [Obsolete("Use ReadHighestSequenceNrAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        public sealed override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr)
-            => ReadHighestSequenceNrAsync(persistenceId, fromSequenceNr, CancellationToken.None);
-        
         // <ReadHighestSequenceNrAsync>
         public sealed override async Task<long> ReadHighestSequenceNrAsync(
             string persistenceId,
@@ -302,10 +298,6 @@ namespace Akka.Persistence.Custom.Journal
         }
         // </ReadHighestSequenceNrAsync>
 
-        [Obsolete("Use WriteMessagesAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected sealed override async Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages)
-            => await WriteMessagesAsync(messages, CancellationToken.None);
-        
         // <WriteMessagesAsync>
         protected sealed override async Task<IImmutableList<Exception>> WriteMessagesAsync(
             IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
@@ -399,10 +391,6 @@ namespace Akka.Persistence.Custom.Journal
         }
         // </WriteMessagesAsync>
 
-        [Obsolete("Use DeleteMessagesToAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected sealed override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr)
-            => DeleteMessagesToAsync(persistenceId, toSequenceNr, CancellationToken.None);
-        
         //<DeleteMessagesToAsync>
         protected sealed override async Task DeleteMessagesToAsync(
             string persistenceId,

--- a/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
+++ b/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
@@ -184,12 +184,13 @@ namespace Akka.Persistence.Custom.Snapshot
         //<LoadAsync>
         protected sealed override async Task<SelectedSnapshot> LoadAsync(
             string persistenceId,
-            SnapshotSelectionCriteria criteria)
+            SnapshotSelectionCriteria criteria, 
+            CancellationToken cancellationToken)
         {
             // Create a new DbConnection instance
             using (var connection = new SqliteConnection(_connectionString))
             using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token, cancellationToken))
             {
                 await connection.OpenAsync(cts.Token);
                 
@@ -234,12 +235,13 @@ namespace Akka.Persistence.Custom.Snapshot
         //<SaveAsync>
         protected sealed override async Task SaveAsync(
             SnapshotMetadata metadata,
-            object snapshot)
+            object snapshot, 
+            CancellationToken cancellationToken)
         {
             // Create a new DbConnection instance
             using (var connection = new SqliteConnection(_connectionString))
             using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token, cancellationToken))
             {
                 await connection.OpenAsync(cts.Token);
                 
@@ -302,12 +304,12 @@ namespace Akka.Persistence.Custom.Snapshot
         //</SaveAsync>
 
         //<DeleteAsync>
-        protected sealed override async Task DeleteAsync(SnapshotMetadata metadata)
+        protected sealed override async Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
             // Create a new DbConnection instance
             using (var connection = new SqliteConnection(_connectionString))
             using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))    
+                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token, cancellationToken))    
             {
                 await connection.OpenAsync(cts.Token);
                 var timestamp = metadata.Timestamp != DateTime.MinValue 
@@ -346,12 +348,13 @@ namespace Akka.Persistence.Custom.Snapshot
         //<DeleteAsync2>
         protected sealed override async Task DeleteAsync(
             string persistenceId, 
-            SnapshotSelectionCriteria criteria)
+            SnapshotSelectionCriteria criteria, 
+            CancellationToken cancellationToken)
         {
             // Create a new DbConnection instance
             using (var connection = new SqliteConnection(_connectionString))
             using (var cts = CancellationTokenSource
-                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token))
+                       .CreateLinkedTokenSource(_pendingRequestsCancellation.Token, cancellationToken))
             {
                 await connection.OpenAsync(cts.Token);
                 

--- a/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
+++ b/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
@@ -181,6 +181,10 @@ namespace Akka.Persistence.Custom.Snapshot
         }
         //</Startup>
         
+        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            => LoadAsync(persistenceId, criteria, CancellationToken.None);
+
         //<LoadAsync>
         protected sealed override async Task<SelectedSnapshot> LoadAsync(
             string persistenceId,
@@ -231,6 +235,10 @@ namespace Akka.Persistence.Custom.Snapshot
             }
         }
         //</LoadAsync>
+
+        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
+            => SaveAsync(metadata, snapshot, CancellationToken.None);
 
         //<SaveAsync>
         protected sealed override async Task SaveAsync(
@@ -303,6 +311,10 @@ namespace Akka.Persistence.Custom.Snapshot
         }
         //</SaveAsync>
 
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(SnapshotMetadata metadata)
+            => DeleteAsync(metadata, CancellationToken.None);
+
         //<DeleteAsync>
         protected sealed override async Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
@@ -344,6 +356,10 @@ namespace Akka.Persistence.Custom.Snapshot
             }
         }
         //</DeleteAsync>
+
+        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
+        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
+            => DeleteAsync(persistenceId, criteria, CancellationToken.None);
 
         //<DeleteAsync2>
         protected sealed override async Task DeleteAsync(

--- a/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
+++ b/src/examples/Akka.Persistence.Custom/Snapshot/SqliteSnapshotStore.cs
@@ -181,10 +181,6 @@ namespace Akka.Persistence.Custom.Snapshot
         }
         //</Startup>
         
-        [Obsolete("Use LoadAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-            => LoadAsync(persistenceId, criteria, CancellationToken.None);
-
         //<LoadAsync>
         protected sealed override async Task<SelectedSnapshot> LoadAsync(
             string persistenceId,
@@ -235,10 +231,6 @@ namespace Akka.Persistence.Custom.Snapshot
             }
         }
         //</LoadAsync>
-
-        [Obsolete("Use SaveAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot)
-            => SaveAsync(metadata, snapshot, CancellationToken.None);
 
         //<SaveAsync>
         protected sealed override async Task SaveAsync(
@@ -311,10 +303,6 @@ namespace Akka.Persistence.Custom.Snapshot
         }
         //</SaveAsync>
 
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(SnapshotMetadata metadata)
-            => DeleteAsync(metadata, CancellationToken.None);
-
         //<DeleteAsync>
         protected sealed override async Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
@@ -356,10 +344,6 @@ namespace Akka.Persistence.Custom.Snapshot
             }
         }
         //</DeleteAsync>
-
-        [Obsolete("Use DeleteAsync() that takes a CancellationToken argument instead. Since 1.5.42")]
-        protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria)
-            => DeleteAsync(persistenceId, criteria, CancellationToken.None);
 
         //<DeleteAsync2>
         protected sealed override async Task DeleteAsync(


### PR DESCRIPTION
## Changes

Introduce CancellationToken to `WithCircuitBreaker`

The changes to `CircuitBreaker` is backward compatible, but the changes to `Akka.Persistence` is not, because these methods need to follow the new changes of the delegate function.

> [!Warning]
> ## Breaking Change
>
> Because the change was done to the delegate method fingerprint, it is impossible to make this change backward compatible.
>
> All plugins that is based on `Akka.Persistence` will need to be updated to use these new `Akka.Persistence` internal APIs

* [ ] Akka.Persistence.Sql
* [ ] Akka.Persistence.MongoDb
* [ ] Akka.Persistence.Azure
* [ ] Akka.Persistence.Redis
