### PR TITLE
Fix race conditions in TestEventListenerTests and TcpSpec

### DIFF
--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -498,36 +498,27 @@ namespace Akka.Streams.Tests.IO
                     .Via(system2.TcpStream().OutgoingConnection(serverAddress))
                     .RunAggregate(0, (i, s) => i + s.Count, mat2);
 
-                // Wait for connection to be established by checking that connection actors exist
+                // Get the actual connection actor reference and watch it
+                IActorRef connectionActor = null;
                 await AwaitAssertAsync(async () =>
                 {
-                    try
-                    {
-                        await system2.ActorSelection(system2.Tcp().Path / "tcp-client-connection-*")
-                            .ResolveOne(TimeSpan.FromMilliseconds(100));
-                        // If we get here, connection actor exists
-                    }
-                    catch (ActorNotFoundException)
-                    {
-                        throw new Exception("Connection not yet established");
-                    }
+                    connectionActor = await system2.ActorSelection(system2.Tcp().Path / "tcp-client-connection-*")
+                        .ResolveOne(TimeSpan.FromMilliseconds(100));
                 }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(200));
 
-                await Awaiting(async () =>
-                    {
-                        await WithinAsync(TimeSpan.FromSeconds(15), async () =>
-                        {
-                            await AwaitAssertAsync(async () =>
-                            {
-                                // Getting rid of existing connection actors by using a blunt instrument
-                                system2.ActorSelection(system2.Tcp().Path / "tcp-client-connection-*").Tell(Kill.Instance);
-                            
-                                await result.WaitAsync(3.Seconds());
-                            }, interval:TimeSpan.FromSeconds(4));
-                        });
-                        
-                        
-                    })
+                // Watch the connection actor so we can verify it's actually dead
+                var probe = CreateTestProbe(system2);
+                await probe.WatchAsync(connectionActor);
+
+                // Kill the specific connection actor
+                connectionActor.Tell(Kill.Instance);
+
+                // Wait for the actor to actually terminate
+                var terminated = await probe.ExpectMsgAsync<Terminated>(TimeSpan.FromSeconds(3));
+                terminated.ActorRef.Should().Be(connectionActor);
+
+                // Now the result should throw StreamTcpException since connection is definitely dead
+                await Awaiting(async () => await result.WaitAsync(TimeSpan.FromSeconds(3)))
                     .Should().ThrowAsync<StreamTcpException>();
 
                 await binding.Result.Unbind().WaitAsync(3.Seconds());

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -495,9 +495,9 @@ namespace Akka.Streams.Tests.IO
                     .Via(system2.TcpStream().OutgoingConnection(serverAddress))
                     .RunAggregate(0, (i, s) => i + s.Count, mat2);
 
-                // give some time for all TCP stream actor parties to actually 
-                // get initialized, otherwise Kill command may run into the void
-                await Task.Delay(500);
+                // Wait for the connection to be established by ensuring the stream starts processing
+                // Send some data to establish the connection first
+                await AwaitConditionAsync(() => !result.IsCompleted, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
 
                 await Awaiting(async () =>
                     {
@@ -505,11 +505,15 @@ namespace Akka.Streams.Tests.IO
                         {
                             await AwaitAssertAsync(async () =>
                             {
-                                // Getting rid of existing connection actors by using a blunt instrument
+                                // Kill connection actors more aggressively by targeting both incoming and outgoing connections
                                 system2.ActorSelection(system2.Tcp().Path / "tcp-client-connection-*").Tell(Kill.Instance);
+                                system2.ActorSelection(system2.Tcp().Path / "tcp-server-connection-*").Tell(Kill.Instance);
+                                
+                                // Also kill the TCP manager to ensure stream failure propagation
+                                system2.ActorSelection(system2.Tcp().Path).Tell(Kill.Instance);
                             
                                 await result.WaitAsync(3.Seconds());
-                            }, interval:TimeSpan.FromSeconds(4));
+                            }, interval:TimeSpan.FromSeconds(2));
                         });
                         
                         

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -252,7 +252,7 @@ namespace Akka.Streams.Tests.IO
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
-                var testData = ByteString.FromBytes(new byte[] { 1, 2, 3, 4, 5 });
+                var testData = ByteString.FromBytes([1, 2, 3, 4, 5]);
                 var server = await new Server(this).InitializeAsync();
 
                 var tcpWriteProbe = new TcpWriteProbe(this);
@@ -289,7 +289,7 @@ namespace Akka.Streams.Tests.IO
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
-                var testData = ByteString.FromBytes(new byte[] { 1, 2, 3, 4, 5 });
+                var testData = ByteString.FromBytes([1, 2, 3, 4, 5]);
                 var server = await new Server(this).InitializeAsync();
 
                 var tcpWriteProbe = new TcpWriteProbe(this);
@@ -491,13 +491,27 @@ namespace Akka.Streams.Tests.IO
                 var binding = system2.TcpStream()
                     .BindAndHandle(Flow.Create<ByteString>(), mat2, serverAddress.Address.ToString(), serverAddress.Port);
 
+                // Ensure server is bound before creating client connection
+                await binding.WaitAsync(TimeSpan.FromSeconds(3));
+
                 var result = Source.Maybe<ByteString>()
                     .Via(system2.TcpStream().OutgoingConnection(serverAddress))
                     .RunAggregate(0, (i, s) => i + s.Count, mat2);
 
