### PR TITLE
Cleanup build warnings

### DIFF
--- a/src/core/Akka.Streams.Tests.TCK/TransformProcessorTest.cs
+++ b/src/core/Akka.Streams.Tests.TCK/TransformProcessorTest.cs
@@ -11,21 +11,45 @@ using Reactive.Streams;
 
 namespace Akka.Streams.Tests.TCK
 {
-    class TransformProcessorTest : AkkaIdentityProcessorVerification<int?>
+    internal class TransformProcessorTest : AkkaIdentityProcessorVerification<int?>
     {
         public override int? CreateElement(int element) => element;
 
         public override IProcessor<int?,int?> CreateIdentityProcessor(int bufferSize)
         {
-            var settings = ActorMaterializerSettings.Create(System).WithInputBuffer(bufferSize/2, bufferSize);
-            var materializer = ActorMaterializer.Create(System, settings);
-
-            return Flow.Create<int?>().Transform(() => new Stage()).ToProcessor().Run(materializer);
+            return Flow.Create<int?>()
+                .Via(new Stage())
+                .ToProcessor()
+                .WithAttributes(Attributes.CreateInputBuffer(bufferSize / 2, bufferSize))
+                .Run(System.Materializer());
         }
 
-        private sealed class Stage : PushStage<int?, int?>
+        private sealed class Stage : GraphStage<FlowShape<int?, int?>>
         {
-            public override ISyncDirective OnPush(int? element, IContext<int?> context) => context.Push(element);
+            private class Logic: InAndOutGraphStageLogic
+            {
+                private readonly Stage _parent;
+                public Logic(Stage parent) : base(parent.Shape)
+                {
+                    _parent = parent;
+                    SetHandlers(_parent.In, _parent.Out, this);
+                }
+                
+                public override void OnPush() => Push(_parent.Out, Grab(_parent.In));
+                public override void OnPull() => Pull(_parent.In);
+            }
+
+            public Stage()
+            {
+                Shape = new FlowShape<int?, int?>(In, Out);
+            }
+            
+            public readonly Inlet<int?> In = new("Stage.in");
+            public readonly Outlet<int?> Out = new("Stage.out");
+            public override FlowShape<int?, int?> Shape { get; }
+
+            protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
+                => new Logic(this);
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterSpecKit.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/GraphInterpreterSpecKit.cs
@@ -980,19 +980,11 @@ namespace Akka.Streams.Tests.Implementation.Fusing
             }
         }
 
-#pragma warning disable CS0618 // Type or member is obsolete
+        [Obsolete("Obsolete, but we need to keep this because of backward compatibility unit tests")]
         public PushPullGraphStage<TIn, TOut> ToGraphStage<TIn, TOut>(IStage<TIn, TOut> stage)
-#pragma warning restore CS0618 // Type or member is obsolete
         {
             var s = stage;
             return new PushPullGraphStage<TIn, TOut>(_ => s, Attributes.None);
-        }
-
-#pragma warning disable CS0618 // Type or member is obsolete
-        public IGraphStageWithMaterializedValue<Shape, object>[] ToGraphStage<TIn, TOut>(IStage<TIn, TOut>[] stages)
-#pragma warning restore CS0618 // Type or member is obsolete
-        {
-            return stages.Select(ToGraphStage).Cast<IGraphStageWithMaterializedValue<Shape, object>>().ToArray();
         }
 
         public void WithTestSetup(Action<TestSetup, Func<ISet<TestSetup.ITestEvent>>> spec)
@@ -1017,26 +1009,6 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         {
             var setup = new TestSetup(Sys);
             spec(setup, setup.Builder, setup.LastEvents);
-        }
-
-#pragma warning disable CS0618 // Type or member is obsolete
-        public void WithOneBoundedSetup<T>(IStage<T, T> op,
-#pragma warning restore CS0618 // Type or member is obsolete
-            Action
-                <Func<ISet<OneBoundedSetup.ITestEvent>>, OneBoundedSetup.UpstreamOneBoundedProbe<T>,
-                    OneBoundedSetup.DownstreamOneBoundedPortProbe<T>> spec)
-        {
-            WithOneBoundedSetup<T>(ToGraphStage(op), spec);
-        }
-
-#pragma warning disable CS0618 // Type or member is obsolete
-        public void WithOneBoundedSetup<T>(IStage<T, T>[] ops,
-#pragma warning restore CS0618 // Type or member is obsolete
-            Action
-                <Func<ISet<OneBoundedSetup.ITestEvent>>, OneBoundedSetup.UpstreamOneBoundedProbe<T>,
-                    OneBoundedSetup.DownstreamOneBoundedPortProbe<T>> spec)
-        {
-            WithOneBoundedSetup<T>(ToGraphStage(ops), spec);
         }
 
         public void WithOneBoundedSetup<T>(IGraphStageWithMaterializedValue<Shape, object> op,

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/InterpreterSpec.cs
@@ -96,7 +96,8 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         [Fact]
         public void Interpreter_should_work_with_only_boundary_ops()
         {
-            WithOneBoundedSetup(Array.Empty<IStage<int, int>>(),
+            WithOneBoundedSetup<int>(
+                [],
                 (lastEvents, upstream, downstream) =>
                 {
                     lastEvents().Should().BeEmpty();
@@ -690,6 +691,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
         public void Interpreter_should_not_allow_AbsorbTermination_from_OnDownstreamFinish()
         {
             // This test must be kept since it tests the compatibility layer, which while is deprecated it is still here.
+#pragma warning disable CS0618 // Type or member is obsolete, see comment above
             WithOneBoundedSetup(ToGraphStage(new InvalidAbsorbTermination<int>()),
                 (lastEvents, _, downstream) =>
                 {
@@ -703,6 +705,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                             lastEvents().Should().BeEquivalentTo(new Cancel(new NotSupportedException("It is not allowed to call AbsorbTermination() from OnDownstreamFinish.")));
                         });
                 });
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public class Doubler<T> : SimpleLinearGraphStage<T>


### PR DESCRIPTION
Cleanup final build warnings in Akka.Streams.Tests.TCK and Akka.Streams.Tests due to obsolete methods/classes from v1.1.0