### PR TITLE
Stop failing remembered entity if supervisor strategy failed

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesExcessiveFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesExcessiveFailureSpec.cs
@@ -1,0 +1,319 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RememberEntitiesFailureSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Internal;
+using Akka.Cluster.Sharding.Internal;
+using Akka.Cluster.Tools.Singleton;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using Akka.Util;
+using Akka.Util.Internal;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Cluster.Sharding.Tests;
+
+public class RememberEntitiesExcessiveFailureSpec : AkkaSpec
+{
+    private sealed record EntityEnvelope(long Id, object Payload);
+
+    private class ConstructorFailActor : ActorBase
+    {
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        public ConstructorFailActor()
+        {
+            throw new Exception("EXPLODING CONSTRUCTOR!");
+        }
+
+        protected override bool Receive(object message)
+        {
+            _log.Info("Msg {0}", message);
+            Sender.Tell($"ack {message}");
+            return true;
+        }
+    }
+
+    private class PreStartFailActor : ActorBase
+    {
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        protected override void PreStart()
+        {
+            base.PreStart();
+            throw new Exception("EXPLODING PRE-START!");
+        }
+
+        protected override bool Receive(object message)
+        {
+            _log.Info("Msg {0}", message);
+            Sender.Tell($"ack {message}");
+            return true;
+        }
+    }
+    
+    private sealed class TestMessageExtractor: IMessageExtractor
+    {
+        public string EntityId(object message)
+            => message switch
+            {
+                EntityEnvelope env => env.Id.ToString(),
+                _ => null
+            };
+
+        public object EntityMessage(object message)
+            => message switch
+            {
+                EntityEnvelope env => env.Payload,
+                _ => message
+            };
+
+        public string ShardId(object message)
+            => message switch
+            {
+                EntityEnvelope msg => msg.Id.ToString(),
+                _ => null
+            };
+
+        public string ShardId(string entityId, object messageHint = null)
+            => entityId;
+    }
+    
+    private class FakeShardRegion : ReceiveActor
+    {
+        private readonly ClusterShardingSettings _settings;
+        private readonly Props _entityProps;
+        private IActorRef? _shard;
+        
+        public FakeShardRegion(ClusterShardingSettings settings, Props entityProps)
+        {
+            _settings = settings;
+            _entityProps = entityProps;
+            
+            Receive<ShardInitialized>(_ =>
+            {
+                // no-op
+            });
+            Receive<ShardRegion.StartEntity>(msg =>
+            {
+                _shard.Forward(msg);
+            });
+        }
+
+        protected override void PreStart()
+        {
+            base.PreStart();
+            var provider = new FakeStore(_settings, "cats");
+
+            var props = Props.Create(() => new Shard(
+                "cats",
+                "shard-1",
+                _ => _entityProps,
+                _settings,
+                new TestMessageExtractor(),
+                PoisonPill.Instance,
+                provider,
+                null
+            ));
+            _shard = Context.ActorOf(props);
+        }
+    }
+    
+    private class ShardStoreCreated
+    {
+        public ShardStoreCreated(IActorRef store, string shardId)
+        {
+            Store = store;
+            ShardId = shardId;
+        }
+
+        public IActorRef Store { get; }
+        public string ShardId { get; }
+    }
+
+    private class CoordinatorStoreCreated
+    {
+        public CoordinatorStoreCreated(IActorRef store)
+        {
+            Store = store;
+        }
+
+        public IActorRef Store { get; }
+    }
+
+    private class FakeStore : IRememberEntitiesProvider
+    {
+        public FakeStore(ClusterShardingSettings settings, string typeName)
+        {
+        }
+
+        public Props ShardStoreProps(string shardId)
+        {
+            return FakeShardStoreActor.Props(shardId);
+        }
+
+        public Props CoordinatorStoreProps()
+        {
+            return FakeCoordinatorStoreActor.Props();
+        }
+    }
+
+    private class FakeShardStoreActor : ActorBase, IWithTimers
+    {
+        public static Props Props(string shardId) => Actor.Props.Create(() => new FakeShardStoreActor(shardId));
+
+        private readonly string _shardId;
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        public FakeShardStoreActor(string shardId)
+        {
+            _shardId = shardId;
+            Context.System.EventStream.Publish(new ShardStoreCreated(Self, shardId));
+        }
+
+        public ITimerScheduler Timers { get; set; }
+
+        protected override bool Receive(object message)
+        {
+            switch (message)
+            {
+                case RememberEntitiesShardStore.GetEntities _:
+                    Sender.Tell(new RememberEntitiesShardStore.RememberedEntities(ImmutableHashSet<string>.Empty.Add("1")));
+                    return true;
+                case RememberEntitiesShardStore.Update m:
+                    Sender.Tell(new RememberEntitiesShardStore.UpdateDone(m.Started, m.Stopped));
+                    return true;
+            }
+            return false;
+        }
+    }
+
+    private class FakeCoordinatorStoreActor : ActorBase, IWithTimers
+    {
+        public static Props Props() => Actor.Props.Create(() => new FakeCoordinatorStoreActor());
+
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        public ITimerScheduler Timers { get; set; }
+
+        public FakeCoordinatorStoreActor()
+        {
+            Context.System.EventStream.Publish(new CoordinatorStoreCreated(Context.Self));
+        }
+
+        protected override bool Receive(object message)
+        {
+            switch (message)
+            {
+                case RememberEntitiesCoordinatorStore.GetShards _:
+                    Sender.Tell(new RememberEntitiesCoordinatorStore.RememberedShards(ImmutableHashSet<string>.Empty.Add("1")));
+                    return true;
+                case RememberEntitiesCoordinatorStore.AddShard m:
+                    Sender.Tell(new RememberEntitiesCoordinatorStore.UpdateDone(m.ShardId));
+                    return true;
+            }
+            return false;
+        }
+    }
+
+    private class TestSupervisionStrategy: ShardSupervisionStrategy
+    {
+        private readonly AtomicCounter _counter;
+        
+        public TestSupervisionStrategy(AtomicCounter counter, int maxRetry, int window, Func<Exception, Directive> localOnlyDecider)
+            : base(maxRetry, window, localOnlyDecider)
+        {
+            _counter = counter;
+        }
+
+        public override void ProcessFailure(IActorContext context, bool restart, IActorRef child, Exception cause, ChildRestartStats stats,
+            IReadOnlyCollection<ChildRestartStats> children)
+        {
+            _counter.GetAndIncrement();
+            base.ProcessFailure(context, restart, child, cause, stats, children);
+        }
+    }
+    
+    private static Config SpecConfig =>
+        ConfigurationFactory.ParseString(
+                """
+                akka {
+                    loglevel = DEBUG
+                    actor.provider = cluster
+                    remote.dot-netty.tcp.port = 0
+                    
+                    cluster.sharding {
+                        distributed-data.durable.keys = []
+                        state-store-mode = ddata
+                        remember-entities = on
+                        remember-entities-store = custom
+                        remember-entities-custom-store = "Akka.Cluster.Sharding.Tests.RememberEntitiesExcessiveFailureSpec+FakeStore, Akka.Cluster.Sharding.Tests"
+                        verbose-debug-logging = on
+                    }
+                }
+                """)
+            .WithFallback(ClusterSingleton.DefaultConfig())
+            .WithFallback(ClusterSharding.DefaultConfig());
+
+    public RememberEntitiesExcessiveFailureSpec(ITestOutputHelper helper) : base(SpecConfig, helper)
+    {
+    }
+
+    protected override void AtStartup()
+    {
+        // Form a one node cluster
+        var cluster = Cluster.Get(Sys);
+        cluster.Join(cluster.SelfAddress);
+        AwaitAssert(() =>
+        {
+            cluster.ReadView.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(1);
+        });
+    }
+
+    public Directive TestDecider(Exception cause)
+    {
+        return Directive.Restart;
+    }
+    
+    [Fact(DisplayName = "Persistent shard must stop remembered entity with excessive failures on start")]
+    public async Task Persistent_Shard_must_stop_remembered_entity_with_excessive_constructor_failure()
+    {
+        var strategyCounter = new AtomicCounter(0);
+        
+        var settings = ClusterShardingSettings.Create(Sys);
+        settings = settings
+            .WithTuningParameters(settings.TuningParameters.WithEntityRestartBackoff(0.1.Seconds()))
+            .WithRememberEntities(true)
+            .WithSupervisorStrategy(new TestSupervisionStrategy(strategyCounter, 3, 1000, TestDecider));
+
+        var storeProbe = CreateTestProbe();
+        Sys.EventStream.Subscribe<ShardStoreCreated>(storeProbe);
+        Sys.EventStream.Subscribe<Error>(TestActor);
+
+        var entityProps = Props.Create(() => new PreStartFailActor());
+        await EventFilter.Error(contains: "cats: Remembered entity 1 was stopped because it has failed repeatedly")
+            .ExpectOneAsync(async () =>
+            {
+                _ = Sys.ActorOf(Props.Create(() => new FakeShardRegion(settings, entityProps)));
+                storeProbe.ExpectMsg<ShardStoreCreated>();
+                await Task.Yield();
+            });
+
+        // Failed on the 4th call
+        strategyCounter.Current.Should().Be(4);
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesSupervisionStrategyDecisionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesSupervisionStrategyDecisionSpec.cs
@@ -27,7 +27,7 @@ using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests;
 
-public class RememberEntitiesExcessiveFailureSpec : AkkaSpec
+public class RememberEntitiesSupervisionStrategyDecisionSpec : AkkaSpec
 {
     private sealed record EntityEnvelope(long Id, object Payload);
 
@@ -261,7 +261,7 @@ public class RememberEntitiesExcessiveFailureSpec : AkkaSpec
                         state-store-mode = ddata
                         remember-entities = on
                         remember-entities-store = custom
-                        remember-entities-custom-store = "Akka.Cluster.Sharding.Tests.RememberEntitiesExcessiveFailureSpec+FakeStore, Akka.Cluster.Sharding.Tests"
+                        remember-entities-custom-store = "Akka.Cluster.Sharding.Tests.RememberEntitiesSupervisionStrategyDecisionSpec+FakeStore, Akka.Cluster.Sharding.Tests"
                         verbose-debug-logging = on
                     }
                 }
@@ -269,7 +269,7 @@ public class RememberEntitiesExcessiveFailureSpec : AkkaSpec
             .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSharding.DefaultConfig());
 
