### PR TITLE
Port #7769 to 1.5 branch, remove FluentAssertions dependency from all TestKit

### DIFF
--- a/src/contrib/testkits/Akka.TestKit.Xunit/XunitAssertions.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/XunitAssertions.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.TestKit.Xunit.Internals;
 using Xunit;
 
@@ -84,5 +85,25 @@ public class XunitAssertions : ITestKitAssertions
     {
         if(!comparer(expected, actual))
             throw AkkaEqualException.ForMismatchedValues(expected, actual, format, args);
+    }
+
+    public Exception AssertThrows(Action action)
+    {
+        return Assert.ThrowsAny<Exception>(action);
+    }
+    
+    public TException AssertThrows<TException>(Action action) where TException : Exception
+    {
+        return Assert.ThrowsAny<TException>(action);
+    }
+
+    public async Task<Exception> AssertThrowsAsync(Func<Task> action)
+    {
+        return await Assert.ThrowsAnyAsync<Exception>(action);
+    }
+    
+    public async Task<TException> AssertThrowsAsync<TException>(Func<Task> action) where TException : Exception
+    {
+        return await Assert.ThrowsAnyAsync<TException>(action);
     }
 }

--- a/src/contrib/testkits/Akka.TestKit.Xunit2/XunitAssertions.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2/XunitAssertions.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.TestKit.Xunit2.Internals;
 using Xunit;
 
@@ -84,6 +85,26 @@ namespace Akka.TestKit.Xunit2
         {
             if(!comparer(expected, actual))
                 throw AkkaEqualException.ForMismatchedValues(expected, actual, format, args);
+        }
+
+        public Exception AssertThrows(Action action)
+        {
+            return Assert.ThrowsAny<Exception>(action);
+        }
+    
+        public TException AssertThrows<TException>(Action action) where TException : Exception
+        {
+            return Assert.ThrowsAny<TException>(action);
+        }
+
+        public async Task<Exception> AssertThrowsAsync(Func<Task> action)
+        {
+            return await Assert.ThrowsAnyAsync<Exception>(action);
+        }
+    
+        public Task<TException> AssertThrowsAsync<TException>(Func<Task> action) where TException : Exception
+        {
+            return Assert.ThrowsAnyAsync<TException>(action);
         }
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
@@ -127,6 +127,12 @@ namespace Akka.TestKit
         void AssertEqual<T>(T expected, T actual, string format = "", params object[] args);
         void AssertEqual<T>(T expected, T actual, System.Func<T, T, bool> comparer, string format = "", params object[] args);
         void AssertFalse(bool condition, string format = "", params object[] args);
+        System.Exception AssertThrows(System.Action action);
+        TException AssertThrows<TException>(System.Action action)
+            where TException : System.Exception;
+        System.Threading.Tasks.Task<System.Exception> AssertThrowsAsync(System.Func<System.Threading.Tasks.Task> action);
+        System.Threading.Tasks.Task<TException> AssertThrowsAsync<TException>(System.Func<System.Threading.Tasks.Task> action)
+            where TException : System.Exception;
         void AssertTrue(bool condition, string format = "", params object[] args);
         void Fail(string format = "", params object[] args);
     }
@@ -611,13 +617,6 @@ namespace Akka.TestKit.Extensions
     public class static TaskExtensions
     {
         public static System.Threading.Tasks.Task<bool> AwaitWithTimeout(this System.Threading.Tasks.Task parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = null) { }
-        public static System.Threading.Tasks.Task ShouldCompleteWithin<T>(this System.Threading.Tasks.Task<T> task, T expected, System.TimeSpan timeout, string because = "", params object[] becauseArgs) { }
-        public static System.Threading.Tasks.Task<T> ShouldCompleteWithin<T>(this System.Threading.Tasks.Task<T> task, System.TimeSpan timeout, string because = "", params object[] becauseArgs) { }
-        public static System.Threading.Tasks.Task ShouldCompleteWithin(this System.Threading.Tasks.Task task, System.TimeSpan timeout, string because = "", params object[] becauseArgs) { }
-        public static System.Threading.Tasks.Task ShouldThrowWithin<T>(this System.Threading.Tasks.Task task, T expected, System.TimeSpan timeout, string because = "", params object[] becauseArgs)
-            where T : System.Exception { }
-        public static System.Threading.Tasks.Task<T> ShouldThrowWithin<T>(this System.Threading.Tasks.Task task, System.TimeSpan timeout, string because = "", params object[] becauseArgs)
-            where T : System.Exception { }
         public static System.Threading.Tasks.Task<T> WithTimeout<T>(this System.Threading.Tasks.Task<T> parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = null) { }
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.Net.verified.txt
@@ -127,6 +127,12 @@ namespace Akka.TestKit
         void AssertEqual<T>(T expected, T actual, string format = "", params object[] args);
         void AssertEqual<T>(T expected, T actual, System.Func<T, T, bool> comparer, string format = "", params object[] args);
         void AssertFalse(bool condition, string format = "", params object[] args);
+        System.Exception AssertThrows(System.Action action);
+        TException AssertThrows<TException>(System.Action action)
+            where TException : System.Exception;
+        System.Threading.Tasks.Task<System.Exception> AssertThrowsAsync(System.Func<System.Threading.Tasks.Task> action);
+        System.Threading.Tasks.Task<TException> AssertThrowsAsync<TException>(System.Func<System.Threading.Tasks.Task> action)
+            where TException : System.Exception;
         void AssertTrue(bool condition, string format = "", params object[] args);
         void Fail(string format = "", params object[] args);
     }
@@ -611,13 +617,6 @@ namespace Akka.TestKit.Extensions
     public class static TaskExtensions
     {
         public static System.Threading.Tasks.Task<bool> AwaitWithTimeout(this System.Threading.Tasks.Task parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = null) { }
-        public static System.Threading.Tasks.Task ShouldCompleteWithin<T>(this System.Threading.Tasks.Task<T> task, T expected, System.TimeSpan timeout, string because = "", params object[] becauseArgs) { }
-        public static System.Threading.Tasks.Task<T> ShouldCompleteWithin<T>(this System.Threading.Tasks.Task<T> task, System.TimeSpan timeout, string because = "", params object[] becauseArgs) { }
-        public static System.Threading.Tasks.Task ShouldCompleteWithin(this System.Threading.Tasks.Task task, System.TimeSpan timeout, string because = "", params object[] becauseArgs) { }
-        public static System.Threading.Tasks.Task ShouldThrowWithin<T>(this System.Threading.Tasks.Task task, T expected, System.TimeSpan timeout, string because = "", params object[] becauseArgs)
-            where T : System.Exception { }
-        public static System.Threading.Tasks.Task<T> ShouldThrowWithin<T>(this System.Threading.Tasks.Task task, System.TimeSpan timeout, string because = "", params object[] becauseArgs)
-            where T : System.Exception { }
         public static System.Threading.Tasks.Task<T> WithTimeout<T>(this System.Threading.Tasks.Task<T> parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = null) { }
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKitXunit2.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKitXunit2.DotNet.verified.txt
@@ -70,6 +70,12 @@ namespace Akka.TestKit.Xunit2
         public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args) { }
         public void AssertEqual<T>(T expected, T actual, System.Func<T, T, bool> comparer, string format = "", params object[] args) { }
         public void AssertFalse(bool condition, string format = "", params object[] args) { }
+        public System.Exception AssertThrows(System.Action action) { }
+        public TException AssertThrows<TException>(System.Action action)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<System.Exception> AssertThrowsAsync(System.Func<System.Threading.Tasks.Task> action) { }
+        public System.Threading.Tasks.Task<TException> AssertThrowsAsync<TException>(System.Func<System.Threading.Tasks.Task> action)
+            where TException : System.Exception { }
         public void AssertTrue(bool condition, string format = "", params object[] args) { }
         public void Fail(string format = "", params object[] args) { }
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKitXunit2.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKitXunit2.Net.verified.txt
@@ -70,6 +70,12 @@ namespace Akka.TestKit.Xunit2
         public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args) { }
         public void AssertEqual<T>(T expected, T actual, System.Func<T, T, bool> comparer, string format = "", params object[] args) { }
         public void AssertFalse(bool condition, string format = "", params object[] args) { }
+        public System.Exception AssertThrows(System.Action action) { }
+        public TException AssertThrows<TException>(System.Action action)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<System.Exception> AssertThrowsAsync(System.Func<System.Threading.Tasks.Task> action) { }
+        public System.Threading.Tasks.Task<TException> AssertThrowsAsync<TException>(System.Func<System.Threading.Tasks.Task> action)
+            where TException : System.Exception { }
         public void AssertTrue(bool condition, string format = "", params object[] args) { }
         public void Fail(string format = "", params object[] args) { }
     }

--- a/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
@@ -73,7 +73,7 @@ namespace Akka.Cluster.Tests
                         tcs.TrySetResult(true);
                     });
                     _cluster.Join(_selfAddress);
-                    await tcs.Task.ShouldCompleteWithin(10.Seconds());
+                    await tcs.Task.WaitAsync(10.Seconds());
                 });
         }
 
@@ -93,7 +93,7 @@ namespace Akka.Cluster.Tests
                         tcs.TrySetResult(true);
                     });
                     _cluster.Down(_selfAddress);
-                    await tcs.Task.ShouldCompleteWithin(10.Seconds());
+                    await tcs.Task.WaitAsync(10.Seconds());
                 });
         }
     }
@@ -125,9 +125,9 @@ namespace Akka.Cluster.Tests
         public async Task A_cluster_must_not_log_verbose_cluster_events_by_default()
         {
             _cluster.Settings.LogInfoVerbose.ShouldBeFalse();
-            await JoinAsync(upLogMessage).ShouldThrowWithin<XunitException>(11.Seconds());
+            await AssertThrowsAsync<XunitException>(() => JoinAsync(upLogMessage)).WaitAsync(11.Seconds());
             await AwaitUpAsync();
-            await DownAsync(downLogMessage).ShouldThrowWithin<XunitException>(11.Seconds());
+            await AssertThrowsAsync<XunitException>(() => DownAsync(downLogMessage)).WaitAsync(11.Seconds());
         }
     }
 

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -206,7 +206,7 @@ namespace Akka.Cluster.Tests
             var removed = (ClusterEvent.MemberRemoved)await probe.FishForMessageAsync(m => m is ClusterEvent.MemberRemoved);
             removed.PreviousStatus.Should().BeEquivalentTo(MemberStatus.Exiting);
 
-            await leaveTask.ShouldCompleteWithin(RemainingOrDefault);
+            await leaveTask.WaitAsync(RemainingOrDefault);
 
             // A second call for LeaveAsync should complete immediately (should be the same task as before)
             Cluster.Get(sys2).LeaveAsync().IsCompleted.Should().BeTrue();
@@ -236,7 +236,7 @@ namespace Akka.Cluster.Tests
             });
 
             // LeaveAsync() task expected to complete immediately
-            await _cluster.LeaveAsync().ShouldCompleteWithin(RemainingOrDefault);
+            await _cluster.LeaveAsync().WaitAsync(RemainingOrDefault);
         }
 
         [Fact]
@@ -325,14 +325,14 @@ namespace Akka.Cluster.Tests
 
             try
             {
-                await _cluster.JoinAsync(_selfAddress).ShouldCompleteWithin(timeout);
+                await _cluster.JoinAsync(_selfAddress).WaitAsync(timeout);
                 LeaderActions();
                 // Member should already be up
                 _cluster.Subscribe(TestActor, ClusterEvent.InitialStateAsEvents, typeof(ClusterEvent.IMemberEvent));
                 await ExpectMsgAsync<ClusterEvent.MemberUp>();
 
                 // join second time - response should be immediate success
-                await _cluster.JoinAsync(_selfAddress).ShouldCompleteWithin(100.Milliseconds());
+                await _cluster.JoinAsync(_selfAddress).WaitAsync(100.Milliseconds());
             }
             finally
             {
@@ -347,7 +347,7 @@ namespace Akka.Cluster.Tests
                     await task;
                 })
                 .Should().ThrowAsync<ClusterJoinFailedException>()
-                .ShouldCompleteWithin(timeout);
+                .WaitAsync(timeout);
         }
 
         [Fact]
@@ -371,7 +371,7 @@ namespace Akka.Cluster.Tests
                         await task;
                     })
                     .Should().ThrowAsync<ClusterJoinFailedException>()
-                    .ShouldCompleteWithin(15.Seconds());
+                    .WaitAsync(15.Seconds());
             }
             finally
             {
@@ -386,14 +386,14 @@ namespace Akka.Cluster.Tests
 
             try
             {
-                await _cluster.JoinSeedNodesAsync(new[] { _selfAddress }).ShouldCompleteWithin(timeout);
+                await _cluster.JoinSeedNodesAsync(new[] { _selfAddress }).WaitAsync(timeout);
                 LeaderActions();
                 // Member should already be up
                 _cluster.Subscribe(TestActor, ClusterEvent.InitialStateAsEvents, typeof(ClusterEvent.IMemberEvent));
                 await ExpectMsgAsync<ClusterEvent.MemberUp>();
 
                 // join second time - response should be immediate success
-                await _cluster.JoinSeedNodesAsync(new[] { _selfAddress }).ShouldCompleteWithin(100.Milliseconds());
+                await _cluster.JoinSeedNodesAsync(new[] { _selfAddress }).WaitAsync(100.Milliseconds());
             }
             finally
             {
@@ -408,7 +408,7 @@ namespace Akka.Cluster.Tests
                     await ExpectMsgAsync<ClusterEvent.MemberRemoved>();
                 })
                 .Should().ThrowAsync<ClusterJoinFailedException>()
-                .ShouldCompleteWithin(timeout);
+                .WaitAsync(timeout);
         }
 
         [Fact]
@@ -432,7 +432,7 @@ namespace Akka.Cluster.Tests
                         await task;
                     })
                     .Should().ThrowAsync<ClusterJoinFailedException>()
-                    .ShouldCompleteWithin(15.Seconds());
+                    .WaitAsync(15.Seconds());
             }
             finally
             {
@@ -478,7 +478,7 @@ namespace Akka.Cluster.Tests
                 var removed = (ClusterEvent.MemberRemoved)await probe.FishForMessageAsync(m => m is ClusterEvent.MemberRemoved);
                 new [] {MemberStatus.Exiting, MemberStatus.Leaving}.Should().Contain(removed.PreviousStatus);
                 
-                await task.ShouldCompleteWithin(3.Seconds());
+                await task.WaitAsync(3.Seconds());
             }
             finally
             {
@@ -538,7 +538,7 @@ namespace Akka.Cluster.Tests
                 var probe = CreateTestProbe(sys2);
                 Cluster.Get(sys2).Subscribe(probe.Ref, typeof(ClusterEvent.IMemberEvent));
                 await probe.ExpectMsgAsync<ClusterEvent.CurrentClusterState>();
-                await Cluster.Get(sys2).JoinAsync(Cluster.Get(sys2).SelfAddress).ShouldCompleteWithin(10.Seconds());
+                await Cluster.Get(sys2).JoinAsync(Cluster.Get(sys2).SelfAddress).WaitAsync(10.Seconds());
                 await probe.ExpectMsgAsync<ClusterEvent.MemberUp>();
 
                 Cluster.Get(sys2).Leave(Cluster.Get(sys2).SelfAddress);
@@ -547,7 +547,7 @@ namespace Akka.Cluster.Tests
                 // MemberExited might not be published before MemberRemoved
                 var removed = (ClusterEvent.MemberRemoved)await probe.FishForMessageAsync(m => m is ClusterEvent.MemberRemoved);
                 removed.PreviousStatus.Should().BeEquivalentTo(MemberStatus.Exiting);
-                await sys2.WhenTerminated.ShouldCompleteWithin(10.Seconds());
+                await sys2.WhenTerminated.WaitAsync(10.Seconds());
                 Cluster.Get(sys2).IsTerminated.Should().BeTrue();
                 CoordinatedShutdown.Get(sys2).ShutdownReason.Should().BeOfType<CoordinatedShutdown.ClusterLeavingReason>();
             }
@@ -573,14 +573,14 @@ namespace Akka.Cluster.Tests
                 var probe = CreateTestProbe(sys3);
                 Cluster.Get(sys3).Subscribe(probe.Ref, typeof(ClusterEvent.IMemberEvent));
                 await probe.ExpectMsgAsync<ClusterEvent.CurrentClusterState>();
-                await Cluster.Get(sys3).JoinAsync(Cluster.Get(sys3).SelfAddress).ShouldCompleteWithin(10.Seconds());
+                await Cluster.Get(sys3).JoinAsync(Cluster.Get(sys3).SelfAddress).WaitAsync(10.Seconds());
                 await probe.ExpectMsgAsync<ClusterEvent.MemberUp>();
 
                 Cluster.Get(sys3).Down(Cluster.Get(sys3).SelfAddress);
 
                 await probe.ExpectMsgAsync<ClusterEvent.MemberDowned>();
                 await probe.ExpectMsgAsync<ClusterEvent.MemberRemoved>();
-                await sys3.WhenTerminated.ShouldCompleteWithin(10.Seconds());
+                await sys3.WhenTerminated.WaitAsync(10.Seconds());
                 Cluster.Get(sys3).IsTerminated.Should().BeTrue();
                 CoordinatedShutdown.Get(sys3).ShutdownReason.Should().BeOfType<CoordinatedShutdown.ClusterDowningReason>();
             }

--- a/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
@@ -148,7 +148,7 @@ namespace Akka.Remote.Tests.Transport
         private async Task<IActorRef> Here()
         {
             var identity = await Sys.ActorSelection(RootB / "user" / "echo").Ask<ActorIdentity>(new Identify(null))
-                .ShouldCompleteWithin(DefaultTimeout);
+                .WaitAsync(DefaultTimeout);
             return identity.Subject;
         }
 
@@ -159,7 +159,7 @@ namespace Akka.Remote.Tests.Transport
                 Sys.AsInstanceOf<ExtendedActorSystem>().Provider.AsInstanceOf<RemoteActorRefProvider>().Transport;
 
             return transport.ManagementCommand(new SetThrottle(rootBAddress, direction, mode))
-                .ShouldCompleteWithin(DefaultTimeout);
+                .WaitAsync(DefaultTimeout);
         }
 
         private Task<bool> Disassociate()
@@ -169,7 +169,7 @@ namespace Akka.Remote.Tests.Transport
                 Sys.AsInstanceOf<ExtendedActorSystem>().Provider.AsInstanceOf<RemoteActorRefProvider>().Transport;
 
             return transport.ManagementCommand(new ForceDisassociate(rootBAddress))
-                .ShouldCompleteWithin(DefaultTimeout);
+                .WaitAsync(DefaultTimeout);
         }
 
         #endregion
@@ -189,7 +189,7 @@ namespace Akka.Remote.Tests.Transport
             await Throttle(
                     ThrottleTransportAdapter.Direction.Send,
                     new Remote.Transport.TokenBucket(PingPacketSize * 4, BytesPerSecond, 0, 0))
