### PR TITLE
Akka.Benchmarks: adding `ActorPath.GetHashCode` benchmarks

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Actor/ActorPathBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorPathBenchmarks.cs
@@ -10,19 +10,24 @@ using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using BenchmarkDotNet.Attributes;
 using static Akka.Benchmarks.Configurations.BenchmarkCategories;
+using BenchmarkDotNet.Configs;
 
 namespace Akka.Benchmarks.Actor
 {
     [Config(typeof(MicroBenchmarkConfig))]
     public class ActorPathBenchmarks
     {
-        private ActorPath x;
-        private ActorPath y;
+        private ActorPath _x;
+        private ActorPath _y;
         private ActorPath _childPath;
-        private Address _sysAdr = new("akka.tcp", "system", "127.0.0.1", 1337);
-        private Address _otherAdr = new("akka.tcp", "system", "127.0.0.1", 1338);
+        private readonly Address _sysAdr = new("akka.tcp", "system", "127.0.0.1", 1337);
+        private readonly Address _otherAdr = new("akka.tcp", "system", "127.0.0.1", 1338);
 
         private string _actorPathStr;
+        private ActorPath _mediumPath;
+        private ActorPath _complexPath;
+
+        private const string HashCodeCategory = "ActorPathHashCodeBenchmark";
         
         [Params(1, 100000, int.MaxValue)]
         public int Uid { get; set; }
@@ -30,11 +35,22 @@ namespace Akka.Benchmarks.Actor
         [GlobalSetup]
         public void Setup()
         {
-            x = new RootActorPath(_sysAdr, "user");
-            y = new RootActorPath(_sysAdr, "system");
-            var parentPath = x / "parent";
+            _x = new RootActorPath(_sysAdr, "user");
+            _y = new RootActorPath(_sysAdr, "system");
+            var parentPath = _x / "parent";
             _childPath = new ChildActorPath(parentPath, "child", Uid);
             _actorPathStr = _childPath.ToSerializationFormat();
+
+            // Medium complexity: /user/parent/child/grandchild
+            _mediumPath = _x / "parent" / "child" / "grandchild";
+
+            // Complex: deeply nested, long names
+            var complex = _x;
+            for (int i = 0; i < 20; i++)
+            {
+                complex /= ("segment_" + i.ToString("D2") + new string('x', 10));
+            }
+            _complexPath = complex;
         }
 
         [Benchmark]
@@ -48,14 +64,14 @@ namespace Akka.Benchmarks.Actor
         [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public ActorPath ActorPath_Concat()
         {
-            return x / "parent" / "child";
+            return _x / "parent" / "child";
         }
         
         [Benchmark]
         [BenchmarkCategory(MicroBenchmark, AkkaActorBenchmark)]
         public bool ActorPath_Equals()
         {
-            return x == y;
+            return _x == _y;
         }
 
         [Benchmark]
@@ -77,6 +93,30 @@ namespace Akka.Benchmarks.Actor
         public string ActorPath_ToSerializationFormatWithAddress()
         {
             return _childPath.ToSerializationFormatWithAddress(_otherAdr);
+        }
+
+        [Benchmark(Baseline = true)]
+        [BenchmarkCategory(HashCodeCategory)]
+        public int ActorPath_GetHashCode_Baseline()
+        {
+            // Simple root path
+            return _x.GetHashCode();
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(HashCodeCategory)]
+        public int ActorPath_GetHashCode_Medium()
+        {
+            // Medium complexity path
+            return _mediumPath.GetHashCode();
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(HashCodeCategory)]
+        public int ActorPath_GetHashCode_Complex()
+        {
+            // Deeply nested, long names
+            return _complexPath.GetHashCode();
         }
     }
 }

--- a/src/benchmark/Akka.Benchmarks/Actor/ActorPathBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Actor/ActorPathBenchmarks.cs
@@ -28,9 +28,8 @@ namespace Akka.Benchmarks.Actor
         private ActorPath _complexPath;
 
         private const string HashCodeCategory = "ActorPathHashCodeBenchmark";
-        
-        [Params(1, 100000, int.MaxValue)]
-        public int Uid { get; set; }
+
+        public int Uid { get; set; } = 10000;
 
         [GlobalSetup]
         public void Setup()


### PR DESCRIPTION
## Changes

this is the primary cost driver for `IActorRef.GetHashCode`, which gets used everywhere

### This PR's Benchmarks

```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.26100.4061)
12th Gen Intel Core i7-1260P, 1 CPU, 16 logical and 12 physical cores
.NET SDK 8.0.403
  [Host]     : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.14 (8.0.1425.11118), X64 RyuJIT AVX2
```

| Method                                     | Uid        | Mean       | Error     | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------------------------------------- |----------- |-----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
| ActorPath_GetHashCode_Baseline             | 1          |  19.443 ns | 0.2654 ns | 0.2482 ns |  1.00 |    0.00 |      - |         - |          NA |
| ActorPath_GetHashCode_Medium               | 1          |  33.618 ns | 0.6254 ns | 0.5850 ns |  1.73 |    0.05 |      - |         - |          NA |
| ActorPath_GetHashCode_Complex              | 1          | 236.194 ns | 4.0690 ns | 3.3978 ns | 12.12 |    0.18 |      - |         - |          NA |
| ActorPath_Parse                            | 1          | 155.480 ns | 1.6629 ns | 1.3886 ns |  7.98 |    0.12 | 0.0441 |     416 B |          NA |
| ActorPath_Concat                           | 1          |  24.562 ns | 0.4901 ns | 0.3826 ns |  1.26 |    0.02 | 0.0119 |     112 B |          NA |
| ActorPath_Equals                           | 1          |   1.402 ns | 0.0568 ns | 0.0557 ns |  0.07 |    0.00 |      - |         - |          NA |
| ActorPath_ToString                         | 1          |  27.408 ns | 0.7282 ns | 2.0299 ns |  1.40 |    0.08 | 0.0119 |     112 B |          NA |
| ActorPath_ToSerializationFormat            | 1          |  33.767 ns | 1.0141 ns | 2.9096 ns |  1.91 |    0.10 | 0.0127 |     120 B |          NA |
| ActorPath_ToSerializationFormatWithAddress | 1          |  30.524 ns | 0.6542 ns | 1.4082 ns |  1.56 |    0.07 | 0.0127 |     120 B |          NA |
|                                            |            |            |           |           |       |         |        |           |             |
| ActorPath_GetHashCode_Baseline             | 100000     |  19.393 ns | 0.2098 ns | 0.1752 ns |  1.00 |    0.00 |      - |         - |          NA |
| ActorPath_GetHashCode_Medium               | 100000     |  33.522 ns | 0.3546 ns | 0.3317 ns |  1.73 |    0.03 |      - |         - |          NA |
| ActorPath_GetHashCode_Complex              | 100000     | 248.719 ns | 4.7059 ns | 9.6128 ns | 12.37 |    0.59 |      - |         - |          NA |
| ActorPath_Parse                            | 100000     | 150.317 ns | 2.7309 ns | 2.2804 ns |  7.75 |    0.11 | 0.0441 |     416 B |          NA |
| ActorPath_Concat                           | 100000     |  24.162 ns | 0.5328 ns | 1.4853 ns |  1.22 |    0.09 | 0.0119 |     112 B |          NA |
| ActorPath_Equals                           | 100000     |   1.395 ns | 0.0562 ns | 0.1400 ns |  0.07 |    0.01 |      - |         - |          NA |
| ActorPath_ToString                         | 100000     |  27.096 ns | 0.5946 ns | 1.6277 ns |  1.50 |    0.04 | 0.0119 |     112 B |          NA |
| ActorPath_ToSerializationFormat            | 100000     |  37.477 ns | 0.7938 ns | 1.8239 ns |  1.95 |    0.12 | 0.0136 |     128 B |          NA |
| ActorPath_ToSerializationFormatWithAddress | 100000     |  37.141 ns | 0.7915 ns | 1.8810 ns |  1.92 |    0.07 | 0.0136 |     128 B |          NA |
|                                            |            |            |           |           |       |         |        |           |             |
| ActorPath_GetHashCode_Baseline             | 2147483647 |  21.738 ns | 0.4395 ns | 0.4703 ns |  1.00 |    0.00 |      - |         - |          NA |
| ActorPath_GetHashCode_Medium               | 2147483647 |  37.504 ns | 0.2642 ns | 0.2472 ns |  1.72 |    0.05 |      - |         - |          NA |
| ActorPath_GetHashCode_Complex              | 2147483647 | 269.709 ns | 5.2110 ns | 5.7920 ns | 12.42 |    0.34 |      - |         - |          NA |
| ActorPath_Parse                            | 2147483647 | 173.871 ns | 3.5311 ns | 4.9502 ns |  8.05 |    0.30 | 0.0441 |     416 B |          NA |
| ActorPath_Concat                           | 2147483647 |  23.915 ns | 0.5846 ns | 1.7052 ns |  1.17 |    0.07 | 0.0119 |     112 B |          NA |
| ActorPath_Equals                           | 2147483647 |   1.359 ns | 0.0548 ns | 0.0870 ns |  0.07 |    0.00 |      - |         - |          NA |
| ActorPath_ToString                         | 2147483647 |  25.268 ns | 0.5499 ns | 1.3176 ns |  1.18 |    0.06 | 0.0119 |     112 B |          NA |
| ActorPath_ToSerializationFormat            | 2147483647 |  41.299 ns | 0.8218 ns | 1.5635 ns |  1.95 |    0.09 | 0.0144 |     136 B |          NA |
| ActorPath_ToSerializationFormatWithAddress | 2147483647 |  39.174 ns | 0.5146 ns | 0.4814 ns |  1.80 |    0.05 | 0.0144 |     136 B |          NA |
