### PR TITLE
Convert Akka.Cluster.Sharding.Tests.MultiNode to async

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowning2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowning2Spec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Akka.MultiNode.TestAdapter;
@@ -184,16 +185,16 @@ namespace Akka.Cluster.Sharding.Tests
         #endregion
 
         [MultiNodeFact]
-        public void Cluster_sharding_with_down_member_scenario_2_specs()
+        public async Task Cluster_sharding_with_down_member_scenario_2_specs()
         {
-            Cluster_sharding_with_down_member_scenario_2_must_join_cluster();
-            Cluster_sharding_with_down_member_scenario_2_must_initialize_shards();
-            Cluster_sharding_with_down_member_scenario_2_must_recover_after_downing_other_node_not_coordinator();
+            await Cluster_sharding_with_down_member_scenario_2_must_join_cluster();
+            await Cluster_sharding_with_down_member_scenario_2_must_initialize_shards();
+            await Cluster_sharding_with_down_member_scenario_2_must_recover_after_downing_other_node_not_coordinator();
         }
 
-        private void Cluster_sharding_with_down_member_scenario_2_must_join_cluster()
+        private async Task Cluster_sharding_with_down_member_scenario_2_must_join_cluster()
         {
-            Within(TimeSpan.FromSeconds(20), () =>
+            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
             {
                 StartPersistenceIfNeeded(startOn: Config.First, Config.First, Config.Second);
 
@@ -210,11 +211,11 @@ namespace Akka.Cluster.Sharding.Tests
                     });
                 }, Config.First, Config.Second);
 
-                EnterBarrier("after-2");
+                await EnterBarrierAsync("after-2");
             });
         }
 
-        private void Cluster_sharding_with_down_member_scenario_2_must_initialize_shards()
+        private async Task Cluster_sharding_with_down_member_scenario_2_must_initialize_shards()
         {
             RunOn(() =>
             {
@@ -228,18 +229,18 @@ namespace Akka.Cluster.Sharding.Tests
                 shardLocations.Tell(new Locations(locations));
                 Sys.Log.Debug("Original locations: [{0}]", string.Join(", ", locations.Select(i => $"{i.Key}: {i.Value}")));
             }, Config.First);
-            EnterBarrier("after-3");
+            await EnterBarrierAsync("after-3");
         }
 
-        private void Cluster_sharding_with_down_member_scenario_2_must_recover_after_downing_other_node_not_coordinator()
+        private async Task Cluster_sharding_with_down_member_scenario_2_must_recover_after_downing_other_node_not_coordinator()
         {
-            Within(TimeSpan.FromSeconds(20), () =>
+            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
             {
                 var secondAddress = GetAddress(Config.Second);
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
-                    TestConductor.Blackhole(Config.First, Config.Second, Direction.Both).Wait();
+                    await TestConductor.BlackholeAsync(Config.First, Config.Second, Direction.Both);
                 }, Config.First);
 
                 Thread.Sleep(3000);
@@ -289,7 +290,7 @@ namespace Akka.Cluster.Sharding.Tests
                 }, Config.First);
             });
 
-            EnterBarrier("after-4");
+            await EnterBarrierAsync("after-4");
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowning2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowning2Spec.cs
@@ -19,278 +19,278 @@ using Akka.Util;
 using FluentAssertions;
 using static Akka.Remote.Transport.ThrottleTransportAdapter;
 
-namespace Akka.Cluster.Sharding.Tests
-{
-    public class ClusterShardCoordinatorDowning2SpecConfig : MultiNodeClusterShardingConfig
-    {
-        public RoleName First { get; }
-        public RoleName Second { get; }
+namespace Akka.Cluster.Sharding.Tests;
 
-        public ClusterShardCoordinatorDowning2SpecConfig(StateStoreMode mode)
-            : base(mode: mode, loglevel: "DEBUG", additionalConfig: @"
+public class ClusterShardCoordinatorDowning2SpecConfig : MultiNodeClusterShardingConfig
+{
+    public RoleName First { get; }
+    public RoleName Second { get; }
+
+    public ClusterShardCoordinatorDowning2SpecConfig(StateStoreMode mode)
+        : base(mode: mode, loglevel: "DEBUG", additionalConfig: @"
                 akka.cluster.sharding.rebalance-interval = 120 s
                 # setting down-removal-margin, for testing of issue #29131
                 akka.cluster.down-removal-margin = 3 s
                 akka.remote.watch-failure-detector.acceptable-heartbeat-pause = 3s
             ")
-        {
-            First = Role("first");
-            Second = Role("second");
-
-            TestTransport = true;
-        }
-    }
-
-    public class PersistentClusterShardCoordinatorDowning2SpecConfig : ClusterShardCoordinatorDowning2SpecConfig
     {
-        public PersistentClusterShardCoordinatorDowning2SpecConfig()
-            : base(StateStoreMode.Persistence)
-        {
-        }
-    }
+        First = Role("first");
+        Second = Role("second");
 
-    public class DDataClusterShardCoordinatorDowning2SpecConfig : ClusterShardCoordinatorDowning2SpecConfig
-    {
-        public DDataClusterShardCoordinatorDowning2SpecConfig()
-            : base(StateStoreMode.DData)
-        {
-        }
-    }
-
-    public class PersistentClusterShardCoordinatorDowning2Spec : ClusterShardCoordinatorDowning2Spec
-    {
-        public PersistentClusterShardCoordinatorDowning2Spec()
-            : base(new PersistentClusterShardCoordinatorDowning2SpecConfig(), typeof(PersistentClusterShardCoordinatorDowning2Spec))
-        {
-        }
-    }
-
-    public class DDataClusterShardCoordinatorDowning2Spec : ClusterShardCoordinatorDowning2Spec
-    {
-        public DDataClusterShardCoordinatorDowning2Spec()
-            : base(new DDataClusterShardCoordinatorDowning2SpecConfig(), typeof(DDataClusterShardCoordinatorDowning2Spec))
-        {
-        }
-    }
-
-    public abstract class ClusterShardCoordinatorDowning2Spec : MultiNodeClusterShardingSpec<ClusterShardCoordinatorDowning2SpecConfig>
-    {
-        #region setup
-
-        internal sealed class Ping
-        {
-            public readonly string Id;
-
-            public Ping(string id)
-            {
-                Id = id;
-            }
-        }
-
-        internal class Entity : ActorBase
-        {
-            protected override bool Receive(object message)
-            {
-                if (message is Ping)
-                {
-                    Sender.Tell(Self);
-                    return true;
-                }
-                return false;
-            }
-        }
-
-        internal class GetLocations
-        {
-            public static readonly GetLocations Instance = new();
-
-            private GetLocations()
-            {
-            }
-        }
-
-        internal class Locations
-        {
-            public Locations(ImmutableDictionary<string, IActorRef> locations)
-            {
-                Locs = locations;
-            }
-
-            public ImmutableDictionary<string, IActorRef> Locs { get; }
-        }
-
-        internal class ShardLocations : ActorBase
-        {
-            private Locations locations;
-
-            public ShardLocations()
-            {
-            }
-
-            protected override bool Receive(object message)
-            {
-                switch (message)
-                {
-                    case GetLocations _:
-                        Sender.Tell(locations);
-                        return true;
-                    case Locations l:
-                        locations = l;
-                        return true;
-                }
-                return false;
-            }
-        }
-
-        private sealed class MessageExtractor: IMessageExtractor
-        {
-            public string EntityId(object message)
-                => message switch
-                {
-                    Ping p => p.Id,
-                    _ => null
-                };
-
-            public object EntityMessage(object message)
-                => message;
-
-            public string ShardId(object message)
-                => message switch
-                {
-                    Ping p => p.Id[0].ToString(),
-                    _ => null
-                };
-
-            public string ShardId(string entityId, object messageHint = null)
-                => entityId[0].ToString();
-        }
-
-        private readonly Lazy<IActorRef> _region;
-
-        protected ClusterShardCoordinatorDowning2Spec(ClusterShardCoordinatorDowning2SpecConfig config, Type type)
-            : base(config, type)
-        {
-            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
-        }
-
-        private void StartSharding()
-        {
-            StartSharding(
-                Sys,
-                typeName: "Entity",
-                entityProps: Props.Create(() => new Entity()), 
-                messageExtractor: new MessageExtractor());
-        }
-
-        #endregion
-
-        [MultiNodeFact]
-        public async Task Cluster_sharding_with_down_member_scenario_2_specs()
-        {
-            await Cluster_sharding_with_down_member_scenario_2_must_join_cluster();
-            await Cluster_sharding_with_down_member_scenario_2_must_initialize_shards();
-            await Cluster_sharding_with_down_member_scenario_2_must_recover_after_downing_other_node_not_coordinator();
-        }
-
-        private async Task Cluster_sharding_with_down_member_scenario_2_must_join_cluster()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
-            {
-                StartPersistenceIfNeeded(startOn: Config.First, Config.First, Config.Second);
-
-                Join(Config.First, Config.First, onJoinedRunOnFrom: StartSharding);
-                Join(Config.Second, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
-
-                // all Up, everywhere before continuing
-                RunOn(() =>
-                {
-                    AwaitAssert(() =>
-                    {
-                        Cluster.State.Members.Count.Should().Be(2);
-                        Cluster.State.Members.Should().OnlyContain(m => m.Status == MemberStatus.Up);
-                    });
-                }, Config.First, Config.Second);
-
-                await EnterBarrierAsync("after-2");
-            });
-        }
-
-        private async Task Cluster_sharding_with_down_member_scenario_2_must_initialize_shards()
-        {
-            RunOn(() =>
-            {
-                var shardLocations = Sys.ActorOf(Props.Create(() => new ShardLocations()), "shardLocations");
-                var locations = Enumerable.Range(1, 4).Select(n =>
-                {
-                    var id = n.ToString();
-                    _region.Value.Tell(new Ping(id));
-                    return new KeyValuePair<string, IActorRef>(id, ExpectMsg<IActorRef>());
-                }).ToImmutableDictionary();
-                shardLocations.Tell(new Locations(locations));
-                Sys.Log.Debug("Original locations: [{0}]", string.Join(", ", locations.Select(i => $"{i.Key}: {i.Value}")));
-            }, Config.First);
-            await EnterBarrierAsync("after-3");
-        }
-
-        private async Task Cluster_sharding_with_down_member_scenario_2_must_recover_after_downing_other_node_not_coordinator()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
-            {
-                var secondAddress = GetAddress(Config.Second);
-
-                await RunOnAsync(async () =>
-                {
-                    await TestConductor.BlackholeAsync(Config.First, Config.Second, Direction.Both);
-                }, Config.First);
-
-                Thread.Sleep(3000);
-
-                RunOn(() =>
-                {
-                    Cluster.Down(GetAddress(Config.Second));
-                    AwaitAssert(() =>
-                    {
-                        Cluster.State.Members.Count.Should().Be(1);
-                    });
-
-                    // start a few more new shards, could be allocated to second but should notice that it's terminated
-                    ImmutableDictionary<string, IActorRef> additionalLocations = null;
-                    AwaitAssert(() =>
-                    {
-                        var probe = CreateTestProbe();
-                        additionalLocations = Enumerable.Range(5, 4).Select(n =>
-                        {
-                            var id = n.ToString();
-                            _region.Value.Tell(new Ping(id), probe.Ref);
-                            return new KeyValuePair<string, IActorRef>(id, probe.ExpectMsg<IActorRef>(TimeSpan.FromSeconds(1)));
-                        }).ToImmutableDictionary();
-                    });
-                    Sys.Log.Debug("Additional locations: [{0}]", string.Join(", ", additionalLocations.Select(i => $"{i.Key}: {i.Value}")));
-
-                    Sys.ActorSelection(Node(Config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
-                    var originalLocations = ExpectMsg<Locations>().Locs;
-
-                    AwaitAssert(() =>
-                    {
-                        var probe = CreateTestProbe();
-                        foreach (var loc in originalLocations.SetItems(additionalLocations))
-                        {
-                            _region.Value.Tell(new Ping(loc.Key), probe.Ref);
-                            if (loc.Value.Path.Address.Equals(secondAddress))
-                            {
-                                var newRef = probe.ExpectMsg<IActorRef>(TimeSpan.FromSeconds(1));
-                                newRef.Should().NotBe(loc.Value);
-                                Sys.Log.Debug("Moved [{0}] from [{1}] to [{2}]", loc.Key, loc.Value, newRef);
-                            }
-                            else
-                                probe.ExpectMsg(loc.Value, TimeSpan.FromSeconds(1)); // should not move
-
-                        }
-                    });
-                }, Config.First);
-            });
-
-            await EnterBarrierAsync("after-4");
-        }
+        TestTransport = true;
     }
 }
+
+public class PersistentClusterShardCoordinatorDowning2SpecConfig : ClusterShardCoordinatorDowning2SpecConfig
+{
+    public PersistentClusterShardCoordinatorDowning2SpecConfig()
+        : base(StateStoreMode.Persistence)
+    {
+    }
+}
+
+public class DDataClusterShardCoordinatorDowning2SpecConfig : ClusterShardCoordinatorDowning2SpecConfig
+{
+    public DDataClusterShardCoordinatorDowning2SpecConfig()
+        : base(StateStoreMode.DData)
+    {
+    }
+}
+
+public class PersistentClusterShardCoordinatorDowning2Spec : ClusterShardCoordinatorDowning2Spec
+{
+    public PersistentClusterShardCoordinatorDowning2Spec()
+        : base(new PersistentClusterShardCoordinatorDowning2SpecConfig(), typeof(PersistentClusterShardCoordinatorDowning2Spec))
+    {
+    }
+}
+
+public class DDataClusterShardCoordinatorDowning2Spec : ClusterShardCoordinatorDowning2Spec
+{
+    public DDataClusterShardCoordinatorDowning2Spec()
+        : base(new DDataClusterShardCoordinatorDowning2SpecConfig(), typeof(DDataClusterShardCoordinatorDowning2Spec))
+    {
+    }
+}
+
+public abstract class ClusterShardCoordinatorDowning2Spec : MultiNodeClusterShardingSpec<ClusterShardCoordinatorDowning2SpecConfig>
+{
+    #region setup
+
+    internal sealed class Ping
+    {
+        public readonly string Id;
+
+        public Ping(string id)
+        {
+            Id = id;
+        }
+    }
+
+    internal class Entity : ActorBase
+    {
+        protected override bool Receive(object message)
+        {
+            if (message is Ping)
+            {
+                Sender.Tell(Self);
+                return true;
+            }
+            return false;
+        }
+    }
+
+    internal class GetLocations
+    {
+        public static readonly GetLocations Instance = new();
+
+        private GetLocations()
+        {
+        }
+    }
+
+    internal class Locations
+    {
+        public Locations(ImmutableDictionary<string, IActorRef> locations)
+        {
+            Locs = locations;
+        }
+
+        public ImmutableDictionary<string, IActorRef> Locs { get; }
+    }
+
+    internal class ShardLocations : ActorBase
+    {
+        private Locations locations;
+
+        public ShardLocations()
+        {
+        }
+
+        protected override bool Receive(object message)
+        {
+            switch (message)
+            {
+                case GetLocations _:
+                    Sender.Tell(locations);
+                    return true;
+                case Locations l:
+                    locations = l;
+                    return true;
+            }
+            return false;
+        }
+    }
+
+    private sealed class MessageExtractor: IMessageExtractor
+    {
+        public string EntityId(object message)
+            => message switch
+            {
+                Ping p => p.Id,
+                _ => null
+            };
+
+        public object EntityMessage(object message)
+            => message;
+
+        public string ShardId(object message)
+            => message switch
+            {
+                Ping p => p.Id[0].ToString(),
+                _ => null
+            };
+
+        public string ShardId(string entityId, object messageHint = null)
+            => entityId[0].ToString();
+    }
+
+    private readonly Lazy<IActorRef> _region;
+
+    protected ClusterShardCoordinatorDowning2Spec(ClusterShardCoordinatorDowning2SpecConfig config, Type type)
+        : base(config, type)
+    {
+        _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
+    }
+
+    private void StartSharding()
+    {
+        StartSharding(
+            Sys,
+            typeName: "Entity",
+            entityProps: Props.Create(() => new Entity()), 
+            messageExtractor: new MessageExtractor());
+    }
+
+    #endregion
+
+    [MultiNodeFact]
+    public async Task Cluster_sharding_with_down_member_scenario_2_specs()
+    {
+        await Cluster_sharding_with_down_member_scenario_2_must_join_cluster();
+        await Cluster_sharding_with_down_member_scenario_2_must_initialize_shards();
+        await Cluster_sharding_with_down_member_scenario_2_must_recover_after_downing_other_node_not_coordinator();
+    }
+
+    private async Task Cluster_sharding_with_down_member_scenario_2_must_join_cluster()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(20), async () =>
+        {
+            await StartPersistenceIfNeededAsync(Config.First, CancellationToken.None, Config.First, Config.Second);
+
+            await JoinAsync(Config.First, Config.First, onJoinedRunOnFrom: StartSharding);
+            await JoinAsync(Config.Second, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
+
+            // all Up, everywhere before continuing
+            RunOn(() =>
+            {
+                AwaitAssert(() =>
+                {
+                    Cluster.State.Members.Count.Should().Be(2);
+                    Cluster.State.Members.Should().OnlyContain(m => m.Status == MemberStatus.Up);
+                });
+            }, Config.First, Config.Second);
+
+            await EnterBarrierAsync("after-2");
+        });
+    }
+
+    private async Task Cluster_sharding_with_down_member_scenario_2_must_initialize_shards()
+    {
+        RunOn(() =>
+        {
+            var shardLocations = Sys.ActorOf(Props.Create(() => new ShardLocations()), "shardLocations");
+            var locations = Enumerable.Range(1, 4).Select(n =>
+            {
+                var id = n.ToString();
+                _region.Value.Tell(new Ping(id));
+                return new KeyValuePair<string, IActorRef>(id, ExpectMsg<IActorRef>());
+            }).ToImmutableDictionary();
+            shardLocations.Tell(new Locations(locations));
+            Sys.Log.Debug("Original locations: [{0}]", string.Join(", ", locations.Select(i => $"{i.Key}: {i.Value}")));
+        }, Config.First);
+        await EnterBarrierAsync("after-3");
+    }
+
+    private async Task Cluster_sharding_with_down_member_scenario_2_must_recover_after_downing_other_node_not_coordinator()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(20), async () =>
+        {
+            var secondAddress = GetAddress(Config.Second);
+
+            await RunOnAsync(async () =>
+            {
+                await TestConductor.BlackholeAsync(Config.First, Config.Second, Direction.Both);
+            }, Config.First);
+
+            await Task.Delay(3000);
+
+            await RunOnAsync(async () =>
+            {
+                Cluster.Down(GetAddress(Config.Second));
+                await AwaitAssertAsync(() =>
+                {
+                    Cluster.State.Members.Count.Should().Be(1);
+                });
+
+                // start a few more new shards, could be allocated to second but should notice that it's terminated
+                ImmutableDictionary<string, IActorRef> additionalLocations = null;
+                await AwaitAssertAsync(() =>
+                {
+                    var probe = CreateTestProbe();
+                    additionalLocations = Enumerable.Range(5, 4).Select(n =>
+                    {
+                        var id = n.ToString();
+                        _region.Value.Tell(new Ping(id), probe.Ref);
+                        return new KeyValuePair<string, IActorRef>(id, probe.ExpectMsg<IActorRef>(TimeSpan.FromSeconds(1)));
+                    }).ToImmutableDictionary();
+                });
+                Sys.Log.Debug("Additional locations: [{0}]", string.Join(", ", additionalLocations.Select(i => $"{i.Key}: {i.Value}")));
+
+                Sys.ActorSelection(await NodeAsync(Config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
+                var originalLocations = (await ExpectMsgAsync<Locations>()).Locs;
+
+                await AwaitAssertAsync(async () =>
+                {
+                    var probe = CreateTestProbe();
+                    foreach (var loc in originalLocations.SetItems(additionalLocations))
+                    {
+                        _region.Value.Tell(new Ping(loc.Key), probe.Ref);
+                        if (loc.Value.Path.Address.Equals(secondAddress))
+                        {
+                            var newRef = await probe.ExpectMsgAsync<IActorRef>(TimeSpan.FromSeconds(1));
+                            newRef.Should().NotBe(loc.Value);
+                            Sys.Log.Debug("Moved [{0}] from [{1}] to [{2}]", loc.Key, loc.Value, newRef);
+                        }
+                        else
+                            await probe.ExpectMsgAsync(loc.Value, TimeSpan.FromSeconds(1)); // should not move
+
+                    }
+                });
+            }, Config.First);
+        });
+
+        await EnterBarrierAsync("after-4");
+    }
+}
+

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowningSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowningSpec.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Akka.MultiNode.TestAdapter;
@@ -186,16 +187,16 @@ namespace Akka.Cluster.Sharding.Tests
         #endregion
 
         [MultiNodeFact]
-        public void Cluster_sharding_with_down_member_scenario_1_specs()
+        public async Task Cluster_sharding_with_down_member_scenario_1_specs()
         {
-            Cluster_sharding_with_down_member_scenario_1_must_join_cluster();
-            Cluster_sharding_with_down_member_scenario_1_must_initialize_shards();
-            Cluster_sharding_with_down_member_scenario_1_must_recover_after_downing_coordinator_node();
+            await Cluster_sharding_with_down_member_scenario_1_must_join_cluster();
+            await Cluster_sharding_with_down_member_scenario_1_must_initialize_shards();
+            await Cluster_sharding_with_down_member_scenario_1_must_recover_after_downing_coordinator_node();
         }
 
-        private void Cluster_sharding_with_down_member_scenario_1_must_join_cluster()
+        private async Task Cluster_sharding_with_down_member_scenario_1_must_join_cluster()
         {
-            Within(TimeSpan.FromSeconds(20), () =>
+            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
             {
                 StartPersistenceIfNeeded(startOn: Config.Controller, Config.First, Config.Second);
 
@@ -212,12 +213,12 @@ namespace Akka.Cluster.Sharding.Tests
                     });
                 }, Config.First, Config.Second);
 
-                EnterBarrier("after-2");
+                await EnterBarrierAsync("after-2");
             });
         }
 
 
-        private void Cluster_sharding_with_down_member_scenario_1_must_initialize_shards()
+        private async Task Cluster_sharding_with_down_member_scenario_1_must_initialize_shards()
         {
             RunOn(() =>
             {
@@ -231,22 +232,22 @@ namespace Akka.Cluster.Sharding.Tests
                 shardLocations.Tell(new Locations(locations));
                 Sys.Log.Debug("Original locations: [{0}]", string.Join(", ", locations.Select(i => $"{i.Key}: {i.Value}")));
             }, Config.First);
-            EnterBarrier("after-3");
+            await EnterBarrierAsync("after-3");
         }
 
-        private void Cluster_sharding_with_down_member_scenario_1_must_recover_after_downing_coordinator_node()
+        private async Task Cluster_sharding_with_down_member_scenario_1_must_recover_after_downing_coordinator_node()
         {
-            Within(TimeSpan.FromSeconds(20), () =>
+            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
             {
                 var firstAddress = GetAddress(Config.First);
                 Sys.ActorSelection(Node(Config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
                 var originalLocations = ExpectMsg<Locations>().Locs;
 
-                EnterBarrier("after-3-locations");
+                await EnterBarrierAsync("after-3-locations");
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
-                    TestConductor.Blackhole(Config.First, Config.Second, Direction.Both).Wait();
+                    await TestConductor.BlackholeAsync(Config.First, Config.Second, Direction.Both);
                 }, Config.Controller);
 
                 Thread.Sleep(3000);
@@ -293,7 +294,7 @@ namespace Akka.Cluster.Sharding.Tests
                 }, Config.Second);
             });
 
-            EnterBarrier("after-4");
+            await EnterBarrierAsync("after-4");
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowningSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardCoordinatorDowningSpec.cs
@@ -19,282 +19,281 @@ using Akka.Util;
 using FluentAssertions;
 using static Akka.Remote.Transport.ThrottleTransportAdapter;
 
-namespace Akka.Cluster.Sharding.Tests
-{
-    public class ClusterShardCoordinatorDowningSpecConfig : MultiNodeClusterShardingConfig
-    {
-        public RoleName Controller { get; }
-        public RoleName First { get; }
-        public RoleName Second { get; }
+namespace Akka.Cluster.Sharding.Tests;
 
-        public ClusterShardCoordinatorDowningSpecConfig(StateStoreMode mode)
-            : base(mode: mode, loglevel: "DEBUG", additionalConfig: @"
+public class ClusterShardCoordinatorDowningSpecConfig : MultiNodeClusterShardingConfig
+{
+    public RoleName Controller { get; }
+    public RoleName First { get; }
+    public RoleName Second { get; }
+
+    public ClusterShardCoordinatorDowningSpecConfig(StateStoreMode mode)
+        : base(mode: mode, loglevel: "DEBUG", additionalConfig: @"
                 akka.cluster.sharding.rebalance-interval = 120 s
                 # setting down-removal-margin, for testing of issue #29131
                 akka.cluster.down-removal-margin = 3 s
                 akka.remote.watch-failure-detector.acceptable-heartbeat-pause = 3s
             ")
-        {
-            Controller = Role("controller");
-            First = Role("first");
-            Second = Role("second");
+    {
+        Controller = Role("controller");
+        First = Role("first");
+        Second = Role("second");
 
-            TestTransport = true;
+        TestTransport = true;
+    }
+}
+
+public class PersistentClusterShardCoordinatorDowningSpecConfig : ClusterShardCoordinatorDowningSpecConfig
+{
+    public PersistentClusterShardCoordinatorDowningSpecConfig()
+        : base(StateStoreMode.Persistence)
+    {
+    }
+}
+
+public class DDataClusterShardCoordinatorDowningSpecConfig : ClusterShardCoordinatorDowningSpecConfig
+{
+    public DDataClusterShardCoordinatorDowningSpecConfig()
+        : base(StateStoreMode.DData)
+    {
+    }
+}
+
+public class PersistentClusterShardCoordinatorDowningSpec : ClusterShardCoordinatorDowningSpec
+{
+    public PersistentClusterShardCoordinatorDowningSpec()
+        : base(new PersistentClusterShardCoordinatorDowningSpecConfig(), typeof(PersistentClusterShardCoordinatorDowningSpec))
+    {
+    }
+}
+
+public class DDataClusterShardCoordinatorDowningSpec : ClusterShardCoordinatorDowningSpec
+{
+    public DDataClusterShardCoordinatorDowningSpec()
+        : base(new DDataClusterShardCoordinatorDowningSpecConfig(), typeof(DDataClusterShardCoordinatorDowningSpec))
+    {
+    }
+}
+
+public abstract class ClusterShardCoordinatorDowningSpec : MultiNodeClusterShardingSpec<ClusterShardCoordinatorDowningSpecConfig>
+{
+    #region setup
+
+    internal sealed class Ping
+    {
+        public readonly string Id;
+
+        public Ping(string id)
+        {
+            Id = id;
         }
     }
 
-    public class PersistentClusterShardCoordinatorDowningSpecConfig : ClusterShardCoordinatorDowningSpecConfig
+    internal class Entity : ActorBase
     {
-        public PersistentClusterShardCoordinatorDowningSpecConfig()
-            : base(StateStoreMode.Persistence)
+        protected override bool Receive(object message)
         {
-        }
-    }
-
-    public class DDataClusterShardCoordinatorDowningSpecConfig : ClusterShardCoordinatorDowningSpecConfig
-    {
-        public DDataClusterShardCoordinatorDowningSpecConfig()
-            : base(StateStoreMode.DData)
-        {
-        }
-    }
-
-    public class PersistentClusterShardCoordinatorDowningSpec : ClusterShardCoordinatorDowningSpec
-    {
-        public PersistentClusterShardCoordinatorDowningSpec()
-            : base(new PersistentClusterShardCoordinatorDowningSpecConfig(), typeof(PersistentClusterShardCoordinatorDowningSpec))
-        {
-        }
-    }
-
-    public class DDataClusterShardCoordinatorDowningSpec : ClusterShardCoordinatorDowningSpec
-    {
-        public DDataClusterShardCoordinatorDowningSpec()
-            : base(new DDataClusterShardCoordinatorDowningSpecConfig(), typeof(DDataClusterShardCoordinatorDowningSpec))
-        {
-        }
-    }
-
-    public abstract class ClusterShardCoordinatorDowningSpec : MultiNodeClusterShardingSpec<ClusterShardCoordinatorDowningSpecConfig>
-    {
-        #region setup
-
-        internal sealed class Ping
-        {
-            public readonly string Id;
-
-            public Ping(string id)
+            if (message is Ping)
             {
-                Id = id;
+                Sender.Tell(Self);
+                return true;
             }
+            return false;
+        }
+    }
+
+    internal class GetLocations
+    {
+        public static readonly GetLocations Instance = new();
+
+        private GetLocations()
+        {
+        }
+    }
+
+    internal class Locations
+    {
+        public Locations(ImmutableDictionary<string, IActorRef> locations)
+        {
+            Locs = locations;
         }
 
-        internal class Entity : ActorBase
+        public ImmutableDictionary<string, IActorRef> Locs { get; }
+    }
+
+    internal class ShardLocations : ActorBase
+    {
+        private Locations _locations;
+
+        public ShardLocations()
         {
-            protected override bool Receive(object message)
+        }
+
+        protected override bool Receive(object message)
+        {
+            switch (message)
             {
-                if (message is Ping)
-                {
-                    Sender.Tell(Self);
+                case GetLocations _:
+                    Sender.Tell(_locations);
                     return true;
-                }
-                return false;
+                case Locations l:
+                    _locations = l;
+                    return true;
             }
+            return false;
         }
+    }
 
-        internal class GetLocations
-        {
-            public static readonly GetLocations Instance = new();
-
-            private GetLocations()
+    private sealed class MessageExtractor: IMessageExtractor
+    {
+        public string EntityId(object message)
+            => message switch
             {
-            }
-        }
+                Ping p => p.Id,
+                _ => null
+            };
 
-        internal class Locations
-        {
-            public Locations(ImmutableDictionary<string, IActorRef> locations)
+        public object EntityMessage(object message)
+            => message;
+
+        public string ShardId(object message)
+            => message switch
             {
-                Locs = locations;
-            }
+                Ping p => p.Id[0].ToString(),
+                _ => null
+            };
 
-            public ImmutableDictionary<string, IActorRef> Locs { get; }
-        }
+        public string ShardId(string entityId, object messageHint = null)
+            => entityId[0].ToString();
+    }
 
-        internal class ShardLocations : ActorBase
+    private readonly Lazy<IActorRef> _region;
+
+    protected ClusterShardCoordinatorDowningSpec(ClusterShardCoordinatorDowningSpecConfig config, Type type)
+        : base(config, type)
+    {
+        _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
+    }
+
+    private void StartSharding()
+    {
+        StartSharding(
+            Sys,
+            typeName: "Entity",
+            entityProps: Props.Create(() => new Entity()),
+            messageExtractor: new MessageExtractor());
+    }
+
+    #endregion
+
+    [MultiNodeFact]
+    public async Task Cluster_sharding_with_down_member_scenario_1_specs()
+    {
+        await Cluster_sharding_with_down_member_scenario_1_must_join_cluster();
+        await Cluster_sharding_with_down_member_scenario_1_must_initialize_shards();
+        await Cluster_sharding_with_down_member_scenario_1_must_recover_after_downing_coordinator_node();
+    }
+
+    private async Task Cluster_sharding_with_down_member_scenario_1_must_join_cluster()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(20), async () =>
         {
-            private Locations locations;
+            StartPersistenceIfNeeded(startOn: Config.Controller, Config.First, Config.Second);
 
-            public ShardLocations()
-            {
-            }
+            await JoinAsync(Config.First, Config.First, onJoinedRunOnFrom: StartSharding);
+            await JoinAsync(Config.Second, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
 
-            protected override bool Receive(object message)
-            {
-                switch (message)
-                {
-                    case GetLocations _:
-                        Sender.Tell(locations);
-                        return true;
-                    case Locations l:
-                        locations = l;
-                        return true;
-                }
-                return false;
-            }
-        }
-
-        private sealed class MessageExtractor: IMessageExtractor
-        {
-            public string EntityId(object message)
-                => message switch
-                {
-                    Ping p => p.Id,
-                    _ => null
-                };
-
-            public object EntityMessage(object message)
-                => message;
-
-            public string ShardId(object message)
-                => message switch
-                {
-                    Ping p => p.Id[0].ToString(),
-                    _ => null
-                };
-
-            public string ShardId(string entityId, object messageHint = null)
-                => entityId[0].ToString();
-        }
-
-        private readonly Lazy<IActorRef> _region;
-
-        protected ClusterShardCoordinatorDowningSpec(ClusterShardCoordinatorDowningSpecConfig config, Type type)
-            : base(config, type)
-        {
-            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
-        }
-
-        private void StartSharding()
-        {
-            StartSharding(
-              Sys,
-              typeName: "Entity",
-              entityProps: Props.Create(() => new Entity()),
-              messageExtractor: new MessageExtractor());
-        }
-
-        #endregion
-
-        [MultiNodeFact]
-        public async Task Cluster_sharding_with_down_member_scenario_1_specs()
-        {
-            await Cluster_sharding_with_down_member_scenario_1_must_join_cluster();
-            await Cluster_sharding_with_down_member_scenario_1_must_initialize_shards();
-            await Cluster_sharding_with_down_member_scenario_1_must_recover_after_downing_coordinator_node();
-        }
-
-        private async Task Cluster_sharding_with_down_member_scenario_1_must_join_cluster()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
-            {
-                StartPersistenceIfNeeded(startOn: Config.Controller, Config.First, Config.Second);
-
-                Join(Config.First, Config.First, onJoinedRunOnFrom: StartSharding);
-                Join(Config.Second, Config.First, onJoinedRunOnFrom: StartSharding, assertNodeUp: false);
-
-                // all Up, everywhere before continuing
-                RunOn(() =>
-                {
-                    AwaitAssert(() =>
-                    {
-                        Cluster.State.Members.Count.Should().Be(2);
-                        Cluster.State.Members.Should().OnlyContain(m => m.Status == MemberStatus.Up);
-                    });
-                }, Config.First, Config.Second);
-
-                await EnterBarrierAsync("after-2");
-            });
-        }
-
-
-        private async Task Cluster_sharding_with_down_member_scenario_1_must_initialize_shards()
-        {
+            // all Up, everywhere before continuing
             RunOn(() =>
             {
-                var shardLocations = Sys.ActorOf(Props.Create(() => new ShardLocations()), "shardLocations");
-                var locations = Enumerable.Range(1, 4).Select(n =>
+                AwaitAssert(() =>
                 {
-                    var id = n.ToString();
-                    _region.Value.Tell(new Ping(id));
-                    return new KeyValuePair<string, IActorRef>(id, ExpectMsg<IActorRef>());
-                }).ToImmutableDictionary();
-                shardLocations.Tell(new Locations(locations));
-                Sys.Log.Debug("Original locations: [{0}]", string.Join(", ", locations.Select(i => $"{i.Key}: {i.Value}")));
-            }, Config.First);
-            await EnterBarrierAsync("after-3");
-        }
+                    Cluster.State.Members.Count.Should().Be(2);
+                    Cluster.State.Members.Should().OnlyContain(m => m.Status == MemberStatus.Up);
+                });
+            }, Config.First, Config.Second);
 