-                .ShouldCompleteWithin(true, TimeSpan.FromSeconds(3));
+                .WaitAsync(TimeSpan.FromSeconds(3));
 
             var here = await Here();
             var tester = Sys.ActorOf(Props.Create(() => new ThrottlingTester(here, TestActor)));
@@ -200,7 +200,7 @@ namespace Akka.Remote.Tests.Transport
             time.Should().BeGreaterThan(TotalTime - 12);
 
             await Throttle(ThrottleTransportAdapter.Direction.Send, Unthrottled.Instance)
-                .ShouldCompleteWithin(true, TimeSpan.FromSeconds(3));
+                .WaitAsync(TimeSpan.FromSeconds(3));
         }
 
         [Fact]
@@ -215,15 +215,15 @@ namespace Akka.Remote.Tests.Transport
             MuteDeadLetters(_systemB, typeof(ThrottlingTester.Lost));
 
             await Throttle(ThrottleTransportAdapter.Direction.Both, Blackhole.Instance)
-                .ShouldCompleteWithin(true, 3.Seconds());
+                .WaitAsync(3.Seconds());
 
             here.Tell(new ThrottlingTester.Lost("BlackHole 2"));
             await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
-            await Disassociate().ShouldCompleteWithin(true, TimeSpan.FromSeconds(3));
+            await Disassociate().WaitAsync(TimeSpan.FromSeconds(3));
             await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
 
             await Throttle(ThrottleTransportAdapter.Direction.Both, Unthrottled.Instance)
-                .ShouldCompleteWithin(true, TimeSpan.FromSeconds(3));
+                .WaitAsync(TimeSpan.FromSeconds(3));
 
             // after we remove the Blackhole we can't be certain of the state
             // of the connection, repeat until success

--- a/src/core/Akka.Streams.TestKit/Akka.Streams.TestKit.csproj
+++ b/src/core/Akka.Streams.TestKit/Akka.Streams.TestKit.csproj
@@ -12,6 +12,10 @@
     <ProjectReference Include="..\Akka.TestKit\Akka.TestKit.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetStandardLibVersion)' ">
+    <PackageReference Include="Polyfill" Version="1.28.0" PrivateAssets="all" />
+  </ItemGroup>
+  
   <ItemGroup>
     <EmbeddedResource Include="reference.conf" />
   </ItemGroup>

--- a/src/core/Akka.Streams.TestKit/Utils.cs
+++ b/src/core/Akka.Streams.TestKit/Utils.cs
@@ -16,8 +16,6 @@ using Akka.Streams.Implementation;
 using Akka.TestKit;
 using Akka.TestKit.Extensions;
 using Akka.Util.Internal;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 
 namespace Akka.Streams.TestKit
 {
@@ -67,15 +65,12 @@ namespace Akka.Streams.TestKit
             TimeSpan? timeout = null,
             CancellationToken cancellationToken = default)
         {
-            timeout ??= 20.Seconds();
-            var result = await block().ShouldCompleteWithin(timeout.Value);
+            timeout ??= TimeSpan.FromSeconds(20);
+            var result = await block().WaitAsync(timeout.Value, cancellationToken);
             if (materializer is not ActorMaterializerImpl impl)
                 return result;
 
             var probe = spec.CreateTestProbe(impl.System);
-            probe.Send(impl.Supervisor, StreamSupervisor.StopChildren.Instance);
-            await probe.ExpectMsgAsync<StreamSupervisor.StoppedChildren>(cancellationToken: cancellationToken);
-
             await probe.WithinAsync(TimeSpan.FromSeconds(5), async () =>
             {
                 IImmutableSet<IActorRef> children = ImmutableHashSet<IActorRef>.Empty;
@@ -83,6 +78,9 @@ namespace Akka.Streams.TestKit
                 {
                     await probe.AwaitAssertAsync(async () =>
                     {
+                        impl.Supervisor.Tell(StreamSupervisor.StopChildren.Instance, probe.Ref);
+                        await probe.ExpectMsgAsync<StreamSupervisor.StoppedChildren>(cancellationToken: cancellationToken);
+                        
                         impl.Supervisor.Tell(StreamSupervisor.GetChildren.Instance, probe.Ref);
                         children = (await probe.ExpectMsgAsync<StreamSupervisor.Children>(cancellationToken: cancellationToken)).Refs;
                         if (children.Count != 0)
@@ -112,13 +110,6 @@ namespace Akka.Streams.TestKit
 
             if (r.Underlying.Props.Dispatcher != dispatcher)
                 throw new Exception($"Expected {@ref} to use dispatcher [{dispatcher}], yet used : [{r.Underlying.Props.Dispatcher}]");
-        }
-
-        [Obsolete("Use ShouldCompleteWithin instead")]
-        public static T AwaitResult<T>(this Task<T> task, TimeSpan? timeout = null)
-        {
-            task.Wait(timeout??TimeSpan.FromSeconds(3)).Should().BeTrue();
-            return task.Result;
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/ActorMaterializerSpec.cs
+++ b/src/core/Akka.Streams.Tests/ActorMaterializerSpec.cs
@@ -45,7 +45,7 @@ namespace Akka.Streams.Tests
 
             m.Shutdown();
 
-            Func<Task> task = () => f.ShouldCompleteWithin(3.Seconds());
+            Func<Task> task = () => f.WaitAsync(3.Seconds());
             await task.Should().ThrowAsync<AbruptTerminationException>();
         }
 

--- a/src/core/Akka.Streams.Tests/BugSpec.cs
+++ b/src/core/Akka.Streams.Tests/BugSpec.cs
@@ -53,7 +53,7 @@ namespace Akka.Streams.Tests
             var readFromStreamTask = StreamConverters.FromInputStream(() => clientPipe, 1)
                 .RunForeach(bs => result.Add(bs.ToString(Encoding.ASCII)), Materializer);
 
-            await Task.WhenAll(writeToStreamTask, readFromStreamTask).ShouldCompleteWithin(3.Seconds());
+            await Task.WhenAll(writeToStreamTask, readFromStreamTask).WaitAsync(3.Seconds());
 
             var expected = Enumerable.Range(0, 100)
                 .SelectMany(i => i == 10 ? Array.Empty<string>() : i.ToString().Select(c => c.ToString()));

--- a/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AsyncEnumerableSpec.cs
@@ -59,7 +59,7 @@ namespace Akka.Streams.Tests.Dsl
                     {
                         cts.Cancel();
                     }
-                }).Should().ThrowAsync<OperationCanceledException>().ShouldCompleteWithin(3.Seconds());
+                }).Should().ThrowAsync<OperationCanceledException>().WaitAsync(3.Seconds());
             }, Materializer);
         }
 
@@ -70,7 +70,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var input = Enumerable.Range(1, 6).ToList();
                 var asyncEnumerable = Source.From(input).RunAsAsyncEnumerable(Materializer);
-                var output = await asyncEnumerable.ToListAsync().AsTask().ShouldCompleteWithin(3.Seconds());
+                var output = await asyncEnumerable.ToListAsync().AsTask().WaitAsync(3.Seconds());
                 output.Should().BeEquivalentTo(input, options => options.WithStrictOrdering());
             }, Materializer);
         }
@@ -83,10 +83,10 @@ namespace Akka.Streams.Tests.Dsl
                 var input = Enumerable.Range(1, 6).ToList();
                 var asyncEnumerable = Source.From(input).RunAsAsyncEnumerable(Materializer);
 
-                var output = await asyncEnumerable.ToListAsync().AsTask().ShouldCompleteWithin(3.Seconds());
+                var output = await asyncEnumerable.ToListAsync().AsTask().WaitAsync(3.Seconds());
                 output.Should().BeEquivalentTo(input, options => options.WithStrictOrdering());
 
-                output = await asyncEnumerable.ToListAsync().AsTask().ShouldCompleteWithin(3.Seconds());
+                output = await asyncEnumerable.ToListAsync().AsTask().WaitAsync(3.Seconds());
                 output.Should().BeEquivalentTo(input, options => options.WithStrictOrdering());
             }, Materializer);
         }
@@ -115,7 +115,7 @@ namespace Akka.Streams.Tests.Dsl
             var thrown = false;
             try
             {
-                await a.ShouldCompleteWithin(10.Seconds());
+                await a.WaitAsync(10.Seconds());
             }
             catch (StreamDetachedException)
             {
@@ -142,7 +142,7 @@ namespace Akka.Streams.Tests.Dsl
                 await foreach (var a in task)
                 {
                 }
-            }).Should().ThrowAsync<IllegalStateException>().ShouldCompleteWithin(3.Seconds());
+            }).Should().ThrowAsync<IllegalStateException>().WaitAsync(3.Seconds());
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/AttributesSpec.cs
@@ -41,7 +41,7 @@ namespace Akka.Streams.Tests.Dsl
                         Keep.Right);
             var task = runnable.Run(Materializer);
 
-            var complete = await task.ShouldCompleteWithin(3.Seconds());
+            var complete = await task.WaitAsync(3.Seconds());
             complete.GetAttribute<Attributes.Name>().Value.Should().Contain("new-name");
         }
 
@@ -60,7 +60,7 @@ namespace Akka.Streams.Tests.Dsl
                 .ToMaterialized(AttributesSink.Create(), Keep.Right)
                 .WithAttributes(Attributes.CreateName("new-name"))
                 .Run(Materializer);
-            var complete = await task.ShouldCompleteWithin(3.Seconds());
+            var complete = await task.WaitAsync(3.Seconds());
             complete.GetAttribute<Attributes.Name>().Value.Should().Contain("attributesSink");
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAggregateAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAggregateAsyncSpec.cs
@@ -61,7 +61,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async() =>
             {
                 var task = AggregateSource.RunWith(Sink.First<int>(), Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Expected);
             }, Materializer);
         }
@@ -72,7 +72,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async() =>
             {
                 var task = InputSource.RunWith(AggregateSink, Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Expected);
             }, Materializer);
         }
@@ -84,7 +84,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async() =>
             {
                 var task = InputSource.Via(AggregateFlow).RunWith(Sink.First<int>(), Materializer);
-                var complete = await task.ShouldCompleteWithin(flowTimeout);
+                var complete = await task.WaitAsync(flowTimeout);
                 complete.Should().Be(Expected);
             }, Materializer);
         }
@@ -95,7 +95,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async() =>
             {
                 var task = AggregateSource.Via(AggregateFlow).RunWith(AggregateSink, Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Expected);
             }, Materializer);
         }
@@ -274,7 +274,7 @@ namespace Akka.Streams.Tests.Dsl
                 var result = await Source.From(tasks)
                     .AggregateAsync(string.Empty, (_, t) => t)
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
-                    .RunWith(Sink.First<string>(), Materializer).ShouldCompleteWithin(3.Seconds());
+                    .RunWith(Sink.First<string>(), Materializer).WaitAsync(3.Seconds());
                     
                 result.Should().Be("happy!");
             }, Materializer);
@@ -294,7 +294,7 @@ namespace Akka.Streams.Tests.Dsl
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                     .Grouped(10)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer)
-                    .ShouldCompleteWithin(3.Seconds());
+                    .WaitAsync(3.Seconds());
                 complete.Should().BeEquivalentTo(2);
             }, Materializer);
         }
@@ -426,7 +426,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var task = Source.From(Enumerable.Empty<int>())
                     .RunAggregateAsync(0, (acc, element) => Task.FromResult(acc + element), Materializer);
-                var complete = await task.ShouldCompleteWithin(RemainingOrDefault);
+                var complete = await task.WaitAsync(RemainingOrDefault);
                 complete.ShouldBe(0);
             }, Materializer);
         }
@@ -438,7 +438,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var task = Source.Single(100)
                     .RunAggregateAsync(5, (acc, element) => Task.FromResult(acc + element), Materializer);
-                var complete = await task.ShouldCompleteWithin(RemainingOrDefault);
+                var complete = await task.WaitAsync(RemainingOrDefault);
                 complete.ShouldBe(105);
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAggregateSpec.cs
@@ -43,7 +43,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async() =>
             {
                 var task = InputSource.RunAggregate(0, (sum, i) => sum + i, Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Expected);
             }, Materializer);
         }
@@ -54,7 +54,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async() =>
             {
                 var task = AggregateSource.RunWith(Sink.First<int>(), Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Expected);
             }, Materializer);
         }
@@ -65,7 +65,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async() =>
             {
                 var task = InputSource.RunWith(AggregateSink, Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Expected);
             }, Materializer);
         }
@@ -76,7 +76,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async() =>
             {
                 var task = InputSource.Via(AggregateFlow).RunWith(Sink.First<int>(), Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Expected);
             }, Materializer);
         }
@@ -87,7 +87,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async() =>
             {
                 var task = AggregateSource.Via(AggregateFlow).RunWith(AggregateSink, Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Expected);
             }, Materializer);
         }
@@ -149,7 +149,7 @@ namespace Akka.Streams.Tests.Dsl
                 var task = InputSource.RunWith(
                     aggregate.WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider)),
                     Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Expected - 50);
             }, Materializer);
         }
@@ -170,7 +170,7 @@ namespace Akka.Streams.Tests.Dsl
                 var task = InputSource.RunWith(
                     aggregate.WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.RestartingDecider)),
                     Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Enumerable.Range(51, 50).Sum());
             }, Materializer);
         }
@@ -182,7 +182,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var task = Source.From(Enumerable.Empty<int>())
                     .RunAggregate(0, (acc, element) => acc + element, Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(0);
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowAskSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowAskSpec.cs
@@ -276,7 +276,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 r.Tell(PoisonPill.Instance);
                 await done;
-            }).ShouldCompleteWithin(RemainingOrDefault);
+            }).WaitAsync(RemainingOrDefault);
             
         }, _materializer);
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowBatchSpec.cs
@@ -88,7 +88,7 @@ namespace Akka.Streams.Tests.Dsl
                     Thread.Sleep(10);
                 return i;
             }).RunAggregate(0, (i, i1) => i + i1, Materializer);
-            var result = await task.ShouldCompleteWithin(10.Seconds());
+            var result = await task.WaitAsync(10.Seconds());
             result.Should().Be(500500);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowFlattenMergeSpec.cs
@@ -55,7 +55,7 @@ namespace Akka.Streams.Tests.Dsl
                 var task = Source.From(new[] {Src10(0), Src10(10), Src10(20), Src10(30)})
                     .MergeMany(4, s => s)
                     .RunWith(ToSet, Materializer);
-                await task.ShouldCompleteWithin(1.Seconds());
+                await task.WaitAsync(1.Seconds());
                 task.Result.Should().BeEquivalentTo(Enumerable.Range(0, 40));
             }, Materializer);
         }
@@ -69,7 +69,7 @@ namespace Akka.Streams.Tests.Dsl
                     .MergeMany(3, s => s)
                     .Take(40)
                     .RunWith(ToSet, Materializer);
-                await task.ShouldCompleteWithin(1.Seconds());
+                await task.WaitAsync(1.Seconds());
                 task.Result.Should().BeEquivalentTo(Enumerable.Range(0, 40));
             }, Materializer);
         }
@@ -84,7 +84,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Take(40)
                     .RunWith(ToSeq, Materializer);
 
-                await task.ShouldCompleteWithin(1.Seconds());
+                await task.WaitAsync(1.Seconds());
 
                 task.Result.Take(30).Should().BeEquivalentTo(Enumerable.Range(0, 30));
                 task.Result.Drop(30).Should().BeEquivalentTo(Enumerable.Range(30, 10));
@@ -101,7 +101,7 @@ namespace Akka.Streams.Tests.Dsl
                     .MergeMany(1, x => x)
                     .RunWith(Sink.First<int>(), Materializer);
 
-                (await Awaiting(() => future.ShouldCompleteWithin(1.Seconds()))
+                (await Awaiting(() => future.WaitAsync(1.Seconds()))
                     .Should().ThrowAsync<TestException>()).And.Should().Be(ex);
             }, Materializer);
         }
@@ -118,7 +118,7 @@ namespace Akka.Streams.Tests.Dsl
                     .MergeMany(10, x => x)
                     .RunWith(Sink.First<int>(), Materializer);
 
-                (await Awaiting(() => future.ShouldCompleteWithin(1.Seconds()))
+                (await Awaiting(() => future.WaitAsync(1.Seconds()))
                     .Should().ThrowAsync<TestException>()).And.Should().Be(ex);
             }, Materializer);
         }
@@ -138,7 +138,7 @@ namespace Akka.Streams.Tests.Dsl
                     })
                     .RunWith(Sink.First<int>(), Materializer);
 
-                (await Awaiting(() => future.ShouldCompleteWithin(1.Seconds()))
+                (await Awaiting(() => future.WaitAsync(1.Seconds()))
                     .Should().ThrowAsync<TestException>()).And.Should().Be(ex);
             }, Materializer);
         }
@@ -153,7 +153,7 @@ namespace Akka.Streams.Tests.Dsl
                     .MergeMany(10, x => x)
                     .RunWith(Sink.First<int>(), Materializer);
 
-                (await Awaiting(() => future.ShouldCompleteWithin(1.Seconds()))
+                (await Awaiting(() => future.WaitAsync(1.Seconds()))
                     .Should().ThrowAsync<TestException>()).And.Should().Be(ex);
             }, Materializer);
         }
@@ -334,7 +334,7 @@ namespace Akka.Streams.Tests.Dsl
                     .AddAttributes(Attributes.CreateName("outer"))
                     .RunWith(Sink.First<Attributes>(), Materializer);
 
-                var attributes = (await task.ShouldCompleteWithin(3.Seconds())).AttributeList.ToList();
+                var attributes = (await task.WaitAsync(3.Seconds())).AttributeList.ToList();
                 var innerName = new Attributes.Name("inner");
                 var outerName = new Attributes.Name("outer");
 
@@ -355,7 +355,7 @@ namespace Akka.Streams.Tests.Dsl
                     .MergeMany(4, _ => Source.FromGraph(new FailingInnerMat(matFail)))
                     .RunWith(Sink.Ignore<string>(), Materializer);
 
-                await task.ShouldThrowWithin(matFail, 1.Seconds());
+                await AssertThrowsAsync(async () => await task).WaitAsync(1.Seconds());
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowGroupBySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowGroupBySpec.cs
@@ -101,7 +101,7 @@ namespace Akka.Streams.Tests.Dsl
                     ((Source<IEnumerable<IEnumerable<string>>, NotUsed>)source).RunWith(
                         Sink.First<IEnumerable<IEnumerable<string>>>(), Materializer);
 
-                await task.ShouldCompleteWithin(3.Seconds());
+                await task.WaitAsync(3.Seconds());
                 task.Result.OrderBy(e => e.First())
                     .Should().BeEquivalentTo(new[] { "Aaa", "Abb" }, new[] { "Bcc" }, new[] { "Cdd", "Cee" });
             }, Materializer);
@@ -426,7 +426,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Select(t => t.Item2)
                     .ConcatSubstream();
                 var futureGroupSource = source.RunWith(Sink.First<Source<int, NotUsed>>(), Materializer);
