### PR TITLE
Unset ActorCellKeepingSynchronizationContext in CallingThreadDispatcher

### DIFF
--- a/src/core/Akka.TestKit/ActorCellKeepingSynchronizationContext.cs
+++ b/src/core/Akka.TestKit/ActorCellKeepingSynchronizationContext.cs
@@ -22,8 +22,6 @@ namespace Akka.TestKit
     class ActorCellKeepingSynchronizationContext : SynchronizationContext
     {
         private readonly ActorCell _cell;
-        
-        internal static ActorCell AsyncCache { get; set; }
 
         /// <summary>
         /// TBD
@@ -46,7 +44,8 @@ namespace Akka.TestKit
                 var oldCell = InternalCurrentActorCellKeeper.Current;
                 var oldContext = Current;
                 SetSynchronizationContext(this);
-                InternalCurrentActorCellKeeper.Current = AsyncCache ?? _cell;
+
+                InternalCurrentActorCellKeeper.Current = _cell;
 
                 try
                 {

--- a/src/core/Akka.TestKit/CallingThreadDispatcher.cs
+++ b/src/core/Akka.TestKit/CallingThreadDispatcher.cs
@@ -58,13 +58,11 @@ namespace Akka.TestKit
 
             try
             {
-                // Actors should not run with ActorCellKeepingSynchronizationContext otherwise continuations in
-                // async message handlers will use ActorCellKeepingSynchronizationContext instead of ActorTaskScheduler
-                // which cause ActorContext to be incorrect.
-                if (currentSyncContext is ActorCellKeepingSynchronizationContext)
-                {
-                    SynchronizationContext.SetSynchronizationContext(null);
-                }
+                // Actors should not run with ActorCellKeepingSynchronizationContext
+                // (or any sync context that wraps ActorCellKeepingSynchronizationContext, e.g. Xunit's AsyncTestSyncContext)
+                // otherwise continuations in async message handlers will use ActorCellKeepingSynchronizationContext
+                // instead of ActorTaskScheduler which causes ActorContext to be incorrect.
+                SynchronizationContext.SetSynchronizationContext(null);
 
                 run.Run();
             }

--- a/src/core/Akka.TestKit/CallingThreadDispatcher.cs
+++ b/src/core/Akka.TestKit/CallingThreadDispatcher.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using Akka.Configuration;
 using Akka.Dispatch;
 
@@ -53,7 +54,24 @@ namespace Akka.TestKit
         
         protected override void ExecuteTask(IRunnable run)
         {
-            run.Run();
+            var currentSyncContext = SynchronizationContext.Current;
+
+            try
+            {
+                // Actors should not run with ActorCellKeepingSynchronizationContext otherwise continuations in
+                // async message handlers will use ActorCellKeepingSynchronizationContext instead of ActorTaskScheduler
+                // which cause ActorContext to be incorrect.
+                if (currentSyncContext is ActorCellKeepingSynchronizationContext)
+                {
+                    SynchronizationContext.SetSynchronizationContext(null);
+                }
+
+                run.Run();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(currentSyncContext);
+            }
         }
         
         protected override void Shutdown()

--- a/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
+++ b/src/core/Akka.TestKit/Internal/InternalTestActorRef.cs
@@ -323,18 +323,6 @@ namespace Akka.TestKit.Internal
                 _testActorCell = (TestActorCell) testActorCell;
             }
 
-            /// <inheritdoc />
-            protected override void OnBeforeTaskStarted()
-            {
-                ActorCellKeepingSynchronizationContext.AsyncCache = _testActorCell;
-            }
-
-            /// <inheritdoc />
-            protected override void OnAfterTaskCompleted()
-            {
-                ActorCellKeepingSynchronizationContext.AsyncCache = null;
-            }
-
             public void OnTaskCompleted(object message, Exception exception)
             {
                 _taskCallback(message, exception);


### PR DESCRIPTION
Unset ActorCellKeepingSynchronizationContext in CallingThreadDispatcher before running actor's mailbox. Also remove ActorCellKeepingSynchronizationContext.AsyncCache property.

Fixes #

## Changes

Please provide a brief description of the changes here.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [x] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
