### PR TITLE
Add shutdown reason to exit code propagation

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -400,6 +400,7 @@ namespace Akka.Actor
         public abstract Akka.Actor.IScheduler Scheduler { get; }
         public abstract Akka.Serialization.Serialization Serialization { get; }
         public abstract Akka.Actor.Settings Settings { get; }
+        public abstract Akka.Actor.CoordinatedShutdown.Reason ShutdownReason { get; }
         public System.TimeSpan StartTime { get; }
         public System.TimeSpan Uptime { get; }
         public abstract System.Threading.Tasks.Task WhenTerminated { get; }
@@ -579,30 +580,41 @@ namespace Akka.Actor
         public class ActorSystemTerminateReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
         public class ClrExitReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
         public class ClusterDowningReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
         public class ClusterJoinUnsuccessfulReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
         public class ClusterLeavingReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
-        public class Reason
+        public abstract class Reason
         {
             protected Reason() { }
+            public abstract int ExitCode { get; }
+            public static string GetReason(int code) { }
+            public static void RegisterReason(int code, string reason) { }
+            public override string ToString() { }
+            public static bool TryGetReason(int code, out string reason) { }
         }
         public class UnknownReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
     }
     public sealed class CoordinatedShutdownExtension : Akka.Actor.ExtensionIdProvider<Akka.Actor.CoordinatedShutdown>
@@ -2025,6 +2037,7 @@ namespace Akka.Actor.Internal
         public override Akka.Actor.IScheduler Scheduler { get; }
         public override Akka.Serialization.Serialization Serialization { get; }
         public override Akka.Actor.Settings Settings { get; }
+        public override Akka.Actor.CoordinatedShutdown.Reason ShutdownReason { get; }
         public override Akka.Actor.IInternalActorRef SystemGuardian { get; }
         public override System.Threading.Tasks.Task WhenTerminated { get; }
         public override void Abort() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -400,6 +400,7 @@ namespace Akka.Actor
         public abstract Akka.Actor.IScheduler Scheduler { get; }
         public abstract Akka.Serialization.Serialization Serialization { get; }
         public abstract Akka.Actor.Settings Settings { get; }
+        public abstract Akka.Actor.CoordinatedShutdown.Reason ShutdownReason { get; }
         public System.TimeSpan StartTime { get; }
         public System.TimeSpan Uptime { get; }
         public abstract System.Threading.Tasks.Task WhenTerminated { get; }
@@ -579,30 +580,41 @@ namespace Akka.Actor
         public class ActorSystemTerminateReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
         public class ClrExitReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
         public class ClusterDowningReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
         public class ClusterJoinUnsuccessfulReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
         public class ClusterLeavingReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
-        public class Reason
+        public abstract class Reason
         {
             protected Reason() { }
+            public abstract int ExitCode { get; }
+            public static string GetReason(int code) { }
+            public static void RegisterReason(int code, string reason) { }
+            public override string ToString() { }
+            public static bool TryGetReason(int code, out string reason) { }
         }
         public class UnknownReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
+            public override int ExitCode { get; }
         }
     }
     public sealed class CoordinatedShutdownExtension : Akka.Actor.ExtensionIdProvider<Akka.Actor.CoordinatedShutdown>
@@ -2023,6 +2035,7 @@ namespace Akka.Actor.Internal
         public override Akka.Actor.IScheduler Scheduler { get; }
         public override Akka.Serialization.Serialization Serialization { get; }
         public override Akka.Actor.Settings Settings { get; }
+        public override Akka.Actor.CoordinatedShutdown.Reason ShutdownReason { get; }
         public override Akka.Actor.IInternalActorRef SystemGuardian { get; }
         public override System.Threading.Tasks.Task WhenTerminated { get; }
         public override void Abort() { }

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -214,10 +214,10 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public async Task ActorSystem_exit_code_must_be_OK_on_terminate()
+        public async Task ActorSystem_shutdown_reason_must_be_Ok()
         {
-            var shutdownResult = await Sys.Terminate();
-            shutdownResult.Should().Be((int)CoordinatedShutdown.CommonExitCodes.Ok);
+            await Sys.Terminate();
+            Sys.ShutdownReason.ExitCode.Should().Be(0);
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -221,14 +221,6 @@ namespace Akka.Tests.Actor
         }
 
         [Fact]