-                await futureGroupSource.ShouldCompleteWithin(3.Seconds());
+                await futureGroupSource.WaitAsync(3.Seconds());
                 var publisher = futureGroupSource.Result.RunWith(Sink.AsPublisher<int>(false), Materializer);
                 
                 var probe = this.CreateSubscriberProbe<int>();
@@ -732,7 +732,7 @@ namespace Akka.Streams.Tests.Dsl
                     }
                     else
                     {
-                        var probe = await props.Probes[props.ProbesReaderTop].Task.ShouldCompleteWithin(3.Seconds());
+                        var probe = await props.Probes[props.ProbesReaderTop].Task.WaitAsync(3.Seconds());
                         props.ProbesReaderTop++;
                         map[index] = new SubFlowState(probe, false, byteString);
                         //stream automatically requests next element 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowOrElseSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowOrElseSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var sink = Sink.Seq<int>();
 
-            var complete = await source1.OrElse(source2).RunWith(sink, Materializer).ShouldCompleteWithin(3.Seconds());
+            var complete = await source1.OrElse(source2).RunWith(sink, Materializer).WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(new[] { 1, 2, 3 });
         }
 
@@ -50,7 +50,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var sink = Sink.Seq<int>();
 
-            var complete = await source1.OrElse(source2).RunWith(sink, Materializer).ShouldCompleteWithin(3.Seconds());
+            var complete = await source1.OrElse(source2).RunWith(sink, Materializer).WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(new[] { 4, 5, 6 });
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowScanAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowScanAsyncSpec.cs
@@ -68,7 +68,7 @@ namespace Akka.Streams.Tests.Dsl
             var eventualActual = Source.From(elements)
                 .ScanAsync(0L, (l, l1) => Task.FromResult(l + l1))
                 .RunWith(Sink.Last<long>(), Materializer);
-            var complete = await eventualActual.ShouldCompleteWithin(3.Seconds());
+            var complete = await eventualActual.WaitAsync(3.Seconds());
             complete.ShouldBe(expectedSum);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncSpec.cs
@@ -124,7 +124,7 @@ namespace Akka.Streams.Tests.Dsl
                 await c.ExpectNextNAsync(Enumerable.Range(1, 13));
             
                 await c.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
-            }, Materializer).ShouldCompleteWithin(RemainingOrDefault);
+            }, Materializer).WaitAsync(RemainingOrDefault);
         }
 
         // Turning this on in CI/CD for now
@@ -150,7 +150,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 var exception = await c.ExpectErrorAsync();
                 exception.InnerException!.Message.Should().Be("err1");
-            }, Materializer).ShouldCompleteWithin(RemainingOrDefault);
+            }, Materializer).WaitAsync(RemainingOrDefault);
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Request(10)
                     .ExpectNextN([1, 2])
                     .ExpectErrorAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
                 exception.Message.Should().Be("err1");
             }, Materializer);
         }
@@ -205,7 +205,7 @@ namespace Akka.Streams.Tests.Dsl
                 await Awaiting(async () => await done).Should()
                     .ThrowAsync<Exception>()
                     .WithMessage("err1")
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
                 
                 latch.CountDown();
             }, Materializer);
@@ -509,7 +509,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Grouped(10)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
                 
-                var complete = await t.ShouldCompleteWithin(3.Seconds());
+                var complete = await t.WaitAsync(3.Seconds());
                 complete.Should().BeEquivalentTo(new[] { 1, 2 });
             }, Materializer);
         }
@@ -732,7 +732,7 @@ namespace Akka.Streams.Tests.Dsl
                         return 1;
                     })
                     .RunAggregate(0, (acc, i) => acc + i, Materializer)
-                    .ShouldCompleteWithin(3.Seconds());
+                    .WaitAsync(3.Seconds());
 
                 result.Should().Be(n);
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSelectAsyncUnorderedSpec.cs
@@ -240,7 +240,7 @@ namespace Akka.Streams.Tests.Dsl
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                     .RunWith(Sink.First<string>(), Materializer);
 
-                var complete = await t.ShouldCompleteWithin(3.Seconds());
+                var complete = await t.WaitAsync(3.Seconds());
                 complete.Should().Be("happy");
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSpec.cs
@@ -389,7 +389,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Limit(100)
                     .RunWith(Sink.Seq<int>(), Materializer);
 
-                await task.ShouldCompleteWithin(3.Seconds());
+                await task.WaitAsync(3.Seconds());
                 task.Result.Should().BeEquivalentTo(Enumerable.Range(1,10));
 
                 // Reusable:
@@ -398,7 +398,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Limit(100)
                     .RunWith(Sink.Seq<int>(), Materializer);
 
-                await task.ShouldCompleteWithin(3.Seconds());
+                await task.WaitAsync(3.Seconds());
                 task.Result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
@@ -682,7 +682,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Via(Flow.FromFunction<int, int>(i => i + 1))
                     .RunWith(Sink.Seq<int>(), Materializer);
                 
-                await task.ShouldCompleteWithin(3.Seconds());
+                await task.WaitAsync(3.Seconds());
                 task.Result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
@@ -780,7 +780,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ToMaterialized(Sink.First<int>(), Keep.Right);
                 
                 var task = Source.Single(4711).RunWith(sink, noFusingMaterializer);
-                await task.ShouldCompleteWithin(3.Seconds());
+                await task.WaitAsync(3.Seconds());
                 task.Result.Should().Be(4712);
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSplitWhenSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSplitWhenSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Pattern;
 using Akka.Streams.Dsl;
@@ -136,7 +137,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.FirstOrDefault<IEnumerable<int>>(), Materializer);
                 result.Should().BeEquivalentTo(default(IEnumerable<int>));
             }, Materializer)
-                .ShouldCompleteWithin(RemainingOrDefault);
+                .WaitAsync(RemainingOrDefault);
         }
 
         [Fact]
@@ -158,8 +159,7 @@ namespace Akka.Streams.Tests.Dsl
                         masterSubscription.Request(1);
                         await masterSubscriber.ExpectCompleteAsync();
                     });
-            }, Materializer)
-                .ShouldCompleteWithin(RemainingOrDefault);
+            }, Materializer);
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace Akka.Streams.Tests.Dsl
                         await masterSubscriber.ExpectCompleteAsync();
                     });
             }, Materializer)
-                .ShouldCompleteWithin(RemainingOrDefault);
+                .WaitAsync(RemainingOrDefault);
         }
 
         [Fact]
@@ -257,7 +257,7 @@ namespace Akka.Streams.Tests.Dsl
                 masterStream3.Cancel();
                 await inputs3.ExpectCancellationAsync();
             }, Materializer)
-                .ShouldCompleteWithin(RemainingOrDefault);
+                .WaitAsync(RemainingOrDefault);
         }
 
         [Fact]
@@ -278,9 +278,8 @@ namespace Akka.Streams.Tests.Dsl
                         await s1.ExpectNextAsync(4);
                         s1.Request(1);
                         await s1.ExpectCompleteAsync();
-                    });
-            }, Materializer)
-                .ShouldCompleteWithin(RemainingOrDefault);
+                    }).WaitAsync(TimeSpan.FromSeconds(3));
+            }, Materializer);
         }
 
         [Fact]
@@ -320,7 +319,7 @@ namespace Akka.Streams.Tests.Dsl
                 await substreamPuppet.ExpectErrorAsync(ex);
                 await upstreamSubscription.ExpectCancellationAsync();
             }, Materializer)
-                .ShouldCompleteWithin(RemainingOrDefault);
+                .WaitAsync(RemainingOrDefault);
         }
 
         [Fact]
@@ -335,7 +334,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
                 result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
             }, Materializer)
-                .ShouldCompleteWithin(RemainingOrDefault);
+                .WaitAsync(RemainingOrDefault);
         }
 
         [LocalFact(SkipLocal = "Racy on Azure DevOps")]
@@ -360,7 +359,7 @@ namespace Akka.Streams.Tests.Dsl
                             .RunWith(Sink.Ignore<int>(), Materializer)
                     ).Should().ThrowAsync<IllegalStateException>();
                 }, Materializer)
-                .ShouldCompleteWithin(RemainingOrDefault);
+                .WaitAsync(RemainingOrDefault);
         }
 
         [Fact]
@@ -386,7 +385,7 @@ namespace Akka.Streams.Tests.Dsl
                         .RunWith(Sink.Ignore<int>(), tightTimeoutMaterializer);
                 }).Should().ThrowAsync<SubscriptionTimeoutException>();
             }, Materializer)
-                .ShouldCompleteWithin(RemainingOrDefault);
+                .WaitAsync(RemainingOrDefault);
         }
 
         [Fact(Skip = "Supervision is not supported fully by GraphStages yet")]
@@ -413,7 +412,7 @@ namespace Akka.Streams.Tests.Dsl
                 var upSub = await up.ExpectSubscriptionAsync();
                 await upSub.ExpectCancellationAsync();
             }, Materializer)
-                .ShouldCompleteWithin(RemainingOrDefault);
+                .WaitAsync(RemainingOrDefault);
         }
 
         [Fact]
@@ -430,7 +429,7 @@ namespace Akka.Streams.Tests.Dsl
                         await masterSubscriber.ExpectCompleteAsync();
                     });
             }, Materializer)
-                .ShouldCompleteWithin(RemainingOrDefault);
+                .WaitAsync(RemainingOrDefault);
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowSumSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowSumSpec.cs
@@ -147,7 +147,7 @@ namespace Akka.Streams.Tests.Dsl
                 var task = InputSource.RunWith(
                     sum.WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider)),
                     Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Expected - 50);
             }, Materializer);
         }
@@ -168,7 +168,7 @@ namespace Akka.Streams.Tests.Dsl
                 var task = InputSource.RunWith(
                     sum.WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.RestartingDecider)),
                     Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Be(Enumerable.Range(51, 50).Sum());
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowThrottleSpec.cs
@@ -68,7 +68,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(1, 2, 4, 5)
                     .ExpectComplete()
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
             }, Materializer);
         }
         
@@ -84,7 +84,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(1, 2, 3, 4, 5)
                     .ExpectComplete()
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
             }, Materializer);
         }
 
@@ -100,7 +100,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(1, 2, 3, 4, 5)                                                                             
                     .ExpectComplete()
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
             }, Materializer);
         }
 
@@ -116,7 +116,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(1)
                     .ExpectNoMsg(TimeSpan.FromMilliseconds(100))
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
                 probe.Cancel();
             }, Materializer);
         }
@@ -133,7 +133,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Via(sharedThrottle)
                     .Via(sharedThrottle)
                     .RunWith(Sink.First<int>(), Materializer)
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
                 t.Should().Be(1);
 
                 // It works with a new stream, too
@@ -141,7 +141,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Via(sharedThrottle)
                     .Via(sharedThrottle)
                     .RunWith(Sink.First<int>(), Materializer)
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
                 t.Should().Be(2);
             }, Materializer);
         }
@@ -225,7 +225,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNoMsg(TimeSpan.FromMilliseconds(150))
                     .ExpectNext(4)
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
                 probe.Cancel();
                 // assertion may take longer then the throttle and therefore the next assertion fails
                 result.Should().BeEquivalentTo(new[] { new OnNext(1), new OnNext(2) });
@@ -324,7 +324,7 @@ namespace Akka.Streams.Tests.Dsl
                 var t1 = await Source.From(Enumerable.Range(1, 5))
                     .Throttle(1, TimeSpan.FromMilliseconds(200), 5, ThrottleMode.Enforcing)
                     .RunWith(Sink.Seq<int>(), Materializer) // Burst is 5 so this will not fail
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
                 t1.Should().BeEquivalentTo(Enumerable.Range(1, 5));
 
                 await Awaiting(async () =>
@@ -333,7 +333,7 @@ namespace Akka.Streams.Tests.Dsl
                             .Throttle(1, TimeSpan.FromMilliseconds(200), 5, ThrottleMode.Enforcing)
                             .RunWith(Sink.Ignore<int>(), Materializer);
                     }).Should().ThrowAsync<OverflowException>()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
             }, Materializer);
         }
 
@@ -351,7 +351,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(1, 2, 3, 4, 5)                                                                             
                     .ExpectComplete()
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
             }, Materializer);
         }
 
@@ -367,7 +367,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(1, 2, 3, 4, 5)                                                                             
                     .ExpectComplete()
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
             }, Materializer);
         }
 
@@ -391,7 +391,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(list[3])
                     .ExpectComplete()
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
             }, Materializer);
         }
 
@@ -450,7 +450,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNoMsg(TimeSpan.FromMilliseconds(100))
                     .ExpectNext(4)
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
                 probe.Cancel();
                 
                 // assertion may take longer then the throttle and therefore the next assertion fails
@@ -548,7 +548,7 @@ namespace Akka.Streams.Tests.Dsl
                 var t1 = await Source.From(Enumerable.Range(1, 4))
                     .Throttle(2, TimeSpan.FromMilliseconds(200), 10, x => x, ThrottleMode.Enforcing)
                     .RunWith(Sink.Seq<int>(), Materializer)
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
                 t1.Should().BeEquivalentTo(Enumerable.Range(1, 4)); // Burst is 10 so this will not fail
 
                 await Awaiting(async () =>
@@ -557,7 +557,7 @@ namespace Akka.Streams.Tests.Dsl
                             .Throttle(2, TimeSpan.FromMilliseconds(200), 5, x => x, ThrottleMode.Enforcing)
                             .RunWith(Sink.Ignore<int>(), Materializer);
                     }).Should().ThrowAsync<OverflowException>()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
             }, Materializer);
         }
 
@@ -574,7 +574,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectNext(1, 2, 3, 4, 5)
                     .ExpectComplete()
                     .ExecuteAsync()
-                    .ShouldCompleteWithin(RemainingOrDefault);
+                    .WaitAsync(RemainingOrDefault);
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FramingSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FramingSpec.cs
@@ -204,7 +204,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Grouped(1000)
                     .RunWith(Sink.First<IEnumerable<string>>(), Materializer);
 
-            var complete = await task.ShouldCompleteWithin(3.Seconds());
+            var complete = await task.WaitAsync(3.Seconds());
             complete.Should().ContainSingle(s => s.Equals("I have no end"));
         }
 
@@ -443,7 +443,7 @@ namespace Akka.Streams.Tests.Dsl
             await Awaiting(async () => await result)
                 .Should().ThrowAsync<Framing.FramingException>()
                 .WithMessage("Decoded frame header reported negative size -4")
-                .ShouldCompleteWithin(3.Seconds());
+                .WaitAsync(3.Seconds());
         }
         
         [Fact]
@@ -459,7 +459,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Via(Flow.Create<ByteString>().Via(Framing.LengthField(4, 0, 1000, ByteOrder.LittleEndian, ComputeFrameSize)))
                 .RunWith(Sink.Seq<ByteString>(), Materializer);
 
-            var complete = await result.ShouldCompleteWithin(3.Seconds());
+            var complete = await result.WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(ImmutableArray.Create(bs));
         }
         
@@ -478,7 +478,7 @@ namespace Akka.Streams.Tests.Dsl
             await Awaiting(async () => await result)
                 .Should().ThrowAsync<Framing.FramingException>()
                 .WithMessage("Computed frame size 3 is less than minimum chunk size 4")
-                .ShouldCompleteWithin(3.Seconds());
+                .WaitAsync(3.Seconds());
         }
 
         [Fact]
@@ -494,7 +494,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Via(Flow.Create<ByteString>().Via(Framing.LengthField(4, 1000)))
                 .RunWith(Sink.Seq<ByteString>(), Materializer);
 
-            var complete = await result.ShouldCompleteWithin(3.Seconds());
+            var complete = await result.WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(bytes.ToImmutableList());
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/FutureFlattenSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FutureFlattenSourceSpec.cs
@@ -45,8 +45,8 @@ namespace Akka.Streams.Tests.Dsl
                     .Run(_materializer);
 
                 // wait until the underlying task is completed
-                await sourceMatVal.ShouldCompleteWithin(3.Seconds());
-                await sinkMatVal.ShouldCompleteWithin(3.Seconds());
+                await sourceMatVal.WaitAsync(3.Seconds());
+                await sinkMatVal.WaitAsync(3.Seconds());
 
                 // should complete as soon as inner source has been materialized
                 sourceMatVal.Result.Should().Be("foo");
@@ -90,8 +90,8 @@ namespace Akka.Streams.Tests.Dsl
                 sourcePromise.SetResult(Underlying);
 
                 // wait until the underlying task is completed
-                await sourceMatVal.ShouldCompleteWithin(3.Seconds());
-                await sinkMatVal.ShouldCompleteWithin(3.Seconds());
+                await sourceMatVal.WaitAsync(3.Seconds());
+                await sinkMatVal.WaitAsync(3.Seconds());
                 
                 // should complete as soon as inner source has been materialized
                 sourceMatVal.Result.Should().Be("foo");
@@ -125,7 +125,10 @@ namespace Akka.Streams.Tests.Dsl
                 sourcePromise.SetResult(Underlying);
                 
                 // wait until the underlying task is completed
-                var ex = await sourceMatVal.ShouldThrowWithin<StreamDetachedException>(3.Seconds());
+                var task = AssertThrowsAsync<StreamDetachedException>(() => sourceMatVal);
+                await task.WaitAsync(3.Seconds());
+
+                var ex = task.Result;
                 ex.Message.Should().Be("Stream cancelled before Source Task completed");
             }, _materializer);
         }
@@ -143,8 +146,8 @@ namespace Akka.Streams.Tests.Dsl
                     .Run(_materializer);
 
                 // wait until the underlying task is completed
-                await sourceMatVal.ShouldThrowWithin(failure, 3.Seconds());
-                await sinkMatVal.ShouldThrowWithin(failure, 3.Seconds());
+                await AssertThrowsAsync(() => sourceMatVal, failure).WaitAsync(3.Seconds());
+                await AssertThrowsAsync(() => sinkMatVal, failure).WaitAsync(3.Seconds());
             }, _materializer);
         }
 
@@ -171,8 +174,8 @@ namespace Akka.Streams.Tests.Dsl
                 sourcePromise.SetException(failure);
                 
                 // wait until the underlying tasks are completed
-                await sourceMatVal.ShouldThrowWithin(failure, 3.Seconds());
-                await sinkMatVal.ShouldThrowWithin(failure, 3.Seconds());
+                await AssertThrowsAsync(() => sourceMatVal, failure).WaitAsync(3.Seconds());
+                await AssertThrowsAsync(() => sinkMatVal, failure).WaitAsync(3.Seconds());
             }, _materializer);
         }
 
@@ -193,7 +196,7 @@ namespace Akka.Streams.Tests.Dsl
                 sourcePromise.SetException(failure);
                 
                 // wait until the underlying tasks are completed
-                await sourceMatVal.ShouldThrowWithin(failure, 3.Seconds());
+                await AssertThrowsAsync(() => sourceMatVal, failure).WaitAsync(3.Seconds());
             }, _materializer);
         }
 
@@ -213,7 +216,7 @@ namespace Akka.Streams.Tests.Dsl
                 await subscriber.EnsureSubscriptionAsync();
                 sourcePromise.SetResult(Source.FromPublisher(publisher).MapMaterializedValue(_ => "woho"));
 
