### PR TITLE
fix: scrub CustomLogger removal log from DefaultLogFormatSpec

### DIFF
--- a/src/core/Akka.API.Tests/LogFormatSpec.cs
+++ b/src/core/Akka.API.Tests/LogFormatSpec.cs
@@ -110,6 +110,7 @@ public sealed class DefaultLogFormatSpec : TestKit.Xunit2.TestKit
         // to resolve https://github.com/akkadotnet/akka.net/issues/7421
         text = SanitizeTestEventListener(text);
         text = SanitizeDefaultLoggersStarted(text);
+        text = SanitizeCustomLoggerRemoved(text);
 
         await Verifier.Verify(text);
     }
@@ -117,6 +118,13 @@ public sealed class DefaultLogFormatSpec : TestKit.Xunit2.TestKit
     private static string SanitizeDefaultLoggersStarted(string logs)
     {
         var pattern = @"^.*Default Loggers started.*$";
+        var result = Regex.Replace(logs, pattern, string.Empty, RegexOptions.Multiline);
+        return result;
+    }
+
+    private static string SanitizeCustomLoggerRemoved(string logs)
+    {
+        var pattern = @"^.*CustomLogger being removed.*$";
         var result = Regex.Replace(logs, pattern, string.Empty, RegexOptions.Multiline);
         return result;
     }


### PR DESCRIPTION
## Summary
- Fixed flaky test failure in `DefaultLogFormatSpec.ShouldUseDefaultLogFormat`
- Added sanitization for non-deterministic "CustomLogger being removed" log line

## Details
The test was failing due to a "CustomLogger being removed" log message appearing during test cleanup. This message appears non-deterministically in the console output, similar to other log messages that were already being scrubbed (TestEventListener, Default Loggers started).

Added `SanitizeCustomLoggerRemoved()` method following the same pattern as existing sanitization functions to filter out this line from the captured logs before verification.

## Test plan
- [x] Test passes locally on .NET 8.0
- [x] Follows existing sanitization patterns in the test