### PR TITLE
Add MemoryJournal performance benchmarks

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Hocon/HoconBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Hocon/HoconBenchmarks.cs
@@ -76,7 +76,7 @@ namespace Akka.Benchmarks.Hocon
                                                                           ]
                                                                       }
                                                           """);
-            _fallback3 = Persistence.Persistence.DefaultConfig();
+            _fallback3 = Akka.Persistence.Persistence.DefaultConfig();
         }
 
         [Benchmark]

--- a/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalBenchmarks.cs
@@ -1,0 +1,163 @@
+//-----------------------------------------------------------------------
+// <copyright file="MemoryJournalBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Configuration;
+using Akka.Persistence;
+using BenchmarkDotNet.Attributes;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
+
+namespace Akka.Benchmarks.Persistence
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class MemoryJournalBenchmarks
+    {
+        private static readonly Config Config = ConfigurationFactory.ParseString(@"
+            akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
+            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+        ");
+
+        private ActorSystem _system;
+        private IActorRef _persistentActor;
+
+        [Params(10, 100, 1000)]
+        public int EventCount { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _system = ActorSystem.Create("benchmark", Config);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _system?.Dispose();
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _persistentActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor($"benchmark-{Guid.NewGuid()}")));
+        }
+
+        [IterationCleanup]
+        public async Task IterationCleanup()
+        {
+            if (_persistentActor != null)
+            {
+                await _persistentActor.GracefulStop(TimeSpan.FromSeconds(5));
+            }
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(MicroBenchmark)]
+        public async Task Write_events_to_memory_journal()
+        {
+            for (int i = 0; i < EventCount; i++)
+            {
+                await _persistentActor.Ask<string>($"event-{i}", TimeSpan.FromSeconds(10));
+            }
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(MicroBenchmark)]
+        public async Task Write_and_replay_events()
+        {
+            // Write events
+            for (int i = 0; i < EventCount; i++)
+            {
+                await _persistentActor.Ask<string>($"event-{i}", TimeSpan.FromSeconds(10));
+            }
+
+            // Trigger recovery by stopping and restarting
+            var persistenceId = await _persistentActor.Ask<string>("get-id", TimeSpan.FromSeconds(5));
+            await _persistentActor.GracefulStop(TimeSpan.FromSeconds(5));
+
+            _persistentActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(persistenceId)));
+
+            // Wait for recovery to complete
+            await _persistentActor.Ask<int>("get-count", TimeSpan.FromSeconds(10));
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(MicroBenchmark)]
+        public async Task Write_tagged_events_and_query()
+        {
+            // Write tagged events
+            for (int i = 0; i < EventCount; i++)
+            {
+                await _persistentActor.Ask<string>($"tagged-event-{i}", TimeSpan.FromSeconds(10));
+            }
+
+            // Query by tag (simulated via replay)
+            var persistenceId = await _persistentActor.Ask<string>("get-id", TimeSpan.FromSeconds(5));
+            await _persistentActor.GracefulStop(TimeSpan.FromSeconds(5));
+
+            _persistentActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(persistenceId)));
+            await _persistentActor.Ask<int>("get-count", TimeSpan.FromSeconds(10));
+        }
+
+        #region Test Actor
+
+        private class BenchmarkPersistentActor : ReceivePersistentActor
+        {
+            private int _eventCount;
+
+            public BenchmarkPersistentActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+
+                Command<string>(msg =>
+                {
+                    if (msg == "get-count")
+                    {
+                        Sender.Tell(_eventCount);
+                    }
+                    else if (msg == "get-id")
+                    {
+                        Sender.Tell(PersistenceId);
+                    }
+                    else if (msg.StartsWith("tagged-event-"))
+                    {
+                        var tagged = new Tagged(msg, new[] { "benchmark-tag" });
+                        Persist(tagged, _ =>
+                        {
+                            _eventCount++;
+                            Sender.Tell(msg);
+                        });
+                    }
+                    else
+                    {
+                        Persist(msg, _ =>
+                        {
+                            _eventCount++;
+                            Sender.Tell(msg);
+                        });
+                    }
+                });
+
+                Recover<string>(msg =>
+                {
+                    _eventCount++;
+                });
+
+                Recover<Tagged>(tagged =>
+                {
+                    _eventCount++;
+                });
+            }
+
+            public override string PersistenceId { get; }
+        }
+
+        #endregion
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalBenchmarks.cs
@@ -11,6 +11,7 @@ using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using Akka.Configuration;
 using Akka.Persistence;
+using Akka.Persistence.Journal;
 using BenchmarkDotNet.Attributes;
 using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 


### PR DESCRIPTION
## Summary
Adds performance benchmarks for the MemoryJournal to establish baseline metrics before/after the race condition fixes in #7869.

## Benchmarks Included

1. **Write_events_to_memory_journal** - Baseline write performance
2. **Write_and_replay_events** - Recovery performance (write + stop + restart + replay)
3. **Write_tagged_events_and_query** - Tagged event handling performance

Each benchmark runs with 10, 100, and 1000 events to measure scalability.

## Changes

- Added `src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalBenchmarks.cs`
- Fixed namespace collision in `HoconBenchmarks.cs`

## Test Plan

Benchmarks can be run with:
```bash
dotnet run --project src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj -c Release --framework net8.0 -- --filter "*MemoryJournal*"
```

Results will be saved to `BenchmarkDotNet.Artifacts/results/`.

## Related

- #7869 - MemoryJournal race condition fixes