-                await matVal.ShouldCompleteWithin(3.Seconds());
+                await matVal.WaitAsync(3.Seconds());
                 // materialized value completes but still no demand
                 matVal.Result.Should().Be("woho");
 
@@ -243,7 +246,7 @@ namespace Akka.Streams.Tests.Dsl
                 await subscriber.EnsureSubscriptionAsync();
                 sourcePromise.SetResult(Source.FromPublisher(publisher).MapMaterializedValue(_ => "woho"));
 
-                await matVal.ShouldCompleteWithin(3.Seconds());
+                await matVal.WaitAsync(3.Seconds());
                 // materialized value completes but still no demand
                 matVal.Result.Should().Be("woho");
 
@@ -265,8 +268,8 @@ namespace Akka.Streams.Tests.Dsl
                 var (innerSourceMat, outerSinkMat) = Source.FromTaskSource(inner).ToMaterialized(Sink.Seq<int>(), Keep.Both).Run(_materializer);
 
                 // wait until the underlying tasks are completed
-                await outerSinkMat.ShouldThrowWithin(FailingMatGraphStage.Exception, 3.Seconds());
-                await innerSourceMat.ShouldThrowWithin(FailingMatGraphStage.Exception, 3.Seconds());
+                await AssertThrowsAsync(() => outerSinkMat, FailingMatGraphStage.Exception).WaitAsync(3.Seconds());
+                await AssertThrowsAsync(() => innerSourceMat, FailingMatGraphStage.Exception).WaitAsync(3.Seconds());
             }, _materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/GraphMergeSortedSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/GraphMergeSortedSpec.cs
@@ -63,7 +63,7 @@ namespace Akka.Streams.Tests.Dsl
                     .Concat(Source.Single<IEnumerable<int>>(new List<int>()))
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().BeEquivalentTo(Enumerable.Range(0, n), o => o.WithStrictOrdering());
             }
         }
@@ -75,7 +75,7 @@ namespace Akka.Streams.Tests.Dsl
                     .MergeSorted(Source.From(new[] { 0, 1, 2, 7 }), (l, r) => 2 * l.CompareTo(r))
                     .RunWith(Sink.Seq<int>(), Materializer);
 
-            var complete = await task.ShouldCompleteWithin(3.Seconds());
+            var complete = await task.WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(new[] { 0, 1, 1, 2, 5, 7 }, o => o.WithStrictOrdering());
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -46,7 +46,7 @@ namespace Akka.Streams.Tests.Dsl
                 Source.From(Enumerable.Range(1, 10)).RunWith(sink, Materializer);
                 Source.From(Enumerable.Range(11, 10)).RunWith(sink, Materializer);
 
-                var result = await task.ShouldCompleteWithin(3.Seconds());
+                var result = await task.WaitAsync(3.Seconds());
                 result.OrderBy(x => x).Should().BeEquivalentTo(Enumerable.Range(1, 20));
             }, Materializer);
         }
@@ -79,7 +79,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectCancellation()
                     .ExecuteAsync();
                 
-                var result = await task.ShouldCompleteWithin(3.Seconds());
+                var result = await task.WaitAsync(3.Seconds());
                 result.Should().BeEquivalentTo(Enumerable.Range(1, 5));
             }, Materializer);
         }
@@ -99,7 +99,7 @@ namespace Akka.Streams.Tests.Dsl
                     .ExpectCancellation()
                     .ExecuteAsync();
 
-                var result = await task.ShouldCompleteWithin(3.Seconds());
+                var result = await task.WaitAsync(3.Seconds());
                 result.Should().BeEquivalentTo(Enumerable.Range(1, 5));
 
                 Source.FromPublisher(upstream2).RunWith(sink, Materializer);
@@ -176,7 +176,7 @@ namespace Akka.Streams.Tests.Dsl
                 Source.From(Enumerable.Range(1, 10000)).RunWith(sink, Materializer);
                 Source.From(Enumerable.Range(10001, 10000)).RunWith(sink, Materializer);
 
-                var result = await task.ShouldCompleteWithin(3.Seconds());
+                var result = await task.WaitAsync(3.Seconds());
                 result.OrderBy(x => x).Should().BeEquivalentTo(Enumerable.Range(1, 20000));
             }, Materializer);
         }
@@ -213,7 +213,7 @@ namespace Akka.Streams.Tests.Dsl
                 Source.From(Enumerable.Range(1, 1000)).RunWith(sink, Materializer);
                 Source.From(Enumerable.Range(1001, 1000)).RunWith(sink, Materializer);
 
-                var result = await task.ShouldCompleteWithin(3.Seconds());
+                var result = await task.WaitAsync(3.Seconds());
                 result.OrderBy(x => x).Should().BeEquivalentTo(Enumerable.Range(1, 2000));
 
             }, Materializer);
@@ -232,7 +232,7 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(sink, Materializer);
                 Source.From(Enumerable.Range(1001, 1000)).RunWith(sink, Materializer);
 
-                var result = await task.ShouldCompleteWithin(3.Seconds());
+                var result = await task.WaitAsync(3.Seconds());
                 result.OrderBy(x => x).Should().BeEquivalentTo(Enumerable.Range(1, 2000));
             }, Materializer);
         }
@@ -271,7 +271,7 @@ namespace Akka.Streams.Tests.Dsl
                         {
                             Source.Failed<int>(new TestException("failing")).RunWith(sink, Materializer);
                             Source.From(Enumerable.Range(1, 10)).RunWith(sink, Materializer);
-                            var result = await task.ShouldCompleteWithin(3.Seconds());
+                            var result = await task.WaitAsync(3.Seconds());
                             result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
                         });
                 });
@@ -301,7 +301,7 @@ namespace Akka.Streams.Tests.Dsl
                         {
                             Source.Failed<int>(ActorPublisher.NormalShutdownReason).RunWith(sink, Materializer);
                             Source.From(Enumerable.Range(1, 10)).RunWith(sink, Materializer);
-                            var result = await task.ShouldCompleteWithin(3.Seconds());
+                            var result = await task.WaitAsync(3.Seconds());
                             result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
                         });
                 });
@@ -314,7 +314,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async () =>
             {
                 var source = Source.From(Enumerable.Range(1, 10)).RunWith(BroadcastHub.Sink<int>(8), Materializer);
-                var result = await source.RunWith(Sink.Seq<int>(), Materializer).ShouldCompleteWithin(3.Seconds());
+                var result = await source.RunWith(Sink.Seq<int>(), Materializer).WaitAsync(3.Seconds());
                 result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
@@ -338,8 +338,8 @@ namespace Akka.Streams.Tests.Dsl
                 await Task.Delay(500);
                 
                 firstElement.SetResult(1);
-                (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
-                (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await f1.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await f2.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
 
@@ -362,8 +362,8 @@ namespace Akka.Streams.Tests.Dsl
                 await Task.Delay(500);
                 
                 firstElement.SetResult(1);
-                (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 20));
-                (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await f1.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 20));
+                (await f2.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
 
@@ -373,9 +373,9 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async () =>
             {
                 var source = Source.From(Enumerable.Range(1, 20)).RunWith(BroadcastHub.Sink<int>(8), Materializer);
-                (await source.Take(10).RunWith(Sink.Seq<int>(), Materializer).ShouldCompleteWithin(3.Seconds()))
+                (await source.Take(10).RunWith(Sink.Seq<int>(), Materializer).WaitAsync(3.Seconds()))
                     .Should().BeEquivalentTo(Enumerable.Range(1, 10));
-                (await source.Take(10).RunWith(Sink.Seq<int>(), Materializer).ShouldCompleteWithin(3.Seconds()))
+                (await source.Take(10).RunWith(Sink.Seq<int>(), Materializer).WaitAsync(3.Seconds()))
                     .Should().BeEquivalentTo(Enumerable.Range(11, 10));
             }, Materializer);
         }
@@ -400,8 +400,8 @@ namespace Akka.Streams.Tests.Dsl
                 await Task.Delay(500);
                 
                 firstElement.SetResult(1);
-                (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
-                (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await f1.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await f2.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
 
@@ -425,8 +425,8 @@ namespace Akka.Streams.Tests.Dsl
                 await Task.Delay(500);
                 
                 firstElement.SetResult(1);
-                (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
-                (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await f1.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await f2.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
 
@@ -454,8 +454,8 @@ namespace Akka.Streams.Tests.Dsl
                 await Task.Delay(500);
                 
                 firstElement.SetResult(1);
-                (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 20));
-                (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 20));
+                (await f1.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 20));
+                (await f2.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 20));
             }, Materializer);
         }
 
@@ -478,8 +478,8 @@ namespace Akka.Streams.Tests.Dsl
                 await Task.Delay(500);
                 
                 firstElement.SetResult(1);
-                (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
-                (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await f1.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
+                (await f2.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
 
@@ -515,7 +515,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 await downstream.CancelAsync();
                 killSwitch.Shutdown();
-                await ignoredTask.ShouldCompleteWithin(3.Seconds());
+                await ignoredTask.WaitAsync(3.Seconds());
             }, Materializer);
         }
 
@@ -592,7 +592,7 @@ namespace Akka.Streams.Tests.Dsl
                 // cases should work in the end
                 await Task.Delay(50);
 
-                (await source.RunWith(Sink.Seq<int>(), Materializer).ShouldCompleteWithin(3.Seconds()))
+                (await source.RunWith(Sink.Seq<int>(), Materializer).WaitAsync(3.Seconds()))
                     .Should().BeEmpty();
             }, Materializer);
         }
@@ -611,7 +611,7 @@ namespace Akka.Streams.Tests.Dsl
                 await Awaiting(async () =>
                 {
                     await source.RunWith(Sink.Seq<int>(), Materializer);
-                }).Should().ThrowAsync<TestException>().ShouldCompleteWithin(3.Seconds());
+                }).Should().ThrowAsync<TestException>().WaitAsync(3.Seconds());
             }, Materializer);
         }
 
@@ -655,7 +655,7 @@ namespace Akka.Streams.Tests.Dsl
                 var items = Enumerable.Range(1, 10).ToList();
                 var source = Source.From(items)
                     .RunWith(PartitionHub.Sink<int>((_, _) => 0, 0, 8), Materializer);
-                var result = await source.RunWith(Sink.Seq<int>(), Materializer).ShouldCompleteWithin(3.Seconds());
+                var result = await source.RunWith(Sink.Seq<int>(), Materializer).WaitAsync(3.Seconds());
                 result.Should().BeEquivalentTo(items);
             }, Materializer);
         }
@@ -673,8 +673,8 @@ namespace Akka.Streams.Tests.Dsl
                 await Task.Delay(50);
                 var result2 = source.RunWith(Sink.Seq<int>(), Materializer);
                 
-                (await result1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(new[] { 0, 2, 4, 6, 8 });
-                (await result2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(new[] { 1, 3, 5, 7, 9 });
+                (await result1.WaitAsync(3.Seconds())).Should().BeEquivalentTo(new[] { 0, 2, 4, 6, 8 });
+                (await result2.WaitAsync(3.Seconds())).Should().BeEquivalentTo(new[] { 1, 3, 5, 7, 9 });
             }, Materializer);
         }
 
@@ -697,8 +697,8 @@ namespace Akka.Streams.Tests.Dsl
                 var result1 = source.RunWith(Sink.Seq<int>(), Materializer);
                 var result2 = source.RunWith(Sink.Seq<int>(), Materializer);
                 
-                (await result1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(new[] { 1, 3, 5, 7, 9 });
-                (await result2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(new[] { 0, 2, 4, 6, 8 });
+                (await result1.WaitAsync(3.Seconds())).Should().BeEquivalentTo(new[] { 1, 3, 5, 7, 9 });
+                (await result2.WaitAsync(3.Seconds())).Should().BeEquivalentTo(new[] { 0, 2, 4, 6, 8 });
             }, Materializer);
         }
 
@@ -726,8 +726,8 @@ namespace Akka.Streams.Tests.Dsl
                 var result1 = source.RunWith(Sink.Seq<string>(), Materializer);
                 var result2 = source.RunWith(Sink.Seq<string>(), Materializer);
                 
-                (await result1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo("usr-2");
-                (await result2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo("usr-1", "usr-1", "usr-3");
+                (await result1.WaitAsync(3.Seconds())).Should().BeEquivalentTo("usr-2");
+                (await result2.WaitAsync(3.Seconds())).Should().BeEquivalentTo("usr-1", "usr-1", "usr-3");
             }, Materializer);
         }
 
@@ -745,8 +745,8 @@ namespace Akka.Streams.Tests.Dsl
                 var result2 = source.Throttle(10, TimeSpan.FromMilliseconds(100), 10, ThrottleMode.Shaping)
                     .RunWith(Sink.Seq<int>(), Materializer);
 
-                var count1 = (await result1.ShouldCompleteWithin(3.Seconds())).Count;
-                var count2 = (await result2.ShouldCompleteWithin(3.Seconds())).Count;
+                var count1 = (await result1.WaitAsync(3.Seconds())).Count;
+                var count2 = (await result2.WaitAsync(3.Seconds())).Count;
                 count1.ShouldBeGreaterThan(count2);
             }, Materializer);
         }
@@ -894,8 +894,8 @@ namespace Akka.Streams.Tests.Dsl
                 var expectationF1 = Enumerable.Range(1, 18).Where(v => v % 2 == 0).ToList();
                 expectationF1.Insert(0, 50);
 
-                (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(expectationF1);
-                (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 19).Where(v => v % 2 != 0));
+                (await f1.WaitAsync(3.Seconds())).Should().BeEquivalentTo(expectationF1);
+                (await f2.WaitAsync(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 19).Where(v => v % 2 != 0));
             }, Materializer);
         }
 
@@ -945,7 +945,7 @@ namespace Akka.Streams.Tests.Dsl
                 // cases should work in the end
                 await Task.Delay(50);
 
-                (await source.RunWith(Sink.Seq<int>(), Materializer).ShouldCompleteWithin(3.Seconds()))
+                (await source.RunWith(Sink.Seq<int>(), Materializer).WaitAsync(3.Seconds()))
                     .Should().BeEmpty();
             }, Materializer);
         }
@@ -991,7 +991,7 @@ namespace Akka.Streams.Tests.Dsl
                 await Awaiting(async () =>
                 {
                     await source.RunWith(Sink.Seq<int>(), Materializer);
-                }).Should().ThrowAsync<TestException>().WithMessage("Fail!").ShouldCompleteWithin(3.Seconds());
+                }).Should().ThrowAsync<TestException>().WithMessage("Fail!").WaitAsync(3.Seconds());
             }, Materializer);
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/JsonFramingSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/JsonFramingSpec.cs
@@ -54,7 +54,7 @@ namespace Akka.Streams.Tests.Dsl
                     return list;
                 }, Materializer);
 
-            var complete = await result.ShouldCompleteWithin(3.Seconds());
+            var complete = await result.WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(new []
             {
                 @"{ ""name"" : ""john"" }",
@@ -80,7 +80,7 @@ namespace Akka.Streams.Tests.Dsl
                     return list;
                 }, Materializer);
 
-            var complete = await result.ShouldCompleteWithin(3.Seconds());
+            var complete = await result.WaitAsync(3.Seconds());
             complete.Should().HaveCount(1).And.Subject.Should().Contain(@"{ ""name"" : ""john"" }");
         }
 
@@ -101,7 +101,7 @@ namespace Akka.Streams.Tests.Dsl
                     return list;
                 }, Materializer);
 
-            var complete = await result.ShouldCompleteWithin(3.Seconds());
+            var complete = await result.WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(new[]
             {
                 @"{ ""name"" : ""john"" }",
@@ -124,7 +124,7 @@ namespace Akka.Streams.Tests.Dsl
                     return list;
                 }, Materializer);
 
-            var complete = await result.ShouldCompleteWithin(3.Seconds());
+            var complete = await result.WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(new[]
             {
                 @"{ ""name"" : ""john"" }",
@@ -150,7 +150,7 @@ namespace Akka.Streams.Tests.Dsl
                     list.Add(s.ToString());
                     return list;
                 }, Materializer)
-                .ShouldCompleteWithin(3.Seconds()); ;
+                .WaitAsync(3.Seconds()); ;
 
 
             result.Should().BeEquivalentTo(new[]

--- a/src/core/Akka.Streams.Tests/Dsl/KeepAliveConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/KeepAliveConcatSpec.cs
@@ -40,7 +40,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<IEnumerable<int>>>(), Sys.Materializer());
 
-            var complete = await t.ShouldCompleteWithin(3.Seconds());
+            var complete = await t.WaitAsync(3.Seconds());
             complete
                 .SelectMany(x => x)
                 .Should().BeEquivalentTo(Enumerable.Range(1, 10), o => o.WithStrictOrdering());
@@ -60,7 +60,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<IEnumerable<int>>>(), Sys.Materializer());
 
-            var complete = await t.ShouldCompleteWithin(TimeSpan.FromSeconds(6));
+            var complete = await t.WaitAsync(TimeSpan.FromSeconds(6));
             complete
                 .SelectMany(x => x)
                 .Should().BeEquivalentTo(Enumerable.Range(1, 10), o => o.WithStrictOrdering());

--- a/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LastElementSpec.cs
@@ -36,7 +36,7 @@ namespace Akka.Streams.Tests.Dsl
                 .ExpectNext( 1, 2, 3)
                 .ExpectComplete();
 
-            var complete = await lastElement.ShouldCompleteWithin(TimeSpan.FromSeconds(1));
+            var complete = await lastElement.WaitAsync(TimeSpan.FromSeconds(1));
             complete.Should().Be(Option<int>.Create(3));
         }
 
@@ -54,7 +54,7 @@ namespace Akka.Streams.Tests.Dsl
             probe.Request(3)
                 .ExpectComplete();
 
-            var complete = await lastElement.ShouldCompleteWithin(1.Seconds());
+            var complete = await lastElement.WaitAsync(1.Seconds());
             complete.Should().Be(Option<int>.None);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/LastSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LastSinkSpec.cs
@@ -36,7 +36,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var result = await Source.From(Enumerable.Range(1,42)).Select(x=>x)
                     .RunWith(Sink.Last<int>(), Materializer)
-                    .ShouldCompleteWithin(3.Seconds());
+                    .WaitAsync(3.Seconds());
                 result.Should().Be(42);
             }, Materializer);
         }
@@ -46,8 +46,9 @@ namespace Akka.Streams.Tests.Dsl
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
-                (await Source.Failed<int>(new Exception("ex")).RunWith(Sink.Last<int>(), Materializer)
-                    .ShouldThrowWithin<Exception>(1.Seconds())).Message.Should().Be("ex");
+                var task = Source.Failed<int>(new Exception("ex")).RunWith(Sink.Last<int>(), Materializer);
+                var ex = await AssertThrowsAsync(() => task).WaitAsync(1.Seconds());
+                ex.Message.Should().Be("ex");
             }, Materializer);
         }
 
