### PR TITLE
Allow sharding delivery consumer to passivate self

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/DurableRememberEntitiesShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/DurableRememberEntitiesShardingSpec.cs
@@ -33,6 +33,7 @@ public class DurableRememberEntitiesShardingSpec : AkkaSpec
         akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.inmem"
         akka.remote.dot-netty.tcp.port = 0
         
+        akka.cluster.sharding.remember-entities = on
         akka.cluster.sharding.state-store-mode = ddata
         # no leaks between test runs thank you
         akka.cluster.sharding.distributed-data.durable.keys = []

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/DurableRememberEntitiesShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/DurableRememberEntitiesShardingSpec.cs
@@ -1,0 +1,139 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DurableShardingSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Dsl;
+using Akka.Cluster.Sharding.Delivery;
+using Akka.Configuration;
+using Akka.Delivery;
+using Akka.Event;
+using Akka.Persistence.Delivery;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+using FluentAssertions;
+using static Akka.Tests.Delivery.TestConsumer;
+
+namespace Akka.Cluster.Sharding.Tests.Delivery;
+
+public class DurableRememberEntitiesShardingSpec : AkkaSpec
+{
+    private static readonly Config Config = 
+        """
+        akka.loglevel = DEBUG
+        akka.actor.provider = cluster
+        akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+        akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.inmem"
+        akka.remote.dot-netty.tcp.port = 0
+        
+        akka.cluster.sharding.state-store-mode = ddata
+        # no leaks between test runs thank you
+        akka.cluster.sharding.distributed-data.durable.keys = []
+        akka.cluster.sharding.verbose-debug-logging = on
+        akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
+        akka.cluster.sharding.entity-restart-backoff = 250ms
+        """;
+
+    public DurableRememberEntitiesShardingSpec(ITestOutputHelper output) : base(Config, output)
+    {
+        // TODO: add journal operations subscriptions, once that's properly supported in Akka.Persistence
+    }
+
+    private int _idCount;
+
+    private string ProducerId => $"p-{_idCount}";
+
+    private int NextId()
+    {
+        return _idCount++;
+    }
+
+    private async Task JoinCluster()
+    {
+        var cluster = Cluster.Get(Sys);
+        await cluster.JoinAsync(cluster.SelfAddress);
+        await AwaitAssertAsync(() => Assert.True(cluster.IsUp));
+    }
+
+    [Fact]
+    public async Task ReliableDelivery_with_remember_entity_sharding_must_allow_consumer_to_passivate_self_using_Passivate()
+    {
+        await JoinCluster();
+        NextId();
+
+        var consumerProbe = CreateTestProbe();
+        var sharding = await ClusterSharding.Get(system: Sys).StartAsync(
+            typeName: $"TestConsumer-{_idCount}", 
+            entityPropsFactory: _ => ShardingConsumerController.Create<Job>(
+                c => Props.Create(() => new Consumer(c, consumerProbe)),
+                ShardingConsumerController.Settings.Create(Sys)), settings: ClusterShardingSettings.Create(Sys),
+            messageExtractor: HashCodeMessageExtractor.Create(10, o => string.Empty, o => o));
+
+        var durableQueueProps = EventSourcedProducerQueue.Create<Job>(ProducerId, Sys);
+        var shardingProducerController = Sys.ActorOf(
+            props: ShardingProducerController.Create<Job>(
+                ProducerId, sharding, durableQueueProps, ShardingProducerController.Settings.Create(Sys)), 
+            name: $"shardingProducerController-{_idCount}");
+        var producerProbe = CreateTestProbe();
+        shardingProducerController.Tell(new ShardingProducerController.Start<Job>(producerProbe.Ref));
+        
+        var replyProbe = CreateTestProbe();
+        var next = await producerProbe.ExpectMsgAsync<ShardingProducerController.RequestNext<Job>>();
+        next.AskNextTo(
+            msgWithConfirmation: new ShardingProducerController.MessageWithConfirmation<Job>(EntityId: "entity-1", Message: new Job("ping"),
+            ReplyTo: replyProbe.Ref));
+        await replyProbe.ExpectMsgAsync<Done>();
+
+        consumerProbe.ExpectMsg("pong");
+        var entity = consumerProbe.LastSender;
+        await consumerProbe.WatchAsync(entity);
+        
+        next = await producerProbe.ExpectMsgAsync<ShardingProducerController.RequestNext<Job>>();
+        next.AskNextTo(
+            msgWithConfirmation: new ShardingProducerController.MessageWithConfirmation<Job>(EntityId: "entity-1", Message: new Job("passivate"),
+                ReplyTo: replyProbe.Ref));
+        await replyProbe.ExpectMsgAsync<Done>();
+        
+        consumerProbe.ExpectMsg("passivate");
+        await consumerProbe.ExpectTerminatedAsync(entity);
+    }
+
+    private class Consumer : ReceiveActor
+    {
+        private readonly IActorRef _consumerController;
+        public Consumer(IActorRef consumerController, IActorRef consumerProbe)
+        {
+            _consumerController = consumerController;
+
+            Receive<ConsumerController.Delivery<Job>>(delivery =>
+            {
+                Sender.Tell(ConsumerController.Confirmed.Instance);
+                switch (delivery.Message.Payload)
+                {
+                    case "stop":
+                        Context.Stop(Self);
+                        break;
+                    case "ping":
+                        consumerProbe.Tell("pong");
+                        break;
+                    case "passivate":
+                        consumerProbe.Tell("passivate");
+                        Context.Parent.Tell(new Passivate(PoisonPill.Instance));
+                        break;
+                }
+            });
+        }
+
+        protected override void PreStart()
+        {
+            _consumerController.Tell(new ConsumerController.Start<Job>(Self));
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/Internal/ShardingConsumerControllerImpl.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/Internal/ShardingConsumerControllerImpl.cs
@@ -69,6 +69,11 @@ internal class ShardingConsumerController<T> : ReceiveActor, IWithStash
             _log.Debug("Consumer terminated before initialized.");
             Context.Stop(Self);
         });
+
+        Receive<Passivate>(_ => Sender.Equals(_consumer), p =>
+        {
+            Context.Parent.Tell(p);
+        });
         
         ReceiveAny(msg =>
         {
@@ -140,6 +145,11 @@ internal class ShardingConsumerController<T> : ReceiveActor, IWithStash
                     _log.Debug("Unknown [{0}] terminated.", t.ActorRef);
                 }
             }
+        });
+
+        Receive<Passivate>(_ => Sender.Equals(_consumer), p =>
+        {
+            Context.Parent.Tell(p);
         });
         
         ReceiveAny(msg =>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/Internal/ShardingConsumerControllerImpl.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/Internal/ShardingConsumerControllerImpl.cs
@@ -72,7 +72,21 @@ internal class ShardingConsumerController<T> : ReceiveActor, IWithStash
 
         Receive<Passivate>(_ => Sender.Equals(_consumer), p =>
         {
-            Context.Parent.Tell(p);
+            // only consume message if remember entities is enabled
+            if(ClusterSharding.Get(Context.System).Settings.RememberEntities)
+            {
+                Context.Parent.Tell(p);
+            }
+            else if(Settings.AllowBypass)
+            {
+                // I don't know why the consumer would want to do this, but preserve the old behavior
+                _consumer.Forward(p);
+            }
+            else
+            {
+                _log.Warning($"Message unhandled [{p}]. If you need to pass this message to the consumer sharding entity actor, set \"akka.reliable-delivery.sharding.consumer-controller.allow-bypass\" to true");
+                Unhandled(p);
+            }
         });
         
         ReceiveAny(msg =>
@@ -149,7 +163,21 @@ internal class ShardingConsumerController<T> : ReceiveActor, IWithStash
 
         Receive<Passivate>(_ => Sender.Equals(_consumer), p =>
         {
-            Context.Parent.Tell(p);
+            // only consume message if remember entities is enabled
+            if(ClusterSharding.Get(Context.System).Settings.RememberEntities)
+            {
+                Context.Parent.Tell(p);
+            }
+            else if(Settings.AllowBypass)
+            {
+                // I don't know why the consumer would want to do this, but preserve the old behavior
+                _consumer.Forward(p);
+            }
+            else
+            {
+                _log.Warning($"Message unhandled [{p}]. If you need to pass this message to the consumer sharding entity actor, set \"akka.reliable-delivery.sharding.consumer-controller.allow-bypass\" to true");
+                Unhandled(p);
+            }
         });
         
         ReceiveAny(msg =>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/Internal/ShardingConsumerControllerImpl.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Delivery/Internal/ShardingConsumerControllerImpl.cs
@@ -72,21 +72,7 @@ internal class ShardingConsumerController<T> : ReceiveActor, IWithStash
 
         Receive<Passivate>(_ => Sender.Equals(_consumer), p =>
         {
-            // only consume message if remember entities is enabled
-            if(ClusterSharding.Get(Context.System).Settings.RememberEntities)
-            {
-                Context.Parent.Tell(p);
-            }
-            else if(Settings.AllowBypass)
-            {
-                // I don't know why the consumer would want to do this, but preserve the old behavior
-                _consumer.Forward(p);
-            }
-            else
-            {
-                _log.Warning($"Message unhandled [{p}]. If you need to pass this message to the consumer sharding entity actor, set \"akka.reliable-delivery.sharding.consumer-controller.allow-bypass\" to true");
-                Unhandled(p);
-            }
+            Context.Parent.Tell(p);
         });
         
         ReceiveAny(msg =>
@@ -163,21 +149,7 @@ internal class ShardingConsumerController<T> : ReceiveActor, IWithStash
 
         Receive<Passivate>(_ => Sender.Equals(_consumer), p =>
         {
-            // only consume message if remember entities is enabled
-            if(ClusterSharding.Get(Context.System).Settings.RememberEntities)
-            {
-                Context.Parent.Tell(p);
-            }
-            else if(Settings.AllowBypass)
-            {
-                // I don't know why the consumer would want to do this, but preserve the old behavior
-                _consumer.Forward(p);
-            }
-            else
-            {
-                _log.Warning($"Message unhandled [{p}]. If you need to pass this message to the consumer sharding entity actor, set \"akka.reliable-delivery.sharding.consumer-controller.allow-bypass\" to true");
-                Unhandled(p);
-            }
+            Context.Parent.Tell(p);
         });
         
         ReceiveAny(msg =>


### PR DESCRIPTION
Fixes #7664

Allows user Akka.Cluster.Sharding.Delivery remember entity consumer actor to use `Context.Parent.Tell(new Passivate())` message convention to passivate itself.

## Changes

* Add `Passivate` message handler in `ShardingConsumerController"

