### PR TITLE
Akka.Benchmarks: run real duplex messaging over Akka.IO.Tcp

### DIFF
--- a/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -40,7 +41,7 @@ namespace Akka.Benchmarks
             _system = ActorSystem.Create("system", "akka.log-dead-letters = off");
             _message = new byte[MessageLength];
             
-            _server = _system.ActorOf(Props.Create(() => new EchoServer()));
+            _server = _system.ActorOf(Props.Create(() => new EchoServer(MessageLength)));
             _clientCoordinator =
                 _system.ActorOf(Props.Create(() => new ClientCoordinator(_server, ClientsCount)));
         }
@@ -88,9 +89,10 @@ namespace Akka.Benchmarks
         private class EchoServer : ReceiveActor, IWithStash
         {
             private EndPoint? _endpoint;
-            
-            public EchoServer()
+            private readonly int _messageSize;
+            public EchoServer(int messageSize)
             {
+                _messageSize = messageSize;
                 Context.System.Tcp().Tell(new Tcp.Bind(Self, new IPEndPoint(IPAddress.Loopback, 0)));
 
                 Receive<Tcp.Bound>(bound =>
@@ -124,7 +126,7 @@ namespace Akka.Benchmarks
             {
                 Receive<Tcp.Connected>(_ =>
                 {
-                    var connection = Context.ActorOf(Props.Create(() => new EchoConnection(Sender)));
+                    var connection = Context.ActorOf(Props.Create(() => new EchoConnection(Sender, _messageSize)));
                     Sender.Tell(new Tcp.Register(connection));
                 });
                 
@@ -156,9 +158,19 @@ namespace Akka.Benchmarks
 
         private class EchoConnection : ReceiveActor
         {
-            public EchoConnection(IActorRef connection)
+            private readonly Framer _fr;
+            
+            public EchoConnection(IActorRef connection, int messageSize)
             {
-                Receive<Tcp.Received>(received => { connection.Tell(Tcp.Write.Create(received.Data)); });
+                _fr = new Framer(messageSize);
+                Receive<Tcp.Received>(received =>
+                { 
+                    foreach(var m in _fr.Deframe(received.Data))
+                    {
+                        // echo the message back
+                        connection.Tell(Tcp.Write.Create(m));
+                    }
+                });
             }
         }
 
@@ -256,12 +268,59 @@ namespace Akka.Benchmarks
             public IStash Stash { get; set; }
         }
 
+        private sealed class Framer
+        {
+            private readonly int _messageSize;
+            private ByteString _partialRead = ByteString.Empty;
+
+            public Framer(int messageSize)
+            {
+                _messageSize = messageSize;
+            }
+
+            public IEnumerable<ByteString> Deframe(ByteString data)
+            {
+                var totalSize = _partialRead.Count + data.Count;
+                if (totalSize < _messageSize)
+                {
+                    _partialRead = _partialRead.Concat(data);
+                    return [];
+                }
+
+                var msgs = new List<ByteString>();
+                if (_partialRead.Count > 0)
+                {
+                    var msg1 = _partialRead.Concat(data[..(_messageSize - _partialRead.Count)]);
+                    msgs.Add(msg1);
+                        
+                    data = data[(_messageSize - _partialRead.Count)..];
+                    _partialRead = ByteString.Empty;
+                }
+                    
+                var remaining = data.Count % _messageSize;
+                var count = data.Count - remaining;
+                for (var i = 0; i < count; i += _messageSize)
+                {
+                    msgs.Add(data.Slice(i, _messageSize));
+                }
+                    
+                if (remaining > 0)
+                {
+                    _partialRead = data.Slice(count, remaining);
+                }
+                    
+                return msgs;
+            }
+        }
+
         private class Client : ReceiveActor, IWithTimers
         {
             private readonly ILoggingAdapter _log = Context.GetLogger();
             private int _receivedCount = 0;
             private IActorRef _connection;
             private int _connectAttemptsRemaining = 5;
+            
+            private Framer _framer;
 
             private class RetryConnect
             {
@@ -271,9 +330,11 @@ namespace Akka.Benchmarks
                 {
                 }
             }
+            
 
             public Client(EndPoint endpoint, int messagesToSend, byte[] message)
             {
+                _framer = new Framer(message.Length);
                 var write =
                     // create the write only once
                     Tcp.Write.Create(ByteString.FromBytes(message));
@@ -318,14 +379,17 @@ namespace Akka.Benchmarks
                 });
                 Receive<Tcp.Received>(r =>
                 {
-                    _receivedCount++;
-                    if (_receivedCount >= messagesToSend)
+                    foreach (var m in _framer.Deframe(r.Data))
                     {
-                        _connection.Tell(Tcp.Close.Instance);
-                    }
-                    else
-                    {
-                        _connection.Tell(write);
+                        _receivedCount++;
+                        if (_receivedCount >= messagesToSend)
+                        {
+                            _connection.Tell(Tcp.Close.Instance);
+                        }
+                        else
+                        {
+                            _connection.Tell(write);
+                        }
                     }
                 });
                 Receive<Tcp.Closed>(_ => { Context.Parent.Tell(new ChildCommunicationFinished()); });

--- a/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
@@ -296,17 +296,17 @@ namespace Akka.Benchmarks
                     data = data[(_messageSize - _partialRead.Count)..];
                     _partialRead = ByteString.Empty;
                 }
-                    
-                var remaining = data.Count % _messageSize;
-                var count = data.Count - remaining;
+                
+                var remainingBytes = data.Count % _messageSize;
+                var count = data.Count / _messageSize;
                 for (var i = 0; i < count; i += _messageSize)
                 {
                     msgs.Add(data.Slice(i, _messageSize));
                 }
                     
-                if (remaining > 0)
+                if (remainingBytes > 0)
                 {
-                    _partialRead = data.Slice(count, remaining);
+                    _partialRead = data.Slice(count, remainingBytes);
                 }
                     
                 return msgs;

--- a/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
@@ -37,7 +37,7 @@ namespace Akka.Benchmarks
         [GlobalSetup]
         public void Setup()
         {
-            _system = ActorSystem.Create("system");
+            _system = ActorSystem.Create("system", "akka.log-dead-letters = off");
             _message = new byte[MessageLength];
             
             _server = _system.ActorOf(Props.Create(() => new EchoServer()));
@@ -197,8 +197,6 @@ namespace Akka.Benchmarks
                     // stash messages until we have the endpoint
                     Stash.Stash();
                 });
-                
-                
             }
 
             private void ServerDiedHandler()