@@ -56,9 +57,9 @@ namespace Akka.Streams.Tests.Dsl
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
-                (await Source.Empty<int>().RunWith(Sink.Last<int>(), Materializer)
-                    .ShouldThrowWithin<NoSuchElementException>(1.Seconds()))
-                    .Message.Should().Be("Last of empty stream");
+                var task = Source.Empty<int>().RunWith(Sink.Last<int>(), Materializer);
+                var ex = await AssertThrowsAsync(() => task).WaitAsync(1.Seconds());
+                ex.Message.Should().Be("Last of empty stream");
             }, Materializer);
         }
 
@@ -69,7 +70,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var result = await Source.From(Enumerable.Range(1, 42)).Select(x => x)
                     .RunWith(Sink.LastOrDefault<int>(), Materializer)
-                    .ShouldCompleteWithin(1.Seconds());
+                    .WaitAsync(1.Seconds());
                 result.Should().Be(42);
             }, Materializer);
         }
@@ -79,8 +80,9 @@ namespace Akka.Streams.Tests.Dsl
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
-                (await Source.Failed<int>(new Exception("ex")).RunWith(Sink.LastOrDefault<int>(), Materializer)
-                    .ShouldThrowWithin<Exception>(1.Seconds())).Message.Should().Be("ex");
+                var task = Source.Failed<int>(new Exception("ex")).RunWith(Sink.LastOrDefault<int>(), Materializer);
+                var ex = await AssertThrowsAsync(() => task).WaitAsync(1.Seconds());
+                ex.Message.Should().Be("ex");
             }, Materializer);
         }
 
@@ -91,7 +93,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var result = await Source.Empty<int>()
                     .RunWith(Sink.LastOrDefault<int>(), Materializer)
-                    .ShouldCompleteWithin(1.Seconds());
+                    .WaitAsync(1.Seconds());
                 result.Should().Be(0);
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/LazySinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LazySinkSpec.cs
@@ -50,7 +50,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var lazySink = Sink.LazyInitAsync(() => Task.FromResult(this.SinkProbe<int>()));
                 var taskProbe = Source.From(Enumerable.Range(0, 11)).RunWith(lazySink, Materializer);
-                var probe = await taskProbe.ShouldCompleteWithin(RemainingOrDefault);
+                var probe = await taskProbe.WaitAsync(RemainingOrDefault);
                 probe.Value.Request(100);
                 foreach (var i in Enumerable.Range(0, 11)) 
                 {
@@ -77,7 +77,7 @@ namespace Akka.Streams.Tests.Dsl
                 taskProbe.Wait(TimeSpan.FromMilliseconds(200)).ShouldBeFalse();
 
                 p.SetResult(this.SinkProbe<int>());
-                var complete = await taskProbe.ShouldCompleteWithin(RemainingOrDefault);
+                var complete = await taskProbe.WaitAsync(RemainingOrDefault);
                 var probe = complete.Value;
                 probe.Request(100);
                 await probe.ExpectNextAsync(0);
@@ -98,7 +98,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var lazySink = Sink.LazyInitAsync(() => Task.FromResult(Sink.Aggregate(0, (int i, int i2) => i + i2)));
                 var taskProbe = Source.Empty<int>().RunWith(lazySink, Materializer);
-                var complete = await taskProbe.ShouldCompleteWithin(RemainingOrDefault);
+                var complete = await taskProbe.WaitAsync(RemainingOrDefault);
                 complete.ShouldBe(Option<Task<int>>.None);
             }, Materializer);
         }
@@ -110,7 +110,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var lazySink = Sink.LazyInitAsync(() => Task.FromResult(this.SinkProbe<int>()));
                 var taskProbe = Source.Single(1).RunWith(lazySink, Materializer);
-                var taskResult = await taskProbe.ShouldCompleteWithin(RemainingOrDefault);
+                var taskResult = await taskProbe.WaitAsync(RemainingOrDefault);
                 await taskResult.Value.Request(1).ExpectNext(1).ExpectCompleteAsync();
             }, Materializer);
         }
@@ -141,7 +141,7 @@ namespace Akka.Streams.Tests.Dsl
                 var sourceSub = await sourceProbe.ExpectSubscriptionAsync();
                 await sourceSub.ExpectRequestAsync(1);
                 sourceSub.SendNext(0);
-                var complete = await taskProbe.ShouldCompleteWithin(RemainingOrDefault);
+                var complete = await taskProbe.WaitAsync(RemainingOrDefault);
                 var probe = complete.Value;
                 await probe.Request(1).ExpectNextAsync(0);
                 sourceSub.SendError(Ex);
@@ -182,7 +182,7 @@ namespace Akka.Streams.Tests.Dsl
                 await sourceSub.ExpectRequestAsync(1);
                 sourceSub.SendNext(0);
                 await sourceSub.ExpectRequestAsync(1);
-                var complete = await taskProbe.ShouldCompleteWithin(RemainingOrDefault);
+                var complete = await taskProbe.WaitAsync(RemainingOrDefault);
                 var probe = complete.Value;
                 await probe.Request(1).ExpectNextAsync(0);
                 probe.Cancel();

--- a/src/core/Akka.Streams.Tests/Dsl/LazySourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LazySourceSpec.cs
@@ -39,7 +39,7 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async() =>
             {
                 var result = Source.Lazily(() => Source.From(new[] { 1, 2, 3 })).RunWith(Sink.Seq<int>(), Materializer);
-                var complete = await result.ShouldCompleteWithin(3.Seconds());
+                var complete = await result.WaitAsync(3.Seconds());
                 complete.Should().BeEquivalentTo(ImmutableList.Create(1, 2, 3));
             }, Materializer);
         }
@@ -72,7 +72,7 @@ namespace Akka.Streams.Tests.Dsl
                     await Source.Lazily(() => Source.From(new[] { 1, 2, 3 }))
                         .ToMaterialized(Sink.Cancelled<int>(), Keep.Left)
                         .Run(Materializer);
-                }).Should().ThrowAsync<Exception>().ShouldCompleteWithin(3.Seconds());
+                }).Should().ThrowAsync<Exception>().WaitAsync(3.Seconds());
             }, Materializer);
         }
 
@@ -180,7 +180,7 @@ namespace Akka.Streams.Tests.Dsl
                     .AddAttributes(Attributes.CreateName("outer"))
                     .RunWith(Sink.First<Attributes>(), Materializer);
 
-                var complete = await first.ShouldCompleteWithin(3.Seconds());
+                var complete = await first.WaitAsync(3.Seconds());
                 var attributes = complete.AttributeList.ToList();
                 var inner = new Attributes.Name("inner");
                 var outer = new Attributes.Name("outer");

--- a/src/core/Akka.Streams.Tests/Dsl/PagedSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/PagedSourceSpec.cs
@@ -49,7 +49,7 @@ namespace Akka.Streams.Tests.Dsl
                 var source = PagedSource.Create(0, new MultiplesOfTwoPage().Page);
                 var t = source.Take(3).RunWith(Sink.Seq<int>(), Sys.Materializer());
 
-                var complete = await t.ShouldCompleteWithin(3.Seconds());
+                var complete = await t.WaitAsync(3.Seconds());
                 complete.Should().BeEquivalentTo(new[] { 0, 2, 4 }, o => o.WithStrictOrdering());
             }
 
@@ -59,7 +59,7 @@ namespace Akka.Streams.Tests.Dsl
                 var source = PagedSource.Create(0, new MultiplesOfTwoPage(4).Page);
                 var t = source.Take(10).RunWith(Sink.Seq<int>(), Sys.Materializer());
 
-                var complete = await t.ShouldCompleteWithin(3.Seconds());
+                var complete = await t.WaitAsync(3.Seconds());
                 complete.Should().HaveCount(4);
             }
         }
@@ -88,7 +88,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var t = _source.Take(4).RunWith(Sink.Seq<string>(), Sys.Materializer());
 
-                var complete = await t.ShouldCompleteWithin(3.Seconds());
+                var complete = await t.WaitAsync(3.Seconds());
                 complete.Should().BeEquivalentTo(new[] { "a", "b", "c", "d" }, o => o.WithStrictOrdering());
             }
 
@@ -97,7 +97,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var t = _source.RunWith(Sink.Seq<string>(), Sys.Materializer());
 
-                var complete = await t.ShouldCompleteWithin(3.Seconds());
+                var complete = await t.WaitAsync(3.Seconds());
                 complete.Should().BeEquivalentTo(new[] { "a", "b", "c", "d", "e" }, o => o.WithStrictOrdering());
             }
         }
@@ -133,7 +133,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var t = _source.Take(4).RunWith(Sink.Seq<int>(), Sys.Materializer());
 
-                var complete = await t.ShouldCompleteWithin(3.Seconds());
+                var complete = await t.WaitAsync(3.Seconds());
                 complete.Should().BeEquivalentTo(new[] { 1, 2, 3, 4 }, o => o.WithStrictOrdering());
             }
 
@@ -142,7 +142,7 @@ namespace Akka.Streams.Tests.Dsl
             {
                 var t = _source.RunWith(Sink.Seq<int>(), Sys.Materializer());
 
-                var complete = await t.ShouldCompleteWithin(3.Seconds());
+                var complete = await t.WaitAsync(3.Seconds());
                 complete.Should().BeEquivalentTo(new[] { 1, 2, 3, 4, 5 }, o => o.WithStrictOrdering());
             }
         }

--- a/src/core/Akka.Streams.Tests/Dsl/PulseSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/PulseSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Streams.Tests.Dsl
             probe.ExpectNoMsg(_pulseInterval);
             probe.SendComplete();
 
-            var complete = await task.ShouldCompleteWithin(3.Seconds());
+            var complete = await task.WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(new[] { 1, 2 }, o => o.WithStrictOrdering());
         }
 
@@ -67,7 +67,7 @@ namespace Akka.Streams.Tests.Dsl
                 .InitialTimeout(Dilated(TimeSpan.FromMilliseconds(2)))
                 .RunWith(Sink.First<int>(), Sys.Materializer());
 
-            var complete = await task.ShouldCompleteWithin(3.Seconds());
+            var complete = await task.WaitAsync(3.Seconds());
             complete.Should().Be(1);
         }
 
@@ -88,7 +88,7 @@ namespace Akka.Streams.Tests.Dsl
             probe.ExpectNoMsg(_pulseInterval);
             probe.SendComplete();
 
-            var complete = await task.ShouldCompleteWithin(3.Seconds());
+            var complete = await task.WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(new[] { 1, 2 }, o => o.WithStrictOrdering());
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/RestartSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/RestartSpec.cs
@@ -432,7 +432,7 @@ namespace Akka.Streams.Tests.Dsl
                     .SendComplete()
                     .ExecuteAsync();
 
-                await tcs.Task.ShouldCompleteWithin(3.Seconds());
+                await tcs.Task.WaitAsync(3.Seconds());
                 tcs.Task.Result.Should().ContainInOrder("a", "b", "c");
                 created.Current.Should().Be(1);
             }, Materializer);

--- a/src/core/Akka.Streams.Tests/Dsl/SampleSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SampleSpec.cs
@@ -32,7 +32,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 var expected = list.Where(x => x % n == 0);
 
-                var complete = await future.ShouldCompleteWithin(3.Seconds());
+                var complete = await future.WaitAsync(3.Seconds());
                 complete.Should().BeEquivalentTo(expected, o => o.WithStrictOrdering());
             }
         }
@@ -47,7 +47,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Via(new Sample<int>(next))
                 .RunWith(Sink.Seq<int>(), Sys.Materializer());
 
-            var complete = await future.ShouldCompleteWithin(3.Seconds());
+            var complete = await future.WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(new[] { 1, 3, 6, 10 }, o => o.WithStrictOrdering());
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/SinkForeachAsyncSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SinkForeachAsyncSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Streams.Tests.Dsl
         public async Task A_ForeachAsync_must_handle_empty_source()
         {
             var p = Source.From(new List<int>()).RunWith(Sink.ForEachAsync<int>(3, _ => Task.CompletedTask), Materializer);
-            (await p.ShouldCompleteWithin(RemainingOrDefault)).Should().Be(Done.Instance);
+            (await p.WaitAsync(RemainingOrDefault)).Should().Be(Done.Instance);
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Akka.Streams.Tests.Dsl
             latch[4].CountDown();
             probe.ExpectMsg(4);
 
-            (await p.ShouldCompleteWithin(TimeSpan.FromSeconds(4))).Should().Be(Done.Instance);
+            (await p.WaitAsync(TimeSpan.FromSeconds(4))).Should().Be(Done.Instance);
         }
 
         [Fact]
@@ -142,7 +142,7 @@ namespace Akka.Streams.Tests.Dsl
             latch[4].CountDown();
             probe.ExpectMsg(4);
 
-            (await p.ShouldCompleteWithin(TimeSpan.FromSeconds(4))).Should().Be(Done.Instance);
+            (await p.WaitAsync(TimeSpan.FromSeconds(4))).Should().Be(Done.Instance);
 
             oneCalled.ShouldBeTrue();
             twoCalled.ShouldBeTrue();
@@ -159,7 +159,7 @@ namespace Akka.Streams.Tests.Dsl
                 .ToDictionary(t => t.i, t => t.Item2);
             var p = Source.From(Enumerable.Range(1, 4)).RunWith(Sink.ForEachAsync<int>(4, async n =>
             {
-                await latch[n].WaitAsync().ShouldCompleteWithin(TimeSpan.FromSeconds(5));
+                await latch[n].WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
                 probe.Ref.Tell(n);
             }), Materializer);
 
@@ -175,7 +175,7 @@ namespace Akka.Streams.Tests.Dsl
             latch[1].Signal();
             probe.ExpectMsg(1);
 
-            (await p.ShouldCompleteWithin(TimeSpan.FromSeconds(4))).Should().Be(Done.Instance);
+            (await p.WaitAsync(TimeSpan.FromSeconds(4))).Should().Be(Done.Instance);
         }
 
         [Fact]
@@ -188,7 +188,7 @@ namespace Akka.Streams.Tests.Dsl
             var p = Source.From(Enumerable.Range(1, 5)).RunWith(Sink.ForEachAsync<int>(4, async n =>
             {
                 probe.Ref.Tell(n);
-                await latch[n].WaitAsync().ShouldCompleteWithin(TimeSpan.FromSeconds(5));
+                await latch[n].WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
             }), Materializer);
 
             probe.ExpectMsgAllOf(new[] { 1, 2, 3, 4 });
@@ -201,7 +201,7 @@ namespace Akka.Streams.Tests.Dsl
             latch[5].Signal();
             probe.ExpectMsg(5);
 
-            (await p.ShouldCompleteWithin(TimeSpan.FromSeconds(5))).Should().Be(Done.Instance);
+            (await p.WaitAsync(TimeSpan.FromSeconds(5))).Should().Be(Done.Instance);
         }
 
         [Fact]
@@ -216,13 +216,13 @@ namespace Akka.Streams.Tests.Dsl
                     throw new TestException("err1");
 
                 probe.Ref.Tell(n);
-                await latch.WaitAsync().ShouldCompleteWithin(TimeSpan.FromSeconds(10));
+                await latch.WaitAsync().WaitAsync(TimeSpan.FromSeconds(10));
             }).WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider)), Materializer);
 
             latch.Signal();
             probe.ExpectMsgAllOf(new[] { 1, 2, 4, 5 });
 
-            (await p.ShouldCompleteWithin(TimeSpan.FromSeconds(5))).Should().Be(Done.Instance);
+            (await p.WaitAsync(TimeSpan.FromSeconds(5))).Should().Be(Done.Instance);
         }
 
         [Fact]
@@ -237,13 +237,13 @@ namespace Akka.Streams.Tests.Dsl
                 if (n == 3)
                 {
                     // Error will happen only after elements 1, 2 has been processed
-                    await errorLatch.WaitAsync().ShouldCompleteWithin(TimeSpan.FromSeconds(5));
+                    await errorLatch.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
                     throw new TestException("err2");
                 }
 
                 probe.Ref.Tell(n);
                 errorLatch.Signal();
-                await element4Latch.WaitAsync().ShouldCompleteWithin(TimeSpan.FromSeconds(5)); // Block element 4, 5, 6, ... from entering
+                await element4Latch.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5)); // Block element 4, 5, 6, ... from entering
             }).WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.StoppingDecider)), Materializer);
 
             // Only the first two messages are guaranteed to arrive due to their enforced ordering related to the time

--- a/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/SourceSpec.cs
@@ -111,7 +111,7 @@ namespace Akka.Streams.Tests.Dsl
                 c.ExpectNoMsg(TimeSpan.FromMilliseconds(300));
 
                 subs.Cancel();
-                var complete = await f.Task.ShouldCompleteWithin(3.Seconds());
+                var complete = await f.Task.WaitAsync(3.Seconds());
                 complete.Should().Be(null);
             }, Materializer);
         }
@@ -131,7 +131,7 @@ namespace Akka.Streams.Tests.Dsl
                 //external cancellation
                 neverPromise.TrySetResult(0).Should().BeTrue();
                 
-                var counter = await counterFuture.ShouldCompleteWithin(3.Seconds());
+                var counter = await counterFuture.WaitAsync(3.Seconds());
                 counter.Should().Be(0);
             }, Materializer);
         }
@@ -150,7 +150,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 //external cancellation
                 neverPromise.TrySetResult(6).Should().BeTrue();
-                var complete = await counterFuture.ShouldCompleteWithin(3.Seconds());
+                var complete = await counterFuture.WaitAsync(3.Seconds());
                 complete.Should().Be(6);
             }, Materializer);
         }
@@ -416,7 +416,7 @@ namespace Akka.Streams.Tests.Dsl
             var complete = await Source.Cycle(() => new[] {1, 2, 3}.AsEnumerable().GetEnumerator())
                 .Grouped(9)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer)
-                .ShouldCompleteWithin(3.Seconds());
+                .WaitAsync(3.Seconds());
             
             complete.Should().BeEquivalentTo(expected);
         }
@@ -463,7 +463,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var complete = await Source.ZipN(sources)
                  .RunWith(Sink.Seq<IImmutableList<int>>(), Materializer)
-                 .ShouldCompleteWithin(3.Seconds());
+                 .WaitAsync(3.Seconds());
 
                complete.Should().BeEquivalentTo(new[]
                 {
@@ -485,7 +485,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var complete = await Source.ZipWithN(list => list.Sum(), sources)
                  .RunWith(Sink.Seq<int>(), Materializer)
-                 .ShouldCompleteWithin(3.Seconds());
+                 .WaitAsync(3.Seconds());
             complete.Should().BeEquivalentTo(new[] {111, 222, 333});
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceAsyncSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnfoldResourceAsyncSourceSpec.cs
@@ -103,18 +103,18 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 await probe.RequestAsync(1);
-                await resource.Created.ShouldCompleteWithin(3.Seconds());
+                await resource.Created.WaitAsync(3.Seconds());
                 await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
                 createPromise.SetResult(Done.Instance);
 
                 foreach (var i in values)
                 {
-                    await resource.FirstElementRead.ShouldCompleteWithin(3.Seconds());
+                    await resource.FirstElementRead.WaitAsync(3.Seconds());
                     (await probe.ExpectNextAsync()).ShouldBe(i);
                     await probe.RequestAsync(1);
                 }
 
-                await resource.Closed.ShouldCompleteWithin(3.Seconds());
+                await resource.Closed.WaitAsync(3.Seconds());
                 closePromise.SetResult(Done.Instance);
 
                 await probe.ExpectCompleteAsync();
@@ -137,13 +137,13 @@ namespace Akka.Streams.Tests.Dsl
                     .RunWith(Sink.FromSubscriber(probe), Materializer);
 
                 await probe.RequestAsync(1L);
-                await resource.FirstElementRead.ShouldCompleteWithin(3.Seconds());
+                await resource.FirstElementRead.WaitAsync(3.Seconds());
                 // we cancel before we complete first read (racy)
                 await probe.CancelAsync();
                 await Task.Delay(100);
                 firtRead.SetResult(Done.Instance);
 
-                await resource.Closed.ShouldCompleteWithin(3.Seconds());
+                await resource.Closed.WaitAsync(3.Seconds());
             }, Materializer);
         }
 
