### PR TITLE
Clean build warnings

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
@@ -207,6 +207,7 @@ namespace Akka.Streams
             public static readonly Akka.Streams.Attributes.AsyncBoundary Instance;
             public bool Equals(Akka.Streams.Attributes.AsyncBoundary other) { }
             public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
             public override string ToString() { }
         }
         public sealed class CancellationStrategy : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute
@@ -1472,7 +1473,15 @@ namespace Akka.Streams.Dsl
     }
     public class static FlowWithContextOperations
     {
+        [System.ObsoleteAttribute("Deprecated. Please use Collect(FlowWithContext, Func, Func) instead. Since v1.5.4" +
+            "4, will be removed in v1.6")]
         public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, TOut2> fn)
+            where TOut2 :  class { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                0,
+                0,
+                0})] System.Func<System.ValueTuple<TOut, TCtx>, bool> isDefined, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
         public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, int n) { }
         public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Select<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, TOut2> fn) { }
@@ -2173,7 +2182,15 @@ namespace Akka.Streams.Dsl
     }
     public class static SourceWithContextOperations
     {
+        [System.ObsoleteAttribute("Deprecated. Please use Collect(SourceWithContext, Func, Func) instead. Since v1.5" +
+            ".44, will be removed in v1.6")]
         public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn)
+            where TOut2 :  class { }
+        public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                0,
+                0,
+                0})] System.Func<System.ValueTuple<TOut, TCtx>, bool> isDefined, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
         public static Akka.Streams.Dsl.SourceWithContext<System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, int n) { }
         public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Select<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn) { }
@@ -2282,7 +2299,12 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Batch<TOut, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> BatchWeighted<TOut, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Buffer<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int size, Akka.Streams.OverflowStrategy strategy) { }
+        [System.ObsoleteAttribute("Deprecated. Please use Collect(SubFlow, Func, Func) instead. Since v1.5.44, will " +
+            "be removed in v1.6")]
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, TOut2> collector) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                0})] System.Func<TOut1, bool> isDefined, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> CompletionTimeout<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Concat<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> ConcatMany<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
@@ -206,6 +206,7 @@ namespace Akka.Streams
             public static readonly Akka.Streams.Attributes.AsyncBoundary Instance;
             public bool Equals(Akka.Streams.Attributes.AsyncBoundary other) { }
             public override bool Equals(object obj) { }
+            public override int GetHashCode() { }
             public override string ToString() { }
         }
         public sealed class CancellationStrategy : Akka.Streams.Attributes.IAttribute, Akka.Streams.Attributes.IMandatoryAttribute
@@ -1470,7 +1471,15 @@ namespace Akka.Streams.Dsl
     }
     public class static FlowWithContextOperations
     {
+        [System.ObsoleteAttribute("Deprecated. Please use Collect(FlowWithContext, Func, Func) instead. Since v1.5.4" +
+            "4, will be removed in v1.6")]
         public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, TOut2> fn)
+            where TOut2 :  class { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                0,
+                0,
+                0})] System.Func<System.ValueTuple<TOut, TCtx>, bool> isDefined, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
         public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, int n) { }
         public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Select<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, TOut2> fn) { }
@@ -2171,7 +2180,15 @@ namespace Akka.Streams.Dsl
     }
     public class static SourceWithContextOperations
     {
+        [System.ObsoleteAttribute("Deprecated. Please use Collect(SourceWithContext, Func, Func) instead. Since v1.5" +
+            ".44, will be removed in v1.6")]
         public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn)
+            where TOut2 :  class { }
+        public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                0,
+                0,
+                0})] System.Func<System.ValueTuple<TOut, TCtx>, bool> isDefined, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
         public static Akka.Streams.Dsl.SourceWithContext<System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, int n) { }
         public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Select<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn) { }
@@ -2280,7 +2297,12 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Batch<TOut, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> BatchWeighted<TOut, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Buffer<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int size, Akka.Streams.OverflowStrategy strategy) { }
+        [System.ObsoleteAttribute("Deprecated. Please use Collect(SubFlow, Func, Func) instead. Since v1.5.44, will " +
+            "be removed in v1.6")]
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, TOut2> collector) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                2,
+                0})] System.Func<TOut1, bool> isDefined, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> CompletionTimeout<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Concat<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> ConcatMany<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }

