### PR TITLE
Akka.IO: added `TcpListenerStatistics` and subscription methods

### DIFF
--- a/docs/articles/actors/io.md
+++ b/docs/articles/actors/io.md
@@ -54,3 +54,7 @@ The following code example shows a simple server that echo's data received from 
 [!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Networking/IO/EchoServer.cs?name=echoServer)]
 
 [!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Networking/IO/EchoConnection.cs?name=echoConnection)]
+
+### TCP Statistics
+
+

--- a/docs/articles/actors/io.md
+++ b/docs/articles/actors/io.md
@@ -55,6 +55,10 @@ The following code example shows a simple server that echo's data received from 
 
 [!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Networking/IO/EchoConnection.cs?name=echoConnection)]
 
-### TCP Statistics
+### TCP Listener Statistics
 
+If you're building a long-running TCP server you can subscribe to the `TcpListener` actor's statistics via the `Tcp.SubscribeToTcpListenerStats` message:
 
+[!code-csharp[Main](../../../src/core/Akka.Docs.Tests/Networking/IO/EchoServer.cs?name=echoServerWithStats)]
+
+This will result in a `Tcp.TcpListenerStatistics` message being delivered with updated, rolling statistics once every 10 seconds or so roughly. Each independent `TcpListener` maintains its own statistics and they can support an arbitrary number of subscribers.

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -4097,6 +4097,7 @@ namespace Akka.IO
         {
             public Event() { }
         }
+        public interface ITcpQuery : Akka.Actor.INoSerializationVerificationNeeded { }
         public class Message : Akka.Actor.INoSerializationVerificationNeeded
         {
             public Message() { }
@@ -4148,9 +4149,23 @@ namespace Akka.IO
             public bool WantsAck { get; }
             public Akka.IO.Tcp.CompoundWrite Append(Akka.IO.Tcp.WriteCommand that) { }
         }
+        public sealed class SubscribeToTcpListenerStats : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.SubscribeToTcpListenerStats>
+        {
+            public SubscribeToTcpListenerStats(Akka.Actor.IActorRef Subscriber) { }
+            public Akka.Actor.IActorRef Subscriber { get; set; }
+        }
         public sealed class SuspendReading : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.SuspendReading Instance;
