### PR TITLE
Harden Akka.Streams.Tests.FlowLogSpec

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
@@ -195,4 +195,3 @@ namespace Akka.Streams.Tests.Dsl
         }
     }
 }
-

--- a/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Event;
@@ -40,9 +41,23 @@ namespace Akka.Streams.Tests.Dsl
             _logProbe = p;
         }
 
-        private ValueTask<string[]> LogMessages(int n)
-            => _logProbe.ReceiveWhileAsync<Debug>(shouldContinue:_ => true, msgs: n)
-                .Select(x => x.Message.ToString()).ToArrayAsync();
+        private async Task<string[]> LogMessages(int n, string tag)
+        {
+            return (await LogEvents<Debug>(n, tag)).Select(m => m.Message.ToString()).ToArray();
+        }
+
+        private async Task<T[]> LogEvents<T>(int n, string tag) where T : LogEvent
+        {
+            var count = 0;
+            var messages = new List<T>();
+            while (count < n)
+            {
+                var msg = (T) await _logProbe.FishForMessageAsync(m => m is T d && d.Message.ToString().StartsWith(tag));
+                count++;
+                messages.Add(msg);
+            }
+            return messages.ToArray();
+        }
 
         private static readonly Type LogType = typeof (IMaterializer);
 
@@ -52,7 +67,7 @@ namespace Akka.Streams.Tests.Dsl
             var debugging = Flow.Create<int>().Log("my-debug");
             _ = Source.From([1, 2]).Via(debugging).RunWith(Sink.Ignore<int>(), Materializer);
 
-            var msgs = await LogMessages(3);
+            var msgs = await LogMessages(3, "[my-debug]");
             msgs[0].Should().Be("[my-debug] Element: 1");
             msgs[1].Should().Be("[my-debug] Element: 2");
             msgs[2].Should().Be("[my-debug] Upstream finished.");
@@ -69,7 +84,7 @@ namespace Akka.Streams.Tests.Dsl
                 .WithAttributes(disableElementLogging)
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            var msgs = await LogMessages(1);
+            var msgs = await LogMessages(1, "[my-debug]");
             msgs[0].Should().Be("[my-debug] Upstream finished.");
         }
 
@@ -80,7 +95,7 @@ namespace Akka.Streams.Tests.Dsl
         {
             _ = Source.From([1, 2]).Log("flow-s2").RunWith(Sink.Ignore<int>(), Materializer);
 
-            var msgs = await LogMessages(3);
+            var msgs = await LogMessages(3, "[flow-s2]");
             msgs[0].Should().Be("[flow-s2] Element: 1");
             msgs[1].Should().Be("[flow-s2] Element: 2");
             msgs[2].Should().Be("[flow-s2] Upstream finished.");
@@ -93,7 +108,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Log("flow-s3", t => t.Item2)
                 .RunWith(Sink.Ignore<(int, string)>(), Materializer);
 
-            var msgs = await LogMessages(2);
+            var msgs = await LogMessages(2, "[flow-s3]");
             msgs[0].Should().Be("[flow-s3] Element: 42");
             msgs[1].Should().Be("[flow-s3] Upstream finished.");
         }
@@ -106,7 +121,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Log("flow-s4")
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            var error = (Error) await _logProbe.FishForMessageAsync(o => o is Error);
+            var error = (Error) await _logProbe.FishForMessageAsync(o => o is Error e && e.Message.ToString().StartsWith("[flow-s4]"));
             error.Cause.Should().Be(cause);
             error.Message.ToString().Should().Be("[flow-s4] Upstream failed.");
         }
@@ -120,7 +135,7 @@ namespace Akka.Streams.Tests.Dsl
                 .Log("flow-5", log: log)
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            var msgs = await _logProbe.ReceiveWhileAsync<Debug>(shouldContinue:_ => true, msgs: 2).ToArrayAsync();
+            var msgs = await LogEvents<Debug>(2, "[flow-5]");
             msgs.All(m => m.LogSource.Equals("com.example.ImportantLogger")).Should().BeTrue();
             msgs.All(m => m.LogClass == LogType).Should().BeTrue();
             msgs[0].Message.ToString().Should().Be("[flow-5] Element: 42");