-    public RememberEntitiesExcessiveFailureSpec(ITestOutputHelper helper) : base(SpecConfig, helper)
+    public RememberEntitiesSupervisionStrategyDecisionSpec(ITestOutputHelper helper) : base(SpecConfig, helper)
     {
     }
 
@@ -289,8 +289,8 @@ public class RememberEntitiesExcessiveFailureSpec : AkkaSpec
         return Directive.Restart;
     }
     
-    [Fact(DisplayName = "Persistent shard must stop remembered entity with excessive failures on start")]
-    public async Task Persistent_Shard_must_stop_remembered_entity_with_excessive_constructor_failure()
+    [Fact(DisplayName = "Persistent shard must stop remembered entity with excessive failures")]
+    public async Task Persistent_Shard_must_stop_remembered_entity_with_excessive_restart_attempt()
     {
         var strategyCounter = new AtomicCounter(0);
         
@@ -305,7 +305,7 @@ public class RememberEntitiesExcessiveFailureSpec : AkkaSpec
         Sys.EventStream.Subscribe<Error>(TestActor);
 
         var entityProps = Props.Create(() => new PreStartFailActor());
-        await EventFilter.Error(contains: "cats: Remembered entity 1 was stopped because it has failed repeatedly")
+        await EventFilter.Error(contains: "cats: Remembered entity 1 was stopped: entity failed repeatedly")
             .ExpectOneAsync(async () =>
             {
                 _ = Sys.ActorOf(Props.Create(() => new FakeShardRegion(settings, entityProps)));
@@ -316,4 +316,33 @@ public class RememberEntitiesExcessiveFailureSpec : AkkaSpec
         // Failed on the 4th call
         strategyCounter.Current.Should().Be(4);
     }
+    
+    [Fact(DisplayName = "Persistent shard must stop remembered entity when stopped using Directive.Stop decision")]
+    public async Task Persistent_Shard_must_stop_remembered_entity_with_stop_directive_on_constructor_failure()
+    {
+        var strategyCounter = new AtomicCounter(0);
+        
+        var settings = ClusterShardingSettings.Create(Sys);
+        settings = settings
+            .WithTuningParameters(settings.TuningParameters.WithEntityRestartBackoff(0.1.Seconds()))
+            .WithRememberEntities(true)
+            .WithSupervisorStrategy(new TestSupervisionStrategy(strategyCounter, 3, 1000, SupervisorStrategy.DefaultDecider.Decide));
+
+        var storeProbe = CreateTestProbe();
+        Sys.EventStream.Subscribe<ShardStoreCreated>(storeProbe);
+        Sys.EventStream.Subscribe<Error>(TestActor);
+
+        var entityProps = Props.Create(() => new ConstructorFailActor());
+        await EventFilter.Error(contains: "cats: Remembered entity 1 was stopped: entity stopped by Directive.Stop decision")
+            .ExpectOneAsync(async () =>
+            {
+                _ = Sys.ActorOf(Props.Create(() => new FakeShardRegion(settings, entityProps)));
+                storeProbe.ExpectMsg<ShardStoreCreated>();
+                await Task.Yield();
+            });
+
+        // Failed on the 1st call
+        strategyCounter.Current.Should().Be(1);
+    }
+    
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardEntityFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardEntityFailureSpec.cs
@@ -139,14 +139,15 @@ namespace Akka.Cluster.Sharding.Tests
                 null
             ));
 