+        }
+        [System.Runtime.CompilerServices.NullableAttribute(0)]
+        public sealed class TcpListenerStatistics : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.TcpListenerStatistics>
+        {
+            public TcpListenerStatistics() { }
+            public long AcceptedIncomingConnections { get; set; }
+            public long FailedIncomingConnections { get; set; }
+            public long IncomingConnectionsClosed { get; set; }
+            public long RetriedIncomingConnections { get; set; }
         }
         public class Unbind : Akka.IO.Tcp.Command
         {
@@ -4159,6 +4174,11 @@ namespace Akka.IO
         public sealed class Unbound : Akka.IO.Tcp.Event
         {
             public static readonly Akka.IO.Tcp.Unbound Instance;
+        }
+        public sealed class UnsubscribeFromTcpListenerStats : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.UnsubscribeFromTcpListenerStats>
+        {
+            public UnsubscribeFromTcpListenerStats(Akka.Actor.IActorRef Subscriber) { }
+            public Akka.Actor.IActorRef Subscriber { get; set; }
         }
         public sealed class Write : Akka.IO.Tcp.SimpleWriteCommand
         {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -4087,6 +4087,7 @@ namespace Akka.IO
         {
             public Event() { }
         }
+        public interface ITcpQuery : Akka.Actor.INoSerializationVerificationNeeded { }
         public class Message : Akka.Actor.INoSerializationVerificationNeeded
         {
             public Message() { }
@@ -4138,9 +4139,23 @@ namespace Akka.IO
             public bool WantsAck { get; }
             public Akka.IO.Tcp.CompoundWrite Append(Akka.IO.Tcp.WriteCommand that) { }
         }
+        public sealed class SubscribeToTcpListenerStats : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.SubscribeToTcpListenerStats>
+        {
+            public SubscribeToTcpListenerStats(Akka.Actor.IActorRef Subscriber) { }
+            public Akka.Actor.IActorRef Subscriber { get; set; }
+        }
         public sealed class SuspendReading : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.SuspendReading Instance;
+        }
+        [System.Runtime.CompilerServices.NullableAttribute(0)]
+        public sealed class TcpListenerStatistics : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.TcpListenerStatistics>
+        {
+            public TcpListenerStatistics() { }
+            public long AcceptedIncomingConnections { get; set; }
+            public long FailedIncomingConnections { get; set; }
+            public long IncomingConnectionsClosed { get; set; }
+            public long RetriedIncomingConnections { get; set; }
         }
         public class Unbind : Akka.IO.Tcp.Command
         {
@@ -4149,6 +4164,11 @@ namespace Akka.IO
         public sealed class Unbound : Akka.IO.Tcp.Event
         {
             public static readonly Akka.IO.Tcp.Unbound Instance;
+        }
+        public sealed class UnsubscribeFromTcpListenerStats : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.UnsubscribeFromTcpListenerStats>
+        {
+            public UnsubscribeFromTcpListenerStats(Akka.Actor.IActorRef Subscriber) { }
+            public Akka.Actor.IActorRef Subscriber { get; set; }
         }
         public sealed class Write : Akka.IO.Tcp.SimpleWriteCommand
         {

--- a/src/core/Akka.Docs.Tests/Networking/IO/EchoServer.cs
+++ b/src/core/Akka.Docs.Tests/Networking/IO/EchoServer.cs
@@ -22,18 +22,57 @@ namespace DocsExamples.Networking.IO
 
         protected override void OnReceive(object message)
         {
-            if (message is Tcp.Bound bound)
+            switch (message)
             {
-                Console.WriteLine("Listening on {0}", bound.LocalAddress);
+                case Tcp.Bound bound:
+                    Console.WriteLine("Listening on {0}", bound.LocalAddress);
+                    break;
+                case Tcp.Connected:
+                {
+                    var connection = Context.ActorOf(Props.Create(() => new EchoConnection(Sender)));
+                    Sender.Tell(new Tcp.Register(connection));
+                    break;
+                }
+                default:
+                    Unhandled(message);
+                    break;
             }
-            else if (message is Tcp.Connected)
-            {
-                var connection = Context.ActorOf(Props.Create(() => new EchoConnection(Sender)));
-                Sender.Tell(new Tcp.Register(connection));
-            }
-            else Unhandled(message);
         }
     }
 
     // </echoServer>
+    
+    // <echoServerWithStats>
+    public class EchoServerWithStats : UntypedActor
+    {
+        public EchoServerWithStats(int port)
+        {
+            Context.System.Tcp().Tell(new Tcp.Bind(Self, new IPEndPoint(IPAddress.Any, port)));
+        }
+
+        protected override void OnReceive(object message)
+        {
+            switch (message)
+            {
+                case Tcp.Bound bound:
+                    Sender.Tell(new Tcp.SubscribeToTcpListenerStats(Self));
+                    Console.WriteLine("Listening on {0}", bound.LocalAddress);
+                    break;
+                case Tcp.TcpListenerStatistics stats:
+                    Console.WriteLine("Received TCP stats: {0}", stats);
+                    break;
+                case Tcp.Connected:
+                {
+                    var connection = Context.ActorOf(Props.Create(() => new EchoConnection(Sender)));
+                    Sender.Tell(new Tcp.Register(connection));
+                    break;
+                }
+                default:
+                    Unhandled(message);
+                    break;
+            }
+        }
+    }
+
+    // </echoServerWithStats>
 }

--- a/src/core/Akka.Tests/IO/TcpListenerSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpListenerSpec.cs
@@ -28,7 +28,8 @@ namespace Akka.Tests.IO
                      akka.io.tcp.direct-buffer-size = 512
                      akka.actor.serialize-creators = on
                      akka.io.tcp.batch-accept-limit = 2")
-        { }
+        {
+        }
 
         [Fact]
         public async Task A_TCP_Listener_must_let_the_bind_commander_know_when_binding_is_complete()
@@ -36,7 +37,7 @@ namespace Akka.Tests.IO
             await new TestSetup(this, pullMode: false).RunAsync(async x =>
             {
                 await x.BindCommander.ExpectMsgAsync<Tcp.Bound>();
-            });           
+            });
         }
 
         [Fact]
