### PR TITLE
Fix race condition in StreamRefsSpec remote actor initialization

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
@@ -190,12 +190,12 @@ namespace Akka.Streams.Tests
         }
     }
 
-    public class StreamRefsSpec : AkkaSpec
+    public class StreamRefsSpec : AkkaSpec, IAsyncLifetime
     {
         public static Config Config()
         {
             var address = TestUtils.TemporaryServerAddress();
-            return ConfigurationFactory.ParseString($@"        
+            return ConfigurationFactory.ParseString($@"
             akka {{
               loglevel = INFO
               actor {{
@@ -219,18 +219,26 @@ namespace Akka.Streams.Tests
             RemoteSystem = ActorSystem.Create("remote-system", Config());
             InitializeLogger(RemoteSystem);
             _probe = CreateTestProbe();
+        }
 
+        public async Task InitializeAsync()
+        {
             var it = RemoteSystem.ActorOf(DataSourceActor.Props(_probe.Ref), "remoteActor");
             var remoteAddress = ((ActorSystemImpl)RemoteSystem).Provider.DefaultAddress;
             Sys.ActorSelection(it.Path.ToStringWithAddress(remoteAddress)).Tell(new Identify("hi"));
 
-            _remoteActor = ExpectMsg<ActorIdentity>().Subject;
+            _remoteActor = (await ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(30))).Subject;
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
         }
 
         protected readonly ActorSystem RemoteSystem;
         protected readonly ActorMaterializer Materializer;
         private readonly TestProbe _probe;
-        private readonly IActorRef _remoteActor;
+        private IActorRef _remoteActor;
 
         protected override void BeforeTermination()
         {


### PR DESCRIPTION
## Summary
Fixed flaky test failure in `StreamRefsSpec.SinkRef_must_not_allow_materializing_multiple_times` by refactoring to use xUnit's `IAsyncLifetime` interface for proper async initialization.

## Changes
- Implemented `IAsyncLifetime` interface on `StreamRefsSpec`
- Moved remote actor initialization from constructor to `InitializeAsync()`
- Replaced blocking `ExpectMsg<ActorIdentity>()` with async `await ExpectMsgAsync<ActorIdentity>()`
- Increased timeout from 3 seconds to 30 seconds for remote connection establishment
- Removed `readonly` modifier from `_remoteActor` field (assigned in `InitializeAsync`)

## Root Cause
The original implementation performed async remote actor communication in the constructor using sync-over-async blocking:

```csharp
// In constructor - WRONG
_remoteActor = ExpectMsg<ActorIdentity>().Subject;  // 3 second timeout, blocking on async
```

This created two problems:
1. **Constructor blocking**: Synchronous constructors should not perform async I/O, especially remote actor communication
2. **Insufficient timeout**: The 3-second default was too short for remote TCP connection + Akka.NET association handshake under load

## Solution
Following the pattern established in `EventFilterTestBase`, the fix uses xUnit's `IAsyncLifetime`:

```csharp
public async Task InitializeAsync()
{
    var it = RemoteSystem.ActorOf(DataSourceActor.Props(_probe.Ref), "remoteActor");
    var remoteAddress = ((ActorSystemImpl)RemoteSystem).Provider.DefaultAddress;
    Sys.ActorSelection(it.Path.ToStringWithAddress(remoteAddress)).Tell(new Identify("hi"));
    
    _remoteActor = (await ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(30))).Subject;
}
```

This properly handles async initialization and aligns with xUnit best practices.

## Test Results
- ✅ Previously failing test now passes consistently (5/5 runs)
- ✅ All 14 StreamRefsSpec tests pass (1 skipped by design)