@@ -139,8 +154,11 @@ namespace Akka.Streams.Tests.Dsl
                     LogLevel.DebugLevel))
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            (await _logProbe.ExpectMsgAsync<Warning>()).Message.ToString().Should().Be("[flow-6] Element: 42");
-            (await _logProbe.ExpectMsgAsync<Info>()).Message.ToString().Should().Be("[flow-6] Upstream finished.");
+            var warnings = await LogEvents<Warning>(1, "[flow-6]");
+            warnings[0].Message.ToString().Should().Be("[flow-6] Element: 42");
+            
+            var info = await LogEvents<Info>(1, "[flow-6]");
+            info[0].Message.ToString().Should().Be("[flow-6] Upstream finished.");
 
             var cause = new TestException("test");
             _ = Source.Failed<int>(cause)
@@ -148,8 +166,8 @@ namespace Akka.Streams.Tests.Dsl
                 .WithAttributes(logAttributes)
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            var error = await _logProbe.ExpectMsgAsync<Debug>();
-            error.Message.ToString().Should().Be("[flow-6e] Upstream failed, cause: Akka.Streams.TestKit.TestException test");
+            var error = await LogEvents<Debug>(1, "[flow-6e]");
+            error[0].Message.ToString().Should().Be("[flow-6e] Upstream failed, cause: Akka.Streams.TestKit.TestException test");
         }
 
         [Fact]
@@ -159,7 +177,8 @@ namespace Akka.Streams.Tests.Dsl
                 .Log("flow-6", logLevel: LogLevel.WarningLevel)
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            (await _logProbe.ExpectMsgAsync<Warning>()).Message.ToString().Should().Be("[flow-6] Element: 42");
+            var warnings = await LogEvents<Warning>(1, "[flow-6]");
+            warnings[0].Message.ToString().Should().Be("[flow-6] Element: 42");
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Event;
 using Akka.Streams.Dsl;
 using Akka.Streams.Supervision;
@@ -26,94 +27,100 @@ namespace Akka.Streams.Tests.Dsl
         {
             var settings = ActorMaterializerSettings.Create(Sys).WithInputBuffer(2, 16);
             Materializer = ActorMaterializer.Create(Sys, settings);
-
-            var p = CreateTestProbe();
-            Sys.EventStream.Subscribe(p.Ref, typeof(object));
-            LogProbe = p;
         }
 
-        private TestProbe LogProbe { get; }
+        private TestProbe _logProbe;
 
-        private string[] LogMessages(int n)
-            => LogProbe.ReceiveN(n).Cast<Debug>().Select(x => x.Message.ToString()).ToArray();
+        protected override void AtStartup()
+        {
+            base.AtStartup();
+            
+            var p = CreateTestProbe();
+            Sys.EventStream.Subscribe(p.Ref, typeof(LogEvent));
+            _logProbe = p;
+        }
 
-        private Type LogType => typeof (IMaterializer);
+        private ValueTask<string[]> LogMessages(int n)
+            => _logProbe.ReceiveWhileAsync<Debug>(shouldContinue:_ => true, msgs: n)
+                .Select(x => x.Message.ToString()).ToArrayAsync();
+
+        private static readonly Type LogType = typeof (IMaterializer);
 
         [Fact]
-        public void A_Log_on_Flow_must_debug_each_element()
+        public async Task A_Log_on_Flow_must_debug_each_element()
         {
             var debugging = Flow.Create<int>().Log("my-debug");
-            Source.From(new[] {1, 2}).Via(debugging).RunWith(Sink.Ignore<int>(), Materializer);
+            _ = Source.From([1, 2]).Via(debugging).RunWith(Sink.Ignore<int>(), Materializer);
 
-            var msgs = LogMessages(3);
+            var msgs = await LogMessages(3);
             msgs[0].Should().Be("[my-debug] Element: 1");
             msgs[1].Should().Be("[my-debug] Element: 2");
             msgs[2].Should().Be("[my-debug] Upstream finished.");
         }
 
         [Fact]