@@ -52,9 +53,25 @@ namespace Akka.Tests.IO
         }
 
         [Fact]
+        public async Task A_TCP_Listener_must_provide_metrics()
+        {
+            await new TestSetup(this, pullMode: false).RunAsync(async x =>
+            {
+                await x.BindListener();
+
+                await x.AttemptConnectionToEndpoint();
+                var probe = CreateTestProbe();
+                x.Listener.Tell(new Tcp.SubscribeToTcpListenerStats(probe.Ref));
+                var metrics = await probe.ExpectMsgAsync<Tcp.TcpListenerStatistics>();
+
+                Assert.Equal(1, metrics.AcceptedIncomingConnections);
+            });
+        }
+
+        [Fact]
         public async Task A_TCP_Listener_must_react_to_unbind_commands_by_replying_with_unbound_and_stopping_itself()
         {
-            await new TestSetup(this, pullMode:false).RunAsync(async x =>
+            await new TestSetup(this, pullMode: false).RunAsync(async x =>
             {
                 await x.BindListener();
 
@@ -63,38 +80,36 @@ namespace Akka.Tests.IO
 
                 await unbindCommander.ExpectMsgAsync(Tcp.Unbound.Instance);
                 await x.Parent.ExpectTerminatedAsync(x.Listener);
-            });    
+            });
         }
 
-        class TestSetup
+        private class TestSetup
         {
             private readonly TestKitBase _kit;
-            private readonly bool _pullMode;
 
             private readonly TestProbe _handler;
             private readonly IActorRef _handlerRef;
-            private readonly TestProbe _bindCommander;
-            private readonly TestProbe _parent;
             private readonly TestActorRef<ListenerParent> _parentRef;
-            
+
             public TestSetup(TestKitBase kit, bool pullMode)
             {
                 _kit = kit;
-                _pullMode = pullMode;
 
                 _handler = kit.CreateTestProbe();
                 _handlerRef = _handler.Ref;
-                _bindCommander = kit.CreateTestProbe();
-                _parent = kit.CreateTestProbe();
+                BindCommander = kit.CreateTestProbe();
+                Parent = kit.CreateTestProbe();
                 SelectorRouter = kit.CreateTestProbe();
 
-                _parentRef = new TestActorRef<ListenerParent>(kit.Sys, Props.Create(() => new ListenerParent(this, pullMode)));
+                _parentRef =
+                    new TestActorRef<ListenerParent>(kit.Sys, Props.Create(() => new ListenerParent(this, pullMode)));
             }
 
             public void Run(Action<TestSetup> test)
             {
                 test(this);
             }
+
             public async Task RunAsync(Func<TestSetup, Task> test)
             {
                 await test(this);
@@ -102,7 +117,7 @@ namespace Akka.Tests.IO
 
             public async Task BindListener()
             {
-                var bound = await _bindCommander.ExpectMsgAsync<Tcp.Bound>();
+                var bound = await BindCommander.ExpectMsgAsync<Tcp.Bound>();
                 LocalEndPoint = (IPEndPoint)bound.LocalAddress;
             }
 
@@ -112,12 +127,15 @@ namespace Akka.Tests.IO
                     .ConnectAsync(LocalEndPoint);
             }
 
-            public IActorRef Listener { get { return _parentRef.UnderlyingActor.Listener; } }
+            public IActorRef Listener
+            {
+                get { return _parentRef.UnderlyingActor.Listener; }
+            }
 
             public TestProbe SelectorRouter { get; }
 
-            public TestProbe BindCommander { get { return _bindCommander; } }
-            public TestProbe Parent { get { return _parent; } }
+            public TestProbe BindCommander { get; }
+            public TestProbe Parent { get; }
 
             public IPEndPoint LocalEndPoint { get; private set; }
 
@@ -138,25 +156,28 @@ namespace Akka.Tests.IO
                     var endpoint = new IPEndPoint(IPAddress.Loopback, 0);
 
                     _listener = Context.ActorOf(Props.Create(() =>
-                        new TcpListener(
-                            Tcp.For(Context.System),
-                            test._bindCommander.Ref,
-                            new Tcp.Bind(
-                                _test._handler.Ref, 
-                                endpoint, 
-                                100, 
-                                new Inet.SocketOption[]{ new TestSocketOption(socket => _test.AfterBind(socket)) }, 
-                                pullMode)))
+                            new TcpListener(
+                                Tcp.For(Context.System),
+                                test.BindCommander.Ref,
+                                new Tcp.Bind(
+                                    _test._handler.Ref,
+                                    endpoint,
+                                    100,
+                                    new Inet.SocketOption[] { new TestSocketOption(socket => _test.AfterBind(socket)) },
+                                    pullMode)))
                         .WithDeploy(Deploy.Local));
