### PR TITLE
DnsExt: Resolve ManagerClass Type from IDnsProvider

### DIFF
--- a/src/core/Akka/IO/Dns.cs
+++ b/src/core/Akka/IO/Dns.cs
@@ -275,7 +275,7 @@ namespace Akka.IO
         {
             get
             {
-                return _manager = _manager ?? _system.SystemActorOf(Props.Create(() => new SimpleDnsManager(this))
+                return _manager = _manager ?? _system.SystemActorOf(Props.Create(Provider.ManagerClass, this)
                                                                          .WithDeploy(Deploy.Local)
                                                                          .WithDispatcher(Settings.Dispatcher));
             }


### PR DESCRIPTION
Fixes https://github.com/akkadotnet/akka.net/issues/7726

## Changes

DnsExt resolves `ManagerClass` Type from IDnsProvider instead of hardcoded `SimpleDnsManager`

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [x] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