@@ -254,7 +254,7 @@ namespace Akka.Streams.Tests.Dsl
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                     .RunWith(Sink.Seq<int>(), Materializer);
 
-                var r = await result.ShouldCompleteWithin(3.Seconds());
+                var r = await result.WaitAsync(3.Seconds());
                 r.ShouldBe(new[] { 1, 2, 3 });
             }, Materializer);
         }
@@ -288,7 +288,7 @@ namespace Akka.Streams.Tests.Dsl
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                     .RunWith(Sink.Seq<int>(), Materializer);
 
-                var r = await result.ShouldCompleteWithin(3.Seconds());
+                var r = await result.WaitAsync(3.Seconds());
                 r.ShouldBe(new[] { 1, 2, 3 });
             }, Materializer);
         }
@@ -323,7 +323,7 @@ namespace Akka.Streams.Tests.Dsl
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.RestartingDecider))
                     .RunWith(Sink.Seq<int>(), Materializer);
 
-                var r = await result.ShouldCompleteWithin(3.Seconds());
+                var r = await result.WaitAsync(3.Seconds());
                 r.ShouldBe(new[] { 1, 2, 3 });
                 startCount.Current.ShouldBe(2);
             }, Materializer);
@@ -359,7 +359,7 @@ namespace Akka.Streams.Tests.Dsl
                     .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.RestartingDecider))
                     .RunWith(Sink.Seq<int>(), Materializer);
 
-                var r = await result.ShouldCompleteWithin(3.Seconds());
+                var r = await result.WaitAsync(3.Seconds());
                 r.ShouldBe(new[] { 1, 2, 3 });
                 startCount.Current.ShouldBe(2);
             }, Materializer);
@@ -506,7 +506,7 @@ namespace Akka.Streams.Tests.Dsl
             materializer.Shutdown();
             materializer.IsShutdown.Should().BeTrue();
             
-            var r = await closePromise.Task.ShouldCompleteWithin(3.Seconds());
+            var r = await closePromise.Task.WaitAsync(3.Seconds());
             r.Should().Be("Closed");
         }
 
@@ -528,7 +528,7 @@ namespace Akka.Streams.Tests.Dsl
 
                 await probe.CancelAsync();
                 
-                var r = await closePromise.Task.ShouldCompleteWithin(3.Seconds());
+                var r = await closePromise.Task.WaitAsync(3.Seconds());
                 r.Should().Be("Closed");
             }, Materializer);
         }
@@ -554,7 +554,7 @@ namespace Akka.Streams.Tests.Dsl
                     })
                     .RunWith(Sink.Cancelled<string>(), Materializer);
 
-                var r = await closePromise.Task.ShouldCompleteWithin(3.Seconds());
+                var r = await closePromise.Task.WaitAsync(3.Seconds());
                 r.Should().Be("Closed");
             }, Materializer);
         }
@@ -581,7 +581,7 @@ namespace Akka.Streams.Tests.Dsl
                 await probe.RequestAsync(1L);
                 await probe.ExpectErrorAsync();
 
-                var r = await closePromise.Task.ShouldCompleteWithin(3.Seconds());
+                var r = await closePromise.Task.WaitAsync(3.Seconds());
                 r.Should().Be("Closed");
             }, Materializer);
         }
@@ -610,7 +610,7 @@ namespace Akka.Streams.Tests.Dsl
                 await probe.RequestAsync(1L);
                 await probe.ExpectErrorAsync();
 
-                var r = await closePromise.Task.ShouldCompleteWithin(3.Seconds());
+                var r = await closePromise.Task.WaitAsync(3.Seconds());
                 r.Should().Be("Closed");
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/ValveSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/ValveSpec.cs
@@ -32,10 +32,10 @@ namespace Akka.Streams.Tests.Dsl
             var switchTask = t.Item1;
             var seq = t.Item2;
 
-            var valveSwitch = await switchTask.ShouldCompleteWithin(3.Seconds());
+            var valveSwitch = await switchTask.WaitAsync(3.Seconds());
             await Task.Delay(100);
             var flip = valveSwitch.Flip(SwitchMode.Open);
-            var complete = await flip.ShouldCompleteWithin(3.Seconds());
+            var complete = await flip.WaitAsync(3.Seconds());
             complete.Should().BeTrue();
         }
 
@@ -48,12 +48,12 @@ namespace Akka.Streams.Tests.Dsl
                 .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
                 .Run(Sys.Materializer());
             
-            IValveSwitch valveSwitch = await switchTask.ShouldCompleteWithin(3.Seconds());
+            IValveSwitch valveSwitch = await switchTask.WaitAsync(3.Seconds());
             probe.Request(2);
             probe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             Task<bool> flip = valveSwitch.Flip(SwitchMode.Open);
-            var complete = await flip.ShouldCompleteWithin(3.Seconds());
+            var complete = await flip.WaitAsync(3.Seconds());
             // valve is now open
             complete.Should().BeTrue();
             // </OpenValve>
@@ -78,11 +78,11 @@ namespace Akka.Streams.Tests.Dsl
             var switchTask = t.Item1.Item2;
             var sinkProbe = t.Item2;
 
-            var valveSwitch = await switchTask.ShouldCompleteWithin(3.Seconds());
+            var valveSwitch = await switchTask.WaitAsync(3.Seconds());
 
             sinkProbe.Request(1);
             var flip = valveSwitch.Flip(SwitchMode.Open);
-            var complete = await flip.ShouldCompleteWithin(3.Seconds());
+            var complete = await flip.WaitAsync(3.Seconds());
             complete.Should().BeTrue();
 
             sourceProbe.SendNext(1);
@@ -90,13 +90,13 @@ namespace Akka.Streams.Tests.Dsl
             sinkProbe.ExpectNext().Should().Be(1);
 
             flip = valveSwitch.Flip(SwitchMode.Close);
-            var complete1 = await flip.ShouldCompleteWithin(3.Seconds());
+            var complete1 = await flip.WaitAsync(3.Seconds());
             complete1.Should().BeTrue();
 
             sinkProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             flip = valveSwitch.Flip(SwitchMode.Open);
-            var complete2 = await flip.ShouldCompleteWithin(3.Seconds());
+            var complete2 = await flip.WaitAsync(3.Seconds());
             complete2.Should().BeTrue();   
 
             sinkProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
@@ -123,12 +123,12 @@ namespace Akka.Streams.Tests.Dsl
             var switchTask = t.Item1;
             var probe = t.Item2;
 
-            var valveSwitch = await switchTask.ShouldCompleteWithin(3.Seconds());
+            var valveSwitch = await switchTask.WaitAsync(3.Seconds());
 
-            var complete = await valveSwitch.Flip(SwitchMode.Close).ShouldCompleteWithin(3.Seconds());
+            var complete = await valveSwitch.Flip(SwitchMode.Close).WaitAsync(3.Seconds());
             complete.Should().BeFalse();
 
-            var complete1 = await valveSwitch.Flip(SwitchMode.Close).ShouldCompleteWithin(3.Seconds());
+            var complete1 = await valveSwitch.Flip(SwitchMode.Close).WaitAsync(3.Seconds());
             complete1.Should().BeFalse();
         }
 
@@ -142,7 +142,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var seq = t.Item2;
 
-            var complete = await seq.ShouldCompleteWithin(3.Seconds());
+            var complete = await seq.WaitAsync(3.Seconds());
             complete.Should().BeEmpty();
         }
 
@@ -159,7 +159,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var resultException = await Awaiting(async () => await seq)
             .Should().ThrowAsync<Exception>()
-            .ShouldCompleteWithin(3.Seconds());
+            .WaitAsync(3.Seconds());
 
             resultException.And.Should().Be(ex);
         }
@@ -176,7 +176,7 @@ namespace Akka.Streams.Tests.Dsl
             var switchTask = t.Item2;
             var resultTask = t.Item3;
 
-            var valveSwitch = await switchTask.ShouldCompleteWithin(3.Seconds());
+            var valveSwitch = await switchTask.WaitAsync(3.Seconds());
 
             async Task<int> result()
             {
@@ -189,7 +189,7 @@ namespace Akka.Streams.Tests.Dsl
                 return await resultTask;
             }
 
-            var complete = await result().ShouldCompleteWithin(3.Seconds());
+            var complete = await result().WaitAsync(3.Seconds());
             complete.Should().Be(1);
         }
 
@@ -204,8 +204,8 @@ namespace Akka.Streams.Tests.Dsl
             var switchTask = t.Item1;
             var seq = t.Item2;
 
-            var valveSwitch = await switchTask.ShouldCompleteWithin(3.Seconds());
-            var mode = await valveSwitch.GetMode().ShouldCompleteWithin(3.Seconds());
+            var valveSwitch = await switchTask.WaitAsync(3.Seconds());
+            var mode = await valveSwitch.GetMode().WaitAsync(3.Seconds());
             mode.Should().Be(SwitchMode.Close);
         }
 
@@ -221,28 +221,28 @@ namespace Akka.Streams.Tests.Dsl
             var switchTask = t.Item1.Item2;
             var sinkProbe = t.Item2;
 
-            var valveSwitch = await switchTask.ShouldCompleteWithin(3.Seconds());
+            var valveSwitch = await switchTask.WaitAsync(3.Seconds());
 
             sinkProbe.Request(1);
             var flip = valveSwitch.Flip(SwitchMode.Close);
-            var complete = await flip.ShouldCompleteWithin(3.Seconds());
+            var complete = await flip.WaitAsync(3.Seconds());
             complete.Should().BeTrue();
 
             sourceProbe.SendNext(1);
             sinkProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
 
             flip = valveSwitch.Flip(SwitchMode.Open);
-            var complete1 = await flip.ShouldCompleteWithin(3.Seconds());
+            var complete1 = await flip.WaitAsync(3.Seconds());
             complete1.Should().BeTrue();
 
             sinkProbe.ExpectNext().Should().Be(1);
 
             flip = valveSwitch.Flip(SwitchMode.Close);
-            var complete2 = await flip.ShouldCompleteWithin(3.Seconds());
+            var complete2 = await flip.WaitAsync(3.Seconds());
             complete2.Should().BeTrue();
 
             flip = valveSwitch.Flip(SwitchMode.Open);
-            var complete3 = await flip.ShouldCompleteWithin(3.Seconds());
+            var complete3 = await flip.WaitAsync(3.Seconds());
             complete3.Should().BeTrue();
 
             sinkProbe.ExpectNoMsg(TimeSpan.FromMilliseconds(100));
@@ -268,12 +268,12 @@ namespace Akka.Streams.Tests.Dsl
 
             var switchTask = t.Item1;
 
-            var valveSwitch = await switchTask.ShouldCompleteWithin(3.Seconds());
+            var valveSwitch = await switchTask.WaitAsync(3.Seconds());
 
-            var complete = await valveSwitch.Flip(SwitchMode.Open).ShouldCompleteWithin(3.Seconds());
+            var complete = await valveSwitch.Flip(SwitchMode.Open).WaitAsync(3.Seconds());
             complete.Should().BeFalse();
 
-            var complete1 = await valveSwitch.Flip(SwitchMode.Open).ShouldCompleteWithin(3.Seconds());
+            var complete1 = await valveSwitch.Flip(SwitchMode.Open).WaitAsync(3.Seconds());
             complete1.Should().BeFalse();
         }
 
@@ -287,7 +287,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var seq = t.Item2;
 
-            var complete = await seq.ShouldCompleteWithin(TimeSpan.FromMilliseconds(200));
+            var complete = await seq.WaitAsync(TimeSpan.FromMilliseconds(200));
             complete.Should().ContainInOrder(1, 2, 3);
         }
 
@@ -301,7 +301,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var seq = t.Item2;
 
-            var complete = await seq.ShouldCompleteWithin(3.Seconds());
+            var complete = await seq.WaitAsync(3.Seconds());
             complete.Should().BeEmpty();
         }
 
@@ -319,7 +319,7 @@ namespace Akka.Streams.Tests.Dsl
 
             var resultException = await Awaiting(async () => await seq)
             .Should().ThrowAsync<Exception>()
-            .ShouldCompleteWithin(3.Seconds());
+            .WaitAsync(3.Seconds());
 
             resultException.And.Should().Be(ex);
         }
@@ -336,7 +336,7 @@ namespace Akka.Streams.Tests.Dsl
             var switchTask = t.Item2;
             var resultTask = t.Item3;
 
-            var valveSwitch = await switchTask.ShouldCompleteWithin(3.Seconds());
+            var valveSwitch = await switchTask.WaitAsync(3.Seconds());
 
             async Task<int> result()
             {
@@ -348,7 +348,7 @@ namespace Akka.Streams.Tests.Dsl
                 return await resultTask;
             }
 
-            var complete = await result().ShouldCompleteWithin(3.Seconds());
+            var complete = await result().WaitAsync(3.Seconds());
             complete.Should().Be(1);
         }
 
@@ -362,8 +362,8 @@ namespace Akka.Streams.Tests.Dsl
 
             var switchTask = t.Item1;
 
-            var valveSwitch = await switchTask.ShouldCompleteWithin(3.Seconds());
-            var complete = await valveSwitch.GetMode().ShouldCompleteWithin(3.Seconds());
+            var valveSwitch = await switchTask.WaitAsync(3.Seconds());
+            var complete = await valveSwitch.GetMode().WaitAsync(3.Seconds());
             complete.Should().Be(SwitchMode.Open);
         }
     }

--- a/src/core/Akka.Streams.Tests/FusingSpec.cs
+++ b/src/core/Akka.Streams.Tests/FusingSpec.cs
@@ -50,7 +50,7 @@ namespace Akka.Streams.Tests
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-            await t.ShouldCompleteWithin(3.Seconds());
+            await t.WaitAsync(3.Seconds());
             t.Result.Distinct().OrderBy(i => i).Should().BeEquivalentTo(Enumerable.Range(0, 199).Where(i => i%2 == 0));
         }
 
@@ -72,7 +72,7 @@ namespace Akka.Streams.Tests
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-            await t.ShouldCompleteWithin(3.Seconds());
+            await t.WaitAsync(3.Seconds());
             t.Result.Should().BeEquivalentTo(Enumerable.Range(0, 10));
 
             var refs = await ReceiveNAsync(20).Distinct().ToListAsync();
@@ -111,7 +111,7 @@ namespace Akka.Streams.Tests
                 .Grouped(1000)
                 .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-            await t.ShouldCompleteWithin(3.Seconds());
+            await t.WaitAsync(3.Seconds());
             t.Result.Should().BeEquivalentTo(Enumerable.Range(0, 10));
 
             var refs = await ReceiveNAsync(20).Distinct().ToListAsync();

--- a/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSinkSpec.cs
@@ -65,7 +65,7 @@ namespace Akka.Streams.Tests.IO
                         var completion = Source.From(_testByteStrings)
                             .RunWith(FileIO.ToFile(f), _materializer);
                         
-                        var result = await completion.ShouldCompleteWithin(Remaining); 
+                        var result = await completion.WaitAsync(Remaining); 
                         result.Count.Should().Be(6006);
 
                         await AwaitAssertAsync(
@@ -85,7 +85,7 @@ namespace Akka.Streams.Tests.IO
                     var completion = Source.From(_testByteStrings)
                         .RunWith(FileIO.ToFile(f), _materializer);
                     
-                    var result = await completion.ShouldCompleteWithin(Remaining);
+                    var result = await completion.WaitAsync(Remaining);
                     result.Count.Should().Be(6006);
                     await AwaitAssertAsync(
                         () => CheckFileContent(f, _testLines.Aggregate((s, s1) => s + s1)),
@@ -106,7 +106,7 @@ namespace Akka.Streams.Tests.IO
                         .RunWith(FileIO.ToFile(f, FileMode.OpenOrCreate), _materializer);
 
                     var completion1 = Write(_testLines);
-                    await completion1.ShouldCompleteWithin(Remaining);
+                    await completion1.WaitAsync(Remaining);
 
                     var lastWrite = new string[100];
                     for (var i = 0; i < 100; i++)
@@ -114,7 +114,7 @@ namespace Akka.Streams.Tests.IO
 
                     var completion2 = Write(lastWrite);
                     
-                    var result = await completion2.ShouldCompleteWithin(Remaining); 
+                    var result = await completion2.WaitAsync(Remaining); 
 
                     var lastWriteString = new string(lastWrite.SelectMany(x => x).ToArray());
                     result.Count.Should().Be(lastWriteString.Length);
@@ -139,11 +139,11 @@ namespace Akka.Streams.Tests.IO
                             .RunWith(FileIO.ToFile(f), _materializer);
 
                     var task1 = Write(_testLines);
-                    await task1.ShouldCompleteWithin(Remaining);
+                    await task1.WaitAsync(Remaining);
                     var lastWrite = Enumerable.Range(0, 100).Select(_ => "x").ToList();
 
                     var task2 = Write(lastWrite);
-                    var result = await task2.ShouldCompleteWithin(Remaining);
+                    var result = await task2.WaitAsync(Remaining);
 
                     result.Count.Should().Be(lastWrite.Count);
 
@@ -167,7 +167,7 @@ namespace Akka.Streams.Tests.IO
 
                     var completion1 = Write(_testLines);
                     
-                    var result1 = await completion1.ShouldCompleteWithin(Remaining); ;
+                    var result1 = await completion1.WaitAsync(Remaining); ;
 
                     var lastWrite = new List<string>();
                     for (var i = 0; i < 100; i++)
@@ -175,7 +175,7 @@ namespace Akka.Streams.Tests.IO
 
                     var completion2 = Write(lastWrite);
                     
-                    var result2 = await completion2.ShouldCompleteWithin(Remaining);
+                    var result2 = await completion2.WaitAsync(Remaining);
 
                     var lastWriteString = new string(lastWrite.SelectMany(x => x).ToArray());
                     var testLinesString = new string(_testLines.SelectMany(x => x).ToArray());
@@ -222,10 +222,10 @@ namespace Akka.Streams.Tests.IO
                             _materializer);
 
                     var completion1 = Write(_testLines, 0);
-                    await completion1.ShouldCompleteWithin(Remaining);
+                    await completion1.WaitAsync(Remaining);
 
                     var completion2 = Write(testLinesPart2, startPosition);
-                    var result2 = await completion2.ShouldCompleteWithin(Remaining);
+                    var result2 = await completion2.WaitAsync(Remaining);
 
                     f.Length.ShouldBe(startPosition + result2.Count);
 
@@ -322,7 +322,7 @@ namespace Akka.Streams.Tests.IO
                     var completion = Source.From(new []{_testByteStrings.Head()})
                         .RunWith(lazySink, _materializer);
 
-                    await completion.ShouldCompleteWithin(Remaining);
+                    await completion.WaitAsync(Remaining);
                     await AwaitAssertAsync(
                         () => CheckFileContent(f, _testLines.Head()),
                         Remaining);
@@ -343,7 +343,7 @@ namespace Akka.Streams.Tests.IO
                     })
                     .RunWith(FileIO.ToFile(f), _materializer);
 
