### PR TITLE
Akka.Cluster.Tools: `DistributedPubSubMediator` topic names with URI-unfriendly characters

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorUriEncodingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorUriEncodingSpec.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Cluster.Tools.PublishSubscribe;
+using Akka.Configuration;
+using Akka.TestKit;
+using Akka.TestKit.Xunit2;
+using Xunit;
+using FluentAssertions;
+
+namespace Akka.Cluster.Tools.Tests.PublishSubscribe
+{
+    public class DistributedPubSubMediatorUriEncodingSpec : AkkaSpec
+    {
+        public DistributedPubSubMediatorUriEncodingSpec() 
+            : base(ConfigurationFactory.ParseString(@"
+                akka.actor.provider = cluster
+                akka.remote.dot-netty.tcp.port = 0
+                akka.cluster.pub-sub.max-delta-elements = 50
+                akka.cluster.pub-sub.log-buffer-size = 1000").WithFallback(TestKitBase.DefaultConfig))
+        {
+        }
+
+        [Fact]
+        public async Task DistributedPubSubMediator_Should_Handle_Topic_Names_With_Special_Characters()
+        {
+            // Arrange
+            var pubSubMediator = DistributedPubSub.Get(Sys).Mediator;
+            
+            // Act & Assert - Topic with colon
+            await TestTopicWithSpecialCharacter(pubSubMediator, "parent:child");
+            
+            // Act & Assert - Topic with forward slash
+            await TestTopicWithSpecialCharacter(pubSubMediator, "parent/child");
+            
+            // Act & Assert - Topic with question mark
+            await TestTopicWithSpecialCharacter(pubSubMediator, "parent?child");
+            
+            // Act & Assert - Topic with hash
+            await TestTopicWithSpecialCharacter(pubSubMediator, "parent#child");
+            
+            // Act & Assert - Topic with percent sign
+            await TestTopicWithSpecialCharacter(pubSubMediator, "parent%child");
+            
+            // Act & Assert - Topic with plus sign
+            await TestTopicWithSpecialCharacter(pubSubMediator, "parent+child");
+            
+            // Act & Assert - Topic with at sign
+            await TestTopicWithSpecialCharacter(pubSubMediator, "parent@child");
+        }
+        
+        private async Task TestTopicWithSpecialCharacter(IActorRef pubSubMediator, string topic)
+        {
+            // Arrange
+            var probe = CreateTestProbe();
+            var message = new TestMessage($"Hello from {topic}");
+            
+            // Subscribe to the topic with special character
+            await pubSubMediator.Ask<SubscribeAck>(
+                new Subscribe(topic, probe.Ref));
+            
+            // Act - publish a message to the topic
+            pubSubMediator.Tell(new Publish(topic, message));
+            
+            // Assert - the message should be received
+            probe.ExpectMsg<TestMessage>(m => 
+                m.Content == message.Content, 
+                TimeSpan.FromSeconds(3), 
+                $"Failed to receive message for topic: {topic}");
+        }
+        
+        private class TestMessage
+        {
+            public TestMessage(string content)
+            {
+                Content = content;
+            }
+            
+            public string Content { get; }
+        }
+    }
+} 

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
@@ -211,6 +211,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             {
                 var encodedTopic = _cache.EncodeName(publish.Topic);
                 var key = _cache.MakeKey(Self.Path, encodedTopic);
+                
                 if (publish.SendOneMessageToEachGroup)
                     PublishToEachGroup(key, publish);
                 else
@@ -249,14 +250,21 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             {
                 // each topic is managed by a child actor with the same name as the topic
                 var encodedTopic = _cache.EncodeName(subscribe.Topic);
-
+                var key = _cache.MakeKey(Self.Path, encodedTopic);
+                
                 _buffer.BufferOr(_cache.MakeKey(Self.Path, encodedTopic), subscribe, Sender, () =>
                 {
                     var child = Context.Child(encodedTopic);
+                    
                     if (!child.IsNobody())
+                    {
                         child.Forward(subscribe);
+                    }
                     else
-                        NewTopicActor(encodedTopic).Forward(subscribe);
+                    {
+                        var newActor = NewTopicActor(encodedTopic);
+                        newActor.Forward(subscribe);
+                    }
                 });
             });
             Receive<RegisterTopic>(register =>
@@ -785,12 +793,14 @@ namespace Akka.Cluster.Tools.PublishSubscribe
 
         private IActorRef NewTopicActor(string encodedTopic)
         {
-            var t = Context.ActorOf(
+            _log.Debug("Creating new topic actor with encoded name: '{0}'", encodedTopic);
+            var a = Context.ActorOf(
                 Actor.Props.Create(() => new Topic(_settings.RemovedTimeToLive, _settings.RoutingLogic, _settings.SendToDeadLettersWhenNoSubscribers))
                     .WithDeploy(Deploy.Local), 
                 encodedTopic);
-            HandleRegisterTopic(t);
-            return t;
+            _log.Debug("Created new topic actor: '{0}'", a.Path);
+            HandleRegisterTopic(a);
+            return a;
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
@@ -380,15 +380,23 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static string MakeKey(this PubSubCache cache, ActorPath path, string topic)
+        public static string MakeKey(this PubSubCache cache, ActorPath path, string encodedTopic)
         {
-            var info = new MakeKeyInfo(path, topic);
+            var info = new MakeKeyInfo(path, encodedTopic);
             if(cache.MakeKeyMap.TryGetValue(info, out var key))
+            {
                 return key;
+            }
             
-            key = PathRegex.Replace((path / topic).ToStringWithoutAddress(), "$1");
+            // Create the path string representation first, then append the encoded topic
+            // This avoids any issues with the / operator possibly double-encoding or otherwise mishandling 
+            // already encoded topic names
+            var pathString = path.ToStringWithoutAddress();
+            key = PathRegex.Replace(pathString + "/" + encodedTopic, "$1");
+            
             cache.MakeKeyMap[info] = key;
             cache.MakeKeyReverseMap[key] = info;
+            
             return key;
         }
 
@@ -428,6 +436,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
             encoded = Uri.EscapeDataString(name);
             cache.TopicToEncodedMap[name] = encoded;
             cache.EncodedToTopicMap[encoded] = name;
+            
             return encoded;
         }
 


### PR DESCRIPTION
## Changes

Fix issue #7628: DistributedPubSubMediator fails with URI-unfriendly topic names

## Issue
The DistributedPubSubMediator fails to properly handle topic names containing URI-unfriendly characters like colons, slashes, question marks, etc. These characters are already URI-encoded when passed to the `MakeKey` method, but then the ActorPath `/` operator was being used, potentially causing double-encoding or other URI handling issues.

## Root Cause
In `Topics.cs`, the `MakeKey` method was using the ActorPath `/` operator with an already encoded topic name:
```csharp
key = PathRegex.Replace((path / encodedTopic).ToStringWithoutAddress(), "$1");
```

This approach can cause URI encoding problems because the `/` operator on ActorPath might perform additional encoding or mishandle already encoded strings.

## Fix
Modified the `MakeKey` method to construct the path manually by:
1. Getting the string representation of the path first
2. Manually appending the encoded topic with a separator:
```csharp
var pathString = path.ToStringWithoutAddress();
key = PathRegex.Replace(pathString + "/" + encodedTopic, "$1");
```

## Testing

Added a dedicated test case `DistributedPubSubMediatorUriEncodingSpec.cs` that verifies:
- Subscription works with special characters in topic names
- Publishing to topics with special characters works correctly
- Messages are properly delivered to subscribers

Tested with the following special characters in topic names:
- Colon (parent:child)
- Forward slash (parent/child)
- Question mark (parent?child)
- Hash (parent#child)
- Percent sign (parent%child)
- Plus sign (parent+child)
- At sign (parent@child)

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7628
* [ ] Changes in public API reviewed, if any.
