### PR TITLE
Fix race condition in RemoteActorTelemetrySpecs

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteActorTelemetrySpecs.cs
+++ b/src/core/Akka.Remote.Tests/RemoteActorTelemetrySpecs.cs
@@ -136,10 +136,10 @@ namespace Akka.Remote.Tests
                 // send a request for the current telemetry counters
                 telemetry = await subscriber
                     .Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance);
-                
-                // verify that created actors is greater than 0 (we created the subscriber)
+
+                // verify that no actors have been created yet (subscriber filters out its own events)
                 var previouslyCreated = telemetry.ActorCreated;
-                Assert.True(previouslyCreated >= 1); // should have at least the subscriber
+                Assert.Equal(0, previouslyCreated);
                 Assert.Equal(0, telemetry.ActorStopped);
                 Assert.Equal(0, telemetry.ActorRestarted);
 

--- a/src/core/Akka.Remote.Tests/RemoteActorTelemetrySpecs.cs
+++ b/src/core/Akka.Remote.Tests/RemoteActorTelemetrySpecs.cs
@@ -77,17 +77,17 @@ namespace Akka.Remote.Tests
                 // Only count user actors, not system actors
                 Receive<ActorStarted>(e =>
                 {
-                    if (!e.Subject.Path.ToString().Contains("/system/"))
+                    if (!e.Subject.Path.ToString().Contains("/system/") && !e.Subject.Equals(Self))
                         _actorCreated++;
                 });
                 Receive<ActorStopped>(e =>
                 {
-                    if (!e.Subject.Path.ToString().Contains("/system/"))
+                    if (!e.Subject.Path.ToString().Contains("/system/") && !e.Subject.Equals(Self))
                         _actorStopped++;
                 });
                 Receive<ActorRestarted>(e =>
                 {
-                    if (!e.Subject.Path.ToString().Contains("/system/"))
+                    if (!e.Subject.Path.ToString().Contains("/system/") && !e.Subject.Equals(Self))
                         _actorRestarted++;
                 });
                 // receive a request for current counter values and return a GetTelemetry result


### PR DESCRIPTION
## Summary
- Fixed race condition in `RemoteActorRefs_should_not_produce_telemetry` test where `TelemetrySubscriber` counted its own lifecycle events
- Added `!e.Subject.Equals(Self)` filter to all telemetry event handlers to exclude the subscriber's own events

## Root Cause
When `TelemetrySubscriber` is created:
1. `PreStart()` subscribes to telemetry events
2. The actor's own `ActorStarted` event is immediately published
3. Race condition: message ordering in the mailbox determined whether this self-event was processed before or after the test's first `Ask`
4. The subscriber's path (`/user/$a`) doesn't contain `/system/`, so it passed the existing filter

## Test Plan
- [x] Run `RemoteActorRefs_should_not_produce_telemetry` test multiple times to verify race condition is fixed
- [x] Verify all telemetry counters still work correctly for non-self events
- [x] CI pipeline validation