-            Sys.EventStream.Subscribe<Error>(TestActor);
+            var errorProbe = CreateTestProbe();
+            Sys.EventStream.Subscribe<Error>(errorProbe);
 
             var persistentShard = Sys.ActorOf(props);
 
             persistentShard.Tell(new EntityEnvelope(1, "Start"));
 
             // entity died here
-            var err = ExpectMsg<Error>();
+            var err = errorProbe.ExpectMsg<Error>();
             err.Cause.Should().BeOfType<ActorInitializationException>();
 
             // Need to wait for the internal state to reset, else everything we sent will go to dead letter

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingSettings.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ClusterShardingSettings.cs
@@ -338,6 +338,8 @@ namespace Akka.Cluster.Sharding
         /// </summary>
         public readonly LeaseUsageSettings LeaseSettings;
 
+        public SupervisorStrategy? SupervisorStrategy { get; }
+        
         /// <summary>
         /// Create settings from the default configuration `akka.cluster.sharding`.
         /// </summary>
@@ -517,6 +519,34 @@ namespace Akka.Cluster.Sharding
             LeaseSettings = leaseSettings;
         }
 
+        private ClusterShardingSettings(
+            string role,
+            bool rememberEntities,
+            string journalPluginId,
+            string snapshotPluginId,
+            TimeSpan passivateIdleEntityAfter,
+            StateStoreMode stateStoreMode,
+            RememberEntitiesStore rememberEntitiesStore,
+            TimeSpan shardRegionQueryTimeout,
+            TuningParameters tuningParameters,
+            ClusterSingletonManagerSettings coordinatorSingletonSettings,
+            LeaseUsageSettings leaseSettings,
+            SupervisorStrategy supervisorStrategy)
+        {
+            Role = role;
+            RememberEntities = rememberEntities;
+            JournalPluginId = journalPluginId;
+            SnapshotPluginId = snapshotPluginId;
+            PassivateIdleEntityAfter = passivateIdleEntityAfter;
+            StateStoreMode = stateStoreMode;
+            RememberEntitiesStore = rememberEntitiesStore;
+            ShardRegionQueryTimeout = shardRegionQueryTimeout;
+            TuningParameters = tuningParameters;
+            CoordinatorSingletonSettings = coordinatorSingletonSettings;
+            LeaseSettings = leaseSettings;
+            SupervisorStrategy = supervisorStrategy;
+        }
+
         /// <summary>
         /// If true, this node should run the shard region, otherwise just a shard proxy should started on this node.
         /// </summary>
