### PR TITLE
Harden `LogFormatSpec` to handle 'Default Loggers started' race condition

### DIFF
--- a/src/core/Akka.API.Tests/LogFormatSpec.cs
+++ b/src/core/Akka.API.Tests/LogFormatSpec.cs
@@ -109,10 +109,18 @@ public sealed class DefaultLogFormatSpec : TestKit.Xunit2.TestKit
         text = SanitizeThreadNumber(text);
         // to resolve https://github.com/akkadotnet/akka.net/issues/7421
         text = SanitizeTestEventListener(text);
-        
+        text = SanitizeDefaultLoggersStarted(text);
+
         await Verifier.Verify(text);
     }
-    
+
+    private static string SanitizeDefaultLoggersStarted(string logs)
+    {
+        var pattern = @"^.*Default Loggers started.*$";
+        var result = Regex.Replace(logs, pattern, string.Empty, RegexOptions.Multiline);
+        return result;
+    }
+
     private static string SanitizeTestEventListener(string logs)
     {
         var pattern = @"^.*Akka\.TestKit\.TestEventListener.*$";


### PR DESCRIPTION
## Changes

Add sanitization for intermittent log line that appears during test execution.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).