### PR TITLE
Refactor memory journal benchmarks into separate classes

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalRecoveryBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalRecoveryBenchmarks.cs
@@ -45,7 +45,7 @@ namespace Akka.Benchmarks.Persistence
         }
 
         [IterationSetup]
-        public async Task IterationSetup()
+        public void IterationSetup()
         {
             // Generate unique persistence ID for this iteration
             _persistenceId = $"benchmark-{Guid.NewGuid()}";
@@ -54,9 +54,9 @@ namespace Akka.Benchmarks.Persistence
             var prepActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(_persistenceId)));
             for (var i = 0; i < EventCount; i++)
             {
-                await prepActor.Ask<string>($"event-{i}", TimeSpan.FromSeconds(10));
+                prepActor.Ask<string>($"event-{i}", TimeSpan.FromSeconds(10)).Wait();
             }
-            await prepActor.GracefulStop(TimeSpan.FromSeconds(5));
+            prepActor.GracefulStop(TimeSpan.FromSeconds(5)).Wait();
 
             // Create the actor that will recover (but don't wait for recovery yet)
             _persistentActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(_persistenceId)));
@@ -81,7 +81,7 @@ namespace Akka.Benchmarks.Persistence
         }
 
         [IterationSetup(Target = nameof(Recover_tagged_events_from_memory_journal))]
-        public async Task IterationSetupTagged()
+        public void IterationSetupTagged()
         {
             // Generate unique persistence ID for this iteration
             _persistenceId = $"benchmark-{Guid.NewGuid()}";
@@ -90,9 +90,9 @@ namespace Akka.Benchmarks.Persistence
             var prepActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(_persistenceId)));
             for (var i = 0; i < EventCount; i++)
             {
-                await prepActor.Ask<string>($"tagged-event-{i}", TimeSpan.FromSeconds(10));
+                prepActor.Ask<string>($"tagged-event-{i}", TimeSpan.FromSeconds(10)).Wait();
             }
-            await prepActor.GracefulStop(TimeSpan.FromSeconds(5));
+            prepActor.GracefulStop(TimeSpan.FromSeconds(5)).Wait();
 
             // Create the actor that will recover (but don't wait for recovery yet)
             _persistentActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(_persistenceId)));

--- a/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalRecoveryBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalRecoveryBenchmarks.cs
@@ -11,6 +11,7 @@ using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using Akka.Configuration;
 using Akka.Persistence;
+using Akka.Persistence.Journal;
 using BenchmarkDotNet.Attributes;
 using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 

--- a/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalRecoveryBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalRecoveryBenchmarks.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="MemoryJournalBenchmarks.cs" company="Akka.NET Project">
+// <copyright file="MemoryJournalRecoveryBenchmarks.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -11,14 +11,13 @@ using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using Akka.Configuration;
 using Akka.Persistence;
-using Akka.Persistence.Journal;
 using BenchmarkDotNet.Attributes;
 using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 
 namespace Akka.Benchmarks.Persistence
 {
     [Config(typeof(MicroBenchmarkConfig))]
-    public class MemoryJournalBenchmarks
+    public class MemoryJournalRecoveryBenchmarks
     {
         private static readonly Config Config = ConfigurationFactory.ParseString(@"
             akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
@@ -27,6 +26,7 @@ namespace Akka.Benchmarks.Persistence
 
         private ActorSystem _system;
         private IActorRef _persistentActor;
+        private string _persistenceId;
 
         [Params(10, 100, 1000)]
         public int EventCount { get; set; }
@@ -44,9 +44,21 @@ namespace Akka.Benchmarks.Persistence
         }
 
         [IterationSetup]
-        public void IterationSetup()
+        public async Task IterationSetup()
         {
-            _persistentActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor($"benchmark-{Guid.NewGuid()}")));
+            // Generate unique persistence ID for this iteration
+            _persistenceId = $"benchmark-{Guid.NewGuid()}";
+
+            // Pre-populate the journal with events
+            var prepActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(_persistenceId)));
+            for (var i = 0; i < EventCount; i++)
+            {
+                await prepActor.Ask<string>($"event-{i}", TimeSpan.FromSeconds(10));
+            }
+            await prepActor.GracefulStop(TimeSpan.FromSeconds(5));
+
+            // Create the actor that will recover (but don't wait for recovery yet)
+            _persistentActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(_persistenceId)));
         }
 
         [IterationCleanup]