-        public void A_Log_on_Flow_must_allow_disabling_elements_logging()
+        public async Task A_Log_on_Flow_must_allow_disabling_elements_logging()
         {
             var disableElementLogging = Attributes.CreateLogLevels(Attributes.LogLevels.Off, LogLevel.DebugLevel,
                 LogLevel.DebugLevel);
             var debugging = Flow.Create<int>().Log("my-debug");
-            Source.From(new[] {1, 2})
+            _ = Source.From([1, 2])
                 .Via(debugging)
                 .WithAttributes(disableElementLogging)
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            var msgs = LogMessages(1);
+            var msgs = await LogMessages(1);
             msgs[0].Should().Be("[my-debug] Upstream finished.");
         }
 
 
 
         [Fact]
-        public void A_Log_on_source_must_debug_each_element()
+        public async Task A_Log_on_source_must_debug_each_element()
         {
-            Source.From(new[] {1, 2}).Log("flow-s2").RunWith(Sink.Ignore<int>(), Materializer);
+            _ = Source.From([1, 2]).Log("flow-s2").RunWith(Sink.Ignore<int>(), Materializer);
 
-            var msgs = LogMessages(3);
+            var msgs = await LogMessages(3);
             msgs[0].Should().Be("[flow-s2] Element: 1");
             msgs[1].Should().Be("[flow-s2] Element: 2");
             msgs[2].Should().Be("[flow-s2] Upstream finished.");
         }
 
         [Fact]
-        public void A_Log_on_source_must_allow_extracting_value_to_be_logged()
+        public async Task A_Log_on_source_must_allow_extracting_value_to_be_logged()
         {
-            Source.Single((1, "42"))
+            _ = Source.Single((1, "42"))
                 .Log("flow-s3", t => t.Item2)
                 .RunWith(Sink.Ignore<(int, string)>(), Materializer);
 
-            var msgs = LogMessages(2);
+            var msgs = await LogMessages(2);
             msgs[0].Should().Be("[flow-s3] Element: 42");
             msgs[1].Should().Be("[flow-s3] Upstream finished.");
         }
 
         [Fact]
-        public void A_Log_on_source_must_log_upstream_failure()
+        public async Task A_Log_on_source_must_log_upstream_failure()
         {
             var cause = new TestException("test");
-            Source.Failed<int>(cause)
+            _ = Source.Failed<int>(cause)
                 .Log("flow-s4")
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            var error = LogProbe.ExpectMsg<Error>();
+            var error = (Error) await _logProbe.FishForMessageAsync(o => o is Error);
             error.Cause.Should().Be(cause);
             error.Message.ToString().Should().Be("[flow-s4] Upstream failed.");
         }
 
         [Fact]