-        private async Task Cluster_sharding_with_down_member_scenario_1_must_recover_after_downing_coordinator_node()
+            await EnterBarrierAsync("after-2");
+        });
+    }
+
+
+    private async Task Cluster_sharding_with_down_member_scenario_1_must_initialize_shards()
+    {
+        RunOn(() =>
         {
-            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
+            var shardLocations = Sys.ActorOf(Props.Create(() => new ShardLocations()), "shardLocations");
+            var locations = Enumerable.Range(1, 4).Select(n =>
             {
-                var firstAddress = GetAddress(Config.First);
-                Sys.ActorSelection(Node(Config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
-                var originalLocations = ExpectMsg<Locations>().Locs;
+                var id = n.ToString();
+                _region.Value.Tell(new Ping(id));
+                return new KeyValuePair<string, IActorRef>(id, ExpectMsg<IActorRef>());
+            }).ToImmutableDictionary();
+            shardLocations.Tell(new Locations(locations));
+            Sys.Log.Debug("Original locations: [{0}]", string.Join(", ", locations.Select(i => $"{i.Key}: {i.Value}")));
+        }, Config.First);
+        await EnterBarrierAsync("after-3");
+    }
 
-                await EnterBarrierAsync("after-3-locations");
+    private async Task Cluster_sharding_with_down_member_scenario_1_must_recover_after_downing_coordinator_node()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(20), async () =>
+        {
+            var firstAddress = GetAddress(Config.First);
+            Sys.ActorSelection(await NodeAsync(Config.First) / "user" / "shardLocations").Tell(GetLocations.Instance);
+            var originalLocations = (await ExpectMsgAsync<Locations>()).Locs;
 
-                await RunOnAsync(async () =>
+            await EnterBarrierAsync("after-3-locations");
+
+            await RunOnAsync(async () =>
+            {
+                await TestConductor.BlackholeAsync(Config.First, Config.Second, Direction.Both);
+            }, Config.Controller);
+
+            await Task.Delay(3000);
+
+            await RunOnAsync(async () =>
+            {
+                Cluster.Down(GetAddress(Config.First));
+                await AwaitAssertAsync(() =>
                 {
-                    await TestConductor.BlackholeAsync(Config.First, Config.Second, Direction.Both);
-                }, Config.Controller);
+                    Cluster.State.Members.Count.Should().Be(1);
+                });
 
-                Thread.Sleep(3000);
-
-                RunOn(() =>
+                // start a few more new shards, could be allocated to first but should notice that it's terminated
+                ImmutableDictionary<string, IActorRef> additionalLocations = null;
+                await AwaitAssertAsync(() =>
                 {
-                    Cluster.Down(GetAddress(Config.First));
-                    AwaitAssert(() =>
+                    var probe = CreateTestProbe();
+                    additionalLocations = Enumerable.Range(5, 4).Select(n =>
                     {
-                        Cluster.State.Members.Count.Should().Be(1);
-                    });
+                        var id = n.ToString();
+                        _region.Value.Tell(new Ping(id), probe.Ref);
+                        return new KeyValuePair<string, IActorRef>(id, probe.ExpectMsg<IActorRef>(TimeSpan.FromSeconds(1)));
+                    }).ToImmutableDictionary();
+                });
+                Sys.Log.Debug("Additional locations: [{0}]", string.Join(", ", additionalLocations.Select(i => $"{i.Key}: {i.Value}")));
 
-                    // start a few more new shards, could be allocated to first but should notice that it's terminated
-                    ImmutableDictionary<string, IActorRef> additionalLocations = null;
-                    AwaitAssert(() =>
+                await AwaitAssertAsync(async () =>
+                {
+                    var probe = CreateTestProbe();
+                    foreach (var loc in originalLocations.SetItems(additionalLocations))
                     {
-                        var probe = CreateTestProbe();
-                        additionalLocations = Enumerable.Range(5, 4).Select(n =>
+                        _region.Value.Tell(new Ping(loc.Key), probe.Ref);
+                        if (loc.Value.Path.Address.Equals(firstAddress))
                         {
-                            var id = n.ToString();
-                            _region.Value.Tell(new Ping(id), probe.Ref);
-                            return new KeyValuePair<string, IActorRef>(id, probe.ExpectMsg<IActorRef>(TimeSpan.FromSeconds(1)));
-                        }).ToImmutableDictionary();
-                    });
-                    Sys.Log.Debug("Additional locations: [{0}]", string.Join(", ", additionalLocations.Select(i => $"{i.Key}: {i.Value}")));
-
-                    AwaitAssert(() =>
-                    {
-                        var probe = CreateTestProbe();
-                        foreach (var loc in originalLocations.SetItems(additionalLocations))
-                        {
-                            _region.Value.Tell(new Ping(loc.Key), probe.Ref);
-                            if (loc.Value.Path.Address.Equals(firstAddress))
-                            {
-                                var newRef = probe.ExpectMsg<IActorRef>(TimeSpan.FromSeconds(1));
-                                newRef.Should().NotBe(loc.Value);
-                                Sys.Log.Debug("Moved [{0}] from [{1}] to [{2}]", loc.Key, loc.Value, newRef);
-                            }
-                            else
-                                probe.ExpectMsg(loc.Value, TimeSpan.FromSeconds(1)); // should not move
-
+                            var newRef = await probe.ExpectMsgAsync<IActorRef>(TimeSpan.FromSeconds(1));
+                            newRef.Should().NotBe(loc.Value);
+                            Sys.Log.Debug("Moved [{0}] from [{1}] to [{2}]", loc.Key, loc.Value, newRef);
                         }
-                    });
-                }, Config.Second);
-            });
+                        else
+                            await probe.ExpectMsgAsync(loc.Value, TimeSpan.FromSeconds(1)); // should not move
 
-            await EnterBarrierAsync("after-4");
-        }
+                    }
+                });
+            }, Config.Second);
+        });
+
+        await EnterBarrierAsync("after-4");
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -15,16 +16,16 @@ using Akka.Remote.Transport;
 using Akka.Util;
 using FluentAssertions;
 
-namespace Akka.Cluster.Sharding.Tests
-{
-    public class ClusterShardingFailureSpecConfig : MultiNodeClusterShardingConfig
-    {
-        public RoleName Controller { get; }
-        public RoleName First { get; }
-        public RoleName Second { get; }
+namespace Akka.Cluster.Sharding.Tests;
 
-        public ClusterShardingFailureSpecConfig(StateStoreMode mode)
-            : base(mode: mode, loglevel: "DEBUG", additionalConfig: @"
+public class ClusterShardingFailureSpecConfig : MultiNodeClusterShardingConfig
+{
+    public RoleName Controller { get; }
+    public RoleName First { get; }
+    public RoleName Second { get; }
+
+    public ClusterShardingFailureSpecConfig(StateStoreMode mode)
+        : base(mode: mode, loglevel: "DEBUG", additionalConfig: @"
             akka.cluster.roles = [""backend""]
             akka.cluster.sharding {
                 coordinator-failure-backoff = 3s
@@ -33,298 +34,272 @@ namespace Akka.Cluster.Sharding.Tests
             # don't leak ddata state across runs
             akka.cluster.sharding.distributed-data.durable.keys = []
             ")
-        {
-            Controller = Role("controller");
-            First = Role("first");
-            Second = Role("second");
-
-            TestTransport = true;
-        }
-    }
-
-    public class PersistentClusterShardingFailureSpecConfig : ClusterShardingFailureSpecConfig
     {
-        public PersistentClusterShardingFailureSpecConfig()
-            : base(StateStoreMode.Persistence)
-        {
-        }
+        Controller = Role("controller");
+        First = Role("first");
+        Second = Role("second");
+
+        TestTransport = true;
     }
+}
 
-    public class DDataClusterShardingFailureSpecConfig : ClusterShardingFailureSpecConfig
+public class PersistentClusterShardingFailureSpecConfig : ClusterShardingFailureSpecConfig
+{
+    public PersistentClusterShardingFailureSpecConfig()
+        : base(StateStoreMode.Persistence)
     {
-        public DDataClusterShardingFailureSpecConfig()
-            : base(StateStoreMode.DData)
-        {
-        }
     }
+}
 
-    public class PersistentClusterShardingFailureSpec : ClusterShardingFailureSpec
+public class DDataClusterShardingFailureSpecConfig : ClusterShardingFailureSpecConfig
+{
+    public DDataClusterShardingFailureSpecConfig()
+        : base(StateStoreMode.DData)
     {
-        public PersistentClusterShardingFailureSpec()
-            : base(new PersistentClusterShardingFailureSpecConfig(), typeof(PersistentClusterShardingFailureSpec))
-        {
-        }
     }
+}
 
-    public class DDataClusterShardingFailureSpec : ClusterShardingFailureSpec
+public class PersistentClusterShardingFailureSpec : ClusterShardingFailureSpec
+{
+    public PersistentClusterShardingFailureSpec()
+        : base(new PersistentClusterShardingFailureSpecConfig(), typeof(PersistentClusterShardingFailureSpec))
     {
-        public DDataClusterShardingFailureSpec()
-            : base(new DDataClusterShardingFailureSpecConfig(), typeof(DDataClusterShardingFailureSpec))
-        {
-        }
     }
+}
 
-    public abstract class ClusterShardingFailureSpec : MultiNodeClusterShardingSpec<ClusterShardingFailureSpecConfig>
+public class DDataClusterShardingFailureSpec : ClusterShardingFailureSpec
+{
+    public DDataClusterShardingFailureSpec()
+        : base(new DDataClusterShardingFailureSpecConfig(), typeof(DDataClusterShardingFailureSpec))
     {
-        #region setup
+    }
+}
 
-        [Serializable]
-        internal sealed class Get
+public abstract class ClusterShardingFailureSpec : MultiNodeClusterShardingSpec<ClusterShardingFailureSpecConfig>
+{
+    #region setup
+
+    [Serializable]
+    internal sealed record Get(string Id);
+
+    [Serializable]
+    internal sealed record Add(string Id, int I);
+
+    [Serializable]
+    internal sealed record Value(string Id, int N);
+
+    internal class Entity : ReceiveActor
+    {
+        private ILoggingAdapter log = Context.GetLogger();
+        private int _n = 0;
+
+        public Entity()
         {
-            public readonly string Id;
-            public Get(string id)
+            log.Debug("Starting");
+            Receive<Get>(get =>
             {
-                Id = id;
-            }
-        }
-
-        [Serializable]
-        internal sealed class Add
-        {
-            public readonly string Id;
-            public readonly int I;
-            public Add(string id, int i)
+                log.Debug("Got get request from {0}", Sender);
+                Sender.Tell(new Value(get.Id, _n));
+            });
+            Receive<Add>(add =>
             {
-                Id = id;
-                I = i;
-            }
-        }
-
-        [Serializable]
-        internal sealed class Value
-        {
-            public readonly string Id;
-            public readonly int N;
-            public Value(string id, int n)
-            {
-                Id = id;
-                N = n;
-            }
-        }
-
-        internal class Entity : ReceiveActor
-        {
-            private ILoggingAdapter log = Context.GetLogger();
-            private int _n = 0;
-
-            public Entity()
-            {
-                log.Debug("Starting");
-                Receive<Get>(get =>
-                {
-                    log.Debug("Got get request from {0}", Sender);
-                    Sender.Tell(new Value(get.Id, _n));
-                });
-                Receive<Add>(add =>
-                {
-                    _n += add.I;
-                    log.Debug("Got add request from {0}", Sender);
-                });
-            }
-
-            protected override void PostStop()
-            {
-                log.Debug("Stopping");
-                base.PostStop();
-            }
-        }
-
-        private sealed class MessageExtractor: IMessageExtractor
-        {
-            public string EntityId(object message)
-                => message switch
-                {
-                    Get msg => msg.Id,
-                    Add msg => msg.Id,
-                    _ => null
-                };
-
-            public object EntityMessage(object message)
-                => message;
-
-            public string ShardId(object message)
-                => message switch
-                {
-                    Get msg => msg.Id[0].ToString(),
-                    Add msg => msg.Id[0].ToString(),
-                    _ => null
-                };
-
-            public string ShardId(string entityId, object messageHint = null)
-                => entityId[0].ToString();
-        }
-
-        private readonly Lazy<IActorRef> _region;
-
-        protected ClusterShardingFailureSpec(ClusterShardingFailureSpecConfig config, Type type)
-            : base(config, type)
-        {
-            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
-        }
-
-        private void Join(RoleName from, RoleName to)
-        {
-            Join(from, to, () =>
-                StartSharding(
-                    Sys,
-                    typeName: "Entity",
-                    entityProps: Props.Create(() => new Entity()),
-                    messageExtractor: new MessageExtractor())
-                );
-        }
-
-        #endregion
-
-        [MultiNodeFact]
-        public async Task ClusterSharding_with_flaky_journal_network_specs()
-        {
-            await ClusterSharding_with_flaky_journal_network_must_join_cluster();
-            await ClusterSharding_with_flaky_journal_network_must_recover_after_journal_network_failure();
-        }
-
-        private async Task ClusterSharding_with_flaky_journal_network_must_join_cluster()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
-            {
-                StartPersistenceIfNeeded(startOn: Config.Controller, Config.First, Config.Second);
-
-                Join(Config.First, Config.First);
-                Join(Config.Second, Config.First);
-
-                RunOn(() =>
-                {
-                    var region = _region.Value;
-                    region.Tell(new Add("10", 1));
-                    region.Tell(new Add("20", 2));
-                    region.Tell(new Add("21", 3));
-                    region.Tell(new Get("10"));
-                    ExpectMsg<Value>(v => v.Id == "10" && v.N == 1);
-                    region.Tell(new Get("20"));
-                    ExpectMsg<Value>(v => v.Id == "20" && v.N == 2);
-                    region.Tell(new Get("21"));
-                    ExpectMsg<Value>(v => v.Id == "21" && v.N == 3);
-                }, Config.First);
-                await EnterBarrierAsync("after-2");
+                _n += add.I;
+                log.Debug("Got add request from {0}", Sender);
             });
         }
 
-        private async Task ClusterSharding_with_flaky_journal_network_must_recover_after_journal_network_failure()
+        protected override void PostStop()
         {
-            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
-            {
-                await RunOnAsync(async () =>
-                {
-                    if (PersistenceIsNeeded)
-                    {
-                        await TestConductor.BlackholeAsync(Config.Controller, Config.First, ThrottleTransportAdapter.Direction.Both);
-                        await TestConductor.BlackholeAsync(Config.Controller, Config.Second, ThrottleTransportAdapter.Direction.Both);
-                    }
-                    else
-                    {
-                        await TestConductor.BlackholeAsync(Config.First, Config.Second, ThrottleTransportAdapter.Direction.Both);
-                    }
-                }, Config.Controller);
-                await EnterBarrierAsync("journal-backholded");
-
-                RunOn(() =>
-                {
-                    // try with a new shard, will not reply until journal/network is available again
-                    var region = _region.Value;
-                    region.Tell(new Add("40", 4));
-                    var probe = CreateTestProbe();
-                    region.Tell(new Get("40"), probe.Ref);
-                    probe.ExpectNoMsg(TimeSpan.FromSeconds(1));
-                }, Config.First);
-                await EnterBarrierAsync("first-delayed");
-
-                await RunOnAsync(async () =>
-                {
-                    if (PersistenceIsNeeded)
-                    {
-                        await TestConductor.PassThroughAsync(Config.Controller, Config.First, ThrottleTransportAdapter.Direction.Both);
-                        await TestConductor.PassThroughAsync(Config.Controller, Config.Second, ThrottleTransportAdapter.Direction.Both);
-                    }
-                    else
-                    {
-                        await TestConductor.PassThroughAsync(Config.First, Config.Second, ThrottleTransportAdapter.Direction.Both);
-                    }
-                }, Config.Controller);
-                await EnterBarrierAsync("journal-ok");
-
-                RunOn(() =>
-                {
-                    var region = _region.Value;
-                    region.Tell(new Get("21"));
-                    ExpectMsg<Value>(v => v.Id == "21" && v.N == 3);
-                    var entity21 = LastSender;
-                    var shard2 = Sys.ActorSelection(entity21.Path.Parent);
-
-
-                    //Test the ShardCoordinator allocating shards after a journal/network failure
-                    region.Tell(new Add("30", 3));
-
-                    //Test the Shard starting entities and persisting after a journal/network failure
-                    region.Tell(new Add("11", 1));
-
-                    //Test the Shard passivate works after a journal failure
-                    shard2.Tell(new Passivate(PoisonPill.Instance), entity21);
-
-                    AwaitAssert(() =>
-                    {
-                        // Note that the order between this Get message to 21 and the above Passivate to 21 is undefined.
-                        // If this Get arrives first the reply will be Value("21", 3) and then it is retried by the
-                        // awaitAssert.
-                        // Also note that there is no timeout parameter on below expectMsg because messages should not
-                        // be lost here. They should be buffered and delivered also after Passivate completed.
-                        region.Tell(new Get("21"));
-                        // counter reset to 0 when started again
-                        ExpectMsg<Value>(v => v.Id == "21" && v.N == 0, hint: "Passivating did not reset Value down to 0");
-                    });
-
-                    region.Tell(new Add("21", 1));
-
-                    region.Tell(new Get("21"));
-                    ExpectMsg<Value>(v => v.Id == "21" && v.N == 1);
-
-                    region.Tell(new Get("30"));
-                    ExpectMsg<Value>(v => v.Id == "30" && v.N == 3);
-
-                    region.Tell(new Get("11"));
-                    ExpectMsg<Value>(v => v.Id == "11" && v.N == 1);
-
-                    region.Tell(new Get("40"));
-                    ExpectMsg<Value>(v => v.Id == "40" && v.N == 4);
-                }, Config.First);
-                await EnterBarrierAsync("verified-first");
-
-                RunOn(() =>
-                {
-                    var region = _region.Value;
-                    region.Tell(new Add("10", 1));
-                    region.Tell(new Add("20", 2));
-                    region.Tell(new Add("30", 3));
-                    region.Tell(new Add("11", 4));
-                    region.Tell(new Get("10"));
-                    ExpectMsg<Value>(v => v.Id == "10" && v.N == 2);
-                    region.Tell(new Get("11"));
-                    ExpectMsg<Value>(v => v.Id == "11" && v.N == 5);
-                    region.Tell(new Get("20"));
-                    ExpectMsg<Value>(v => v.Id == "20" && v.N == 4);
-                    region.Tell(new Get("30"));
-                    ExpectMsg<Value>(v => v.Id == "30" && v.N == 6);
-                }, Config.Second);
-                await EnterBarrierAsync("after-3");
-            });
+            log.Debug("Stopping");
+            base.PostStop();
         }
+    }
+
+    private sealed class MessageExtractor: IMessageExtractor
+    {
+        public string EntityId(object message)
+            => message switch
+            {
+                Get msg => msg.Id,
+                Add msg => msg.Id,
+                _ => null
+            };
+
+        public object EntityMessage(object message)
+            => message;
+
+        public string ShardId(object message)
+            => message switch
+            {
+                Get msg => msg.Id[0].ToString(),
+                Add msg => msg.Id[0].ToString(),
+                _ => null
+            };
+
+        public string ShardId(string entityId, object messageHint = null)
+            => entityId[0].ToString();
+    }
+
+    private readonly Lazy<IActorRef> _region;
+
+    protected ClusterShardingFailureSpec(ClusterShardingFailureSpecConfig config, Type type)
+        : base(config, type)
+    {
+        _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
+    }
+
+    private Task JoinAsync(RoleName from, RoleName to)
+    {
+        return JoinAsync(from, to, () =>
+            StartSharding(
+                Sys,
+                typeName: "Entity",
+                entityProps: Props.Create(() => new Entity()),
+                messageExtractor: new MessageExtractor())
+        );
+    }
+
+    #endregion
+
+    [MultiNodeFact]
+    public async Task ClusterSharding_with_flaky_journal_network_specs()
+    {
+        await ClusterSharding_with_flaky_journal_network_must_join_cluster();
+        await ClusterSharding_with_flaky_journal_network_must_recover_after_journal_network_failure();
+    }
+
+    private async Task ClusterSharding_with_flaky_journal_network_must_join_cluster()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(20), async () =>
+        {
+            await StartPersistenceIfNeededAsync(Config.Controller, CancellationToken.None, Config.First, Config.Second);
+
+            await JoinAsync(Config.First, Config.First);
+            await JoinAsync(Config.Second, Config.First);
+
+            await RunOnAsync(async () =>
+            {
+                var region = _region.Value;
+                region.Tell(new Add("10", 1));
+                region.Tell(new Add("20", 2));
+                region.Tell(new Add("21", 3));
+                region.Tell(new Get("10"));
+                await ExpectMsgAsync<Value>(v => v.Id == "10" && v.N == 1);
+                region.Tell(new Get("20"));
+                await ExpectMsgAsync<Value>(v => v.Id == "20" && v.N == 2);
+                region.Tell(new Get("21"));
+                await ExpectMsgAsync<Value>(v => v.Id == "21" && v.N == 3);
+            }, Config.First);
+            await EnterBarrierAsync("after-2");
+        });
+    }
+
+    private async Task ClusterSharding_with_flaky_journal_network_must_recover_after_journal_network_failure()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(20), async () =>
+        {
+            await RunOnAsync(async () =>
+            {
+                if (PersistenceIsNeeded)
+                {
+                    await TestConductor.BlackholeAsync(Config.Controller, Config.First, ThrottleTransportAdapter.Direction.Both);
+                    await TestConductor.BlackholeAsync(Config.Controller, Config.Second, ThrottleTransportAdapter.Direction.Both);
+                }
+                else
+                {
+                    await TestConductor.BlackholeAsync(Config.First, Config.Second, ThrottleTransportAdapter.Direction.Both);
+                }
+            }, Config.Controller);
+            await EnterBarrierAsync("journal-backholded");
+
+            await RunOnAsync(async () =>
+            {
+                // try with a new shard, will not reply until journal/network is available again
+                var region = _region.Value;
+                region.Tell(new Add("40", 4));
+                var probe = CreateTestProbe();
+                region.Tell(new Get("40"), probe.Ref);
+                await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            }, Config.First);
+            await EnterBarrierAsync("first-delayed");
+
+            await RunOnAsync(async () =>
+            {
+                if (PersistenceIsNeeded)
+                {
+                    await TestConductor.PassThroughAsync(Config.Controller, Config.First, ThrottleTransportAdapter.Direction.Both);
+                    await TestConductor.PassThroughAsync(Config.Controller, Config.Second, ThrottleTransportAdapter.Direction.Both);
+                }
+                else
+                {
+                    await TestConductor.PassThroughAsync(Config.First, Config.Second, ThrottleTransportAdapter.Direction.Both);
+                }
+            }, Config.Controller);
+            await EnterBarrierAsync("journal-ok");
+
+            await RunOnAsync(async () =>
+            {
+                var region = _region.Value;
+                region.Tell(new Get("21"));
+                await ExpectMsgAsync<Value>(v => v.Id == "21" && v.N == 3);
+                var entity21 = LastSender;
+                var shard2 = Sys.ActorSelection(entity21.Path.Parent);
+
+
+                //Test the ShardCoordinator allocating shards after a journal/network failure
+                region.Tell(new Add("30", 3));
+
+                //Test the Shard starting entities and persisting after a journal/network failure
+                region.Tell(new Add("11", 1));
+
+                //Test the Shard passivate works after a journal failure
+                shard2.Tell(new Passivate(PoisonPill.Instance), entity21);
+
+                await AwaitAssertAsync(async () =>
+                {
+                    // Note that the order between this Get message to 21 and the above Passivate to 21 is undefined.
+                    // If this Get arrives first the reply will be Value("21", 3) and then it is retried by the
+                    // awaitAssert.
+                    // Also note that there is no timeout parameter on below expectMsg because messages should not
+                    // be lost here. They should be buffered and delivered also after Passivate completed.
+                    region.Tell(new Get("21"));
+                    // counter reset to 0 when started again
+                    await ExpectMsgAsync<Value>(v => v.Id == "21" && v.N == 0, hint: "Passivating did not reset Value down to 0");
+                });
+
+                region.Tell(new Add("21", 1));
+
+                region.Tell(new Get("21"));
+                await ExpectMsgAsync<Value>(v => v.Id == "21" && v.N == 1);
+
+                region.Tell(new Get("30"));
+                await ExpectMsgAsync<Value>(v => v.Id == "30" && v.N == 3);
+
+                region.Tell(new Get("11"));
+                await ExpectMsgAsync<Value>(v => v.Id == "11" && v.N == 1);
+
+                region.Tell(new Get("40"));
+                await ExpectMsgAsync<Value>(v => v.Id == "40" && v.N == 4);
+            }, Config.First);
+            await EnterBarrierAsync("verified-first");
+
+            await RunOnAsync(async () =>
+            {
+                var region = _region.Value;
+                region.Tell(new Add("10", 1));
+                region.Tell(new Add("20", 2));
+                region.Tell(new Add("30", 3));
+                region.Tell(new Add("11", 4));
+                region.Tell(new Get("10"));
+                await ExpectMsgAsync<Value>(v => v.Id == "10" && v.N == 2);
+                region.Tell(new Get("11"));
+                await ExpectMsgAsync<Value>(v => v.Id == "11" && v.N == 5);
+                region.Tell(new Get("20"));
+                await ExpectMsgAsync<Value>(v => v.Id == "20" && v.N == 4);
+                region.Tell(new Get("30"));
+                await ExpectMsgAsync<Value>(v => v.Id == "30" && v.N == 6);
+            }, Config.Second);
+            await EnterBarrierAsync("after-3");
+        });
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingFailureSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Akka.MultiNode.TestAdapter;
@@ -185,15 +186,15 @@ namespace Akka.Cluster.Sharding.Tests
         #endregion
 
         [MultiNodeFact]
