### PR TITLE
Parameterize Incrementalist base branch for Azure DevOps pipelines 

### DIFF
--- a/build-system/azure-pipeline.mntr-template.yaml
+++ b/build-system/azure-pipeline.mntr-template.yaml
@@ -20,6 +20,19 @@ jobs:
         inputs:
           packageType: 'sdk'
           useGlobalJson: true
+      
+      # Set the Incrementalist base branch based on PR target branch
+      - pwsh: |
+          if ('$(Build.Reason)' -eq 'PullRequest') {
+            # Extract branch name from refs/heads/branch format
+            $targetBranch = '$(System.PullRequest.TargetBranch)'.Replace('refs/heads/', '')
+            Write-Host "PR detected - using base branch: $targetBranch"
+            Write-Host "##vso[task.setvariable variable=IncrementalistBaseBranch]$targetBranch"
+          } else {
+            Write-Host "Not a PR - using default base branch: dev"
+            Write-Host "##vso[task.setvariable variable=IncrementalistBaseBranch]dev"
+          }
+        displayName: 'Set Incrementalist base branch'
 
       - script: dotnet tool restore
         displayName: 'Restore dotnet tools'

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -27,6 +27,19 @@ jobs:
         inputs:
           packageType: 'sdk'
           useGlobalJson: true
+      
+      # Set the Incrementalist base branch based on PR target branch
+      - pwsh: |
+          if ('$(Build.Reason)' -eq 'PullRequest') {
+            # Extract branch name from refs/heads/branch format
+            $targetBranch = '$(System.PullRequest.TargetBranch)'.Replace('refs/heads/', '')
+            Write-Host "PR detected - using base branch: $targetBranch"
+            Write-Host "##vso[task.setvariable variable=IncrementalistBaseBranch]$targetBranch"
+          } else {
+            Write-Host "Not a PR - using default base branch: dev"
+            Write-Host "##vso[task.setvariable variable=IncrementalistBaseBranch]dev"
+          }
+        displayName: 'Set Incrementalist base branch'
 
       - script: dotnet tool restore
         displayName: 'Restore dotnet tools'

--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -59,7 +59,7 @@ jobs:
       name: "netfx_tests_windows"
       displayName: ".NET Framework Unit Tests (Windows)"
       vmImage: "windows-latest"
-      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json -- test -c Release --no-build --framework net48 --logger:trx --results-directory TestResults"
+      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(IncrementalistBaseBranch) -- test -c Release --no-build --framework net48 --logger:trx --results-directory TestResults"
       outputDirectory: "TestResults"
       artifactName: "netfx_tests_windows-$(Build.BuildId)"
 
@@ -80,7 +80,7 @@ jobs:
       name: "net_tests_windows"
       displayName: ".NET Unit Tests (Windows)"
       vmImage: "windows-latest"
-      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
+      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(IncrementalistBaseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
       outputDirectory: "TestResults"
       artifactName: "net_tests_windows-$(Build.BuildId)"
 
@@ -89,7 +89,7 @@ jobs:
       name: "net_tests_linux"
       displayName: ".NET Unit Tests (Linux)"
       vmImage: "ubuntu-latest"
-      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
+      command: "dotnet incrementalist run --config .incrementalist/testsOnly.json --branch $(IncrementalistBaseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults"
       outputDirectory: "TestResults"
       artifactName: "net_tests_linux-$(Build.BuildId)"
 
@@ -98,7 +98,7 @@ jobs:
       name: "net_mntr_windows"
       displayName: ".NET Multi-Node Tests (Windows)"
       vmImage: "windows-latest"
-      command: "dotnet incrementalist run --config .incrementalist/mutliNodeOnly.json -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults/multinode"
+      command: "dotnet incrementalist run --config .incrementalist/mutliNodeOnly.json --branch $(IncrementalistBaseBranch) -- test -c Release --no-build --framework net8.0 --logger:trx --results-directory TestResults/multinode"
       outputDirectory: "TestResults"
       artifactName: "net_mntr_windows-$(Build.BuildId)"
       mntrFailuresDir: 'TestResults\\multinode'


### PR DESCRIPTION
Cherry-picked this from #7791

- Add dynamic incrementalist.baseBranch variable to pipeline templates
- Use System.PullRequest.TargetBranch for PR builds
- Default to 'dev' for non-PR builds
- Update all Incrementalist commands to use --branch parameter

This allows PRs targeting version branches (e.g., v1.5) to correctly compare against their target branch instead of always using dev, avoiding unnecessary full builds.

* Fix Incrementalist base branch detection for Azure DevOps PRs

- Use PowerShell script to extract branch name from System.PullRequest.TargetBranch
- Strip 'refs/heads/' prefix from target branch reference
- Set IncrementalistBaseBranch variable dynamically at runtime
- Update all Incrementalist commands to use the new variable

This fixes the issue where PR builds always used 'dev' as the base branch even when targeting version branches like v1.5.