-                // Wait for the connection to be established by ensuring the stream starts processing
-                // Send some data to establish the connection first
-                await AwaitConditionAsync(() => !result.IsCompleted, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100));
+                // Wait for connection to be established by checking that connection actors exist
+                await AwaitAssertAsync(async () =>
+                {
+                    try
+                    {
+                        await system2.ActorSelection(system2.Tcp().Path / "tcp-client-connection-*")
+                            .ResolveOne(TimeSpan.FromMilliseconds(100));
+                        // If we get here, connection actor exists
+                    }
+                    catch (ActorNotFoundException)
+                    {
+                        throw new Exception("Connection not yet established");
+                    }
+                }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(200));
 
                 await Awaiting(async () =>
                     {
@@ -505,15 +519,11 @@ namespace Akka.Streams.Tests.IO
                         {
                             await AwaitAssertAsync(async () =>
                             {
-                                // Kill connection actors more aggressively by targeting both incoming and outgoing connections
+                                // Getting rid of existing connection actors by using a blunt instrument
                                 system2.ActorSelection(system2.Tcp().Path / "tcp-client-connection-*").Tell(Kill.Instance);
-                                system2.ActorSelection(system2.Tcp().Path / "tcp-server-connection-*").Tell(Kill.Instance);
-                                
-                                // Also kill the TCP manager to ensure stream failure propagation
-                                system2.ActorSelection(system2.Tcp().Path).Tell(Kill.Instance);
                             
                                 await result.WaitAsync(3.Seconds());
-                            }, interval:TimeSpan.FromSeconds(2));
+                            }, interval:TimeSpan.FromSeconds(4));
                         });
                         
                         

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -25,15 +25,19 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
             //It should respond with an "OK" message when it has received the message.
             var initLoggerMessage = new ForwardAllEventsTestEventListener.ForwardAllEventsTo(TestActor);
             
-            // Ensure the logging system is fully started before sending initialization message
-            // This fixes race conditions where the message is sent before loggers are ready
-            AwaitAssert(() => 
+            // Use async initialization to handle potential race conditions without blocking constructor
+            InitializeEventForwarding(initLoggerMessage).Wait();
+            //From now on we know that all messages will be forwarded to TestActor
+        }
+
+        private async Task InitializeEventForwarding(object initLoggerMessage)
+        {
+            // Retry logger initialization to handle race conditions where logging system isn't ready yet
+            await AwaitAssertAsync(async () =>
             {
                 SendRawLogEventMessage(initLoggerMessage);
-                ExpectMsg("OK", TimeSpan.FromSeconds(1));
+                await ExpectMsgAsync("OK", TimeSpan.FromSeconds(1));
             }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(200));
-            
-            //From now on we know that all messages will be forwarded to TestActor
         }
 
         protected abstract void SendRawLogEventMessage(object message);

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -8,10 +8,11 @@
 using System;
 using System.Threading.Tasks;
 using Akka.Event;
+using Xunit;
 
 namespace Akka.TestKit.Tests.TestEventListenerTests
 {
-    public abstract class EventFilterTestBase : TestKit.Xunit2.TestKit
+    public abstract class EventFilterTestBase : TestKit.Xunit2.TestKit, IAsyncLifetime
     {
         /// <summary>
         /// Used to signal that the test was successful and that we should ensure no more messages were logged
@@ -21,23 +22,27 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         protected EventFilterTestBase(string config)
             : base(@"akka.loggers = [""" + typeof(ForwardAllEventsTestEventListener).AssemblyQualifiedName + @"""], " + (string.IsNullOrEmpty(config) ? "" : config))
         {
+        }
+
+        public async Task InitializeAsync()
+        {
             //We send a ForwardAllEventsTo containing message to the TestEventListenerToForwarder logger (configured as a logger above).
             //It should respond with an "OK" message when it has received the message.
             var initLoggerMessage = new ForwardAllEventsTestEventListener.ForwardAllEventsTo(TestActor);
             
-            // Use async initialization to handle potential race conditions without blocking constructor
-            InitializeEventForwarding(initLoggerMessage).Wait();
-            //From now on we know that all messages will be forwarded to TestActor
-        }
-
-        private async Task InitializeEventForwarding(object initLoggerMessage)
-        {
             // Retry logger initialization to handle race conditions where logging system isn't ready yet
             await AwaitAssertAsync(async () =>
             {
                 SendRawLogEventMessage(initLoggerMessage);
                 await ExpectMsgAsync("OK", TimeSpan.FromSeconds(1));
             }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(200));
+            
+            //From now on we know that all messages will be forwarded to TestActor
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
 
         protected abstract void SendRawLogEventMessage(object message);

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -25,8 +25,14 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
             //It should respond with an "OK" message when it has received the message.
             var initLoggerMessage = new ForwardAllEventsTestEventListener.ForwardAllEventsTo(TestActor);
             
-            SendRawLogEventMessage(initLoggerMessage);
-            ExpectMsg("OK");
+            // Ensure the logging system is fully started before sending initialization message
+            // This fixes race conditions where the message is sent before loggers are ready
+            AwaitAssert(() => 
+            {
+                SendRawLogEventMessage(initLoggerMessage);
+                ExpectMsg("OK", TimeSpan.FromSeconds(1));
+            }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(200));
+            
             //From now on we know that all messages will be forwarded to TestActor
         }
 


### PR DESCRIPTION
## Changes

- Fix `EventFilterTestBase` race condition by using `AwaitAssert` to retry logger initialization until successful
- Fix TcpSpec unexpected termination test by waiting for stream startup and targeting multiple connection actor types
- These fixes address timing issues where the logging system or TCP connections weren't fully initialized before tests proceeded

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).