### PR TITLE
Release v1.5.53

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.52</VersionPrefix>
+    <VersionPrefix>1.5.53</VersionPrefix>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>https://getakka.net/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -50,25 +50,24 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>**SECURITY PATCH**
+    <PackageReleaseNotes>Akka.NET v1.5.53 is a security patch containing important fixes for TLS/SSL hostname validation and improved error diagnostics for certificate authentication issues.
 
-Akka.NET v1.5.52 is a security patch containing crucial fixes for enforcing certificate-based authentication using mTLS enforcement. Please see https://getakka.net/articles/remoting/security.html for details on how this works.
+**Security Fixes:**
 
-* [Akka.Remote: implement mutual TLS authentication support](https://github.com/akkadotnet/akka.net/pull/7851)
-* [Akka.Remote: validate SSL certificate private key access at server startup](https://github.com/akkadotnet/akka.net/pull/7847)
+* [Fix TLS hostname validation bug and add configurable validation](https://github.com/akkadotnet/akka.net/pull/7897) - Fixes a critical bug where TLS clients validated against their own certificate DNS name instead of the remote server address, particularly affecting mutual TLS scenarios. This release also adds a new `validate-certificate-hostname` configuration option to `akka.remote.dot-netty.tcp` (defaults to `false` for backward compatibility) and introduces type-safe validation APIs through the new `TlsValidationCallbacks` factory class.
 
-Other fixes:
+**Improvements:**
 
-* [Akka.Cluster.Sharding: ShardedDaemonSets: randomize starting worker index](https://github.com/akkadotnet/akka.net/pull/7857)
+* [Improve TLS/SSL certificate error messages during handshake failures](https://github.com/akkadotnet/akka.net/pull/7891) - Provides human-readable, actionable error messages for TLS/SSL certificate validation failures with detailed troubleshooting guidance, significantly improving the developer experience when configuring certificate-based authentication.
 
-1 contributors since release 1.5.51
+1 contributor since release 1.5.52
 
 | COMMITS | LOC+ | LOC- | AUTHOR |
 | --- | --- | --- | --- |
-| 3 | 1193 | 149 | Aaron Stannard |
+| 2 | 1060 | 77 | Aaron Stannard |
 
 
-To [see the full set of changes in Akka.NET v1.5.52, click here](https://github.com/akkadotnet/akka.net/milestone/135?closed=1)</PackageReleaseNotes>
+To [see the full set of changes in Akka.NET v1.5.53, click here](https://github.com/akkadotnet/akka.net/milestone/136?closed=1)</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup Label="Analyzers" Condition="'$(MSBuildProjectName)' != 'Akka'">
     <PackageReference Include="Akka.Analyzers" Version="$(AkkaAnalyzerVersion)" PrivateAssets="all" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+#### 1.5.53 October 9th, 2025 ####
+
+Akka.NET v1.5.53 is a security patch containing important fixes for TLS/SSL hostname validation and improved error diagnostics for certificate authentication issues.
+
+**Security Fixes:**
+
+* [Fix TLS hostname validation bug and add configurable validation](https://github.com/akkadotnet/akka.net/pull/7897) - Fixes a critical bug where TLS clients validated against their own certificate DNS name instead of the remote server address, particularly affecting mutual TLS scenarios. This release also adds a new `validate-certificate-hostname` configuration option to `akka.remote.dot-netty.tcp` (defaults to `false` for backward compatibility) and introduces type-safe validation APIs through the new `TlsValidationCallbacks` factory class.
+
+**Improvements:**
+
+* [Improve TLS/SSL certificate error messages during handshake failures](https://github.com/akkadotnet/akka.net/pull/7891) - Provides human-readable, actionable error messages for TLS/SSL certificate validation failures with detailed troubleshooting guidance, significantly improving the developer experience when configuring certificate-based authentication.
+
+1 contributor since release 1.5.52
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 2 | 1060 | 77 | Aaron Stannard |
+
+
+To [see the full set of changes in Akka.NET v1.5.53, click here](https://github.com/akkadotnet/akka.net/milestone/136?closed=1)
+
 #### 1.5.52 October 6th, 2025 ####
 
 **SECURITY PATCH**


### PR DESCRIPTION
## Summary
Release preparation for Akka.NET v1.5.53 - a security patch containing important fixes for TLS/SSL hostname validation and improved error diagnostics.

### Changes
- Updated version to 1.5.53 in `Directory.Build.props`
- Added release notes to `RELEASE_NOTES.md`

### Security Fixes
- [#7897](https://github.com/akkadotnet/akka.net/pull/7897) - Fix TLS hostname validation bug and add configurable validation
  - Fixes critical bug where TLS clients validated against their own certificate DNS name instead of the remote server address
  - Adds new `validate-certificate-hostname` configuration option (defaults to `false` for backward compatibility)
  - Introduces type-safe validation APIs through new `TlsValidationCallbacks` factory class

### Improvements  
- [#7891](https://github.com/akkadotnet/akka.net/pull/7891) - Improve TLS/SSL certificate error messages during handshake failures
  - Provides human-readable, actionable error messages for TLS/SSL certificate validation failures
  - Significantly improves developer experience when troubleshooting TLS issues

### Release Information
- **Version**: 1.5.53
- **Release Date**: October 9th, 2025
- **Milestone**: https://github.com/akkadotnet/akka.net/milestone/136?closed=1
- **Contributors**: 1 (Aaron Stannard)
- **Commits since 1.5.52**: 2

This is a security patch release that continues the TLS/SSL improvements from v1.5.52.