-        public async Task ActorSystem_exit_code_must_be_ABORT_on_abort()
-        {
-            ((ExtendedActorSystem)Sys).Abort();
-            var shutdownResult = await Sys.WhenTerminated;
-            shutdownResult.Should().Be((int)CoordinatedShutdown.CommonExitCodes.Abort);
-        }
-
-        [Fact]
         public async Task Reliably_create_waves_of_actors()
         {
             var timeout = Dilated(TimeSpan.FromSeconds(20));

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -23,6 +23,7 @@ using Akka.Event;
 using Akka.TestKit.Extensions;
 using FluentAssertions.Execution;
 using Akka.Tests.Util;
+using FluentAssertions;
 
 namespace Akka.Tests.Actor
 {
@@ -210,6 +211,21 @@ namespace Akka.Tests.Actor
             
             var ex = Assert.Throws<InvalidOperationException>(() => actorSystem.RegisterOnTermination(() => { }));
             Assert.Equal("ActorSystem already terminated.", ex.Message);
+        }
+
+        [Fact]
+        public async Task ActorSystem_exit_code_must_be_OK_on_terminate()
+        {
+            var shutdownResult = await Sys.Terminate();
+            shutdownResult.Should().Be((int)CoordinatedShutdown.CommonExitCodes.Ok);
+        }
+
+        [Fact]
+        public async Task ActorSystem_exit_code_must_be_ABORT_on_abort()
+        {
+            ((ExtendedActorSystem)Sys).Abort();
+            var shutdownResult = await Sys.WhenTerminated;
+            shutdownResult.Should().Be((int)CoordinatedShutdown.CommonExitCodes.Abort);
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
+++ b/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
@@ -71,10 +71,10 @@ namespace Akka.Tests.Actor
             // Intentionally running as a detached task
             _ = CoordinatedShutdown.Get(Sys).Run(customReason);
 
-            var systemResult = await Sys.WhenTerminated.WaitAsync(TimeSpan.FromSeconds(10));
-            systemResult.Should().Be(CustomReason.CustomExitCode);
+            await Sys.WhenTerminated.WaitAsync(TimeSpan.FromSeconds(10));
+            Sys.ShutdownReason.ExitCode.Should().Be(CustomReason.CustomExitCode);
 
-            Reason.TryGetReason(systemResult, out var reason).Should().BeTrue();
+            Reason.TryGetReason(Sys.ShutdownReason.ExitCode, out var reason).Should().BeTrue();
             reason.Should().Be(CustomReason.CustomMessage);
         }
 

--- a/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
+++ b/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
@@ -53,10 +53,30 @@ namespace Akka.Tests.Actor
 
         private class CustomReason : CoordinatedShutdown.Reason
         {
+            public const int CustomExitCode = 999;
+            public const string CustomMessage = "Custom Exit Code";
+            static CustomReason()
+            {
+                Reason.RegisterReason(CustomExitCode, CustomMessage);
+            }
+            
+            public override int ExitCode => CustomExitCode;
         }
 
         private static CoordinatedShutdown.Reason customReason = new CustomReason();
 
+        [Fact]
+        public async Task CoordinatedShutdown_must_set_ActorSystem_exit_code_to_Reason_ExitCode()
+        {
+            // Intentionally running as a detached task
+            _ = CoordinatedShutdown.Get(Sys).Run(customReason);
+
+            var systemResult = await Sys.WhenTerminated.WaitAsync(TimeSpan.FromSeconds(10));
+            systemResult.Should().Be(CustomReason.CustomExitCode);
+
+            Reason.TryGetReason(systemResult, out var reason).Should().BeTrue();
+            reason.Should().Be(CustomReason.CustomMessage);
+        }
 
         [Fact]
         public void CoordinatedShutdown_must_sort_phases_in_topological_order()

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -362,9 +362,9 @@ namespace Akka.Actor
         /// <returns>
         /// A <see cref="Task"/> that will complete once the actor system has finished terminating and all actors are stopped.
         /// </returns>
-        public abstract Task<int> Terminate();
+        public abstract Task Terminate();
 
-        internal abstract Task<int> FinalTerminate();
+        internal abstract Task FinalTerminate();
 
         /// <summary>
         /// Returns a task which will be completed after the <see cref="ActorSystem"/> has been
@@ -372,8 +372,10 @@ namespace Akka.Actor
         /// operations on the `dispatcher` of this actor system as it will have been shut down
         /// before this task completes.
         /// </summary>
-        public abstract Task<int> WhenTerminated { get; }
+        public abstract Task WhenTerminated { get; }
 
+        public abstract CoordinatedShutdown.Reason ShutdownReason { get; }
+        
         /// <summary>
         /// Stops the specified actor permanently.
         /// </summary>

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -364,7 +364,7 @@ namespace Akka.Actor
         /// </returns>
         public abstract Task<int> Terminate();
 
-        internal abstract Task<int> FinalTerminate(int exitCode);
+        internal abstract Task<int> FinalTerminate();
 
         /// <summary>
         /// Returns a task which will be completed after the <see cref="ActorSystem"/> has been

--- a/src/core/Akka/Actor/ActorSystem.cs
+++ b/src/core/Akka/Actor/ActorSystem.cs
@@ -362,9 +362,9 @@ namespace Akka.Actor
         /// <returns>
         /// A <see cref="Task"/> that will complete once the actor system has finished terminating and all actors are stopped.
         /// </returns>
-        public abstract Task Terminate();
+        public abstract Task<int> Terminate();
 
-        internal abstract Task FinalTerminate();
+        internal abstract Task<int> FinalTerminate(int exitCode);
 
         /// <summary>
         /// Returns a task which will be completed after the <see cref="ActorSystem"/> has been
@@ -372,7 +372,7 @@ namespace Akka.Actor
         /// operations on the `dispatcher` of this actor system as it will have been shut down
         /// before this task completes.
         /// </summary>
-        public abstract Task WhenTerminated { get; }
+        public abstract Task<int> WhenTerminated { get; }
 
         /// <summary>
         /// Stops the specified actor permanently.

--- a/src/core/Akka/Actor/CoordinatedShutdown.cs
+++ b/src/core/Akka/Actor/CoordinatedShutdown.cs
@@ -168,11 +168,8 @@ namespace Akka.Actor
             Ok = 0,
             UnknownReason = 1,
             // Exit code 2 is reserved for Linux Bash for "Incorrect Usage"
-            Abort = 3,
-            ClrExit = 4,
-            ClusterDowned = 5,
-            ClusterLeft = 6,
-            ClusterJoinFailed = 7,
+            ClusterDowned = 3,
+            ClusterJoinFailed = 4,
             // Exit codes 64-78 is reserved by Linux sysexits.h
             // Exit codes 126 and above is reserved by Linux shell
         }
