### PR TITLE
Fix race condition in IdleInject GraphStage

### DIFF
--- a/src/core/Akka.Streams/Implementation/Timers.cs
+++ b/src/core/Akka.Streams/Implementation/Timers.cs
@@ -586,15 +586,20 @@ namespace Akka.Streams.Implementation
             public Logic(IdleInject<TIn, TOut> stage) : base(stage.Shape)
             {
                 _stage = stage;
-                _nextDeadline = DateTime.UtcNow.Ticks + _stage._timeout.Ticks;
+                ResetDeadline();
 
                 SetHandler(_stage._in, this);
                 SetHandler(_stage._out, this);
             }
 
-            public void OnPush()
+            private void ResetDeadline()
             {
                 _nextDeadline = DateTime.UtcNow.Ticks + _stage._timeout.Ticks;
+            }
+
+            public void OnPush()
+            {
+                ResetDeadline();
                 CancelTimer(Timers.GraphStageLogicTimer);
                 if (IsAvailable(_stage._out))
                 {
@@ -616,6 +621,7 @@ namespace Akka.Streams.Implementation
                 if (IsAvailable(_stage._in))
                 {
                     Push(_stage._out, Grab(_stage._in));
+                    ResetDeadline();
                     if (IsClosed(_stage._in))
                         CompleteStage();
                     else
@@ -626,8 +632,8 @@ namespace Akka.Streams.Implementation
                     var time = DateTime.UtcNow.Ticks;
                     if (_nextDeadline - time < 0)
                     {
-                        _nextDeadline = time + _stage._timeout.Ticks;
                         Push(_stage._out, _stage._inject());
+                        ResetDeadline();
                     }
                     else
                         ScheduleOnce(Timers.GraphStageLogicTimer, TimeSpan.FromTicks(_nextDeadline - time));
@@ -638,11 +644,15 @@ namespace Akka.Streams.Implementation
 
             protected internal override void OnTimer(object timerKey)
             {
+                // Don't inject if upstream element is already available
+                if (IsAvailable(_stage._in))
+                    return;
+
                 var time = DateTime.UtcNow.Ticks;
                 if ((_nextDeadline - time < 0) && IsAvailable(_stage._out))
                 {
                     Push(_stage._out, _stage._inject());
-                    _nextDeadline = DateTime.UtcNow.Ticks + _stage._timeout.Ticks;
+                    ResetDeadline();
                 }
             }
 


### PR DESCRIPTION
## Summary
Fixes a race condition in the `IdleInject` (KeepAlive) GraphStage that caused `FlowIdleInjectSpec.KeepAlive_must_prefer_upstream_element_over_injected_after_busy_period` to fail intermittently.

## Problem
The test was failing with: `Expected item[9] to be 10, but found 0`

This indicated that the idle injection timer was firing and injecting a `0` element instead of forwarding the expected upstream element `10`.

### Root Causes
1. **Timer/Data Race**: `OnTimer()` didn't check if upstream elements were buffered before injecting, allowing timer-based injection to preempt actual upstream elements
2. **Stale Deadline**: `OnPull()` didn't reset the idle deadline when forwarding buffered upstream elements, causing premature timer fires
3. **Code Duplication**: Deadline reset logic was duplicated across multiple methods without proper synchronization

## Changes
1. Added `ResetDeadline()` helper method to centralize deadline management
2. Updated `OnTimer()` to check `IsAvailable(_stage._in)` before injecting - ensures upstream elements are always preferred over injected values
3. Updated `OnPull()` to reset deadline when pushing upstream elements - prevents stale deadlines from causing premature injection
4. Refactored all deadline reset calls to use the helper method for consistency

## Verification
- ✅ Ran the previously failing test 25+ times consecutively - all passed
- ✅ Ran all 9 FlowIdleInjectSpec tests 25+ times - all passed
- ✅ Each test run takes ~11s (includes timing-dependent delays), total validation ~5 minutes

## Semantic Guarantee
This fix ensures the documented behavior: **"prefer upstream element over injected after busy period"** is correctly implemented even under race conditions.

## Test Plan
```bash
# Run the specific fixed test
dotnet test -c Release --filter "FullyQualifiedName~FlowIdleInjectSpec.KeepAlive_must_prefer_upstream_element_over_injected_after_busy_period" --framework net8.0

# Run all IdleInject tests
dotnet test -c Release --filter "FullyQualifiedName~FlowIdleInjectSpec" --framework net8.0
```