### PR TITLE
[PubSub] Push ack responsibility to topic actors

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubPublishWithAckSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubPublishWithAckSpec.cs
@@ -6,9 +6,11 @@
 // -----------------------------------------------------------------------
 
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Tools.PublishSubscribe;
+using Akka.Cluster.Tools.PublishSubscribe.Internal;
 using Akka.Configuration;
 using Akka.TestKit;
 using FluentAssertions.Extensions;
@@ -31,7 +33,68 @@ public class DistributedPubSubPublishWithAckSpec : AkkaSpec
             akka.actor.provider = cluster
             akka.cluster.pub-sub.buffered-messages.max-per-topic = 2
             akka.cluster.pub-sub.buffered-messages.timeout-check-interval = 100ms
+            akka.cluster.pub-sub.gossip-interval = 250ms
+            # akka.cluster.pub-sub.removed-time-to-live = 500ms
             """);
+    }
+
+    private sealed class ProbeActor: ReceiveActor
+    {
+        public ProbeActor(IActorRef probe)
+        {
+            Receive<string>(s => s is "die", _ => Context.Stop(Self));
+            ReceiveAny(probe.Tell);
+        }
+    }
+    
+    [Fact(DisplayName = "Mediator should detect missing remote subscriber and PublishWithAck should return PublishFailed")]
+    public async Task PublishWithAckMissingRemoteSubscriber()
+    {
+        var cluster = Cluster.Get(Sys);
+        await cluster.JoinAsync(cluster.SelfAddress);
+        var mediator = DistributedPubSub.Get(Sys).Mediator;
+        
+        var sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+        InitializeLogger(sys2, "SYS2");
+        
+        await Cluster.Get(sys2).JoinAsync(cluster.SelfAddress);
+        var mediator2 = DistributedPubSub.Get(sys2).Mediator;
+        
+        var messageProbe = CreateTestProbe(sys2);
+        var probeActor = sys2.ActorOf(Props.Create(() => new ProbeActor(messageProbe)));
+        
+        var probe2 = CreateTestProbe(sys2);
+        mediator2.Tell(new Subscribe("topic", probeActor), probe2);
+        await probe2.ExpectMsgAsync<SubscribeAck>();
+        
+        var probe1 = CreateTestProbe();
+        mediator.Tell(new PublishWithAck("topic", "message", 5.Seconds()), probe1);
+        await probe1.ExpectMsgAsync<PublishSucceeded>(5.Seconds());
+        await messageProbe.ExpectMsgAsync("message");
+        
+        await probe2.WatchAsync(probeActor);
+        probeActor.Tell("die");
+        await probe2.ExpectTerminatedAsync(probeActor);
+
+        await AwaitConditionAsync(() =>
+        {
+            mediator2.Tell(new CountSubscribers("topic"), probe2);
+            var subs = probe2.ExpectMsg<int>();
+            Output.WriteLine($">>>> {subs}");
+            return subs == 0;
+        }, 5.Seconds(), 100.Milliseconds(), "Timed out", CancellationToken.None);
+        
+        /*
+        await AwaitConditionAsync(() =>
+        {
+            mediator.Tell(Count.Instance, TestActor);
+            var subs = ExpectMsg<int>();
+            return subs == 0;
+        }, 5.Seconds(), 100.Milliseconds(), "Timed out", CancellationToken.None);
+        */
+        
+        mediator.Tell(new PublishWithAck("topic", "message", 200.Milliseconds()), TestActor);
+        await ExpectMsgAsync<PublishFailed>();
     }
 
     [Fact(DisplayName = "PublishWithAck message should be buffered")]

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
@@ -19,6 +19,7 @@ using Akka.Routing;
 using Akka.Util;
 using Status = Akka.Cluster.Tools.PublishSubscribe.Internal.Status;
 
+#nullable enable
 namespace Akka.Cluster.Tools.PublishSubscribe
 {
     /// <summary>
@@ -133,8 +134,8 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         private readonly TimeSpan _bufferedMessageTimeoutCheckInterval;
         private readonly Dictionary<string, List<BufferedMessage>> _bufferedMessages = new();
         private readonly List<string> _newlyAddedKeys = new();
-        
-        public ITimerScheduler Timers { get; set; }
+
+        public ITimerScheduler Timers { get; set; } = null!;
 
         /// <summary>
         /// TBD
@@ -403,6 +404,9 @@ namespace Akka.Cluster.Tools.PublishSubscribe
 
                 _buffer.RecreateAndForwardMessagesIfNeeded(key, () => NewTopicActor(terminated.ActorRef.Path.Name));
             });
+
+            #region Cluster events
+
             Receive<ClusterEvent.CurrentClusterState>(state =>
             {
                 var nodes = state.Members
@@ -449,6 +453,9 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                 }
             });
             Receive<ClusterEvent.IMemberEvent>(_ => { /* ignore */ });
+
+            #endregion
+            
             Receive<Count>(_ =>
             {
                 var count = _registry.Sum(entry => entry.Value.Content.Count(kv => !kv.Value.Ref.IsNobody()));
@@ -559,7 +566,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                 foreach (var (key, _) in bucket.Content)
                 {
                     var encodedTopic = Internal.Utils.KeyToEncodedTopic(key, topicPrefix);
-                    if (key is null)
+                    if (key is null || encodedTopic is null)
                         continue;
                     yield return encodedTopic;
                 }
@@ -572,7 +579,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             Context.Watch(actorRef);
         }
 
-        private void PutToRegistry(string key, IActorRef value)
+        private void PutToRegistry(string key, IActorRef? value)
         {
             var v = NextVersion();
             var newBucket = _registry.TryGetValue(_cluster.SelfAddress, out var bucket)
@@ -616,7 +623,6 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             var counter = 0;
             foreach (var r in Refs())
             {
-                if (r == null) continue;
                 r.Forward(publish.Message);
                 counter++;
             }
@@ -637,11 +643,13 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             {
                 foreach (var (address, bucket) in _registry)
                 {
-                    if (!(allButSelf && address == _cluster.SelfAddress) && bucket.Content.TryGetValue(path, out var valueHolder))
-                    {
-                        if (valueHolder != null && !valueHolder.Ref.IsNobody())
-                            yield return valueHolder.Ref;
-                    }
+                    if (allButSelf && address == _cluster.SelfAddress || !bucket.Content.TryGetValue(path, out var valueHolder)) 
+                        continue;
+                    
+                    if(valueHolder?.Ref is null || valueHolder.Ref.IsNobody())
+                        continue;
+                    
+                    yield return valueHolder.Ref;
                 }
             }
         }
@@ -680,8 +688,11 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             foreach (var (_, bucket) in _registry)
             {
                 //TODO: optimize into tree-aware key range [prefix, lastKey]
-                foreach (var (key, value) in bucket.Content.Where(kv => kv.Key.CompareTo(prefix) != -1 && kv.Key.CompareTo(lastKey) != 1))
+                foreach (var (key, value) in bucket.Content
+                             .Where(kv => string.Compare(kv.Key, prefix, StringComparison.Ordinal) != -1 && string.Compare(kv.Key, lastKey, StringComparison.Ordinal) != 1))
                 {
+                    if (value.Routee is null)
+                        continue;
                     yield return new KeyValuePair<string, Routee>(key, value.Routee);
                 }
             }
@@ -723,9 +734,9 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Address SelectRandomNode(IList<Address> addresses)
+        private static Address? SelectRandomNode(IList<Address>? addresses)
         {
-            if (addresses == null || addresses.Count == 0) return null;
+            if (addresses is null || addresses.Count == 0) return null;
             return addresses[ThreadLocalRandom.Current.Next(addresses.Count)];
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/DistributedPubSubMediator.cs
@@ -623,7 +623,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
             var counter = 0;
             foreach (var r in Refs())
             {
-                r.Forward(publish.Message);
+                r.Forward(publish is PublishWithAck ? publish : publish.Message);
                 counter++;
             }
 
@@ -634,8 +634,6 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                 else
                     IgnoreOrSendToDeadLetters(publish, Sender);
             }
-            else if(publish is PublishWithAck needAck)
-                Sender.Tell(new PublishSucceeded(needAck));
             
             return;
 
@@ -677,9 +675,6 @@ namespace Akka.Cluster.Tools.PublishSubscribe
                     if (routees.Length != 0)
                         new Router(_settings.RoutingLogic, routees).Route(wrappedMessage, Sender);
                 }
-                
-                if(publish is PublishWithAck needAck)
-                    Sender.Tell(new PublishSucceeded(needAck));
             }
         }
 
@@ -797,7 +792,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         private IActorRef NewTopicActor(string encodedTopic)
         {
             var t = Context.ActorOf(
-                Actor.Props.Create(() => new Topic(_settings.RemovedTimeToLive, _settings.RoutingLogic, _settings.SendToDeadLettersWhenNoSubscribers))
+                Actor.Props.Create(() => new Topic(_settings.RemovedTimeToLive, _settings.RoutingLogic, _settings.SendToDeadLettersWhenNoSubscribers, _settings.BufferedMessageTimeoutCheckInterval, _settings.MaxBufferedMessagePerTopic))
                     .WithDeploy(Deploy.Local), 
                 encodedTopic);
             HandleRegisterTopic(t);

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/TopicMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/TopicMessages.cs
@@ -129,43 +129,27 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         }
     }
 
-    /// <summary>
-    /// TBD
-    /// </summary>
+    #nullable enable
     [Serializable]
     internal sealed class ValueHolder : IEquatable<ValueHolder>
     {
-        /// <summary>
-        /// TBD
-        /// </summary>
         public long Version { get; }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public IActorRef Ref { get; }
+        public IActorRef? Ref { get; }
 
         [NonSerialized]
-        private Routee _routee;
+        private Routee? _routee;
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        /// <param name="version">TBD</param>
-        /// <param name="ref">TBD</param>
-        public ValueHolder(long version, IActorRef @ref)
+        public ValueHolder(long version, IActorRef? @ref)
         {
             Version = version;
             Ref = @ref;
         }
 
-        /// <summary>
-        /// TBD
-        /// </summary>
-        public Routee Routee { get { return _routee ??= Ref != null ? new ActorRefRoutee(Ref) : null; } }
+        public Routee? Routee { get { return _routee ??= Ref != null ? new ActorRefRoutee(Ref) : null; } }
 
         /// <inheritdoc/>
-        public bool Equals(ValueHolder other)
+        public bool Equals(ValueHolder? other)
         {
             if (ReferenceEquals(other, null)) return false;
             if (ReferenceEquals(other, this)) return true;
@@ -174,9 +158,9 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
-            return Equals(obj as ValueHolder);
+            return obj is ValueHolder holder && Equals(holder);
         }
 
         /// <inheritdoc/>
@@ -190,6 +174,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
             }
         }
     }
+    #nullable restore
 
     /// <summary>
     /// TBD

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
@@ -43,7 +43,8 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
     /// </summary>
     internal abstract class TopicLike : ActorBase, IWithTimers
     {
-        private const string PruneTimerKey = "PruneTimer";
+        private const string PruneTimerKey = nameof(PruneTimerKey);
+        private const string PruneBufferTimerKey = nameof(PruneBufferTimerKey);
         
         /// <summary>
         /// TBD
@@ -70,18 +71,31 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// </summary>
         protected readonly bool SendToDeadLettersWhenNoSubscribers;
 
+        protected readonly TimeSpan PruneBufferInterval;
+
+        private readonly ILoggingAdapter _log;
+        
+        protected int MaxBufferSize { get; }
+        
+        private readonly List<BufferedMessage> _buffer = new();
+
         /// <summary>
         /// Creates a new instance of a topic or group actor.
         /// </summary>
         /// <param name="emptyTimeToLive">The TTL for how often this actor will be removed.</param>
         /// <param name="sendToDeadLettersWhenNone">When set to <c>true</c>, this actor will
         /// publish a <see cref="DeadLetter"/> for each message if the total number of subscribers == 0.</param>
-        protected TopicLike(TimeSpan emptyTimeToLive, bool sendToDeadLettersWhenNone)
+        /// <param name="pruneBufferInterval">Time interval to check for timed out PublishWithAck</param>
+        /// <param name="maxBufferSize">Maximum buffer size for each topic</param>
+        protected TopicLike(TimeSpan emptyTimeToLive, bool sendToDeadLettersWhenNone, TimeSpan pruneBufferInterval, int maxBufferSize)
         {
             Subscribers = new HashSet<IActorRef>();
             EmptyTimeToLive = emptyTimeToLive;
             SendToDeadLettersWhenNoSubscribers = sendToDeadLettersWhenNone;
             PruneInterval = new TimeSpan(emptyTimeToLive.Ticks / 2);
+            PruneBufferInterval = pruneBufferInterval;
+            MaxBufferSize = maxBufferSize;
+            _log = Context.GetLogger();
         }
 
         public ITimerScheduler Timers { get; set; }
@@ -90,6 +104,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         {
             base.PreStart();
             Timers.StartPeriodicTimer(PruneTimerKey, Prune.Instance, PruneInterval, PruneInterval, Self);
+            Timers.StartPeriodicTimer(PruneBufferTimerKey, PruneBufferTick.Instance, PruneBufferInterval, PruneBufferInterval, Self);
         }
 
         /// <inheritdoc cref="ActorBase.PostStop"/>
@@ -113,12 +128,29 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
                     Subscribers.Add(subscribe.Ref);
                     PruneDeadline = null;
                     Context.Parent.Tell(new Subscribed(new SubscribeAck(subscribe), Sender));
+                    
+                    if(_buffer.Count == 0)
+                        return true;
+            
+                    foreach (var msg in _buffer)
+                        Self.Tell(msg.Message, msg.Sender);
+                    _buffer.Clear();
+
                     return true;
 
                 case Unsubscribe unsubscribe:
                     Context.Unwatch(unsubscribe.Ref);
                     Remove(unsubscribe.Ref);
                     Context.Parent.Tell(new Unsubscribed(new UnsubscribeAck(unsubscribe), Sender));
+                    return true;
+                
+                case PruneBufferTick:
+                    var removed = _buffer.Where(b => b.Deadline.IsOverdue).ToArray();
+                    foreach (var item in removed)
+                    {
+                        _buffer.Remove(item);
+                        IgnoreOrSendToDeadLetters(item.Message, item.Sender);
+                    }
                     return true;
 
                 case Terminated terminated:
@@ -137,6 +169,9 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
                 case TerminateRequest:
                     if (Subscribers.Count == 0 && !Context.GetChildren().Any())
                     {
+                        foreach (var msg in _buffer)
+                            IgnoreOrSendToDeadLetters(msg.Message, msg.Sender);
+                        _buffer.Clear();
                         Context.Stop(Self);
                     }
                     else
@@ -152,17 +187,61 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
 
                 default:
                     foreach (var subscriber in Subscribers)
-                        subscriber.Forward(message);
+                    {
+                        if(message is PublishWithAck needAck)
+                        {
+                            subscriber.Forward(needAck.Message);
+                            Sender.Tell(new PublishSucceeded(needAck));
+                        }
+                        else
+                        {
+                            subscriber.Forward(message);
+                        }
+                    }
 
                     // no subscribers
-                    if (Subscribers.Count == 0 && SendToDeadLettersWhenNoSubscribers)
+                    if (Subscribers.Count == 0)
                     {
-                        var noSubs = new NoSubscribersDeadLetter(Context.Self.Path.Name, message);
-                        var deadLetter = new DeadLetter(noSubs, Sender, Self);
-                        Context.System.EventStream.Publish(deadLetter);
+                        if(message is PublishWithAck publish)
+                            BufferMessageOrDeadLetter(publish, Sender);
+                        else
+                            IgnoreOrSendToDeadLetters(message, Sender);
                     }
 
                     return true;
+            }
+        }
+
+        private void BufferMessageOrDeadLetter(PublishWithAck message, IActorRef sender)
+        {
+            if(_buffer.Count >= MaxBufferSize)
+            {
+                _log.Warning("PublishWithAck buffer overflowed for topic [{0}]. New message inserted: {1}", Self.Path.Name, message);
+                while (_buffer.Count >= MaxBufferSize)
+                {
+                    var removed = _buffer[0];
+                    _buffer.RemoveAt(0);
+                    IgnoreOrSendToDeadLetters(removed.Message, removed.Sender);
+                }
+            }
+            
+            _buffer.Add(new BufferedMessage(message, new Deadline(DateTime.UtcNow + message.Timeout), sender));
+        }
+
+        private void IgnoreOrSendToDeadLetters(object message, IActorRef sender)
+        {
+            if (message is PublishWithAck needAck)
+            {
+                sender.Tell(new PublishFailed(needAck, PublishFailReason.Timeout));
+            }
+            
+            if (SendToDeadLettersWhenNoSubscribers)
+            {
+                // Use the specialized NoSubscribersDeadLetter struct to clearly indicate
+                // that the message was not delivered because there were no subscribers
+                var noSubs = new NoSubscribersDeadLetter(Context.Self.Path.Name, message);
+                var deadLetter = new DeadLetter(noSubs, Sender, Self);
+                Context.System.EventStream.Publish(deadLetter);
             }
         }
 
@@ -203,7 +282,10 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// <param name="sendToDeadLettersWhenNone">When set to <c>true</c>, this actor will
         /// publish a <see cref="DeadLetter"/> for each message if the total number of subscribers == 0.</param>
         /// <param name="routingLogic">The routing logic to use for distributing messages to subscribers.</param>
-        public Topic(TimeSpan emptyTimeToLive, RoutingLogic routingLogic, bool sendToDeadLettersWhenNone) : base(emptyTimeToLive, sendToDeadLettersWhenNone)
+        /// <param name="pruneBufferInterval">Time interval to check for timed out PublishWithAck</param>
+        /// <param name="maxBufferSize">Maximum buffer size for each topic</param>
+        public Topic(TimeSpan emptyTimeToLive, RoutingLogic routingLogic, bool sendToDeadLettersWhenNone, TimeSpan pruneBufferInterval, int maxBufferSize) 
+            : base(emptyTimeToLive, sendToDeadLettersWhenNone, pruneBufferInterval, maxBufferSize)
         {
             _routingLogic = routingLogic;
             _buffer = new PerGroupingBuffer();
@@ -284,7 +366,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         private IActorRef NewGroupActor(string encodedGroup)
         {
             var g = Context.ActorOf(
-                Props.Create(() => new Group(EmptyTimeToLive, _routingLogic, SendToDeadLettersWhenNoSubscribers))
+                Props.Create(() => new Group(EmptyTimeToLive, _routingLogic, SendToDeadLettersWhenNoSubscribers, PruneBufferInterval, MaxBufferSize))
                     .WithDeploy(Deploy.Local),
                 encodedGroup);
             Context.Watch(g);
@@ -307,7 +389,10 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
         /// <param name="sendToDeadLettersWhenNone">When set to <c>true</c>, this actor will
         /// publish a <see cref="DeadLetter"/> for each message if the total number of subscribers == 0.</param>
         /// <param name="routingLogic">The routing logic to use for distributing messages to subscribers.</param>
-        public Group(TimeSpan emptyTimeToLive, RoutingLogic routingLogic, bool sendToDeadLettersWhenNone) : base(emptyTimeToLive, sendToDeadLettersWhenNone)
+        /// <param name="pruneBufferInterval">Time interval to check for timed out PublishWithAck</param>
+        /// <param name="maxBufferSize">Maximum buffer size for each topic</param>
+        public Group(TimeSpan emptyTimeToLive, RoutingLogic routingLogic, bool sendToDeadLettersWhenNone, TimeSpan pruneBufferInterval, int maxBufferSize) 
+            : base(emptyTimeToLive, sendToDeadLettersWhenNone, pruneBufferInterval, maxBufferSize)
         {
             _routingLogic = routingLogic;
         }

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Internal/Topics.cs
@@ -186,17 +186,16 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Internal
                     return true;
 
                 default:
-                    foreach (var subscriber in Subscribers)
+                    if(message is PublishWithAck needAck)
                     {
-                        if(message is PublishWithAck needAck)
-                        {
+                        foreach (var subscriber in Subscribers)
                             subscriber.Forward(needAck.Message);
-                            Sender.Tell(new PublishSucceeded(needAck));
-                        }
-                        else
-                        {
+                        Sender.Tell(new PublishSucceeded(needAck));
+                    }
+                    else
+                    {
+                        foreach (var subscriber in Subscribers)
                             subscriber.Forward(message);
-                        }
                     }
 
                     // no subscribers

--- a/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/PublishSubscribe/Serialization/DistributedPubSubMessageSerializer.cs
@@ -32,6 +32,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
         private const string SendToAllManifest = "D";
         private const string PublishManifest = "E";
         private const string SendToOneSubscriberManifest = "F";
+        private const string PublishWithAckManifest = "G";
 
         private readonly IDictionary<string, Func<byte[], object>> _fromBinaryMap;
 
@@ -51,7 +52,8 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
                 {SendManifest, SendFrom},
                 {SendToAllManifest, SendToAllFrom},
                 {PublishManifest, PublishFrom},
-                {SendToOneSubscriberManifest, SendToOneSubscriberFrom}
+                {SendToOneSubscriberManifest, SendToOneSubscriberFrom},
+                {PublishWithAckManifest, PublishWithAckFrom}
             };
         }
 
@@ -79,8 +81,8 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
                     return SendToAllToProto(all);
                 case Publish publish:
                     return PublishToProto(publish);
-                case PublishWithAck:
-                    throw new SerializationException("ClusterClient does not support PublishWithAck");
+                case PublishWithAck publishWithAck:
+                    return PublishWithAckToProto(publishWithAck);
                 case SendToOneSubscriber subscriber:
                     return SendToOneSubscriberToProto(subscriber);
                 default:
@@ -132,6 +134,8 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
                     return PublishManifest;
                 case SendToOneSubscriber _:
                     return SendToOneSubscriberManifest;
+                case PublishWithAck:
+                    return PublishWithAckManifest;
                 default:
                     throw new ArgumentException($"Serializer {nameof(DistributedPubSubMessageSerializer)} cannot serialize message of type {o.GetType()}");
             }
@@ -267,6 +271,29 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
             return new SendToOneSubscriber(_payloadSupport.PayloadFrom(sendToOneSubscriberProto.Payload));
         }
 
+        private byte[] PublishWithAckToProto(PublishWithAck publishWithAck)
+        {
+            var protoMessage = new Proto.Msg.PublishWithAck
+            {
+                Topic = publishWithAck.Topic,
+                Payload = _payloadSupport.PayloadToProto(publishWithAck.Message),
+                SendOneMessageToEachGroup = publishWithAck.SendOneMessageToEachGroup,
+                Timeout = publishWithAck.Timeout.Ticks
+            };
+            return protoMessage.ToByteArray();
+        }
+        
+        private PublishWithAck PublishWithAckFrom(byte[] bytes)
+        {
+            var publishWithAckProto = Proto.Msg.PublishWithAck.Parser.ParseFrom(bytes);
+            return new PublishWithAck(
+                publishWithAckProto.Topic,
+                _payloadSupport.PayloadFrom(publishWithAckProto.Payload),
+                TimeSpan.FromTicks(publishWithAckProto.Timeout),
+                publishWithAckProto.SendOneMessageToEachGroup
+            );
+        }
+        
         //
         // Address
         //

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -243,6 +243,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public DistributedPubSubExtensionProvider() { }
         public override Akka.Cluster.Tools.PublishSubscribe.DistributedPubSub CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class DistributedPubSubMediator : Akka.Actor.ReceiveActor, Akka.Actor.IWithTimers
     {
         public DistributedPubSubMediator(Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings settings) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -243,6 +243,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public DistributedPubSubExtensionProvider() { }
         public override Akka.Cluster.Tools.PublishSubscribe.DistributedPubSub CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class DistributedPubSubMediator : Akka.Actor.ReceiveActor, Akka.Actor.IWithTimers
     {
         public DistributedPubSubMediator(Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings settings) { }

--- a/src/protobuf/DistributedPubSubMessages.proto
+++ b/src/protobuf/DistributedPubSubMessages.proto
@@ -50,6 +50,13 @@ message Publish {
   bool sendOneMessageToEachGroup = 4;
 }
 
+message PublishWithAck {
+  string topic = 1;
+  Akka.Remote.Serialization.Proto.Msg.Payload payload = 2;
+  bool sendOneMessageToEachGroup = 3;
+  int64 timeout = 4;
+}
+
 // Send a message to only one subscriber of a group.
 message SendToOneSubscriber {
   Akka.Remote.Serialization.Proto.Msg.Payload payload = 1;


### PR DESCRIPTION
Make `DistributedPubSub` `PublishWithAck` response more responsive to subscription changes by pushing the buffering and ack responsibility to the `Topic` actor.

The current `PublishWithAck` logic have a problem in that, for it to switch back to sending `PublishFailed` messages, the actual topic has to be pruned from all nodes.

## Changes

Push buffering and ack responsibility to the `Topic` actor.

> [!NOTE]
>
> This change is not the silver bullet, it introduces another problem. Lets say we have a 3 node cluster, (**Pub**, **SubA**, and **SubB** nodes).
> * An actor subscribes to topic in **SubA** node, `Topic` actor gets created in **SubA**
> * **SubA** subscriber is downed or unsubscribed itself
> * An actor subscribes to topic in **SubB** node, another `Topic` actor gets created in **SubB**
> * An actor sends a `PublishWithAck` to the mediator in **Pub**
> * The actor receives `PublishFailed` from **SubA** and a `PublishSucceeded` from **SubB**

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.
