### PR TITLE
Fix race condition in TcpSpec connection failure test

### DIFF
--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -120,7 +120,7 @@ namespace Akka.Streams.Tests.IO
                     Source.FromPublisher(tcpWriteProbe.PublisherProbe)
                         .ViaMaterialized(
                             Sys.TcpStream()
-                                .OutgoingConnection(new DnsEndPoint("example.com", 666),
+                                .OutgoingConnection(new IPEndPoint(IPAddress.Parse("192.0.2.1"), 666),
                                     connectionTimeout: TimeSpan.FromSeconds(1)), Keep.Right)
                         .ToMaterialized(Sink.Ignore<ByteString>(), Keep.Left)
                         .Run(Materializer);


### PR DESCRIPTION
## Summary
Fixes a race condition in `TcpSpec.Outgoing_TCP_stream_must_fail_the_materialized_task_when_the_connection_fails` that caused flaky test failures.

## Problem
The test was experiencing non-deterministic failures where it expected a "Connection failed*" exception but sometimes received "The operation has timed out." instead.

**Root Cause:** DNS resolution for `example.com` was taking 2+ seconds in some environments, consuming most of the 3-second test timeout window. This left insufficient time for the 1-second connection timeout to fire and propagate the exception before the test timeout.

## Solution
Replaced `new DnsEndPoint("example.com", 666)` with `new IPEndPoint(IPAddress.Parse("192.0.2.1"), 666)` using the TEST-NET-1 reserved address.

**Benefits:**
- Eliminates non-deterministic DNS resolution delays
- Connection attempt starts immediately
- Timeout fires reliably within 1 second
- Exception propagates before test/shutdown timeouts

## Testing
- ✅ Test now passes consistently (verified 5 consecutive runs)
- ✅ Connection timeout fires at expected 1-second mark
- ✅ Correct exception message propagates reliably

## Test plan
- [x] Unit tests pass locally
- [x] CI passes all checks