### PR TITLE
Harden Streams.Tests.IO.TcpSpec Outgoing_TCP_stream_must_handle_when_connection_actor_terminates_unexpectedly

### DIFF
--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -491,7 +491,7 @@ namespace Akka.Streams.Tests.IO
             var system2 = ActorSystem.Create("system2", Sys.Settings.Config);
             try
             {
-                InitializeLogger(system2);
+                InitializeLogger(system2, "[SYS2]");
                 var mat2 = ActorMaterializer.Create(system2);
 
                 var serverAddress = TestUtils.TemporaryServerAddress();
@@ -501,11 +501,20 @@ namespace Akka.Streams.Tests.IO
                 // Ensure server is bound before creating client connection
                 await binding.WaitAsync(TimeSpan.FromSeconds(3));
 
-                var result = Source.Maybe<ByteString>()
+                // Build a client stream with a controllable upstream and an echo gate to ensure full registration
+                var tapped = Source.Queue<ByteString>(16, OverflowStrategy.Backpressure)
                     .Via(system2.TcpStream().OutgoingConnection(serverAddress))
-                    .RunAggregate(0, (i, s) => i + s.Count, mat2);
+                    .AlsoToMaterialized(Sink.First<ByteString>(), Keep.Both);
 
-                // Get the actual connection actor reference and watch it
+                var ((queue, firstEcho), result) = tapped
+                    .ToMaterialized(Sink.Aggregate<ByteString, int>(0, (i, s) => i + s.Count), Keep.Both)
+                    .Run(mat2);
+
+                // Send a ping and wait for the echo to guarantee Connected+Registered+Watched state
+                (await queue.OfferAsync(ByteString.FromString("ping"))).Should().BeOfType<QueueOfferResult.Enqueued>();
+                await firstEcho.WaitAsync(5.Seconds());
+
+                // Resolve the actual connection actor reference and watch it
                 IActorRef connectionActor = null;
                 await AwaitAssertAsync(async () =>
                 {
@@ -513,7 +522,6 @@ namespace Akka.Streams.Tests.IO
                         .ResolveOne(TimeSpan.FromMilliseconds(100));
                 }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(200));
 
-                // Watch the connection actor so we can verify it's actually dead
                 var probe = CreateTestProbe(system2);
                 await probe.WatchAsync(connectionActor);
 
@@ -524,9 +532,14 @@ namespace Akka.Streams.Tests.IO
                 var terminated = await probe.ExpectMsgAsync<Terminated>(TimeSpan.FromSeconds(3));
                 terminated.ActorRef.Should().Be(connectionActor);
 
-                // Now the result should throw StreamTcpException since connection is definitely dead
-                await Awaiting(async () => await result.WaitAsync(TimeSpan.FromSeconds(3)))
-                    .Should().ThrowAsync<StreamTcpException>();
+                // Verify the stream fails deterministically with StreamTcpException
+                await AwaitAssertAsync(() =>
+                {
+                    result.IsFaulted.Should().BeTrue();
+                    var flattened = result.Exception?.Flatten();
+                    flattened.Should().NotBeNull();
+                    flattened!.InnerExceptions.Should().Contain(e => e is StreamTcpException);
+                }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(200));
 
                 await binding.Result.Unbind().WaitAsync(3.Seconds());
             }

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -786,3 +786,4 @@ namespace Akka.Streams.Tests.IO
         }
     }
 }
+


### PR DESCRIPTION
## Background
- Flaky test: `Akka.Streams.Tests.IO.TcpSpec.Outgoing_TCP_stream_must_handle_when_connection_actor_terminates_unexpectedly()`.
- Flakes under resource‑limited CI (AzDO). Timeouts are not the solution; aim for deterministic sequencing.
- Symptom: expected `StreamTcpException` not thrown within the assertion window.

## Observed Evidence (from console output)
- `Attempting connection to [127.0.0.1:PORT]` from `tcp-client-connection-0` before the server bind starts.
- `Binding TCP channel on endpoint [127.0.0.1:PORT]` happens after the client begins connecting.
- `Kill` delivered to `tcp-client-connection-0` while still connecting.
- Follow‑up `Kill` messages to `tcp-client-connection-*` end up as dead letters (actor already terminated).
- An `ObjectDisposedException` in `Socket.ConnectAsync` occurs after kill (expected fallout).

Interpretation: the test kills the client connection actor while the stream is in the Connecting phase, before the streams stage fully registers with and watches the connection actor.

## Theory: Where the Race Comes From
- OutgoingConnection stage (`OutgoingConnectionStage` in `TcpStages.cs`):
  - Watches the IO manager during connect; switches to watch the connection actor only after receiving `Tcp.Connected`.
  - Registers the stage as handler via `Tcp.Register` only after `Tcp.Connected`.
  - In Connected state, it fails the stage on `Terminated`, `Tcp.Aborted`, `Tcp.ErrorClosed`, `Tcp.CommandFailed`.
  - It completes the stage on normal `Tcp.Closed`/`Tcp.ConfirmedClosed`/`Tcp.PeerClosed`.
- Connection actor (`TcpConnection` / `TcpOutgoingConnection`):
  - On `Register`, sets a default close notification to `Aborted` for the registered handler; in `PostStop`, notifies the handler.
  - If killed before `Register`, there is no handler to notify and thus no close event reaches the stage.

Conclusion: Killing the connection actor pre‑registration means the streams stage may not observe a failure. The test currently assumes that resolving an actor selection and sending `Kill` implies the stream will fail soon after, but that’s only guaranteed after Connected+Register+Watch are in place.

## Deterministic Fix Strategy (No Timeout Changes)
Goal: ensure the stream has fully transitioned to Connected+Registered+Watched before killing the connection actor; keep the connection open to avoid normal completion; then assert a failure deterministically.

Recommended approach:
1. Client upstream: use `Source.Queue<ByteString>` (backpressured) instead of `Source.Maybe` so we can push a "ping".
2. Server: use echo flow (`conn.Flow.Join(Flow.Create<ByteString>())`) and keep it open (avoid single‑element sources that complete), with default half‑close behavior suitable for clients.
3. Client pipeline: tee output to `AlsoTo(Sink.First<ByteString>())` and await the first echoed element ("pong"). This proves the stage is fully registered and data has flowed in both directions.
4. After the echo is observed, resolve `system2.ActorSelection(system2.Tcp().Path / "tcp-client-connection-*")`, watch that specific actor, send `Kill`, and `Expect` its `Terminated`.
5. Replace the one‑shot `ThrowAsync`/`WaitAsync` assertion with a deterministic `AwaitAssert` that the aggregate `Task` becomes `Faulted` with `StreamTcpException`.
6. Cleanup: complete the `Source.Queue`, unbind the server.

## Why This Fix Is Deterministic
- After an echo is observed, the stage has registered with and is watching the connection actor.
- Killing a registered connection actor guarantees either:
  - `Terminated` to the stage → `FailStage(new StreamTcpException(...))`, or
  - `TcpConnection.PostStop` sends `Aborted` to the registered handler → `FailStage(new StreamTcpException(...))`.
- The failure will propagate without relying on short time windows.

## Risks and Fallbacks
- If failure still isn’t observed: suggests a deeper race where a normal close is processed before termination. Current code sets default `Aborted` after `Register`, so normal closure on `Kill` is unlikely. If reproduced:
  - Stage hardening ideas: prefer failure if `Terminated` has been observed; audit to ensure `PostStop` always results in an abnormal close after `Register`.
