### PR TITLE
[v1.5] Fix LWWDictionary.Delta ArgumentNullException when underlying delta is null

### DIFF
--- a/src/contrib/cluster/Akka.DistributedData.Tests/LWWDictionarySpec.cs
+++ b/src/contrib/cluster/Akka.DistributedData.Tests/LWWDictionarySpec.cs
@@ -161,5 +161,33 @@ namespace Akka.DistributedData.Tests
             merged1.Entries["b"].Should().BeEquivalentTo("B2");
             merged1.Entries["c"].Should().BeEquivalentTo("C");
         }
+
+        /// <summary>
+        /// Bug reproduction: https://github.com/akkadotnet/akka.net/issues/7910
+        /// LWWDictionary.Delta should return null when underlying ORDictionary.Delta is null
+        /// </summary>
+        [Fact]
+        public void Bugfix_7910_LWWDictionary_Delta_should_handle_null_underlying_delta()
+        {
+            // Empty dictionary has no delta
+            var empty = LWWDictionary<string, string>.Empty;
+            empty.Delta.Should().BeNull("empty dictionary should have null delta");
+
+            // After ResetDelta(), delta should be null
+            var m1 = LWWDictionary<string, string>.Empty
+                .SetItem(_node1, "a", "A")
+                .SetItem(_node1, "b", "B");
+
+            m1.Delta.Should().NotBeNull("dictionary with modifications should have a delta");
+
+            var m2 = m1.ResetDelta();
+            m2.Delta.Should().BeNull("after ResetDelta(), delta should be null");
+
+            // Verify the dictionary still contains the data
+            m2.ContainsKey("a").Should().BeTrue();
+            m2.ContainsKey("b").Should().BeTrue();
+            m2["a"].Should().Be("A");
+            m2["b"].Should().Be("B");
+        }
     }
 }

--- a/src/contrib/cluster/Akka.DistributedData/LWWDictionary.cs
+++ b/src/contrib/cluster/Akka.DistributedData/LWWDictionary.cs
@@ -402,8 +402,8 @@ namespace Akka.DistributedData
         }
 
         // TODO: optimize this so it doesn't allocate each time it's called
-        public ORDictionary<TKey, LWWRegister<TValue>>.IDeltaOperation Delta => 
-            new LWWDictionaryDelta(Underlying.Delta);
+        public ORDictionary<TKey, LWWRegister<TValue>>.IDeltaOperation Delta =>
+            Underlying.Delta == null ? null : new LWWDictionaryDelta(Underlying.Delta);
 
         IReplicatedDelta IDeltaReplicatedData.Delta => Delta;
 


### PR DESCRIPTION
## Summary
Backport of #7911 to v1.5 branch.

Fixed a bug where `LWWDictionary.Delta` would throw `ArgumentNullException` when the underlying `ORDictionary.Delta` is `null`, which is a legitimate state after initialization or calling `ResetDelta()`.

## Changes
- Modified `LWWDictionary.Delta` property to return `null` when `Underlying.Delta` is `null`
- Added test `Bugfix_7910_LWWDictionary_Delta_should_handle_null_underlying_delta` to verify the fix

## Root Cause
The `LWWDictionary.Delta` property was unconditionally wrapping `Underlying.Delta` in a `LWWDictionaryDelta` constructor, which throws `ArgumentNullException` when passed `null`. However, `ORDictionary.Delta` can legitimately return `null` after construction or `ResetDelta()`.

The Replicator expects deltas to be nullable (uses `??` operator), so this fix aligns `LWWDictionary` with the expected interface contract.

## Test Evidence
All `LWWDictionarySpec` tests pass:
- 5 existing tests (no regressions)
- 1 new test verifying null delta handling

Fixes #7910 for v1.5