### PR TITLE
Fix race condition in FlowInitialDelaySpec tests

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/FlowInitialDelaySpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowInitialDelaySpec.cs
@@ -33,27 +33,26 @@ namespace Akka.Streams.Tests.Dsl
         [Fact]
         public async Task Flow_InitialDelay_must_work_with_zero_delay()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
-                var task = Source.From(Enumerable.Range(1, 10))
-                .InitialDelay(TimeSpan.Zero)
-                .Grouped(100)
-                .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
-                task.Wait(TimeSpan.FromSeconds(1)).Should().BeTrue();
-                task.Result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
-                return Task.CompletedTask;
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var result = await Source.From(Enumerable.Range(1, 10))
+                    .InitialDelay(TimeSpan.Zero)
+                    .Grouped(100)
+                    .RunWith(Sink.First<IEnumerable<int>>(), Materializer);
+
+                result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
 
         [Fact]
         public async Task Flow_InitialDelay_must_delay_elements_by_the_specified_time_but_not_more()
         {
-            await this.AssertAllStagesStoppedAsync(() => {
-                var task = Source.From(Enumerable.Range(1, 10))
-                .InitialDelay(TimeSpan.FromSeconds(2))
-                .InitialTimeout(TimeSpan.FromSeconds(1))
-                .RunWith(Sink.Ignore<int>(), Materializer);
-                task.Invoking(t => t.Wait(TimeSpan.FromSeconds(2))).Should().Throw<TimeoutException>();
-                return Task.CompletedTask;
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var act = async () => await Source.From(Enumerable.Range(1, 10))
+                    .InitialDelay(TimeSpan.FromSeconds(2))
+                    .InitialTimeout(TimeSpan.FromSeconds(1))
+                    .RunWith(Sink.Ignore<int>(), Materializer);
+
+                await act.Should().ThrowAsync<TimeoutException>();
             }, Materializer);
         }
 


### PR DESCRIPTION
## Summary

Fixes a race condition in `FlowInitialDelaySpec.Flow_InitialDelay_must_delay_elements_by_the_specified_time_but_not_more` that caused intermittent test failures.

## Problem

The test had a timing-dependent race condition where it expected a `TimeoutException` to be thrown but sometimes received no exception. The issue stemmed from using `Task.Wait()` with a timeout, which created a race between:

1. Stream materialization and timer initialization
2. Timeout timer firing (1 second)
3. Exception propagation to the task
4. Test's `Wait()` timeout expiring (2 seconds)

Under thread scheduling variance or CPU load, the timeout timer could fire late or the exception could fail to propagate before the test completed, causing flaky failures.

## Solution

Converted all tests in `FlowInitialDelaySpec` to use proper async/await patterns:

### Before
```csharp
task.Invoking(t => t.Wait(TimeSpan.FromSeconds(2))).Should().Throw<TimeoutException>();
```

### After
```csharp
var act = async () => await Source.From(...)
    .InitialDelay(TimeSpan.FromSeconds(2))
    .InitialTimeout(TimeSpan.FromSeconds(1))
    .RunWith(Sink.Ignore<int>(), Materializer);

await act.Should().ThrowAsync<TimeoutException>();
```

Using FluentAssertions' `ThrowAsync` properly awaits the exception instead of relying on `Wait()` timing, making the test deterministic.

## Changes

- `Flow_InitialDelay_must_work_with_zero_delay`: Replaced `task.Wait()` and `task.Result` with proper `await`
- `Flow_InitialDelay_must_delay_elements_by_the_specified_time_but_not_more`: Replaced timing-dependent `Wait()` with `ThrowAsync()`

## Testing

All tests pass consistently. The problematic test now reliably detects the expected timeout exception.