### PR TITLE
Improve ScheduledTellMsg logging

### DIFF
--- a/src/core/Akka/Actor/Scheduler/IScheduledTellMsg.cs
+++ b/src/core/Akka/Actor/Scheduler/IScheduledTellMsg.cs
@@ -31,6 +31,9 @@ internal sealed class ScheduledTellMsg : IScheduledTellMsg
         Message = message;
     }
     public object Message { get; }
+
+    public override string ToString()
+        => $"{{{nameof(ScheduledTellMsg)}: {{Message: {Message}}}}}";
 }
 
 /// <summary>
@@ -44,4 +47,7 @@ internal sealed class ScheduledTellMsgNoInfluenceReceiveTimeout : IScheduledTell
     }
 
     public object Message { get; }
+
+    public override string ToString()
+        => $"{{{nameof(ScheduledTellMsgNoInfluenceReceiveTimeout)}: {{Message: {Message}}}}}";
 }


### PR DESCRIPTION
Fixes #7264

## Changes

* Add `ToString()` overrides for `IScheduledTellMsg` implementations, basically allows users get some insight into which scheduled messages were being dead lettered.

Turns
```
[WARNING][06/24/2024 14:51:03.026Z][Thread 0015][akka://ClusterClientDiscoverySpec/user/$b] DeadLetter from [akka://ClusterClientDiscoverySpec/user/$b#1239270490] to [akka://ClusterClientDiscoverySpec/user/$b#1239270490]: <Received dead letter from [akka://ClusterClientDiscoverySpec/user/$b#1239270490]: Akka.Actor.Scheduler.ScheduledTellMsg>
```

into
```
[WARNING][06/10/2025 17:28:52.161Z][Thread 0022][akka://ClusterClientDiscoverySpec/user/client1/$b] DeadLetter from [akka://ClusterClientDiscoverySpec/user/client1/$b#1665680760] to [akka://ClusterClientDiscoverySpec/user/client1/$b#1665680760]: <Received dead letter from [akka://ClusterClientDiscoverySpec/user/client1/$b#1665680760]: {ScheduledTellMsg: {Message: Akka.Cluster.Tools.Client.ClusterClient+ReconnectTimeout}}>
```