@@ -57,50 +69,44 @@ namespace Akka.Benchmarks.Persistence
 
         [Benchmark]
         [BenchmarkCategory(MicroBenchmark)]
-        public async Task Write_events_to_memory_journal()
+        public async Task Recover_events_from_memory_journal()
         {
+            // Wait for recovery to complete by asking for the event count
+            var count = await _persistentActor.Ask<int>("get-count", TimeSpan.FromSeconds(10));
+            if (count != EventCount)
+            {
+                throw new Exception($"Expected {EventCount} events, but got {count}");
+            }
+        }
+
+        [IterationSetup(Target = nameof(Recover_tagged_events_from_memory_journal))]
+        public async Task IterationSetupTagged()
+        {
+            // Generate unique persistence ID for this iteration
+            _persistenceId = $"benchmark-{Guid.NewGuid()}";
+
+            // Pre-populate the journal with tagged events
+            var prepActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(_persistenceId)));
             for (var i = 0; i < EventCount; i++)
             {
-                await _persistentActor.Ask<string>($"event-{i}", TimeSpan.FromSeconds(10));
+                await prepActor.Ask<string>($"tagged-event-{i}", TimeSpan.FromSeconds(10));
             }
+            await prepActor.GracefulStop(TimeSpan.FromSeconds(5));
+
+            // Create the actor that will recover (but don't wait for recovery yet)
+            _persistentActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(_persistenceId)));
         }
 
         [Benchmark]
         [BenchmarkCategory(MicroBenchmark)]
-        public async Task Write_and_replay_events()
+        public async Task Recover_tagged_events_from_memory_journal()
         {
-            // Write events
-            for (var i = 0; i < EventCount; i++)
+            // Wait for recovery to complete by asking for the event count
+            var count = await _persistentActor.Ask<int>("get-count", TimeSpan.FromSeconds(10));
+            if (count != EventCount)
             {
-                await _persistentActor.Ask<string>($"event-{i}", TimeSpan.FromSeconds(10));
+                throw new Exception($"Expected {EventCount} events, but got {count}");
             }
-
-            // Trigger recovery by stopping and restarting
-            var persistenceId = await _persistentActor.Ask<string>("get-id", TimeSpan.FromSeconds(5));
-            await _persistentActor.GracefulStop(TimeSpan.FromSeconds(5));
-
-            _persistentActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(persistenceId)));
-
-            // Wait for recovery to complete
-            await _persistentActor.Ask<int>("get-count", TimeSpan.FromSeconds(10));
-        }
-
-        [Benchmark]
-        [BenchmarkCategory(MicroBenchmark)]
-        public async Task Write_tagged_events_and_query()
-        {
-            // Write tagged events
-            for (var i = 0; i < EventCount; i++)
-            {
-                await _persistentActor.Ask<string>($"tagged-event-{i}", TimeSpan.FromSeconds(10));
-            }
-
-            // Query by tag (simulated via replay)
-            var persistenceId = await _persistentActor.Ask<string>("get-id", TimeSpan.FromSeconds(5));
-            await _persistentActor.GracefulStop(TimeSpan.FromSeconds(5));
-
-            _persistentActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor(persistenceId)));
-            await _persistentActor.Ask<int>("get-count", TimeSpan.FromSeconds(10));
         }
 
         #region Test Actor

--- a/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalWriteBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalWriteBenchmarks.cs
@@ -11,6 +11,7 @@ using Akka.Actor;
 using Akka.Benchmarks.Configurations;
 using Akka.Configuration;
 using Akka.Persistence;
+using Akka.Persistence.Journal;
 using BenchmarkDotNet.Attributes;
 using static Akka.Benchmarks.Configurations.BenchmarkCategories;
 