-        public void ClusterSharding_with_flaky_journal_network_specs()
+        public async Task ClusterSharding_with_flaky_journal_network_specs()
         {
-            ClusterSharding_with_flaky_journal_network_must_join_cluster();
-            ClusterSharding_with_flaky_journal_network_must_recover_after_journal_network_failure();
+            await ClusterSharding_with_flaky_journal_network_must_join_cluster();
+            await ClusterSharding_with_flaky_journal_network_must_recover_after_journal_network_failure();
         }
 
-        private void ClusterSharding_with_flaky_journal_network_must_join_cluster()
+        private async Task ClusterSharding_with_flaky_journal_network_must_join_cluster()
         {
-            Within(TimeSpan.FromSeconds(20), () =>
+            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
             {
                 StartPersistenceIfNeeded(startOn: Config.Controller, Config.First, Config.Second);
 
@@ -213,27 +214,27 @@ namespace Akka.Cluster.Sharding.Tests
                     region.Tell(new Get("21"));
                     ExpectMsg<Value>(v => v.Id == "21" && v.N == 3);
                 }, Config.First);
-                EnterBarrier("after-2");
+                await EnterBarrierAsync("after-2");
             });
         }
 
-        private void ClusterSharding_with_flaky_journal_network_must_recover_after_journal_network_failure()
+        private async Task ClusterSharding_with_flaky_journal_network_must_recover_after_journal_network_failure()
         {
-            Within(TimeSpan.FromSeconds(20), () =>
+            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
             {
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
                     if (PersistenceIsNeeded)
                     {
-                        TestConductor.Blackhole(Config.Controller, Config.First, ThrottleTransportAdapter.Direction.Both).Wait();
-                        TestConductor.Blackhole(Config.Controller, Config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
+                        await TestConductor.BlackholeAsync(Config.Controller, Config.First, ThrottleTransportAdapter.Direction.Both);
+                        await TestConductor.BlackholeAsync(Config.Controller, Config.Second, ThrottleTransportAdapter.Direction.Both);
                     }
                     else
                     {
-                        TestConductor.Blackhole(Config.First, Config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
+                        await TestConductor.BlackholeAsync(Config.First, Config.Second, ThrottleTransportAdapter.Direction.Both);
                     }
                 }, Config.Controller);
-                EnterBarrier("journal-backholded");
+                await EnterBarrierAsync("journal-backholded");
 
                 RunOn(() =>
                 {
@@ -244,21 +245,21 @@ namespace Akka.Cluster.Sharding.Tests
                     region.Tell(new Get("40"), probe.Ref);
                     probe.ExpectNoMsg(TimeSpan.FromSeconds(1));
                 }, Config.First);
-                EnterBarrier("first-delayed");
+                await EnterBarrierAsync("first-delayed");
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
                     if (PersistenceIsNeeded)
                     {
-                        TestConductor.PassThrough(Config.Controller, Config.First, ThrottleTransportAdapter.Direction.Both).Wait();
-                        TestConductor.PassThrough(Config.Controller, Config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
+                        await TestConductor.PassThroughAsync(Config.Controller, Config.First, ThrottleTransportAdapter.Direction.Both);
+                        await TestConductor.PassThroughAsync(Config.Controller, Config.Second, ThrottleTransportAdapter.Direction.Both);
                     }
                     else
                     {
-                        TestConductor.PassThrough(Config.First, Config.Second, ThrottleTransportAdapter.Direction.Both).Wait();
+                        await TestConductor.PassThroughAsync(Config.First, Config.Second, ThrottleTransportAdapter.Direction.Both);
                     }
                 }, Config.Controller);
-                EnterBarrier("journal-ok");
+                await EnterBarrierAsync("journal-ok");
 
                 RunOn(() =>
                 {
@@ -304,7 +305,7 @@ namespace Akka.Cluster.Sharding.Tests
                     region.Tell(new Get("40"));
                     ExpectMsg<Value>(v => v.Id == "40" && v.N == 4);
                 }, Config.First);
-                EnterBarrier("verified-first");
+                await EnterBarrierAsync("verified-first");
 
                 RunOn(() =>
                 {
@@ -322,7 +323,7 @@ namespace Akka.Cluster.Sharding.Tests
                     region.Tell(new Get("30"));
                     ExpectMsg<Value>(v => v.Id == "30" && v.N == 6);
                 }, Config.Second);
-                EnterBarrier("after-3");
+                await EnterBarrierAsync("after-3");
             });
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Event;
@@ -196,16 +197,16 @@ namespace Akka.Cluster.Sharding.Tests
         #endregion
 
         [MultiNodeFact]
-        public void Cluster_sharding_with_remember_entities_specs()
+        public async Task Cluster_sharding_with_remember_entities_specs()
         {
-            Cluster_with_min_nr_of_members_using_sharding_must_start_up_first_cluster_and_sharding();
-            Cluster_with_min_nr_of_members_using_sharding_must_shutdown_sharding_nodes();
-            Cluster_with_min_nr_of_members_using_sharding_must_start_new_nodes_with_different_extractor_and_have_the_entities_running_on_the_right_shards();
+            await Cluster_with_min_nr_of_members_using_sharding_must_start_up_first_cluster_and_sharding();
+            await Cluster_with_min_nr_of_members_using_sharding_must_shutdown_sharding_nodes();
+            await Cluster_with_min_nr_of_members_using_sharding_must_start_new_nodes_with_different_extractor_and_have_the_entities_running_on_the_right_shards();
         }
 
-        private void Cluster_with_min_nr_of_members_using_sharding_must_start_up_first_cluster_and_sharding()
+        private async Task Cluster_with_min_nr_of_members_using_sharding_must_start_up_first_cluster_and_sharding()
         {
-            Within(TimeSpan.FromSeconds(15), () =>
+            await WithinAsync(TimeSpan.FromSeconds(15), async () =>
             {
                 StartPersistenceIfNeeded(startOn: Config.First, Config.Second, Config.Third);
 
@@ -228,7 +229,7 @@ namespace Akka.Cluster.Sharding.Tests
                 {
                     StartShardingWithExtractor1();
                 }, Config.Second, Config.Third);
-                EnterBarrier("first-cluster-up");
+                await EnterBarrierAsync("first-cluster-up");
 
                 RunOn(() =>
                 {
@@ -239,18 +240,18 @@ namespace Akka.Cluster.Sharding.Tests
                         ExpectMsg(n);
                     }
                 }, Config.Second, Config.Third);
-                EnterBarrier("first-cluster-entities-up");
+                await EnterBarrierAsync("first-cluster-entities-up");
             });
         }
 
-        private void Cluster_with_min_nr_of_members_using_sharding_must_shutdown_sharding_nodes()
+        private async Task Cluster_with_min_nr_of_members_using_sharding_must_shutdown_sharding_nodes()
         {
-            Within(TimeSpan.FromSeconds(30), () =>
+            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
             {
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
-                    TestConductor.Exit(Config.Second, 0).Wait();
-                    TestConductor.Exit(Config.Third, 0).Wait();
+                    await TestConductor.ExitAsync(Config.Second, 0);
+                    await TestConductor.ExitAsync(Config.Third, 0);
                 }, Config.First);
 
                 RunOn(() =>
@@ -265,12 +266,12 @@ namespace Akka.Cluster.Sharding.Tests
                 }, Config.First);
 
             });
-            EnterBarrier("first-sharding-cluster-stopped");
+            await EnterBarrierAsync("first-sharding-cluster-stopped");
         }
 
-        private void Cluster_with_min_nr_of_members_using_sharding_must_start_new_nodes_with_different_extractor_and_have_the_entities_running_on_the_right_shards()
+        private async Task Cluster_with_min_nr_of_members_using_sharding_must_start_new_nodes_with_different_extractor_and_have_the_entities_running_on_the_right_shards()
         {
-            Within(TimeSpan.FromSeconds(30), () =>
+            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
             {
                 // start it with a new shard id messageExtractor, which will put the entities
                 // on different shards
@@ -286,10 +287,10 @@ namespace Akka.Cluster.Sharding.Tests
                     });
 
                 }, Config.Second, Config.Third);
-                EnterBarrier("first-cluster-terminated");
+                await EnterBarrierAsync("first-cluster-terminated");
 
                 // no sharding nodes left of the original cluster, start a new nodes
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
                     var sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
                     var probe2 = CreateTestProbe(sys2);
@@ -331,16 +332,16 @@ namespace Akka.Cluster.Sharding.Tests
                         }
                     }
 
-                    EnterBarrier("verified");
+                    await EnterBarrierAsync("verified");
                     Shutdown(sys2);
                 }, Config.Second, Config.Third);
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
-                    EnterBarrier("verified");
+                    await EnterBarrierAsync("verified");
                 }, Config.First);
 
-                EnterBarrier("done");
+                await EnterBarrierAsync("done");
             });
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesNewExtractorSpec.cs
@@ -16,333 +16,325 @@ using Akka.Remote.TestKit;
 using Akka.Util;
 using FluentAssertions;
 
-namespace Akka.Cluster.Sharding.Tests
+namespace Akka.Cluster.Sharding.Tests;
+
+public class ClusterShardingRememberEntitiesNewExtractorSpecConfig : MultiNodeClusterShardingConfig
 {
-    public class ClusterShardingRememberEntitiesNewExtractorSpecConfig : MultiNodeClusterShardingConfig
+    public RoleName First { get; }
+    public RoleName Second { get; }
+    public RoleName Third { get; }
+
+    public ClusterShardingRememberEntitiesNewExtractorSpecConfig(StateStoreMode mode)
+        : base(mode: mode, loglevel: "DEBUG")
     {
-        public RoleName First { get; }
-        public RoleName Second { get; }
-        public RoleName Third { get; }
+        First = Role("first");
+        Second = Role("second");
+        Third = Role("third");
 
-        public ClusterShardingRememberEntitiesNewExtractorSpecConfig(StateStoreMode mode)
-            : base(mode: mode, loglevel: "DEBUG")
-        {
-            First = Role("first");
-            Second = Role("second");
-            Third = Role("third");
+        var roleConfig = ConfigurationFactory.ParseString(@"akka.cluster.roles = [sharding]");
 
-            var roleConfig = ConfigurationFactory.ParseString(@"akka.cluster.roles = [sharding]");
-
-            // we pretend node 4 and 5 are new incarnations of node 2 and 3 as they never run in parallel
-            // so we can use the same lmdb store for them and have node 4 pick up the persisted data of node 2
-            var ddataNodeAConfig = ConfigurationFactory.ParseString(@"
+        // we pretend node 4 and 5 are new incarnations of node 2 and 3 as they never run in parallel
+        // so we can use the same lmdb store for them and have node 4 pick up the persisted data of node 2
+        var ddataNodeAConfig = ConfigurationFactory.ParseString(@"
                 akka.cluster.sharding.distributed-data.durable.lmdb {
                     dir = ""target/ShardingRememberEntitiesNewExtractorSpec/sharding-node-a""
                 }
                 ");
-            var ddataNodeBConfig = ConfigurationFactory.ParseString(@"
+        var ddataNodeBConfig = ConfigurationFactory.ParseString(@"
                 akka.cluster.sharding.distributed-data.durable.lmdb {
                 dir = ""target/ShardingRememberEntitiesNewExtractorSpec/sharding-node-b""
                 }
                 ");
 
-            NodeConfig(new[] { Second }, new[] { roleConfig.WithFallback(ddataNodeAConfig) });
-            NodeConfig(new[] { Third }, new[] { roleConfig.WithFallback(ddataNodeBConfig) });
+        NodeConfig(new[] { Second }, new[] { roleConfig.WithFallback(ddataNodeAConfig) });
+        NodeConfig(new[] { Third }, new[] { roleConfig.WithFallback(ddataNodeBConfig) });
+    }
+}
+
+public class PersistentClusterShardingRememberEntitiesSpecNewExtractorConfig : ClusterShardingRememberEntitiesNewExtractorSpecConfig
+{
+    public PersistentClusterShardingRememberEntitiesSpecNewExtractorConfig()
+        : base(StateStoreMode.Persistence)
+    {
+    }
+}
+
+public class DDataClusterShardingRememberEntitiesNewExtractorSpecConfig : ClusterShardingRememberEntitiesNewExtractorSpecConfig
+{
+    public DDataClusterShardingRememberEntitiesNewExtractorSpecConfig()
+        : base(StateStoreMode.DData)
+    {
+    }
+}
+
+public class PersistentClusterShardingRememberEntitiesNewExtractorSpec : ClusterShardingRememberEntitiesNewExtractorSpec
+{
+    public PersistentClusterShardingRememberEntitiesNewExtractorSpec()
+        : base(new PersistentClusterShardingRememberEntitiesSpecNewExtractorConfig(), typeof(PersistentClusterShardingRememberEntitiesNewExtractorSpec))
+    {
+    }
+}
+
+public class DDataClusterShardingRememberEntitiesNewExtractorSpec : ClusterShardingRememberEntitiesNewExtractorSpec
+{
+    public DDataClusterShardingRememberEntitiesNewExtractorSpec()
+        : base(new DDataClusterShardingRememberEntitiesNewExtractorSpecConfig(), typeof(DDataClusterShardingRememberEntitiesNewExtractorSpec))
+    {
+    }
+}
+
+public abstract class ClusterShardingRememberEntitiesNewExtractorSpec : MultiNodeClusterShardingSpec<ClusterShardingRememberEntitiesNewExtractorSpecConfig>
+{
+    #region setup
+
+    [Serializable]
+    internal sealed record Started(IActorRef Ref);
+
+    internal class TestEntity : ActorBase
+    {
+        private readonly ILoggingAdapter _log = Context.GetLogger();
+
+        public TestEntity(IActorRef probe)
+        {
+            _log.Info("Entity started: " + Self.Path);
+            probe?.Tell(new Started(Self));
+        }
+
+        protected override bool Receive(object message)
+        {
+            Sender.Tell(message);
+            return true;
         }
     }
 
-    public class PersistentClusterShardingRememberEntitiesSpecNewExtractorConfig : ClusterShardingRememberEntitiesNewExtractorSpecConfig
+    private sealed class MessageExtractor1: IMessageExtractor
     {
-        public PersistentClusterShardingRememberEntitiesSpecNewExtractorConfig()
-            : base(StateStoreMode.Persistence)
-        {
-        }
-    }
-
-    public class DDataClusterShardingRememberEntitiesNewExtractorSpecConfig : ClusterShardingRememberEntitiesNewExtractorSpecConfig
-    {
-        public DDataClusterShardingRememberEntitiesNewExtractorSpecConfig()
-            : base(StateStoreMode.DData)
-        {
-        }
-    }
-
-    public class PersistentClusterShardingRememberEntitiesNewExtractorSpec : ClusterShardingRememberEntitiesNewExtractorSpec
-    {
-        public PersistentClusterShardingRememberEntitiesNewExtractorSpec()
-            : base(new PersistentClusterShardingRememberEntitiesSpecNewExtractorConfig(), typeof(PersistentClusterShardingRememberEntitiesNewExtractorSpec))
-        {
-        }
-    }
-
-    public class DDataClusterShardingRememberEntitiesNewExtractorSpec : ClusterShardingRememberEntitiesNewExtractorSpec
-    {
-        public DDataClusterShardingRememberEntitiesNewExtractorSpec()
-            : base(new DDataClusterShardingRememberEntitiesNewExtractorSpecConfig(), typeof(DDataClusterShardingRememberEntitiesNewExtractorSpec))
-        {
-        }
-    }
-
-    public abstract class ClusterShardingRememberEntitiesNewExtractorSpec : MultiNodeClusterShardingSpec<ClusterShardingRememberEntitiesNewExtractorSpecConfig>
-    {
-        #region setup
-
-        [Serializable]
-        internal sealed class Started
-        {
-            public readonly IActorRef Ref;
-            public Started(IActorRef @ref)
+        public string EntityId(object message)
+            => message switch
             {
-                Ref = @ref;
-            }
-        }
+                int id => id.ToString(),
+                _ => null
+            };
 
-        internal class TestEntity : ActorBase
-        {
-            private readonly ILoggingAdapter log = Context.GetLogger();
+        public object EntityMessage(object message)
+            => message;
 
-            public TestEntity(IActorRef probe)
+        public string ShardId(object message)
+            => message switch
             {
-                log.Info("Entity started: " + Self.Path);
-                probe?.Tell(new Started(Self));
-            }
+                int id => (id % ShardCount).ToString(),
+                _ => null
+            };
 
-            protected override bool Receive(object message)
-            {
-                Sender.Tell(message);
-                return true;
-            }
-        }
-
-        private sealed class MessageExtractor1: IMessageExtractor
-        {
-            public string EntityId(object message)
-                => message switch
-                {
-                    int id => id.ToString(),
-                    _ => null
-                };
-
-            public object EntityMessage(object message)
-                => message;
-
-            public string ShardId(object message)
-                => message switch
-                {
-                    int id => (id % ShardCount).ToString(),
-                    _ => null
-                };
-
-            public string ShardId(string entityId, object messageHint = null)
-                => (int.Parse(entityId) % ShardCount).ToString();
-        }
+        public string ShardId(string entityId, object messageHint = null)
+            => (int.Parse(entityId) % ShardCount).ToString();
+    }
         
-        private sealed class MessageExtractor2: IMessageExtractor
-        {
-            public string EntityId(object message)
-                => message switch
-                {
-                    int id => id.ToString(),
-                    _ => null
-                };
-
-            public object EntityMessage(object message)
-                => message;
-
-            public string ShardId(object message)
-                => message switch
-                {
-                    int id => ((id + 1) % ShardCount).ToString(),
-                    _ => null
-                };
-
-            public string ShardId(string entityId, object messageHint = null)
-                => ((int.Parse(entityId) + 1) % ShardCount).ToString();
-        }
-
-        private const int ShardCount = 3;
-        private const string TypeName = "Entity";
-
-        protected ClusterShardingRememberEntitiesNewExtractorSpec(ClusterShardingRememberEntitiesNewExtractorSpecConfig config, Type type)
-            : base(config, type)
-        {
-        }
-
-        private void StartShardingWithExtractor1()
-        {
-            StartSharding(
-                Sys,
-                typeName: TypeName,
-                entityProps: Props.Create(() => new TestEntity(null)),
-                settings: Settings.Value.WithRole("sharding"),
-                messageExtractor: new MessageExtractor1());
-        }
-
-        private void StartShardingWithExtractor2(ActorSystem sys, IActorRef probe)
-        {
-            StartSharding(
-                sys,
-                typeName: TypeName,
-                entityProps: Props.Create(() => new TestEntity(probe)),
-                settings: ClusterShardingSettings.Create(sys).WithRememberEntities(Config.RememberEntities).WithRole("sharding"),
-                messageExtractor: new MessageExtractor2());
-        }
-
-        private IActorRef Region(ActorSystem sys = null)
-        {
-            return ClusterSharding.Get(sys ?? Sys).ShardRegion(TypeName);
-        }
-
-
-        #endregion
-
-        [MultiNodeFact]
-        public async Task Cluster_sharding_with_remember_entities_specs()
-        {
-            await Cluster_with_min_nr_of_members_using_sharding_must_start_up_first_cluster_and_sharding();
-            await Cluster_with_min_nr_of_members_using_sharding_must_shutdown_sharding_nodes();
-            await Cluster_with_min_nr_of_members_using_sharding_must_start_new_nodes_with_different_extractor_and_have_the_entities_running_on_the_right_shards();
-        }
-
-        private async Task Cluster_with_min_nr_of_members_using_sharding_must_start_up_first_cluster_and_sharding()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(15), async () =>
+    private sealed class MessageExtractor2: IMessageExtractor
+    {
+        public string EntityId(object message)
+            => message switch
             {
-                StartPersistenceIfNeeded(startOn: Config.First, Config.Second, Config.Third);
+                int id => id.ToString(),
+                _ => null
+            };
 
-                Join(Config.First, Config.First);
-                Join(Config.Second, Config.First);
-                Join(Config.Third, Config.First);
+        public object EntityMessage(object message)
+            => message;
 
-                RunOn(() =>
-                {
-                    Within(Remaining, () =>
-                    {
-                        AwaitAssert(() =>
-                        {
-                            Cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(3);
-                        });
-                    });
-                }, Config.First, Config.Second, Config.Third);
-
-                RunOn(() =>
-                {
-                    StartShardingWithExtractor1();
-                }, Config.Second, Config.Third);
-                await EnterBarrierAsync("first-cluster-up");
-
-                RunOn(() =>
-                {
-                    // one entity for each shard id
-                    foreach (var n in Enumerable.Range(1, 10))
-                    {
-                        Region().Tell(n);
-                        ExpectMsg(n);
-                    }
-                }, Config.Second, Config.Third);
-                await EnterBarrierAsync("first-cluster-entities-up");
-            });
-        }
-
-        private async Task Cluster_with_min_nr_of_members_using_sharding_must_shutdown_sharding_nodes()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
+        public string ShardId(object message)
+            => message switch
             {
-                await RunOnAsync(async () =>
-                {
-                    await TestConductor.ExitAsync(Config.Second, 0);
-                    await TestConductor.ExitAsync(Config.Third, 0);
-                }, Config.First);
+                int id => ((id + 1) % ShardCount).ToString(),
+                _ => null
+            };
 
-                RunOn(() =>
-                {
-                    Within(Remaining, () =>
-                    {
-                        AwaitAssert(() =>
-                        {
-                            Cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(1);
-                        });
-                    });
-                }, Config.First);
+        public string ShardId(string entityId, object messageHint = null)
+            => ((int.Parse(entityId) + 1) % ShardCount).ToString();
+    }
 
-            });
-            await EnterBarrierAsync("first-sharding-cluster-stopped");
-        }
+    private const int ShardCount = 3;
+    private const string TypeName = "Entity";
 
-        private async Task Cluster_with_min_nr_of_members_using_sharding_must_start_new_nodes_with_different_extractor_and_have_the_entities_running_on_the_right_shards()
+    protected ClusterShardingRememberEntitiesNewExtractorSpec(ClusterShardingRememberEntitiesNewExtractorSpecConfig config, Type type)
+        : base(config, type)
+    {
+    }
+
+    private void StartShardingWithExtractor1()
+    {
+        StartSharding(
+            Sys,
+            typeName: TypeName,
+            entityProps: Props.Create(() => new TestEntity(null)),
+            settings: Settings.Value.WithRole("sharding"),
+            messageExtractor: new MessageExtractor1());
+    }
+
+    private void StartShardingWithExtractor2(ActorSystem sys, IActorRef probe)
+    {
+        StartSharding(
+            sys,
+            typeName: TypeName,
+            entityProps: Props.Create(() => new TestEntity(probe)),
+            settings: ClusterShardingSettings.Create(sys).WithRememberEntities(Config.RememberEntities).WithRole("sharding"),
+            messageExtractor: new MessageExtractor2());
+    }
+
+    private IActorRef Region(ActorSystem sys = null)
+    {
+        return ClusterSharding.Get(sys ?? Sys).ShardRegion(TypeName);
+    }
+
+
+    #endregion
+
+    [MultiNodeFact]
+    public async Task Cluster_sharding_with_remember_entities_specs()
+    {
+        await Cluster_with_min_nr_of_members_using_sharding_must_start_up_first_cluster_and_sharding();
+        await Cluster_with_min_nr_of_members_using_sharding_must_shutdown_sharding_nodes();
+        await Cluster_with_min_nr_of_members_using_sharding_must_start_new_nodes_with_different_extractor_and_have_the_entities_running_on_the_right_shards();
+    }
+
+    private async Task Cluster_with_min_nr_of_members_using_sharding_must_start_up_first_cluster_and_sharding()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(15), async () =>
         {
-            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
-            {
-                // start it with a new shard id messageExtractor, which will put the entities
-                // on different shards
+            StartPersistenceIfNeeded(startOn: Config.First, Config.Second, Config.Third);
 
-                RunOn(() =>
+            await JoinAsync(Config.First, Config.First);
+            await JoinAsync(Config.Second, Config.First);
+            await JoinAsync(Config.Third, Config.First);
+
+            RunOn(() =>
+            {
+                Within(Remaining, () =>
                 {
-                    Watch(Region());
-                    Cluster.Get(Sys).Leave(Cluster.Get(Sys).SelfAddress);
-                    ExpectTerminated(Region());
                     AwaitAssert(() =>
                     {
-                        Cluster.Get(Sys).IsTerminated.Should().BeTrue();
+                        Cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(3);
                     });
+                });
+            }, Config.First, Config.Second, Config.Third);
 
-                }, Config.Second, Config.Third);
-                await EnterBarrierAsync("first-cluster-terminated");
+            RunOn(() =>
+            {
+                StartShardingWithExtractor1();
+            }, Config.Second, Config.Third);
+            await EnterBarrierAsync("first-cluster-up");
 
-                // no sharding nodes left of the original cluster, start a new nodes
-                await RunOnAsync(async () =>
+            await RunOnAsync(async () =>
+            {
+                // one entity for each shard id
+                foreach (var n in Enumerable.Range(1, 10))
                 {
-                    var sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
-                    var probe2 = CreateTestProbe(sys2);
+                    Region().Tell(n);
+                    await ExpectMsgAsync(n);
+                }
+            }, Config.Second, Config.Third);
+            await EnterBarrierAsync("first-cluster-entities-up");
+        });
+    }
 
-                    if (PersistenceIsNeeded)
+    private async Task Cluster_with_min_nr_of_members_using_sharding_must_shutdown_sharding_nodes()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(30), async () =>
+        {
+            await RunOnAsync(async () =>
+            {
+                await TestConductor.ExitAsync(Config.Second, 0);
+                await TestConductor.ExitAsync(Config.Third, 0);
+            }, Config.First);
+
+            RunOn(() =>
+            {
+                Within(Remaining, () =>
+                {
+                    AwaitAssert(() =>
                     {
-                        SetStore(sys2, storeOn: Config.First);
-
-                        ////Persistence.Persistence.Instance.Apply(sys2);
-                        //sys2.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.sqlite").Tell(new Identify(null), probe2.Ref);
-                        //var sharedStore = probe2.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
-                        //sharedStore.Should().NotBeNull();
-                        //SqliteJournalShared.SetStore(sharedStore, sys2);
-                    }
-
-                    Cluster.Get(sys2).Join(Node(Config.First).Address);
-                    StartShardingWithExtractor2(sys2, probe2.Ref);
-                    probe2.ExpectMsg<Started>(TimeSpan.FromSeconds(20));
-
-                    CurrentShardRegionState stats = null;
-                    Within(TimeSpan.FromSeconds(10), () =>
-                    {
-                        AwaitAssert(() =>
-                        {
-                            Region(sys2).Tell(GetShardRegionState.Instance);
-                            var reply = ExpectMsg<CurrentShardRegionState>();
-                            reply.Shards.Should().NotBeEmpty();
-                            stats = reply;
-                        });
+                        Cluster.State.Members.Count(m => m.Status == MemberStatus.Up).Should().Be(1);
                     });
+                });
+            }, Config.First);
 
-                    var extractor = new MessageExtractor2();
-                    foreach (var shardState in stats.Shards)
-                    {
-                        foreach (var entityId in shardState.EntityIds)
-                        {
-                            var calculatedShardId = extractor.ShardId(entityId);
-                            calculatedShardId.Should().BeEquivalentTo(shardState.ShardId);
-                        }
-                    }
+        });
+        await EnterBarrierAsync("first-sharding-cluster-stopped");
+    }
 
-                    await EnterBarrierAsync("verified");
-                    Shutdown(sys2);
-                }, Config.Second, Config.Third);
+    private async Task Cluster_with_min_nr_of_members_using_sharding_must_start_new_nodes_with_different_extractor_and_have_the_entities_running_on_the_right_shards()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(30), async () =>
+        {
+            // start it with a new shard id messageExtractor, which will put the entities
+            // on different shards
 
-                await RunOnAsync(async () =>
+            await RunOnAsync(async () =>
+            {
+                await WatchAsync(Region());
+                Cluster.Get(Sys).Leave(Cluster.Get(Sys).SelfAddress);
+                await ExpectTerminatedAsync(Region());
+                AwaitAssert(() =>
                 {
-                    await EnterBarrierAsync("verified");
-                }, Config.First);
+                    Cluster.Get(Sys).IsTerminated.Should().BeTrue();
+                });
 
-                await EnterBarrierAsync("done");
-            });
-        }
+            }, Config.Second, Config.Third);
+            await EnterBarrierAsync("first-cluster-terminated");
+
+            // no sharding nodes left of the original cluster, start a new nodes
+            await RunOnAsync(async () =>
+            {
+                var sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+                var probe2 = CreateTestProbe(sys2);
+
+                if (PersistenceIsNeeded)
+                {
+                    await SetStoreAsync(sys2, storeOn: Config.First);
+
+                    ////Persistence.Persistence.Instance.Apply(sys2);
+                    //sys2.ActorSelection(Node(_config.First) / "system" / "akka.persistence.journal.sqlite").Tell(new Identify(null), probe2.Ref);
+                    //var sharedStore = probe2.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(10)).Subject;
+                    //sharedStore.Should().NotBeNull();
+                    //SqliteJournalShared.SetStore(sharedStore, sys2);
+                }
+
+                Cluster.Get(sys2).Join((await NodeAsync(Config.First)).Address);
+                StartShardingWithExtractor2(sys2, probe2.Ref);
+                await probe2.ExpectMsgAsync<Started>(TimeSpan.FromSeconds(20));
+
+                CurrentShardRegionState stats = null;
+                await WithinAsync(TimeSpan.FromSeconds(10), async() =>
+                {
+                    await AwaitAssertAsync(async () =>
+                    {
+                        Region(sys2).Tell(GetShardRegionState.Instance);
+                        var reply = await ExpectMsgAsync<CurrentShardRegionState>();
+                        reply.Shards.Should().NotBeEmpty();
+                        stats = reply;
+                    });
+                });
+
+                var extractor = new MessageExtractor2();
+                foreach (var shardState in stats.Shards)
+                {
+                    foreach (var entityId in shardState.EntityIds)
+                    {
+                        var calculatedShardId = extractor.ShardId(entityId);
+                        calculatedShardId.Should().BeEquivalentTo(shardState.ShardId);
+                    }
+                }
+
+                await EnterBarrierAsync("verified");
+                Shutdown(sys2);
+            }, Config.Second, Config.Third);
+
+            await RunOnAsync(async () =>
+            {
+                await EnterBarrierAsync("verified");
+            }, Config.First);
+
+            await EnterBarrierAsync("done");
+        });
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.MultiNode.TestAdapter;
@@ -182,18 +183,18 @@ namespace Akka.Cluster.Sharding.Tests
         #endregion
 
         [MultiNodeFact]
