### PR TITLE
fix: remove blank lines in DefaultLogFormatSpec scrubbers

### DIFF
--- a/src/core/Akka.API.Tests/LogFormatSpec.cs
+++ b/src/core/Akka.API.Tests/LogFormatSpec.cs
@@ -117,21 +117,21 @@ public sealed class DefaultLogFormatSpec : TestKit.Xunit2.TestKit
 
     private static string SanitizeDefaultLoggersStarted(string logs)
     {
-        var pattern = @"^.*Default Loggers started.*$";
+        var pattern = @"^.*Default Loggers started.*$\r?\n?";
         var result = Regex.Replace(logs, pattern, string.Empty, RegexOptions.Multiline);
         return result;
     }
 
     private static string SanitizeCustomLoggerRemoved(string logs)
     {
-        var pattern = @"^.*CustomLogger being removed.*$";
+        var pattern = @"^.*CustomLogger being removed.*$\r?\n?";
         var result = Regex.Replace(logs, pattern, string.Empty, RegexOptions.Multiline);
         return result;
     }
 
     private static string SanitizeTestEventListener(string logs)
     {
-        var pattern = @"^.*Akka\.TestKit\.TestEventListener.*$";
+        var pattern = @"^.*Akka\.TestKit\.TestEventListener.*$\r?\n?";
         var result = Regex.Replace(logs, pattern, string.Empty, RegexOptions.Multiline);
         return result;
     }


### PR DESCRIPTION
## Summary
- Fixed regex patterns in `DefaultLogFormatSpec` scrubber methods to remove newline characters along with matched log lines
- Prevents blank lines from appearing in verified test output

## Changes
Updated three sanitization methods in `LogFormatSpec.cs`:
- `SanitizeDefaultLoggersStarted`
- `SanitizeCustomLoggerRemoved`  
- `SanitizeTestEventListener`

Changed regex patterns from `^.*pattern.*$` to `^.*pattern.*$\r?\n?` to match and remove both the line content and its trailing newline(s).

## Problem
The scrubbers were removing log lines by replacing them with `string.Empty`, but leaving the newline characters behind. This created blank lines in the output that didn't match the verified baseline, causing test failures.

## Test Plan
- Verified `DefaultLogFormatSpec.ShouldUseDefaultLogFormat` passes locally on Linux
- CI will verify cross-platform compatibility (Windows, Linux)