-                var ex = await InterceptAsync<AbruptIOTerminationException>(() => completion).ShouldCompleteWithin(3.Seconds());
+                var ex = await InterceptAsync<AbruptIOTerminationException>(() => completion).WaitAsync(3.Seconds());
                 ex.IoResult.Count.ShouldBe(1001);
                 CheckFileContent(f, string.Join("", _testLines.TakeWhile(s => !s.Contains('b'))));
                 await Task.CompletedTask;
@@ -358,12 +358,7 @@ namespace Akka.Streams.Tests.IO
                 var completion = Source.Single(ByteString.FromString("42"))
                     .RunWith(FileIO.ToFile(new FileInfo("I-hope-this-file-doesnt-exist.txt"), FileMode.Open), _materializer);
 
-                async Task Exec()
-                {
-                    await completion;
-                }
-
-                await Exec().ShouldThrowWithin<FileNotFoundException>(RemainingOrDefault);
+                await AssertThrowsAsync<FileNotFoundException>(() => completion).WaitAsync(RemainingOrDefault);
             }, _materializer);
         }
 
@@ -398,7 +393,7 @@ namespace Akka.Streams.Tests.IO
 
                     // We still have to wait for the task to complete, because the signal
                     // came from the FileSink actor, not the source actor.
-                    await task.ShouldCompleteWithin(Remaining);
+                    await task.WaitAsync(Remaining);
                     await ExpectTerminatedAsync(actor, Remaining);
 
                     f.Length.ShouldBe(8);

--- a/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/FileSourceSpec.cs
@@ -242,7 +242,7 @@ namespace Akka.Streams.Tests.IO
 
                 c.ExpectSubscription();
                 c.ExpectError();
-                var complete = await r.ShouldCompleteWithin(Dilated(TimeSpan.FromSeconds(3)));
+                var complete = await r.WaitAsync(Dilated(TimeSpan.FromSeconds(3)));
                 complete.WasSuccessful.ShouldBeFalse();
             }, _materializer);
         }

--- a/src/core/Akka.Streams.Tests/IO/OutputStreamSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/OutputStreamSinkSpec.cs
@@ -222,7 +222,7 @@ namespace Akka.Streams.Tests.IO
                 await p.ExpectMsgAsync(datas[0].ToString());
                 await p.ExpectMsgAsync(datas[1].ToString());
                 await p.ExpectMsgAsync(datas[2].ToString());
-                await completion.ShouldCompleteWithin(3.Seconds());
+                await completion.WaitAsync(3.Seconds());
             }, _materializer);
         }
 
@@ -236,7 +236,8 @@ namespace Akka.Streams.Tests.IO
                     .RunWith(StreamConverters.FromOutputStream(() => new CloseOutputStream(p)), _materializer);
 
                 await p.ExpectMsgAsync("closed");
-                await completion.ShouldThrowWithin<AbruptIOTerminationException>(3.Seconds());
+
+                await AssertThrowsAsync<AbruptIOTerminationException>(() => completion).WaitAsync(3.Seconds());
             }, _materializer);
         }
 
@@ -249,7 +250,7 @@ namespace Akka.Streams.Tests.IO
                 {
                     await Source.Failed<ByteString>(new Exception("Boom!"))
                         .RunWith(StreamConverters.FromOutputStream(() => new OutputStream()), _materializer)
-                        .ShouldCompleteWithin(3.Seconds());
+                        .WaitAsync(3.Seconds());
                 }).Should().ThrowAsync<AbruptIOTerminationException>();
             }, _materializer);
         }
@@ -264,7 +265,7 @@ namespace Akka.Streams.Tests.IO
                     .RunWith(StreamConverters.FromOutputStream(() => new CompletionOutputStream(p)), _materializer);
 
                 await p.ExpectMsgAsync("closed");
-                await completion.ShouldCompleteWithin(3.Seconds());
+                await completion.WaitAsync(3.Seconds());
             }, _materializer);
         }
     }

--- a/src/core/Akka.Streams.Tests/IO/OutputStreamSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/OutputStreamSourceSpec.cs
@@ -68,7 +68,7 @@ namespace Akka.Streams.Tests.IO
                 var s = await probe.ExpectSubscriptionAsync();
 
                 await outputStream.WriteAsync(_bytesArray, 0, _bytesArray.Length)
-                    .ShouldCompleteWithin(Timeout);
+                    .WaitAsync(Timeout);
                 s.Request(1);
                 await probe.ExpectNextAsync(_byteString);
                 outputStream.Dispose();
@@ -90,14 +90,14 @@ namespace Akka.Streams.Tests.IO
                     var s = await probe.ExpectSubscriptionAsync();
                     
                     await outputStream.WriteAsync(_bytesArray, 0, _bytesArray.Length)
-                        .ShouldCompleteWithin(Timeout);
+                        .WaitAsync(Timeout);
                     var f = outputStream.FlushAsync();
 
                     await ExpectTimeout(f, Timeout);
                     await probe.ExpectNoMsgAsync(TimeSpan.Zero);
 
                     s.Request(1);
-                    await f.ShouldCompleteWithin(Timeout);
+                    await f.WaitAsync(Timeout);
                     await probe.AsyncBuilder().ExpectNext(_byteString).ExecuteAsync();
                 }
 
@@ -119,14 +119,14 @@ namespace Akka.Streams.Tests.IO
                     var s = await probe.ExpectSubscriptionAsync();
 
                     await outputStream.WriteAsync(_bytesArray, 0, _byteString.Count)
-                        .ShouldCompleteWithin(Timeout);
+                        .WaitAsync(Timeout);
                     var f = outputStream.FlushAsync();
                     s.Request(1);
-                    await f.ShouldCompleteWithin(Timeout);
+                    await f.WaitAsync(Timeout);
                     await probe.ExpectNextAsync(_byteString);
 
                     var f2 = outputStream.FlushAsync();
-                    await f2.ShouldCompleteWithin(Timeout);
+                    await f2.WaitAsync(Timeout);
                 }
 
                 await probe.ExpectCompleteAsync();
@@ -149,7 +149,7 @@ namespace Akka.Streams.Tests.IO
 
                     foreach (var _ in Enumerable.Range(1, 16))
                         await outputStream.WriteAsync(_bytesArray, 0, _byteString.Count)
-                            .ShouldCompleteWithin(Timeout);
+                            .WaitAsync(Timeout);
 
                     //blocked call
                     var f = outputStream.WriteAsync(_bytesArray, 0, _byteString.Count);
@@ -158,7 +158,7 @@ namespace Akka.Streams.Tests.IO
                     await probe.ExpectNoMsgAsync(TimeSpan.Zero);
 
                     s.Request(17);
-                    await f.ShouldCompleteWithin(Timeout);
+                    await f.WaitAsync(Timeout);
                     await probe.ExpectNextNAsync(Enumerable.Repeat(_byteString, 17).ToList());
                 }
 
@@ -179,8 +179,8 @@ namespace Akka.Streams.Tests.IO
                 outputStream.Dispose();
                 await probe.ExpectCompleteAsync();
 
-                await outputStream.WriteAsync(_bytesArray, 0, _byteString.Count)
-                    .ShouldThrowWithin<IOException>(Timeout);
+                await AssertThrowsAsync<IOException>(() => outputStream.WriteAsync(_bytesArray, 0, _byteString.Count))
+                    .WaitAsync(Timeout);
             }, _materializer);
         }
 
@@ -220,7 +220,7 @@ namespace Akka.Streams.Tests.IO
                 var s = await probe.ExpectSubscriptionAsync();
 
                 await outputStream.WriteAsync(_bytesArray, 0, _bytesArray.Length)
-                    .ShouldCompleteWithin(Timeout);
+                    .WaitAsync(Timeout);
                 s.Request(1);
                 await sourceProbe.ExpectMsgAsync<GraphStageMessages.Pull>();
 
@@ -230,8 +230,8 @@ namespace Akka.Streams.Tests.IO
                 await sourceProbe.ExpectMsgAsync<GraphStageMessages.DownstreamFinish>();
 
                 await Task.Delay(500);
-                await outputStream.WriteAsync(_bytesArray, 0, _bytesArray.Length)
-                    .ShouldThrowWithin<IOException>(Timeout);
+                await AssertThrowsAsync<IOException>(() => outputStream.WriteAsync(_bytesArray, 0, _bytesArray.Length))
+                    .WaitAsync(Timeout);
             }, _materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -106,7 +106,7 @@ namespace Akka.Streams.Tests.IO
 
             serverConnection.ConfirmedClose();
             // Reduced timeout - otherwise we're just waiting longer for the failure
-            var result = await resultFuture.ShouldCompleteWithin(3.Seconds());
+            var result = await resultFuture.WaitAsync(3.Seconds());
             result.ShouldBe(expectedOutput);
         }
 
@@ -125,7 +125,7 @@ namespace Akka.Streams.Tests.IO
                         .ToMaterialized(Sink.Ignore<ByteString>(), Keep.Left)
                         .Run(Materializer);
 
-                await Awaiting(() => task.ShouldCompleteWithin(3.Seconds()))
+                await Awaiting(() => task.WaitAsync(3.Seconds()))
                     .Should().ThrowAsync<Exception>().WithMessage("Connection failed*");
             }, Materializer);
         }
@@ -439,7 +439,7 @@ namespace Akka.Streams.Tests.IO
                             Sink.ForEach<Tcp.IncomingConnection>(conn => conn.Flow.Join(writeButIgnoreRead).Run(Materializer)),
                             Keep.Left)
                         .Run(Materializer);
-                await task.ShouldCompleteWithin(3.Seconds());
+                await task.WaitAsync(3.Seconds());
                 var binding = task.Result;
 
                 var (promise, result) = Source.Maybe<ByteString>()
@@ -447,11 +447,11 @@ namespace Akka.Streams.Tests.IO
                     .ToMaterialized(Sink.Aggregate<ByteString, ByteString>(ByteString.Empty, (s, s1) => s + s1), Keep.Both)
                     .Run(Materializer);
 
-                await result.ShouldCompleteWithin(5.Seconds());
+                await result.WaitAsync(5.Seconds());
                 result.Result.Should().BeEquivalentTo(ByteString.FromString("Early response"));
 
                 promise.SetResult(null); // close client upstream, no more data
-                await binding.Unbind().ShouldCompleteWithin(3.Seconds());
+                await binding.Unbind().WaitAsync(3.Seconds());
 
             }, Materializer);
         }
@@ -471,7 +471,7 @@ namespace Akka.Streams.Tests.IO
             var result = await Source.From(Enumerable.Repeat(0, 1000)
                 .Select(i => ByteString.FromBytes([Convert.ToByte(i)])))
                 .Via(Sys.TcpStream().OutgoingConnection(serverAddress, halfClose: true))
-                .RunAggregate(0, (i, s) => i + s.Count, Materializer).ShouldCompleteWithin(10.Seconds());
+                .RunAggregate(0, (i, s) => i + s.Count, Materializer).WaitAsync(10.Seconds());
             
             result.Should().Be(1000);
 
@@ -508,7 +508,7 @@ namespace Akka.Streams.Tests.IO
                                 // Getting rid of existing connection actors by using a blunt instrument
                                 system2.ActorSelection(system2.Tcp().Path / "tcp-client-connection-*").Tell(Kill.Instance);
                             
-                                await result.ShouldCompleteWithin(3.Seconds());
+                                await result.WaitAsync(3.Seconds());
                             }, interval:TimeSpan.FromSeconds(4));
                         });
                         
@@ -516,7 +516,7 @@ namespace Akka.Streams.Tests.IO
                     })
                     .Should().ThrowAsync<StreamTcpException>();
 
-                await binding.Result.Unbind().ShouldCompleteWithin(3.Seconds());
+                await binding.Result.Unbind().WaitAsync(3.Seconds());
             }
             finally
             {
@@ -541,10 +541,10 @@ namespace Akka.Streams.Tests.IO
                 // and is possible to communicate with 
                 await Source.Single(ByteString.FromString(""))
                     .Via(sys2.TcpStream().OutgoingConnection(address))
-                    .RunWith(Sink.Ignore<ByteString>(), mat2).ShouldCompleteWithin(10.Seconds());
+                    .RunWith(Sink.Ignore<ByteString>(), mat2).WaitAsync(10.Seconds());
 
-                await sys2.Terminate().ShouldCompleteWithin(10.Seconds());
-                await binding.Unbind().ShouldCompleteWithin(10.Seconds());
+                await sys2.Terminate().WaitAsync(10.Seconds());
+                await binding.Unbind().WaitAsync(10.Seconds());
             }
             finally
             {
@@ -574,7 +574,7 @@ namespace Akka.Streams.Tests.IO
                 .Run(Materializer);
 
             // make sure that the server has bound to the socket
-            var binding = await bindTask.ShouldCompleteWithin(3.Seconds());
+            var binding = await bindTask.WaitAsync(3.Seconds());
 
             var testInput = Enumerable.Range(0, 255)
                 .Select(i => ByteString.FromBytes([Convert.ToByte(i)]))
@@ -585,11 +585,11 @@ namespace Akka.Streams.Tests.IO
             var result = await Source.From(testInput)
                     .Via(Sys.TcpStream().OutgoingConnection(serverAddress))
                     .RunAggregate(ByteString.Empty, (agg, b) => agg.Concat(b), Materializer)
-                    .ShouldCompleteWithin(10.Seconds());
+                    .WaitAsync(10.Seconds());
             
             result.Should().BeEquivalentTo(expectedOutput);
-            await binding.Unbind().ShouldCompleteWithin(3.Seconds());
-            await echoServerFinish.ShouldCompleteWithin(3.Seconds());
+            await binding.Unbind().WaitAsync(3.Seconds());
+            await echoServerFinish.WaitAsync(3.Seconds());
         }
 
         [Fact]
@@ -602,7 +602,7 @@ namespace Akka.Streams.Tests.IO
                 .Run(Materializer);
 
             // make sure that the server has bound to the socket
-            var binding = await bindTask.ShouldCompleteWithin(3.Seconds());
+            var binding = await bindTask.WaitAsync(3.Seconds());
 
             var echoConnection = Sys.TcpStream().OutgoingConnection(serverAddress);
 
@@ -618,11 +618,11 @@ namespace Akka.Streams.Tests.IO
                 .Via(echoConnection)
                 .Via(echoConnection)
                 .RunAggregate(ByteString.Empty, (agg, b) => agg.Concat(b), Materializer)
-                .ShouldCompleteWithin(10.Seconds());
+                .WaitAsync(10.Seconds());
             
             result.Should().BeEquivalentTo(expectedOutput);
-            await binding.Unbind().ShouldCompleteWithin(3.Seconds());
-            await echoServerFinish.ShouldCompleteWithin(3.Seconds());
+            await binding.Unbind().WaitAsync(3.Seconds());
+            await echoServerFinish.WaitAsync(3.Seconds());
         }
 
         [Fact]
@@ -635,7 +635,7 @@ namespace Akka.Streams.Tests.IO
                 .Run(Materializer);
 
             // make sure that the server has bound to the socket
-            var binding = await bindTask.ShouldCompleteWithin(3.Seconds());
+            var binding = await bindTask.WaitAsync(3.Seconds());
 
             await Task.WhenAll(
                 binding.Unbind(),
@@ -645,9 +645,9 @@ namespace Akka.Streams.Tests.IO
                 binding.Unbind(),
                 binding.Unbind(),
                 binding.Unbind())
-                .ShouldCompleteWithin(3.Seconds());
+                .WaitAsync(3.Seconds());
             
-            await echoServerFinish.ShouldCompleteWithin(3.Seconds());
+            await echoServerFinish.WaitAsync(3.Seconds());
         }
 
         [Fact]
@@ -662,7 +662,7 @@ namespace Akka.Streams.Tests.IO
 
                 // bind succeed, we have local address
                 var binding1 = await bind.To(Sink.FromSubscriber(probe1)).Run(Materializer)
-                    .ShouldCompleteWithin(3.Seconds());
+                    .WaitAsync(3.Seconds());
 
                 await probe1.ExpectSubscriptionAsync();
 
@@ -674,22 +674,22 @@ namespace Akka.Streams.Tests.IO
                 var binding3F = bind.To(Sink.FromSubscriber(probe3)).Run(Materializer);
                 (await probe3.ExpectSubscriptionAndErrorAsync()).Should().BeOfType<BindFailedException>();
 
-                await Awaiting(() => binding2F.ShouldCompleteWithin(3.Seconds()))
+                await Awaiting(() => binding2F.WaitAsync(3.Seconds()))
                     .Should().ThrowAsync<BindFailedException>();
-                await Awaiting(() => binding3F.ShouldCompleteWithin(3.Seconds()))
+                await Awaiting(() => binding3F.WaitAsync(3.Seconds()))
                     .Should().ThrowAsync<BindFailedException>();
                 
                 // Now unbind first
-                await binding1.Unbind().ShouldCompleteWithin(3.Seconds());
+                await binding1.Unbind().WaitAsync(3.Seconds());
                 probe1.ExpectComplete();
 
                 var probe4 = this.CreateManualSubscriberProbe<Tcp.IncomingConnection>();
                 // bind succeeded, we have local address
-                var binding4 = await bind.To(Sink.FromSubscriber(probe4)).Run(Materializer).ShouldCompleteWithin(3.Seconds());
+                var binding4 = await bind.To(Sink.FromSubscriber(probe4)).Run(Materializer).WaitAsync(3.Seconds());
                 await probe4.ExpectSubscriptionAsync();
 
                 // clean up
-                await binding4.Unbind().ShouldCompleteWithin(5.Seconds());
+                await binding4.Unbind().WaitAsync(5.Seconds());
             });
         }
 
@@ -714,7 +714,7 @@ namespace Akka.Streams.Tests.IO
                     .Run(Materializer);
 
                 // make sure server is running first
-                await bindingTask.ShouldCompleteWithin(3.Seconds());
+                await bindingTask.WaitAsync(3.Seconds());
                 var result = bindingTask.Result;
 
                 // then connect, should trigger a block and then
@@ -722,7 +722,7 @@ namespace Akka.Streams.Tests.IO
                     .Via(Sys.TcpStream().OutgoingConnection(serverAddress))
                     .RunAggregate(0, (i, s) => i + s.Count, Materializer);
 