-        public void Cluster_sharding_with_remember_entities_specs()
+        public async Task Cluster_sharding_with_remember_entities_specs()
         {
-            Cluster_sharding_with_remember_entities_must_start_remembered_entities_when_coordinator_fail_over();
+            await Cluster_sharding_with_remember_entities_must_start_remembered_entities_when_coordinator_fail_over();
 
             // https://github.com/akkadotnet/akka.net/issues/4262 - need to resolve this and then we can remove if statement
             if (!IsDdataMode)
-                Cluster_sharding_with_remember_entities_must_start_remembered_entities_in_new_cluster();
+                await Cluster_sharding_with_remember_entities_must_start_remembered_entities_in_new_cluster();
         }
 
-        private void Cluster_sharding_with_remember_entities_must_start_remembered_entities_when_coordinator_fail_over()
+        private async Task Cluster_sharding_with_remember_entities_must_start_remembered_entities_when_coordinator_fail_over()
         {
-            Within(TimeSpan.FromSeconds(30), () =>
+            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
             {
                 StartPersistenceIfNeeded(startOn: Config.First, Config.First, Config.Second, Config.Third);
 
@@ -207,7 +208,7 @@ namespace Akka.Cluster.Sharding.Tests
                     probe.ExpectMsg(1);
                     entityProbe.ExpectMsg<EntityActor.Started>();
                 }, Config.Second);
-                EnterBarrier("second-started");
+                await EnterBarrierAsync("second-started");
 
                 Join(Config.Third, Config.Second);
                 RunOn(() =>
@@ -226,9 +227,9 @@ namespace Akka.Cluster.Sharding.Tests
                         });
                     });
                 }, Config.Second, Config.Third);
-                EnterBarrier("all-up");
+                await EnterBarrierAsync("all-up");
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
                     if (IsDdataMode)
                     {
@@ -237,23 +238,23 @@ namespace Akka.Cluster.Sharding.Tests
                         // gossip. So we must give that a chance to replicate before shutting down second.
                         Thread.Sleep(5000);
                     }
-                    TestConductor.Exit(Config.Second, 0).Wait();
+                    await TestConductor.ExitAsync(Config.Second, 0);
                 }, Config.First);
 
-                EnterBarrier("crash-second");
+                await EnterBarrierAsync("crash-second");
 
                 RunOn(() =>
                 {
                     ExpectEntityRestarted(Sys, 1, probe, entityProbe);
                 }, Config.Third);
 
-                EnterBarrier("after-2");
+                await EnterBarrierAsync("after-2");
             });
         }
 
-        private void Cluster_sharding_with_remember_entities_must_start_remembered_entities_in_new_cluster()
+        private async Task Cluster_sharding_with_remember_entities_must_start_remembered_entities_in_new_cluster()
         {
-            Within(TimeSpan.FromSeconds(30), () =>
+            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
             {
                 RunOn(() =>
                 {
@@ -282,7 +283,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                     Shutdown(sys2);
                 }, Config.Third);
-                EnterBarrier("after-3");
+                await EnterBarrierAsync("after-3");
             });
         }
     }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRememberEntitiesSpec.cs
@@ -16,275 +16,274 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 
-namespace Akka.Cluster.Sharding.Tests
-{
-    public class ClusterShardingRememberEntitiesSpecConfig : MultiNodeClusterShardingConfig
-    {
-        public RoleName First { get; }
-        public RoleName Second { get; }
-        public RoleName Third { get; }
+namespace Akka.Cluster.Sharding.Tests;
 
-        public ClusterShardingRememberEntitiesSpecConfig(
-            StateStoreMode mode,
-            bool rememberEntities,
-            RememberEntitiesStore rememberEntitiesStore = RememberEntitiesStore.DData)
-            : base(mode: mode, rememberEntities: rememberEntities, rememberEntitiesStore: rememberEntitiesStore,
-                  loglevel: "DEBUG", additionalConfig: @"
+public class ClusterShardingRememberEntitiesSpecConfig : MultiNodeClusterShardingConfig
+{
+    public RoleName First { get; }
+    public RoleName Second { get; }
+    public RoleName Third { get; }
+
+    public ClusterShardingRememberEntitiesSpecConfig(
+        StateStoreMode mode,
+        bool rememberEntities,
+        RememberEntitiesStore rememberEntitiesStore = RememberEntitiesStore.DData)
+        : base(mode: mode, rememberEntities: rememberEntities, rememberEntitiesStore: rememberEntitiesStore,
+            loglevel: "DEBUG", additionalConfig: @"
               akka.testconductor.barrier-timeout = 60 s
               akka.test.single-expect-default = 60 s
             ")
-        {
-            First = Role("first");
-            Second = Role("second");
-            Third = Role("third");
+    {
+        First = Role("first");
+        Second = Role("second");
+        Third = Role("third");
 
-            NodeConfig(new[] { Third }, new[] { ConfigurationFactory.ParseString(@"
+        NodeConfig(new[] { Third }, new[] { ConfigurationFactory.ParseString(@"
                 akka.cluster.sharding.distributed-data.durable.lmdb {
                     # use same directory when starting new node on third (not used at same time)
                     dir = ""target/ShardingRememberEntitiesSpec/sharding-third""
                 }
             ") });
-        }
     }
+}
 
-    public class PersistentClusterShardingRememberEntitiesSpecConfig : ClusterShardingRememberEntitiesSpecConfig
+public class PersistentClusterShardingRememberEntitiesSpecConfig : ClusterShardingRememberEntitiesSpecConfig
+{
+    public PersistentClusterShardingRememberEntitiesSpecConfig(bool rememberEntities)
+        : base(StateStoreMode.Persistence, rememberEntities)
     {
-        public PersistentClusterShardingRememberEntitiesSpecConfig(bool rememberEntities)
-            : base(StateStoreMode.Persistence, rememberEntities)
-        {
-        }
     }
+}
 
-    public class DDataClusterShardingRememberEntitiesSpecConfig : ClusterShardingRememberEntitiesSpecConfig
+public class DDataClusterShardingRememberEntitiesSpecConfig : ClusterShardingRememberEntitiesSpecConfig
+{
+    public DDataClusterShardingRememberEntitiesSpecConfig(bool rememberEntities)
+        : base(StateStoreMode.DData, rememberEntities)
     {
-        public DDataClusterShardingRememberEntitiesSpecConfig(bool rememberEntities)
-            : base(StateStoreMode.DData, rememberEntities)
-        {
-        }
     }
+}
 
-    public class DDataClusterShardingEventSourcedRememberEntitiesSpecConfig : ClusterShardingRememberEntitiesSpecConfig
+public class DDataClusterShardingEventSourcedRememberEntitiesSpecConfig : ClusterShardingRememberEntitiesSpecConfig
+{
+    public DDataClusterShardingEventSourcedRememberEntitiesSpecConfig(bool rememberEntities)
+        : base(StateStoreMode.DData, rememberEntities, RememberEntitiesStore.Eventsourced)
     {
-        public DDataClusterShardingEventSourcedRememberEntitiesSpecConfig(bool rememberEntities)
-            : base(StateStoreMode.DData, rememberEntities, RememberEntitiesStore.Eventsourced)
-        {
-        }
     }
+}
 
-    public class PersistentClusterShardingRememberEntitiesEnabledSpec : ClusterShardingRememberEntitiesSpec
+public class PersistentClusterShardingRememberEntitiesEnabledSpec : ClusterShardingRememberEntitiesSpec
+{
+    public PersistentClusterShardingRememberEntitiesEnabledSpec()
+        : base(new PersistentClusterShardingRememberEntitiesSpecConfig(true), typeof(PersistentClusterShardingRememberEntitiesEnabledSpec))
     {
-        public PersistentClusterShardingRememberEntitiesEnabledSpec()
-            : base(new PersistentClusterShardingRememberEntitiesSpecConfig(true), typeof(PersistentClusterShardingRememberEntitiesEnabledSpec))
-        {
-        }
     }
+}
 
-    public class PersistentClusterShardingRememberEntitiesDefaultSpec : ClusterShardingRememberEntitiesSpec
+public class PersistentClusterShardingRememberEntitiesDefaultSpec : ClusterShardingRememberEntitiesSpec
+{
+    public PersistentClusterShardingRememberEntitiesDefaultSpec()
+        : base(new PersistentClusterShardingRememberEntitiesSpecConfig(false), typeof(PersistentClusterShardingRememberEntitiesDefaultSpec))
     {
-        public PersistentClusterShardingRememberEntitiesDefaultSpec()
-            : base(new PersistentClusterShardingRememberEntitiesSpecConfig(false), typeof(PersistentClusterShardingRememberEntitiesDefaultSpec))
-        {
-        }
     }
+}
 
-    public class DDataClusterShardingRememberEntitiesEnabledSpec : ClusterShardingRememberEntitiesSpec
+public class DDataClusterShardingRememberEntitiesEnabledSpec : ClusterShardingRememberEntitiesSpec
+{
+    public DDataClusterShardingRememberEntitiesEnabledSpec()
+        : base(new DDataClusterShardingRememberEntitiesSpecConfig(true), typeof(DDataClusterShardingRememberEntitiesEnabledSpec))
     {
-        public DDataClusterShardingRememberEntitiesEnabledSpec()
-            : base(new DDataClusterShardingRememberEntitiesSpecConfig(true), typeof(DDataClusterShardingRememberEntitiesEnabledSpec))
-        {
-        }
     }
+}
 
-    public class DDataClusterShardingRememberEntitiesDefaultSpec : ClusterShardingRememberEntitiesSpec
+public class DDataClusterShardingRememberEntitiesDefaultSpec : ClusterShardingRememberEntitiesSpec
+{
+    public DDataClusterShardingRememberEntitiesDefaultSpec()
+        : base(new DDataClusterShardingRememberEntitiesSpecConfig(false), typeof(DDataClusterShardingRememberEntitiesDefaultSpec))
     {
-        public DDataClusterShardingRememberEntitiesDefaultSpec()
-            : base(new DDataClusterShardingRememberEntitiesSpecConfig(false), typeof(DDataClusterShardingRememberEntitiesDefaultSpec))
-        {
-        }
     }
+}
 
-    public class DDataClusterShardingEventSourcedRememberEntitiesEnabledSpec : ClusterShardingRememberEntitiesSpec
+public class DDataClusterShardingEventSourcedRememberEntitiesEnabledSpec : ClusterShardingRememberEntitiesSpec
+{
+    public DDataClusterShardingEventSourcedRememberEntitiesEnabledSpec()
+        : base(new DDataClusterShardingEventSourcedRememberEntitiesSpecConfig(true), typeof(DDataClusterShardingEventSourcedRememberEntitiesEnabledSpec))
     {
-        public DDataClusterShardingEventSourcedRememberEntitiesEnabledSpec()
-            : base(new DDataClusterShardingEventSourcedRememberEntitiesSpecConfig(true), typeof(DDataClusterShardingEventSourcedRememberEntitiesEnabledSpec))
-        {
-        }
     }
+}
 
-    public abstract class ClusterShardingRememberEntitiesSpec : MultiNodeClusterShardingSpec<ClusterShardingRememberEntitiesSpecConfig>
+public abstract class ClusterShardingRememberEntitiesSpec : MultiNodeClusterShardingSpec<ClusterShardingRememberEntitiesSpecConfig>
+{
+    #region setup
+
+    private sealed class MyMessageExtractor : IMessageExtractor
     {
-        #region setup
-
-        private sealed class MyMessageExtractor : IMessageExtractor
+        public string? EntityId(object message)
         {
-            public string? EntityId(object message)
+            switch(message)
             {
-                switch(message)
-                {
-                    case int id:
-                        return id.ToString();
-                    default:
-                        return null;
-                }
-            }
-
-            public object? EntityMessage(object message)
-            {
-                return message;
-            }
-
-            public string? ShardId(object message)
-            {
-                throw new NotImplementedException();
-            }
-
-            public string ShardId(string entityId, object? messageHint = null)
-            {
-                return entityId;
+                case int id:
+                    return id.ToString();
+                default:
+                    return null;
             }
         }
+
+        public object? EntityMessage(object message)
+        {
+            return message;
+        }
+
+        public string? ShardId(object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string ShardId(string entityId, object? messageHint = null)
+        {
+            return entityId;
+        }
+    }
         
-        private const string dataType = "Entity";
+    private const string DataType = "Entity";
 
-        private readonly Lazy<IActorRef> _region;
+    private readonly Lazy<IActorRef> _region;
 
-        protected ClusterShardingRememberEntitiesSpec(ClusterShardingRememberEntitiesSpecConfig config, Type type)
-            : base(config, type)
+    protected ClusterShardingRememberEntitiesSpec(ClusterShardingRememberEntitiesSpecConfig config, Type type)
+        : base(config, type)
+    {
+        _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion(DataType));
+    }
+
+
+    private IActorRef StartSharding(ActorSystem sys, IActorRef probe)
+    {
+        return StartSharding(
+            sys,
+            typeName: DataType,
+            new MyMessageExtractor(),
+            entityProps: Props.Create(() => new EntityActor(probe)),
+            settings: ClusterShardingSettings.Create(sys).WithRememberEntities(Config.RememberEntities));
+    }
+
+    private async Task<EntityActor.Started> ExpectEntityRestarted(
+        ActorSystem sys,
+        int @event,
+        TestProbe probe,
+        TestProbe entityProbe)
+    {
+        if (!Config.RememberEntities)
         {
-            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion(dataType));
+            probe.Send(ClusterSharding.Get(sys).ShardRegion(DataType), @event);
+            await probe.ExpectMsgAsync(1);
         }
 
+        return await entityProbe.ExpectMsgAsync<EntityActor.Started>(TimeSpan.FromSeconds(30));
+    }
 
-        private IActorRef StartSharding(ActorSystem sys, IActorRef probe)
-        {
-            return StartSharding(
-                sys,
-                typeName: dataType,
-                new MyMessageExtractor(),
-                entityProps: Props.Create(() => new EntityActor(probe)),
-                settings: ClusterShardingSettings.Create(sys).WithRememberEntities(Config.RememberEntities));
-        }
+    #endregion
 
-        private EntityActor.Started ExpectEntityRestarted(
-            ActorSystem sys,
-            int @event,
-            TestProbe probe,
-            TestProbe entityProbe)
+    [MultiNodeFact]
+    public async Task Cluster_sharding_with_remember_entities_specs()
+    {
+        await Cluster_sharding_with_remember_entities_must_start_remembered_entities_when_coordinator_fail_over();
+
+        // https://github.com/akkadotnet/akka.net/issues/4262 - need to resolve this and then we can remove if statement
+        if (!IsDdataMode)
+            await Cluster_sharding_with_remember_entities_must_start_remembered_entities_in_new_cluster();
+    }
+
+    private async Task Cluster_sharding_with_remember_entities_must_start_remembered_entities_when_coordinator_fail_over()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(30), async () =>
         {
-            if (!Config.RememberEntities)
+            await StartPersistenceIfNeededAsync(Config.First, CancellationToken.None, Config.First, Config.Second, Config.Third);
+
+            var entityProbe = CreateTestProbe();
+            var probe = CreateTestProbe();
+            await JoinAsync(Config.Second, Config.Second);
+            await RunOnAsync(async () =>
             {
-                probe.Send(ClusterSharding.Get(sys).ShardRegion(dataType), @event);
-                probe.ExpectMsg(1);
-            }
+                StartSharding(Sys, entityProbe.Ref);
+                probe.Send(_region.Value, 1);
+                await probe.ExpectMsgAsync(1);
+                await entityProbe.ExpectMsgAsync<EntityActor.Started>();
+            }, Config.Second);
+            await EnterBarrierAsync("second-started");
 
-            return entityProbe.ExpectMsg<EntityActor.Started>(TimeSpan.FromSeconds(30));
-        }
-
-        #endregion
-
-        [MultiNodeFact]
-        public async Task Cluster_sharding_with_remember_entities_specs()
-        {
-            await Cluster_sharding_with_remember_entities_must_start_remembered_entities_when_coordinator_fail_over();
-
-            // https://github.com/akkadotnet/akka.net/issues/4262 - need to resolve this and then we can remove if statement
-            if (!IsDdataMode)
-                await Cluster_sharding_with_remember_entities_must_start_remembered_entities_in_new_cluster();
-        }
-
-        private async Task Cluster_sharding_with_remember_entities_must_start_remembered_entities_when_coordinator_fail_over()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
+            await JoinAsync(Config.Third, Config.Second);
+            RunOn(() =>
             {
-                StartPersistenceIfNeeded(startOn: Config.First, Config.First, Config.Second, Config.Third);
+                StartSharding(Sys, entityProbe.Ref);
+            }, Config.Third);
 
-                var entityProbe = CreateTestProbe();
-                var probe = CreateTestProbe();
-                Join(Config.Second, Config.Second);
-                RunOn(() =>
-                {
-                    StartSharding(Sys, entityProbe.Ref);
-                    probe.Send(_region.Value, 1);
-                    probe.ExpectMsg(1);
-                    entityProbe.ExpectMsg<EntityActor.Started>();
-                }, Config.Second);
-                await EnterBarrierAsync("second-started");
-
-                Join(Config.Third, Config.Second);
-                RunOn(() =>
-                {
-                    StartSharding(Sys, entityProbe.Ref);
-                }, Config.Third);
-
-                RunOn(() =>
-                {
-                    Within(Remaining, () =>
-                    {
-                        AwaitAssert(() =>
-                        {
-                            Cluster.State.Members.Count.Should().Be(2);
-                            Cluster.State.Members.Should().OnlyContain(i => i.Status == MemberStatus.Up);
-                        });
-                    });
-                }, Config.Second, Config.Third);
-                await EnterBarrierAsync("all-up");
-
-                await RunOnAsync(async () =>
-                {
-                    if (IsDdataMode)
-                    {
-                        // Entity 1 in region of first node was started when there was only one node
-                        // and then the remembering state will be replicated to second node by the
-                        // gossip. So we must give that a chance to replicate before shutting down second.
-                        Thread.Sleep(5000);
-                    }
-                    await TestConductor.ExitAsync(Config.Second, 0);
-                }, Config.First);
-
-                await EnterBarrierAsync("crash-second");
-
-                RunOn(() =>
-                {
-                    ExpectEntityRestarted(Sys, 1, probe, entityProbe);
-                }, Config.Third);
-
-                await EnterBarrierAsync("after-2");
-            });
-        }
-
-        private async Task Cluster_sharding_with_remember_entities_must_start_remembered_entities_in_new_cluster()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
+            RunOn(() =>
             {
-                RunOn(() =>
+                Within(Remaining, () =>
                 {
-                    Watch(_region.Value);
-
-                    Cluster.Get(Sys).Leave(Cluster.Get(Sys).SelfAddress);
-                    ExpectTerminated(_region.Value);
                     AwaitAssert(() =>
                     {
-                        Cluster.Get(Sys).IsTerminated.Should().BeTrue();
+                        Cluster.State.Members.Count.Should().Be(2);
+                        Cluster.State.Members.Should().OnlyContain(i => i.Status == MemberStatus.Up);
                     });
-                    // no nodes left of the original cluster, start a new cluster
+                });
+            }, Config.Second, Config.Third);
+            await EnterBarrierAsync("all-up");
 
-                    var sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
-                    var entityProbe2 = CreateTestProbe(sys2);
-                    var probe2 = CreateTestProbe(sys2);
+            await RunOnAsync(async () =>
+            {
+                if (IsDdataMode)
+                {
+                    // Entity 1 in region of first node was started when there was only one node
+                    // and then the remembering state will be replicated to second node by the
+                    // gossip. So we must give that a chance to replicate before shutting down second.
+                    await Task.Delay(5000);
+                }
+                await TestConductor.ExitAsync(Config.Second, 0);
+            }, Config.First);
 
-                    if (PersistenceIsNeeded)
-                        SetStore(sys2, storeOn: Config.First);
+            await EnterBarrierAsync("crash-second");
 
-                    Cluster.Get(sys2).Join(Cluster.Get(sys2).SelfAddress);
+            await RunOnAsync(async () =>
+            {
+                await ExpectEntityRestarted(Sys, 1, probe, entityProbe);
+            }, Config.Third);
 
-                    StartSharding(sys2, entityProbe2.Ref);
+            await EnterBarrierAsync("after-2");
+        });
+    }
 
-                    ExpectEntityRestarted(sys2, 1, probe2, entityProbe2);
+    private async Task Cluster_sharding_with_remember_entities_must_start_remembered_entities_in_new_cluster()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(30), async () =>
+        {
+            await RunOnAsync(async () =>
+            {
+                await WatchAsync(_region.Value);
 
-                    Shutdown(sys2);
-                }, Config.Third);
-                await EnterBarrierAsync("after-3");
-            });
-        }
+                Cluster.Get(Sys).Leave(Cluster.Get(Sys).SelfAddress);
+                await ExpectTerminatedAsync(_region.Value);
+                AwaitAssert(() =>
+                {
+                    Cluster.Get(Sys).IsTerminated.Should().BeTrue();
+                });
+                // no nodes left of the original cluster, start a new cluster
+
+                var sys2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
+                var entityProbe2 = CreateTestProbe(sys2);
+                var probe2 = CreateTestProbe(sys2);
+
+                if (PersistenceIsNeeded)
+                    await SetStoreAsync(sys2, storeOn: Config.First);
+
+                Cluster.Get(sys2).Join(Cluster.Get(sys2).SelfAddress);
+
+                StartSharding(sys2, entityProbe2.Ref);
+
+                await ExpectEntityRestarted(sys2, 1, probe2, entityProbe2);
+
+                Shutdown(sys2);
+            }, Config.Third);
+            await EnterBarrierAsync("after-3");
+        });
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSingleShardPerEntitySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSingleShardPerEntitySpec.cs
@@ -15,123 +15,122 @@ using Akka.Remote.Transport;
 using Akka.TestKit;
 using FluentAssertions;
 
-namespace Akka.Cluster.Sharding.Tests
+namespace Akka.Cluster.Sharding.Tests;
+
+public class ClusterShardingSingleShardPerEntitySpecConfig : MultiNodeClusterShardingConfig
 {
-    public class ClusterShardingSingleShardPerEntitySpecConfig : MultiNodeClusterShardingConfig
-    {
-        public RoleName First { get; }
-        public RoleName Second { get; }
-        public RoleName Third { get; }
-        public RoleName Fourth { get; }
-        public RoleName Fifth { get; }
+    public RoleName First { get; }
+    public RoleName Second { get; }
+    public RoleName Third { get; }
+    public RoleName Fourth { get; }
+    public RoleName Fifth { get; }
 
-        public Config R1Config { get; }
-        public Config R2Config { get; }
+    public Config R1Config { get; }
+    public Config R2Config { get; }
 
-        public ClusterShardingSingleShardPerEntitySpecConfig()
-            : base(loglevel: "DEBUG", additionalConfig: @"
+    public ClusterShardingSingleShardPerEntitySpecConfig()
+        : base(loglevel: "DEBUG", additionalConfig: @"
                 akka.cluster.sharding.updating-state-timeout = 1s
             ")
-        {
-            First = Role("first");
-            Second = Role("second");
-            Third = Role("third");
-            Fourth = Role("fourth");
-            Fifth = Role("fifth");
+    {
+        First = Role("first");
+        Second = Role("second");
+        Third = Role("third");
+        Fourth = Role("fourth");
+        Fifth = Role("fifth");
 
-            TestTransport = true;
-        }
+        TestTransport = true;
+    }
+}
+
+public class ClusterShardingSingleShardPerEntitySpec : MultiNodeClusterShardingSpec<ClusterShardingSingleShardPerEntitySpecConfig>
+{
+    #region setup
+
+    private readonly Lazy<IActorRef> _region;
+
+    public ClusterShardingSingleShardPerEntitySpec()
+        : this(new ClusterShardingSingleShardPerEntitySpecConfig(), typeof(ClusterShardingSingleShardPerEntitySpec))
+    {
     }
 
-    public class ClusterShardingSingleShardPerEntitySpec : MultiNodeClusterShardingSpec<ClusterShardingSingleShardPerEntitySpecConfig>
+    protected ClusterShardingSingleShardPerEntitySpec(ClusterShardingSingleShardPerEntitySpecConfig config, Type type)
+        : base(config, type)
     {
-        #region setup
+        _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
+    }
 
-        private readonly Lazy<IActorRef> _region;
+    private Task JoinAsync(RoleName from, RoleName to)
+    {
+        return JoinAsync(
+            from,
+            to,
+            () => StartSharding(
+                Sys,
+                typeName: "Entity",
+                entityProps: Props.Create(() => new ShardedEntity())));
+    }
 
-        public ClusterShardingSingleShardPerEntitySpec()
-            : this(new ClusterShardingSingleShardPerEntitySpecConfig(), typeof(ClusterShardingSingleShardPerEntitySpec))
+    private async Task JoinAndAllocate(RoleName node, int entityId)
+    {
+        await WithinAsync(TimeSpan.FromSeconds(10), async () =>
         {
-        }
-
-        protected ClusterShardingSingleShardPerEntitySpec(ClusterShardingSingleShardPerEntitySpecConfig config, Type type)
-            : base(config, type)
-        {
-            _region = new Lazy<IActorRef>(() => ClusterSharding.Get(Sys).ShardRegion("Entity"));
-        }
-
-        private void Join(RoleName from, RoleName to)
-        {
-            Join(
-                from,
-                to,
-                () => StartSharding(
-                    Sys,
-                    typeName: "Entity",
-                    entityProps: Props.Create(() => new ShardedEntity())));
-        }
-
-        private async Task JoinAndAllocate(RoleName node, int entityId)
-        {
-            Within(TimeSpan.FromSeconds(10), () =>
-            {
-                Join(node, Config.First);
-                RunOn(() =>
-                {
-                    _region.Value.Tell(entityId);
-
-                    ExpectMsg(entityId);
-
-                    LastSender.Path.Should().Be(_region.Value.Path / $"{entityId}" / $"{entityId}");
-                }, node);
-            });
-            await EnterBarrierAsync($"started-{entityId}");
-        }
-
-
-        #endregion
-
-        [MultiNodeFact]
-        public async Task Cluster_sharding_with_single_shard_per_entity_specs()
-        {
-            await Cluster_sharding_with_single_shard_per_entity_must_use_specified_region();
-        }
-
-        private async Task Cluster_sharding_with_single_shard_per_entity_must_use_specified_region()
-        {
-            await JoinAndAllocate(Config.First, 1);
-            await JoinAndAllocate(Config.Second, 2);
-            await JoinAndAllocate(Config.Third, 3);
-            await JoinAndAllocate(Config.Fourth, 4);
-            await JoinAndAllocate(Config.Fifth, 5);
-
+            await JoinAsync(node, Config.First);
             await RunOnAsync(async () =>
             {
-                // coordinator is on 'first', blackhole 3 other means that it can't update with WriteMajority
-                await TestConductor.BlackholeAsync(Config.First, Config.Third, ThrottleTransportAdapter.Direction.Both);
-                await TestConductor.BlackholeAsync(Config.First, Config.Fourth, ThrottleTransportAdapter.Direction.Both);
-                await TestConductor.BlackholeAsync(Config.First, Config.Fifth, ThrottleTransportAdapter.Direction.Both);
+                _region.Value.Tell(entityId);
 
-                // shard 6 not allocated yet and due to the blackhole it will not be completed
-                _region.Value.Tell(6);
+                await ExpectMsgAsync(entityId);
 
-                // shard 1 location is know by 'first' region, not involving coordinator
-                _region.Value.Tell(1);
-                ExpectMsg(1);
+                LastSender.Path.Should().Be(_region.Value.Path / $"{entityId}" / $"{entityId}");
+            }, node);
+        });
+        await EnterBarrierAsync($"started-{entityId}");
+    }
 
-                // shard 2 location not known at 'first' region yet, but coordinator is on 'first' and should
-                // be able to answer GetShardHome even though previous request for shard 4 has not completed yet
-                _region.Value.Tell(2);
-                ExpectMsg(2);
-                LastSender.Path.Should().Be(Node(Config.Second) / "system" / "sharding" / "Entity" / "2" / "2");
 
-                await TestConductor.PassThroughAsync(Config.First, Config.Third, ThrottleTransportAdapter.Direction.Both);
-                await TestConductor.PassThroughAsync(Config.First, Config.Fourth, ThrottleTransportAdapter.Direction.Both);
-                await TestConductor.PassThroughAsync(Config.First, Config.Fifth, ThrottleTransportAdapter.Direction.Both);
-                ExpectMsg(6, TimeSpan.FromSeconds(10));
-            }, Config.First);
+    #endregion
 
-            await EnterBarrierAsync("after-1");
-        }
+    [MultiNodeFact]
+    public async Task Cluster_sharding_with_single_shard_per_entity_specs()
+    {
+        await Cluster_sharding_with_single_shard_per_entity_must_use_specified_region();
+    }
+
+    private async Task Cluster_sharding_with_single_shard_per_entity_must_use_specified_region()
+    {
+        await JoinAndAllocate(Config.First, 1);
+        await JoinAndAllocate(Config.Second, 2);
+        await JoinAndAllocate(Config.Third, 3);
+        await JoinAndAllocate(Config.Fourth, 4);
+        await JoinAndAllocate(Config.Fifth, 5);
+
+        await RunOnAsync(async () =>
+        {
+            // coordinator is on 'first', blackhole 3 other means that it can't update with WriteMajority
+            await TestConductor.BlackholeAsync(Config.First, Config.Third, ThrottleTransportAdapter.Direction.Both);
+            await TestConductor.BlackholeAsync(Config.First, Config.Fourth, ThrottleTransportAdapter.Direction.Both);
+            await TestConductor.BlackholeAsync(Config.First, Config.Fifth, ThrottleTransportAdapter.Direction.Both);
+
+            // shard 6 not allocated yet and due to the blackhole it will not be completed
+            _region.Value.Tell(6);
+
+            // shard 1 location is know by 'first' region, not involving coordinator
+            _region.Value.Tell(1);
+            await ExpectMsgAsync(1);
+
+            // shard 2 location not known at 'first' region yet, but coordinator is on 'first' and should
+            // be able to answer GetShardHome even though previous request for shard 4 has not completed yet
+            _region.Value.Tell(2);
+            await ExpectMsgAsync(2);
+            LastSender.Path.Should().Be(await NodeAsync(Config.Second) / "system" / "sharding" / "Entity" / "2" / "2");
+
+            await TestConductor.PassThroughAsync(Config.First, Config.Third, ThrottleTransportAdapter.Direction.Both);
+            await TestConductor.PassThroughAsync(Config.First, Config.Fourth, ThrottleTransportAdapter.Direction.Both);
+            await TestConductor.PassThroughAsync(Config.First, Config.Fifth, ThrottleTransportAdapter.Direction.Both);
+            await ExpectMsgAsync(6, TimeSpan.FromSeconds(10));
+        }, Config.First);
+
+        await EnterBarrierAsync("after-1");
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSingleShardPerEntitySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSingleShardPerEntitySpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.MultiNode.TestAdapter;
@@ -70,7 +71,7 @@ namespace Akka.Cluster.Sharding.Tests
                     entityProps: Props.Create(() => new ShardedEntity())));
         }
 