@@ -284,7 +282,12 @@ namespace Akka.Benchmarks
                 Receive<Tcp.Connected>(_ =>
                 {
                     Sender.Tell(new Tcp.Register(Self));
-                    Sender.Tell(Tcp.Write.Create(ByteString.FromBytes(message)));
+                    
+                    // send messages in bursts of 20
+                    for (var i = 0; i < 20; i++)
+                    {
+                        Sender.Tell(write);
+                    }
                     _connection = Sender;
                 });
                 Receive<RetryConnect>(_ => { DoConnect(endpoint); });

--- a/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -20,6 +19,7 @@ using Tcp = Akka.IO.Tcp;
 namespace Akka.Benchmarks
 {
     [Config(typeof(MacroBenchmarkConfig))]
+    [MemoryDiagnoser]
     public class TcpOperationsBenchmarks
     {
         private ActorSystem _system;
@@ -27,7 +27,7 @@ namespace Akka.Benchmarks
         private IActorRef _server;
         private IActorRef _clientCoordinator;
         
-        public int MessageCount { get; } = 1_000_000;
+        public const int MessageCount = 1_000_000;
 
         [Params(10, 100)]
         public int MessageLength { get; set; }
@@ -52,7 +52,7 @@ namespace Akka.Benchmarks
             _system.Dispose();
         }
 
-        [Benchmark(OperationsPerInvoke = 10_000)]
+        [Benchmark(OperationsPerInvoke = MessageCount)]
         public async Task ClientServerCommunication()
         {
             await _clientCoordinator.Ask<CommunicationFinished>(new CommunicationRequest(MessageCount, _message));

--- a/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="TcpOperationsBenchmarks.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -14,6 +15,7 @@ using Akka.Benchmarks.Configurations;
 using Akka.Event;
 using Akka.IO;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
 using Tcp = Akka.IO.Tcp;
 
 namespace Akka.Benchmarks
@@ -24,8 +26,6 @@ namespace Akka.Benchmarks
     {
         private ActorSystem _system;
         private byte[] _message;
-        private IActorRef _server;
-        private IActorRef _clientCoordinator;
         
         public const int MessageCount = 1_000_000;
 
@@ -40,10 +40,6 @@ namespace Akka.Benchmarks
         {
             _system = ActorSystem.Create("system", "akka.log-dead-letters = off");
             _message = new byte[MessageLength];
-            
-            _server = _system.ActorOf(Props.Create(() => new EchoServer(MessageLength)));
-            _clientCoordinator =
-                _system.ActorOf(Props.Create(() => new ClientCoordinator(_server, ClientsCount)));
         }
 
         [GlobalCleanup]
@@ -52,9 +48,30 @@ namespace Akka.Benchmarks
             _system.Dispose();
         }
 
+        private IActorRef _server;
+        private IActorRef _clientCoordinator;
+        
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            // Create new server and client before each iteration measurement
+            _server = _system.ActorOf(Props.Create(() => new EchoServer(MessageLength)));
+            _clientCoordinator = _system.ActorOf(Props.Create(() => new ClientCoordinator(_server, ClientsCount)));
+        }
+        
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            // Clean up actors after each iteration measurement
+            var clientStop = _clientCoordinator.GracefulStop(TimeSpan.FromSeconds(3));
+            var serverStop = _server.GracefulStop(TimeSpan.FromSeconds(3));
+            Task.WhenAll(clientStop, serverStop).Wait();
+        }
+        
         [Benchmark(OperationsPerInvoke = MessageCount)]
         public async Task ClientServerCommunication()
         {
+            // Only the communication is measured, not setup/teardown
             await _clientCoordinator.Ask<CommunicationFinished>(new CommunicationRequest(MessageCount, _message));
         }
 

