### PR TITLE
Harden Akka.Streams.Tests.Dsl.FlowPrefixAndTailSpec.PrefixAndTail_must_throw_if_tail_is_attempted_to_be_materialized_twice

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
@@ -173,6 +173,7 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
         
+        
         [Fact]
         public async Task PrefixAndTail_must_signal_error_if_substream_has_been_not_subscribed_in_time()
         {

--- a/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
@@ -172,6 +172,7 @@ namespace Akka.Streams.Tests.Dsl
                 await success.RequestNext(2).ExpectCompleteAsync();
             }, Materializer);
         }
+        
 
         [Fact]
         public async Task PrefixAndTail_must_signal_error_if_substream_has_been_not_subscribed_in_time()

--- a/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
@@ -15,6 +15,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 // ReSharper disable InvokeAsExtensionMethod
@@ -143,20 +144,32 @@ namespace Akka.Streams.Tests.Dsl
             await this.AssertAllStagesStoppedAsync(async() => {
                 var futureSink = NewHeadSink;
                 var fut = Source.From(Enumerable.Range(1, 2)).PrefixAndTail(1).RunWith(futureSink, Materializer);
-                fut.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
-                fut.Result.Item1.Should().BeEquivalentTo(Enumerable.Range(1, 1));
-                var tail = fut.Result.Item2;
+                var (list, tail) = await fut.WaitAsync(3.Seconds());
+                list.Should().BeEquivalentTo(Enumerable.Range(1, 1));
 
                 var subscriber1 = this.CreateSubscriberProbe<int>();
                 tail.To(Sink.FromSubscriber(subscriber1)).Run(Materializer);
+                await subscriber1.EnsureSubscriptionAsync();
 
                 var subscriber2 = this.CreateSubscriberProbe<int>();
                 tail.To(Sink.FromSubscriber(subscriber2)).Run(Materializer);
+                await subscriber2.EnsureSubscriptionAsync();
 
-                subscriber2.ExpectSubscriptionAndError(signalDemand: false)
-                    .Message.Should()
-                    .Be("Substream Source cannot be materialized more than once");
-                await subscriber1.RequestNext(2).ExpectCompleteAsync();
+                // One of the subscriber must fail, which one, we don't know yet
+                TestSubscriber.Probe<int> success;
+                using (var cts = new CancellationTokenSource())
+                {
+                    var t1 = subscriber1.ExpectErrorAsync(cts.Token);
+                    var t2 = subscriber2.ExpectErrorAsync(cts.Token);
+                    var failed = await Task.WhenAny(t1, t2);
+                    await cts.CancelAsync();
+                    
+                    (await failed).Message.Should().Be("Substream Source cannot be materialized more than once");
+                    
+                    success = failed == t1 ? subscriber2 : subscriber1;
+                }
+
+                await success.RequestNext(2).ExpectCompleteAsync();
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
@@ -173,7 +173,6 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
         
-
         [Fact]
         public async Task PrefixAndTail_must_signal_error_if_substream_has_been_not_subscribed_in_time()
         {

--- a/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowPrefixAndTailSpec.cs
@@ -173,7 +173,6 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
         
-        
         [Fact]
         public async Task PrefixAndTail_must_signal_error_if_substream_has_been_not_subscribed_in_time()
         {


### PR DESCRIPTION
# Make FlowPrefixAndTailSpec double‑materialization test deterministic

## Background
- Failing test: `Akka.Streams.Tests.Dsl.FlowPrefixAndTailSpec.PrefixAndTail_must_throw_if_tail_is_attempted_to_be_materialized_twice`.
- Symptom in CI (resource‑constrained VMs): timeout while waiting for `OnError` on the “second” tail materialization.
- Error logged by the stream: `Substream Source cannot be materialized more than once` during `PreStart` of `TailSource`.

## Theory of the race
- `PrefixAndTail(n)` exposes a single tail sub‑source. Materializing it twice must fail exactly once.
- Internally, `SubSource<T>.Logic.SetCallback(...)` uses an atomic `CompareExchange(null, callback)` to install the first materialization’s callback. The second attempt fails with `IllegalStateException`.
- Which `PreStart` (and thus `SetCallback`) runs first across two independent materializations is not guaranteed. On constrained schedulers either subscriber can be the “second” one. Therefore, “who gets the error” is inherently nondeterministic.

## Previous assumption (flaky)
- The test assumed the second materialization (in code order) would observe the error. Under CI scheduling the first subscriber sometimes receives the error instead, causing the assertion on the second subscriber to hang and eventually time out.

## Fix (deterministic test)
- Change the test to accept the error from either subscriber:
  - Materialize the same tail `Source` twice to `subscriber1` and `subscriber2`.
  - Start `ExpectErrorAsync` for both and use `Task.WhenAny` to capture the one that actually fails.
  - Cancel the other pending wait via a shared `CancellationTokenSource` to avoid unnecessary timeout.
  - Assert the error message equals `"Substream Source cannot be materialized more than once"`.
  - On the non‑failing subscriber, request and assert it receives `2` then completes.

## Why this is deterministic
- The test no longer encodes which subscriber must fail; it encodes the contract: exactly one materialization fails with the expected message, the other can consume the tail and complete.
- No reliance on sleeps or extended timeouts; no ordering side effects.