-        private void JoinAndAllocate(RoleName node, int entityId)
+        private async Task JoinAndAllocate(RoleName node, int entityId)
         {
             Within(TimeSpan.FromSeconds(10), () =>
             {
@@ -84,32 +85,32 @@ namespace Akka.Cluster.Sharding.Tests
                     LastSender.Path.Should().Be(_region.Value.Path / $"{entityId}" / $"{entityId}");
                 }, node);
             });
-            EnterBarrier($"started-{entityId}");
+            await EnterBarrierAsync($"started-{entityId}");
         }
 
 
         #endregion
 
         [MultiNodeFact]
-        public void Cluster_sharding_with_single_shard_per_entity_specs()
+        public async Task Cluster_sharding_with_single_shard_per_entity_specs()
         {
-            Cluster_sharding_with_single_shard_per_entity_must_use_specified_region();
+            await Cluster_sharding_with_single_shard_per_entity_must_use_specified_region();
         }
 
-        private void Cluster_sharding_with_single_shard_per_entity_must_use_specified_region()
+        private async Task Cluster_sharding_with_single_shard_per_entity_must_use_specified_region()
         {
-            JoinAndAllocate(Config.First, 1);
-            JoinAndAllocate(Config.Second, 2);
-            JoinAndAllocate(Config.Third, 3);
-            JoinAndAllocate(Config.Fourth, 4);
-            JoinAndAllocate(Config.Fifth, 5);
+            await JoinAndAllocate(Config.First, 1);
+            await JoinAndAllocate(Config.Second, 2);
+            await JoinAndAllocate(Config.Third, 3);
+            await JoinAndAllocate(Config.Fourth, 4);
+            await JoinAndAllocate(Config.Fifth, 5);
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 // coordinator is on 'first', blackhole 3 other means that it can't update with WriteMajority
-                TestConductor.Blackhole(Config.First, Config.Third, ThrottleTransportAdapter.Direction.Both).Wait();
-                TestConductor.Blackhole(Config.First, Config.Fourth, ThrottleTransportAdapter.Direction.Both).Wait();
-                TestConductor.Blackhole(Config.First, Config.Fifth, ThrottleTransportAdapter.Direction.Both).Wait();
+                await TestConductor.BlackholeAsync(Config.First, Config.Third, ThrottleTransportAdapter.Direction.Both);
+                await TestConductor.BlackholeAsync(Config.First, Config.Fourth, ThrottleTransportAdapter.Direction.Both);
+                await TestConductor.BlackholeAsync(Config.First, Config.Fifth, ThrottleTransportAdapter.Direction.Both);
 
                 // shard 6 not allocated yet and due to the blackhole it will not be completed
                 _region.Value.Tell(6);
@@ -124,13 +125,13 @@ namespace Akka.Cluster.Sharding.Tests
                 ExpectMsg(2);
                 LastSender.Path.Should().Be(Node(Config.Second) / "system" / "sharding" / "Entity" / "2" / "2");
 
-                TestConductor.PassThrough(Config.First, Config.Third, ThrottleTransportAdapter.Direction.Both).Wait();
-                TestConductor.PassThrough(Config.First, Config.Fourth, ThrottleTransportAdapter.Direction.Both).Wait();
-                TestConductor.PassThrough(Config.First, Config.Fifth, ThrottleTransportAdapter.Direction.Both).Wait();
+                await TestConductor.PassThroughAsync(Config.First, Config.Third, ThrottleTransportAdapter.Direction.Both);
+                await TestConductor.PassThroughAsync(Config.First, Config.Fourth, ThrottleTransportAdapter.Direction.Both);
+                await TestConductor.PassThroughAsync(Config.First, Config.Fifth, ThrottleTransportAdapter.Direction.Both);
                 ExpectMsg(6, TimeSpan.FromSeconds(10));
             }, Config.First);
 
-            EnterBarrier("after-1");
+            await EnterBarrierAsync("after-1");
         }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -25,38 +25,38 @@ using Akka.Util;
 using FluentAssertions;
 using static Akka.Cluster.Sharding.ShardCoordinator;
 
-namespace Akka.Cluster.Sharding.Tests
+namespace Akka.Cluster.Sharding.Tests;
+
+public class ClusterShardingSpecConfig : MultiNodeClusterShardingConfig
 {
-    public class ClusterShardingSpecConfig : MultiNodeClusterShardingConfig
+    public RoleName Controller { get; }
+    public RoleName First { get; }
+    public RoleName Second { get; }
+    public RoleName Third { get; }
+    public RoleName Fourth { get; }
+    public RoleName Fifth { get; }
+    public RoleName Sixth { get; }
+
+    public ClusterShardingSpecConfig(
+        StateStoreMode mode,
+        RememberEntitiesStore rememberEntitiesStore,
+        string entityRecoveryStrategy = "all")
+        : base(mode: mode, rememberEntitiesStore: rememberEntitiesStore, loglevel: "DEBUG")
     {
-        public RoleName Controller { get; }
-        public RoleName First { get; }
-        public RoleName Second { get; }
-        public RoleName Third { get; }
-        public RoleName Fourth { get; }
-        public RoleName Fifth { get; }
-        public RoleName Sixth { get; }
+        Controller = Role("controller");
+        First = Role("first");
+        Second = Role("second");
+        Third = Role("third");
+        Fourth = Role("fourth");
+        Fifth = Role("fifth");
+        Sixth = Role("sixth");
 
-        public ClusterShardingSpecConfig(
-            StateStoreMode mode,
-            RememberEntitiesStore rememberEntitiesStore,
-            string entityRecoveryStrategy = "all")
-            : base(mode: mode, rememberEntitiesStore: rememberEntitiesStore, loglevel: "DEBUG")
-        {
-            Controller = Role("controller");
-            First = Role("first");
-            Second = Role("second");
-            Third = Role("third");
-            Fourth = Role("fourth");
-            Fifth = Role("fifth");
-            Sixth = Role("sixth");
-
-            // This is the only test that creates the shared store regardless of mode,
-            // because it uses a PersistentActor. So unlike all other uses of
-            // `MultiNodeClusterShardingConfig`, we use `MultiNodeConfig.commonConfig` here,
-            // and call `MultiNodeClusterShardingConfig.persistenceConfig` which does not check
-            // mode, then leverage the common _config and fallbacks after these specific test configs:
-            CommonConfig = ConfigurationFactory.ParseString($@"
+        // This is the only test that creates the shared store regardless of mode,
+        // because it uses a PersistentActor. So unlike all other uses of
+        // `MultiNodeClusterShardingConfig`, we use `MultiNodeConfig.commonConfig` here,
+        // and call `MultiNodeClusterShardingConfig.persistenceConfig` which does not check
+        // mode, then leverage the common _config and fallbacks after these specific test configs:
+        CommonConfig = ConfigurationFactory.ParseString($@"
                 akka.cluster.sharding.verbose-debug-logging = on
                 #akka.loggers = [""akka.testkit.SilenceAllTestEventListener""]
                 akka.cluster.auto-down-unreachable-after = 0s
@@ -86,1198 +86,1173 @@ namespace Akka.Cluster.Sharding.Tests
                 akka.testconductor.barrier-timeout = 70s
               ").WithFallback(PersistenceConfig()).WithFallback(Common);
 
-            NodeConfig(new[] { Sixth }, new[] { ConfigurationFactory.ParseString(@"akka.cluster.roles = [""frontend""]") });
-        }
+        NodeConfig(new[] { Sixth }, new[] { ConfigurationFactory.ParseString(@"akka.cluster.roles = [""frontend""]") });
     }
+}
 
-    public class PersistentClusterShardingSpecConfig : ClusterShardingSpecConfig
+public class PersistentClusterShardingSpecConfig : ClusterShardingSpecConfig
+{
+    public PersistentClusterShardingSpecConfig()
+        : base(StateStoreMode.Persistence, RememberEntitiesStore.Eventsourced)
     {
-        public PersistentClusterShardingSpecConfig()
-            : base(StateStoreMode.Persistence, RememberEntitiesStore.Eventsourced)
+    }
+}
+
+public class DDataClusterShardingSpecConfig : ClusterShardingSpecConfig
+{
+    public DDataClusterShardingSpecConfig()
+        : base(StateStoreMode.DData, RememberEntitiesStore.DData)
+    {
+    }
+}
+
+public class PersistentClusterShardingWithEntityRecoverySpecConfig : ClusterShardingSpecConfig
+{
+    public PersistentClusterShardingWithEntityRecoverySpecConfig()
+        : base(StateStoreMode.Persistence, RememberEntitiesStore.Eventsourced, "constant")
+    {
+    }
+}
+
+public class DDataClusterShardingWithEntityRecoverySpecConfig : ClusterShardingSpecConfig
+{
+    public DDataClusterShardingWithEntityRecoverySpecConfig()
+        : base(StateStoreMode.DData, RememberEntitiesStore.DData, "constant")
+    {
+    }
+}
+
+public class PersistentClusterShardingSpec : ClusterShardingSpec
+{
+    public PersistentClusterShardingSpec()
+        : base(new PersistentClusterShardingSpecConfig(), typeof(PersistentClusterShardingSpec))
+    {
+    }
+}
+
+public class DDataClusterShardingSpec : ClusterShardingSpec
+{
+    public DDataClusterShardingSpec()
+        : base(new DDataClusterShardingSpecConfig(), typeof(DDataClusterShardingSpec))
+    {
+    }
+}
+
+public class PersistentClusterShardingWithEntityRecoverySpec : ClusterShardingSpec
+{
+    public PersistentClusterShardingWithEntityRecoverySpec()
+        : base(new PersistentClusterShardingWithEntityRecoverySpecConfig(), typeof(PersistentClusterShardingWithEntityRecoverySpec))
+    {
+    }
+}
+
+public class DDataClusterShardingWithEntityRecoverySpec : ClusterShardingSpec
+{
+    public DDataClusterShardingWithEntityRecoverySpec()
+        : base(new DDataClusterShardingWithEntityRecoverySpecConfig(), typeof(DDataClusterShardingWithEntityRecoverySpec))
+    {
+    }
+}
+
+public abstract class ClusterShardingSpec : MultiNodeClusterShardingSpec<ClusterShardingSpecConfig>
+{
+    #region Setup
+
+    [Serializable]
+    internal sealed class Increment
+    {
+        public static readonly Increment Instance = new();
+
+        private Increment()
         {
         }
     }
 
-    public class DDataClusterShardingSpecConfig : ClusterShardingSpecConfig
+    [Serializable]
+    internal sealed class Decrement
     {
-        public DDataClusterShardingSpecConfig()
-            : base(StateStoreMode.DData, RememberEntitiesStore.DData)
+        public static readonly Decrement Instance = new();
+
+        private Decrement()
         {
         }
     }
 
-    public class PersistentClusterShardingWithEntityRecoverySpecConfig : ClusterShardingSpecConfig
+    [Serializable]
+    internal sealed record Get(long CounterId);
+
+    [Serializable]
+    internal sealed record EntityEnvelope(long Id, object Payload);
+
+    [Serializable]
+    internal sealed class Stop
     {
-        public PersistentClusterShardingWithEntityRecoverySpecConfig()
-            : base(StateStoreMode.Persistence, RememberEntitiesStore.Eventsourced, "constant")
+        public static readonly Stop Instance = new();
+
+        private Stop()
         {
         }
     }
 
-    public class DDataClusterShardingWithEntityRecoverySpecConfig : ClusterShardingSpecConfig
+    [Serializable]
+    internal sealed record CounterChanged(int Delta);
+
+    internal class Counter : PersistentActor
     {
-        public DDataClusterShardingWithEntityRecoverySpecConfig()
-            : base(StateStoreMode.DData, RememberEntitiesStore.DData, "constant")
+        private int _count = 0;
+
+        public static Props Props() => Actor.Props.Create(() => new Counter());
+
+        public Counter()
         {
+            Context.SetReceiveTimeout(TimeSpan.FromSeconds(120));
         }
-    }
 
-    public class PersistentClusterShardingSpec : ClusterShardingSpec
-    {
-        public PersistentClusterShardingSpec()
-            : base(new PersistentClusterShardingSpecConfig(), typeof(PersistentClusterShardingSpec))
+        protected override void PostStop()
         {
+            base.PostStop();
+            // Simulate that the passivation takes some time, to verify passivation buffering
+            Thread.Sleep(500);
         }
-    }
 
-    public class DDataClusterShardingSpec : ClusterShardingSpec
-    {
-        public DDataClusterShardingSpec()
-            : base(new DDataClusterShardingSpecConfig(), typeof(DDataClusterShardingSpec))
+        public override string PersistenceId { get { return $"Counter-{Self.Path.Name}"; } }
+
+        protected override bool ReceiveRecover(object message)
         {
-        }
-    }
-
-    public class PersistentClusterShardingWithEntityRecoverySpec : ClusterShardingSpec
-    {
-        public PersistentClusterShardingWithEntityRecoverySpec()
-            : base(new PersistentClusterShardingWithEntityRecoverySpecConfig(), typeof(PersistentClusterShardingWithEntityRecoverySpec))
-        {
-        }
-    }
-
-    public class DDataClusterShardingWithEntityRecoverySpec : ClusterShardingSpec
-    {
-        public DDataClusterShardingWithEntityRecoverySpec()
-            : base(new DDataClusterShardingWithEntityRecoverySpecConfig(), typeof(DDataClusterShardingWithEntityRecoverySpec))
-        {
-        }
-    }
-
-    public abstract class ClusterShardingSpec : MultiNodeClusterShardingSpec<ClusterShardingSpecConfig>
-    {
-        #region Setup
-
-        [Serializable]
-        internal sealed class Increment
-        {
-            public static readonly Increment Instance = new();
-
-            private Increment()
+            switch (message)
             {
+                case CounterChanged cc:
+                    UpdateState(cc);
+                    return true;
             }
+            return false;
         }
 
-        [Serializable]
-        internal sealed class Decrement
+        protected override bool ReceiveCommand(object message)
         {
-            public static readonly Decrement Instance = new();
-
-            private Decrement()
+            switch (message)
             {
+                case Increment _:
+                    Persist(new CounterChanged(1), UpdateState);
+                    return true;
+                case Decrement _:
+                    Persist(new CounterChanged(-1), UpdateState);
+                    return true;
+                case Get _:
+                    Sender.Tell(_count);
+                    return true;
+                case ReceiveTimeout _:
+                    Context.Parent.Tell(new Passivate(Stop.Instance));
+                    return true;
+                case Stop _:
+                    Context.Stop(Self);
+                    return true;
             }
+            return false;
         }
 
-        [Serializable]
-        internal sealed class Get
+        private void UpdateState(CounterChanged e)
         {
-            public readonly long CounterId;
-            public Get(long counterId)
+            _count += e.Delta;
+        }
+    }
+
+    private sealed class MessageExtractor: IMessageExtractor
+    {
+        public string EntityId(object message)
+            => message switch
             {
-                CounterId = counterId;
-            }
+                EntityEnvelope env => env.Id.ToString(),
+                Get msg => msg.CounterId.ToString(),
+                _ => null
+            };
+
+        public object EntityMessage(object message)
+            => message switch
+            {
+                EntityEnvelope env => env.Payload,
+                _ => message
+            };
+
+        public string ShardId(object message)
+            => message switch
+            {
+                EntityEnvelope env => (env.Id % NumberOfShards).ToString(),
+                Get msg => (msg.CounterId % NumberOfShards).ToString(),
+                _ => null
+            };
+
+        public string ShardId(string entityId, object messageHint = null)
+            => (long.Parse(entityId) % NumberOfShards).ToString();
+    }
+
+    private const int NumberOfShards = 12;
+
+
+    internal class QualifiedCounter : Counter
+    {
+        public static Props Props(string typeName)
+        {
+            return Actor.Props.Create(() => new QualifiedCounter(typeName));
         }
 
-        [Serializable]
-        internal sealed class EntityEnvelope
+        private readonly string _typeName;
+
+        public QualifiedCounter(string typeName)
+            : base()
         {
-            public readonly long Id;
-            public readonly object Payload;
-            public EntityEnvelope(long id, object payload)
-            {
-                Id = id;
-                Payload = payload;
-            }
+            _typeName = typeName;
         }
 
-        [Serializable]
-        internal sealed class Stop
-        {
-            public static readonly Stop Instance = new();
+        public override string PersistenceId => _typeName + "-" + Self.Path.Name;
+    }
 
-            private Stop()
-            {
-            }
+    internal class AnotherCounter : QualifiedCounter
+    {
+        public static new Props Props()
+        {
+            return Actor.Props.Create(() => new AnotherCounter());
         }
 
-        [Serializable]
-        internal sealed class CounterChanged
+        public AnotherCounter()
+            : base("AnotherCounter")
         {
-            public readonly int Delta;
-            public CounterChanged(int delta)
-            {
-                Delta = delta;
-            }
+        }
+    }
+
+    internal class CounterSupervisor : ActorBase
+    {
+        public static Props Props()
+        {
+            return Actor.Props.Create(() => new CounterSupervisor());
         }
 
-        internal class Counter : PersistentActor
+        private readonly IActorRef _counter;
+
+        public CounterSupervisor()
         {
-            private int _count = 0;
+            _counter = Context.ActorOf(Counter.Props(), "theCounter");
+        }
 
-            public static Props Props() => Actor.Props.Create(() => new Counter());
-
-            public Counter()
+        protected override SupervisorStrategy SupervisorStrategy()
+        {
+            return new OneForOneStrategy(Decider.From(ex =>
             {
-                Context.SetReceiveTimeout(TimeSpan.FromSeconds(120));
-            }
-
-            protected override void PostStop()
-            {
-                base.PostStop();
-                // Simulate that the passivation takes some time, to verify passivation buffering
-                Thread.Sleep(500);
-            }
-
-            public override string PersistenceId { get { return $"Counter-{Self.Path.Name}"; } }
-
-            protected override bool ReceiveRecover(object message)
-            {
-                switch (message)
+                switch (ex)
                 {
-                    case CounterChanged cc:
-                        UpdateState(cc);
-                        return true;
+                    //case _: IllegalArgumentException     ⇒ SupervisorStrategy.Resume
+                    //case _: ActorInitializationException ⇒ SupervisorStrategy.Stop
+                    //case _: DeathPactException           ⇒ SupervisorStrategy.Stop
+                    //case _: Exception                    ⇒ SupervisorStrategy.Restart
+                    case ActorInitializationException _:
+                    case DeathPactException _:
+                        return Directive.Stop;
+                    default:
+                        return Directive.Restart;
                 }
-                return false;
-            }
-
-            protected override bool ReceiveCommand(object message)
-            {
-                switch (message)
-                {
-                    case Increment _:
-                        Persist(new CounterChanged(1), UpdateState);
-                        return true;
-                    case Decrement _:
-                        Persist(new CounterChanged(-1), UpdateState);
-                        return true;
-                    case Get _:
-                        Sender.Tell(_count);
-                        return true;
-                    case ReceiveTimeout _:
-                        Context.Parent.Tell(new Passivate(Stop.Instance));
-                        return true;
-                    case Stop _:
-                        Context.Stop(Self);
-                        return true;
-                }
-                return false;
-            }
-
-            private void UpdateState(CounterChanged e)
-            {
-                _count += e.Delta;
-            }
+            }));
         }
 
-        private sealed class MessageExtractor: IMessageExtractor
+        protected override bool Receive(object message)
         {
-            public string EntityId(object message)
-                => message switch
-                {
-                    EntityEnvelope env => env.Id.ToString(),
-                    Get msg => msg.CounterId.ToString(),
-                    _ => null
-                };
-
-            public object EntityMessage(object message)
-                => message switch
-                {
-                    EntityEnvelope env => env.Payload,
-                    _ => message
-                };
-
-            public string ShardId(object message)
-                => message switch
-                {
-                    EntityEnvelope env => (env.Id % NumberOfShards).ToString(),
-                    Get msg => (msg.CounterId % NumberOfShards).ToString(),
-                    _ => null
-                };
-
-            public string ShardId(string entityId, object messageHint = null)
-                => (long.Parse(entityId) % NumberOfShards).ToString();
+            _counter.Forward(message);
+            return true;
         }
+    }
 
-        private const int NumberOfShards = 12;
+    private readonly Lazy<IActorRef> _replicator;
+    private readonly Lazy<IActorRef> _region;
+    private readonly Lazy<IActorRef> _rebalancingRegion;
+    private readonly Lazy<IActorRef> _persistentEntitiesRegion;
+    private readonly Lazy<IActorRef> _anotherPersistentRegion;
+    private readonly Lazy<IActorRef> _persistentRegion;
+    private readonly Lazy<IActorRef> _rebalancingPersistentRegion;
+    private readonly Lazy<IActorRef> _autoMigrateRegion;
 
-
-        internal class QualifiedCounter : Counter
-        {
-            public static Props Props(string typeName)
-            {
-                return Actor.Props.Create(() => new QualifiedCounter(typeName));
-            }
-
-            private readonly string typeName;
-
-            public QualifiedCounter(string typeName)
-                : base()
-            {
-                this.typeName = typeName;
-            }
-
-            public override string PersistenceId => typeName + "-" + Self.Path.Name;
-        }
-
-        internal class AnotherCounter : QualifiedCounter
-        {
-            public static new Props Props()
-            {
-                return Actor.Props.Create(() => new AnotherCounter());
-            }
-
-            public AnotherCounter()
-                : base("AnotherCounter")
-            {
-            }
-        }
-
-        internal class CounterSupervisor : ActorBase
-        {
-            public static Props Props()
-            {
-                return Actor.Props.Create(() => new CounterSupervisor());
-            }
-
-            public readonly IActorRef counter;
-
-            public CounterSupervisor()
-            {
-                counter = Context.ActorOf(Counter.Props(), "theCounter");
-            }
-
-            protected override SupervisorStrategy SupervisorStrategy()
-            {
-                return new OneForOneStrategy(Decider.From(ex =>
-                {
-                    switch (ex)
-                    {
-                        //case _: IllegalArgumentException     ⇒ SupervisorStrategy.Resume
-                        //case _: ActorInitializationException ⇒ SupervisorStrategy.Stop
-                        //case _: DeathPactException           ⇒ SupervisorStrategy.Stop
-                        //case _: Exception                    ⇒ SupervisorStrategy.Restart
-                        case ActorInitializationException _:
-                        case DeathPactException _:
-                            return Directive.Stop;
-                        default:
-                            return Directive.Restart;
-                    }
-                }));
-            }
-
-            protected override bool Receive(object message)
-            {
-                counter.Forward(message);
-                return true;
-            }
-        }
-
-        private readonly Lazy<IActorRef> _replicator;
-        private readonly Lazy<IActorRef> _region;
-        private readonly Lazy<IActorRef> _rebalancingRegion;
-        private readonly Lazy<IActorRef> _persistentEntitiesRegion;
-        private readonly Lazy<IActorRef> _anotherPersistentRegion;
-        private readonly Lazy<IActorRef> _persistentRegion;
-        private readonly Lazy<IActorRef> _rebalancingPersistentRegion;
-        private readonly Lazy<IActorRef> _autoMigrateRegion;
-
-        protected ClusterShardingSpec(ClusterShardingSpecConfig config, Type type)
-            : base(config, type)
-        {
-            _replicator = new Lazy<IActorRef>(() => Sys.ActorOf(
-                Replicator.Props(ReplicatorSettings.Create(Sys)
+    protected ClusterShardingSpec(ClusterShardingSpecConfig config, Type type)
+        : base(config, type)
+    {
+        _replicator = new Lazy<IActorRef>(() => Sys.ActorOf(
+            Replicator.Props(ReplicatorSettings.Create(Sys)
                 .WithGossipInterval(TimeSpan.FromSeconds(1))
                 .WithMaxDeltaElements(10)),
-                "replicator")
-            );
+            "replicator")
+        );
 
-            _region = new Lazy<IActorRef>(() => CreateRegion("counter", false));
-            _rebalancingRegion = new Lazy<IActorRef>(() => CreateRegion("rebalancingCounter", rememberEntities: false));
+        _region = new Lazy<IActorRef>(() => CreateRegion("counter", false));
+        _rebalancingRegion = new Lazy<IActorRef>(() => CreateRegion("rebalancingCounter", rememberEntities: false));
 
-            _persistentEntitiesRegion = new Lazy<IActorRef>(() => CreateRegion("RememberCounterEntities", rememberEntities: true));
-            _anotherPersistentRegion = new Lazy<IActorRef>(() => CreateRegion("AnotherRememberCounter", rememberEntities: true));
-            _persistentRegion = new Lazy<IActorRef>(() => CreateRegion("RememberCounter", rememberEntities: true));
-            _rebalancingPersistentRegion = new Lazy<IActorRef>(() => CreateRegion("RebalancingRememberCounter", rememberEntities: true));
-            _autoMigrateRegion = new Lazy<IActorRef>(() => CreateRegion("AutoMigrateRememberRegionTest", rememberEntities: true));
-        }
+        _persistentEntitiesRegion = new Lazy<IActorRef>(() => CreateRegion("RememberCounterEntities", rememberEntities: true));
+        _anotherPersistentRegion = new Lazy<IActorRef>(() => CreateRegion("AnotherRememberCounter", rememberEntities: true));
+        _persistentRegion = new Lazy<IActorRef>(() => CreateRegion("RememberCounter", rememberEntities: true));
+        _rebalancingPersistentRegion = new Lazy<IActorRef>(() => CreateRegion("RebalancingRememberCounter", rememberEntities: true));
+        _autoMigrateRegion = new Lazy<IActorRef>(() => CreateRegion("AutoMigrateRememberRegionTest", rememberEntities: true));
+    }
 
 
-        private void Join(RoleName from, RoleName to)
+    private Task JoinAsync(RoleName from, RoleName to)
+    {
+        return JoinAsync(from, to, CreateCoordinator);
+    }
+
+    private DDataRememberEntitiesProvider DdataRememberEntitiesProvider(string typeName)
+    {
+        var majorityMinCap = Sys.Settings.Config.GetInt("akka.cluster.sharding.distributed-data.majority-min-cap");
+        return new DDataRememberEntitiesProvider(typeName, Settings.Value, majorityMinCap, _replicator.Value);
+    }
+
+    private EventSourcedRememberEntitiesProvider EventSourcedRememberEntitiesProvider(string typeName, ClusterShardingSettings settings)
+    {
+        return new EventSourcedRememberEntitiesProvider(typeName, settings);
+    }
+
+    private void CreateCoordinator()
+    {
+
+        Props CoordinatorProps(string typeName, bool rebalanceEnabled, bool rememberEntities)
         {
-            Join(from, to, CreateCoordinator);
-        }
-
-        private DDataRememberEntitiesProvider DdataRememberEntitiesProvider(string typeName)
-        {
-            var majorityMinCap = Sys.Settings.Config.GetInt("akka.cluster.sharding.distributed-data.majority-min-cap");
-            return new DDataRememberEntitiesProvider(typeName, Settings.Value, majorityMinCap, _replicator.Value);
-        }
-
-        private EventSourcedRememberEntitiesProvider EventSourcedRememberEntitiesProvider(string typeName, ClusterShardingSettings settings)
-        {
-            return new EventSourcedRememberEntitiesProvider(typeName, settings);
-        }
-
-        private void CreateCoordinator()
-        {
-
-            Props CoordinatorProps(string typeName, bool rebalanceEnabled, bool rememberEntities)
-            {
-                var allocationStrategy =
-                    ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit: 2, relativeLimit: 1.0);
-                var cfg = ConfigurationFactory.ParseString($@"
+            var allocationStrategy =
+                ShardAllocationStrategy.LeastShardAllocationStrategy(absoluteLimit: 2, relativeLimit: 1.0);
+            var cfg = ConfigurationFactory.ParseString($@"
                     handoff-timeout = 10s
                     shard-start-timeout = 10s
                     rebalance-interval = {(rebalanceEnabled ? "2s" : "3600s")}
                 ").WithFallback(Sys.Settings.Config.GetConfig("akka.cluster.sharding"));
-                var settings = ClusterShardingSettings.Create(cfg, Sys.Settings.Config.GetConfig("akka.cluster.singleton"))
-                    .WithRememberEntities(rememberEntities);
+            var settings = ClusterShardingSettings.Create(cfg, Sys.Settings.Config.GetConfig("akka.cluster.singleton"))
+                .WithRememberEntities(rememberEntities);
 
-                if (settings.StateStoreMode == StateStoreMode.Persistence)
-                    return PersistentShardCoordinator.Props(typeName, settings, allocationStrategy);
-                else
-                {
-                    var majorityMinCap = Sys.Settings.Config.GetInt("akka.cluster.sharding.distributed-data.majority-min-cap");
+            if (settings.StateStoreMode == StateStoreMode.Persistence)
+                return PersistentShardCoordinator.Props(typeName, settings, allocationStrategy);
+            else
+            {
+                var majorityMinCap = Sys.Settings.Config.GetInt("akka.cluster.sharding.distributed-data.majority-min-cap");
 
-                    // only store provider if ddata for now, persistence uses all-in-one-coordinator
-                    var rememberEntitiesStore = (settings.RememberEntities) ? DdataRememberEntitiesProvider(typeName) : null;
+                // only store provider if ddata for now, persistence uses all-in-one-coordinator
+                var rememberEntitiesStore = (settings.RememberEntities) ? DdataRememberEntitiesProvider(typeName) : null;
 
-                    return DDataShardCoordinator.Props(
-                        typeName,
-                        settings,
-                        allocationStrategy,
-                        _replicator.Value,
-                        majorityMinCap,
-                        rememberEntitiesStore);
-                }
+                return DDataShardCoordinator.Props(
+                    typeName,
+                    settings,
+                    allocationStrategy,
+                    _replicator.Value,
+                    majorityMinCap,
+                    rememberEntitiesStore);
             }
+        }
 
-            var typeNames = new[]
-            {
-                "counter",
-                "rebalancingCounter",
-                "RememberCounterEntities",
-                "AnotherRememberCounter",
-                "RememberCounter",
-                "RebalancingRememberCounter",
-                "AutoMigrateRememberRegionTest"
-            };
+        var typeNames = new[]
+        {
+            "counter",
+            "rebalancingCounter",
+            "RememberCounterEntities",
+            "AnotherRememberCounter",
+            "RememberCounter",
+            "RebalancingRememberCounter",
+            "AutoMigrateRememberRegionTest"
+        };
 
-            foreach (var typeName in typeNames)
-            {
-                var rebalanceEnabled = typeName.ToLowerInvariant().StartsWith("rebalancing");
-                var rememberEnabled = typeName.ToLowerInvariant().Contains("remember");
-                var singletonProps =
-                    BackoffSupervisor.Props(
+        foreach (var typeName in typeNames)
+        {
+            var rebalanceEnabled = typeName.ToLowerInvariant().StartsWith("rebalancing");
+            var rememberEnabled = typeName.ToLowerInvariant().Contains("remember");
+            var singletonProps =
+                BackoffSupervisor.Props(
                         childProps: CoordinatorProps(typeName, rebalanceEnabled, rememberEnabled),
                         childName: "coordinator",
                         minBackoff: TimeSpan.FromSeconds(5),
                         maxBackoff: TimeSpan.FromSeconds(5),
                         randomFactor: 0.1)
-                        .WithDeploy(Deploy.Local);
+                    .WithDeploy(Deploy.Local);
 
-                Sys.ActorOf(
-                    ClusterSingletonManager.Props(
-                        singletonProps,
-                        terminationMessage: Terminate.Instance,
-                        settings: ClusterSingletonManagerSettings.Create(Sys)),
-                        name: typeName + "Coordinator");
-            }
+            Sys.ActorOf(
+                ClusterSingletonManager.Props(
+                    singletonProps,
+                    terminationMessage: Terminate.Instance,
+                    settings: ClusterSingletonManagerSettings.Create(Sys)),
+                name: typeName + "Coordinator");
         }
+    }
 
-        private IActorRef CreateRegion(string typeName, bool rememberEntities)
-        {
-            var cfg = ConfigurationFactory.ParseString(@"
+    private IActorRef CreateRegion(string typeName, bool rememberEntities)
+    {
+        var cfg = ConfigurationFactory.ParseString(@"
                 retry-interval = 1s
                 shard-failure-backoff = 1s
                 entity-restart-backoff = 1s
                 buffer-size = 1000
             ").WithFallback(Sys.Settings.Config.GetConfig("akka.cluster.sharding"));
-            var settings = ClusterShardingSettings.Create(cfg, Sys.Settings.Config.GetConfig("akka.cluster.singleton"))
-                .WithRememberEntities(rememberEntities);
+        var settings = ClusterShardingSettings.Create(cfg, Sys.Settings.Config.GetConfig("akka.cluster.singleton"))
+            .WithRememberEntities(rememberEntities);
 
-            IRememberEntitiesProvider rememberEntitiesProvider = null;
-            if (rememberEntities)
+        IRememberEntitiesProvider rememberEntitiesProvider = null;
+        if (rememberEntities)
+        {
+            switch (settings.RememberEntitiesStore)
             {
-                switch (settings.RememberEntitiesStore)
-                {
-                    case RememberEntitiesStore.DData:
-                        rememberEntitiesProvider = DdataRememberEntitiesProvider(typeName);
-                        break;
-                    case RememberEntitiesStore.Eventsourced:
-                        rememberEntitiesProvider = EventSourcedRememberEntitiesProvider(typeName, settings);
-                        break;
-                }
+                case RememberEntitiesStore.DData:
+                    rememberEntitiesProvider = DdataRememberEntitiesProvider(typeName);
+                    break;
+                case RememberEntitiesStore.Eventsourced:
+                    rememberEntitiesProvider = EventSourcedRememberEntitiesProvider(typeName, settings);
+                    break;
             }
-
-            return Sys.ActorOf(
-                ShardRegion.Props(
-                    typeName: typeName,
-                    entityProps: _ => QualifiedCounter.Props(typeName),
-                    settings: settings,
-                    coordinatorPath: "/user/" + typeName + "Coordinator/singleton/coordinator",
-                    new MessageExtractor(),
-                    handOffStopMessage: PoisonPill.Instance,
-                    rememberEntitiesProvider: rememberEntitiesProvider),
-                name: typeName + "Region");
         }
 
-        #endregion
+        return Sys.ActorOf(
+            ShardRegion.Props(
+                typeName: typeName,
+                entityProps: _ => QualifiedCounter.Props(typeName),
+                settings: settings,
+                coordinatorPath: "/user/" + typeName + "Coordinator/singleton/coordinator",
+                new MessageExtractor(),
+                handOffStopMessage: PoisonPill.Instance,
+                rememberEntitiesProvider: rememberEntitiesProvider),
+            name: typeName + "Region");
+    }
 
-        #region Cluster shardings specs
+    #endregion
 
-        [MultiNodeFact]
-        public async Task ClusterSharding_specs()
+    #region Cluster shardings specs
+
+    [MultiNodeFact]
+    public async Task ClusterSharding_specs()
+    {
+        // must be done also in ddata mode since Counter is PersistentActor
+        await ClusterSharding_should_setup_shared_journal();
+        await ClusterSharding_should_work_in_single_node_cluster();
+        await ClusterSharding_should_use_second_node();
+        await ClusterSharding_should_support_passivation_and_activation_of_entities();
+        await ClusterSharding_should_support_proxy_only_mode();
+        await ClusterSharding_should_failover_shards_on_crashed_node();
+        await ClusterSharding_should_use_third_and_fourth_node();
+        await ClusterSharding_should_recover_coordinator_state_after_coordinator_crash();
+        await ClusterSharding_should_rebalance_to_nodes_with_less_shards();
+        await ClusterSharding_should_be_easy_to_use_with_extensions();
+        await ClusterSharding_should_be_easy_API_for_starting();
+
+        await PersistentClusterSharding_should_recover_entities_upon_restart();
+        await PersistentClusterSharding_should_permanently_stop_entities_which_passivate();
+        await PersistentClusterSharding_should_restart_entities_which_stop_without_passivation();
+        await PersistentClusterSharding_should_be_migrated_to_new_regions_upon_region_failure();
+        await PersistentClusterSharding_should_ensure_rebalance_restarts_shards();
+    }
+
+    private Task ClusterSharding_should_setup_shared_journal()
+    {
+        return StartPersistenceAsync(Config.Controller, CancellationToken.None,
+            Config.First, Config.Second, Config.Third, Config.Fourth, Config.Fifth, Config.Sixth);
+    }
+
+    private async Task ClusterSharding_should_work_in_single_node_cluster()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(20), async () =>
         {
-            // must be done also in ddata mode since Counter is PersistentActor
-            ClusterSharding_should_setup_shared_journal();
-            await ClusterSharding_should_work_in_single_node_cluster();
-            await ClusterSharding_should_use_second_node();
-            await ClusterSharding_should_support_passivation_and_activation_of_entities();
-            await ClusterSharding_should_support_proxy_only_mode();
-            await ClusterSharding_should_failover_shards_on_crashed_node();
-            await ClusterSharding_should_use_third_and_fourth_node();
-            await ClusterSharding_should_recover_coordinator_state_after_coordinator_crash();
-            await ClusterSharding_should_rebalance_to_nodes_with_less_shards();
-            await ClusterSharding_should_be_easy_to_use_with_extensions();
-            await ClusterSharding_should_be_easy_API_for_starting();
+            await JoinAsync(Config.First, Config.First);
 
-            await PersistentClusterSharding_should_recover_entities_upon_restart();
-            await PersistentClusterSharding_should_permanently_stop_entities_which_passivate();
-            await PersistentClusterSharding_should_restart_entities_which_stop_without_passivation();
-            await PersistentClusterSharding_should_be_migrated_to_new_regions_upon_region_failure();
-            await PersistentClusterSharding_should_ensure_rebalance_restarts_shards();
-        }
-
-        private void ClusterSharding_should_setup_shared_journal()
-        {
-            StartPersistence(Config.Controller,
-                Config.First, Config.Second, Config.Third, Config.Fourth, Config.Fifth, Config.Sixth);
-        }
-
-        private async Task ClusterSharding_should_work_in_single_node_cluster()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
+            await RunOnAsync(async () =>
             {
-                Join(Config.First, Config.First);
+                var r = _region.Value;
+                r.Tell(new EntityEnvelope(1, Increment.Instance));
+                r.Tell(new EntityEnvelope(1, Increment.Instance));
+                r.Tell(new EntityEnvelope(1, Increment.Instance));
+                r.Tell(new EntityEnvelope(1, Decrement.Instance));
+                r.Tell(new Get(1));
+                await ExpectMsgAsync(2);
 
-                RunOn(() =>
-                {
-                    var r = _region.Value;
-                    r.Tell(new EntityEnvelope(1, Increment.Instance));
-                    r.Tell(new EntityEnvelope(1, Increment.Instance));
-                    r.Tell(new EntityEnvelope(1, Increment.Instance));
-                    r.Tell(new EntityEnvelope(1, Decrement.Instance));
-                    r.Tell(new Get(1));
-                    ExpectMsg(2);
+                r.Tell(GetCurrentRegions.Instance);
+                await ExpectMsgAsync(new CurrentRegions(ImmutableHashSet.Create(Cluster.SelfAddress)));
+            }, Config.First);
 
-                    r.Tell(GetCurrentRegions.Instance);
-                    ExpectMsg(new CurrentRegions(ImmutableHashSet.Create(Cluster.SelfAddress)));
-                }, Config.First);
+            await EnterBarrierAsync("after-2");
+        });
+    }
 
-                await EnterBarrierAsync("after-2");
-            });
-        }
-
-        private async Task ClusterSharding_should_use_second_node()
+    private async Task ClusterSharding_should_use_second_node()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(20), async () =>
         {
-            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
+            await JoinAsync(Config.Second, Config.First);
+
+            await RunOnAsync(async () =>
             {
-                Join(Config.Second, Config.First);
+                var r = _region.Value;
+                r.Tell(new EntityEnvelope(2, Increment.Instance));
+                r.Tell(new EntityEnvelope(2, Increment.Instance));
+                r.Tell(new EntityEnvelope(2, Increment.Instance));
+                r.Tell(new EntityEnvelope(2, Decrement.Instance));
+                r.Tell(new Get(2));
+                await ExpectMsgAsync(2);
 
-                RunOn(() =>
-                {
-                    var r = _region.Value;
-                    r.Tell(new EntityEnvelope(2, Increment.Instance));
-                    r.Tell(new EntityEnvelope(2, Increment.Instance));
-                    r.Tell(new EntityEnvelope(2, Increment.Instance));
-                    r.Tell(new EntityEnvelope(2, Decrement.Instance));
-                    r.Tell(new Get(2));
-                    ExpectMsg(2);
+                r.Tell(new EntityEnvelope(11, Increment.Instance));
+                r.Tell(new EntityEnvelope(12, Increment.Instance));
+                r.Tell(new Get(11));
+                await ExpectMsgAsync(1);
+                r.Tell(new Get(12));
+                await ExpectMsgAsync(1);
+            }, Config.Second);
+            await EnterBarrierAsync("second-update");
 
-                    r.Tell(new EntityEnvelope(11, Increment.Instance));
-                    r.Tell(new EntityEnvelope(12, Increment.Instance));
-                    r.Tell(new Get(11));
-                    ExpectMsg(1);
-                    r.Tell(new Get(12));
-                    ExpectMsg(1);
-                }, Config.Second);
-                await EnterBarrierAsync("second-update");
+            await RunOnAsync(async () =>
+            {
+                var r = _region.Value;
+                r.Tell(new EntityEnvelope(2, Increment.Instance));
+                r.Tell(new Get(2));
+                await ExpectMsgAsync(3);
+                LastSender.Path.Should().Be(await NodeAsync(Config.Second) / "user" / "counterRegion" / "2" / "2");
 
-                RunOn(() =>
-                {
-                    var r = _region.Value;
-                    r.Tell(new EntityEnvelope(2, Increment.Instance));
-                    r.Tell(new Get(2));
-                    ExpectMsg(3);
-                    LastSender.Path.Should().Be(Node(Config.Second) / "user" / "counterRegion" / "2" / "2");
+                r.Tell(new Get(11));
+                await ExpectMsgAsync(1);
+                // local on first
+                var path11 = LastSender.Path;
+                LastSender.Path.ToStringWithoutAddress().Should().Be((r.Path / "11" / "11").ToStringWithoutAddress());
+                //LastSender.Path.Should().Be((r.Path / "11" / "11"));
+                r.Tell(new Get(12));
+                await ExpectMsgAsync(1);
+                var path12 = LastSender.Path;
+                LastSender.Path.ToStringWithoutAddress().Should().Be((r.Path / "0" / "12").ToStringWithoutAddress());
+                //LastSender.Path.Should().Be(Node(_config.Second) / "user" / "counterRegion" / "0" / "12");
 
-                    r.Tell(new Get(11));
-                    ExpectMsg(1);
-                    // local on first
-                    var path11 = LastSender.Path;
-                    LastSender.Path.ToStringWithoutAddress().Should().Be((r.Path / "11" / "11").ToStringWithoutAddress());
-                    //LastSender.Path.Should().Be((r.Path / "11" / "11"));
-                    r.Tell(new Get(12));
-                    ExpectMsg(1);
-                    var path12 = LastSender.Path;
-                    LastSender.Path.ToStringWithoutAddress().Should().Be((r.Path / "0" / "12").ToStringWithoutAddress());
-                    //LastSender.Path.Should().Be(Node(_config.Second) / "user" / "counterRegion" / "0" / "12");
+                //one has to be local, the other one remote
+                (path11.Address.HasLocalScope && path12.Address.HasGlobalScope || path11.Address.HasGlobalScope && path12.Address.HasLocalScope).Should().BeTrue();
+            }, Config.First);
+            await EnterBarrierAsync("first-update");
 
-                    //one has to be local, the other one remote
-                    (path11.Address.HasLocalScope && path12.Address.HasGlobalScope || path11.Address.HasGlobalScope && path12.Address.HasLocalScope).Should().BeTrue();
-                }, Config.First);
-                await EnterBarrierAsync("first-update");
-
-                RunOn(() =>
-                {
-                    var r = _region.Value;
-                    r.Tell(new Get(2));
-                    ExpectMsg(3);
-                    LastSender.Path.Should().Be(r.Path / "2" / "2");
-
-                    r.Tell(GetCurrentRegions.Instance);
-                    ExpectMsg(new CurrentRegions(ImmutableHashSet.Create(Cluster.SelfAddress, Node(Config.First).Address)));
-                }, Config.Second);
-                await EnterBarrierAsync("after-3");
-            });
-        }
-
-        private async Task ClusterSharding_should_support_passivation_and_activation_of_entities()
-        {
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 var r = _region.Value;
                 r.Tell(new Get(2));
-                ExpectMsg(3);
-                r.Tell(new EntityEnvelope(2, ReceiveTimeout.Instance));
-                // let the Passivate-Stop roundtrip begin to trigger buffering of subsequent messages
-                Thread.Sleep(200);
-                r.Tell(new EntityEnvelope(2, Increment.Instance));
-                r.Tell(new Get(2));
-                ExpectMsg(4);
-            }, Config.Second);
-            await EnterBarrierAsync("after-4");
-        }
+                await ExpectMsgAsync(3);
+                LastSender.Path.Should().Be(r.Path / "2" / "2");
 