-        public void A_Log_on_source_must_allow_passing_in_custom_LoggingAdapter()
+        public async Task A_Log_on_source_must_allow_passing_in_custom_LoggingAdapter()
         {
             var log = new BusLogging(Sys.EventStream, "com.example.ImportantLogger", LogType, DefaultLogMessageFormatter.Instance);
 
-            Source.Single(42)
+            _ = Source.Single(42)
                 .Log("flow-5", log: log)
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            var msgs = LogProbe.ReceiveN(2).Cast<Debug>().ToArray();
+            var msgs = await _logProbe.ReceiveWhileAsync<Debug>(shouldContinue:_ => true, msgs: 2).ToArrayAsync();
             msgs.All(m => m.LogSource.Equals("com.example.ImportantLogger")).Should().BeTrue();
             msgs.All(m => m.LogClass == LogType).Should().BeTrue();
             msgs[0].Message.ToString().Should().Be("[flow-5] Element: 42");
@@ -121,50 +128,50 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void A_Log_on_source_must_allow_configuring_log_levels_via_Attributes()
+        public async Task A_Log_on_source_must_allow_configuring_log_levels_via_Attributes()
         {
             var logAttributes = Attributes.CreateLogLevels(LogLevel.WarningLevel, LogLevel.InfoLevel,
                 LogLevel.DebugLevel);
 
-            Source.Single(42)
+            _ = Source.Single(42)
                 .Log("flow-6")
                 .WithAttributes(Attributes.CreateLogLevels(LogLevel.WarningLevel, LogLevel.InfoLevel,
                     LogLevel.DebugLevel))
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            LogProbe.ExpectMsg<Warning>().Message.ToString().Should().Be("[flow-6] Element: 42");
-            LogProbe.ExpectMsg<Info>().Message.ToString().Should().Be("[flow-6] Upstream finished.");
+            (await _logProbe.ExpectMsgAsync<Warning>()).Message.ToString().Should().Be("[flow-6] Element: 42");
+            (await _logProbe.ExpectMsgAsync<Info>()).Message.ToString().Should().Be("[flow-6] Upstream finished.");
 
             var cause = new TestException("test");
-            Source.Failed<int>(cause)
+            _ = Source.Failed<int>(cause)
                 .Log("flow-6e")
                 .WithAttributes(logAttributes)
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            var error = LogProbe.ExpectMsg<Debug>();
+            var error = await _logProbe.ExpectMsgAsync<Debug>();
             error.Message.ToString().Should().Be("[flow-6e] Upstream failed, cause: Akka.Streams.TestKit.TestException test");
         }
 
         [Fact]
-        public void A_Log_on_source_must_allow_configuring_log_levels_via_Method_argument()
+        public async Task A_Log_on_source_must_allow_configuring_log_levels_via_Method_argument()
         {
-            Source.Single(42)
+            _ = Source.Single(42)
                 .Log("flow-6", logLevel: LogLevel.WarningLevel)
                 .RunWith(Sink.Ignore<int>(), Materializer);
 
-            LogProbe.ExpectMsg<Warning>().Message.ToString().Should().Be("[flow-6] Element: 42");
+            (await _logProbe.ExpectMsgAsync<Warning>()).Message.ToString().Should().Be("[flow-6] Element: 42");
         }
 
         [Fact]
-        public void A_Log_on_Source_must_follow_supervision_strategy_when_Exception_thrown()
+        public async Task A_Log_on_Source_must_follow_supervision_strategy_when_Exception_thrown()
         {
             var ex = new TestException("test");
             var future = Source.From(Enumerable.Range(1, 5))
-                .Log("hi", _ => { throw ex; })
+                .Log("hi", _ => throw ex)
                 .WithAttributes(ActorAttributes.CreateSupervisionStrategy(Deciders.ResumingDecider))
                 .RunWith(Sink.Aggregate<int, int>(0, (i, i1) => i + i1), Materializer);
 
-            future.Wait(TimeSpan.FromMilliseconds(500)).Should().BeTrue();
+            await future.WaitAsync(TimeSpan.FromMilliseconds(500));
             future.Result.Should().Be(0);
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowLogSpec.cs
@@ -195,3 +195,4 @@ namespace Akka.Streams.Tests.Dsl
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- Fixes a racy/flaky test in `Akka.Streams.Tests` (`FlowLogSpec`) observed on constrained CI runners.
- Root cause: test captured all EventStream traffic and then casted blindly to `Debug`, which intermittently included non-`Debug` messages (e.g., `SuppressedDeadLetter`).
- Resolution: scope log capture to the specific stage messages by tag and type, using `FishForMessageAsync`-based helpers. No timeouts changed.

## Root Cause
- The test previously subscribed a probe to `typeof(object)` and used `ReceiveN(n).Cast<Debug>()` to read the next N logs.
- On busy/slow CI, unrelated EventStream events (e.g., `Akka.Event.SuppressedDeadLetter`) interleaved and caused `InvalidCastException` when casting to `Debug`.
- Additionally, asserting “next message is X” (`ExpectMsgAsync<T>`) was fragile under DEBUG-level noise.

## Changes
- Probe now subscribes to `typeof(LogEvent)` only, excluding non-log traffic.
- Added helpers:
  - `LogEvents<T>(n, tag)` and `LogMessages(n, tag)` that use `FishForMessageAsync` with a prefix tag (e.g., `[my-debug]`) to capture only the stage’s log messages, in order.
- Replaced brittle `ReceiveN(n).Cast<Debug>()` and raw `ExpectMsgAsync<T>` uses with tag- and type-filtered fishing across the spec.
- Kept test logic and expected messages intact; only the capture mechanism changed.

## Why Deterministic
- Filters by `LogEvent` type and `[tag]` prefix ensure the probe ignores unrelated EventStream messages.
- `FishForMessageAsync` waits for the exact expected message without draining needed entries or depending on head-of-queue type.
- Unique tags per test isolate assertions even in noisy DEBUG environments.