@@ -193,10 +190,7 @@ namespace Akka.Actor
                 {
                     [(int)CommonExitCodes.Ok] = "ActorSystem shutdown successfully",
                     [(int)CommonExitCodes.UnknownReason] = "Unknown shutdown reason",
-                    [(int)CommonExitCodes.Abort] = "ActorSystem aborted",
-                    [(int)CommonExitCodes.ClrExit] = "CLR exit",
                     [(int)CommonExitCodes.ClusterDowned] = "Cluster node downed",
-                    [(int)CommonExitCodes.ClusterLeft] = "Cluster node left the cluster",
                     [(int)CommonExitCodes.ClusterJoinFailed] = "Cluster join unsuccessful",
                 };
             }
@@ -241,7 +235,7 @@ namespace Akka.Actor
         {
             public static readonly Reason Instance = new ActorSystemTerminateReason();
 
-            public override int ExitCode => (byte)CommonExitCodes.Ok;
+            public override int ExitCode => (int)CommonExitCodes.Ok;
             private ActorSystemTerminateReason()
             {
             }
@@ -254,7 +248,7 @@ namespace Akka.Actor
         {
             public static readonly Reason Instance = new ClrExitReason();
 
-            public override int ExitCode => (byte)CommonExitCodes.ClrExit;
+            public override int ExitCode => (int)CommonExitCodes.Ok;
             private ClrExitReason()
             {
 
@@ -269,7 +263,7 @@ namespace Akka.Actor
         {
             public static readonly Reason Instance = new ClusterDowningReason();
 
-            public override int ExitCode => (byte)CommonExitCodes.ClusterDowned;
+            public override int ExitCode => (int)CommonExitCodes.ClusterDowned;
             private ClusterDowningReason()
             {
 
@@ -284,7 +278,7 @@ namespace Akka.Actor
         {
             public static readonly Reason Instance = new ClusterLeavingReason();
 
-            public override int ExitCode => (byte)CommonExitCodes.ClusterLeft;
+            public override int ExitCode => (int)CommonExitCodes.Ok;
             private ClusterLeavingReason()
             {
 
@@ -298,7 +292,7 @@ namespace Akka.Actor
         {
             public static readonly Reason Instance = new ClusterJoinUnsuccessfulReason();
             
-            public override int ExitCode => (byte)CommonExitCodes.ClusterJoinFailed;
+            public override int ExitCode => (int)CommonExitCodes.ClusterJoinFailed;
             private ClusterJoinUnsuccessfulReason() { }
         }
 
@@ -700,7 +694,6 @@ namespace Akka.Actor
                         {
                             if (!system.WhenTerminated.Wait(timeout) && !coord._runningClrHook)
                             {
-                                // TODO: We're forcefully stopping the process due to timeout, should this return 0?
                                 Environment.Exit(coord.ShutdownReason?.ExitCode ?? 0);
                             }
                         });
@@ -708,7 +701,7 @@ namespace Akka.Actor
 
                     if (terminateActorSystem)
                     {
-                        return system.FinalTerminate(coord.ShutdownReason?.ExitCode ?? 0).ContinueWith(_ =>
+                        return system.FinalTerminate().ContinueWith(_ =>
                         {
                             if (exitClr && !coord._runningClrHook)
                             {

--- a/src/core/Akka/Actor/CoordinatedShutdown.cs
+++ b/src/core/Akka/Actor/CoordinatedShutdown.cs
@@ -156,20 +156,69 @@ namespace Akka.Actor
         public const string PhaseBeforeActorSystemTerminate = "before-actor-system-terminate";
         public const string PhaseActorSystemTerminate = "actor-system-terminate";
 
-
+        /// <summary>
+        /// Common exit codes supported out of the box.
+        /// Note: When adding new exit codes, make sure that the exit code adheres
+        ///       to the Linux standard.
+        /// See: https://manpages.ubuntu.com/manpages/lunar/man3/sysexits.h.3head.html
+        /// See: https://manpages.ubuntu.com/manpages/noble/man3/EXIT_SUCCESS.3const.html
+        /// </summary>
+        internal enum CommonExitCodes
+        {
+            Ok = 0,
+            UnknownReason = 1,
+            // Exit code 2 is reserved for Linux Bash for "Incorrect Usage"
+            Abort = 3,
+            ClrExit = 4,
+            ClusterDowned = 5,
+            ClusterLeft = 6,
+            ClusterJoinFailed = 7,
+            // Exit codes 64-78 is reserved by Linux sysexits.h
+            // Exit codes 126 and above is reserved by Linux shell
+        }
 
         /// <summary>
-        /// Reason for the shutdown, which can be used by tasks in case they need to do
+        /// Reason for the shutdown, which tasks can use in case they need to do
         /// different things depending on what caused the shutdown. There are some
         /// predefined reasons, but external libraries applications may also define
         /// other reasons.
         /// </summary>
-        public class Reason
+        public abstract class Reason
         {
+            private static readonly Dictionary<int, string> ReasonMap;
+
+            static Reason()
+            {
+                ReasonMap = new Dictionary<int, string>
+                {
+                    [(int)CommonExitCodes.Ok] = "ActorSystem shutdown successfully",
+                    [(int)CommonExitCodes.UnknownReason] = "Unknown shutdown reason",
+                    [(int)CommonExitCodes.Abort] = "ActorSystem aborted",
+                    [(int)CommonExitCodes.ClrExit] = "CLR exit",
+                    [(int)CommonExitCodes.ClusterDowned] = "Cluster node downed",
+                    [(int)CommonExitCodes.ClusterLeft] = "Cluster node left the cluster",
+                    [(int)CommonExitCodes.ClusterJoinFailed] = "Cluster join unsuccessful",
+                };
+            }
+            
+            public abstract int ExitCode { get; }
+            
             protected Reason()
             {
 
             }
+            
+            public static void RegisterReason(int code, string reason)
+                => ReasonMap[code] = reason;
+
+            public static bool TryGetReason(int code, out string reason)
+                => ReasonMap.TryGetValue(code, out reason);
+
+            public static string GetReason(int code)
+                => ReasonMap.TryGetValue(code, out var reason) ? reason : $"Reason code not found: {code}";
+
+            public override string ToString()
+                => $"CoordinatedShutdown [{ExitCode}]: {GetReason(ExitCode)}";
         }
 
         /// <summary>
@@ -179,9 +228,9 @@ namespace Akka.Actor
         {
             public static readonly Reason Instance = new UnknownReason();
 
+            public override int ExitCode => (byte)CommonExitCodes.UnknownReason;
             private UnknownReason()
             {
-
             }
         }
 
@@ -192,9 +241,9 @@ namespace Akka.Actor
         {
             public static readonly Reason Instance = new ActorSystemTerminateReason();
 
+            public override int ExitCode => (byte)CommonExitCodes.Ok;
             private ActorSystemTerminateReason()
             {
-
             }
         }
 
@@ -205,6 +254,7 @@ namespace Akka.Actor
         {
             public static readonly Reason Instance = new ClrExitReason();
 
+            public override int ExitCode => (byte)CommonExitCodes.ClrExit;
             private ClrExitReason()
             {
 
@@ -219,6 +269,7 @@ namespace Akka.Actor
         {
             public static readonly Reason Instance = new ClusterDowningReason();
 
+            public override int ExitCode => (byte)CommonExitCodes.ClusterDowned;
             private ClusterDowningReason()
             {
 
@@ -233,6 +284,7 @@ namespace Akka.Actor
         {
             public static readonly Reason Instance = new ClusterLeavingReason();
 
+            public override int ExitCode => (byte)CommonExitCodes.ClusterLeft;
             private ClusterLeavingReason()
             {
 
@@ -245,6 +297,8 @@ namespace Akka.Actor
         public class ClusterJoinUnsuccessfulReason : Reason
         {
             public static readonly Reason Instance = new ClusterJoinUnsuccessfulReason();
+            
+            public override int ExitCode => (byte)CommonExitCodes.ClusterJoinFailed;
             private ClusterJoinUnsuccessfulReason() { }
         }
 
@@ -274,7 +328,7 @@ namespace Akka.Actor
         private readonly ConcurrentDictionary<string, ImmutableList<(string, Func<Task<Done>>)>> _tasks = new();
         private readonly AtomicReference<Reason> _runStarted = new(null);
         private readonly AtomicBoolean _clrHooksStarted = new(false);
-        private readonly TaskCompletionSource<Done> _runPromise = new();
+        private readonly TaskCompletionSource<int> _runPromise = new();
         private readonly TaskCompletionSource<Done> _hooksRunPromise = new();
 
         private volatile bool _runningClrHook = false;
@@ -395,7 +449,7 @@ namespace Akka.Actor
         /// <remarks>
         /// It is safe to call this method multiple times. It will only run the shutdown sequence once.
         /// </remarks>
-        public Task<Done> Run(Reason reason, string fromPhase = null)
+        public Task<int> Run(Reason reason, string fromPhase = null)
         {
             if (_runStarted.CompareAndSet(null, reason))
             {
@@ -516,7 +570,7 @@ namespace Akka.Actor
                 done.ContinueWith(tr =>
                 {
                     if (!tr.IsFaulted && !tr.IsCanceled)
-                        _runPromise.SetResult(tr.Result);
+                        _runPromise.SetResult(reason.ExitCode);
                     else
                     {
                         // ReSharper disable once PossibleNullReferenceException
@@ -646,32 +700,31 @@ namespace Akka.Actor
                         {
                             if (!system.WhenTerminated.Wait(timeout) && !coord._runningClrHook)
                             {
-                                Environment.Exit(0);
+                                // TODO: We're forcefully stopping the process due to timeout, should this return 0?
+                                Environment.Exit(coord.ShutdownReason?.ExitCode ?? 0);
                             }
                         });
                     }
 
                     if (terminateActorSystem)
                     {
-                        return system.FinalTerminate().ContinueWith(_ =>
+                        return system.FinalTerminate(coord.ShutdownReason?.ExitCode ?? 0).ContinueWith(_ =>
                         {
                             if (exitClr && !coord._runningClrHook)
                             {
-                                Environment.Exit(0);
+                                Environment.Exit(coord.ShutdownReason?.ExitCode ?? 0);
                             }
 
                             return Done.Instance;
                         });
                     }
-                    else if (exitClr)
+                    
+                    if (exitClr)
                     {
-                        Environment.Exit(0);
-                        return TaskEx.Completed;
+                        Environment.Exit(Get(system).ShutdownReason?.ExitCode ?? 0);
                     }
-                    else
-                    {
-                        return TaskEx.Completed;
-                    }
+                    
+                    return TaskEx.Completed;
                 });
             }
         }

--- a/src/core/Akka/Actor/CoordinatedShutdown.cs
+++ b/src/core/Akka/Actor/CoordinatedShutdown.cs
@@ -322,7 +322,7 @@ namespace Akka.Actor
         private readonly ConcurrentDictionary<string, ImmutableList<(string, Func<Task<Done>>)>> _tasks = new();
         private readonly AtomicReference<Reason> _runStarted = new(null);
         private readonly AtomicBoolean _clrHooksStarted = new(false);
-        private readonly TaskCompletionSource<int> _runPromise = new();
+        private readonly TaskCompletionSource<Done> _runPromise = new();
         private readonly TaskCompletionSource<Done> _hooksRunPromise = new();
 
         private volatile bool _runningClrHook = false;
@@ -443,7 +443,7 @@ namespace Akka.Actor
         /// <remarks>
         /// It is safe to call this method multiple times. It will only run the shutdown sequence once.
         /// </remarks>
-        public Task<int> Run(Reason reason, string fromPhase = null)
+        public Task<Done> Run(Reason reason, string fromPhase = null)
         {
             if (_runStarted.CompareAndSet(null, reason))
             {
@@ -564,7 +564,7 @@ namespace Akka.Actor
                 done.ContinueWith(tr =>
                 {
                     if (!tr.IsFaulted && !tr.IsCanceled)
-                        _runPromise.SetResult(reason.ExitCode);
+                        _runPromise.SetResult(tr.Result);
                     else
                     {
                         // ReSharper disable once PossibleNullReferenceException

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -203,7 +203,7 @@ namespace Akka.Actor.Internal
         public override void Abort()
         {
             Aborting = true;
-            FinalTerminate((byte)CoordinatedShutdown.CommonExitCodes.Abort); // Skip CoordinatedShutdown check and aggressively shutdown the ActorSystem
+            FinalTerminate(); // Skip CoordinatedShutdown check and aggressively shutdown the ActorSystem
         }
 
         /// <summary>Starts this system</summary>
@@ -531,13 +531,12 @@ namespace Akka.Actor.Internal
                 return CoordinatedShutdown.Get(this)
                     .Run(CoordinatedShutdown.ActorSystemTerminateReason.Instance);
             }
-            return FinalTerminate(0);
+            return FinalTerminate();
         }
 
-        internal override Task<int> FinalTerminate(int exitCode)
+        internal override Task<int> FinalTerminate()
         {
             Log.Debug("System shutdown initiated");
-            _terminationCallbacks.FinalExitCode = exitCode;
             if (!Settings.LogDeadLettersDuringShutdown && _logDeadLetterListener != null)
                 Stop(_logDeadLetterListener);
             _provider.Guardian.Stop();
@@ -655,9 +654,6 @@ namespace Akka.Actor.Internal
         private readonly TaskCompletionSource<int> _terminationPromise = new ();
         private readonly AtomicReference<Task?> _atomicRef;
 
-        // Final exit code will be 0, unless overriden by something else (like Abort() call)
-        public int FinalExitCode { get; set; }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TerminationCallbacks" /> class.
         /// </summary>
@@ -668,7 +664,7 @@ namespace Akka.Actor.Internal
             _atomicRef = new AtomicReference<Task?>(new Task(() =>
             {
                 // CoordinatedShutdown must be fetched in a lazy way because it might not be initialized yet.
-                var exitCode = CoordinatedShutdown.Get(system).ShutdownReason?.ExitCode ?? FinalExitCode;
+                var exitCode = CoordinatedShutdown.Get(system).ShutdownReason?.ExitCode ?? 0;
                 _terminationPromise.TrySetResult(exitCode);
             }));
 

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -203,7 +203,7 @@ namespace Akka.Actor.Internal
         public override void Abort()
         {
             Aborting = true;
-            FinalTerminate(); // Skip CoordinatedShutdown check and aggressively shutdown the ActorSystem
+            FinalTerminate((byte)CoordinatedShutdown.CommonExitCodes.Abort); // Skip CoordinatedShutdown check and aggressively shutdown the ActorSystem
         }
 
         /// <summary>Starts this system</summary>
@@ -488,7 +488,7 @@ namespace Akka.Actor.Internal
 
         private void ConfigureTerminationCallbacks()
         {
-            _terminationCallbacks = new TerminationCallbacks(Provider.TerminationTask);
+            _terminationCallbacks = new TerminationCallbacks(Provider.TerminationTask, this);
         }
 
         /// <summary>
@@ -524,19 +524,20 @@ namespace Akka.Actor.Internal
         /// <returns>
         /// A <see cref="Task"/> that will complete once the actor system has finished terminating and all actors are stopped.
         /// </returns>
-        public override Task Terminate()
+        public override Task<int> Terminate()
         {
             if(Settings.CoordinatedShutdownRunByActorSystemTerminate)
             {
                 return CoordinatedShutdown.Get(this)
                     .Run(CoordinatedShutdown.ActorSystemTerminateReason.Instance);
             }
-            return FinalTerminate();
+            return FinalTerminate(0);
         }
 
-        internal override Task FinalTerminate()
+        internal override Task<int> FinalTerminate(int exitCode)
         {
             Log.Debug("System shutdown initiated");
+            _terminationCallbacks.FinalExitCode = exitCode;
             if (!Settings.LogDeadLettersDuringShutdown && _logDeadLetterListener != null)
                 Stop(_logDeadLetterListener);
             _provider.Guardian.Stop();
@@ -549,7 +550,7 @@ namespace Akka.Actor.Internal
         /// operations on the `dispatcher` of this actor system as it will have been shut down
         /// before this task completes.
         /// </summary>
-        public override Task WhenTerminated { get { return _terminationCallbacks.TerminationTask; } }
+        public override Task<int> WhenTerminated { get { return _terminationCallbacks.TerminationTask; } }
 
         /// <summary>
         /// Stops the specified actor permanently.
@@ -648,23 +649,33 @@ namespace Akka.Actor.Internal
     /// <summary>
     /// This class represents a callback used to run a task when the actor system is terminating.
     /// </summary>
+    #nullable enable
     internal class TerminationCallbacks
     {
-        private Task _terminationTask;
-        private readonly AtomicReference<Task> _atomicRef;
+        private readonly TaskCompletionSource<int> _terminationPromise = new ();
+        private readonly AtomicReference<Task?> _atomicRef;
+
+        // Final exit code will be 0, unless overriden by something else (like Abort() call)
+        public int FinalExitCode { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TerminationCallbacks" /> class.
         /// </summary>
         /// <param name="upStreamTerminated">The task to run when the actor system is terminating</param>
-        public TerminationCallbacks(Task upStreamTerminated)
+        /// <param name="system">The ActorSystem parent of this instance</param>
+        public TerminationCallbacks(Task upStreamTerminated, ActorSystem system)
         {
-            _atomicRef = new AtomicReference<Task>(new Task(() => { }));
+            _atomicRef = new AtomicReference<Task?>(new Task(() =>
+            {
+                // CoordinatedShutdown must be fetched in a lazy way because it might not be initialized yet.
+                var exitCode = CoordinatedShutdown.Get(system).ShutdownReason?.ExitCode ?? FinalExitCode;
+                _terminationPromise.TrySetResult(exitCode);
+            }));
 
             upStreamTerminated.ContinueWith(_ =>
             {
-                _terminationTask = _atomicRef.GetAndSet(null);
-                _terminationTask.Start();
+                var task = _atomicRef.GetAndSet(null);
+                task!.Start(); // task shouldn't be null
             });
         }
 
@@ -677,7 +688,7 @@ namespace Akka.Actor.Internal
         {
             var previous = _atomicRef.Value;
 
-            if (_atomicRef.Value == null)
+            if (_atomicRef.Value == null || previous is null)
                 throw new InvalidOperationException("ActorSystem already terminated.");
 
             var t = new Task(code);
@@ -694,7 +705,7 @@ namespace Akka.Actor.Internal
         /// <summary>
         /// The task that is currently being performed
         /// </summary>
-        public Task TerminationTask { get { return _atomicRef.Value ?? _terminationTask; } }
+        public Task<int> TerminationTask => _terminationPromise.Task;
     }
 }
 

--- a/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
+++ b/src/core/Akka/Actor/Internal/ActorSystemImpl.cs
@@ -154,6 +154,9 @@ namespace Akka.Actor.Internal
 
         public Option<Props> GuardianProps { get; }
 
+        public override CoordinatedShutdown.Reason ShutdownReason 
+            => CoordinatedShutdown.Get(this).ShutdownReason ?? CoordinatedShutdown.ActorSystemTerminateReason.Instance;
+
         /// <summary>
         /// Creates a new system actor that lives under the "/system" guardian.
         /// </summary>
@@ -524,7 +527,7 @@ namespace Akka.Actor.Internal
         /// <returns>
         /// A <see cref="Task"/> that will complete once the actor system has finished terminating and all actors are stopped.
         /// </returns>
-        public override Task<int> Terminate()
+        public override Task Terminate()
         {
             if(Settings.CoordinatedShutdownRunByActorSystemTerminate)
             {
@@ -534,7 +537,7 @@ namespace Akka.Actor.Internal
             return FinalTerminate();
         }
 
-        internal override Task<int> FinalTerminate()
+        internal override Task FinalTerminate()
         {
             Log.Debug("System shutdown initiated");
             if (!Settings.LogDeadLettersDuringShutdown && _logDeadLetterListener != null)
@@ -549,7 +552,7 @@ namespace Akka.Actor.Internal
         /// operations on the `dispatcher` of this actor system as it will have been shut down
         /// before this task completes.
         /// </summary>
-        public override Task<int> WhenTerminated { get { return _terminationCallbacks.TerminationTask; } }
+        public override Task WhenTerminated { get { return _terminationCallbacks.TerminationTask; } }
 
         /// <summary>
         /// Stops the specified actor permanently.


### PR DESCRIPTION
Fixes #7517

## Changes

* Add exit code output to ActorSystem `WhenTerminated` property and `.Terminate()` method task.
* If the `CoordinatedShutdown` stack was run, its reason will be propagated to the `WhenTerminated` task.
* If "exit-clr" is set, the exit code will be passed to the `Environment.Exit()` call.
* Exit codes conforms to the Linux exit code convention

See: https://manpages.ubuntu.com/manpages/lunar/man3/sysexits.h.3head.html
See: https://manpages.ubuntu.com/manpages/noble/man3/EXIT_SUCCESS.3const.html

### Possible Exit Codes

| Exit code | Description |
|---:|---|
| 0 | `ActorSystem` shutdown cleanly due to `.Terminate()`, `.Abort()`, or normal cluster events |
| 1 | Unknown shutdown cause |
| 3 | [CLUSTER] `ActorSystem` terminated because it is downed |
| 4 | [CLUSTER] `ActorSystem` terminated because it failed to join the cluster |