-        private async Task ClusterSharding_should_support_proxy_only_mode()
+                r.Tell(GetCurrentRegions.Instance);
+                await ExpectMsgAsync(new CurrentRegions(ImmutableHashSet.Create(Cluster.SelfAddress, (await NodeAsync(Config.First)).Address)));
+            }, Config.Second);
+            await EnterBarrierAsync("after-3");
+        });
+    }
+
+    private async Task ClusterSharding_should_support_passivation_and_activation_of_entities()
+    {
+        await RunOnAsync(async () =>
         {
-            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
+            var r = _region.Value;
+            r.Tell(new Get(2));
+            await ExpectMsgAsync(3);
+            r.Tell(new EntityEnvelope(2, ReceiveTimeout.Instance));
+            // let the Passivate-Stop roundtrip begin to trigger buffering of subsequent messages
+            await Task.Delay(200);
+            r.Tell(new EntityEnvelope(2, Increment.Instance));
+            r.Tell(new Get(2));
+            await ExpectMsgAsync(4);
+        }, Config.Second);
+        await EnterBarrierAsync("after-4");
+    }
+
+    private async Task ClusterSharding_should_support_proxy_only_mode()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(10), async () =>
+        {
+            await RunOnAsync(async () =>
             {
-                RunOn(() =>
-                {
-                    var cfg = ConfigurationFactory.ParseString(@"
+                var cfg = ConfigurationFactory.ParseString(@"
                         retry-interval = 1s
                         buffer-size = 1000")
-                        .WithFallback(Sys.Settings.Config.GetConfig("akka.cluster.sharding"));
+                    .WithFallback(Sys.Settings.Config.GetConfig("akka.cluster.sharding"));
 
-                    var settings = ClusterShardingSettings.Create(cfg, Sys.Settings.Config.GetConfig("akka.cluster.singleton"));
-                    var proxy = Sys.ActorOf(ShardRegion.ProxyProps(
+                var settings = ClusterShardingSettings.Create(cfg, Sys.Settings.Config.GetConfig("akka.cluster.singleton"));
+                var proxy = Sys.ActorOf(ShardRegion.ProxyProps(
                         typeName: "counter",
                         settings: settings,
                         coordinatorPath: "/user/counterCoordinator/singleton/coordinator",
                         new MessageExtractor()),
-                        "regionProxy");
+                    "regionProxy");
 
-                    proxy.Tell(new Get(1));
-                    ExpectMsg(2);
-                    proxy.Tell(new Get(2));
-                    ExpectMsg(4);
-                }, Config.Second);
-                await EnterBarrierAsync("after-5");
-            });
-        }
+                proxy.Tell(new Get(1));
+                await ExpectMsgAsync(2);
+                proxy.Tell(new Get(2));
+                await ExpectMsgAsync(4);
+            }, Config.Second);
+            await EnterBarrierAsync("after-5");
+        });
+    }
 
-        private async Task ClusterSharding_should_failover_shards_on_crashed_node()
+    private async Task ClusterSharding_should_failover_shards_on_crashed_node()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(30), async () =>
         {
-            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
+            // mute logging of deadLetters during shutdown of systems
+            if (!Log.IsDebugEnabled)
+                Sys.EventStream.Publish(new Mute(new DeadLettersFilter(new PredicateMatcher(_ => true), new PredicateMatcher(_ => true))));
+            await EnterBarrierAsync("logs-muted");
+
+            await RunOnAsync(async () =>
             {
-                // mute logging of deadLetters during shutdown of systems
-                if (!Log.IsDebugEnabled)
-                    Sys.EventStream.Publish(new Mute(new DeadLettersFilter(new PredicateMatcher(_ => true), new PredicateMatcher(_ => true))));
-                await EnterBarrierAsync("logs-muted");
+                await TestConductor.ExitAsync(Config.Second, 0);
+            }, Config.Controller);
+            await EnterBarrierAsync("crash-second");
 
-                await RunOnAsync(async () =>
+            await RunOnAsync(async () =>
+            {
+                var probe1 = CreateTestProbe();
+                await AwaitAssertAsync(async () =>
                 {
-                    await TestConductor.ExitAsync(Config.Second, 0);
-                }, Config.Controller);
-                await EnterBarrierAsync("crash-second");
+                    await WithinAsync(TimeSpan.FromSeconds(1), async () =>
+                    {
+                        var r = _region.Value;
+                        r.Tell(new Get(2), probe1.Ref);
+                        await probe1.ExpectMsgAsync(4);
+                        probe1.LastSender.Path.Should().Be(r.Path / "2" / "2");
+                    });
+                });
 
-                RunOn(() =>
+                var probe2 = CreateTestProbe();
+                await AwaitAssertAsync(async () =>
                 {
-                    var probe1 = CreateTestProbe();
-                    AwaitAssert(() =>
+                    await WithinAsync(TimeSpan.FromSeconds(1), async () =>
                     {
-                        Within(TimeSpan.FromSeconds(1), () =>
-                        {
-                            var r = _region.Value;
-                            r.Tell(new Get(2), probe1.Ref);
-                            probe1.ExpectMsg(4);
-                            probe1.LastSender.Path.Should().Be(r.Path / "2" / "2");
-                        });
+                        var r = _region.Value;
+                        r.Tell(new Get(12), probe2.Ref);
+                        await probe2.ExpectMsgAsync(1);
+                        probe2.LastSender.Path.Should().Be(r.Path / "0" / "12");
                     });
+                });
+            }, Config.First);
+            await EnterBarrierAsync("after-6");
+        });
+    }
 
-                    var probe2 = CreateTestProbe();
-                    AwaitAssert(() =>
-                    {
-                        Within(TimeSpan.FromSeconds(1), () =>
-                        {
-                            var r = _region.Value;
-                            r.Tell(new Get(12), probe2.Ref);
-                            probe2.ExpectMsg(1);
-                            probe2.LastSender.Path.Should().Be(r.Path / "0" / "12");
-                        });
-                    });
-                }, Config.First);
-                await EnterBarrierAsync("after-6");
-            });
-        }
-
-        private async Task ClusterSharding_should_use_third_and_fourth_node()
+    private async Task ClusterSharding_should_use_third_and_fourth_node()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(15), async () =>
         {
-            await WithinAsync(TimeSpan.FromSeconds(15), async () =>
+            await JoinAsync(Config.Third, Config.First);
+
+            await RunOnAsync(async () =>
             {
-                Join(Config.Third, Config.First);
-
-                RunOn(() =>
-                {
-                    var r = _region.Value;
-                    for (int i = 1; i <= 10; i++)
-                        r.Tell(new EntityEnvelope(3, Increment.Instance));
-
-                    r.Tell(new Get(3));
-                    ExpectMsg(10);
-                    LastSender.Path.Should().Be(r.Path / "3" / "3"); // local
-                }, Config.Third);
-                await EnterBarrierAsync("third-update");
-
-                Join(Config.Fourth, Config.First);
-
-                RunOn(() =>
-                {
-                    var r = _region.Value;
-                    for (int i = 1; i <= 20; i++)
-                        r.Tell(new EntityEnvelope(4, Increment.Instance));
-
-                    r.Tell(new Get(4));
-                    ExpectMsg(20);
-                    LastSender.Path.Should().Be(r.Path / "4" / "4"); // local
-                }, Config.Fourth);
-                await EnterBarrierAsync("fourth-update");
-
-                RunOn(() =>
-                {
-                    var r = _region.Value;
+                var r = _region.Value;
+                for (var i = 1; i <= 10; i++)
                     r.Tell(new EntityEnvelope(3, Increment.Instance));
-                    r.Tell(new Get(3));
-                    ExpectMsg(11);
-                    LastSender.Path.Should().Be(Node(Config.Third) / "user" / "counterRegion" / "3" / "3");
 
+                r.Tell(new Get(3));
+                await ExpectMsgAsync(10);
+                LastSender.Path.Should().Be(r.Path / "3" / "3"); // local
+            }, Config.Third);
+            await EnterBarrierAsync("third-update");
+
+            await JoinAsync(Config.Fourth, Config.First);
+
+            await RunOnAsync(async () =>
+            {
+                var r = _region.Value;
+                for (var i = 1; i <= 20; i++)
                     r.Tell(new EntityEnvelope(4, Increment.Instance));
-                    r.Tell(new Get(4));
-                    ExpectMsg(21);
-                    LastSender.Path.Should().Be(Node(Config.Fourth) / "user" / "counterRegion" / "4" / "4");
-                }, Config.First);
-                await EnterBarrierAsync("first-update");
 
-                RunOn(() =>
-                {
-                    var r = _region.Value;
-                    r.Tell(new Get(3));
-                    ExpectMsg(11);
-                    LastSender.Path.Should().Be(r.Path / "3" / "3");
-                }, Config.Third);
+                r.Tell(new Get(4));
+                await ExpectMsgAsync(20);
+                LastSender.Path.Should().Be(r.Path / "4" / "4"); // local
+            }, Config.Fourth);
+            await EnterBarrierAsync("fourth-update");
 
-                RunOn(() =>
-                {
-                    var r = _region.Value;
-                    r.Tell(new Get(4));
-                    ExpectMsg(21);
-                    LastSender.Path.Should().Be(r.Path / "4" / "4");
-                }, Config.Fourth);
-                await EnterBarrierAsync("after-7");
-            });
-        }
+            await RunOnAsync(async () =>
+            {
+                var r = _region.Value;
+                r.Tell(new EntityEnvelope(3, Increment.Instance));
+                r.Tell(new Get(3));
+                await ExpectMsgAsync(11);
+                LastSender.Path.Should().Be(await NodeAsync(Config.Third) / "user" / "counterRegion" / "3" / "3");
 
-        private async Task ClusterSharding_should_recover_coordinator_state_after_coordinator_crash()
+                r.Tell(new EntityEnvelope(4, Increment.Instance));
+                r.Tell(new Get(4));
+                await ExpectMsgAsync(21);
+                LastSender.Path.Should().Be(await NodeAsync(Config.Fourth) / "user" / "counterRegion" / "4" / "4");
+            }, Config.First);
+            await EnterBarrierAsync("first-update");
+
+            await RunOnAsync(async () =>
+            {
+                var r = _region.Value;
+                r.Tell(new Get(3));
+                await ExpectMsgAsync(11);
+                LastSender.Path.Should().Be(r.Path / "3" / "3");
+            }, Config.Third);
+
+            await RunOnAsync(async () =>
+            {
+                var r = _region.Value;
+                r.Tell(new Get(4));
+                await ExpectMsgAsync(21);
+                LastSender.Path.Should().Be(r.Path / "4" / "4");
+            }, Config.Fourth);
+            await EnterBarrierAsync("after-7");
+        });
+    }
+
+    private async Task ClusterSharding_should_recover_coordinator_state_after_coordinator_crash()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(60), async () =>
         {
-            await WithinAsync(TimeSpan.FromSeconds(60), async () =>
+            await JoinAsync(Config.Fifth, Config.Fourth);
+            await RunOnAsync(async () =>
             {
-                Join(Config.Fifth, Config.Fourth);
-                await RunOnAsync(async () =>
+                await TestConductor.ExitAsync(Config.First, 0);
+            }, Config.Controller);
+            await EnterBarrierAsync("crash-first");
+
+            await RunOnAsync(async () =>
+            {
+                var probe3 = CreateTestProbe();
+                await AwaitAssertAsync(async () =>
                 {
-                    await TestConductor.ExitAsync(Config.First, 0);
-                }, Config.Controller);
-                await EnterBarrierAsync("crash-first");
+                    await WithinAsync(TimeSpan.FromSeconds(1), async () =>
+                    {
+                        _region.Value.Tell(new Get(3), probe3.Ref);
+                        await probe3.ExpectMsgAsync(11);
+                        probe3.LastSender.Path.Should().Be(await NodeAsync(Config.Third) / "user" / "counterRegion" / "3" / "3");
+                    });
+                });
 
-                RunOn(() =>
+                var probe4 = CreateTestProbe();
+                await AwaitAssertAsync(async () =>
                 {
-                    var probe3 = CreateTestProbe();
-                    AwaitAssert(() =>
+                    await WithinAsync(TimeSpan.FromSeconds(1), async () =>
                     {
-                        Within(TimeSpan.FromSeconds(1), () =>
-                        {
-                            _region.Value.Tell(new Get(3), probe3.Ref);
-                            probe3.ExpectMsg(11);
-                            probe3.LastSender.Path.Should().Be(Node(Config.Third) / "user" / "counterRegion" / "3" / "3");
-                        });
+                        _region.Value.Tell(new Get(4), probe4.Ref);
+                        await probe4.ExpectMsgAsync(21);
+                        probe4.LastSender.Path.Should().Be(await NodeAsync(Config.Fourth) / "user" / "counterRegion" / "4" / "4");
                     });
+                });
+            }, Config.Fifth);
+            await EnterBarrierAsync("after-8");
+        });
+    }
 