-                (await total.ShouldCompleteWithin(5.Seconds())).Should().Be(1000);
+                (await total.WaitAsync(5.Seconds())).Should().Be(1000);
             }, Materializer);
         }
 
@@ -751,12 +751,12 @@ namespace Akka.Streams.Tests.IO
 
                 var total = folder.Run(Materializer);
 
-                await firstClientConnected.Task.ShouldCompleteWithin(2.Seconds());
+                await firstClientConnected.Task.WaitAsync(2.Seconds());
                 var rejected = folder.Run(Materializer);
 
-                (await total.ShouldCompleteWithin(10.Seconds())).Should().Be(100);
+                (await total.WaitAsync(10.Seconds())).Should().Be(100);
                 
-                await rejected.ShouldThrowWithin<StreamTcpException>(3.Seconds());
+                await AssertThrowsAsync<StreamTcpException>(() => rejected).WaitAsync(3.Seconds());
             }, Materializer);
         }
     }

--- a/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Fusing/ActorGraphInterpreterSpec.cs
@@ -48,7 +48,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     .Via(identity)
                     .Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Equal(Enumerable.Range(1, 100));
             }, Materializer);
         }
@@ -67,7 +67,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     .Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Equal(Enumerable.Range(1, 100));
             }, Materializer);
         }
@@ -85,7 +85,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     .Grouped(100)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Equal(Enumerable.Range(1, 10));
             }, Materializer);
         }
@@ -104,7 +104,7 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                     .Grouped(100)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                var complete = await task.ShouldCompleteWithin(3.Seconds());
+                var complete = await task.WaitAsync(3.Seconds());
                 complete.Should().Equal(Enumerable.Range(1, 10));
             }, Materializer);
         }
@@ -136,9 +136,9 @@ namespace Akka.Streams.Tests.Implementation.Fusing
                         return ClosedShape.Instance;
                     })).Run(Materializer);
                 
-                var complete = await tasks.Item1.ShouldCompleteWithin(3.Seconds());
+                var complete = await tasks.Item1.WaitAsync(3.Seconds());
                 complete.Should().Equal(Enumerable.Range(1, 100));
-                var complete1 = await tasks.Item2.ShouldCompleteWithin(3.Seconds());
+                var complete1 = await tasks.Item2.WaitAsync(3.Seconds());
                 complete1.Should().Equal(Enumerable.Range(1, 10));
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Implementation/StreamLayoutSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/StreamLayoutSpec.cs
@@ -260,7 +260,7 @@ namespace Akka.Streams.Tests.Implementation
 
             var t = g.ToMaterialized(Sink.Seq<int>(), Keep.Both).Run(_materializer);
             var materialized = t.Item1;
-            var result = await t.Item2.ShouldCompleteWithin(VeryPatient);
+            var result = await t.Item2.WaitAsync(VeryPatient);
 
             materialized.Should().Be(1);
             result.Count.Should().Be(1);
@@ -275,7 +275,7 @@ namespace Akka.Streams.Tests.Implementation
 
             var t = g.RunWith(Source.Single(42).MapMaterializedValue(_ => 1), Sink.Seq<int>(), _materializer);
             var materialized = t.Item1;
-            var result = await t.Item2.ShouldCompleteWithin(VeryPatient);
+            var result = await t.Item2.WaitAsync(VeryPatient);
 
             materialized.Should().Be(1);
             result.Count.Should().Be(1);
@@ -290,7 +290,7 @@ namespace Akka.Streams.Tests.Implementation
 
             var t = g.ToMaterialized(Sink.Seq<int>(), Keep.Both).Run(_materializer);
             var materialized = t.Item1;
-            var result = await t.Item2.ShouldCompleteWithin(VeryPatient);
+            var result = await t.Item2.WaitAsync(VeryPatient);
 
             materialized.Should().Be(1);
             result.Count.Should().Be(1);
@@ -306,7 +306,7 @@ namespace Akka.Streams.Tests.Implementation
             var m = g.ToMaterialized(Sink.Seq<int>(), Keep.Both);
             var t = m.Run(_materializer);
             var materialized = t.Item1;
-            var result = await t.Item2.ShouldCompleteWithin(VeryPatient);
+            var result = await t.Item2.WaitAsync(VeryPatient);
 
             materialized.Should().Be(1);
             result.Count.Should().Be(1);
@@ -321,7 +321,7 @@ namespace Akka.Streams.Tests.Implementation
 
             var t = g.RunWith(Source.Single(42).MapMaterializedValue(_ => 1), Sink.Seq<int>(), _materializer);
             var materialized = t.Item1;
-            var result = await t.Item2.ShouldCompleteWithin(VeryPatient);
+            var result = await t.Item2.WaitAsync(VeryPatient);
 
             materialized.Should().Be(1);
             result.Count.Should().Be(1);
@@ -336,7 +336,7 @@ namespace Akka.Streams.Tests.Implementation
 
             var t = g.ToMaterialized(Sink.Seq<int>(), Keep.Both).Run(_materializer);
             var materialized = t.Item1;
-            var result = await t.Item2.ShouldCompleteWithin(VeryPatient);
+            var result = await t.Item2.WaitAsync(VeryPatient);
 
             materialized.Should().Be(1);
             result.Count.Should().Be(1);

--- a/src/core/Akka.Streams.Tests/Implementation/TimeoutsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/TimeoutsSpec.cs
@@ -40,7 +40,7 @@ namespace Akka.Streams.Tests.Implementation
                     .InitialTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await t.ShouldCompleteWithin(3.Seconds());
+                await t.WaitAsync(3.Seconds());
                 t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
             }, Materializer);
         }
@@ -55,7 +55,7 @@ namespace Akka.Streams.Tests.Implementation
                     .InitialTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await Awaiting(() => task.ShouldCompleteWithin(3.Seconds()))
+                await Awaiting(() => task.WaitAsync(3.Seconds()))
                     .Should().ThrowAsync<TestException>().WithMessage("test");
             }, Materializer);
         }
@@ -88,7 +88,7 @@ namespace Akka.Streams.Tests.Implementation
                     .CompletionTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await t.ShouldCompleteWithin(3.Seconds());
+                await t.WaitAsync(3.Seconds());
                 t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
             }, Materializer);
         }
@@ -103,7 +103,7 @@ namespace Akka.Streams.Tests.Implementation
                     .CompletionTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await Awaiting(() => task.ShouldCompleteWithin(3.Seconds()))
+                await Awaiting(() => task.WaitAsync(3.Seconds()))
                     .Should().ThrowAsync<TestException>().WithMessage("test");
             }, Materializer);
         }
@@ -148,7 +148,7 @@ namespace Akka.Streams.Tests.Implementation
                     .IdleTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await t.ShouldCompleteWithin(3.Seconds());
+                await t.WaitAsync(3.Seconds());
                 t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
             }, Materializer);
         }
@@ -163,7 +163,7 @@ namespace Akka.Streams.Tests.Implementation
                     .IdleTimeout(TimeSpan.FromSeconds(2)).Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await Awaiting(() => task.ShouldCompleteWithin(3.Seconds()))
+                await Awaiting(() => task.WaitAsync(3.Seconds()))
                     .Should().ThrowAsync<TestException>().WithMessage("test");
             }, Materializer);
         }
@@ -207,7 +207,7 @@ namespace Akka.Streams.Tests.Implementation
                     .Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await task.ShouldCompleteWithin(3.Seconds());
+                await task.WaitAsync(3.Seconds());
                 task.Result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
             }, Materializer);
         }
@@ -368,7 +368,7 @@ namespace Akka.Streams.Tests.Implementation
                     .Via(timeoutIdentity).Grouped(200)
                     .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
 
-                await t.ShouldCompleteWithin(3.Seconds());
+                await t.WaitAsync(3.Seconds());
                 t.Result.Should().BeEquivalentTo(Enumerable.Range(1, 100));
             }, Materializer);
         }
@@ -401,8 +401,8 @@ namespace Akka.Streams.Tests.Implementation
                 upstreamWriter.SendComplete();
                 downstreamWriter.SendComplete();
 
-                await upFinished.ShouldCompleteWithin(3.Seconds());
-                await downFinished.ShouldCompleteWithin(3.Seconds());
+                await upFinished.WaitAsync(3.Seconds());
+                await downFinished.WaitAsync(3.Seconds());
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/ScriptedTest.cs
+++ b/src/core/Akka.Streams.Tests/ScriptedTest.cs
@@ -341,7 +341,7 @@ namespace Akka.Streams.Tests
             else
             {
                 // guard against deadlocks, assuming that a test would not take more than 30 seconds.
-                await Run().ShouldCompleteWithin(30.Seconds()); 
+                await Run().WaitAsync(30.Seconds()); 
             }
         }
 

--- a/src/core/Akka.TestKit/Akka.TestKit.csproj
+++ b/src/core/Akka.TestKit/Akka.TestKit.csproj
@@ -29,7 +29,6 @@
         <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
         <PackageReference Include="Nito.AsyncEx.Context" Version="5.1.2" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     </ItemGroup>
 
 </Project>

--- a/src/core/Akka.TestKit/Extensions/TaskExtensions.cs
+++ b/src/core/Akka.TestKit/Extensions/TaskExtensions.cs
@@ -9,8 +9,6 @@ using System;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
-using static FluentAssertions.FluentActions;
 
 namespace Akka.TestKit.Extensions
 {
@@ -74,89 +72,5 @@ namespace Akka.TestKit.Extensions
                 }
             }
         }
-        
-        /// <summary>
-        /// Guard a <see cref="Task{T}"/> with a timeout and checks to see if
-        /// the <see cref="Task{T}.Result"/> matches the provided expected value.
-        /// </summary>
-        /// <param name="task">The Task to be guarded</param>
-        /// <param name="expected">The expected Task.Result</param>
-        /// <param name="timeout">The allowed time span for the operation.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
-        /// </param>
-        /// <typeparam name="T"></typeparam>
-        public static async Task ShouldCompleteWithin<T>(
-            this Task<T> task, T expected, TimeSpan timeout, string because = "", params object[] becauseArgs)
-        {
-            await Awaiting(async () =>
-            {
-                var result = await task;
-                result.Should().Be(expected);
-            }).Should().CompleteWithinAsync(timeout, because, becauseArgs);
-        }
-        
-        public static async Task ShouldThrowWithin<T>(
-            this Task task, T expected, TimeSpan timeout, string because = "", params object[] becauseArgs)
-            where T: Exception
-        {
-            (await Awaiting(async () =>
-            {
-                await task.ShouldCompleteWithin(timeout);
-            }).Should().ThrowAsync<T>()).And.Should().Be(expected);
-        }
-
-        public static async Task<T> ShouldThrowWithin<T>(
-            this Task task, TimeSpan timeout, string because = "", params object[] becauseArgs)
-            where T: Exception
-        {
-            var exception = await Awaiting(async () =>
-            {
-                await task.ShouldCompleteWithin(timeout);
-            }).Should().ThrowAsync<T>();
-            return (T) exception.And.Should().Subject;
-        }
-        
-        /// <summary>
-        /// Guard a <see cref="Task{T}"/> with a timeout and returns the <see cref="Task{T}.Result"/>.
-        /// </summary>
-        /// <param name="task">The Task to be guarded</param>
-        /// <param name="timeout">The allowed time span for the operation.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
-        /// </param>
-        /// <typeparam name="T"></typeparam>
-        public static async Task<T> ShouldCompleteWithin<T>(
-            this Task<T> task, TimeSpan timeout, string because = "", params object[] becauseArgs)
-        {
-            return (await Awaiting(async () => await task).Should().CompleteWithinAsync(timeout), because, becauseArgs)
-                .Item1.Subject;
-        }
-        
-        /// <summary>
-        /// Guard a <see cref="Task"/> with a timeout.
-        /// </summary>
-        /// <param name="task">The Task to be guarded</param>
-        /// <param name="timeout">The allowed time span for the operation.</param>
-        /// <param name="because">
-        /// A formatted phrase as is supported by <see cref="M:System.String.Format(System.String,System.Object[])" /> explaining why the assertion
-        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
-        /// </param>
-        /// <param name="becauseArgs">
-        /// Zero or more objects to format using the placeholders in <paramref name="because"/>.
-        /// </param>
-        public static async Task ShouldCompleteWithin(
-            this Task task, TimeSpan timeout, string because = "", params object[] becauseArgs)
-        {
-            await Awaiting(async () => await task).Should().CompleteWithinAsync(timeout, because, becauseArgs);
-        }        
     }
 }

--- a/src/core/Akka.TestKit/ITestKitAssertions.cs
+++ b/src/core/Akka.TestKit/ITestKitAssertions.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 
 namespace Akka.TestKit
 {
@@ -54,5 +55,13 @@ namespace Akka.TestKit
         /// <param name="format">A template string to display if the assertion fails.</param>
         /// <param name="args">An optional object array that contains zero or more objects to format.</param>
         void AssertEqual<T>(T expected, T actual, Func<T,T,bool> comparer, string format = "", params object[] args);
+
+        Exception AssertThrows(Action action);
+        
+        TException AssertThrows<TException>(Action action) where TException : Exception;
+        
+        Task<Exception> AssertThrowsAsync(Func<Task> action);
+        
+        Task<TException> AssertThrowsAsync<TException>(Func<Task> action) where TException : Exception;
     }
 }

--- a/src/core/Akka.TestKit/TestKitBase_Within.cs
+++ b/src/core/Akka.TestKit/TestKitBase_Within.cs
@@ -9,7 +9,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.TestKit.Internal;
-using FluentAssertions.Extensions;
 using Nito.AsyncEx.Synchronous;
 
 namespace Akka.TestKit
@@ -304,7 +303,7 @@ namespace Akka.TestKit
                     var executionTask = function();
                     // Limit the execution time block to the maximum allowed execution time.
                     // 200 milliseconds is added because Task.Delay() timer is not precise and can return prematurely.
-                    var resultTask = await Task.WhenAny(executionTask, Task.Delay(max + 200.Milliseconds(), cts.Token));
+                    var resultTask = await Task.WhenAny(executionTask, Task.Delay(max + TimeSpan.FromMilliseconds(200), cts.Token));
 
                     if (resultTask == executionTask)
                     {

--- a/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
+++ b/src/core/Akka.Tests.Shared.Internals/AkkaSpec.cs
@@ -17,13 +17,9 @@ using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.TestKit.Internal.StringMatcher;
 using Akka.TestKit.TestEvent;
-using Akka.Util;
 using Akka.Util.Internal;
-using FluentAssertions;
-using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
-using static FluentAssertions.FluentActions;
 
 // ReSharper disable once CheckNamespace
 namespace Akka.TestKit
@@ -281,13 +277,12 @@ namespace Akka.TestKit
         /// <exception cref="ThrowsException">If the passed action does not complete abruptly with an exception that's an instance of the specified type.</exception>
         protected T Intercept<T>(Action actionThatThrows) where T : Exception
         {
-            return Invoking(actionThatThrows)
-                .Should().ThrowExactly<T>().And;
+            return Assertions.AssertThrows<T>(actionThatThrows);
         }
 
-        protected async Task<T> InterceptAsync<T>(Func<Task> funcThatThrows) where T : Exception
+        protected Task<T> InterceptAsync<T>(Func<Task> funcThatThrows) where T : Exception
         {
-            return (await funcThatThrows.Should().ThrowExactlyAsync<T>()).And;
+            return Assertions.AssertThrowsAsync<T>(funcThatThrows);
         }
 
         /// <summary>
@@ -311,10 +306,30 @@ namespace Akka.TestKit
             Intercept<T>(actionThatThrows); 
         }
 
-        [Obsolete("Use AssertThrows instead.")]
-        protected void Intercept(Action actionThatThrows)
+        protected async Task AssertThrowsAsync(Func<Task> funcThatThrows, Exception expected)
         {
-            Invoking(actionThatThrows).Should().Throw<Exception>();
+            var exception = await Assertions.AssertThrowsAsync(funcThatThrows);
+            
+            // NOTE:
+            // This is how FluentAssertions do exception equality, more or less
+            // It unwraps AggregateException and checks to see if any of the internal exceptions
+            // matches the expected exception.
+            // Without this code, some unit tests will fail.
+            if (exception is AggregateException ae)
+            {
+                exception = ae.InnerExceptions[0];
+            }
+            Assertions.AssertEqual(expected, exception);
+        }
+        
+        protected Task<T> AssertThrowsAsync<T>(Func<Task> funcThatThrows) where T : Exception
+        {
+            return Assertions.AssertThrowsAsync<T>(funcThatThrows);
+        }
+        
+        protected Task<Exception> AssertThrowsAsync(Func<Task> funcThatThrows)
+        {
+            return Assertions.AssertThrowsAsync(funcThatThrows);
         }
 
         protected void MuteDeadLetters(params Type[] messageClasses)

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Schedule_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Schedule_Tests.cs
@@ -20,10 +20,12 @@ namespace Akka.Tests.Actor.Scheduler
     // ReSharper disable once InconsistentNaming
     public class DefaultScheduler_TellScheduler_Schedule_Tests : AkkaSpec
     {
+#pragma warning disable xUnit1008
         [LocalTheory(SkipLocal = "Tests that messages are sent with the specified interval, however due to inaccuracy " +
                                  "of Task.Delay this often fails. Run this especially if you've made changes to DedicatedThreadScheduler")]
         [InlineData(10, 1000)]
         public async Task ScheduleTellRepeatedly_in_milliseconds_Tests(int initialDelay, int interval)
+#pragma warning restore xUnit1008
         {
             // Prepare, set up actions to be fired
             IScheduler scheduler = new HashedWheelTimerScheduler(Sys.Settings.Config, Log);

--- a/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
@@ -140,7 +140,7 @@ namespace Akka.Tests.Actor
                 // manager + all workers should be restarted by only killing a worker
                 // manager doesn't trap exits, so boss will restart manager
 
-                await countDown.WaitAsync().ShouldCompleteWithin(5.Seconds());
+                await countDown.WaitAsync().WaitAsync(5.Seconds());
                 //countDown.Wait(TimeSpan.FromSeconds(5)).ShouldBe(true);
             });
 
@@ -176,8 +176,8 @@ namespace Akka.Tests.Actor
                 boss.Tell("killCrasher");
                 return Task.CompletedTask;
             });
-            await countDownMessages.WaitAsync().ShouldCompleteWithin(2.Seconds());
-            await countDownMax.WaitAsync().ShouldCompleteWithin(2.Seconds());
+            await countDownMessages.WaitAsync().WaitAsync(2.Seconds());
+            await countDownMax.WaitAsync().WaitAsync(2.Seconds());
         }
 
         private async Task Helper_A_supervisor_hierarchy_must_resume_children_after_Resume<T>() 


### PR DESCRIPTION
## Changes

* Remove FluentAssertions dependency from all TestKit
* Fix assertion logic

(cherry picked from commit d924e57e205527d2e2c263792f52af290b22709a)

> [!NOTE]
> Would need to be propagated to other TestKit implementation if released.