### PR TITLE
Parameterize Incrementalist base branch for Azure DevOps pipelines

### DIFF
--- a/build-system/azure-pipeline.mntr-template.yaml
+++ b/build-system/azure-pipeline.mntr-template.yaml
@@ -14,19 +14,25 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     pool:
       vmImage: ${{ parameters.vmImage }}
-    variables:
-      # Determine the base branch for Incrementalist based on the target branch
-      - name: incrementalist.baseBranch
-        ${{ if eq(variables['System.PullRequest.TargetBranch'], '') }}:
-          value: 'dev' # Default for non-PR builds
-        ${{ else }}:
-          value: $(System.PullRequest.TargetBranch)
     steps:
       - task: UseDotNet@2
         displayName: 'Use .NET'
         inputs:
           packageType: 'sdk'
           useGlobalJson: true
+      
+      # Set the Incrementalist base branch based on PR target branch
+      - pwsh: |
+          if ('$(Build.Reason)' -eq 'PullRequest') {
+            # Extract branch name from refs/heads/branch format
+            $targetBranch = '$(System.PullRequest.TargetBranch)'.Replace('refs/heads/', '')
+            Write-Host "PR detected - using base branch: $targetBranch"
+            Write-Host "##vso[task.setvariable variable=IncrementalistBaseBranch]$targetBranch"
+          } else {
+            Write-Host "Not a PR - using default base branch: dev"
+            Write-Host "##vso[task.setvariable variable=IncrementalistBaseBranch]dev"
+          }
+        displayName: 'Set Incrementalist base branch'
 
       - script: dotnet tool restore
         displayName: 'Restore dotnet tools'

--- a/build-system/azure-pipeline.mntr-template.yaml
+++ b/build-system/azure-pipeline.mntr-template.yaml
@@ -14,6 +14,13 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     pool:
       vmImage: ${{ parameters.vmImage }}
+    variables:
+      # Determine the base branch for Incrementalist based on the target branch
+      - name: incrementalist.baseBranch
+        ${{ if eq(variables['System.PullRequest.TargetBranch'], '') }}:
+          value: 'dev' # Default for non-PR builds
+        ${{ else }}:
+          value: $(System.PullRequest.TargetBranch)
     steps:
       - task: UseDotNet@2
         displayName: 'Use .NET'

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -21,6 +21,12 @@ jobs:
         value: true
       - name: xunit.skip.local.theory
         value: true
+      # Determine the base branch for Incrementalist based on the target branch
+      - name: incrementalist.baseBranch
+        ${{ if eq(variables['System.PullRequest.TargetBranch'], '') }}:
+          value: 'dev' # Default for non-PR builds
+        ${{ else }}:
+          value: $(System.PullRequest.TargetBranch)
     steps:
       - task: UseDotNet@2
         displayName: 'Use .NET'

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -21,18 +21,25 @@ jobs:
         value: true
       - name: xunit.skip.local.theory
         value: true
-      # Determine the base branch for Incrementalist based on the target branch
-      - name: incrementalist.baseBranch
-        ${{ if eq(variables['System.PullRequest.TargetBranch'], '') }}:
-          value: 'dev' # Default for non-PR builds
-        ${{ else }}:
-          value: $(System.PullRequest.TargetBranch)
     steps:
       - task: UseDotNet@2
         displayName: 'Use .NET'
         inputs:
           packageType: 'sdk'
           useGlobalJson: true
+      
+      # Set the Incrementalist base branch based on PR target branch
+      - pwsh: |
+          if ('$(Build.Reason)' -eq 'PullRequest') {
+            # Extract branch name from refs/heads/branch format
+            $targetBranch = '$(System.PullRequest.TargetBranch)'.Replace('refs/heads/', '')
+            Write-Host "PR detected - using base branch: $targetBranch"
+            Write-Host "##vso[task.setvariable variable=IncrementalistBaseBranch]$targetBranch"
+          } else {
+            Write-Host "Not a PR - using default base branch: dev"
+            Write-Host "##vso[task.setvariable variable=IncrementalistBaseBranch]dev"
+          }
+        displayName: 'Set Incrementalist base branch'
 
       - script: dotnet tool restore
         displayName: 'Restore dotnet tools'

--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -59,7 +59,7 @@ jobs:
       name: "netfx_tests_windows"
       displayName: ".NET Framework Unit Tests (Windows)"
       vmImage: "windows-latest"
