### PR TITLE
Fix `TcpSpec.Outgoing_TCP_stream_must_shut_down_both_streams_when_connection_is_aborted_remotely` race condition on Linux

### DIFF
--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -367,14 +367,21 @@ namespace Akka.Streams.Tests.IO
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
 
-                Source.FromPublisher(tcpWriteProbe.PublisherProbe)
-                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
+                // Wait for TCP connection to be fully established before aborting
+                var connectionTask = Source.FromPublisher(tcpWriteProbe.PublisherProbe)
+                    .ViaMaterialized(Sys.TcpStream().OutgoingConnection(server.Address), Keep.Right)
                     .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
+                    
                 var serverConnection = await server.WaitAcceptAsync();
+                var clientConnection = await connectionTask;
+                
+                // Start active reading to ensure Linux can detect TCP RST
+                var readSub = await tcpReadProbe.SubscriberProbe.ExpectSubscriptionAsync();
+                readSub.Request(1);
 
                 serverConnection.Abort();
-                await tcpReadProbe.SubscriberProbe.ExpectSubscriptionAndErrorAsync();
+                await tcpReadProbe.SubscriberProbe.ExpectErrorAsync();
                 var subscription = await tcpWriteProbe.TcpWriteSubscription();
                 await subscription.ExpectCancellationAsync();
 


### PR DESCRIPTION
## Problem

The test `Outgoing_TCP_stream_must_shut_down_both_streams_when_connection_is_aborted_remotely` was failing intermittently on Linux due to platform-specific TCP behavior. This issue caused 11 failed attempts in PR #7813.

## Root Cause

**Linux requires active recv() calls to detect TCP RST during connection establishment.**

- Linux: RST detection depends on active socket reading
- Windows: More aggressive RST detection works automatically  
- Test was creating "zombie" connections (established but not actively reading)
- When abort happened before active reading, RST detection failed on Linux

## Solution

1. **Wait for TCP connection establishment**: Use `ViaMaterialized(..., Keep.Right)` to ensure connection is fully ready
2. **Start active reading**: Add `readSub.Request(1)` to trigger `recv()` calls on Linux
3. **Then abort**: RST detection now works reliably across platforms

This makes the test behave like real applications that immediately start using their TCP connections.

## Testing

- ✅ Test passes consistently on multiple runs
- ✅ All TCP tests still pass (19 passed, 3 skipped)  
- ✅ Works on both .NET Framework 4.8 and .NET 8.0

## Files Changed

- `src/core/Akka.Streams.Tests/IO/TcpSpec.cs` - Updated test to wait for connection and start reading

Closes #7813