-                    
-                    _test._parent.Watch(_listener);
+
+                    _test.Parent.Watch(_listener);
                 }
 
-                internal IActorRef Listener { get { return _listener; } }
+                internal IActorRef Listener
+                {
+                    get { return _listener; }
+                }
 
                 protected override bool Receive(object message)
                 {
-                    _test._parent.Forward(message);
+                    _test.Parent.Forward(message);
                     return true;
                 }
 

--- a/src/core/Akka.Tests/IO/TcpListenerSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpListenerSpec.cs
@@ -13,21 +13,24 @@ using Akka.Actor;
 using Akka.IO;
 using Akka.TestKit;
 using Xunit;
+using Xunit.Abstractions;
 using TcpListener = Akka.IO.TcpListener;
 
 namespace Akka.Tests.IO
 {
     public class TcpListenerSpec : AkkaSpec
     {
-        public TcpListenerSpec()
-            : base(@"
-                     akka.actor.serialize-creators = on
-                     akka.actor.serialize-messages = on
-                     akka.io.tcp.register-timeout = 500ms
-                     akka.io.tcp.max-received-message-size = 1024
-                     akka.io.tcp.direct-buffer-size = 512
-                     akka.actor.serialize-creators = on
-                     akka.io.tcp.batch-accept-limit = 2")
+        public TcpListenerSpec(ITestOutputHelper output)
+            : base("""
+
+                                        akka.actor.serialize-creators = on
+                                        akka.actor.serialize-messages = on
+                                        akka.io.tcp.register-timeout = 500ms
+                                        akka.io.tcp.max-received-message-size = 1024
+                                        akka.io.tcp.direct-buffer-size = 512
+                                        akka.actor.serialize-creators = on
+                                        akka.io.tcp.batch-accept-limit = 2
+                   """, output)
         {
         }
 
@@ -59,12 +62,27 @@ namespace Akka.Tests.IO
             {
                 await x.BindListener();
 
-                await x.AttemptConnectionToEndpoint();
+                var socket = await x.AttemptConnectionToEndpoint();
+                await x.Handler.ExpectMsgAsync<Tcp.Connected>();
+
                 var probe = CreateTestProbe();
                 x.Listener.Tell(new Tcp.SubscribeToTcpListenerStats(probe.Ref));
                 var metrics = await probe.ExpectMsgAsync<Tcp.TcpListenerStatistics>();
 
                 Assert.Equal(1, metrics.AcceptedIncomingConnections);
+                //
+                // // close the socket
+                // socket.Close();
+                // socket.Dispose();
+                //
+                // // wait for the connection to be closed
+                // await x.Handler.ExpectMsgAsync<Tcp.ConnectionClosed>();
+                //
+                // // force the listener to publish stats
+                // x.Listener.Tell(TcpListener.PublishStats.Instance);
+                // metrics = await probe.ExpectMsgAsync<Tcp.TcpListenerStatistics>();
+                // Assert.Equal(1, metrics.AcceptedIncomingConnections);
+                // Assert.Equal(1, metrics.IncomingConnectionsClosed);
             });
         }
 
@@ -121,10 +139,12 @@ namespace Akka.Tests.IO
                 LocalEndPoint = (IPEndPoint)bound.LocalAddress;
             }
 
