### PR TITLE
Fix race condition in PersistentStartEntitySpec

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentStartEntitySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentStartEntitySpec.cs
@@ -125,8 +125,12 @@ namespace Akka.Cluster.Sharding.Tests
 
             // trigger shard start by messaging other actor in it
             Sys.Log.Info("Starting shard again");
-            sharding.Tell(new EntityEnvelope(11, "give-me-shard"));
-            var secondShardIncarnation = await ExpectMsgAsync<IActorRef>();
+            IActorRef secondShardIncarnation = null;
+            await AwaitAssertAsync(async () =>
+            {
+                sharding.Tell(new EntityEnvelope(11, "give-me-shard"));
+                secondShardIncarnation = await ExpectMsgAsync<IActorRef>(TimeSpan.FromSeconds(1));
+            }, TimeSpan.FromSeconds(5));
 
             await AwaitAssertAsync(async () =>
             {


### PR DESCRIPTION
## Summary
Fixes a race condition in `PersistentStartEntitySpec.Persistent_Shard_must_remember_entities_started_with_StartEntity` that caused intermittent test timeouts.

## Problem
The test would occasionally fail with a 3-second timeout while waiting for an `IActorRef` message. This race condition was introduced in commit e33dca403 (Oct 3, 2025) which removed a timing buffer but didn't add proper retry logic.

**Race condition sequence:**
1. Test sends `PoisonPill` to shard and waits for termination
2. Test immediately sends `EntityEnvelope(11)` to trigger new shard creation  
3. Message arrives during shard restart window → goes to dead letters
4. Test times out waiting for response that never comes

## Solution
Added `AwaitAssertAsync` with retry logic around the message send and response:

```csharp
// Before (racy):
sharding.Tell(new EntityEnvelope(11, "give-me-shard"));
var secondShardIncarnation = await ExpectMsgAsync<IActorRef>();

// After (with retry):
IActorRef secondShardIncarnation = null;
await AwaitAssertAsync(async () =>
{
    sharding.Tell(new EntityEnvelope(11, "give-me-shard"));
    secondShardIncarnation = await ExpectMsgAsync<IActorRef>(TimeSpan.FromSeconds(1));
}, TimeSpan.FromSeconds(5));
```

**How retry logic fixes the race:**
- First attempt may arrive during shard recovery → message properly **stashed**
- Shard completes recovery and initialization
- Stashed message is unstashed and processed
- Entity 11 responds with shard ref
- Test receives response and passes

## Testing
- ✅ Verified with 3 consecutive test runs showing 100% pass rate
- ✅ No dead letters in logs (messages properly stashed during recovery)
- ✅ Test completes in ~1-2 seconds vs timing out at 3 seconds

## Changes
- Modified `PersistentStartEntitySpec.cs` line 127-133
- No production code changes required