### PR TITLE
Fix race condition in `ClusterLogVerboseDefaultSpec` test

### DIFF
--- a/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
@@ -125,9 +125,35 @@ namespace Akka.Cluster.Tests
         public async Task A_cluster_must_not_log_verbose_cluster_events_by_default()
         {
             _cluster.Settings.LogInfoVerbose.ShouldBeFalse();
-            await AssertThrowsAsync<XunitException>(() => JoinAsync(upLogMessage)).WaitAsync(11.Seconds());
+            
+            // Join the cluster but verify verbose log messages are NOT emitted
+            await EventFilter
+                .Info(contains: upLogMessage)
+                .ExpectAsync(0, async () => {
+                    var tcs = new TaskCompletionSource<bool>();
+                    _cluster.RegisterOnMemberUp(() =>
+                    {
+                        tcs.TrySetResult(true);
+                    });
+                    _cluster.Join(_selfAddress);
+                    await tcs.Task.WaitAsync(10.Seconds());
+                });
+            
             await AwaitUpAsync();
-            await AssertThrowsAsync<XunitException>(() => DownAsync(downLogMessage)).WaitAsync(11.Seconds());
+            
+            // Down the cluster but verify verbose log messages are NOT emitted
+            await EventFilter
+                .Info(contains: downLogMessage)
+                .ExpectAsync(0, async () =>
+                {
+                    var tcs = new TaskCompletionSource<bool>();
+                    _cluster.RegisterOnMemberRemoved(() =>
+                    {
+                        tcs.TrySetResult(true);
+                    });
+                    _cluster.Down(_selfAddress);
+                    await tcs.Task.WaitAsync(10.Seconds());
+                });
         }
     }
 


### PR DESCRIPTION
## Changes

The test was using a convoluted pattern of expecting a timeout exception when verbose logging was disabled. This created a race condition with nested timeouts.

Changed to directly assert that 0 verbose log messages are emitted when verbose logging is disabled, making the test more deterministic and clear.

- Use E`ventFilter.ExpectAsync(0, ...)` instead of expecting timeout failure
- Remove nested timeout complexity with `WaitAsync(11.Seconds())`
- Test now directly asserts the expected behavior (no verbose logs)

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).