@@ -603,6 +633,11 @@ namespace Akka.Cluster.Sharding
             return Copy(leaseSettings: leaseSettings);
         }
 
+        public ClusterShardingSettings WithSupervisorStrategy(SupervisorStrategy supervisorStrategy)
+        {
+            return Copy(supervisorStrategy: supervisorStrategy);
+        }
+        
         /// <summary>
         /// TBD
         /// </summary>
@@ -630,7 +665,8 @@ namespace Akka.Cluster.Sharding
             TimeSpan? shardRegionQueryTimeout = null,
             TuningParameters tuningParameters = null,
             ClusterSingletonManagerSettings coordinatorSingletonSettings = null,
-            Option<LeaseUsageSettings> leaseSettings = default)
+            Option<LeaseUsageSettings> leaseSettings = default,
+            SupervisorStrategy? supervisorStrategy = null)
         {
             return new ClusterShardingSettings(
                 role: role.HasValue ? role.Value : Role,
@@ -643,7 +679,8 @@ namespace Akka.Cluster.Sharding
                 shardRegionQueryTimeout: shardRegionQueryTimeout ?? ShardRegionQueryTimeout,
                 tuningParameters: tuningParameters ?? TuningParameters,
                 coordinatorSingletonSettings: coordinatorSingletonSettings ?? CoordinatorSingletonSettings,
-                leaseSettings: leaseSettings.HasValue ? leaseSettings.Value : LeaseSettings);
+                leaseSettings: leaseSettings.HasValue ? leaseSettings.Value : LeaseSettings,
+                supervisorStrategy: supervisorStrategy ?? SupervisorStrategy);
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -1261,8 +1261,8 @@ namespace Akka.Cluster.Sharding
                 case Passivate p:
                     Passivate(Sender, p.StopMessage);
                     return true;
