### PR TITLE
Fix race condition in QueueSinkSpec

### DIFF
--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -712,6 +712,7 @@ namespace Akka.Streams.Implementation
             private readonly int _maxBuffer;
             private IBuffer<Result<Option<T>>>? _buffer;
             private Option<TaskCompletionSource<Option<T>>> _currentRequest;
+            private bool _closed;
 
             public Logic(QueueSink<T> stage, int maxBuffer) : base(stage.Shape)
             {
@@ -751,14 +752,16 @@ namespace Akka.Streams.Implementation
                 return GetAsyncCallback<TaskCompletionSource<Option<T>>>(
                     promise =>
                     {
-                        if (_currentRequest.HasValue)
+                        if (_closed)
+                            promise.SetException(new StreamDetachedException());
+                        else if (_currentRequest.HasValue)
                             promise.SetException(
                                 new IllegalStateException(
                                     "You have to wait for previous future to be resolved to send another request"));
                         else
                         {
                             Debug.Assert(_buffer != null, nameof(_buffer) + " != null");
-                
+
                             if (_buffer!.IsEmpty)
                                 _currentRequest = promise;
                             else
@@ -774,13 +777,16 @@ namespace Akka.Streams.Implementation
             private void SendDownstream(TaskCompletionSource<Option<T>> promise)
             {
                 Debug.Assert(_buffer != null, nameof(_buffer) + " != null");
-                
+
                 var e = _buffer!.Dequeue();
                 if (e.IsSuccess)
                 {
                     promise.SetResult(e.Value);
                     if (!e.Value.HasValue)
+                    {
+                        _closed = true;
                         CompleteStage();
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

Fixed a race condition in `QueueSink` that caused `QueueSink_should_fail_pull_future_when_stream_is_completed` to intermittently timeout after 20 seconds.

## Problem

The race occurred when:
1. Second `PullAsync()` dequeued the completion marker (`Option<T>.None`), triggering `CompleteStage()`
2. Third `PullAsync()` was called during the window between `CompleteStage()` and `PostStop()` execution
3. The callback accepted the request but the stage shutdown prevented it from being completed
4. The `TaskCompletionSource` hung indefinitely, causing `AssertAllStagesStoppedAsync` to timeout

## Root Cause

This was a **timing-dependent race condition** (not struct tearing or cross-thread visibility):
- `CompleteStage()` initiates asynchronous shutdown
- `PostStop()` transitions callback state to `Stopped` (which rejects new requests)
- If `PullAsync()` arrives between these two steps, it gets accepted but never completed

## Solution

Added `_closed` flag that is set **immediately** when the completion marker is sent downstream:
- Set `_closed = true` in `SendDownstream()` before calling `CompleteStage()`
- Check `_closed` first in the callback and immediately fail with `StreamDetachedException`
- Eliminates the race window by synchronously marking the sink as closed

## Test Results

✅ Test now passes consistently (10/10 runs)
✅ Previously failed intermittently with 20-second timeout

## Changes

- `src/core/Akka.Streams/Implementation/Sinks.cs:715` - Added `_closed` flag
- `src/core/Akka.Streams/Implementation/Sinks.cs:787` - Set flag before `CompleteStage()`
- `src/core/Akka.Streams/Implementation/Sinks.cs:755` - Check flag and reject requests