-            public async Task AttemptConnectionToEndpoint()
+            public async Task<Socket> AttemptConnectionToEndpoint()
             {
-                await new Socket(LocalEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)
+                var s = new Socket(LocalEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+                await s
                     .ConnectAsync(LocalEndPoint);
+                return s;
             }
 
             public IActorRef Listener
@@ -136,6 +156,8 @@ namespace Akka.Tests.IO
 
             public TestProbe BindCommander { get; }
             public TestProbe Parent { get; }
+
+            public TestProbe Handler => _handler;
 
             public IPEndPoint LocalEndPoint { get; private set; }
 

--- a/src/core/Akka/IO/Tcp.cs
+++ b/src/core/Akka/IO/Tcp.cs
@@ -76,6 +76,7 @@ namespace Akka.IO
         }
 
         #endregion
+        
 
         /// <summary>
         /// Akka.IO Tcp messages are all derived from this class.
@@ -83,6 +84,51 @@ namespace Akka.IO
         public class Message : INoSerializationVerificationNeeded { }
 
         #region user commands
+        
+        /// <summary>
+        /// Queries against Akka.IO.Tcp class types
+        /// </summary>
+        public interface ITcpQuery : INoSerializationVerificationNeeded{}
+
+        /// <summary>
+        /// Subscribe to receive ongoing statistics from a TCP listener. See <see cref="TcpListenerStatistics" />
+        /// </summary>
+        public sealed record SubscribeToTcpListenerStats(IActorRef Subscriber) : ITcpQuery;
+        
+        /// <summary>
+        /// Unsubscribe from receiving ongoing statistics from a TCP listener.
+        /// </summary>
+        public sealed record UnsubscribeFromTcpListenerStats(IActorRef Subscriber) : ITcpQuery;
+        
+        /// <summary>
+        /// A set of statistics from a specific TCP listener.
+        /// </summary>
+        /// <remarks>
+        /// These are ongoing, rolling statistics that are updated as the listener
+        /// processes incoming connections. They will not reset unless the listener is killed.
+        /// </remarks>
+        public sealed record TcpListenerStatistics : ITcpQuery
+        {
+            /// <summary>
+            /// Total number of accepted incoming connections
+            /// </summary>
+            public long AcceptedIncomingConnections { get; init; }
+            
+            /// <summary>
+            /// Incoming connections that could not be accepted
+            /// </summary>
+            public long FailedIncomingConnections { get; init; }
+            
+            /// <summary>
+            /// Incoming connections that had to be retried
+            /// </summary>
+            public long RetriedIncomingConnections { get; init; }
+            
+            /// <summary>
+            /// Total number of incoming connections that were closed
+            /// </summary>
+            public long IncomingConnectionsClosed { get; init; }
+        }
 
         // COMMANDS
         

--- a/src/core/Akka/IO/TcpListener.cs
+++ b/src/core/Akka/IO/TcpListener.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Net.Sockets;
 using Akka.Actor;
 using Akka.Dispatch;
