### PR TITLE
Fix race condition in KeepAliveConcatSpec test

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/KeepAliveConcatSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/KeepAliveConcatSpec.cs
@@ -134,7 +134,7 @@ namespace Akka.Streams.Tests.Dsl
         }
 
         [Fact]
-        public void KeepAliveConcat_should_emit_buffered_elements_when_upstream_completed()
+        public async Task KeepAliveConcat_should_emit_buffered_elements_when_upstream_completed()
         {
             var upstream = this.CreatePublisherProbe<int>();
             var downstream = this.CreateSubscriberProbe<int>();
@@ -143,15 +143,19 @@ namespace Akka.Streams.Tests.Dsl
                 .Via(new KeepAliveConcat<int>(5, TimeSpan.FromSeconds(60), x => new[] { x }))
                 .RunWith(Sink.FromSubscriber(downstream), Sys.Materializer());
 
-            upstream.SendNext(1);
-            upstream.SendNext(2);            
-            upstream.SendComplete();
+            // Wait for KeepAliveConcat to pull from upstream (respecting reactive streams protocol)
+            await upstream.ExpectRequestAsync();
 
-            downstream.Request(2);
-            downstream.ExpectNextN(2).Should().BeEquivalentTo(new[] { 1, 2 }, o => o.WithStrictOrdering());
+            // Now send elements in response to the demand
+            await upstream.SendNextAsync(1);
+            await upstream.SendNextAsync(2);
+            await upstream.SendCompleteAsync();
 
-            downstream.Request(1);
-            downstream.ExpectComplete();
+            await downstream.RequestAsync(2);
+            await downstream.ExpectNextNAsync(new[] { 1, 2 });
+
+            await downstream.RequestAsync(1);
+            await downstream.ExpectCompleteAsync();
         }
     }
 


### PR DESCRIPTION
## Summary
Fixed a race condition in the `KeepAliveConcat_should_emit_buffered_elements_when_upstream_completed` test that was causing intermittent failures with timeout errors.

## Problem
The test was failing with:
```
Failed: Timeout 00:00:03 while waiting for a message of type Akka.Streams.TestKit.TestPublisher+RequestMore
```

## Root Cause
The `TestPublisher.SendNext` method enforces reactive streams backpressure - it waits for demand before sending elements. The test was calling `SendNext` before the `KeepAliveConcat` stage's initial pull had propagated to the publisher, causing a timeout.

## Solution
- Added `await upstream.ExpectRequestAsync()` to wait for the initial pull from KeepAliveConcat
- Updated all test operations to use async/await consistently
- Ensured the test respects reactive streams protocol (no sends without demand)

## Notes
- This test was added in the .NET port and doesn't exist in the Scala Akka version
- All Scala tests follow the pattern of creating demand before sending elements
- The fix ensures proper sequencing without violating reactive streams semantics

## Test Results
All 6 tests in `KeepAliveConcatSpec` pass after the fix.

Fixes #[issue number if applicable]