--- a/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
@@ -280,35 +280,27 @@ namespace Akka.Benchmarks
 
             public IEnumerable<ByteString> Deframe(ByteString data)
             {
-                var totalSize = _partialRead.Count + data.Count;
-                if (totalSize < _messageSize)
+                // Prepend any partial read from last time
+                if (_partialRead.Count > 0)
                 {
-                    _partialRead = _partialRead.Concat(data);
-                    return [];
+                    data = _partialRead.Concat(data);
+                    _partialRead = ByteString.Empty;
                 }
 
                 var msgs = new List<ByteString>();
-                if (_partialRead.Count > 0)
+                int offset = 0;
+                while (offset + _messageSize <= data.Count)
                 {
-                    var msg1 = _partialRead.Concat(data[..(_messageSize - _partialRead.Count)]);
-                    msgs.Add(msg1);
-                        
-                    data = data[(_messageSize - _partialRead.Count)..];
-                    _partialRead = ByteString.Empty;
+                    msgs.Add(data.Slice(offset, _messageSize));
+                    offset += _messageSize;
                 }
-                
-                var remainingBytes = data.Count % _messageSize;
-                var count = data.Count / _messageSize;
-                for (var i = 0; i < count; i += _messageSize)
+
+                // Buffer any remaining bytes for next time
+                if (offset < data.Count)
                 {
-                    msgs.Add(data.Slice(i, _messageSize));
+                    _partialRead = data.Slice(offset, data.Count - offset);
                 }
-                    
-                if (remainingBytes > 0)
-                {
-                    _partialRead = data.Slice(count, remainingBytes);
-                }
-                    
+
                 return msgs;
             }
         }

--- a/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/IO/TcpOperationsBenchmarks.cs
@@ -27,7 +27,7 @@ namespace Akka.Benchmarks
         private IActorRef _server;
         private IActorRef _clientCoordinator;
         
-        public int MessageCount { get; } = 10_000;
+        public int MessageCount { get; } = 1_000_000;
 
         [Params(10, 100)]
         public int MessageLength { get; set; }

--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -579,7 +579,14 @@ namespace Akka.IO
             else
             {
                 if (_traceLogging) Log.Debug("Got Close command, closing connection.");
-                Socket.Shutdown(SocketShutdown.Both);
+                try
+                {
+                    Socket.Shutdown(SocketShutdown.Both);
+                }
+                catch (SocketException e)
+                {
+                     Log.Error("Socket shutdown failed with [{0}]", e);
+                }
                 DoCloseConnection(info, closeCommander, closedEvent);
             }
         }


### PR DESCRIPTION
## Changes

This is a more realistic test of how fast the system can go, is more similar to real world usage, and is also what we do inside `RemotePingPong`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

```
BenchmarkDotNet v0.13.12, Pop!_OS 22.04 LTS
13th Gen Intel Core i7-1360P, 1 CPU, 16 logical and 12 physical cores
.NET SDK 8.0.404
  [Host]  : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2
  LongRun : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2

Job=LongRun  Concurrent=True  Server=True
InvocationCount=1  IterationCount=10  LaunchCount=3
RunStrategy=Monitoring  UnrollFactor=1  WarmupCount=3
```

