### PR TITLE
[DRAFT] Test: Remove ConfigureAwait(false) only - no locking changes

### DIFF
--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -391,8 +391,10 @@ namespace Akka.Persistence.Journal
                 // try in case AsyncWriteMessages throws
                 try
                 {
-                    var writeResult =
-                        await _breaker.WithCircuitBreaker((prepared, awj: this), (state, ct) => state.awj.WriteMessagesAsync(state.prepared, ct)).ConfigureAwait(false);
+                    // NOTE: Not using ConfigureAwait(false) to ensure continuation runs on actor's dispatcher thread.
+                // This ensures proper synchronization context and avoids potential race conditions and deadlocks.
+                var writeResult =
+                        await _breaker.WithCircuitBreaker((prepared, awj: this), (state, ct) => state.awj.WriteMessagesAsync(state.prepared, ct));
 
                     ProcessResults(writeResult, atomicWriteCount, message, _resequencer, resequencerCounter, self);
                 }


### PR DESCRIPTION
## Purpose
This is an **experimental draft PR** to test whether removing `ConfigureAwait(false)` from `AsyncWriteJournal.ExecuteBatch` is sufficient to fix the intermittent `InMemoryEventsByTagSpec` test failures, WITHOUT any of the locking or data structure changes.

## What This Tests
This branch is based on commit `59b2cbb87` (before PR #7869 and #7887) and applies ONLY the ConfigureAwait fix.

**No other changes:**
- ❌ No ReaderWriterLockSlim → Monitor conversion
- ❌ No ConcurrentDictionary changes  
- ❌ No lock timing diagnostics
- ✅ Only removes `ConfigureAwait(false)` from line 395 of AsyncWriteJournal.cs

## Hypothesis
The `ConfigureAwait(false)` was causing async continuations to run on thread pool threads instead of the actor's dispatcher thread. This created race conditions when `WriteMessagesAsync` implementations tried to access actor state or when timing-sensitive operations occurred.

If this PR's tests pass consistently, it would suggest:
1. The locking changes in PR #7887 were treating symptoms, not the root cause
2. The original locking mechanism (ReaderWriterLockSlim) was fine
3. The ConfigureAwait was the actual problem

## Testing
Focus on: `Akka.Persistence.Query.InMemory.Tests.InMemoryEventsByTagSpec.ReadJournal_live_query_EventsByTag_should_find_events_from_offset_exclusive`

This test has been failing intermittently for a long time and was the motivation for both PR #7869 and PR #7887.