-                case ExcessiveSupervisorRestartPassivation ex:
-                    HandleExcessiveErrors(ex);
+                case SupervisorStopDirectivePassivation ex:
+                    HandleSupervisorStop(ex);
                     return true;
                 case IShardQuery msg:
                     ReceiveShardQuery(msg);
@@ -1381,8 +1381,8 @@ namespace Akka.Cluster.Sharding
                                 _entities.EntityId(Sender) ?? $"Unknown actor {Sender}");
                         Passivate(Sender, p.StopMessage);
                         return true;
-                    case ExcessiveSupervisorRestartPassivation ex:
-                        HandleExcessiveErrors(ex);
+                    case SupervisorStopDirectivePassivation ex:
+                        HandleSupervisorStop(ex);
                         return true;
                     case IShardQuery msg:
                         ReceiveShardQuery(msg);
@@ -1851,7 +1851,7 @@ namespace Akka.Cluster.Sharding
             }
         }
 
-        private void HandleExcessiveErrors(ExcessiveSupervisorRestartPassivation msg)
+        private void HandleSupervisorStop(SupervisorStopDirectivePassivation msg)
         {
             // We only have to do this if we have R-E enabled
             if (!_rememberEntities)
@@ -1870,8 +1870,8 @@ namespace Akka.Cluster.Sharding
             
             Log.Error(
                 msg.LastCause, 
-                "{0}: Remembered entity {1} was stopped because it has failed repeatedly within {2} ms, exceeding the supervisor strategy maximum restart count of {3}", 
-                _typeName, id, msg.TimeWindowInMilliseconds, msg.MaxRestartCount);
+                "{0}: Remembered entity {1} was stopped: {2}", 
+                _typeName, id, msg.Reason);
         }
 
         private void DeliverMessage(string entityId, object msg, IActorRef snd)

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -945,6 +945,7 @@ namespace Akka.Cluster.Sharding
             }
         }
 