--- a/src/core/Akka.Streams/Attributes.cs
+++ b/src/core/Akka.Streams/Attributes.cs
@@ -182,8 +182,9 @@ namespace Akka.Streams
         {
             public static readonly AsyncBoundary Instance = new();
             private AsyncBoundary() { }
-            public bool Equals(AsyncBoundary other) => other is AsyncBoundary;
+            public bool Equals(AsyncBoundary other) => other is not null;
             public override bool Equals(object obj) => obj is AsyncBoundary;
+            public override int GetHashCode() => 1087;
             public override string ToString() => "AsyncBoundary";
         }
 

--- a/src/core/Akka.Streams/Dsl/FlowWithContextOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowWithContextOperations.cs
@@ -36,13 +36,22 @@ namespace Akka.Streams.Dsl
             return flow.Via(Flow.FromGraph(stage));
         }
 
+        // Backward compatibility
+        /// <summary>
+        /// Context-preserving variant of <see cref="Collect{TIn,TOut}"/>
+        /// </summary>
+        [Obsolete("Deprecated. Please use Collect(FlowWithContext, Func, Func) instead. Since v1.5.44, will be removed in v1.6")]
+        public static FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, Func<TOut, TOut2> fn) where TOut2 : class
+            => Collect(flow, null, fn);
+
         /// <summary>
         /// Context-preserving variant of <see cref="Collect{TIn,TOut}"/>
         /// </summary>
         public static FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(
-            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, Func<TOut, TOut2> fn) where TOut2 : class
+            this FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, Func<(TOut, TCtx), bool>? isDefined, Func<TOut, TOut2> fn) where TOut2 : class
         {
-            var stage = new Collect<(TOut, TCtx), (TOut2, TCtx)>(func: x =>
+            var stage = new Collect<(TOut, TCtx), (TOut2, TCtx)>(isDefined, x =>
             {
                 var result = fn(x.Item1);
                 return ReferenceEquals(result, null) ? default((TOut2, TCtx)) : (result, x.Item2);
@@ -178,13 +187,22 @@ namespace Akka.Streams.Dsl
             return flow.Via(Flow.FromGraph(stage));
         }
 
+        // Backward compatibility
+        /// <summary>
+        /// Context-preserving variant of <see cref="Collect{TIn,TOut}"/>
+        /// </summary>
+        [Obsolete("Deprecated. Please use Collect(SourceWithContext, Func, Func) instead. Since v1.5.44, will be removed in v1.6")]
+        public static SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(
+            this SourceWithContext<TOut, TCtx, TMat> flow, Func<TOut, TOut2> fn) where TOut2 : class
+            => Collect(flow, null, fn);
+
         /// <summary>
         /// Context-preserving variant of <see cref="Collect{TIn,TOut}"/>
         /// </summary>
         public static SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(
-            this SourceWithContext<TOut, TCtx, TMat> flow, Func<TOut, TOut2> fn) where TOut2 : class
+            this SourceWithContext<TOut, TCtx, TMat> flow, Func<(TOut, TCtx), bool>? isDefined, Func<TOut, TOut2> fn) where TOut2 : class
         {
-            var stage = new Collect<(TOut, TCtx), (TOut2, TCtx)>(func: x =>
+            var stage = new Collect<(TOut, TCtx), (TOut2, TCtx)>(isDefined, x =>
             {
                 var result = fn(x.Item1);
                 return ReferenceEquals(result, null) ? default((TOut2, TCtx)) : (result, x.Item2);

--- a/src/core/Akka.Streams/Dsl/SubFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SubFlowOperations.cs
@@ -467,6 +467,7 @@ namespace Akka.Streams.Dsl
             return (SubFlow<TOut, TMat, TClosed>)InternalFlowOperations.SkipWhile(flow, predicate);
         }
 
+        // Backward compatibility
         /// <summary>
         /// Transform this stream by applying the given function <paramref name="collector"/> to each of the elements
         /// on which the function is defined (read: returns not null) as they pass through this processing step.
@@ -480,17 +481,25 @@ namespace Akka.Streams.Dsl
         /// </para>
         /// Cancels when downstream cancels
         /// </summary>
-        /// <typeparam name="TOut1">TBD</typeparam>
-        /// <typeparam name="TOut2">TBD</typeparam>
-        /// <typeparam name="TMat">TBD</typeparam>
-        /// <typeparam name="TClosed">TBD</typeparam>
-        /// <param name="flow">TBD</param>
-        /// <param name="collector">TBD</param>
-        /// <returns>TBD</returns>
+        [Obsolete("Deprecated. Please use Collect(SubFlow, Func, Func) instead. Since v1.5.44, will be removed in v1.6")]
         public static SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this SubFlow<TOut1, TMat, TClosed> flow, Func<TOut1, TOut2> collector)
-        {
-            return (SubFlow<TOut2, TMat, TClosed>)InternalFlowOperations.Collect(flow, collector);
-        }
+            => (SubFlow<TOut2, TMat, TClosed>)InternalFlowOperations.Collect(flow, null, collector);
+
+        /// <summary>
+        /// Transform this stream by applying the given function <paramref name="collector"/> to each of the elements
+        /// on which the delegate <paramref name="isDefined"/> returns <c>true</c> as they pass through this processing step.
+        /// Non-matching elements are filtered out.
+        /// <para>
+        /// Emits when the provided function <paramref name="collector"/> is defined for the element
+        /// </para>
+        /// Backpressures when the function <paramref name="collector"/> is defined for the element and downstream backpressures
+        /// <para>
+        /// Completes when upstream completes
+        /// </para>
+        /// Cancels when downstream cancels
+        /// </summary>
+        public static SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this SubFlow<TOut1, TMat, TClosed> flow, Func<TOut1, bool>? isDefined, Func<TOut1, TOut2> collector)
+            => (SubFlow<TOut2, TMat, TClosed>)InternalFlowOperations.Collect(flow, isDefined, collector);
 
         /// <summary>
         /// Chunk up this stream into groups of the given size, with the last group

--- a/src/core/Akka.Streams/Implementation/FanOut.cs
+++ b/src/core/Akka.Streams/Implementation/FanOut.cs
@@ -740,7 +740,7 @@ namespace Akka.Streams.Implementation
         /// This exception is thrown when the elements in <see cref="Akka.Streams.Implementation.FanOut{T}.PrimaryInputs"/>
         /// are of an unknown type.
         /// </exception>>
-        /// If this gets changed you must change <see cref="Akka.Streams.Implementation.FanOut.Unzip{T}"/> as well!
+        /// If this gets changed you must change <see cref="Unzip{T}"/> as well!
         public Unzip(ActorMaterializerSettings settings, int outputCount = 2) : base(settings, outputCount)
         {
             OutputBunch.MarkAllOutputs();

--- a/src/core/Akka.Streams/Implementation/JsonObjectParser.cs
+++ b/src/core/Akka.Streams/Implementation/JsonObjectParser.cs
@@ -49,7 +49,6 @@ namespace Akka.Streams.Implementation
         private int _pos; // latest position of pointer while scanning for json object end
         private int _trimFront;
         private int _depth;
-        private int _charsInObject;
         private bool _completedObject;
         private bool _inStringExpression;
         private bool _isStartOfEscapeSequence;
@@ -166,7 +165,6 @@ namespace Akka.Streams.Implementation
                 _pos++;
                 if (_depth == 0)
                 {
-                    _charsInObject = 0;
                     _completedObject = true;
                 }
             }

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -266,7 +266,7 @@ namespace Akka.Streams.Stage
     /// </summary>
     /// <remarks>
     ///  To be thread safe the methods of this class must only be called from either the constructor of the graph operator during
-    /// materialization or one of the methods invoked by the graph operator machinery, such as <see cref="GraphStageLogic.OnPush"/>
+    /// materialization or one of the methods invoked by the graph operator machinery, such as <see cref="IInHandler.OnPush"/>
     /// </remarks>
     public abstract class TimerGraphStageLogic : GraphStageLogic
     {


### PR DESCRIPTION
## Changes

* Add new method overrides for obsolete base methods
* fix missing `GetHashCode` warnings
* Remove unused variables
* Fix XML-DOC warnings