-      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(incrementalist.baseBranch) -- test -c Release --no-build --framework net48 --logger:trx --results-directory TestResults"
+      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(IncrementalistBaseBranch) -- test -c Release --no-build --framework net48 --logger:trx --results-directory TestResults"
       outputDirectory: "TestResults"
       artifactName: "netfx_tests_windows-$(Build.BuildId)"
 
@@ -80,7 +80,7 @@ jobs:
       name: "net_tests_windows"
       displayName: ".NET Unit Tests (Windows)"
       vmImage: "windows-latest"
-      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(incrementalist.baseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
+      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(IncrementalistBaseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
       outputDirectory: "TestResults"
       artifactName: "net_tests_windows-$(Build.BuildId)"
 
@@ -89,7 +89,7 @@ jobs:
       name: "net_tests_linux"
       displayName: ".NET Unit Tests (Linux)"
       vmImage: "ubuntu-latest"
-      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(incrementalist.baseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
+      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(IncrementalistBaseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
       outputDirectory: "TestResults"
       artifactName: "net_tests_linux-$(Build.BuildId)"
 
@@ -98,7 +98,7 @@ jobs:
       name: "net_mntr_windows"
       displayName: ".NET Multi-Node Tests (Windows)"
       vmImage: "windows-latest"
-      command: "dotnet incrementalist run --config .incrementalist/mutliNodeOnly.json --branch $(incrementalist.baseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults/multinode"
+      command: "dotnet incrementalist run --config .incrementalist/mutliNodeOnly.json --branch $(IncrementalistBaseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults/multinode"
       outputDirectory: "TestResults"
       artifactName: "net_mntr_windows-$(Build.BuildId)"
       mntrFailuresDir: 'TestResults\\multinode'

--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -59,7 +59,7 @@ jobs:
       name: "netfx_tests_windows"
       displayName: ".NET Framework Unit Tests (Windows)"
       vmImage: "windows-latest"
-      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json -- test -c Release --no-build --framework net48 --logger:trx --results-directory TestResults"
+      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(incrementalist.baseBranch) -- test -c Release --no-build --framework net48 --logger:trx --results-directory TestResults"
       outputDirectory: "TestResults"
       artifactName: "netfx_tests_windows-$(Build.BuildId)"
 
@@ -80,7 +80,7 @@ jobs:
       name: "net_tests_windows"
       displayName: ".NET Unit Tests (Windows)"
       vmImage: "windows-latest"
-      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
+      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(incrementalist.baseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
       outputDirectory: "TestResults"
       artifactName: "net_tests_windows-$(Build.BuildId)"
 
@@ -89,7 +89,7 @@ jobs:
       name: "net_tests_linux"
       displayName: ".NET Unit Tests (Linux)"
       vmImage: "ubuntu-latest"
-      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
+      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(incrementalist.baseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
       outputDirectory: "TestResults"
       artifactName: "net_tests_linux-$(Build.BuildId)"
 
@@ -98,7 +98,7 @@ jobs:
       name: "net_mntr_windows"
       displayName: ".NET Multi-Node Tests (Windows)"
       vmImage: "windows-latest"
-      command: "dotnet incrementalist run --config .incrementalist/mutliNodeOnly.json -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults/multinode"
+      command: "dotnet incrementalist run --config .incrementalist/mutliNodeOnly.json --branch $(incrementalist.baseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults/multinode"
       outputDirectory: "TestResults"
       artifactName: "net_mntr_windows-$(Build.BuildId)"
       mntrFailuresDir: 'TestResults\\multinode'


### PR DESCRIPTION
## Summary
- Adds dynamic base branch detection for Incrementalist in Azure DevOps pipelines
- Prevents unnecessary full builds when PRs target version branches (e.g., v1.5) instead of dev

## Changes
- Added `incrementalist.baseBranch` variable to pipeline templates that:
  - Uses `System.PullRequest.TargetBranch` for PR builds
  - Defaults to 'dev' for non-PR builds
- Updated all Incrementalist commands to use `--branch $(incrementalist.baseBranch)` parameter

## Impact
When a PR targets v1.5, Incrementalist will now correctly compare against v1.5 instead of dev, avoiding full builds when only specific projects have changed between v1.5 and the PR branch.

This solves the issue where PRs to version branches would always trigger full builds because Incrementalist was comparing against dev (which contains v1.6 code) instead of the actual target branch.

## Test Plan
The pipeline changes will be validated when this PR runs through Azure DevOps.