### PR TITLE
Fix race condition in DistributedPubSubDeadLetterSpec

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubDeadLetterSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubDeadLetterSpec.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Tools.PublishSubscribe;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubDeadLetterSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubDeadLetterSpec.cs
@@ -37,6 +37,16 @@ namespace Akka.Cluster.Tools.Tests.PublishSubscribe
             var mediator = DistributedPubSub.Get(Sys).Mediator;
             var testMessage = "test-message";
 
+            // Ensure DeadLetterListener is active by retrying until it logs a warmup message
+            await AwaitAssertAsync(async () =>
+            {
+                await EventFilter.Info(contains: "was not delivered").ExpectAsync(1, () =>
+                {
+                    Sys.DeadLetters.Tell("warmup", Nobody.Instance);
+                    return Task.CompletedTask;
+                });
+            }, TimeSpan.FromSeconds(5));
+
             // act - publish to a topic that no one is subscribed to
             await EventFilter.Info(contains: "DeadLetterWithNoSubscribers")
                 .ExpectAsync(1, () =>


### PR DESCRIPTION
## Summary
- Fixed intermittent test failure in `DistributedPubSubDeadLetterSpec.DistributedPubSubMediator_should_send_specialized_dead_letter_message_when_no_subscribers`
- Added warmup check to ensure `DeadLetterListener` is active before testing

## Root Cause
The test was racing against the initialization of the `DeadLetterListener` actor. The listener may not have fully started and subscribed to the `EventStream` before the test attempted to verify dead letter logging, causing the test to timeout waiting for a log message that would never arrive.

## Changes
Added an `AwaitAssertAsync` block that sends a warmup dead letter message and waits (with retries) for it to be logged. This ensures the `DeadLetterListener` is fully initialized and processing messages before running the actual test assertion.

## Test plan
- [x] Ran the test 20 consecutive times - all passed
- [x] Verified the fix eliminates the race condition