### PR TITLE
Fix race condition in RestartWithBackoffLogic deadline management

### DIFF
--- a/src/core/Akka.Streams/Dsl/RestartFlow.cs
+++ b/src/core/Akka.Streams/Dsl/RestartFlow.cs
@@ -402,6 +402,7 @@ namespace Akka.Streams.Dsl
         {
             var restartDelay = BackoffSupervisor.CalculateDelay(_restartCount, _settings.MinBackoff, _settings.MaxBackoff, _settings.RandomFactor);
             Log.Debug("Restarting graph in {0}", restartDelay);
+            _resetDeadline = _settings.MaxRestartsWithin.FromNow();
             ScheduleOnce("RestartTimer", restartDelay);
             _restartCount += 1;
             // And while we wait, we go into backoff mode
@@ -413,8 +414,8 @@ namespace Akka.Streams.Dsl
         /// </summary>
         protected internal override void OnTimer(object timerKey)
         {
-            StartGraph();
             _resetDeadline = _settings.MaxRestartsWithin.FromNow();
+            StartGraph();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Fixed race conditions in `RestartWithBackoffLogic` where the restart deadline was updated after critical decision points, causing `MaxRestartsReached()` to read stale deadline values and incorrectly reset restart counters.

**Root Cause**: The `_resetDeadline` field tracks when a restart cycle begins and is used to determine if enough time has passed to reset the restart counter. However, it was being updated too late in two different code paths, creating timing windows where stale deadline values caused incorrect behavior.

## Two Race Conditions Fixed

### 1. Source Completion Path (OnTimer)
**Affected**: RestartSource and any graph that completes synchronously during materialization

**Problem**: 
```csharp
protected internal override void OnTimer(object timerKey)
{
    StartGraph();  // Graph completes synchronously here
    _resetDeadline = _settings.MaxRestartsWithin.FromNow();  // Too late!
}
```

When `StartGraph()` materializes a source that completes immediately, the completion handler executes before the deadline is updated.

**Fix**: Update deadline **before** calling `StartGraph()`

### 2. Sink/Flow Completion Path (ScheduleRestartTimer)
**Affected**: RestartSink, RestartFlow, and any downstream completion scenarios

**Problem**:
The `onDownstreamFinish` handler calls `MaxRestartsReached()` when scheduling a restart, but the deadline isn't updated until the timer fires later, creating a window where the old deadline is checked against a new completion event.

**Fix**: Update deadline in `ScheduleRestartTimer()` when the restart cycle begins

## Changes

**File**: `src/core/Akka.Streams/Dsl/RestartFlow.cs`

```diff
 internal void ScheduleRestartTimer()
 {
     var restartDelay = BackoffSupervisor.CalculateDelay(_restartCount, _settings.MinBackoff, _settings.MaxBackoff, _settings.RandomFactor);
     Log.Debug("Restarting graph in {0}", restartDelay);
+    _resetDeadline = _settings.MaxRestartsWithin.FromNow();
     ScheduleOnce("RestartTimer", restartDelay);
     _restartCount += 1;
     Backoff();
 }

 protected internal override void OnTimer(object timerKey)
 {
+    _resetDeadline = _settings.MaxRestartsWithin.FromNow();
-    _resetDeadline = _settings.MaxRestartsWithin.FromNow();
     StartGraph();
 }
```

## Fixed Tests

Both flaky tests now pass consistently:
- ✅ `A_restart_with_backoff_source_should_allow_using_withMaxRestarts_instead_of_minBackoff_to_determine_the_maxRestarts_reset_time`
- ✅ `A_restart_with_backoff_sink_should_allow_using_withMaxRestarts_instead_of_minBackoff_to_determine_the_maxRestarts_reset_time`

## Technical Details

The race occurred when:
1. A restart cycle reaches `maxRestarts` (e.g., 2)
2. Test waits for the reset window to pass
3. Next completion happens
4. `MaxRestartsReached()` checks if deadline is overdue to decide whether to reset counter
5. If deadline hasn't been updated yet → counter incorrectly resets → another restart happens
6. Test receives unexpected `OnNext` messages or restarts when expecting completion

The fixes ensure the deadline is always current before any restart decision is made, regardless of whether the completion happens:
- During synchronous graph materialization (sources)
- From downstream cancellation (sinks/flows)
- Before or after the backoff timer fires

Since all restart types (Source, Sink, Flow) share the `RestartWithBackoffLogic` base class, both fixes apply universally.