### PR TITLE
Fix race condition in HubSpec.MergeHub_must_keep_working_even_if_one_of_the_producers_fail

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -270,7 +270,10 @@ namespace Akka.Streams.Tests.Dsl
                         .ExpectOneAsync(async () =>
                         {
                             Source.Failed<int>(new TestException("failing")).RunWith(sink, Materializer);
-                            Source.From(Enumerable.Range(1, 10)).RunWith(sink, Materializer);
+                            // Throttle the successful producer to ensure the failing producer has time to fail and log
+                            Source.From(Enumerable.Range(1, 10))
+                                .Throttle(5, TimeSpan.FromMilliseconds(150), 5, ThrottleMode.Shaping)
+                                .RunWith(sink, Materializer);
                             var result = await task.WaitAsync(3.Seconds());
                             result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
                         });


### PR DESCRIPTION
## Summary
Fixes the flaky test `HubSpec.MergeHub_must_keep_working_even_if_one_of_the_producers_fail` that was intermittently timing out in CI.

## Problem
The test had a race condition where the successful producer could complete the `Take(10)` operation before the failing producer had a chance to fail and log its error. When this happened:
- The MergeHub would complete due to downstream demand being satisfied
- All producers would be cancelled (not failed)
- The expected error log would never appear
- EventFilter would timeout after 10 seconds waiting for a log that never comes

## Solution
Added throttling to the successful producer using `.Throttle(5, TimeSpan.FromMilliseconds(150), 5, ThrottleMode.Shaping)` which allows only 5 elements per 150ms window. This ensures the failing producer has sufficient time to:
1. Register with the MergeHub
2. Fail and throw `ProducerFailed` exception
3. Have that exception logged by the GraphInterpreter

## Test Results
The test now passes consistently. Ran 10+ iterations locally without failures.

Fixes #7712