### PR TITLE
Harden Akka.Streams.Tests.Dsl.HubSpec.MergeHub_must_keep_working_even_if_one_of_the_producers_fail

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -1013,3 +1013,4 @@ namespace Akka.Streams.Tests.Dsl
         }
     }
 }
+

--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -1013,4 +1013,3 @@ namespace Akka.Streams.Tests.Dsl
         }
     }
 }
-

--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -1012,5 +1012,4 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
     }
-
 }

--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -267,17 +267,30 @@ namespace Akka.Streams.Tests.Dsl
 
                 await WithinAsync(10.Seconds(), async () =>
                 {
-                    var errorProbe = CreateTestProbe();
-                    Sys.EventStream.Subscribe(errorProbe, typeof(Error));
-                    
-                    Source.Failed<int>(new TestException("failing")).RunWith(sink, Materializer);
-                    Source.From(Enumerable.Range(1, 10)).RunWith(sink, Materializer);
-                    
-                    var error = (Error) await errorProbe.FishForMessageAsync(m => m is Error e && e.Message.ToString().Contains("Upstream producer failed with exception"));
+                    // Subscribe the spec's TestActor synchronously to avoid EventFilter races
+                    Sys.EventStream.Subscribe(TestActor, typeof(Error));
+
+                    // Attach a controllable failing producer and fail it deterministically after subscription
+                    var failing = this.CreatePublisherProbe<int>();
+                    Source.FromPublisher(failing).RunWith(sink, Materializer);
+                    await failing.EnsureSubscriptionAsync();
+                    await failing.SendErrorAsync(new TestException("failing"));
+
+                    // Observe the MergeHub failure log deterministically
+                    var error = await FishForMessageAsync<Error>(e =>
+                        e.Message.ToString()!.Contains("Upstream producer failed with exception"));
                     error.Cause.Should().BeOfType<MergeHub.ProducerFailed>();
-                    
+                    error.Cause.InnerException.Should().NotBeNull();
+                    error.Cause.InnerException.Should().BeOfType<TestException>();
+                    error.Cause.InnerException!.Message.Should().Be("failing");
+
+                    // Now start the healthy producer and verify downstream behavior
+                    Source.From(Enumerable.Range(1, 10)).RunWith(sink, Materializer);
                     var result = await task.WaitAsync(3.Seconds());
                     result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
+
+                    // Cleanup subscription
+                    Sys.EventStream.Unsubscribe(TestActor, typeof(Error));
                 });
             }, Materializer);
         }

--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -16,6 +16,7 @@ using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
 using Akka.Actor;
+using Akka.Event;
 using Akka.Streams.Dsl.Internal;
 using Akka.Streams.Tests.Actor;
 using Akka.TestKit.Extensions;
@@ -266,14 +267,17 @@ namespace Akka.Streams.Tests.Dsl
 
                 await WithinAsync(10.Seconds(), async () =>
                 {
-                    await EventFilter.Error(contains: "Upstream producer failed with exception")
-                        .ExpectOneAsync(async () =>
-                        {
-                            Source.Failed<int>(new TestException("failing")).RunWith(sink, Materializer);
-                            Source.From(Enumerable.Range(1, 10)).RunWith(sink, Materializer);
-                            var result = await task.WaitAsync(3.Seconds());
-                            result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
-                        });
+                    var errorProbe = CreateTestProbe();
+                    Sys.EventStream.Subscribe(errorProbe, typeof(Error));
+                    
+                    Source.Failed<int>(new TestException("failing")).RunWith(sink, Materializer);
+                    Source.From(Enumerable.Range(1, 10)).RunWith(sink, Materializer);
+                    
+                    var error = (Error) await errorProbe.FishForMessageAsync(m => m is Error e && e.Message.ToString().Contains("Upstream producer failed with exception"));
+                    error.Cause.Should().BeOfType<MergeHub.ProducerFailed>();
+                    
+                    var result = await task.WaitAsync(3.Seconds());
+                    result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
                 });
             }, Materializer);
         }


### PR DESCRIPTION
# Fix flaky HubSpec: MergeHub_must_keep_working_even_if_one_of_the_producers_fail

## Summary
- Stabilizes a racy test that intermittently timed out in CI (AzDO).
- Replaces EventFilter-based log assertion with deterministic EventStream subscription and enforces failure-before-cancel ordering.
- No production code or timeouts changed.

## Theory
- Flake stems from two races: (1) EventFilter installed asynchronously can miss fast error logs; (2) downstream `Take(10)` may complete and cancel producers before a failing producer signals, which (by design) produces no error log.

## Assumptions
- Preserve MergeHub semantics: producer failure logs `MergeHub.ProducerFailed`; cancellation does not log.
- Do not increase timeouts; make ordering deterministic.
- EventStream subscription on `TestActor` is synchronous; `TestPublisher.Probe` lets us drive failure explicitly.

## Fix
- Replace EventFilter with `Sys.EventStream.Subscribe(TestActor, typeof(Error))`.
- Attach a controllable failing producer (`TestPublisher.Probe<int>`), ensure subscription, then `SendError(new TestException("failing"))`.
- Fish for the `Error` and assert `Cause` is `MergeHub.ProducerFailed`.
- Start the healthy producer after the failure and assert downstream result.
- Test-only change; no runtime code or timeouts modified.
