### PR TITLE
[Tests] Fix racy unit tests in Query.InMemory.Tests

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
@@ -18,6 +18,8 @@ namespace Akka.Persistence.Query.InMemory.Tests
 
         public InMemoryAllEventsSpec(ITestOutputHelper output) : base(Config(), nameof(InMemoryAllEventsSpec), output)
         {
+            // Proactively initialize the write journal to avoid cold-start delays on first persist
+            Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.inmem");
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByPersistenceIdSpec.cs
@@ -19,6 +19,8 @@ namespace Akka.Persistence.Query.InMemory.Tests
         public InMemoryEventsByPersistenceIdSpec(ITestOutputHelper output) :
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
         {
+            // Proactively initialize the write journal to avoid cold-start delays on first persist
+            Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.inmem");
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
@@ -28,6 +28,8 @@ namespace Akka.Persistence.Query.InMemory.Tests
         public InMemoryEventsByTagSpec(ITestOutputHelper output) : 
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
         {
+            // Proactively initialize the write journal to avoid cold-start delays on first persist
+            Persistence.Instance.Apply(Sys).JournalFor("akka.persistence.journal.inmem");
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
 

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
@@ -36,3 +36,4 @@ namespace Akka.Persistence.Query.InMemory.Tests
         protected override bool SupportsTagsInEventEnvelope => true;
     }
 }
+

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
@@ -36,4 +36,3 @@ namespace Akka.Persistence.Query.InMemory.Tests
         protected override bool SupportsTagsInEventEnvelope => true;
     }
 }
-


### PR DESCRIPTION
supercede and close #7814

## Changes

* Make sure that memory journal started in test class constructor