### PR TITLE
Fix race condition in SubSource double materialization error handling

### DIFF
--- a/src/core/Akka.Streams/Implementation/Fusing/StreamOfStreams.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/StreamOfStreams.cs
@@ -1257,10 +1257,12 @@ namespace Akka.Streams.Implementation.Fusing
                         FailStage(error.Cause);
                         break;
                     case Action<IActorSubscriberMessage>:
-                        throw new IllegalStateException("Substream Source cannot be materialized more than once");
+                        FailStage(new IllegalStateException("Substream Source cannot be materialized more than once"));
+                        break;
                     default:
                         // Unexpected state - should not happen but be safe
-                        throw new IllegalStateException($"Substream Source cannot be materialized more than once - found [{previous}]");
+                        FailStage(new IllegalStateException($"Substream Source cannot be materialized more than once - found [{previous}]"));
+                        break;
                 }
             }
 


### PR DESCRIPTION
## Summary
Fixes intermittent test failure in `FlowPrefixAndTailSpec.PrefixAndTail_must_throw_if_tail_is_attempted_to_be_materialized_twice` by replacing exception throwing with `FailStage()` call in SubSource double materialization detection.

## Problem
The test was failing intermittently (~1 in 20 runs) with:
```
Failed: Timeout 00:00:03 while waiting for a message of type Akka.Streams.TestKit.TestSubscriber+OnError
```

## Root Cause
When `SubSource.SetCallback()` detected double materialization, it was **throwing** an `IllegalStateException` instead of calling `FailStage()`. This caused a race condition:

1. Exception thrown during `PreStart()`
2. GraphInterpreter catches it, logs error, then calls `FailStage()` 
3. Extra overhead from exception creation/throwing/catching creates timing issues
4. Error might not propagate to subscriber within test timeout

## Solution
Replace `throw new IllegalStateException(...)` with `FailStage(new IllegalStateException(...))` to:
- Eliminate exception overhead (creation, throwing, stack unwinding, catching)
- Ensure direct error propagation through the stream
- Avoid redundant error logging by GraphInterpreter
- Align with Scala Akka's implementation pattern

## Key Insight
The GraphInterpreter's exception handler is a **safety net** for unexpected errors, not the primary error handling mechanism. GraphStages should use `FailStage()` directly for expected error conditions.

This follows the same fix pattern as PR #7830 which fixed `Source.Failed` race conditions.

## Testing
- ✅ The specific failing test now passes consistently (20+ consecutive runs)
- ✅ All 16 tests in FlowPrefixAndTailSpec pass
- ✅ No changes to test code required - production code fix only

## Previous Related PRs
- #7816: Added `signalDemand: false` to test (helped but didn't fully fix)
- #7796: Fixed atomic operations with `CompareExchange` (helped but didn't fully fix)
- #7830: Similar fix for `Source.Failed` race condition

Fixes intermittent CI failures in FlowPrefixAndTailSpec test suite.