-                    var probe4 = CreateTestProbe();
-                    AwaitAssert(() =>
-                    {
-                        Within(TimeSpan.FromSeconds(1), () =>
-                        {
-                            _region.Value.Tell(new Get(4), probe4.Ref);
-                            probe4.ExpectMsg(21);
-                            probe4.LastSender.Path.Should().Be(Node(Config.Fourth) / "user" / "counterRegion" / "4" / "4");
-                        });
-                    });
-                }, Config.Fifth);
-                await EnterBarrierAsync("after-8");
-            });
-        }
-
-        private async Task ClusterSharding_should_rebalance_to_nodes_with_less_shards()
+    private async Task ClusterSharding_should_rebalance_to_nodes_with_less_shards()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(60), async () =>
         {
-            await WithinAsync(TimeSpan.FromSeconds(60), async () =>
+            await RunOnAsync(async () =>
             {
-                RunOn(() =>
+                for (int i = 1; i <= 10; i++)
                 {
-                    for (int i = 1; i <= 10; i++)
-                    {
-                        var rebalancingRegion = this._rebalancingRegion.Value;
-                        rebalancingRegion.Tell(new EntityEnvelope(i, Increment.Instance));
-                        rebalancingRegion.Tell(new Get(i));
-                        ExpectMsg(1);
-                    }
-                }, Config.Fourth);
-                await EnterBarrierAsync("rebalancing-shards-allocated");
-
-                Join(Config.Sixth, Config.Third);
-
-                RunOn(() =>
-                {
-                    AwaitAssert(() =>
-                    {
-                        var probe = CreateTestProbe();
-                        Within(TimeSpan.FromSeconds(3), () =>
-                        {
-                            var count = 0;
-                            for (int i = 1; i <= 10; i++)
-                            {
-                                var rebalancingRegion = this._rebalancingRegion.Value;
-                                rebalancingRegion.Tell(new Get(i), probe.Ref);
-                                probe.ExpectMsg<int>();
-                                if (probe.LastSender.Path.Equals(rebalancingRegion.Path / (i % 12).ToString() / i.ToString()))
-                                    count++;
-                            }
-
-                            count.Should().BeGreaterOrEqualTo(2);
-                        });
-                    });
-                }, Config.Sixth);
-                await EnterBarrierAsync("after-9");
-            });
-        }
-
-        private async Task ClusterSharding_should_be_easy_to_use_with_extensions()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(50), async () =>
-            {
-                RunOn(() =>
-                {
-                    //#counter-start
-                    ClusterSharding.Get(Sys).Start(
-                        typeName: "Counter",
-                        entityProps: Counter.Props(),
-                        settings: ClusterShardingSettings.Create(Sys),
-                        messageExtractor: new MessageExtractor());
-
-                    //#counter-start
-                    ClusterSharding.Get(Sys).Start(
-                        typeName: "AnotherCounter",
-                        entityProps: AnotherCounter.Props(),
-                        settings: ClusterShardingSettings.Create(Sys),
-                        messageExtractor: new MessageExtractor());
-
-                    //#counter-supervisor-start
-                    ClusterSharding.Get(Sys).Start(
-                        typeName: "SupervisedCounter",
-                        entityProps: CounterSupervisor.Props(),
-                        settings: ClusterShardingSettings.Create(Sys),
-                        messageExtractor: new MessageExtractor());
-                }, Config.Third, Config.Fourth, Config.Fifth, Config.Sixth);
-                await EnterBarrierAsync("extension-started");
-
-                RunOn(() =>
-                {
-                    //#counter-usage
-                    var counterRegion = ClusterSharding.Get(Sys).ShardRegion("Counter");
-                    var entityId = 123;
-                    counterRegion.Tell(new Get(entityId));
-                    ExpectMsg(0);
-
-                    counterRegion.Tell(new EntityEnvelope(entityId, Increment.Instance));
-                    counterRegion.Tell(new Get(entityId));
-                    ExpectMsg(1);
-                    //#counter-usage
-
-                    var anotherCounterRegion = ClusterSharding.Get(Sys).ShardRegion("AnotherCounter");
-                    anotherCounterRegion.Tell(new EntityEnvelope(entityId, Decrement.Instance));
-                    anotherCounterRegion.Tell(new Get(entityId));
-                    ExpectMsg(-1);
-                }, Config.Fifth);
-                await EnterBarrierAsync("extension-used");
-
-                // sixth is a frontend node, i.e. proxy only
-                RunOn(() =>
-            {
-                for (int i = 1000; i <= 1010; i++)
-                {
-                    ClusterSharding.Get(Sys).ShardRegion("Counter").Tell(new EntityEnvelope(i, Increment.Instance));
-                    ClusterSharding.Get(Sys).ShardRegion("Counter").Tell(new Get(i));
-                    ExpectMsg(1);
-                    LastSender.Path.Address.Should().NotBe(Cluster.SelfAddress);
+                    var rebalancingRegion = this._rebalancingRegion.Value;
+                    rebalancingRegion.Tell(new EntityEnvelope(i, Increment.Instance));
+                    rebalancingRegion.Tell(new Get(i));
+                    await ExpectMsgAsync(1);
                 }
-            }, Config.Sixth);
-                await EnterBarrierAsync("after-10");
-            });
-        }
+            }, Config.Fourth);
+            await EnterBarrierAsync("rebalancing-shards-allocated");
 
-        private async Task ClusterSharding_should_be_easy_API_for_starting()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(50), async () =>
+            await JoinAsync(Config.Sixth, Config.Third);
+
+            await RunOnAsync(async () =>
             {
-                RunOn(() =>
+                await AwaitAssertAsync(async () =>
                 {
-                    var counterRegionViaStart = ClusterSharding.Get(Sys).Start(
-                        typeName: "ApiTest",
-                        entityProps: Counter.Props(),
-                        settings: ClusterShardingSettings.Create(Sys),
-                        messageExtractor: new MessageExtractor());
-
-                    var counterRegionViaGet = ClusterSharding.Get(Sys).ShardRegion("ApiTest");
-
-                    counterRegionViaStart.Should().Be(counterRegionViaGet);
-                }, Config.First);
-                await EnterBarrierAsync("after-11");
-            });
-        }
-
-        #endregion
-
-        #region Persistent cluster shards specs
-
-        private async Task PersistentClusterSharding_should_recover_entities_upon_restart()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(50), async () =>
-            {
-                RunOn(() =>
-                {
-                    _ = _persistentEntitiesRegion.Value;
-                    _ = _anotherPersistentRegion.Value;
-                }, Config.Third, Config.Fourth, Config.Fifth);
-                await EnterBarrierAsync("persistent-start");
-
-                // watch-out, these two var are only init on 3rd node
-                ActorSelection shard = null;
-                ActorSelection region = null;
-                RunOn(() =>
-                {
-                    //Create an increment counter 1
-                    _persistentEntitiesRegion.Value.Tell(new EntityEnvelope(1, Increment.Instance));
-                    _persistentEntitiesRegion.Value.Tell(new Get(1));
-                    ExpectMsg(1);
-
-                    shard = Sys.ActorSelection(LastSender.Path.Parent);
-                    region = Sys.ActorSelection(LastSender.Path.Parent.Parent);
-                }, Config.Third);
-                await EnterBarrierAsync("counter-incremented");
-
-
-                // clean up shard cache everywhere
-                RunOn(() =>
-                {
-                    _persistentEntitiesRegion.Value.Tell(new BeginHandOff("1"));
-                    ExpectMsg(new BeginHandOffAck("1"), TimeSpan.FromSeconds(10), "ShardStopped not received");
-                }, Config.Third, Config.Fourth, Config.Fifth);
-                await EnterBarrierAsync("everybody-hand-off-ack");
-
-
-
-                RunOn(() =>
-                {
-                    //Stop the shard cleanly
-                    region.Tell(new HandOff("1"));
-                    ExpectMsg(new ShardStopped("1"), TimeSpan.FromSeconds(10), "ShardStopped not received");
-
                     var probe = CreateTestProbe();
-                    AwaitAssert(() =>
-                    {
-                        shard.Tell(new Identify(1), probe.Ref);
-                        probe.ExpectMsg(new ActorIdentity(1, null), TimeSpan.FromSeconds(1), "Shard was still around");
-                    }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
-
-                    //Get the path to where the shard now resides
-                    AwaitAssert(() =>
-                    {
-                        _persistentEntitiesRegion.Value.Tell(new Get(13));
-                        ExpectMsg(0);
-                    }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
-
-                    //Check that counter 1 is now alive again, even though we have
-                    // not sent a message to it via the ShardRegion
-                    var counter1 = Sys.ActorSelection(LastSender.Path.Parent / "1");
-                    Within(TimeSpan.FromSeconds(5), () =>
-                    {
-                        AwaitAssert(() =>
-                        {
-                            var probe2 = CreateTestProbe();
-                            counter1.Tell(new Identify(2), probe2.Ref);
-                            probe2.ExpectMsg<ActorIdentity>(i => i.Subject != null, TimeSpan.FromSeconds(2));
-                        });
-                    });
-
-                    counter1.Tell(new Get(1));
-                    ExpectMsg(1);
-                }, Config.Third);
-                await EnterBarrierAsync("after-shard-restart");
-
-                RunOn(() =>
-                {
-                    //Check a second region does not share the same persistent shards
-
-                    //Create a separate 13 counter
-                    _anotherPersistentRegion.Value.Tell(new EntityEnvelope(13, Increment.Instance));
-                    _anotherPersistentRegion.Value.Tell(new Get(13));
-                    ExpectMsg(1);
-
-                    //Check that no counter "1" exists in this shard
-                    var secondCounter1 = Sys.ActorSelection(LastSender.Path.Parent / "1");
-                    secondCounter1.Tell(new Identify(3));
-                    ExpectMsg(new ActorIdentity(3, null), TimeSpan.FromSeconds(3));
-                }, Config.Fourth);
-                await EnterBarrierAsync("after-12");
-            });
-        }
-
-        private async Task PersistentClusterSharding_should_permanently_stop_entities_which_passivate()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(15), async () =>
-            {
-                RunOn(() =>
-                {
-                    _ = _persistentRegion.Value;
-                }, Config.Third, Config.Fourth, Config.Fifth);
-                await EnterBarrierAsync("cluster-started-12");
-
-                RunOn(() =>
-                {
-                    //create and increment counter 1
-                    _persistentRegion.Value.Tell(new EntityEnvelope(1, Increment.Instance));
-                    _persistentRegion.Value.Tell(new Get(1));
-                    ExpectMsg(1);
-
-                    var counter1 = LastSender;
-                    var shard = Sys.ActorSelection(counter1.Path.Parent);
-                    var region = Sys.ActorSelection(counter1.Path.Parent.Parent);
-
-                    //create and increment counter 13
-                    _persistentRegion.Value.Tell(new EntityEnvelope(13, Increment.Instance));
-                    _persistentRegion.Value.Tell(new Get(13));
-                    ExpectMsg(1);
-
-                    var counter13 = LastSender;
-
-                    counter13.Path.Parent.Should().Be(counter1.Path.Parent);
-
-                    //Send the shard the passivate message from the counter
-                    Watch(counter1);
-                    shard.Tell(new Passivate(Stop.Instance), counter1);
-
-                    // watch for the Terminated message
-                    ExpectTerminated(counter1, TimeSpan.FromSeconds(5));
-
-                    var probe1 = CreateTestProbe();
-                    AwaitAssert(() =>
-                    {
-                        // check counter 1 is dead
-                        counter1.Tell(new Identify(1), probe1.Ref);
-                        probe1.ExpectMsg(new ActorIdentity(1, null), TimeSpan.FromSeconds(1), "Entity 1 was still around");
-                    }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
-
-                    // stop shard cleanly
-                    region.Tell(new HandOff("1"));
-                    ExpectMsg(new ShardStopped("1"), TimeSpan.FromSeconds(10), "ShardStopped not received");
-
-                    var probe2 = CreateTestProbe();
-                    AwaitAssert(() =>
-                    {
-                        shard.Tell(new Identify(2), probe2.Ref);
-                        probe2.ExpectMsg(new ActorIdentity(2, null), TimeSpan.FromSeconds(1), "Shard was still around");
-                    }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
-
-                }, Config.Third);
-                await EnterBarrierAsync("shard-shutdonw-12");
-
-                RunOn(() =>
-                {
-                    // force shard backup
-                    _persistentRegion.Value.Tell(new Get(25));
-                    ExpectMsg(0);
-
-                    var shard = LastSender.Path.Parent;
-
-                    // check counter 1 is still dead
-                    Sys.ActorSelection(shard / "1").Tell(new Identify(3));
-                    ExpectMsg(new ActorIdentity(3, null));
-
-                    // check counter 13 is alive again
-                    var probe3 = CreateTestProbe();
-                    AwaitAssert(() =>
-                    {
-                        Sys.ActorSelection(shard / "13").Tell(new Identify(4), probe3.Ref);
-                        probe3.ExpectMsg<ActorIdentity>(i => i.MessageId.Equals(4) && i.Subject != null);
-                    }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
-                }, Config.Fourth);
-                await EnterBarrierAsync("after-13");
-            });
-        }
-
-        private async Task PersistentClusterSharding_should_restart_entities_which_stop_without_passivation()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(50), async () =>
-            {
-                RunOn(() =>
-                {
-                    _ = _persistentRegion.Value;
-                }, Config.Third, Config.Fourth);
-                await EnterBarrierAsync("cluster-started-12");
-
-                RunOn(() =>
-                {
-                    //create and increment counter 1
-                    _persistentRegion.Value.Tell(new EntityEnvelope(1, Increment.Instance));
-                    _persistentRegion.Value.Tell(new Get(1));
-                    ExpectMsg(2);
-
-                    var counter1 = Sys.ActorSelection(LastSender.Path);
-                    counter1.Tell(Stop.Instance);
-
-                    var probe = CreateTestProbe();
-                    AwaitAssert(() =>
-                    {
-                        counter1.Tell(new Identify(1), probe.Ref);
-                        probe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(1)).Subject.Should().NotBeNull();
-                    }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
-                }, Config.Third);
-                await EnterBarrierAsync("after-14");
-            });
-        }
-
-        private async Task PersistentClusterSharding_should_be_migrated_to_new_regions_upon_region_failure()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(15), async () =>
-            {
-                //Start only one region, and force an entity onto that region
-                RunOn(() =>
-                {
-                    _autoMigrateRegion.Value.Tell(new EntityEnvelope(1, Increment.Instance));
-                    _autoMigrateRegion.Value.Tell(new Get(1));
-                    ExpectMsg(1);
-                }, Config.Third);
-                await EnterBarrierAsync("shard1-region3");
-
-                //Start another region and test it talks to node 3
-                RunOn(() =>
-                {
-                    _autoMigrateRegion.Value.Tell(new EntityEnvelope(1, Increment.Instance));
-                    _autoMigrateRegion.Value.Tell(new Get(1));
-                    ExpectMsg(2);
-
-                    LastSender.Path.Should().Be(Node(Config.Third) / "user" / "AutoMigrateRememberRegionTestRegion" / "1" / "1");
-
-                    // kill region 3
-                    Sys.ActorSelection(LastSender.Path.Parent.Parent).Tell(PoisonPill.Instance);
-                }, Config.Fourth);
-                await EnterBarrierAsync("region4-up");
-
-                // Wait for migration to happen
-                //Test the shard, thus counter was moved onto node 4 and started.
-                RunOn(() =>
-                {
-                    var counter1 = Sys.ActorSelection("user/AutoMigrateRememberRegionTestRegion/1/1");
-                    var probe = CreateTestProbe();
-                    AwaitAssert(() =>
-                    {
-                        counter1.Tell(new Identify(1), probe.Ref);
-                        probe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(1)).Subject.Should().NotBeNull();
-                    }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
-
-                    counter1.Tell(new Get(1));
-                    ExpectMsg(2);
-                }, Config.Fourth);
-                await EnterBarrierAsync("after-15");
-            });
-        }
-
-        private async Task PersistentClusterSharding_should_ensure_rebalance_restarts_shards()
-        {
-            await WithinAsync(TimeSpan.FromSeconds(50), async () =>
-            {
-                RunOn(() =>
-                {
-                    for (int i = 2; i <= 12; i++)
-                        _rebalancingPersistentRegion.Value.Tell(new EntityEnvelope(i, Increment.Instance));
-
-                    for (int i = 2; i <= 12; i++)
-                    {
-                        _rebalancingPersistentRegion.Value.Tell(new Get(i));
-                        ExpectMsg(1);
-                    }
-                }, Config.Fourth);
-                await EnterBarrierAsync("entities-started");
-
-                RunOn(() =>
-                {
-                    _ = _rebalancingPersistentRegion.Value;
-                }, Config.Fifth);
-                await EnterBarrierAsync("fifth-joined-shard");
-
-                RunOn(() =>
-                {
-                    AwaitAssert(() =>
+                    await WithinAsync(TimeSpan.FromSeconds(3), async () =>
                     {
                         var count = 0;
-                        for (int i = 2; i <= 12; i++)
+                        for (int i = 1; i <= 10; i++)
                         {
-                            var entity = Sys.ActorSelection(_rebalancingPersistentRegion.Value.Path / (i % 12).ToString() / i.ToString());
-                            entity.Tell(new Identify(i));
-
-                            var msg = ReceiveOne(TimeSpan.FromSeconds(3)) as ActorIdentity;
-                            if (msg != null && msg.Subject != null && msg.MessageId.Equals(i))
+                            var rebalancingRegion = this._rebalancingRegion.Value;
+                            rebalancingRegion.Tell(new Get(i), probe.Ref);
+                            await probe.ExpectMsgAsync<int>();
+                            if (probe.LastSender.Path.Equals(rebalancingRegion.Path / (i % 12).ToString() / i.ToString()))
                                 count++;
                         }
 
                         count.Should().BeGreaterOrEqualTo(2);
                     });
-                }, Config.Fifth);
-                await EnterBarrierAsync("after-16");
-            });
-        }
-
-        #endregion
+                });
+            }, Config.Sixth);
+            await EnterBarrierAsync("after-9");
+        });
     }
+
+    private async Task ClusterSharding_should_be_easy_to_use_with_extensions()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(50), async () =>
+        {
+            RunOn(() =>
+            {
+                //#counter-start
+                ClusterSharding.Get(Sys).Start(
+                    typeName: "Counter",
+                    entityProps: Counter.Props(),
+                    settings: ClusterShardingSettings.Create(Sys),
+                    messageExtractor: new MessageExtractor());
+
+                //#counter-start
+                ClusterSharding.Get(Sys).Start(
+                    typeName: "AnotherCounter",
+                    entityProps: AnotherCounter.Props(),
+                    settings: ClusterShardingSettings.Create(Sys),
+                    messageExtractor: new MessageExtractor());
+
+                //#counter-supervisor-start
+                ClusterSharding.Get(Sys).Start(
+                    typeName: "SupervisedCounter",
+                    entityProps: CounterSupervisor.Props(),
+                    settings: ClusterShardingSettings.Create(Sys),
+                    messageExtractor: new MessageExtractor());
+            }, Config.Third, Config.Fourth, Config.Fifth, Config.Sixth);
+            await EnterBarrierAsync("extension-started");
+
+            await RunOnAsync(async () =>
+            {
+                //#counter-usage
+                var counterRegion = ClusterSharding.Get(Sys).ShardRegion("Counter");
+                var entityId = 123;
+                counterRegion.Tell(new Get(entityId));
+                await ExpectMsgAsync(0);
+
+                counterRegion.Tell(new EntityEnvelope(entityId, Increment.Instance));
+                counterRegion.Tell(new Get(entityId));
+                await ExpectMsgAsync(1);
+                //#counter-usage
+
+                var anotherCounterRegion = ClusterSharding.Get(Sys).ShardRegion("AnotherCounter");
+                anotherCounterRegion.Tell(new EntityEnvelope(entityId, Decrement.Instance));
+                anotherCounterRegion.Tell(new Get(entityId));
+                await ExpectMsgAsync(-1);
+            }, Config.Fifth);
+            await EnterBarrierAsync("extension-used");
+
+            // sixth is a frontend node, i.e. proxy only
+            await RunOnAsync(async () =>
+            {
+                for (int i = 1000; i <= 1010; i++)
+                {
+                    ClusterSharding.Get(Sys).ShardRegion("Counter").Tell(new EntityEnvelope(i, Increment.Instance));
+                    ClusterSharding.Get(Sys).ShardRegion("Counter").Tell(new Get(i));
+                    await ExpectMsgAsync(1);
+                    LastSender.Path.Address.Should().NotBe(Cluster.SelfAddress);
+                }
+            }, Config.Sixth);
+            await EnterBarrierAsync("after-10");
+        });
+    }
+
+    private async Task ClusterSharding_should_be_easy_API_for_starting()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(50), async () =>
+        {
+            RunOn(() =>
+            {
+                var counterRegionViaStart = ClusterSharding.Get(Sys).Start(
+                    typeName: "ApiTest",
+                    entityProps: Counter.Props(),
+                    settings: ClusterShardingSettings.Create(Sys),
+                    messageExtractor: new MessageExtractor());
+
+                var counterRegionViaGet = ClusterSharding.Get(Sys).ShardRegion("ApiTest");
+
+                counterRegionViaStart.Should().Be(counterRegionViaGet);
+            }, Config.First);
+            await EnterBarrierAsync("after-11");
+        });
+    }
+
+    #endregion
+
+    #region Persistent cluster shards specs
+
+    private async Task PersistentClusterSharding_should_recover_entities_upon_restart()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(50), async () =>
+        {
+            RunOn(() =>
+            {
+                _ = _persistentEntitiesRegion.Value;
+                _ = _anotherPersistentRegion.Value;
+            }, Config.Third, Config.Fourth, Config.Fifth);
+            await EnterBarrierAsync("persistent-start");
+
+            // watch-out, these two var are only init on 3rd node
+            ActorSelection shard = null;
+            ActorSelection region = null;
+            await RunOnAsync(async () =>
+            {
+                //Create an increment counter 1
+                _persistentEntitiesRegion.Value.Tell(new EntityEnvelope(1, Increment.Instance));
+                _persistentEntitiesRegion.Value.Tell(new Get(1));
+                await ExpectMsgAsync(1);
+
+                shard = Sys.ActorSelection(LastSender.Path.Parent);
+                region = Sys.ActorSelection(LastSender.Path.Parent.Parent);
+            }, Config.Third);
+            await EnterBarrierAsync("counter-incremented");
+
+
+            // clean up shard cache everywhere
+            await RunOnAsync(async () =>
+            {
+                _persistentEntitiesRegion.Value.Tell(new BeginHandOff("1"));
+                await ExpectMsgAsync(new BeginHandOffAck("1"), TimeSpan.FromSeconds(10), "ShardStopped not received");
+            }, Config.Third, Config.Fourth, Config.Fifth);
+            await EnterBarrierAsync("everybody-hand-off-ack");
+
+
+
+            await RunOnAsync(async () =>
+            {
+                //Stop the shard cleanly
+                region.Tell(new HandOff("1"));
+                await ExpectMsgAsync(new ShardStopped("1"), TimeSpan.FromSeconds(10), "ShardStopped not received");
+
+                var probe = CreateTestProbe();
+                await AwaitAssertAsync(async () =>
+                {
+                    shard.Tell(new Identify(1), probe.Ref);
+                    await probe.ExpectMsgAsync(new ActorIdentity(1, null), TimeSpan.FromSeconds(1), "Shard was still around");
+                }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
+
+                //Get the path to where the shard now resides
+                await AwaitAssertAsync(async () =>
+                {
+                    _persistentEntitiesRegion.Value.Tell(new Get(13));
+                    await ExpectMsgAsync(0);
+                }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
+
+                //Check that counter 1 is now alive again, even though we have
+                // not sent a message to it via the ShardRegion
+                var counter1 = Sys.ActorSelection(LastSender.Path.Parent / "1");
+                await WithinAsync(TimeSpan.FromSeconds(5), async () =>
+                {
+                    await AwaitAssertAsync(async () =>
+                    {
+                        var probe2 = CreateTestProbe();
+                        counter1.Tell(new Identify(2), probe2.Ref);
+                        await probe2.ExpectMsgAsync<ActorIdentity>(i => i.Subject != null, TimeSpan.FromSeconds(2));
+                    });
+                });
+
+                counter1.Tell(new Get(1));
+                await ExpectMsgAsync(1);
+            }, Config.Third);
+            await EnterBarrierAsync("after-shard-restart");
+
+            await RunOnAsync(async () =>
+            {
+                //Check a second region does not share the same persistent shards
+
+                //Create a separate 13 counter
+                _anotherPersistentRegion.Value.Tell(new EntityEnvelope(13, Increment.Instance));
+                _anotherPersistentRegion.Value.Tell(new Get(13));
+                await ExpectMsgAsync(1);
+
+                //Check that no counter "1" exists in this shard
+                var secondCounter1 = Sys.ActorSelection(LastSender.Path.Parent / "1");
+                secondCounter1.Tell(new Identify(3));
+                await ExpectMsgAsync(new ActorIdentity(3, null), TimeSpan.FromSeconds(3));
+            }, Config.Fourth);
+            await EnterBarrierAsync("after-12");
+        });
+    }
+
+    private async Task PersistentClusterSharding_should_permanently_stop_entities_which_passivate()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(15), async () =>
+        {
+            RunOn(() =>
+            {
+                _ = _persistentRegion.Value;
+            }, Config.Third, Config.Fourth, Config.Fifth);
+            await EnterBarrierAsync("cluster-started-12");
+
+            await RunOnAsync(async () =>
+            {
+                //create and increment counter 1
+                _persistentRegion.Value.Tell(new EntityEnvelope(1, Increment.Instance));
+                _persistentRegion.Value.Tell(new Get(1));
+                await ExpectMsgAsync(1);
+
+                var counter1 = LastSender;
+                var shard = Sys.ActorSelection(counter1.Path.Parent);
+                var region = Sys.ActorSelection(counter1.Path.Parent.Parent);
+
+                //create and increment counter 13
+                _persistentRegion.Value.Tell(new EntityEnvelope(13, Increment.Instance));
+                _persistentRegion.Value.Tell(new Get(13));
+                await ExpectMsgAsync(1);
+
+                var counter13 = LastSender;
+
+                counter13.Path.Parent.Should().Be(counter1.Path.Parent);
+
+                //Send the shard the passivate message from the counter
+                await WatchAsync(counter1);
+                shard.Tell(new Passivate(Stop.Instance), counter1);
+
+                // watch for the Terminated message
+                await ExpectTerminatedAsync(counter1, TimeSpan.FromSeconds(5));
+
+                var probe1 = CreateTestProbe();
+                await AwaitAssertAsync(async () =>
+                {
+                    // check counter 1 is dead
+                    counter1.Tell(new Identify(1), probe1.Ref);
+                    await probe1.ExpectMsgAsync(new ActorIdentity(1, null), TimeSpan.FromSeconds(1), "Entity 1 was still around");
+                }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
+
+                // stop shard cleanly
+                region.Tell(new HandOff("1"));
+                await ExpectMsgAsync(new ShardStopped("1"), TimeSpan.FromSeconds(10), "ShardStopped not received");
+
+                var probe2 = CreateTestProbe();
+                await AwaitAssertAsync(async () =>
+                {
+                    shard.Tell(new Identify(2), probe2.Ref);
+                    await probe2.ExpectMsgAsync(new ActorIdentity(2, null), TimeSpan.FromSeconds(1), "Shard was still around");
+                }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
+
+            }, Config.Third);
+            await EnterBarrierAsync("shard-shutdonw-12");
+
+            await RunOnAsync(async () =>
+            {
+                // force shard backup
+                _persistentRegion.Value.Tell(new Get(25));
+                await ExpectMsgAsync(0);
+
+                var shard = LastSender.Path.Parent;
+
+                // check counter 1 is still dead
+                Sys.ActorSelection(shard / "1").Tell(new Identify(3));
+                await ExpectMsgAsync(new ActorIdentity(3, null));
+
+                // check counter 13 is alive again
+                var probe3 = CreateTestProbe();
+                await AwaitAssertAsync(async () =>
+                {
+                    Sys.ActorSelection(shard / "13").Tell(new Identify(4), probe3.Ref);
+                    await probe3.ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals(4) && i.Subject != null);
+                }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
+            }, Config.Fourth);
+            await EnterBarrierAsync("after-13");
+        });
+    }
+
+    private async Task PersistentClusterSharding_should_restart_entities_which_stop_without_passivation()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(50), async () =>
+        {
+            RunOn(() =>
+            {
+                _ = _persistentRegion.Value;
+            }, Config.Third, Config.Fourth);
+            await EnterBarrierAsync("cluster-started-12");
+
+            await RunOnAsync(async () =>
+            {
+                //create and increment counter 1
+                _persistentRegion.Value.Tell(new EntityEnvelope(1, Increment.Instance));
+                _persistentRegion.Value.Tell(new Get(1));
+                await ExpectMsgAsync(2);
+
+                var counter1 = Sys.ActorSelection(LastSender.Path);
+                counter1.Tell(Stop.Instance);
+
+                var probe = CreateTestProbe();
+                await AwaitAssertAsync(async () =>
+                {
+                    counter1.Tell(new Identify(1), probe.Ref);
+                    (await probe.ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(1))).Subject.Should().NotBeNull();
+                }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
+            }, Config.Third);
+            await EnterBarrierAsync("after-14");
+        });
+    }
+
+    private async Task PersistentClusterSharding_should_be_migrated_to_new_regions_upon_region_failure()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(15), async () =>
+        {
+            //Start only one region, and force an entity onto that region
+            await RunOnAsync(async () =>
+            {
+                _autoMigrateRegion.Value.Tell(new EntityEnvelope(1, Increment.Instance));
+                _autoMigrateRegion.Value.Tell(new Get(1));
+                await ExpectMsgAsync(1);
+            }, Config.Third);
+            await EnterBarrierAsync("shard1-region3");
+
+            //Start another region and test it talks to node 3
+            await RunOnAsync(async () =>
+            {
+                _autoMigrateRegion.Value.Tell(new EntityEnvelope(1, Increment.Instance));
+                _autoMigrateRegion.Value.Tell(new Get(1));
+                await ExpectMsgAsync(2);
+
+                LastSender.Path.Should().Be(await NodeAsync(Config.Third) / "user" / "AutoMigrateRememberRegionTestRegion" / "1" / "1");
+
+                // kill region 3
+                Sys.ActorSelection(LastSender.Path.Parent.Parent).Tell(PoisonPill.Instance);
+            }, Config.Fourth);
+            await EnterBarrierAsync("region4-up");
+
+            // Wait for migration to happen
+            //Test the shard, thus counter was moved onto node 4 and started.
+            await RunOnAsync(async () =>
+            {
+                var counter1 = Sys.ActorSelection("user/AutoMigrateRememberRegionTestRegion/1/1");
+                var probe = CreateTestProbe();
+                await AwaitAssertAsync(async () =>
+                {
+                    counter1.Tell(new Identify(1), probe.Ref);
+                    (await probe.ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(1))).Subject.Should().NotBeNull();
+                }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
+
+                counter1.Tell(new Get(1));
+                await ExpectMsgAsync(2);
+            }, Config.Fourth);
+            await EnterBarrierAsync("after-15");
+        });
+    }
+
+    private async Task PersistentClusterSharding_should_ensure_rebalance_restarts_shards()
+    {
+        await WithinAsync(TimeSpan.FromSeconds(50), async () =>
+        {
+            await RunOnAsync(async () =>
+            {
+                for (var i = 2; i <= 12; i++)
+                    _rebalancingPersistentRegion.Value.Tell(new EntityEnvelope(i, Increment.Instance));
+
+                for (var i = 2; i <= 12; i++)
+                {
+                    _rebalancingPersistentRegion.Value.Tell(new Get(i));
+                    await ExpectMsgAsync(1);
+                }
+            }, Config.Fourth);
+            await EnterBarrierAsync("entities-started");
+
+            RunOn(() =>
+            {
+                _ = _rebalancingPersistentRegion.Value;
+            }, Config.Fifth);
+            await EnterBarrierAsync("fifth-joined-shard");
+
+            await RunOnAsync(async () =>
+            {
+                await AwaitAssertAsync(async () =>
+                {
+                    var count = 0;
+                    for (var i = 2; i <= 12; i++)
+                    {
+                        var entity = Sys.ActorSelection(_rebalancingPersistentRegion.Value.Path / (i % 12).ToString() / i.ToString());
+                        entity.Tell(new Identify(i));
+
+                        if (await ReceiveOneAsync(TimeSpan.FromSeconds(3)) is ActorIdentity { Subject: not null } msg && msg.MessageId.Equals(i))
+                            count++;
+                    }
+
+                    count.Should().BeGreaterOrEqualTo(2);
+                });
+            }, Config.Fifth);
+            await EnterBarrierAsync("after-16");
+        });
+    }
+
+    #endregion
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Sharding.Internal;
 using Akka.Cluster.Tools.Singleton;