| Method                    | MessageLength | ClientsCount | Mean      | Error     | StdDev    | Req/sec    |
|-------------------------- |-------------- |------------- |----------:|----------:|----------:|-----------:|
| ClientServerCommunication | 10            | 1            | 28.126 us | 0.9439 us | 1.4129 us |  35,554.20 |
| ClientServerCommunication | 10            | 3            | 14.388 us | 2.1218 us | 3.1758 us |  69,502.83 |
| ClientServerCommunication | 10            | 5            | 11.058 us | 0.9752 us | 1.4597 us |  90,435.79 |
| ClientServerCommunication | 10            | 7            |  8.393 us | 0.5154 us | 0.7715 us | 119,148.80 |
| ClientServerCommunication | 10            | 10           |  6.226 us | 0.4926 us | 0.7372 us | 160,626.16 |
| ClientServerCommunication | 10            | 20           |  4.470 us | 0.4500 us | 0.6735 us | 223,712.48 |
| ClientServerCommunication | 10            | 30           |  4.412 us | 0.4499 us | 0.6734 us | 226,655.74 |
| ClientServerCommunication | 10            | 40           |  4.270 us | 0.4029 us | 0.6031 us | 234,208.44 |
| ClientServerCommunication | 100           | 1            | 24.766 us | 0.8864 us | 1.3267 us |  40,378.29 |
| ClientServerCommunication | 100           | 3            | 13.921 us | 2.0134 us | 3.0135 us |  71,833.61 |
| ClientServerCommunication | 100           | 5            | 11.419 us | 0.8069 us | 1.2077 us |  87,572.40 |
| ClientServerCommunication | 100           | 7            |  8.471 us | 0.4339 us | 0.6494 us | 118,049.74 |
| ClientServerCommunication | 100           | 10           |  6.204 us | 0.4274 us | 0.6397 us | 161,194.43 |
| ClientServerCommunication | 100           | 20           |  4.123 us | 0.3477 us | 0.5204 us | 242,515.72 |
| ClientServerCommunication | 100           | 30           |  4.584 us | 0.7039 us | 1.0536 us | 218,138.99 |
| ClientServerCommunication | 100           | 40           |  4.176 us | 0.3487 us | 0.5219 us | 239,474.87 |

### This PR's Benchmarks

```
BenchmarkDotNet v0.13.12, Pop!_OS 22.04 LTS
13th Gen Intel Core i7-1360P, 1 CPU, 16 logical and 12 physical cores
.NET SDK 8.0.404
  [Host]  : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2
  LongRun : .NET 8.0.11 (8.0.1124.51707), X64 RyuJIT AVX2

Job=LongRun  Concurrent=True  Server=True
InvocationCount=1  IterationCount=10  LaunchCount=3
RunStrategy=Monitoring  UnrollFactor=1  WarmupCount=3
```

| Method                    | MessageLength | ClientsCount | Mean      | Error     | StdDev    | Req/sec    |
|-------------------------- |-------------- |------------- |----------:|----------:|----------:|-----------:|
| ClientServerCommunication | 10            | 1            | 27.580 us | 1.4212 us | 2.1273 us |  36,258.00 |
| ClientServerCommunication | 10            | 3            | 14.604 us | 2.8916 us | 4.3280 us |  68,474.99 |
| ClientServerCommunication | 10            | 5            | 10.568 us | 1.0643 us | 1.5930 us |  94,629.43 |
| ClientServerCommunication | 10            | 7            |  8.305 us | 0.5406 us | 0.8092 us | 120,406.16 |
| ClientServerCommunication | 10            | 10           |  6.416 us | 0.5650 us | 0.8457 us | 155,870.32 |
| ClientServerCommunication | 10            | 20           |  4.676 us | 0.6057 us | 0.9067 us | 213,846.83 |
| ClientServerCommunication | 10            | 30           |  4.537 us | 0.6251 us | 0.9356 us | 220,414.60 |
| ClientServerCommunication | 10            | 40           |  4.323 us | 0.3606 us | 0.5398 us | 231,317.10 |
| ClientServerCommunication | 100           | 1            | 24.559 us | 1.0431 us | 1.5612 us |  40,719.05 |
| ClientServerCommunication | 100           | 3            | 14.427 us | 2.2594 us | 3.3817 us |  69,315.43 |
| ClientServerCommunication | 100           | 5            | 10.264 us | 1.0891 us | 1.6301 us |  97,428.32 |
| ClientServerCommunication | 100           | 7            |  8.062 us | 0.5350 us | 0.8007 us | 124,034.27 |
| ClientServerCommunication | 100           | 10           |  6.339 us | 0.4514 us | 0.6757 us | 157,748.27 |
| ClientServerCommunication | 100           | 20           |  4.491 us | 0.4884 us | 0.7311 us | 222,675.95 |
| ClientServerCommunication | 100           | 30           |  4.170 us | 0.5644 us | 0.8448 us | 239,827.56 |
| ClientServerCommunication | 100           | 40           |  4.235 us | 0.4853 us | 0.7264 us | 236,104.87 |