+        private static readonly SupervisorStrategy DefaultShardSupervisionStrategy = new ShardSupervisionStrategy();
 
         private readonly string _typeName;
         private readonly string _shardId;
@@ -966,6 +967,7 @@ namespace Akka.Cluster.Sharding
         private readonly TimeSpan _leaseRetryInterval = TimeSpan.FromSeconds(5); // won't be used
 
         private readonly IShardingBufferMessageAdapter _bufferMessageAdapter;
+        private readonly SupervisorStrategy? _supervisorStrategy;
         
         public ILoggingAdapter Log { get; } = Context.GetLogger();
         public IStash Stash { get; set; } = null!;
@@ -1024,11 +1026,12 @@ namespace Akka.Cluster.Sharding
             }
 
             _bufferMessageAdapter = bufferMessageAdapter ?? EmptyBufferMessageAdapter.Instance;
+            _supervisorStrategy = settings.SupervisorStrategy;
         }
 
         protected override SupervisorStrategy SupervisorStrategy()
         {
-            return base.SupervisorStrategy();
+            return _supervisorStrategy ?? DefaultShardSupervisionStrategy;
         }
 
         protected override bool Receive(object message)
@@ -1258,6 +1261,9 @@ namespace Akka.Cluster.Sharding
                 case Passivate p:
                     Passivate(Sender, p.StopMessage);
                     return true;
+                case ExcessiveSupervisorRestartPassivation ex:
+                    HandleExcessiveErrors(ex);
+                    return true;
                 case IShardQuery msg:
                     ReceiveShardQuery(msg);
                     return true;
@@ -1374,6 +1380,9 @@ namespace Akka.Cluster.Sharding
                                 _typeName,
                                 _entities.EntityId(Sender) ?? $"Unknown actor {Sender}");
                         Passivate(Sender, p.StopMessage);
+                        return true;
+                    case ExcessiveSupervisorRestartPassivation ex:
+                        HandleExcessiveErrors(ex);
                         return true;
                     case IShardQuery msg:
                         ReceiveShardQuery(msg);
@@ -1840,6 +1849,29 @@ namespace Akka.Cluster.Sharding
             {
                 Log.Debug("{0}: Entity stopped after passivation [{1}]", _typeName, entityId);
             }
