### PR TITLE
Add AK2003/AK2004/AK2005 documentation

### DIFF
--- a/docs/articles/debugging/akka-analyzers.md
+++ b/docs/articles/debugging/akka-analyzers.md
@@ -24,6 +24,9 @@ Akka.Analyzer is a [Roslyn Analysis and Code Fix](https://learn.microsoft.com/en
 | [AK2000](xref:AK2000) | Do not use `Ask` with `TimeSpan.Zero` for timeout.                                                                      | Error    | API Usage    |
 | [AK2001](xref:AK2001) | Do not use automatically handled messages in inside `Akka.Cluster.Sharding.IMessageExtractor`s.                         | Warning  | API Usage    |
 | [AK2002](xref:AK2002) | `Context.Materializer()` should not be invoked multiple times, use a cached value instead.                              | Warning  | API Usage    |
+| [AK2003](xref:AK2003) | `ReceiveActor.Receive` message handler must not be a void async delegate.                             | Error    | API Usage    |
+| [AK2004](xref:AK2004) | `IDslActor.Receive` message handler delegate must not be a void async delegate. Use `ReceiveAsync` instead. | Error    | API Usage    |
+| [AK2005](xref:AK2005) | `ReceivePersistentActor.Command` message handler delegate must not be a void async delegate. Use `ReceiveAsync` instead. | Error    | API Usage    |
 
 ## Deprecated Rules
 

--- a/docs/articles/debugging/rules/AK2003.md
+++ b/docs/articles/debugging/rules/AK2003.md
@@ -1,0 +1,51 @@
+---
+uid: AK2003
+title: Akka.Analyzers Rule AK2003 - "`ReceiveActor.Receive` message handler must not be a void async delegate."
+---
+
+# AK2003 - Error
+
+`ReceiveActor.Receive` message handler delegate must not be a void async delegate. Use `ReceiveAsync` instead.
+
+## Cause
+
+`ReceiveActor.Receive` accepts an `Action<TMessage>` as a delegate, any `void async` delegate passed as an argument will be invoked as a detached asynchronous function that can cause erroneous message processing behavior.
+
+An example:
+
+```csharp
+using Akka.Actor;
+using System.Threading.Tasks;
+
+public sealed class MyActor : ReceiveActor
+{
+    public MyActor()
+    {
+        Receive<int>(async msg =>
+            {
+                await Task.Yield();
+                Sender.Tell(msg);
+            });
+    }
+}
+```
+
+## Resolution
+
+```csharp
+using Akka.Actor;
+using System.Threading.Tasks;
+
+public sealed class MyActor : ReceiveActor
+{
+    public MyActor()
+    {
+        // Use ReceiveAsync() if you're passing an asynchronous delegate
+        ReceiveAsync<int>(async msg =>
+            {
+                await Task.Yield();
+                Sender.Tell(msg);
+            });
+    }
+}
+```

--- a/docs/articles/debugging/rules/AK2004.md
+++ b/docs/articles/debugging/rules/AK2004.md
@@ -1,0 +1,57 @@
+---
+uid: AK2004
+title: Akka.Analyzers Rule AK2004 - "`IDslActor.Receive` message handler must not be a void async delegate."
+---
+
+# AK2004 - Error
+
+`IDslActor.Receive` message handler delegate must not be a void async delegate. Use `ReceiveAsync` instead.
+
+## Cause
+
+`IDslActor.Receive` accepts an `Action<TMessage, IActorContext>` as a delegate, any `void async` delegate passed as an argument will be invoked as a detached asynchronous function that can cause erroneous message processing behavior.
+
+An example:
+
+```csharp
+using Akka.Actor;
+using System.Threading.Tasks;
+
+public sealed class MyClass
+{
+    public MyClass(ActorSystem sys)
+    {
+        sys.ActorOf(act =>
+        {
+            act.Receive<int>(async (msg, context) =>
+            {
+                await Task.Yield();
+                context.Sender.Tell(msg);
+            });
+        }, "dslActor");
+    }
+}
+```
+
+## Resolution
+
+```csharp
+using Akka.Actor;
+using System.Threading.Tasks;
+
+public sealed class MyClass
+{
+    public MyClass(ActorSystem sys)
+    {
+        sys.ActorOf(act =>
+        {
+            // Use ReceiveAsync() if you're passing an asynchronous delegate
+            act.ReceiveAsync<int>(async (msg, context) =>
+            {
+                await Task.Yield();
+                context.Sender.Tell(msg);
+            });
+        }, "dslActor");
+    }
+}
+```

--- a/docs/articles/debugging/rules/AK2005.md
+++ b/docs/articles/debugging/rules/AK2005.md
@@ -1,0 +1,59 @@
+---
+uid: AK2005
+title: Akka.Analyzers Rule AK2005 - "`ReceivePersistentActor.Command` message handler must not be a void async delegate."
+---
+
+# AK2005 - Error
+
+`ReceivePersistentActor.Command` message handler delegate must not be a void async delegate. Use `ReceiveAsync` instead.
+
+## Cause
+
+`ReceivePersistentActor.Command` accepts an `Action<TMessage>` as a delegate, any `void async` delegate passed as an argument will be invoked as a detached asynchronous function that can cause erroneous message processing behavior.
+
+An example:
+
+```csharp
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        Command<int>(async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+```
+
+## Resolution
+
+```csharp
+using Akka.Actor;
+using Akka.Persistence;
+using System.Threading.Tasks;
+
+public class MyActor: ReceivePersistentActor
+{
+    public MyActor(string persistenceId)
+    {
+        PersistenceId = persistenceId;
+        
+        // Use CommandAsync() if you're passing an asynchronous delegate
+        CommandAsync<int>(async msg =>
+        {
+            await Task.Yield();
+        });
+    }
+    
+    public override string PersistenceId { get; }
+}
+```

--- a/docs/articles/debugging/rules/toc.yml
+++ b/docs/articles/debugging/rules/toc.yml
@@ -22,3 +22,9 @@
   href: AK2001.md
 - name: AK2002
   href: AK2002.md
+- name: AK2003
+  href: AK2003.md
+- name: AK2004
+  href: AK2004.md
+- name: AK2005
+  href: AK2005.md


### PR DESCRIPTION
Documentation for 2004 and 2005 is a repeat of 2003

---
uid: AK2003
title: Akka.Analyzers Rule AK2003 - "`ReceiveActor.Receive` message handler must not be a void async delegate."
---

# AK2003 - Error

`ReceiveActor.Receive` message handler delegate must not be a void async delegate. Use `ReceiveAsync` instead.

## Cause

`ReceiveActor.Receive` accepts an `Action<TMessage>` as a delegate, any `void async` delegate passed as an argument will be invoked as a detached asynchronous function that can cause erroneous message processing behavior.

An example:

```csharp
using Akka.Actor;
using System.Threading.Tasks;

public sealed class MyActor : ReceiveActor
{
    public MyActor()
    {
        Receive<int>(async msg =>
            {
                await Task.Yield();
                Sender.Tell(msg);
            });
    }
}
```

## Resolution

```csharp
using Akka.Actor;
using System.Threading.Tasks;

public sealed class MyActor : ReceiveActor
{
    public MyActor()
    {
        // Use ReceiveAsync() if you're passing an asynchronous delegate
        ReceiveAsync<int>(async msg =>
            {
                await Task.Yield();
                Sender.Tell(msg);
            });
    }
}
```