--- a/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalWriteBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Persistence/MemoryJournalWriteBenchmarks.cs
@@ -1,0 +1,138 @@
+//-----------------------------------------------------------------------
+// <copyright file="MemoryJournalWriteBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Configuration;
+using Akka.Persistence;
+using BenchmarkDotNet.Attributes;
+using static Akka.Benchmarks.Configurations.BenchmarkCategories;
+
+namespace Akka.Benchmarks.Persistence
+{
+    [Config(typeof(MicroBenchmarkConfig))]
+    public class MemoryJournalWriteBenchmarks
+    {
+        private static readonly Config Config = ConfigurationFactory.ParseString(@"
+            akka.persistence.journal.plugin = ""akka.persistence.journal.inmem""
+            akka.persistence.snapshot-store.plugin = ""akka.persistence.snapshot-store.inmem""
+        ");
+
+        private ActorSystem _system;
+        private IActorRef _persistentActor;
+
+        [Params(10, 100, 1000)]
+        public int EventCount { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _system = ActorSystem.Create("benchmark", Config);
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            _system?.Dispose();
+        }
+
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            _persistentActor = _system.ActorOf(Props.Create(() => new BenchmarkPersistentActor($"benchmark-{Guid.NewGuid()}")));
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            _persistentActor?.GracefulStop(TimeSpan.FromSeconds(5)).Wait();
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(MicroBenchmark)]
+        public async Task Write_events_to_memory_journal()
+        {
+            for (var i = 0; i < EventCount; i++)
+            {
+                await _persistentActor.Ask<string>($"event-{i}", TimeSpan.FromSeconds(10));
+            }
+        }
+
+        [Benchmark]
+        [BenchmarkCategory(MicroBenchmark)]
+        public async Task Write_tagged_events_to_memory_journal()
+        {
+            for (var i = 0; i < EventCount; i++)
+            {
+                await _persistentActor.Ask<string>($"tagged-event-{i}", TimeSpan.FromSeconds(10));
+            }
+        }
+
+        #region Test Actor
+
+        private class BenchmarkPersistentActor : ReceivePersistentActor
+        {
+            private int _eventCount;
+
+            public BenchmarkPersistentActor(string persistenceId)
+            {
+                PersistenceId = persistenceId;
+
+                Command<string>(msg =>
+                {
+                    switch (msg)
+                    {
+                        case "get-count":
+                            Sender.Tell(_eventCount);
+                            break;
+                        case "get-id":
+                            Sender.Tell(PersistenceId);
+                            break;
+                        default:
+                        {
+                            if (msg.StartsWith("tagged-event-"))
+                            {
+                                var tagged = new Tagged(msg, new[] { "benchmark-tag" });
+                                Persist(tagged, _ =>
+                                {
+                                    _eventCount++;
+                                    Sender.Tell(msg);
+                                });
+                            }
+                            else
+                            {
+                                Persist(msg, _ =>
+                                {
+                                    _eventCount++;
+                                    Sender.Tell(msg);
+                                });
+                            }
+
+                            break;
+                        }
+                    }
+                });
+
+                Recover<string>(msg =>
+                {
+                    _eventCount++;
+                });
+
+                Recover<Tagged>(tagged =>
+                {
+                    _eventCount++;
+                });
+            }
+
+            public override string PersistenceId { get; }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary

Split `MemoryJournalBenchmarks` into two specialized benchmark classes to provide more accurate performance measurements:

- **MemoryJournalWriteBenchmarks**: Measures pure write performance for standard and tagged events without recovery overhead
- **MemoryJournalRecoveryBenchmarks**: Measures recovery performance with pre-populated data in `IterationSetup` to avoid conflating write and recovery costs

## Changes

- Created `MemoryJournalWriteBenchmarks.cs` with write-only benchmarks
- Created `MemoryJournalRecoveryBenchmarks.cs` with recovery benchmarks that pre-populate data in iteration setup
- Removed original `MemoryJournalBenchmarks.cs`

## Motivation

The original benchmarks measured write + recovery time together, making it impossible to isolate recovery performance. This refactor ensures each benchmark measures exactly one operation type for clearer performance analysis.