+        }
+
+        private void HandleExcessiveErrors(ExcessiveSupervisorRestartPassivation msg)
+        {
+            // We only have to do this if we have R-E enabled
+            if (!_rememberEntities)
+                return;
+            
+            var id = _entities.EntityId(msg.Child);
+            // Just return if the child actor is not a recorded shard entity
+            if (id is null) 
+                return;
+            
+            // Remove the child actor from the entity list
+            _entities.RemoveEntity(id);
+                
+            // Force stop the child actor, it might have been restarted
+            Context.Stop(msg.Child);
+            
+            Log.Error(
+                msg.LastCause, 
+                "{0}: Remembered entity {1} was stopped because it has failed repeatedly within {2} ms, exceeding the supervisor strategy maximum restart count of {3}", 
+                _typeName, id, msg.TimeWindowInMilliseconds, msg.MaxRestartCount);
         }
 
         private void DeliverMessage(string entityId, object msg, IActorRef snd)

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardSupervisionStrategy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardSupervisionStrategy.cs
@@ -59,9 +59,10 @@ public class ShardSupervisionStrategy: OneForOneStrategy
             RestartChild(child, cause, suspendFirst: false);
         else
         {
-            // Only send failure feedback if restart was requested
-            if(restart)
-                context.Self.Tell(new ExcessiveSupervisorRestartPassivation(child, WithinTimeRangeMilliseconds, MaxNumberOfRetries, cause));
+            var reason = restart 
+                ? $"entity failed repeatedly within {WithinTimeRangeMilliseconds} ms, exceeding the supervisor strategy maximum restart count of {MaxNumberOfRetries}" 
+                : "entity stopped by Directive.Stop decision";
+            context.Self.Tell(new SupervisorStopDirectivePassivation(child, reason, cause));
             context.Stop(child);
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardSupervisionStrategy.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardSupervisionStrategy.cs
@@ -1,0 +1,68 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ShardSupervisionStrategy.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Actor.Internal;
+
+namespace Akka.Cluster.Sharding;
+
+public class ShardSupervisionStrategy: OneForOneStrategy
+{
+    public ShardSupervisionStrategy(int? maxNrOfRetries, TimeSpan? withinTimeRange, Func<Exception, Directive> localOnlyDecider) 
+        : base(maxNrOfRetries, withinTimeRange, localOnlyDecider)
+    {
+    }
+
+    public ShardSupervisionStrategy(int? maxNrOfRetries, TimeSpan? withinTimeRange, IDecider decider) 
+        : base(maxNrOfRetries, withinTimeRange, decider)
+    {
+    }
+
+    public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Func<Exception, Directive> localOnlyDecider, bool loggingEnabled = true) 
+        : base(maxNrOfRetries, withinTimeMilliseconds, localOnlyDecider, loggingEnabled)
+    {
+    }
+
+    public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, IDecider decider, bool loggingEnabled = true) 
+        : base(maxNrOfRetries, withinTimeMilliseconds, decider, loggingEnabled)
+    {
+    }
+
+    public ShardSupervisionStrategy(Func<Exception, Directive> localOnlyDecider) 
+        : base(localOnlyDecider)
+    {
+    }
+
+    public ShardSupervisionStrategy(Func<Exception, Directive> localOnlyDecider, bool loggingEnabled = true) 
+        : base(localOnlyDecider, loggingEnabled)
+    {
+    }
+
+    public ShardSupervisionStrategy(IDecider decider) 
+        : base(decider)
+    {
+    }
+
+    public ShardSupervisionStrategy()
+    {
+    }
+
+    public override void ProcessFailure(IActorContext context, bool restart, IActorRef child, Exception cause, ChildRestartStats stats, IReadOnlyCollection<ChildRestartStats> children)
+    {
+        if (restart && stats.RequestRestartPermission(MaxNumberOfRetries, WithinTimeRangeMilliseconds))
+            RestartChild(child, cause, suspendFirst: false);
+        else
+        {
+            // Only send failure feedback if restart was requested
+            if(restart)
+                context.Self.Tell(new ExcessiveSupervisorRestartPassivation(child, WithinTimeRangeMilliseconds, MaxNumberOfRetries, cause));
+            context.Stop(child);
+        }
+    }
+}

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
@@ -61,6 +61,8 @@ namespace Akka.Cluster.Sharding
         public object StopMessage { get; }
     }
 
+    internal sealed record ExcessiveSupervisorRestartPassivation(IActorRef Child, int TimeWindowInMilliseconds, int MaxRestartCount, Exception LastCause) : IShardRegionCommand;
+    
     /// <summary>
     /// Send this message to the <see cref="ShardRegion"/> actor to handoff all shards that are hosted by
     /// the <see cref="ShardRegion"/> and then the <see cref="ShardRegion"/> actor will be stopped. You can <see cref="ICanWatch.Watch"/>

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardingMessages.cs
@@ -61,7 +61,7 @@ namespace Akka.Cluster.Sharding
         public object StopMessage { get; }
     }
 
-    internal sealed record ExcessiveSupervisorRestartPassivation(IActorRef Child, int TimeWindowInMilliseconds, int MaxRestartCount, Exception LastCause) : IShardRegionCommand;
+    internal sealed record SupervisorStopDirectivePassivation(IActorRef Child, string Reason, Exception LastCause) : IShardRegionCommand;
     
     /// <summary>
     /// Send this message to the <see cref="ShardRegion"/> actor to handoff all shards that are hosted by

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
@@ -78,6 +78,8 @@ namespace Akka.Cluster.Sharding
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings) { }
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.RememberEntitiesStore rememberEntitiesStore, System.TimeSpan shardRegionQueryTimeout, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public Akka.Actor.SupervisorStrategy SupervisorStrategy { get; }
         public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Configuration.Config config, Akka.Configuration.Config singletonConfig) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithCoordinatorSingletonSettings(Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings) { }
