### PR TITLE
Fix race condition in UnfoldResourceAsyncSource callback invocation

### DIFF
--- a/src/core/Akka.Streams/Implementation/Sources.cs
+++ b/src/core/Akka.Streams/Implementation/Sources.cs
@@ -564,6 +564,7 @@ namespace Akka.Streams.Implementation
         {
             private readonly UnfoldResourceSourceAsync<TOut, TSource> _stage;
             private readonly Lazy<Decider> _decider;
+            private readonly Lazy<IAsyncCallback<Try<TSource>>> _createdCallback;
             private Option<TSource> _state = Option<TSource>.None;
 
             public Logic(UnfoldResourceSourceAsync<TOut, TSource> stage, Attributes inheritedAttributes)
@@ -576,18 +577,21 @@ namespace Akka.Streams.Implementation
                     return strategy != null ? strategy.Decider : Deciders.StoppingDecider;
                 });
 
+                _createdCallback = new Lazy<IAsyncCallback<Try<TSource>>>(() =>
+                    GetTypedAsyncCallback<Try<TSource>>(resource =>
+                    {
+                        if (resource.IsSuccess)
+                        {
+                            _state = resource.Success;
+                            if (IsAvailable(_stage.Out)) OnPull();
+                        }
+                        else FailStage(resource.Failure.Value);
+                    }));
+
                 SetHandler(_stage.Out, this);
             }
 
-            private Action<Try<TSource>> CreatedCallback => GetAsyncCallback<Try<TSource>>(resource =>
-            {
-                if (resource.IsSuccess)
-                {
-                    _state = resource.Success;
-                    if (IsAvailable(_stage.Out)) OnPull();
-                }
-                else FailStage(resource.Failure.Value);
-            });
+            private IAsyncCallback<Try<TSource>> CreatedCallback => _createdCallback.Value;
 
             private void ErrorHandler(Exception ex)
             {
@@ -697,24 +701,31 @@ namespace Akka.Streams.Implementation
             {
                 _stage._create().OnComplete(resource =>
                 {
-                    try
+                    async Task InvokeCallback()
                     {
-                        CreatedCallback(resource);
-                    }
-                    catch (StreamDetachedException)
-                    {
-                        // stream stopped before created callback could be invoked, we need
-                        // to close the resource if it is was opened, to not leak it
-                        if (resource.IsSuccess)
+                        try
                         {
-                            _stage._close(resource.Success.Value);
+                            await CreatedCallback.InvokeWithFeedback(resource);
                         }
-                        else
+                        catch (StreamDetachedException)
                         {
-                            // failed to open but stream is stopped already
-                            throw resource.Failure.Value;
+                            // stream stopped before created callback could be invoked, we need
+                            // to close the resource if it is was opened, to not leak it
+                            if (resource.IsSuccess)
+                            {
+#pragma warning disable CS4014 // Because this call is not awaited - fire-and-forget is intentional for cleanup
+                                _stage._close(resource.Success.Value);
+#pragma warning restore CS4014
+                            }
+                            else
+                            {
+                                // failed to open but stream is stopped already
+                                throw resource.Failure.Value;
+                            }
                         }
                     }
+
+                    _ = InvokeCallback();
                 });
             }
         }


### PR DESCRIPTION
## Summary
Fixed a race condition in `UnfoldResourceSourceAsync` where resource cleanup was skipped when streams were cancelled quickly (e.g., with `Sink.Cancelled`).

## Changes
- Changed `UnfoldResourceSourceAsync` to use `InvokeWithFeedback` instead of direct callback invocation
- Used `GetTypedAsyncCallback` to obtain `IAsyncCallback<T>` for proper feedback handling
- Implemented async local function pattern to properly catch `StreamDetachedException`
- Ensures resource cleanup occurs even when callback cannot be processed due to stream completion

## Root Cause
The previous implementation used `Action<T>` invocation which silently drops callbacks after stage shutdown. This caused the close callback to never execute when the stream stopped before the resource creation callback could be invoked.

## Technical Details
The fix matches the Scala Akka implementation's use of `invokeWithFeedback`, which returns a Future/Task that fails with `StreamDetachedException` when the stage has stopped. This allows proper cleanup in the exception handler.

## Test Results
- ✅ All 20 tests in `UnfoldResourceAsyncSourceSpec` pass
- ✅ Specifically fixes the flaky test: `A_UnfoldResourceAsyncSource_must_close_resource_when_stream_is_quickly_cancelled_reproducer_2`
- ✅ Verified stable across 10 consecutive runs

## Files Changed
- `src/core/Akka.Streams/Implementation/Sources.cs`