@@ -38,7 +39,7 @@ namespace Akka.IO
     ///
     /// TcpListener is an internal actor that binds to a local address and listens for incoming TCP connections.
     /// </summary>
-    internal sealed class TcpListener : ActorBase, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>
+    internal sealed class TcpListener : ActorBase, IRequiresMessageQueue<IUnboundedMessageQueueSemantics>, IWithTimers
     {
         private readonly TcpExt _tcp;
         private readonly IActorRef _bindCommander; // forwarded destination for Connected
@@ -49,6 +50,43 @@ namespace Akka.IO
         private SocketAsyncActorEventArgs[]? _acceptPool;
         private bool _binding;
         private static readonly EventHandler<SocketAsyncEventArgs> OnCompleted = OnIoCompleted;
+
+        private long _acceptCount;
+        private long _failedCount;
+        private long _retryCount;
+        private long _closedCount;
+
+        private readonly HashSet<IActorRef> _subscribers = [];
+
+        /// <summary>
+        /// Internal for testing purposes
+        /// </summary>
+        internal sealed class PublishStats
+        {
+            private PublishStats()
+            {
+            }
+
+            public static PublishStats Instance { get; } = new();
+        }
+
+        private sealed class BindCommanderDied
+        {
+            private BindCommanderDied()
+            {
+            }
+
+            public static BindCommanderDied Instance { get; } = new();
+        }
+
+        private sealed class ConnectionTerminated
+        {
+            private ConnectionTerminated()
+            {
+            }
+
+            public static ConnectionTerminated Instance { get; } = new();
+        }
 
         private sealed record AcceptCompleted(SocketAsyncEventArgs EventArgs) : INoSerializationVerificationNeeded;
 
@@ -63,15 +101,73 @@ namespace Akka.IO
             if (_acceptLimit <= 0)
             {
                 _log.Warning("Batch accept limit is set to {0}, which is less than or equal to 0. " +
-                             "This value will HANG the listener.", _acceptLimit);;
+                             "This value will HANG the listener.", _acceptLimit);
+                ;
 
                 _acceptLimit = TcpSettings.DefaultAcceptLimit;
                 _log.Warning("Using default value of {0} for batch accept limit", _acceptLimit);
             }
-            
+
             _bindCommander = bindCommander;
 
             Self.Tell(bind);
+        }
+
+        protected override void PreStart()
+        {
+            // periodically publish stats updates to subscribers
+            Timers.StartPeriodicTimer("PublishStats", PublishStats.Instance, TimeSpan.FromSeconds(10));
+        }
+
+        private Tcp.TcpListenerStatistics GetTcpListenerStats()
+        {
+            return new Tcp.TcpListenerStatistics()
+            {
+                AcceptedIncomingConnections = _acceptCount,
+                FailedIncomingConnections = _failedCount,
+                RetriedIncomingConnections = _retryCount,
+                IncomingConnectionsClosed = _closedCount
+            };
+        }
+
+        private bool HandleStatsMessages(object msg)
+        {
+            switch (msg)
+            {
+                case PublishStats:
+                    {
+                        // send stats to all subscribers
+                        var stats = GetTcpListenerStats();
+                        foreach (var subscriber in _subscribers)
+                        {
+                            subscriber.Tell(stats);
+                        }
+                    }   
+                    return true;
+
+                case Tcp.SubscribeToTcpListenerStats subscribe:
+                    if (_subscribers.Add(subscribe.Subscriber))
+                    {
+                        // send some stats immediately
+                        var stats = GetTcpListenerStats();
+                        subscribe.Subscriber.Tell(stats);
+
+                        // set up automatic unsubscribe
+                        Context.WatchWith(subscribe.Subscriber,
+                            new Tcp.UnsubscribeFromTcpListenerStats(subscribe.Subscriber));
+                    }
+                    return true;
+
+                case Tcp.UnsubscribeFromTcpListenerStats unsubscribe:
+                    _subscribers.Remove(unsubscribe.Subscriber);
+                    return true;
+
+                case ConnectionTerminated:
+                    _closedCount++;
+                    return true;
+            }
+
+            return false;
         }
 
         private Receive Bound() => message =>