@@ -88,6 +90,7 @@ namespace Akka.Cluster.Sharding
         public Akka.Cluster.Sharding.ClusterShardingSettings WithRole(string role) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithSnapshotPluginId(string snapshotPluginId) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithStateStoreMode(Akka.Cluster.Sharding.StateStoreMode mode) { }
+        public Akka.Cluster.Sharding.ClusterShardingSettings WithSupervisorStrategy(Akka.Actor.SupervisorStrategy supervisorStrategy) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithTuningParameters(Akka.Cluster.Sharding.TuningParameters tuningParameters) { }
     }
     public sealed class ClusterShardingStats : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ClusterShardingStats>
@@ -295,6 +298,18 @@ namespace Akka.Cluster.Sharding
         public bool Equals(Akka.Cluster.Sharding.ShardState other) { }
         public override int GetHashCode() { }
         public override string ToString() { }
+    }
+    public class ShardSupervisionStrategy : Akka.Actor.OneForOneStrategy
+    {
+        public ShardSupervisionStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public ShardSupervisionStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, Akka.Actor.IDecider decider) { }
+        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
+        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = True) { }
+        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
+        public ShardSupervisionStrategy(Akka.Actor.IDecider decider) { }
+        public ShardSupervisionStrategy() { }
+        public override void ProcessFailure(Akka.Actor.IActorContext context, bool restart, Akka.Actor.IActorRef child, System.Exception cause, Akka.Actor.Internal.ChildRestartStats stats, System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> children) { }
     }
     [Akka.Annotations.ApiMayChangeAttribute()]
     [Akka.Annotations.DoNotInheritAttribute()]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
@@ -78,6 +78,8 @@ namespace Akka.Cluster.Sharding
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings) { }
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.RememberEntitiesStore rememberEntitiesStore, System.TimeSpan shardRegionQueryTimeout, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public Akka.Actor.SupervisorStrategy SupervisorStrategy { get; }
         public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Configuration.Config config, Akka.Configuration.Config singletonConfig) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithCoordinatorSingletonSettings(Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings) { }
@@ -88,6 +90,7 @@ namespace Akka.Cluster.Sharding
         public Akka.Cluster.Sharding.ClusterShardingSettings WithRole(string role) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithSnapshotPluginId(string snapshotPluginId) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithStateStoreMode(Akka.Cluster.Sharding.StateStoreMode mode) { }
+        public Akka.Cluster.Sharding.ClusterShardingSettings WithSupervisorStrategy(Akka.Actor.SupervisorStrategy supervisorStrategy) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithTuningParameters(Akka.Cluster.Sharding.TuningParameters tuningParameters) { }
     }
     public sealed class ClusterShardingStats : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ClusterShardingStats>
@@ -295,6 +298,18 @@ namespace Akka.Cluster.Sharding
         public bool Equals(Akka.Cluster.Sharding.ShardState other) { }
         public override int GetHashCode() { }
         public override string ToString() { }
+    }
+    public class ShardSupervisionStrategy : Akka.Actor.OneForOneStrategy
+    {
+        public ShardSupervisionStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public ShardSupervisionStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, Akka.Actor.IDecider decider) { }
+        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
+        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = True) { }
+        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
+        public ShardSupervisionStrategy(Akka.Actor.IDecider decider) { }
+        public ShardSupervisionStrategy() { }
+        public override void ProcessFailure(Akka.Actor.IActorContext context, bool restart, Akka.Actor.IActorRef child, System.Exception cause, Akka.Actor.Internal.ChildRestartStats stats, System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> children) { }
     }
     [Akka.Annotations.ApiMayChangeAttribute()]
     [Akka.Annotations.DoNotInheritAttribute()]


### PR DESCRIPTION
Fixes #7629

## Changes

* Add specialized shard supervision strategy with feedback mechanism to signal excessive failures
* Add new `SupervisorStrategy` settings to `ShardSupervisionStrategy` (accessible only via C# fluent API)

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #7629
* [x] Changes in public API reviewed, if any.