@@ -537,26 +538,26 @@ namespace Akka.Cluster.Sharding.Tests
         #region Cluster shardings specs
 
         [MultiNodeFact]
-        public void ClusterSharding_specs()
+        public async Task ClusterSharding_specs()
         {
             // must be done also in ddata mode since Counter is PersistentActor
             ClusterSharding_should_setup_shared_journal();
-            ClusterSharding_should_work_in_single_node_cluster();
-            ClusterSharding_should_use_second_node();
-            ClusterSharding_should_support_passivation_and_activation_of_entities();
-            ClusterSharding_should_support_proxy_only_mode();
-            ClusterSharding_should_failover_shards_on_crashed_node();
-            ClusterSharding_should_use_third_and_fourth_node();
-            ClusterSharding_should_recover_coordinator_state_after_coordinator_crash();
-            ClusterSharding_should_rebalance_to_nodes_with_less_shards();
-            ClusterSharding_should_be_easy_to_use_with_extensions();
-            ClusterSharding_should_be_easy_API_for_starting();
+            await ClusterSharding_should_work_in_single_node_cluster();
+            await ClusterSharding_should_use_second_node();
+            await ClusterSharding_should_support_passivation_and_activation_of_entities();
+            await ClusterSharding_should_support_proxy_only_mode();
+            await ClusterSharding_should_failover_shards_on_crashed_node();
+            await ClusterSharding_should_use_third_and_fourth_node();
+            await ClusterSharding_should_recover_coordinator_state_after_coordinator_crash();
+            await ClusterSharding_should_rebalance_to_nodes_with_less_shards();
+            await ClusterSharding_should_be_easy_to_use_with_extensions();
+            await ClusterSharding_should_be_easy_API_for_starting();
 
-            PersistentClusterSharding_should_recover_entities_upon_restart();
-            PersistentClusterSharding_should_permanently_stop_entities_which_passivate();
-            PersistentClusterSharding_should_restart_entities_which_stop_without_passivation();
-            PersistentClusterSharding_should_be_migrated_to_new_regions_upon_region_failure();
-            PersistentClusterSharding_should_ensure_rebalance_restarts_shards();
+            await PersistentClusterSharding_should_recover_entities_upon_restart();
+            await PersistentClusterSharding_should_permanently_stop_entities_which_passivate();
+            await PersistentClusterSharding_should_restart_entities_which_stop_without_passivation();
+            await PersistentClusterSharding_should_be_migrated_to_new_regions_upon_region_failure();
+            await PersistentClusterSharding_should_ensure_rebalance_restarts_shards();
         }
 
         private void ClusterSharding_should_setup_shared_journal()
@@ -565,9 +566,9 @@ namespace Akka.Cluster.Sharding.Tests
                 Config.First, Config.Second, Config.Third, Config.Fourth, Config.Fifth, Config.Sixth);
         }
 
-        private void ClusterSharding_should_work_in_single_node_cluster()
+        private async Task ClusterSharding_should_work_in_single_node_cluster()
         {
-            Within(TimeSpan.FromSeconds(20), () =>
+            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
             {
                 Join(Config.First, Config.First);
 
@@ -585,13 +586,13 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(new CurrentRegions(ImmutableHashSet.Create(Cluster.SelfAddress)));
                 }, Config.First);
 
-                EnterBarrier("after-2");
+                await EnterBarrierAsync("after-2");
             });
         }
 
-        private void ClusterSharding_should_use_second_node()
+        private async Task ClusterSharding_should_use_second_node()
         {
-            Within(TimeSpan.FromSeconds(20), () =>
+            await WithinAsync(TimeSpan.FromSeconds(20), async () =>
             {
                 Join(Config.Second, Config.First);
 
@@ -612,7 +613,7 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(new Get(12));
                     ExpectMsg(1);
                 }, Config.Second);
-                EnterBarrier("second-update");
+                await EnterBarrierAsync("second-update");
 
                 RunOn(() =>
                 {
@@ -637,7 +638,7 @@ namespace Akka.Cluster.Sharding.Tests
                     //one has to be local, the other one remote
                     (path11.Address.HasLocalScope && path12.Address.HasGlobalScope || path11.Address.HasGlobalScope && path12.Address.HasLocalScope).Should().BeTrue();
                 }, Config.First);
-                EnterBarrier("first-update");
+                await EnterBarrierAsync("first-update");
 
                 RunOn(() =>
                 {
@@ -649,11 +650,11 @@ namespace Akka.Cluster.Sharding.Tests
                     r.Tell(GetCurrentRegions.Instance);
                     ExpectMsg(new CurrentRegions(ImmutableHashSet.Create(Cluster.SelfAddress, Node(Config.First).Address)));
                 }, Config.Second);
-                EnterBarrier("after-3");
+                await EnterBarrierAsync("after-3");
             });
         }
 
-        private void ClusterSharding_should_support_passivation_and_activation_of_entities()
+        private async Task ClusterSharding_should_support_passivation_and_activation_of_entities()
         {
             RunOn(() =>
             {
@@ -667,12 +668,12 @@ namespace Akka.Cluster.Sharding.Tests
                 r.Tell(new Get(2));
                 ExpectMsg(4);
             }, Config.Second);
-            EnterBarrier("after-4");
+            await EnterBarrierAsync("after-4");
         }
 
-        private void ClusterSharding_should_support_proxy_only_mode()
+        private async Task ClusterSharding_should_support_proxy_only_mode()
         {
-            Within(TimeSpan.FromSeconds(10), () =>
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
             {
                 RunOn(() =>
                 {
@@ -694,24 +695,24 @@ namespace Akka.Cluster.Sharding.Tests
                     proxy.Tell(new Get(2));
                     ExpectMsg(4);
                 }, Config.Second);
-                EnterBarrier("after-5");
+                await EnterBarrierAsync("after-5");
             });
         }
 
-        private void ClusterSharding_should_failover_shards_on_crashed_node()
+        private async Task ClusterSharding_should_failover_shards_on_crashed_node()
         {
-            Within(TimeSpan.FromSeconds(30), () =>
+            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
             {
                 // mute logging of deadLetters during shutdown of systems
                 if (!Log.IsDebugEnabled)
                     Sys.EventStream.Publish(new Mute(new DeadLettersFilter(new PredicateMatcher(_ => true), new PredicateMatcher(_ => true))));
-                EnterBarrier("logs-muted");
+                await EnterBarrierAsync("logs-muted");
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
-                    TestConductor.Exit(Config.Second, 0).Wait();
+                    await TestConductor.ExitAsync(Config.Second, 0);
                 }, Config.Controller);
-                EnterBarrier("crash-second");
+                await EnterBarrierAsync("crash-second");
 
                 RunOn(() =>
                 {
@@ -739,13 +740,13 @@ namespace Akka.Cluster.Sharding.Tests
                         });
                     });
                 }, Config.First);
-                EnterBarrier("after-6");
+                await EnterBarrierAsync("after-6");
             });
         }
 
-        private void ClusterSharding_should_use_third_and_fourth_node()
+        private async Task ClusterSharding_should_use_third_and_fourth_node()
         {
-            Within(TimeSpan.FromSeconds(15), () =>
+            await WithinAsync(TimeSpan.FromSeconds(15), async () =>
             {
                 Join(Config.Third, Config.First);
 
@@ -759,7 +760,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(10);
                     LastSender.Path.Should().Be(r.Path / "3" / "3"); // local
                 }, Config.Third);
-                EnterBarrier("third-update");
+                await EnterBarrierAsync("third-update");
 
                 Join(Config.Fourth, Config.First);
 
@@ -773,7 +774,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(20);
                     LastSender.Path.Should().Be(r.Path / "4" / "4"); // local
                 }, Config.Fourth);
-                EnterBarrier("fourth-update");
+                await EnterBarrierAsync("fourth-update");
 
                 RunOn(() =>
                 {
@@ -788,7 +789,7 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(21);
                     LastSender.Path.Should().Be(Node(Config.Fourth) / "user" / "counterRegion" / "4" / "4");
                 }, Config.First);
-                EnterBarrier("first-update");
+                await EnterBarrierAsync("first-update");
 
                 RunOn(() =>
                 {
@@ -805,20 +806,20 @@ namespace Akka.Cluster.Sharding.Tests
                     ExpectMsg(21);
                     LastSender.Path.Should().Be(r.Path / "4" / "4");
                 }, Config.Fourth);
-                EnterBarrier("after-7");
+                await EnterBarrierAsync("after-7");
             });
         }
 
-        private void ClusterSharding_should_recover_coordinator_state_after_coordinator_crash()
+        private async Task ClusterSharding_should_recover_coordinator_state_after_coordinator_crash()
         {
-            Within(TimeSpan.FromSeconds(60), () =>
+            await WithinAsync(TimeSpan.FromSeconds(60), async () =>
             {
                 Join(Config.Fifth, Config.Fourth);
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
-                    TestConductor.Exit(Config.First, 0).Wait();
+                    await TestConductor.ExitAsync(Config.First, 0);
                 }, Config.Controller);
-                EnterBarrier("crash-first");
+                await EnterBarrierAsync("crash-first");
 
                 RunOn(() =>
                 {
@@ -844,13 +845,13 @@ namespace Akka.Cluster.Sharding.Tests
                         });
                     });
                 }, Config.Fifth);
-                EnterBarrier("after-8");
+                await EnterBarrierAsync("after-8");
             });
         }
 
-        private void ClusterSharding_should_rebalance_to_nodes_with_less_shards()
+        private async Task ClusterSharding_should_rebalance_to_nodes_with_less_shards()
         {
-            Within(TimeSpan.FromSeconds(60), () =>
+            await WithinAsync(TimeSpan.FromSeconds(60), async () =>
             {
                 RunOn(() =>
                 {
@@ -862,7 +863,7 @@ namespace Akka.Cluster.Sharding.Tests
                         ExpectMsg(1);
                     }
                 }, Config.Fourth);
-                EnterBarrier("rebalancing-shards-allocated");
+                await EnterBarrierAsync("rebalancing-shards-allocated");
 
                 Join(Config.Sixth, Config.Third);
 
@@ -887,13 +888,13 @@ namespace Akka.Cluster.Sharding.Tests
                         });
                     });
                 }, Config.Sixth);
-                EnterBarrier("after-9");
+                await EnterBarrierAsync("after-9");
             });
         }
 
-        private void ClusterSharding_should_be_easy_to_use_with_extensions()
+        private async Task ClusterSharding_should_be_easy_to_use_with_extensions()
         {
-            Within(TimeSpan.FromSeconds(50), () =>
+            await WithinAsync(TimeSpan.FromSeconds(50), async () =>
             {
                 RunOn(() =>
                 {
@@ -918,7 +919,7 @@ namespace Akka.Cluster.Sharding.Tests
                         settings: ClusterShardingSettings.Create(Sys),
                         messageExtractor: new MessageExtractor());
                 }, Config.Third, Config.Fourth, Config.Fifth, Config.Sixth);
-                EnterBarrier("extension-started");
+                await EnterBarrierAsync("extension-started");
 
                 RunOn(() =>
                 {
@@ -938,7 +939,7 @@ namespace Akka.Cluster.Sharding.Tests
                     anotherCounterRegion.Tell(new Get(entityId));
                     ExpectMsg(-1);
                 }, Config.Fifth);
-                EnterBarrier("extension-used");
+                await EnterBarrierAsync("extension-used");
 
                 // sixth is a frontend node, i.e. proxy only
                 RunOn(() =>
@@ -951,13 +952,13 @@ namespace Akka.Cluster.Sharding.Tests
                     LastSender.Path.Address.Should().NotBe(Cluster.SelfAddress);
                 }
             }, Config.Sixth);
-                EnterBarrier("after-10");
+                await EnterBarrierAsync("after-10");
             });
         }
 
-        private void ClusterSharding_should_be_easy_API_for_starting()
+        private async Task ClusterSharding_should_be_easy_API_for_starting()
         {
-            Within(TimeSpan.FromSeconds(50), () =>
+            await WithinAsync(TimeSpan.FromSeconds(50), async () =>
             {
                 RunOn(() =>
                 {
@@ -971,7 +972,7 @@ namespace Akka.Cluster.Sharding.Tests
 
                     counterRegionViaStart.Should().Be(counterRegionViaGet);
                 }, Config.First);
-                EnterBarrier("after-11");
+                await EnterBarrierAsync("after-11");
             });
         }
 
@@ -979,16 +980,16 @@ namespace Akka.Cluster.Sharding.Tests
 
         #region Persistent cluster shards specs
 
-        private void PersistentClusterSharding_should_recover_entities_upon_restart()
+        private async Task PersistentClusterSharding_should_recover_entities_upon_restart()
         {
-            Within(TimeSpan.FromSeconds(50), () =>
+            await WithinAsync(TimeSpan.FromSeconds(50), async () =>
             {
                 RunOn(() =>
                 {
                     _ = _persistentEntitiesRegion.Value;
                     _ = _anotherPersistentRegion.Value;
                 }, Config.Third, Config.Fourth, Config.Fifth);
-                EnterBarrier("persistent-start");
+                await EnterBarrierAsync("persistent-start");
 
                 // watch-out, these two var are only init on 3rd node
                 ActorSelection shard = null;
@@ -1003,7 +1004,7 @@ namespace Akka.Cluster.Sharding.Tests
                     shard = Sys.ActorSelection(LastSender.Path.Parent);
                     region = Sys.ActorSelection(LastSender.Path.Parent.Parent);
                 }, Config.Third);
-                EnterBarrier("counter-incremented");
+                await EnterBarrierAsync("counter-incremented");
 
 
                 // clean up shard cache everywhere
@@ -1012,7 +1013,7 @@ namespace Akka.Cluster.Sharding.Tests
                     _persistentEntitiesRegion.Value.Tell(new BeginHandOff("1"));
                     ExpectMsg(new BeginHandOffAck("1"), TimeSpan.FromSeconds(10), "ShardStopped not received");
                 }, Config.Third, Config.Fourth, Config.Fifth);
-                EnterBarrier("everybody-hand-off-ack");
+                await EnterBarrierAsync("everybody-hand-off-ack");
 
 
 
@@ -1052,7 +1053,7 @@ namespace Akka.Cluster.Sharding.Tests
                     counter1.Tell(new Get(1));
                     ExpectMsg(1);
                 }, Config.Third);
-                EnterBarrier("after-shard-restart");
+                await EnterBarrierAsync("after-shard-restart");
 
                 RunOn(() =>
                 {
@@ -1068,19 +1069,19 @@ namespace Akka.Cluster.Sharding.Tests
                     secondCounter1.Tell(new Identify(3));
                     ExpectMsg(new ActorIdentity(3, null), TimeSpan.FromSeconds(3));
                 }, Config.Fourth);
-                EnterBarrier("after-12");
+                await EnterBarrierAsync("after-12");
             });
         }
 
-        private void PersistentClusterSharding_should_permanently_stop_entities_which_passivate()
+        private async Task PersistentClusterSharding_should_permanently_stop_entities_which_passivate()
         {
-            Within(TimeSpan.FromSeconds(15), () =>
+            await WithinAsync(TimeSpan.FromSeconds(15), async () =>
             {
                 RunOn(() =>
                 {
                     _ = _persistentRegion.Value;
                 }, Config.Third, Config.Fourth, Config.Fifth);
-                EnterBarrier("cluster-started-12");
+                await EnterBarrierAsync("cluster-started-12");
 
                 RunOn(() =>
                 {
@@ -1129,7 +1130,7 @@ namespace Akka.Cluster.Sharding.Tests
                     }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
 
                 }, Config.Third);
-                EnterBarrier("shard-shutdonw-12");
+                await EnterBarrierAsync("shard-shutdonw-12");
 
                 RunOn(() =>
                 {
@@ -1151,19 +1152,19 @@ namespace Akka.Cluster.Sharding.Tests
                         probe3.ExpectMsg<ActorIdentity>(i => i.MessageId.Equals(4) && i.Subject != null);
                     }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
                 }, Config.Fourth);
-                EnterBarrier("after-13");
+                await EnterBarrierAsync("after-13");
             });
         }
 
-        private void PersistentClusterSharding_should_restart_entities_which_stop_without_passivation()
+        private async Task PersistentClusterSharding_should_restart_entities_which_stop_without_passivation()
         {
-            Within(TimeSpan.FromSeconds(50), () =>
+            await WithinAsync(TimeSpan.FromSeconds(50), async () =>
             {
                 RunOn(() =>
                 {
                     _ = _persistentRegion.Value;
                 }, Config.Third, Config.Fourth);
-                EnterBarrier("cluster-started-12");
+                await EnterBarrierAsync("cluster-started-12");
 
                 RunOn(() =>
                 {
@@ -1182,13 +1183,13 @@ namespace Akka.Cluster.Sharding.Tests
                         probe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(1)).Subject.Should().NotBeNull();
                     }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(500));
                 }, Config.Third);
-                EnterBarrier("after-14");
+                await EnterBarrierAsync("after-14");
             });
         }
 
-        private void PersistentClusterSharding_should_be_migrated_to_new_regions_upon_region_failure()
+        private async Task PersistentClusterSharding_should_be_migrated_to_new_regions_upon_region_failure()
         {
-            Within(TimeSpan.FromSeconds(15), () =>
+            await WithinAsync(TimeSpan.FromSeconds(15), async () =>
             {
                 //Start only one region, and force an entity onto that region
                 RunOn(() =>
@@ -1197,7 +1198,7 @@ namespace Akka.Cluster.Sharding.Tests
                     _autoMigrateRegion.Value.Tell(new Get(1));
                     ExpectMsg(1);
                 }, Config.Third);
-                EnterBarrier("shard1-region3");
+                await EnterBarrierAsync("shard1-region3");
 
                 //Start another region and test it talks to node 3
                 RunOn(() =>
@@ -1211,7 +1212,7 @@ namespace Akka.Cluster.Sharding.Tests
                     // kill region 3
                     Sys.ActorSelection(LastSender.Path.Parent.Parent).Tell(PoisonPill.Instance);
                 }, Config.Fourth);
-                EnterBarrier("region4-up");
+                await EnterBarrierAsync("region4-up");
 
                 // Wait for migration to happen
                 //Test the shard, thus counter was moved onto node 4 and started.
@@ -1228,13 +1229,13 @@ namespace Akka.Cluster.Sharding.Tests
                     counter1.Tell(new Get(1));
                     ExpectMsg(2);
                 }, Config.Fourth);
-                EnterBarrier("after-15");
+                await EnterBarrierAsync("after-15");
             });
         }
 
-        private void PersistentClusterSharding_should_ensure_rebalance_restarts_shards()
+        private async Task PersistentClusterSharding_should_ensure_rebalance_restarts_shards()
         {
-            Within(TimeSpan.FromSeconds(50), () =>
+            await WithinAsync(TimeSpan.FromSeconds(50), async () =>
             {
                 RunOn(() =>
                 {
@@ -1247,13 +1248,13 @@ namespace Akka.Cluster.Sharding.Tests
                         ExpectMsg(1);
                     }
                 }, Config.Fourth);
-                EnterBarrier("entities-started");
+                await EnterBarrierAsync("entities-started");
 
                 RunOn(() =>
                 {
                     _ = _rebalancingPersistentRegion.Value;
                 }, Config.Fifth);
-                EnterBarrier("fifth-joined-shard");
+                await EnterBarrierAsync("fifth-joined-shard");
 
                 RunOn(() =>
                 {
@@ -1273,7 +1274,7 @@ namespace Akka.Cluster.Sharding.Tests
                         count.Should().BeGreaterOrEqualTo(2);
                     });
                 }, Config.Fifth);
-                EnterBarrier("after-16");
+                await EnterBarrierAsync("after-16");
             });
         }
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/MultiNodeClusterShardingSpec.cs
@@ -9,6 +9,8 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.Event;
@@ -223,22 +225,35 @@ namespace Akka.Cluster.Sharding.Tests
                bool assertNodeUp = true,
                TimeSpan? max = null)
         {
-            RunOn(() =>
+            JoinAsync(from, to, onJoinedRunOnFrom, assertNodeUp, max).GetAwaiter().GetResult();
+        }
+        
+        protected async Task JoinAsync(
+            RoleName from,
+            RoleName to,
+            Action onJoinedRunOnFrom = null,
+            bool assertNodeUp = true,
+            TimeSpan? max = null,
+            CancellationToken cancellationToken = default)
+        {
+            await RunOnAsync(async () =>
             {
-                Cluster.Join(Node(to).Address);
+                // ReSharper disable once MethodHasAsyncOverloadWithCancellation
+                Cluster.Join((await NodeAsync(to, cancellationToken)).Address);
                 if (assertNodeUp)
                 {
-                    Within(max ?? TimeSpan.FromSeconds(20), () =>
-                     {
-                         AwaitAssert(() =>
-                         {
-                             Cluster.State.IsMemberUp(Node(from).Address).Should().BeTrue();
-                         });
-                     });
+                    await WithinAsync(max ?? TimeSpan.FromSeconds(20), async () =>
+                    {
+                        await AwaitAssertAsync(() =>
+                        {
+                            Cluster.State.IsMemberUp(Node(from).Address).Should().BeTrue();
+                        }, cancellationToken: cancellationToken);
+                    }, cancellationToken: cancellationToken);
                 }
                 onJoinedRunOnFrom?.Invoke();
             }, from);
-            EnterBarrier(from.Name + "-joined");
+            
+            await EnterBarrierAsync(cancellationToken, from.Name + "-joined");
         }
         
         protected IActorRef StartSharding(
@@ -270,23 +285,33 @@ namespace Akka.Cluster.Sharding.Tests
 
         protected void SetStoreIfNeeded(ActorSystem sys, RoleName storeOn)
         {
+            SetStoreIfNeededAsync(sys, storeOn, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        protected async Task SetStoreIfNeededAsync(ActorSystem sys, RoleName storeOn, CancellationToken cancellationToken)
+        {
             if (PersistenceIsNeeded)
-                SetStore(sys, storeOn);
+                await SetStoreAsync(sys, storeOn, cancellationToken);
         }
 
         protected void SetStore(ActorSystem sys, RoleName storeOn)
         {
+            SetStoreAsync(sys, storeOn, CancellationToken.None).GetAwaiter().GetResult();
+        }
+
+        protected async Task SetStoreAsync(ActorSystem sys, RoleName storeOn, CancellationToken cancellationToken = default)
+        {
             Persistence.Persistence.Instance.Apply(sys);
 
             var journalProbe = CreateTestProbe(sys);
-            sys.ActorSelection(Node(storeOn) / "system" / "akka.persistence.journal.inmem").Tell(new Identify(null), journalProbe.Ref);
-            var sharedjournalStore = journalProbe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(20)).Subject;
+            sys.ActorSelection(await NodeAsync(storeOn, cancellationToken) / "system" / "akka.persistence.journal.inmem").Tell(new Identify(null), journalProbe.Ref);
+            var sharedjournalStore = (await journalProbe.ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(20), cancellationToken: cancellationToken)).Subject;
             sharedjournalStore.Should().NotBeNull();
             MemoryJournalShared.SetStore(sharedjournalStore, sys);
 
             var snapshotProbe = CreateTestProbe(sys);
-            sys.ActorSelection(Node(storeOn) / "system" / "akka.persistence.snapshot-store.inmem").Tell(new Identify(null), snapshotProbe.Ref);
-            var sharedSnapshotStore = snapshotProbe.ExpectMsg<ActorIdentity>(TimeSpan.FromSeconds(20)).Subject;
+            sys.ActorSelection(await NodeAsync(storeOn, cancellationToken) / "system" / "akka.persistence.snapshot-store.inmem").Tell(new Identify(null), snapshotProbe.Ref);
+            var sharedSnapshotStore = (await snapshotProbe.ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(20), cancellationToken: cancellationToken)).Subject;
             sharedSnapshotStore.Should().NotBeNull();
             MemorySnapshotStoreShared.SetStore(sharedSnapshotStore, sys);
         }
@@ -297,8 +322,17 @@ namespace Akka.Cluster.Sharding.Tests
         /// <param name="startOn">the node to start the `MemoryJournalShared` store on</param>
         protected void StartPersistenceIfNeeded(RoleName startOn, params RoleName[] setStoreOn)
         {
+            StartPersistenceIfNeededAsync(startOn, CancellationToken.None, setStoreOn).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="startOn">the node to start the `MemoryJournalShared` store on</param>
+        protected async Task StartPersistenceIfNeededAsync(RoleName startOn, CancellationToken cancellationToken, params RoleName[] setStoreOn)
+        {
             if (PersistenceIsNeeded)
-                StartPersistence(startOn, setStoreOn);
+                await StartPersistenceAsync(startOn, cancellationToken, setStoreOn);
         }
 
         /// <summary>
@@ -306,6 +340,15 @@ namespace Akka.Cluster.Sharding.Tests
         /// </summary>
         /// <param name="startOn">the node to start the `MemoryJournalShared` store on</param>
         protected void StartPersistence(RoleName startOn, params RoleName[] setStoreOn)
+        {
+            StartPersistenceAsync(startOn, CancellationToken.None, setStoreOn).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="startOn">the node to start the `MemoryJournalShared` store on</param>
+        protected async Task StartPersistenceAsync(RoleName startOn, CancellationToken cancellationToken, params RoleName[] setStoreOn)
         {
             Log.Info("Setting up setup shared journal & snapshot.");
 
@@ -316,14 +359,14 @@ namespace Akka.Cluster.Sharding.Tests
                 Persistence.Persistence.Instance.Apply(Sys).SnapshotStoreFor("akka.persistence.snapshot-store.inmem");
             }, startOn);
 
-            EnterBarrier("persistence-started");
+            await EnterBarrierAsync(cancellationToken, "persistence-started");
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
-                SetStore(Sys, startOn);
+                await SetStoreAsync(Sys, startOn, cancellationToken);
             }, setStoreOn);
 
-            EnterBarrier($"after-{startOn.Name}");
+            await EnterBarrierAsync(cancellationToken, $"after-{startOn.Name}");
         }
     }
 }


### PR DESCRIPTION
## Summary
Migrates all multi-node tests in Akka.Cluster.Sharding.Tests.MultiNode from blocking synchronous calls to async/await patterns to prevent thread pool starvation in CI environments.

## Changes
- Convert test methods from `public void` to `public async Task`
- Replace `TestConductor.[Method]().Wait()` with `await TestConductor.[Method]Async()`
- Replace `EnterBarrier` with `await EnterBarrierAsync`
- Use `RunOnAsync` for async operations
- Use `WithinAsync` for async timing constraints
- Add `using System.Threading.Tasks` to all test files

## Files Modified
- ClusterShardCoordinatorDowning2Spec.cs
- ClusterShardCoordinatorDowningSpec.cs
- ClusterShardingFailureSpec.cs
- ClusterShardingRememberEntitiesNewExtractorSpec.cs
- ClusterShardingRememberEntitiesSpec.cs
- ClusterShardingSingleShardPerEntitySpec.cs
- ClusterShardingSpec.cs

## Motivation
This migration addresses thread pool starvation issues that can cause 20+ second timeout failures in CI environments. The root cause is blocking `.Wait()` calls on TestConductor operations which exhaust the thread pool.

## Test Results
All migrated tests have been verified to pass:
- ✅ ClusterShardCoordinatorDowning2Spec: All tests passing
- ✅ ClusterShardCoordinatorDowningSpec: 6 tests passing
- ✅ ClusterShardingFailureSpec: 6 tests passing
- ✅ ClusterShardingRememberEntitiesNewExtractorSpec: 6 tests passing
- ✅ ClusterShardingRememberEntitiesSpec: All tests passing
- ✅ ClusterShardingSingleShardPerEntitySpec: 5 tests passing
- ✅ ClusterShardingSpec: 14 tests passing

## Related
Part of the ongoing effort to migrate multi-node tests to async as documented in MULTINODE_TEST_ASYNC_MIGRATION.md