### PR TITLE
Fix race condition in BroadcastHub error signaling test

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -566,6 +566,10 @@ namespace Akka.Streams.Tests.Dsl
                 await downstream1.RequestAsync(4);
                 await downstream2.RequestAsync(8);
 
+                // Sending the first element is in a race with downstream subscribing.
+                // Give a bit of time for the downstream to complete subscriptions.
+                await Task.Delay(100);
+
                 await upstream.AsyncBuilder()
                     .SendNext(Enumerable.Range(1, 8))
                     .ExecuteAsync();


### PR DESCRIPTION
## Summary
Fixes a race condition in `BroadcastHub_must_properly_signal_error_to_consumers` test that was causing intermittent failures.

## Root Cause  
The test has an inherent race condition between sending elements and consumers completing subscription registration. This happens because:
1. Each consumer sends its own `RegistrationPending` message to the hub at slightly different times
2. If downstream1 registers, starts consuming, and advances its offset before downstream2 registers, the hub's `_head` pointer advances (Hub.cs:825)
3. downstream2 then starts from the new `_head` position, missing early elements

This race exists in **both** JVM Akka and Akka.NET due to BroadcastHub's async dynamic consumer attachment design.

## Solution
The JVM Akka test explicitly handles this race with:
```scala
downstream1.request(4)
downstream2.request(8)

// sending the first element is in a race with downstream subscribing
// give a bit of time for the downstream to complete subscriptions  
Thread.sleep(100)

(1 to 8).foreach(upstream.sendNext(_))
```

This fix aligns the .NET test with the JVM version by adding `Task.Delay(100)` after request calls to allow consumers time to complete registration before publishing elements.

## Testing
Verified with 5 consecutive test runs - all passed.