@@ -99,8 +195,14 @@ namespace Akka.IO
                     _log.Error(failure.Cause, "Received SocketAsyncEventArgs failure");
                     return true;
 
+
+                case BindCommanderDied:
+                    _log.Warning("Bind commander died, stopping listener");
+                    Context.Stop(Self);
+                    return true;
+
                 default:
-                    return false;
+                    return HandleStatsMessages(message);
             }
         };
 
@@ -119,8 +221,15 @@ namespace Akka.IO
                     Context.Stop(Self);
                     return true;
 
+                case ConnectionTerminated:
+                    _closedCount++;
+                    return true;
+
+                case BindCommanderDied: // no-op
+                    return true;
+
                 default:
-                    return false;
+                    return HandleStatsMessages(message);
             }
         };
 
@@ -159,11 +268,15 @@ namespace Akka.IO
             switch (saea.SocketError)
             {
                 case SocketError.Success:
+                    _acceptCount++;
                     var accepted = saea.AcceptSocket!;
                     saea.AcceptSocket = null; // ready for re‑use
-                    Context.ActorOf(Props
+                    var incomingConnection = Context.ActorOf(Props
                         .Create<TcpIncomingConnection>(_tcp, accepted, _bind.Handler, _bind.Options, _bind.PullMode)
                         .WithDeploy(Deploy.Local));
+
+                    // set up the watch for monitoring purposes
+                    Context.WatchWith(incomingConnection, ConnectionTerminated.Instance);
                     StartAccept(saea); // keep the pool full
                     break;
 
@@ -172,12 +285,16 @@ namespace Akka.IO
                 case SocketError.TryAgain:
                 case SocketError.TimedOut:
                 case SocketError.WouldBlock:
+                    _retryCount++;
+                    _log.Warning("Retriable socket error in TcpListener: {0} - retrying accept operation in 10ms",
+                        saea.SocketError);
                     // transient – short back‑off then retry
                     saea.AcceptSocket = null;
                     Context.System.Scheduler.ScheduleTellOnce(TimeSpan.FromMilliseconds(10), Self,
                         new RetryAccept(saea), ActorRefs.NoSender);
                     break;
                 default:
+                    _failedCount++;
                     _log.Error("Fatal socket error in TcpListener: {0}", saea.SocketError);
                     Context.Stop(Self);
                     break;
@@ -262,7 +379,7 @@ namespace Akka.IO
                     return true;
 
                 case Tcp.Bound bound:
-                    Context.Watch(_bind.Handler);
+                    Context.WatchWith(_bind.Handler, BindCommanderDied.Instance);
                     _bindCommander.Tell(bound);
                     Become(Bound());
                     _binding = false;
@@ -292,5 +409,7 @@ namespace Akka.IO
                 _log.Debug("Error closing ServerSocketChannel: {0}", e);
             }
         }
+
+        public ITimerScheduler Timers { get; set; }
     }
 }

--- a/src/core/Akka/IO/TcpListener.cs
+++ b/src/core/Akka/IO/TcpListener.cs
@@ -221,10 +221,6 @@ namespace Akka.IO
                     Context.Stop(Self);
                     return true;
 
-                case ConnectionTerminated:
-                    _closedCount++;
-                    return true;
-
                 case BindCommanderDied: // no-op
                     return true;
 


### PR DESCRIPTION
## Changes

This enables the `Akka.IO.TcpListener` to periodically publish connectivity statistics to subscribers on `10s` intervals - designed to help create telemetry for servers built on top of Akka.IO.

close #7631

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7631
* [x] Changes in public API reviewed, if any.
* [x] I have added website documentation for this feature.