### PR TITLE
feat(remote): custom certificate validation with single execution path - fixes mTLS asymmetry bug

### DIFF
--- a/docs/articles/remoting/security.md
+++ b/docs/articles/remoting/security.md
@@ -122,54 +122,82 @@ When `suppress-validation = true`:
 * Any environment processing sensitive data
 * Any multi-tenant environment
 
-### Hostname Validation
+### Validation Strategies: HOCON vs Programmatic (v1.5.52+)
 
-**New in v1.5.52+:** The `validate-certificate-hostname` setting controls whether the certificate CN/SAN must match the target hostname.
+Two independent validation decisions determine your TLS security posture:
 
-**IMPORTANT: This setting defaults to `false` (disabled).** Hostname validation is NOT performed by default to support common Akka.NET deployment patterns like mutual TLS with per-node certificates and IP-based connections.
+1. **Chain Validation** - Verify certificate against trusted CAs (`suppress-validation`)
+2. **Hostname Validation** - Verify certificate CN/SAN matches target (`validate-certificate-hostname`)
+3. **Mutual Authentication** - Require both sides authenticate (`require-mutual-authentication`)
 
-#### Disabled (Default)
+#### Decision Matrix: Which Combination to Use
+
+| Use Case | suppress-validation | validate-hostname | mutual-auth | Config Approach |
+|----------|---------------------|-------------------|-------------|-----------------|
+| **P2P Cluster (Default)** | `false` | `false` | `true` | HOCON ✓ or Programmatic |
+| **Client-Server with Shared Cert** | `false` | `true` | `true` | HOCON ✓ or Programmatic |
+| **Development/Testing** | `true` | `false` | `false` | HOCON only |
+| **Certificate Pinning** | `false` | `false` | `true` | **Programmatic required** |
+| **Custom Subject/Issuer Validation** | `false` | `false` | `true` | **Programmatic required** |
+
+#### HOCON Configuration Approach
 
 When `validate-certificate-hostname = false` (the default):
 
-**What it does:**
-
 * Skips hostname validation
 * Only validates certificate chain (if `suppress-validation = false`)
-
-**When to use:**
-
-* **Mutual TLS with per-node certificates** - Each node has its own unique certificate
-* **IP-based connections** - Connecting via IP addresses instead of DNS names
-* **Dynamic service discovery** - Hostnames change frequently (Kubernetes, auto-scaling)
-* **Internal P2P clusters** - All nodes are trusted and mutually authenticated
-
-**This is the default** for backward compatibility and to support common Akka.NET cluster patterns.
-
-#### Enabled
+* **Best for:** Mutual TLS with per-node certificates, IP-based connections, Kubernetes dynamic discovery
 
 When `validate-certificate-hostname = true`:
 
-**What it validates:**
-
 * Certificate CN (Common Name) or SAN (Subject Alternative Name) must match the target hostname
 * Traditional TLS hostname validation as used in HTTPS
+* **Best for:** Client-server architectures with shared certificates and stable DNS names
 
-**When to use:**
+**HOCON Example - P2P Cluster (Common Default):**
 
-* **Client-server architecture** - Clients connecting to known server hostnames
-* **Shared certificates** - Same certificate used across multiple nodes
-* **DNS-based connections** - Connecting via stable DNS names
-* **Maximum security** - Traditional browser-like TLS validation
+```hocon
+akka.remote.dot-netty.tcp {
+  enable-ssl = true
+  ssl {
+    suppress-validation = false                    # Validate CA chain
+    require-mutual-authentication = true           # Both sides authenticate
+    validate-certificate-hostname = false          # Default: Allow per-node certs
+    certificate {
+      use-thumbprint-over-file = true
+      thumbprint = "2531c78c51e5041d02564697a88af8bc7a7ce3e3"
+    }
+  }
+}
+```
 
-### Validation Mode Combinations
+**HOCON Example - Client-Server with Hostname Validation:**
 
-| suppress-validation | validate-certificate-hostname | Use Case |
-|---------------------|-------------------------------|----------|
-| `false` | `false` | **Common**: Mutual TLS clusters with per-node certs |
-| `false` | `true` | **Traditional**: Client-server TLS with DNS names |
-| `true` | `false` | **Dev/Test**: Self-signed certs, no hostname checks |
-| `true` | `true` | **Test Only**: Self-signed certs WITH hostname validation |
+```hocon
+akka.remote.dot-netty.tcp {
+  enable-ssl = true
+  ssl {
+    suppress-validation = false                    # Validate CA chain
+    require-mutual-authentication = true           # Both sides authenticate
+    validate-certificate-hostname = true           # Hostname must match
+    certificate {
+      use-thumbprint-over-file = true
+      thumbprint = "2531c78c51e5041d02564697a88af8bc7a7ce3e3"
+    }
+  }
+}
+```
+
+#### Programmatic Configuration Approach
+
+Use `DotNettySslSetup` with `CertificateValidation` helpers when you need:
+
+* **Certificate pinning** - Accept only specific certificates
+* **Subject/Issuer validation** - Custom certificate attribute checks
+* **Custom business logic** - Domain-specific validation rules
+* **Dynamic validation** - Load rules from runtime sources
+
+See [Programmatic Certificate Validation](#programmatic-certificate-validation-v1555) below for detailed examples.
 
 ### Self-Signed Certificates: The Right Way
 
@@ -305,6 +333,80 @@ akka.remote.dot-netty.tcp {
 5. Scroll to Thumbprint field
 6. Copy the value (remove spaces)
 
+## Programmatic Certificate Validation (v1.5.55+)
+
+**New in Akka.NET v1.5.55:** Certificate validation can now be configured programmatically using `DotNettySslSetup` with custom validators. This provides fine-grained control over validation logic while maintaining full backward compatibility with HOCON configuration.
+
+### When to Use Programmatic Configuration
+
+Use programmatic setup when you need:
+
+* **Custom validation logic** - Implement domain-specific validation rules
+* **Certificate pinning** - Accept only specific certificates by thumbprint
+* **Subject/Issuer validation** - Verify certificate attributes
+* **Dynamic configuration** - Load validation rules from runtime sources
+* **Composable validators** - Combine multiple validation strategies
+
+### CertificateValidation Helper Factory
+
+The `CertificateValidation` static class provides 7 helper methods for common validation patterns:
+
+#### Basic Chain Validation
+
+[!code-csharp[ProgrammaticMutualTlsSetup](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=ProgrammaticMutualTlsSetup)]
+
+#### Certificate Pinning by Thumbprint
+
+Accept only certificates with specific thumbprints. Prevents man-in-the-middle attacks if CA is compromised:
+
+[!code-csharp[CertificatePinningExample](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=CertificatePinningExample)]
+
+#### Custom Validation Logic with ChainPlusThen
+
+Perform standard chain validation, then apply custom business logic:
+
+[!code-csharp[CustomValidationLogicExample](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=CustomValidationLogicExample)]
+
+#### Hostname Validation
+
+Enable traditional TLS hostname validation (certificate CN/SAN must match target hostname). Use for client-server architectures with shared certificates:
+
+[!code-csharp[HostnameValidationExample](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=HostnameValidationExample)]
+
+#### Subject DN Validation
+
+Accept only certificates with specific subject names:
+
+[!code-csharp[SubjectValidationExample](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=SubjectValidationExample)]
+
+### CertificateValidation Helper Methods
+
+| Method | Purpose |
+|--------|---------|
+| `ValidateChain()` | CA chain validation with full error details |
+| `ValidateHostname()` | Traditional TLS hostname validation (CN/SAN matching) |
+| `PinnedCertificate()` | Certificate pinning by thumbprint whitelist |
+| `ValidateSubject()` | Subject DN pattern matching (e.g., CN, O, OU) |
+| `ValidateIssuer()` | Issuer DN pattern matching |
+| `Combine()` | Compose multiple validators (AND logic) |
+| `ChainPlusThen()` | Chain validation + custom business logic |
+
+### Custom Validator Precedence
+
+When both custom validators and HOCON config are present, custom validators take precedence:
+
+```csharp
+// This validator will be used regardless of HOCON suppress-validation setting
+var customValidator = CertificateValidation.ValidateChain(log);
+var sslSetup = new DotNettySslSetup(
+    certificate: cert,
+    suppressValidation: false,  // Ignored when customValidator provided
+    customValidator: customValidator
+);
+```
+
+This ensures programmatic validation logic always takes priority for explicit security requirements.
+
 ## Startup Certificate Validation (v1.5.52+)
 
 **New in Akka.NET v1.5.52:** The transport now validates certificate configuration at startup, preventing runtime failures.
@@ -344,11 +446,11 @@ $acl.AddAccessRule($accessRule)
 Set-Acl $keyFullPath $acl
 ```
 
-## Mutual TLS Authentication (v1.5.52+)
+## Understanding Mutual TLS (mTLS) vs Standard TLS (v1.5.52+)
 
-**New in Akka.NET v1.5.52:** Support for mutual TLS (mTLS) where both client and server must authenticate with certificates.
+Akka.NET supports both standard TLS and mutual TLS (mTLS), configured via the `require-mutual-authentication` setting in the [Validation Strategies](#validation-strategies-hocon-vs-programmatic-v1552) section above.
 
-### Standard TLS vs Mutual TLS
+### Visual Comparison
 
 **Standard TLS (Server Authentication Only):**
 
@@ -380,38 +482,28 @@ sequenceDiagram
     Note over Client,Server: Mutually authenticated encryption established
 ```
 
-### Configuration
-
-The following example shows how to configure mutual TLS:
-
-[!code-csharp[MutualTlsConfig](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=MutualTlsConfig)]
-
-For production with Windows Certificate Store:
-
-[!code-csharp[WindowsCertStoreConfig](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=WindowsCertStoreConfig)]
-
 ### When to Enable Mutual TLS
 
-**Enable mutual TLS when:**
+**Enable mutual TLS (`require-mutual-authentication = true`) when:**
 
-* All nodes are under your control (typical Akka.NET cluster)
+* All nodes are under your control (typical Akka.NET cluster) ✓ **Recommended**
 * You need defense-in-depth security
 * Compliance requires bidirectional authentication (PCI-DSS, HIPAA, etc.)
 * You want to prevent misconfigured nodes from joining
 
-**Disable mutual TLS when:**
+**Disable mutual TLS (`require-mutual-authentication = false`) when:**
 
 * Clients cannot provide certificates (rare in Akka.NET)
 * You're using client-server architecture where clients are untrusted
 * Backward compatibility with older clients required
 
-**Default is TRUE for security-by-default posture.**
+**Default is TRUE for security-by-default posture** (since v1.5.52).
 
 ### Security Benefits of Mutual TLS
 
 1. **Prevents Asymmetric Connectivity Issues**
-   * Without mutual TLS: A node with broken certificate can connect OUT to cluster (client TLS succeeds)
-   * With mutual TLS: Node cannot connect without working certificate (enforced both ways)
+   * Without mTLS: A node with broken certificate can connect OUT to cluster (client TLS succeeds)
+   * With mTLS: Node cannot connect without working certificate (enforced both ways)
 
 2. **Defense-in-Depth**
    * Startup validation prevents broken servers
@@ -422,92 +514,59 @@ For production with Windows Certificate Store:
    * Every node must prove it owns the certificate
    * Prevents certificate theft attacks (attacker needs private key)
 
+For configuration examples in both HOCON and programmatic styles, see [Validation Strategies](#validation-strategies-hocon-vs-programmatic-v1552) and [Programmatic Certificate Validation](#programmatic-certificate-validation-v1555) sections above.
+
 ## Configuration Examples and Security Analysis
 
-### INSECURE: Development/Testing Only
+This section provides concrete examples of different security configurations and their tradeoffs.
+
+### HOCON Configuration Security Levels
+
+**Development/Testing Only (INSECURE):**
 
 [!code-csharp[DevTlsConfig](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=DevTlsConfig)]
 
-**Why this is bad:**
-
-* `suppress-validation = true` accepts ANY certificate (even self-signed or expired)
+* ⚠️ `suppress-validation = true` accepts ANY certificate (self-signed, expired, invalid chains)
 * Vulnerable to man-in-the-middle attacks
 * No client authentication
+* **Use only:** Local development, never in networked environments
 
-**When to use:** Local development only, never in any environment accessible from network.
-
-### GOOD: Standard TLS for Production
+**Standard TLS (Medium-High Security):**
 
 [!code-csharp[StandardTlsConfig](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=StandardTlsConfig)]
-
-**Security level:** Medium-High
 
 * Server proves identity to clients
 * All traffic encrypted
 * Startup validation prevents misconfigurations
-* Suitable when mutual TLS is not feasible
+* **Use when:** Mutual TLS is not feasible
 
-### BEST: Mutual TLS for Maximum Security
+**Mutual TLS with Windows Certificate Store (Maximum Security - RECOMMENDED):**
 
-```hocon
-akka.remote.dot-netty.tcp {
-  enable-ssl = true
-  ssl {
-    suppress-validation = false  # Validates all certificates (default when SSL enabled)
-    require-mutual-authentication = true  # Requires client certs (default when SSL enabled since v1.5.52)
-    validate-certificate-hostname = false  # DEFAULT: Hostname validation disabled (suitable for P2P with per-node certs)
-    certificate {
-      use-thumbprint-over-file = true
-      thumbprint = "2531c78c51e5041d02564697a88af8bc7a7ce3e3"
-      store-name = "My"
-      store-location = "local-machine"
-    }
-  }
-}
-```
+[!code-csharp[WindowsCertStoreConfig](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=WindowsCertStoreConfig)]
 
-**Note:** When SSL is enabled, both `suppress-validation = false` and `require-mutual-authentication = true` are the secure defaults (since v1.5.52), so you only need to explicitly set them if overriding.
+* ✓ Both client and server prove identity
+* ✓ All traffic encrypted
+* ✓ Prevents misconfigured nodes from connecting
+* ✓ Private keys protected by Windows ACL
+* **Use when:** Production Akka.NET clusters (default recommended configuration)
 
-**About hostname validation:**
+**Mutual TLS for P2P Clusters with Per-Node Certificates:**
 
-* Set `validate-certificate-hostname = false` for peer-to-peer clusters with per-node certificates (default)
-* Set `validate-certificate-hostname = true` for client-server architectures with DNS-based connections
+Refer to the [Validation Strategies](#validation-strategies-hocon-vs-programmatic-v1552) section for HOCON example showing P2P cluster setup.
 
-**Security level:** Maximum
+**Client-Server with Hostname Validation:**
 
-* Both client and server prove identity
-* All traffic encrypted
-* Prevents misconfigured nodes from connecting
-* Defense-in-depth security
-* Recommended for all production deployments
+Refer to the [Validation Strategies](#validation-strategies-hocon-vs-programmatic-v1552) section for HOCON example with hostname validation enabled.
 
-### Configuration with Hostname Validation Enabled
+### Programmatic Configuration Security Levels
 
-For client-server architectures where all nodes connect via DNS names and share the same certificate:
+For certificate pinning, subject/issuer validation, or custom logic, use programmatic setup:
 
-```hocon
-akka.remote.dot-netty.tcp {
-  enable-ssl = true
-  ssl {
-    suppress-validation = false
-    require-mutual-authentication = true
-    validate-certificate-hostname = true  # Enable traditional TLS hostname validation
-    certificate {
-      use-thumbprint-over-file = true
-      thumbprint = "2531c78c51e5041d02564697a88af8bc7a7ce3e3"
-      store-name = "My"
-      store-location = "local-machine"
-    }
-  }
-}
-```
+[!code-csharp[ProgrammaticMutualTlsSetup](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=ProgrammaticMutualTlsSetup)]
 
-**When to use hostname validation:**
+[!code-csharp[CertificatePinningExample](../../../src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs?name=CertificatePinningExample)]
 
-* Your cluster uses stable DNS names (not IPs)
-* All nodes share the same certificate (CN matches DNS names)
-* You want browser-like TLS validation behavior
-* Client-server architecture rather than P2P mesh
+See [Programmatic Certificate Validation](#programmatic-certificate-validation-v1555) section for more examples.
 
 ## Untrusted Mode
 

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.DotNet.verified.txt
@@ -860,12 +860,29 @@ namespace Akka.Remote.Transport
 }
 namespace Akka.Remote.Transport.DotNetty
 {
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    public class static CertificateValidation
+    {
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ChainPlusThen(System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, string, bool> customCheck, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback Combine(params Akka.Remote.Transport.DotNetty.CertificateValidationCallback[] validators) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback PinnedCertificate(params string[] allowedThumbprints) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateChain([System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateHostname(string expectedHostname = null, Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateIssuer(string expectedIssuerPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateSubject(string expectedSubjectPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+    }
+    public delegate bool CertificateValidationCallback(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.X509Certificates.X509Chain chain, string remotePeer, System.Net.Security.SslPolicyErrors errors, Akka.Event.ILoggingAdapter log);
     public sealed class DotNettySslSetup : Akka.Actor.Setup.Setup
     {
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation) { }
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication) { }
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname) { }
+        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Remote.Transport.DotNetty.CertificateValidationCallback customValidator) { }
+        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Remote.Transport.DotNetty.CertificateValidationCallback customValidator) { }
         public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public Akka.Remote.Transport.DotNetty.CertificateValidationCallback CustomValidator { get; }
         public bool RequireMutualAuthentication { get; }
         public bool SuppressValidation { get; }
         public bool ValidateCertificateHostname { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.DotNet.verified.txt
@@ -863,7 +863,11 @@ namespace Akka.Remote.Transport.DotNetty
     [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class static CertificateValidation
     {
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ChainPlusThen(System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, string, bool> customCheck, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ChainPlusThen([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                1,
+                2,
+                2,
+                1})] System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, string, bool> customCheck, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback Combine(params Akka.Remote.Transport.DotNetty.CertificateValidationCallback[] validators) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback PinnedCertificate(params string[] allowedThumbprints) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateChain([System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
@@ -872,7 +876,8 @@ namespace Akka.Remote.Transport.DotNetty
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateIssuer(string expectedIssuerPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateSubject(string expectedSubjectPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
     }
-    public delegate bool CertificateValidationCallback(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.X509Certificates.X509Chain chain, string remotePeer, System.Net.Security.SslPolicyErrors errors, Akka.Event.ILoggingAdapter log);
+    public delegate bool CertificateValidationCallback([System.Runtime.CompilerServices.NullableAttribute(2)] System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, [System.Runtime.CompilerServices.NullableAttribute(2)] System.Security.Cryptography.X509Certificates.X509Chain chain, string remotePeer, System.Net.Security.SslPolicyErrors errors, Akka.Event.ILoggingAdapter log);
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class DotNettySslSetup : Akka.Actor.Setup.Setup
     {
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.Net.verified.txt
@@ -860,12 +860,29 @@ namespace Akka.Remote.Transport
 }
 namespace Akka.Remote.Transport.DotNetty
 {
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    public class static CertificateValidation
+    {
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ChainPlusThen(System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, string, bool> customCheck, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback Combine(params Akka.Remote.Transport.DotNetty.CertificateValidationCallback[] validators) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback PinnedCertificate(params string[] allowedThumbprints) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateChain([System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateHostname(string expectedHostname = null, Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateIssuer(string expectedIssuerPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateSubject(string expectedSubjectPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+    }
+    public delegate bool CertificateValidationCallback(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.X509Certificates.X509Chain chain, string remotePeer, System.Net.Security.SslPolicyErrors errors, Akka.Event.ILoggingAdapter log);
     public sealed class DotNettySslSetup : Akka.Actor.Setup.Setup
     {
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation) { }
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication) { }
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname) { }
+        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Remote.Transport.DotNetty.CertificateValidationCallback customValidator) { }
+        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Remote.Transport.DotNetty.CertificateValidationCallback customValidator) { }
         public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get; }
+        [System.Runtime.CompilerServices.NullableAttribute(2)]
+        public Akka.Remote.Transport.DotNetty.CertificateValidationCallback CustomValidator { get; }
         public bool RequireMutualAuthentication { get; }
         public bool SuppressValidation { get; }
         public bool ValidateCertificateHostname { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.Net.verified.txt
@@ -863,7 +863,11 @@ namespace Akka.Remote.Transport.DotNetty
     [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class static CertificateValidation
     {
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ChainPlusThen(System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, string, bool> customCheck, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ChainPlusThen([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
+                1,
+                2,
+                2,
+                1})] System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, string, bool> customCheck, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback Combine(params Akka.Remote.Transport.DotNetty.CertificateValidationCallback[] validators) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback PinnedCertificate(params string[] allowedThumbprints) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateChain([System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
@@ -872,7 +876,8 @@ namespace Akka.Remote.Transport.DotNetty
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateIssuer(string expectedIssuerPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateSubject(string expectedSubjectPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
     }
-    public delegate bool CertificateValidationCallback(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Security.Cryptography.X509Certificates.X509Chain chain, string remotePeer, System.Net.Security.SslPolicyErrors errors, Akka.Event.ILoggingAdapter log);
+    public delegate bool CertificateValidationCallback([System.Runtime.CompilerServices.NullableAttribute(2)] System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, [System.Runtime.CompilerServices.NullableAttribute(2)] System.Security.Cryptography.X509Certificates.X509Chain chain, string remotePeer, System.Net.Security.SslPolicyErrors errors, Akka.Event.ILoggingAdapter log);
+    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class DotNettySslSetup : Akka.Actor.Setup.Setup
     {
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation) { }

--- a/src/core/Akka.Docs.Tests/Akka.Docs.Tests.csproj
+++ b/src/core/Akka.Docs.Tests/Akka.Docs.Tests.csproj
@@ -10,7 +10,6 @@
     <ProjectReference Include="..\Akka.Coordination.Tests\Akka.Coordination.Tests.csproj" />
     <ProjectReference Include="..\Akka\Akka.csproj" />
     <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj" />
-    <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj" />
     <ProjectReference Include="..\Akka.Streams\Akka.Streams.csproj" />
     <ProjectReference Include="..\Akka.TestKit\Akka.TestKit.csproj" />
     <ProjectReference Include="..\..\contrib\cluster\Akka.Cluster.Tools\Akka.Cluster.Tools.csproj" />

--- a/src/core/Akka.Docs.Tests/Akka.Docs.Tests.csproj
+++ b/src/core/Akka.Docs.Tests/Akka.Docs.Tests.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\Akka.Coordination.Tests\Akka.Coordination.Tests.csproj" />
     <ProjectReference Include="..\Akka\Akka.csproj" />
     <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj" />
+    <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj" />
     <ProjectReference Include="..\Akka.Streams\Akka.Streams.csproj" />
     <ProjectReference Include="..\Akka.TestKit\Akka.TestKit.csproj" />
     <ProjectReference Include="..\..\contrib\cluster\Akka.Cluster.Tools\Akka.Cluster.Tools.csproj" />

--- a/src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs
+++ b/src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs
@@ -85,11 +85,12 @@ namespace Akka.Docs.Tests.Configuration
         #endregion
 
         #region ProgrammaticMutualTlsSetup
+#if NET6_0_OR_GREATER
         /// <summary>
         /// Example of programmatic mutual TLS setup using DotNettySslSetup with custom validation.
         /// This allows full programmatic control over certificate validation logic.
         /// </summary>
-        public static BootstrapSetup ProgrammaticMutualTlsSetup()
+        public static void ProgrammaticMutualTlsSetup()
         {
             // Load or obtain your certificate
             var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
@@ -97,9 +98,9 @@ namespace Akka.Docs.Tests.Configuration
             // Create custom validator combining multiple validation strategies
             var customValidator = CertificateValidation.Combine(
                 // Validate the certificate chain
-                CertificateValidation.ValidateChain(null),
+                CertificateValidation.ValidateChain(),
                 // Also pin against known thumbprints for additional security
-                CertificateValidation.PinnedCertificate(new[] { certificate.Thumbprint }, null)
+                CertificateValidation.PinnedCertificate(certificate.Thumbprint)
             );
 
             // Setup SSL with custom validator taking precedence over HOCON config
@@ -109,28 +110,25 @@ namespace Akka.Docs.Tests.Configuration
                 requireMutualAuthentication: true,
                 customValidator: customValidator
             );
-
-            return new BootstrapSetup().And(sslSetup);
         }
+#endif
         #endregion
 
         #region CertificatePinningExample
+#if NET6_0_OR_GREATER
         /// <summary>
         /// Example of certificate pinning - only accept certificates with specific thumbprints.
         /// Useful for preventing man-in-the-middle attacks with compromised CAs.
         /// </summary>
-        public static BootstrapSetup CertificatePinningSetup()
+        public static void CertificatePinningSetup()
         {
             var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
 
             // Allow only specific certificates by thumbprint
-            var allowedThumbprints = new[]
-            {
+            var validator = CertificateValidation.PinnedCertificate(
                 "2531c78c51e5041d02564697a88af8bc7a7ce3e3",  // Production cert
                 "abc123def456789ghi012jkl345mno678pqr901stu"  // Backup cert
-            };
-
-            var validator = CertificateValidation.PinnedCertificate(allowedThumbprints, null);
+            );
 
             var sslSetup = new DotNettySslSetup(
                 certificate: certificate,
@@ -138,33 +136,32 @@ namespace Akka.Docs.Tests.Configuration
                 requireMutualAuthentication: true,
                 customValidator: validator
             );
-
-            return new BootstrapSetup().And(sslSetup);
         }
+#endif
         #endregion
 
         #region CustomValidationLogicExample
+#if NET6_0_OR_GREATER
         /// <summary>
         /// Example of custom certificate validation logic combined with standard validation.
         /// Allows complete control over what certificates are accepted.
         /// </summary>
-        public static BootstrapSetup CustomValidationLogicSetup()
+        public static void CustomValidationLogicSetup()
         {
             var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
 
             // Start with standard chain validation, then add custom logic
             var validator = CertificateValidation.ChainPlusThen(
-                // First, validate the certificate chain
-                (cert, chain, peer, log) =>
+                // Custom validation - check certificate subject matches expected peer
+                (cert, chain, peer) =>
                 {
-                    // Then apply custom logic - e.g., check certificate attributes
+                    // Accept only certificates from authorized-peer
                     if (cert?.Subject != null && cert.Subject.Contains("CN=authorized-peer"))
                     {
                         return true;  // Accept this certificate
                     }
                     return false;  // Reject all others
-                },
-                null
+                }
             );
 
             var sslSetup = new DotNettySslSetup(
@@ -173,17 +170,17 @@ namespace Akka.Docs.Tests.Configuration
                 requireMutualAuthentication: true,
                 customValidator: validator
             );
-
-            return new BootstrapSetup().And(sslSetup);
         }
+#endif
         #endregion
 
         #region HostnameValidationExample
+#if NET6_0_OR_GREATER
         /// <summary>
         /// Example of enabling traditional hostname validation for client-server architectures.
         /// Use when all nodes share the same certificate with matching CN/SAN.
         /// </summary>
-        public static BootstrapSetup HostnameValidationSetup()
+        public static void HostnameValidationSetup()
         {
             var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
 
@@ -194,29 +191,26 @@ namespace Akka.Docs.Tests.Configuration
                 requireMutualAuthentication: true,
                 validateCertificateHostname: true  // Enable traditional TLS hostname validation
             );
-
-            return new BootstrapSetup().And(sslSetup);
         }
+#endif
         #endregion
 
         #region SubjectValidationExample
+#if NET6_0_OR_GREATER
         /// <summary>
         /// Example of subject DN validation - only accept certificates with specific subject names.
         /// Useful for verifying peer identity based on certificate subject.
+        /// Supports wildcards: "CN=Akka-Node-*" matches "CN=Akka-Node-001"
         /// </summary>
-        public static BootstrapSetup SubjectValidationSetup()
+        public static void SubjectValidationSetup()
         {
             var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
 
-            // Only accept certificates with specific subject names
-            var subjectPatterns = new[]
-            {
-                "CN=node1.example.com",
-                "CN=node2.example.com",
-                "CN=node3.example.com"
-            };
-
-            var validator = CertificateValidation.ValidateSubject(subjectPatterns, null);
+            // Accept certificates matching the subject pattern
+            // Wildcards are supported: CN=Akka-Node-* matches CN=Akka-Node-001
+            var validator = CertificateValidation.ValidateSubject(
+                "CN=Akka-Node-*"  // Pattern to match
+            );
 
             var sslSetup = new DotNettySslSetup(
                 certificate: certificate,
@@ -224,9 +218,8 @@ namespace Akka.Docs.Tests.Configuration
                 requireMutualAuthentication: true,
                 customValidator: validator
             );
-
-            return new BootstrapSetup().And(sslSetup);
         }
+#endif
         #endregion
     }
 }

--- a/src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs
+++ b/src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs
@@ -85,7 +85,6 @@ namespace Akka.Docs.Tests.Configuration
         #endregion
 
         #region ProgrammaticMutualTlsSetup
-#if NET6_0_OR_GREATER
         /// <summary>
         /// Example of programmatic mutual TLS setup using DotNettySslSetup with custom validation.
         /// This allows full programmatic control over certificate validation logic.
@@ -111,11 +110,9 @@ namespace Akka.Docs.Tests.Configuration
                 customValidator: customValidator
             );
         }
-#endif
         #endregion
 
         #region CertificatePinningExample
-#if NET6_0_OR_GREATER
         /// <summary>
         /// Example of certificate pinning - only accept certificates with specific thumbprints.
         /// Useful for preventing man-in-the-middle attacks with compromised CAs.
@@ -137,11 +134,9 @@ namespace Akka.Docs.Tests.Configuration
                 customValidator: validator
             );
         }
-#endif
         #endregion
 
         #region CustomValidationLogicExample
-#if NET6_0_OR_GREATER
         /// <summary>
         /// Example of custom certificate validation logic combined with standard validation.
         /// Allows complete control over what certificates are accepted.
@@ -171,11 +166,9 @@ namespace Akka.Docs.Tests.Configuration
                 customValidator: validator
             );
         }
-#endif
         #endregion
 
         #region HostnameValidationExample
-#if NET6_0_OR_GREATER
         /// <summary>
         /// Example of enabling traditional hostname validation for client-server architectures.
         /// Use when all nodes share the same certificate with matching CN/SAN.
@@ -192,11 +185,9 @@ namespace Akka.Docs.Tests.Configuration
                 validateCertificateHostname: true  // Enable traditional TLS hostname validation
             );
         }
-#endif
         #endregion
 
         #region SubjectValidationExample
-#if NET6_0_OR_GREATER
         /// <summary>
         /// Example of subject DN validation - only accept certificates with specific subject names.
         /// Useful for verifying peer identity based on certificate subject.
@@ -219,7 +210,6 @@ namespace Akka.Docs.Tests.Configuration
                 customValidator: validator
             );
         }
-#endif
         #endregion
     }
 }

--- a/src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs
+++ b/src/core/Akka.Docs.Tests/Configuration/TlsConfigurationSample.cs
@@ -5,7 +5,10 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Security.Cryptography.X509Certificates;
+using Akka.Actor.Setup;
 using Akka.Configuration;
+using Akka.Remote.Transport.DotNetty;
 
 namespace Akka.Docs.Tests.Configuration
 {
@@ -79,6 +82,151 @@ namespace Akka.Docs.Tests.Configuration
                 }
             }
         ");
+        #endregion
+
+        #region ProgrammaticMutualTlsSetup
+        /// <summary>
+        /// Example of programmatic mutual TLS setup using DotNettySslSetup with custom validation.
+        /// This allows full programmatic control over certificate validation logic.
+        /// </summary>
+        public static BootstrapSetup ProgrammaticMutualTlsSetup()
+        {
+            // Load or obtain your certificate
+            var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
+
+            // Create custom validator combining multiple validation strategies
+            var customValidator = CertificateValidation.Combine(
+                // Validate the certificate chain
+                CertificateValidation.ValidateChain(null),
+                // Also pin against known thumbprints for additional security
+                CertificateValidation.PinnedCertificate(new[] { certificate.Thumbprint }, null)
+            );
+
+            // Setup SSL with custom validator taking precedence over HOCON config
+            var sslSetup = new DotNettySslSetup(
+                certificate: certificate,
+                suppressValidation: false,
+                requireMutualAuthentication: true,
+                customValidator: customValidator
+            );
+
+            return new BootstrapSetup().And(sslSetup);
+        }
+        #endregion
+
+        #region CertificatePinningExample
+        /// <summary>
+        /// Example of certificate pinning - only accept certificates with specific thumbprints.
+        /// Useful for preventing man-in-the-middle attacks with compromised CAs.
+        /// </summary>
+        public static BootstrapSetup CertificatePinningSetup()
+        {
+            var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
+
+            // Allow only specific certificates by thumbprint
+            var allowedThumbprints = new[]
+            {
+                "2531c78c51e5041d02564697a88af8bc7a7ce3e3",  // Production cert
+                "abc123def456789ghi012jkl345mno678pqr901stu"  // Backup cert
+            };
+
+            var validator = CertificateValidation.PinnedCertificate(allowedThumbprints, null);
+
+            var sslSetup = new DotNettySslSetup(
+                certificate: certificate,
+                suppressValidation: false,
+                requireMutualAuthentication: true,
+                customValidator: validator
+            );
+
+            return new BootstrapSetup().And(sslSetup);
+        }
+        #endregion
+
+        #region CustomValidationLogicExample
+        /// <summary>
+        /// Example of custom certificate validation logic combined with standard validation.
+        /// Allows complete control over what certificates are accepted.
+        /// </summary>
+        public static BootstrapSetup CustomValidationLogicSetup()
+        {
+            var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
+
+            // Start with standard chain validation, then add custom logic
+            var validator = CertificateValidation.ChainPlusThen(
+                // First, validate the certificate chain
+                (cert, chain, peer, log) =>
+                {
+                    // Then apply custom logic - e.g., check certificate attributes
+                    if (cert?.Subject != null && cert.Subject.Contains("CN=authorized-peer"))
+                    {
+                        return true;  // Accept this certificate
+                    }
+                    return false;  // Reject all others
+                },
+                null
+            );
+
+            var sslSetup = new DotNettySslSetup(
+                certificate: certificate,
+                suppressValidation: false,
+                requireMutualAuthentication: true,
+                customValidator: validator
+            );
+
+            return new BootstrapSetup().And(sslSetup);
+        }
+        #endregion
+
+        #region HostnameValidationExample
+        /// <summary>
+        /// Example of enabling traditional hostname validation for client-server architectures.
+        /// Use when all nodes share the same certificate with matching CN/SAN.
+        /// </summary>
+        public static BootstrapSetup HostnameValidationSetup()
+        {
+            var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
+
+            // Enable both chain validation and hostname validation
+            var sslSetup = new DotNettySslSetup(
+                certificate: certificate,
+                suppressValidation: false,
+                requireMutualAuthentication: true,
+                validateCertificateHostname: true  // Enable traditional TLS hostname validation
+            );
+
+            return new BootstrapSetup().And(sslSetup);
+        }
+        #endregion
+
+        #region SubjectValidationExample
+        /// <summary>
+        /// Example of subject DN validation - only accept certificates with specific subject names.
+        /// Useful for verifying peer identity based on certificate subject.
+        /// </summary>
+        public static BootstrapSetup SubjectValidationSetup()
+        {
+            var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
+
+            // Only accept certificates with specific subject names
+            var subjectPatterns = new[]
+            {
+                "CN=node1.example.com",
+                "CN=node2.example.com",
+                "CN=node3.example.com"
+            };
+
+            var validator = CertificateValidation.ValidateSubject(subjectPatterns, null);
+
+            var sslSetup = new DotNettySslSetup(
+                certificate: certificate,
+                suppressValidation: false,
+                requireMutualAuthentication: true,
+                customValidator: validator
+            );
+
+            return new BootstrapSetup().And(sslSetup);
+        }
         #endregion
     }
 }

--- a/src/core/Akka.Remote.Tests/Transport/CertificateValidationHelpersSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/CertificateValidationHelpersSpec.cs
@@ -1,0 +1,226 @@
+//-----------------------------------------------------------------------
+// <copyright file="CertificateValidationHelpersSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using Akka.Event;
+using Akka.Remote.Transport.DotNetty;
+using Akka.TestKit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Remote.Tests.Transport
+{
+    /// <summary>
+    /// Unit tests for CertificateValidation helper methods to ensure proper edge case handling
+    /// </summary>
+    public class CertificateValidationHelpersSpec : AkkaSpec
+    {
+        private const string ValidCertPath = "Resources/akka-validcert.pfx";
+        private const string Password = "password";
+        private readonly ILoggingAdapter _log;
+
+        public CertificateValidationHelpersSpec(ITestOutputHelper output) : base(output)
+        {
+            _log = Logging.GetLogger(Sys, typeof(CertificateValidationHelpersSpec));
+        }
+
+        #region PinnedCertificate Tests
+
+        [Fact(DisplayName = "PinnedCertificate should reject null certificate")]
+        public void PinnedCertificate_should_reject_null_certificate()
+        {
+            // Arrange
+            var validator = CertificateValidation.PinnedCertificate("ABCD1234");
+
+            // Act
+            var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
+
+            // Assert
+            Assert.False(result);
+            ExpectMsg<Error>(msg => msg.Message.ToString().Contains("certificate is null"), TimeSpan.FromSeconds(1));
+        }
+
+        // Note: X509Certificate2 always has a thumbprint when properly constructed,
+        // so we can't test the empty thumbprint case directly. The null check in
+        // PinnedCertificate is defensive programming for edge cases.
+
+        [Fact(DisplayName = "PinnedCertificate should throw if no thumbprints provided")]
+        public void PinnedCertificate_should_throw_if_no_thumbprints_provided()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => CertificateValidation.PinnedCertificate());
+            Assert.Throws<ArgumentException>(() => CertificateValidation.PinnedCertificate(null));
+            Assert.Throws<ArgumentException>(() => CertificateValidation.PinnedCertificate(new string[0]));
+        }
+
+        [Fact(DisplayName = "PinnedCertificate should throw if only empty/whitespace thumbprints provided")]
+        public void PinnedCertificate_should_throw_if_only_empty_thumbprints_provided()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => CertificateValidation.PinnedCertificate(""));
+            Assert.Throws<ArgumentException>(() => CertificateValidation.PinnedCertificate("", "  ", null));
+            Assert.Throws<ArgumentException>(() => CertificateValidation.PinnedCertificate(" ", "\t", "\n"));
+        }
+
+        [Fact(DisplayName = "PinnedCertificate should filter out empty thumbprints and use valid ones")]
+        public void PinnedCertificate_should_filter_empty_thumbprints()
+        {
+            // Arrange
+            var cert = new X509Certificate2(ValidCertPath, Password);
+            var thumbprint = cert.Thumbprint;
+
+            // Include some empty/null values that should be filtered out
+            var validator = CertificateValidation.PinnedCertificate("", thumbprint, null, "  ", thumbprint.ToLower());
+
+            // Act
+            var result = validator(cert, null, "test-peer", SslPolicyErrors.None, _log);
+
+            // Assert
+            Assert.True(result); // Should accept because valid thumbprint is in the list
+        }
+
+        [Fact(DisplayName = "PinnedCertificate should be case-insensitive for thumbprints")]
+        public void PinnedCertificate_should_be_case_insensitive()
+        {
+            // Arrange
+            var cert = new X509Certificate2(ValidCertPath, Password);
+            var thumbprint = cert.Thumbprint;
+
+            // Test with lowercase thumbprint in allowed list
+            var validator = CertificateValidation.PinnedCertificate(thumbprint.ToLower());
+
+            // Act
+            var result = validator(cert, null, "test-peer", SslPolicyErrors.None, _log);
+
+            // Assert
+            Assert.True(result); // Should accept due to case-insensitive comparison
+        }
+
+        [Fact(DisplayName = "PinnedCertificate should accept certificate with matching thumbprint from multiple allowed")]
+        public void PinnedCertificate_should_accept_from_multiple_allowed()
+        {
+            // Arrange
+            var cert = new X509Certificate2(ValidCertPath, Password);
+            var thumbprint = cert.Thumbprint;
+
+            var validator = CertificateValidation.PinnedCertificate(
+                "1111111111111111111111111111111111111111",
+                thumbprint,
+                "2222222222222222222222222222222222222222");
+
+            // Act
+            var result = validator(cert, null, "test-peer", SslPolicyErrors.None, _log);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        #endregion
+
+        #region ValidateSubject Tests
+
+        [Fact(DisplayName = "ValidateSubject should reject null certificate")]
+        public void ValidateSubject_should_reject_null_certificate()
+        {
+            // Arrange
+            var validator = CertificateValidation.ValidateSubject("CN=TestSubject");
+
+            // Act
+            var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
+
+            // Assert
+            Assert.False(result);
+            ExpectMsg<Error>(msg => msg.Message.ToString().Contains("has no subject"), TimeSpan.FromSeconds(1));
+        }
+
+        [Fact(DisplayName = "ValidateSubject should throw if pattern is null or empty")]
+        public void ValidateSubject_should_throw_if_pattern_null_or_empty()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => CertificateValidation.ValidateSubject(null));
+            Assert.Throws<ArgumentException>(() => CertificateValidation.ValidateSubject(""));
+            Assert.Throws<ArgumentException>(() => CertificateValidation.ValidateSubject("  "));
+        }
+
+        #endregion
+
+        #region ValidateIssuer Tests
+
+        [Fact(DisplayName = "ValidateIssuer should reject null certificate")]
+        public void ValidateIssuer_should_reject_null_certificate()
+        {
+            // Arrange
+            var validator = CertificateValidation.ValidateIssuer("CN=TestIssuer");
+
+            // Act
+            var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
+
+            // Assert
+            Assert.False(result);
+            ExpectMsg<Error>(msg => msg.Message.ToString().Contains("has no issuer"), TimeSpan.FromSeconds(1));
+        }
+
+        [Fact(DisplayName = "ValidateIssuer should throw if pattern is null or empty")]
+        public void ValidateIssuer_should_throw_if_pattern_null_or_empty()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => CertificateValidation.ValidateIssuer(null));
+            Assert.Throws<ArgumentException>(() => CertificateValidation.ValidateIssuer(""));
+            Assert.Throws<ArgumentException>(() => CertificateValidation.ValidateIssuer("  "));
+        }
+
+        #endregion
+
+        #region Combine Tests
+
+        [Fact(DisplayName = "Combine should handle null validators array")]
+        public void Combine_should_handle_null_validators()
+        {
+            // Act & Assert - Should throw ArgumentException
+            Assert.Throws<ArgumentException>(() => CertificateValidation.Combine(null));
+        }
+
+        [Fact(DisplayName = "Combine should handle empty validators array")]
+        public void Combine_should_handle_empty_validators()
+        {
+            // Act & Assert - Should throw ArgumentException
+            Assert.Throws<ArgumentException>(() => CertificateValidation.Combine());
+            Assert.Throws<ArgumentException>(() => CertificateValidation.Combine(new CertificateValidationCallback[0]));
+        }
+
+        [Fact(DisplayName = "Combine should short-circuit on first failure")]
+        public void Combine_should_short_circuit_on_first_failure()
+        {
+            // Arrange
+            var callCount = 0;
+            CertificateValidationCallback validator1 = (cert, chain, peer, errors, log) =>
+            {
+                callCount++;
+                return false; // Fail
+            };
+            CertificateValidationCallback validator2 = (cert, chain, peer, errors, log) =>
+            {
+                callCount++;
+                return true; // This should never be called
+            };
+
+            var combined = CertificateValidation.Combine(validator1, validator2);
+            var cert = new X509Certificate2(ValidCertPath, Password);
+
+            // Act
+            var result = combined(cert, null, "test-peer", SslPolicyErrors.None, _log);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(1, callCount); // Only first validator should be called
+        }
+
+        #endregion
+    }
+}

--- a/src/core/Akka.Remote.Tests/Transport/CertificateValidationHelpersSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/CertificateValidationHelpersSpec.cs
@@ -38,12 +38,12 @@ namespace Akka.Remote.Tests.Transport
             // Arrange
             var validator = CertificateValidation.PinnedCertificate("ABCD1234");
 
-            // Act
-            var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
-
-            // Assert
-            Assert.False(result);
-            ExpectMsg<Error>(msg => msg.Message.ToString().Contains("certificate is null"), TimeSpan.FromSeconds(1));
+            // Act & Assert
+            EventFilter.Error(contains: "certificate is null").ExpectOne(() =>
+            {
+                var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
+                Assert.False(result);
+            });
         }
 
         // Note: X509Certificate2 always has a thumbprint when properly constructed,
@@ -121,6 +121,23 @@ namespace Akka.Remote.Tests.Transport
             Assert.True(result);
         }
 
+        [Fact(DisplayName = "PinnedCertificate should reject certificate with non-matching thumbprint")]
+        public void PinnedCertificate_should_reject_non_matching_thumbprint()
+        {
+            // Arrange
+            var cert = new X509Certificate2(ValidCertPath, Password);
+            var validator = CertificateValidation.PinnedCertificate(
+                "1111111111111111111111111111111111111111",
+                "2222222222222222222222222222222222222222");
+
+            // Act & Assert
+            EventFilter.Error(contains: "not in allowed list").ExpectOne(() =>
+            {
+                var result = validator(cert, null, "test-peer", SslPolicyErrors.None, _log);
+                Assert.False(result);
+            });
+        }
+
         #endregion
 
         #region ValidateSubject Tests
@@ -131,12 +148,12 @@ namespace Akka.Remote.Tests.Transport
             // Arrange
             var validator = CertificateValidation.ValidateSubject("CN=TestSubject");
 
-            // Act
-            var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
-
-            // Assert
-            Assert.False(result);
-            ExpectMsg<Error>(msg => msg.Message.ToString().Contains("has no subject"), TimeSpan.FromSeconds(1));
+            // Act & Assert
+            EventFilter.Error(contains: "certificate is null").ExpectOne(() =>
+            {
+                var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
+                Assert.False(result);
+            });
         }
 
         [Fact(DisplayName = "ValidateSubject should throw if pattern is null or empty")]
@@ -158,12 +175,12 @@ namespace Akka.Remote.Tests.Transport
             // Arrange
             var validator = CertificateValidation.ValidateIssuer("CN=TestIssuer");
 
-            // Act
-            var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
-
-            // Assert
-            Assert.False(result);
-            ExpectMsg<Error>(msg => msg.Message.ToString().Contains("has no issuer"), TimeSpan.FromSeconds(1));
+            // Act & Assert
+            EventFilter.Error(contains: "certificate is null").ExpectOne(() =>
+            {
+                var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
+                Assert.False(result);
+            });
         }
 
         [Fact(DisplayName = "ValidateIssuer should throw if pattern is null or empty")]
@@ -202,23 +219,26 @@ namespace Akka.Remote.Tests.Transport
             CertificateValidationCallback validator1 = (cert, chain, peer, errors, log) =>
             {
                 callCount++;
+                log.Error("First validator failed");
                 return false; // Fail
             };
             CertificateValidationCallback validator2 = (cert, chain, peer, errors, log) =>
             {
                 callCount++;
+                log.Error("Second validator should never be reached");
                 return true; // This should never be called
             };
 
             var combined = CertificateValidation.Combine(validator1, validator2);
             var cert = new X509Certificate2(ValidCertPath, Password);
 
-            // Act
-            var result = combined(cert, null, "test-peer", SslPolicyErrors.None, _log);
-
-            // Assert
-            Assert.False(result);
-            Assert.Equal(1, callCount); // Only first validator should be called
+            // Act & Assert
+            EventFilter.Error(contains: "First validator failed").ExpectOne(() =>
+            {
+                var result = combined(cert, null, "test-peer", SslPolicyErrors.None, _log);
+                Assert.False(result);
+                Assert.Equal(1, callCount); // Only first validator should be called - short-circuit behavior
+            });
         }
 
         #endregion

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -73,13 +73,9 @@ akka {{
         {
         }
 
-        #if !NET471
         [Fact]
         public async Task Secure_transport_should_be_possible_between_systems_sharing_the_same_certificate()
         {
-            // skip this test due to linux/mono certificate issues
-            if (IsMono) return;
-
             Setup(true);
 
             var probe = CreateTestProbe();
@@ -90,7 +86,6 @@ akka {{
                 await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
             }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
         }
-        #endif
 
         [Fact]
         public async Task Secure_transport_should_NOT_be_possible_between_systems_using_SSL_and_one_not_using_it()
@@ -247,13 +242,9 @@ akka {{
             Assert.True(settings.Ssl.ValidateCertificateHostname); // From DotNettySslSetup, not HOCON
         }
 
-        #if !NET471
         [Fact(DisplayName = "DotNettySslSetup with CustomValidator that accepts should allow connection")]
         public async Task CustomValidator_that_accepts_should_allow_connection()
         {
-            // skip this test due to linux/mono certificate issues
-            if (IsMono) return;
-
             var validatorCalled = false;
 
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
@@ -301,15 +292,10 @@ akka {
             // Verify that CustomValidator was actually called
             Assert.True(validatorCalled, "CustomValidator should have been invoked during TLS handshake");
         }
-        #endif
 
-        #if !NET471
         [Fact(DisplayName = "DotNettySslSetup with CustomValidator that rejects should prevent connection")]
         public async Task CustomValidator_that_rejects_should_prevent_connection()
         {
-            // skip this test due to linux/mono certificate issues
-            if (IsMono) return;
-
             var validatorCalled = false;
 
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
@@ -355,7 +341,6 @@ akka {
             // Verify that CustomValidator was actually called
             Assert.True(validatorCalled, "CustomValidator should have been invoked during TLS handshake");
         }
-        #endif
 
         [Fact(DisplayName = "DotNettySslSetup should pass CustomValidator to SslSettings")]
         public void DotNettySslSetup_should_pass_CustomValidator_to_SslSettings()
@@ -426,7 +411,6 @@ akka {{
             Assert.True(settings.Ssl.SuppressValidation); // From DotNettySslSetup, not HOCON (which has false)
         }
 
-        #if !NET471
         [Fact(DisplayName = "CertificateValidation.PinnedCertificate should accept certificates with matching thumbprint")]
         public async Task PinnedCertificate_should_accept_matching_thumbprint()
         {
@@ -467,9 +451,7 @@ akka {
                 await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
             }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
         }
-        #endif
 
-        #if !NET471
         [Fact(DisplayName = "CertificateValidation.PinnedCertificate should reject certificates with non-matching thumbprint")]
         public async Task PinnedCertificate_should_reject_non_matching_thumbprint()
         {
@@ -507,9 +489,7 @@ akka {
             Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
             await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
         }
-        #endif
 
-        #if !NET471
         [Fact(DisplayName = "CertificateValidation.ValidateSubject should accept certificates with matching subject")]
         public async Task ValidateSubject_should_accept_matching_subject()
         {
@@ -550,9 +530,7 @@ akka {
                 await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
             }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
         }
-        #endif
 
-        #if !NET471
         [Fact(DisplayName = "CertificateValidation.ValidateSubject should reject certificates with non-matching subject")]
         public async Task ValidateSubject_should_reject_non_matching_subject()
         {
@@ -590,7 +568,6 @@ akka {
             Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
             await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
         }
-        #endif
 
         [Fact(DisplayName = "CertificateValidation.ValidateSubject should support wildcard patterns")]
         public void ValidateSubject_should_support_wildcards()
@@ -627,7 +604,6 @@ akka {
             }
         }
 
-        #if !NET471
         [Fact(DisplayName = "CertificateValidation.ValidateIssuer should accept certificates with matching issuer")]
         public async Task ValidateIssuer_should_accept_matching_issuer()
         {
@@ -668,9 +644,7 @@ akka {
                 await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
             }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
         }
-        #endif
 
-        #if !NET471
         [Fact(DisplayName = "CertificateValidation.ChainPlusThen should combine chain validation with custom logic")]
         public async Task ChainPlusThen_should_combine_validation()
         {
@@ -729,9 +703,7 @@ akka {
             // Verify custom validation was actually called
             Assert.True(customCheckCalled, "Custom validation logic should have been invoked");
         }
-        #endif
 
-        #if !NET471
         [Fact(DisplayName = "CustomValidator should take precedence over validateCertificateHostname setting")]
         public async Task CustomValidator_should_override_hostname_validation_setting()
         {
@@ -789,7 +761,6 @@ akka {
             // Verify custom validator was called (proving it took precedence)
             Assert.True(customValidatorCalled, "CustomValidator should have been invoked, proving it takes precedence");
         }
-        #endif
 
         #region helper classes / methods
 

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -257,14 +257,14 @@ akka {{
             var validatorCalled = false;
 
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
-            var customValidator = CertificateValidation.Combine(
-                (cert, chain, peer, errors, log) =>
-                {
-                    validatorCalled = true;
-                    Output.WriteLine($"CustomValidator called for peer: {peer}");
-                    return true; // Accept all certificates
-                }
-            );
+
+            // Custom validator that accepts all certificates
+            CertificateValidationCallback customValidator = (cert, chain, peer, errors, log) =>
+            {
+                validatorCalled = true;
+                Output.WriteLine($"CustomValidator called for peer: {peer}");
+                return true; // Accept all certificates
+            };
 
             var sslSetup = new DotNettySslSetup(certificate, suppressValidation: false, requireMutualAuthentication: true, customValidator: customValidator);
 
@@ -313,14 +313,14 @@ akka {
             var validatorCalled = false;
 
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
-            var customValidator = CertificateValidation.Combine(
-                (cert, chain, peer, errors, log) =>
-                {
-                    validatorCalled = true;
-                    Output.WriteLine($"CustomValidator called for peer: {peer}, rejecting certificate");
-                    return false; // Reject all certificates
-                }
-            );
+
+            // Custom validator that rejects all certificates
+            CertificateValidationCallback customValidator = (cert, chain, peer, errors, log) =>
+            {
+                validatorCalled = true;
+                Output.WriteLine($"CustomValidator called for peer: {peer}, rejecting certificate");
+                return false; // Reject all certificates
+            };
 
             var sslSetup = new DotNettySslSetup(certificate, suppressValidation: false, requireMutualAuthentication: true, customValidator: customValidator);
 

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -247,6 +247,144 @@ akka {{
             Assert.True(settings.Ssl.ValidateCertificateHostname); // From DotNettySslSetup, not HOCON
         }
 
+        #if !NET471
+        [Fact(DisplayName = "DotNettySslSetup with CustomValidator that accepts should allow connection")]
+        public async Task CustomValidator_that_accepts_should_allow_connection()
+        {
+            // skip this test due to linux/mono certificate issues
+            if (IsMono) return;
+
+            var validatorCalled = false;
+
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+            var customValidator = CertificateValidation.Combine(
+                (cert, chain, peer, errors, log) =>
+                {
+                    validatorCalled = true;
+                    Output.WriteLine($"CustomValidator called for peer: {peer}");
+                    return true; // Accept all certificates
+                }
+            );
+
+            var sslSetup = new DotNettySslSetup(certificate, suppressValidation: false, requireMutualAuthentication: true, customValidator: customValidator);
+
+            var sys2Setup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create()
+                    .WithConfig(ConfigurationFactory.ParseString(@"
+akka {
+  loglevel = DEBUG
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote.dot-netty.tcp {
+    port = 0
+    hostname = ""127.0.0.1""
+    enable-ssl = true
+    log-transport = true
+  }
+}")))
+                .And(sslSetup);
+
+            _sys2 = ActorSystem.Create("sys2-custom-validator", sys2Setup);
+            InitializeLogger(_sys2);
+            _sys2.ActorOf(Props.Create<Echo>(), "echo");
+
+            var address = RARP.For(_sys2).Provider.DefaultAddress;
+            _echoPath = new RootActorPath(address) / "user" / "echo";
+
+            var probe = CreateTestProbe();
+
+            await AwaitAssertAsync(async () =>
+            {
+                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+
+            // Verify that CustomValidator was actually called
+            Assert.True(validatorCalled, "CustomValidator should have been invoked during TLS handshake");
+        }
+        #endif
+
+        #if !NET471
+        [Fact(DisplayName = "DotNettySslSetup with CustomValidator that rejects should prevent connection")]
+        public async Task CustomValidator_that_rejects_should_prevent_connection()
+        {
+            // skip this test due to linux/mono certificate issues
+            if (IsMono) return;
+
+            var validatorCalled = false;
+
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+            var customValidator = CertificateValidation.Combine(
+                (cert, chain, peer, errors, log) =>
+                {
+                    validatorCalled = true;
+                    Output.WriteLine($"CustomValidator called for peer: {peer}, rejecting certificate");
+                    return false; // Reject all certificates
+                }
+            );
+
+            var sslSetup = new DotNettySslSetup(certificate, suppressValidation: false, requireMutualAuthentication: true, customValidator: customValidator);
+
+            var sys2Setup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create()
+                    .WithConfig(ConfigurationFactory.ParseString(@"
+akka {
+  loglevel = DEBUG
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote.dot-netty.tcp {
+    port = 0
+    hostname = ""127.0.0.1""
+    enable-ssl = true
+    log-transport = true
+  }
+}")))
+                .And(sslSetup);
+
+            _sys2 = ActorSystem.Create("sys2-reject-validator", sys2Setup);
+            InitializeLogger(_sys2);
+            _sys2.ActorOf(Props.Create<Echo>(), "echo");
+
+            var address = RARP.For(_sys2).Provider.DefaultAddress;
+            _echoPath = new RootActorPath(address) / "user" / "echo";
+
+            var probe = CreateTestProbe();
+
+            // Connection should fail due to custom validator rejection - TLS handshake fails, so message never arrives
+            Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+
+            // Verify that CustomValidator was actually called
+            Assert.True(validatorCalled, "CustomValidator should have been invoked during TLS handshake");
+        }
+        #endif
+
+        [Fact(DisplayName = "DotNettySslSetup should pass CustomValidator to SslSettings")]
+        public void DotNettySslSetup_should_pass_CustomValidator_to_SslSettings()
+        {
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+
+            var customValidator = CertificateValidation.ValidateChain();
+            var sslSetup = new DotNettySslSetup(certificate, suppressValidation: false, requireMutualAuthentication: true, customValidator: customValidator);
+
+            var actorSystemSetup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create().WithConfig(ConfigurationFactory.ParseString(@"
+akka {
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote.dot-netty.tcp {
+    port = 0
+    hostname = ""127.0.0.1""
+    enable-ssl = true
+  }
+}")))
+                .And(sslSetup);
+
+            using var sys = ActorSystem.Create("test-custom-validator", actorSystemSetup);
+
+            // Verify that CustomValidator is passed through to SslSettings
+            var settings = DotNettyTransportSettings.Create(sys);
+            Assert.NotNull(settings.Ssl.CustomValidator);
+            Assert.Same(customValidator, settings.Ssl.CustomValidator);
+        }
+
         #region helper classes / methods
 
         protected override void AfterAll()

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -385,6 +385,47 @@ akka {
             Assert.Same(customValidator, settings.Ssl.CustomValidator);
         }
 
+        [Fact(DisplayName = "DotNettySslSetup should take precedence when both setup and HOCON SSL are configured (and log warning)")]
+        public void DotNettySslSetup_should_take_precedence_when_both_configured()
+        {
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+
+            // HOCON certificate (different from setup)
+            const string hoconCertPath = "Resources/akka-validcert.pfx";
+
+            var sslSetup = new DotNettySslSetup(certificate, suppressValidation: true);
+
+            var actorSystemSetup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create().WithConfig(ConfigurationFactory.ParseString($@"
+akka {{
+  loglevel = DEBUG
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote.dot-netty.tcp {{
+    port = 0
+    hostname = ""127.0.0.1""
+    enable-ssl = true
+    ssl {{
+      certificate {{
+        path = ""{hoconCertPath}""
+        password = ""{Password}""
+      }}
+      suppress-validation = false
+    }}
+  }}
+}}")))
+                .And(sslSetup);
+
+            using var sys = ActorSystem.Create("test-precedence", actorSystemSetup);
+
+            // Verify DotNettySslSetup takes precedence over HOCON
+            // (A warning will be logged to help users understand this behavior)
+            var settings = DotNettyTransportSettings.Create(sys);
+
+            Assert.True(settings.EnableSsl);
+            Assert.Equal(certificate.Thumbprint, settings.Ssl.Certificate.Thumbprint);
+            Assert.True(settings.Ssl.SuppressValidation); // From DotNettySslSetup, not HOCON (which has false)
+        }
+
         #region helper classes / methods
 
         protected override void AfterAll()

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -426,6 +426,371 @@ akka {{
             Assert.True(settings.Ssl.SuppressValidation); // From DotNettySslSetup, not HOCON (which has false)
         }
 
+        #if !NET471
+        [Fact(DisplayName = "CertificateValidation.PinnedCertificate should accept certificates with matching thumbprint")]
+        public async Task PinnedCertificate_should_accept_matching_thumbprint()
+        {
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+
+            // Create validator that pins to this specific certificate
+            var validator = CertificateValidation.PinnedCertificate(certificate.Thumbprint);
+            var sslSetup = new DotNettySslSetup(certificate, suppressValidation: false, requireMutualAuthentication: true, customValidator: validator);
+
+            var sys2Setup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create()
+                    .WithConfig(ConfigurationFactory.ParseString(@"
+akka {
+  loglevel = DEBUG
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote.dot-netty.tcp {
+    port = 0
+    hostname = ""127.0.0.1""
+    enable-ssl = true
+    log-transport = true
+  }
+}")))
+                .And(sslSetup);
+
+            _sys2 = ActorSystem.Create("sys2-pinned-accept", sys2Setup);
+            InitializeLogger(_sys2);
+            _sys2.ActorOf(Props.Create<Echo>(), "echo");
+
+            var address = RARP.For(_sys2).Provider.DefaultAddress;
+            _echoPath = new RootActorPath(address) / "user" / "echo";
+
+            var probe = CreateTestProbe();
+
+            // Should successfully connect because thumbprint matches
+            await AwaitAssertAsync(async () =>
+            {
+                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+        }
+        #endif
+
+        #if !NET471
+        [Fact(DisplayName = "CertificateValidation.PinnedCertificate should reject certificates with non-matching thumbprint")]
+        public async Task PinnedCertificate_should_reject_non_matching_thumbprint()
+        {
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+
+            // Create validator that pins to a DIFFERENT thumbprint (connection should fail)
+            var validator = CertificateValidation.PinnedCertificate("0000000000000000000000000000000000000000");
+            var sslSetup = new DotNettySslSetup(certificate, suppressValidation: false, requireMutualAuthentication: true, customValidator: validator);
+
+            var sys2Setup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create()
+                    .WithConfig(ConfigurationFactory.ParseString(@"
+akka {
+  loglevel = DEBUG
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote.dot-netty.tcp {
+    port = 0
+    hostname = ""127.0.0.1""
+    enable-ssl = true
+    log-transport = true
+  }
+}")))
+                .And(sslSetup);
+
+            _sys2 = ActorSystem.Create("sys2-pinned-reject", sys2Setup);
+            InitializeLogger(_sys2);
+            _sys2.ActorOf(Props.Create<Echo>(), "echo");
+
+            var address = RARP.For(_sys2).Provider.DefaultAddress;
+            _echoPath = new RootActorPath(address) / "user" / "echo";
+
+            var probe = CreateTestProbe();
+
+            // Connection should fail due to thumbprint mismatch
+            Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+        }
+        #endif
+
+        #if !NET471
+        [Fact(DisplayName = "CertificateValidation.ValidateSubject should accept certificates with matching subject")]
+        public async Task ValidateSubject_should_accept_matching_subject()
+        {
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+
+            // Create validator that accepts the certificate's actual subject
+            var validator = CertificateValidation.ValidateSubject(certificate.Subject);
+            var sslSetup = new DotNettySslSetup(certificate, suppressValidation: false, requireMutualAuthentication: true, customValidator: validator);
+
+            var sys2Setup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create()
+                    .WithConfig(ConfigurationFactory.ParseString(@"
+akka {
+  loglevel = DEBUG
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote.dot-netty.tcp {
+    port = 0
+    hostname = ""127.0.0.1""
+    enable-ssl = true
+    log-transport = true
+  }
+}")))
+                .And(sslSetup);
+
+            _sys2 = ActorSystem.Create("sys2-subject-accept", sys2Setup);
+            InitializeLogger(_sys2);
+            _sys2.ActorOf(Props.Create<Echo>(), "echo");
+
+            var address = RARP.For(_sys2).Provider.DefaultAddress;
+            _echoPath = new RootActorPath(address) / "user" / "echo";
+
+            var probe = CreateTestProbe();
+
+            // Should successfully connect because subject matches
+            await AwaitAssertAsync(async () =>
+            {
+                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+        }
+        #endif
+
+        #if !NET471
+        [Fact(DisplayName = "CertificateValidation.ValidateSubject should reject certificates with non-matching subject")]
+        public async Task ValidateSubject_should_reject_non_matching_subject()
+        {
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+
+            // Create validator with a subject that won't match
+            var validator = CertificateValidation.ValidateSubject("CN=WrongSubject");
+            var sslSetup = new DotNettySslSetup(certificate, suppressValidation: false, requireMutualAuthentication: true, customValidator: validator);
+
+            var sys2Setup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create()
+                    .WithConfig(ConfigurationFactory.ParseString(@"
+akka {
+  loglevel = DEBUG
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote.dot-netty.tcp {
+    port = 0
+    hostname = ""127.0.0.1""
+    enable-ssl = true
+    log-transport = true
+  }
+}")))
+                .And(sslSetup);
+
+            _sys2 = ActorSystem.Create("sys2-subject-reject", sys2Setup);
+            InitializeLogger(_sys2);
+            _sys2.ActorOf(Props.Create<Echo>(), "echo");
+
+            var address = RARP.For(_sys2).Provider.DefaultAddress;
+            _echoPath = new RootActorPath(address) / "user" / "echo";
+
+            var probe = CreateTestProbe();
+
+            // Connection should fail due to subject mismatch
+            Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+        }
+        #endif
+
+        [Fact(DisplayName = "CertificateValidation.ValidateSubject should support wildcard patterns")]
+        public void ValidateSubject_should_support_wildcards()
+        {
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+
+            // Extract the CN from the subject (e.g., "CN=akka.net, O=Test")
+            // If subject is "CN=akka.net, O=Test", wildcard "CN=akka*" should match
+            var subject = certificate.Subject;
+            Output.WriteLine($"Certificate subject: {subject}");
+
+            // Test that wildcard pattern matching works
+            // Extract just the CN part for wildcard testing
+            var cnStart = subject.IndexOf("CN=");
+            if (cnStart >= 0)
+            {
+                var cnEnd = subject.IndexOf(",", cnStart);
+                var cn = cnEnd > cnStart ? subject.Substring(cnStart, cnEnd - cnStart) : subject.Substring(cnStart);
+
+                // Extract the first few characters of CN for wildcard
+                var cnValue = cn.Substring(3); // Skip "CN="
+                if (cnValue.Length > 3)
+                {
+                    var wildcardPattern = "CN=" + cnValue.Substring(0, cnValue.Length - 2) + "*";
+                    Output.WriteLine($"Testing wildcard pattern: {wildcardPattern}");
+
+                    var validator = CertificateValidation.ValidateSubject(wildcardPattern);
+
+                    // Invoke the validator directly to test pattern matching
+                    var log = Akka.Event.Logging.GetLogger(Sys, "test");
+                    var result = validator(certificate, null, "test-peer", System.Net.Security.SslPolicyErrors.None, log);
+                    Assert.True(result, $"Wildcard pattern '{wildcardPattern}' should match subject '{subject}'");
+                }
+            }
+        }
+
+        #if !NET471
+        [Fact(DisplayName = "CertificateValidation.ValidateIssuer should accept certificates with matching issuer")]
+        public async Task ValidateIssuer_should_accept_matching_issuer()
+        {
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+
+            // Create validator that accepts the certificate's actual issuer
+            var validator = CertificateValidation.ValidateIssuer(certificate.Issuer);
+            var sslSetup = new DotNettySslSetup(certificate, suppressValidation: false, requireMutualAuthentication: true, customValidator: validator);
+
+            var sys2Setup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create()
+                    .WithConfig(ConfigurationFactory.ParseString(@"
+akka {
+  loglevel = DEBUG
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote.dot-netty.tcp {
+    port = 0
+    hostname = ""127.0.0.1""
+    enable-ssl = true
+    log-transport = true
+  }
+}")))
+                .And(sslSetup);
+
+            _sys2 = ActorSystem.Create("sys2-issuer-accept", sys2Setup);
+            InitializeLogger(_sys2);
+            _sys2.ActorOf(Props.Create<Echo>(), "echo");
+
+            var address = RARP.For(_sys2).Provider.DefaultAddress;
+            _echoPath = new RootActorPath(address) / "user" / "echo";
+
+            var probe = CreateTestProbe();
+
+            // Should successfully connect because issuer matches
+            await AwaitAssertAsync(async () =>
+            {
+                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+        }
+        #endif
+
+        #if !NET471
+        [Fact(DisplayName = "CertificateValidation.ChainPlusThen should combine chain validation with custom logic")]
+        public async Task ChainPlusThen_should_combine_validation()
+        {
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+
+            // Create validator that does chain validation PLUS custom check
+            // Note: For self-signed certificates, chain validation will fail, so we'll verify
+            // the custom logic is invoked by using Combine with a custom validator instead
+            var customCheckCalled = false;
+            var validator = CertificateValidation.Combine(
+                // Accept all for testing (since cert is self-signed)
+                (cert, chain, peer, errors, log) => true,
+                // Then custom check - just verify it's called
+                (cert, chain, peer, errors, log) =>
+                {
+                    customCheckCalled = true;
+                    Output.WriteLine($"Custom validation called for peer: {peer}, subject: {cert?.Subject}");
+                    // Accept all - we're just testing that Combine works
+                    return true;
+                }
+            );
+
+            var sslSetup = new DotNettySslSetup(certificate, suppressValidation: false, requireMutualAuthentication: true, customValidator: validator);
+
+            var sys2Setup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create()
+                    .WithConfig(ConfigurationFactory.ParseString(@"
+akka {
+  loglevel = DEBUG
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote.dot-netty.tcp {
+    port = 0
+    hostname = ""127.0.0.1""
+    enable-ssl = true
+    log-transport = true
+  }
+}")))
+                .And(sslSetup);
+
+            _sys2 = ActorSystem.Create("sys2-chainplusthen", sys2Setup);
+            InitializeLogger(_sys2);
+            _sys2.ActorOf(Props.Create<Echo>(), "echo");
+
+            var address = RARP.For(_sys2).Provider.DefaultAddress;
+            _echoPath = new RootActorPath(address) / "user" / "echo";
+
+            var probe = CreateTestProbe();
+
+            // Should successfully connect (custom validator accepts all, then custom check passes)
+            await AwaitAssertAsync(async () =>
+            {
+                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+
+            // Verify custom validation was actually called
+            Assert.True(customCheckCalled, "Custom validation logic should have been invoked");
+        }
+        #endif
+
+        #if !NET471
+        [Fact(DisplayName = "CustomValidator should take precedence over validateCertificateHostname setting")]
+        public async Task CustomValidator_should_override_hostname_validation_setting()
+        {
+            var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
+
+            // Create a custom validator that accepts everything
+            var customValidatorCalled = false;
+            CertificateValidationCallback customValidator = (cert, chain, peer, errors, log) =>
+            {
+                customValidatorCalled = true;
+                Output.WriteLine($"CustomValidator called (should take precedence over hostname validation)");
+                return true; // Accept all
+            };
+
+            // Configure with validateCertificateHostname=true, but customValidator should win
+            var sslSetup = new DotNettySslSetup(
+                certificate,
+                suppressValidation: false,
+                requireMutualAuthentication: true,
+                validateCertificateHostname: true,  // This would normally fail
+                customValidator: customValidator     // But this should take precedence
+            );
+
+            var sys2Setup = ActorSystemSetup.Empty
+                .And(BootstrapSetup.Create()
+                    .WithConfig(ConfigurationFactory.ParseString(@"
+akka {
+  loglevel = DEBUG
+  actor.provider = ""Akka.Remote.RemoteActorRefProvider,Akka.Remote""
+  remote.dot-netty.tcp {
+    port = 0
+    hostname = ""127.0.0.1""
+    enable-ssl = true
+    log-transport = true
+  }
+}")))
+                .And(sslSetup);
+
+            _sys2 = ActorSystem.Create("sys2-custom-precedence", sys2Setup);
+            InitializeLogger(_sys2);
+            _sys2.ActorOf(Props.Create<Echo>(), "echo");
+
+            var address = RARP.For(_sys2).Provider.DefaultAddress;
+            _echoPath = new RootActorPath(address) / "user" / "echo";
+
+            var probe = CreateTestProbe();
+
+            // Should successfully connect because CustomValidator accepts all (overrides hostname validation)
+            await AwaitAssertAsync(async () =>
+            {
+                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+
+            // Verify custom validator was called (proving it took precedence)
+            Assert.True(customValidatorCalled, "CustomValidator should have been invoked, proving it takes precedence");
+        }
+        #endif
+
         #region helper classes / methods
 
         protected override void AfterAll()

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -305,6 +305,7 @@ akka {
             {
                 validatorCalled = true;
                 Output.WriteLine($"CustomValidator called for peer: {peer}, rejecting certificate");
+                log.Error("CustomValidator rejecting certificate for peer: {0}", peer);
                 return false; // Reject all certificates
             };
 
@@ -334,9 +335,13 @@ akka {
 
             var probe = CreateTestProbe();
 
-            // Connection should fail due to custom validator rejection - TLS handshake fails, so message never arrives
-            Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+            // Connection should fail due to custom validator rejection
+            // With mTLS enabled, _sys2 (server) validates Sys's (client) certificate
+            await EventFilter.Error(contains: "CustomValidator rejecting certificate").ExpectAsync(1, async () =>
+            {
+                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+                await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+            }, _sys2);
 
             // Verify that CustomValidator was actually called
             Assert.True(validatorCalled, "CustomValidator should have been invoked during TLS handshake");
@@ -486,8 +491,13 @@ akka {
             var probe = CreateTestProbe();
 
             // Connection should fail due to thumbprint mismatch
-            Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+            // With mTLS enabled, _sys2 (server) validates Sys's (client) certificate
+            // The validation error occurs on _sys2's side when it rejects the client certificate
+            await EventFilter.Error(contains: "not in allowed list").ExpectAsync(1, async () =>
+            {
+                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+                await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+            }, _sys2);
         }
 
         [Fact(DisplayName = "CertificateValidation.ValidateSubject should accept certificates with matching subject")]
@@ -565,8 +575,12 @@ akka {
             var probe = CreateTestProbe();
 
             // Connection should fail due to subject mismatch
-            Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+            // With mTLS enabled, _sys2 (server) validates Sys's (client) certificate
+            await EventFilter.Error(contains: "does not match pattern").ExpectAsync(1, async () =>
+            {
+                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+                await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+            }, _sys2);
         }
 
         [Fact(DisplayName = "CertificateValidation.ValidateSubject should support wildcard patterns")]

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -305,7 +305,6 @@ akka {
             {
                 validatorCalled = true;
                 Output.WriteLine($"CustomValidator called for peer: {peer}, rejecting certificate");
-                log.Error("CustomValidator rejecting certificate for peer: {0}", peer);
                 return false; // Reject all certificates
             };
 
@@ -335,13 +334,9 @@ akka {
 
             var probe = CreateTestProbe();
 
-            // Connection should fail due to custom validator rejection
-            // With mTLS enabled, _sys2 (server) validates Sys's (client) certificate
-            await EventFilter.Error(contains: "CustomValidator rejecting certificate").ExpectAsync(1, async () =>
-            {
-                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
-            }, _sys2);
+            // Connection should fail due to custom validator rejection - TLS handshake fails, so message never arrives
+            Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
 
             // Verify that CustomValidator was actually called
             Assert.True(validatorCalled, "CustomValidator should have been invoked during TLS handshake");
@@ -491,13 +486,8 @@ akka {
             var probe = CreateTestProbe();
 
             // Connection should fail due to thumbprint mismatch
-            // With mTLS enabled, _sys2 (server) validates Sys's (client) certificate
-            // The validation error occurs on _sys2's side when it rejects the client certificate
-            await EventFilter.Error(contains: "not in allowed list").ExpectAsync(1, async () =>
-            {
-                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
-            }, _sys2);
+            Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
         }
 
         [Fact(DisplayName = "CertificateValidation.ValidateSubject should accept certificates with matching subject")]
@@ -575,12 +565,8 @@ akka {
             var probe = CreateTestProbe();
 
             // Connection should fail due to subject mismatch
-            // With mTLS enabled, _sys2 (server) validates Sys's (client) certificate
-            await EventFilter.Error(contains: "does not match pattern").ExpectAsync(1, async () =>
-            {
-                Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
-            }, _sys2);
+            Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
         }
 
         [Fact(DisplayName = "CertificateValidation.ValidateSubject should support wildcard patterns")]

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
@@ -164,9 +164,6 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Secure_transport_should_be_possible_between_systems_sharing_the_same_certificate()
         {
-            // skip this test due to linux/mono certificate issues
-            if (IsMono) return;
-
             Setup(ValidCertPath, Password);
 
             var probe = CreateTestProbe();
@@ -181,8 +178,6 @@ namespace Akka.Remote.Tests.Transport
         [LocalFact(SkipLocal = "Racy in Azure AzDo CI/CD")]
         public async Task Secure_transport_should_be_possible_between_systems_using_thumbprint()
         {
-            // skip this test due to linux/mono certificate issues
-            if (IsMono) return;
             try
             {
                 SetupThumbprint(ValidCertPath, Password);
@@ -221,9 +216,6 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task If_EnableSsl_configuration_is_true_but_not_valid_certificate_is_provided_than_ArgumentNullException_should_be_thrown()
         {
-            // skip this test due to linux/mono certificate issues
-            if (IsMono) return;
-
             var aggregateException = await Assert.ThrowsAsync<AggregateException>(() => {
                 Setup(true, null, Password);
                 return Task.CompletedTask;
@@ -238,9 +230,6 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task If_EnableSsl_configuration_is_true_but_not_valid_certificate_password_is_provided_than_WindowsCryptographicException_should_be_thrown()
         {
-            // skip this test due to linux/mono certificate issues
-            if (IsMono) return;
-
             var aggregateException = await Assert.ThrowsAsync<AggregateException>(() => {
                 Setup(true, ValidCertPath, null);
                 return Task.CompletedTask;

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettySslSetup.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettySslSetup.cs
@@ -22,7 +22,7 @@ public sealed class DotNettySslSetup: Setup
     /// <param name="certificate">X509 certificate used to establish SSL/TLS</param>
     /// <param name="suppressValidation">When true, suppresses certificate chain validation (use only for development/testing)</param>
     public DotNettySslSetup(X509Certificate2 certificate, bool suppressValidation)
-        : this(certificate, suppressValidation, requireMutualAuthentication: true, validateCertificateHostname: false)
+        : this(certificate, suppressValidation, requireMutualAuthentication: true, validateCertificateHostname: false, customValidator: null)
     {
     }
 
@@ -33,7 +33,7 @@ public sealed class DotNettySslSetup: Setup
     /// <param name="suppressValidation">When true, suppresses certificate chain validation (use only for development/testing)</param>
     /// <param name="requireMutualAuthentication">When true, requires mutual TLS authentication (both client and server present certificates)</param>
     public DotNettySslSetup(X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication)
-        : this(certificate, suppressValidation, requireMutualAuthentication, validateCertificateHostname: false)
+        : this(certificate, suppressValidation, requireMutualAuthentication, validateCertificateHostname: false, customValidator: null)
     {
     }
 
@@ -45,11 +45,37 @@ public sealed class DotNettySslSetup: Setup
     /// <param name="requireMutualAuthentication">When true, requires mutual TLS authentication (both client and server present certificates)</param>
     /// <param name="validateCertificateHostname">When true, enables hostname validation (certificate CN/SAN must match target hostname)</param>
     public DotNettySslSetup(X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname)
+        : this(certificate, suppressValidation, requireMutualAuthentication, validateCertificateHostname, customValidator: null)
+    {
+    }
+
+    /// <summary>
+    /// Constructor with custom certificate validation callback
+    /// </summary>
+    /// <param name="certificate">X509 certificate used to establish SSL/TLS</param>
+    /// <param name="suppressValidation">When true, suppresses certificate chain validation (use only for development/testing)</param>
+    /// <param name="requireMutualAuthentication">When true, requires mutual TLS authentication (both client and server present certificates)</param>
+    /// <param name="customValidator">Custom certificate validation callback (overrides config-based validation when provided)</param>
+    public DotNettySslSetup(X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, CertificateValidationCallback? customValidator)
+        : this(certificate, suppressValidation, requireMutualAuthentication, validateCertificateHostname: false, customValidator)
+    {
+    }
+
+    /// <summary>
+    /// Full constructor with all SSL/TLS configuration options including custom validation
+    /// </summary>
+    /// <param name="certificate">X509 certificate used to establish SSL/TLS</param>
+    /// <param name="suppressValidation">When true, suppresses certificate chain validation (use only for development/testing)</param>
+    /// <param name="requireMutualAuthentication">When true, requires mutual TLS authentication (both client and server present certificates)</param>
+    /// <param name="validateCertificateHostname">When true, enables hostname validation (certificate CN/SAN must match target hostname)</param>
+    /// <param name="customValidator">Custom certificate validation callback (overrides config-based validation when provided)</param>
+    public DotNettySslSetup(X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname, CertificateValidationCallback? customValidator)
     {
         Certificate = certificate;
         SuppressValidation = suppressValidation;
         RequireMutualAuthentication = requireMutualAuthentication;
         ValidateCertificateHostname = validateCertificateHostname;
+        CustomValidator = customValidator;
     }
 
     /// <summary>
@@ -76,6 +102,14 @@ public sealed class DotNettySslSetup: Setup
     /// IP-based connections, or dynamic service discovery.
     /// </summary>
     public bool ValidateCertificateHostname { get; }
+
+    /// <summary>
+    /// Custom certificate validation callback for advanced validation scenarios.
+    /// When provided, this callback takes precedence over config-based validation.
+    /// Use with CertificateValidation helper factory to combine multiple validation strategies.
+    /// Example: CertificateValidation.Combine(ValidateChain(log), PinnedCertificate(thumbprints))
+    /// </summary>
+    public CertificateValidationCallback? CustomValidator { get; }
 
     internal SslSettings Settings => new SslSettings(Certificate, SuppressValidation, RequireMutualAuthentication, ValidateCertificateHostname);
 }

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettySslSetup.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettySslSetup.cs
@@ -111,5 +111,5 @@ public sealed class DotNettySslSetup: Setup
     /// </summary>
     public CertificateValidationCallback? CustomValidator { get; }
 
-    internal SslSettings Settings => new SslSettings(Certificate, SuppressValidation, RequireMutualAuthentication, ValidateCertificateHostname);
+    internal SslSettings Settings => new SslSettings(Certificate, SuppressValidation, RequireMutualAuthentication, ValidateCertificateHostname, CustomValidator);
 }

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettySslSetup.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettySslSetup.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+#nullable enable
 using System.Security.Cryptography.X509Certificates;
 using Akka.Actor.Setup;
 

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -365,7 +365,8 @@ namespace Akka.Remote.Transport.DotNetty
                 // The adapter extracts remote peer information from the remote address
                 RemoteCertificateValidationCallback validationCallback = (sender, cert, chain, errors) =>
                 {
-                    var x509Cert = cert as X509Certificate2;
+                    // Convert X509Certificate to X509Certificate2 if needed
+                    var x509Cert = cert as X509Certificate2 ?? (cert != null ? new X509Certificate2(cert) : null);
                     return validator(x509Cert, chain, remoteAddress.ToString(), errors, Log);
                 };
 
@@ -417,7 +418,8 @@ namespace Akka.Remote.Transport.DotNetty
                     {
                         // Extract client address from channel
                         var remoteAddress = channel.RemoteAddress?.ToString() ?? "unknown";
-                        var x509Cert = certificate as X509Certificate2;
+                        // Convert X509Certificate to X509Certificate2 if needed
+                        var x509Cert = certificate as X509Certificate2 ?? (certificate != null ? new X509Certificate2(certificate) : null);
                         return validator(x509Cert, chain, remoteAddress, errors, Log);
                     };
 
@@ -455,38 +457,25 @@ namespace Akka.Remote.Transport.DotNetty
         /// <returns>A CertificateValidationCallback composed from configuration settings.</returns>
         private CertificateValidationCallback ComposeValidatorFromSettings()
         {
-            // Start with chain validation, optionally ignoring CA validation errors
-            CertificateValidationCallback validator = Settings.Ssl.SuppressValidation
-                ? CertificateValidation.ChainPlusThen((cert, chain, peer) =>
-                {
-                    // In suppress mode, accept any certificate that can be parsed
-                    return cert != null;
-                }, Log)
-                : CertificateValidation.ValidateChain(Log);
+            // Use the original TlsValidationCallbacks for configuration-based validation
+            // This maintains the existing proven validation logic
+            var chainValidation = Settings.Ssl.SuppressValidation
+                ? ChainValidationMode.IgnoreChainErrors
+                : ChainValidationMode.ValidateChain;
 
-            // Optionally compose with hostname validation
-            if (Settings.Ssl.ValidateCertificateHostname)
+            var hostnameValidation = Settings.Ssl.ValidateCertificateHostname
+                ? HostnameValidationMode.ValidateHostname
+                : HostnameValidationMode.IgnoreHostnameMismatch;
+
+            var dotnettyCallback = TlsValidationCallbacks.Create(chainValidation, hostnameValidation, Log);
+
+            // Convert DotNetty's RemoteCertificateValidationCallback to our CertificateValidationCallback
+            // by wrapping it to include the peer address parameter
+            return (cert, chain, peer, errors, log) =>
             {
-                // Hostname validation is applied via Combine which runs both validators
-                // The hostname validator will be called with the peer address extracted from the channel
-                validator = CertificateValidation.ChainPlusThen((cert, chain, peer) =>
-                {
-                    // After chain validation passes, check hostname if enabled
-                    if (Settings.Ssl.ValidateCertificateHostname && cert is X509Certificate2 x509Cert)
-                    {
-                        // Extract hostname from peer address (format is typically "akka://system@host:port")
-                        var host = peer?.Contains("://") == true
-                            ? peer.Substring(peer.LastIndexOf("@") + 1).Split(':')[0]
-                            : peer;
-
-                        // Check if certificate CN or SANs match the expected hostname
-                        return ValidateCertificateHostnameMatch(x509Cert, host);
-                    }
-                    return true;
-                }, Log);
-            }
-
-            return validator;
+                // Call the DotNetty validator which doesn't use the peer parameter
+                return dotnettyCallback(null, cert, chain, errors);
+            };
         }
 
         /// <summary>

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -486,61 +486,6 @@ namespace Akka.Remote.Transport.DotNetty
             };
         }
 
-        /// <summary>
-        /// Validates that a certificate's CN or Subject Alternative Name matches the expected hostname.
-        /// Supports wildcard certificates and IP addresses.
-        /// Uses reflection for compatibility across .NET Framework, .NET Standard 2.0, and .NET 6+
-        /// </summary>
-        private bool ValidateCertificateHostnameMatch(X509Certificate2 certificate, string expectedHostname)
-        {
-            if (certificate == null || string.IsNullOrEmpty(expectedHostname))
-                return false;
-
-            try
-            {
-                // Check CN in subject distinguished name
-                var subject = certificate.SubjectName.Name;
-                if (subject?.Contains($"CN={expectedHostname}", StringComparison.OrdinalIgnoreCase) == true)
-                    return true;
-
-                // Try to check Subject Alternative Names (SANs)
-                // Use reflection for compatibility since X509SubjectAlternativeNameExtension
-                // is only available in .NET 6+
-                try
-                {
-                    var sanExtension = certificate.Extensions["2.5.29.17"];
-                    if (sanExtension != null)
-                    {
-                        // Try using the EnumerateSubjectAlternativeNames method (NET 6+)
-                        var enumerateMethod = sanExtension.GetType().GetMethod("EnumerateSubjectAlternativeNames");
-                        if (enumerateMethod != null)
-                        {
-                            var sanNames = enumerateMethod.Invoke(sanExtension, null) as System.Collections.IEnumerable;
-                            if (sanNames != null)
-                            {
-                                foreach (var sanName in sanNames)
-                                {
-                                    if (sanName?.ToString()?.Equals(expectedHostname, StringComparison.OrdinalIgnoreCase) == true)
-                                        return true;
-                                }
-                            }
-                        }
-                    }
-                }
-                catch
-                {
-                    // SAN parsing not supported on this framework version - continue with CN-only matching
-                }
-
-                return false;
-            }
-            catch (Exception ex)
-            {
-                Log.Warning("Error validating certificate hostname for {0}: {1}", expectedHostname, ex.Message);
-                return false;
-            }
-        }
-
         private ServerBootstrap ServerFactory()
         {
             if (InternalTransport != TransportMode.Tcp)

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -470,29 +470,14 @@ namespace Akka.Remote.Transport.DotNetty
             var suppressChain = Settings.Ssl.SuppressValidation;
             var validateHostname = Settings.Ssl.ValidateCertificateHostname;
 
-            if (suppressChain && !validateHostname)
+            return suppressChain switch
             {
-                // Accept all certificates (for development/testing only)
-                return (cert, chain, peer, errors, log) => true;
-            }
-            else if (suppressChain && validateHostname)
-            {
-                // Ignore chain errors, but validate hostname
-                return CertificateValidation.ValidateHostname(log: Log);
-            }
-            else if (!suppressChain && validateHostname)
-            {
-                // Full validation: chain + hostname
-                return CertificateValidation.Combine(
-                    CertificateValidation.ValidateChain(log: Log),
-                    CertificateValidation.ValidateHostname(log: Log)
-                );
-            }
-            else // !suppressChain && !validateHostname
-            {
-                // Chain validation only (default for peer-to-peer mutual TLS)
-                return CertificateValidation.ValidateChain(log: Log);
-            }
+                true when validateHostname => CertificateValidation.ValidateHostname(log: Log),
+                true => (cert, chain, peer, errors, log) => true,
+                false when validateHostname => CertificateValidation.Combine(
+                    CertificateValidation.ValidateChain(log: Log), CertificateValidation.ValidateHostname(log: Log)),
+                _ => CertificateValidation.ValidateChain(log: Log)
+            };
         }
 
         private ServerBootstrap ServerFactory()

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -70,7 +71,7 @@ namespace Akka.Remote.Transport.DotNetty
         protected abstract void RegisterListener(IChannel channel, IHandleEventListener listener, object msg, IPEndPoint remoteAddress);
 
         protected void Init(IChannel channel, IPEndPoint remoteSocketAddress, Address remoteAddress, object msg,
-            out AssociationHandle op)
+            out AssociationHandle? op)
         {
             var localAddress = DotNettyTransport.MapSocketToAddress((IPEndPoint)channel.LocalAddress, Transport.SchemeIdentifier, Transport.System.Name, Transport.Settings.Hostname);
 
@@ -100,7 +101,7 @@ namespace Akka.Remote.Transport.DotNetty
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
         /// <param name="cause">The exception that is the cause of the current exception.</param>
-        public DotNettyTransportException(string message, Exception cause = null) : base(message, cause)
+        public DotNettyTransportException(string message, Exception? cause = null) : base(message, cause)
         {
         }
 
@@ -120,8 +121,8 @@ namespace Akka.Remote.Transport.DotNetty
 
         protected readonly TaskCompletionSource<IAssociationEventListener> AssociationListenerPromise;
         protected readonly ILoggingAdapter Log;
-        protected volatile Address LocalAddress;
-        protected internal volatile IChannel ServerChannel;
+        protected volatile Address? LocalAddress;
+        protected internal volatile IChannel? ServerChannel;
 
         private readonly IEventLoopGroup _serverEventLoopGroup;
         private readonly IEventLoopGroup _clientEventLoopGroup;
@@ -240,8 +241,8 @@ namespace Akka.Remote.Transport.DotNetty
 
         public override Task<AssociationHandle> Associate(Address remoteAddress)
         {
-            if (!ServerChannel.Open)
-                throw new ChannelException("Transport is not open");
+            if (ServerChannel == null || !ServerChannel.Open)
+                throw new ChannelException("Transport is not bound or not open");
 
             return AssociateInternal(remoteAddress);
         }
@@ -372,6 +373,10 @@ namespace Akka.Remote.Transport.DotNetty
 
                 if (Settings.Ssl.RequireMutualAuthentication)
                 {
+                    // Mutual TLS requires a certificate to be configured
+                    if (certificate == null)
+                        throw new InvalidOperationException("Mutual TLS authentication is enabled but no certificate is configured. Please provide a certificate via DotNettySslSetup or HOCON configuration.");
+
                     // Provide client cert for mutual TLS
                     tlsHandler = new TlsHandler(
                         stream => new SslStream(stream, true, validationCallback,
@@ -532,14 +537,14 @@ namespace Akka.Remote.Transport.DotNetty
 
         #region static methods
 
-        public static Address MapSocketToAddress(IPEndPoint socketAddress, string schemeIdentifier, string systemName, string hostName = null, int? publicPort = null)
+        public static Address? MapSocketToAddress(IPEndPoint socketAddress, string schemeIdentifier, string systemName, string? hostName = null, int? publicPort = null)
         {
             return socketAddress == null
                 ? null
                 : new Address(schemeIdentifier, systemName, SafeMapHostName(hostName) ?? SafeMapIPv6(socketAddress.Address), publicPort ?? socketAddress.Port);
         }
 
-        private static string SafeMapHostName(string hostName)
+        private static string? SafeMapHostName(string? hostName)
         {
             return !string.IsNullOrEmpty(hostName) && IPAddress.TryParse(hostName, out var ip) ? SafeMapIPv6(ip) : hostName;
         }

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -416,10 +416,18 @@ namespace Akka.Remote.Transport.DotNetty
                     // For server-side, extract the remote peer (client address) from the channel
                     RemoteCertificateValidationCallback validationCallback = (sender, certificate, chain, errors) =>
                     {
+                        // When mutual TLS is required, reject if no client certificate was provided
+                        if (certificate == null)
+                        {
+                            Log.Warning("Mutual TLS required but client did not provide a certificate from {0}",
+                                channel.RemoteAddress?.ToString() ?? "unknown");
+                            return false;
+                        }
+
                         // Extract client address from channel
                         var remoteAddress = channel.RemoteAddress?.ToString() ?? "unknown";
                         // Convert X509Certificate to X509Certificate2 if needed
-                        var x509Cert = certificate as X509Certificate2 ?? (certificate != null ? new X509Certificate2(certificate) : null);
+                        var x509Cert = certificate as X509Certificate2 ?? new X509Certificate2(certificate);
                         return validator(x509Cert, chain, remoteAddress, errors, Log);
                     };
 

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -465,25 +465,34 @@ namespace Akka.Remote.Transport.DotNetty
         /// <returns>A CertificateValidationCallback composed from configuration settings.</returns>
         private CertificateValidationCallback ComposeValidatorFromSettings()
         {
-            // Use the original TlsValidationCallbacks for configuration-based validation
-            // This maintains the existing proven validation logic
-            var chainValidation = Settings.Ssl.SuppressValidation
-                ? ChainValidationMode.IgnoreChainErrors
-                : ChainValidationMode.ValidateChain;
+            // Build validator from configuration settings
+            // Note: SuppressValidation and ValidateCertificateHostname are independent settings
+            var suppressChain = Settings.Ssl.SuppressValidation;
+            var validateHostname = Settings.Ssl.ValidateCertificateHostname;
 
-            var hostnameValidation = Settings.Ssl.ValidateCertificateHostname
-                ? HostnameValidationMode.ValidateHostname
-                : HostnameValidationMode.IgnoreHostnameMismatch;
-
-            var dotnettyCallback = TlsValidationCallbacks.Create(chainValidation, hostnameValidation, Log);
-
-            // Convert DotNetty's RemoteCertificateValidationCallback to our CertificateValidationCallback
-            // by wrapping it to include the peer address parameter
-            return (cert, chain, peer, errors, log) =>
+            if (suppressChain && !validateHostname)
             {
-                // Call the DotNetty validator which doesn't use the peer parameter
-                return dotnettyCallback(null, cert, chain, errors);
-            };
+                // Accept all certificates (for development/testing only)
+                return (cert, chain, peer, errors, log) => true;
+            }
+            else if (suppressChain && validateHostname)
+            {
+                // Ignore chain errors, but validate hostname
+                return CertificateValidation.ValidateHostname(log: Log);
+            }
+            else if (!suppressChain && validateHostname)
+            {
+                // Full validation: chain + hostname
+                return CertificateValidation.Combine(
+                    CertificateValidation.ValidateChain(log: Log),
+                    CertificateValidation.ValidateHostname(log: Log)
+                );
+            }
+            else // !suppressChain && !validateHostname
+            {
+                // Chain validation only (default for peer-to-peer mutual TLS)
+                return CertificateValidation.ValidateChain(log: Log);
+            }
         }
 
         private ServerBootstrap ServerFactory()

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -357,19 +357,17 @@ namespace Akka.Remote.Transport.DotNetty
 
                 IChannelHandler tlsHandler;
 
-                // Build validation callback using type-safe factory methods
-                // These settings are independent and can be combined:
-                // - suppressValidation: Controls chain/CA validation (for self-signed certs)
-                // - validateCertificateHostname: Controls hostname matching (for per-node certs, IPs, etc.)
-                var chainValidation = Settings.Ssl.SuppressValidation
-                    ? ChainValidationMode.IgnoreChainErrors
-                    : ChainValidationMode.ValidateChain;
+                // Compose validator: either use custom validator or build from config settings
+                // This ensures a single execution path through validation logic
+                var validator = Settings.Ssl.CustomValidator ?? ComposeValidatorFromSettings();
 
-                var hostnameValidation = Settings.Ssl.ValidateCertificateHostname
-                    ? HostnameValidationMode.ValidateHostname
-                    : HostnameValidationMode.IgnoreHostnameMismatch;
-
-                var validationCallback = TlsValidationCallbacks.Create(chainValidation, hostnameValidation, Log);
+                // Create adapter bridge from our CertificateValidationCallback to RemoteCertificateValidationCallback
+                // The adapter extracts remote peer information from the remote address
+                RemoteCertificateValidationCallback validationCallback = (sender, cert, chain, errors) =>
+                {
+                    var x509Cert = cert as X509Certificate2;
+                    return validator(x509Cert, chain, remoteAddress.ToString(), errors, Log);
+                };
 
                 if (Settings.Ssl.RequireMutualAuthentication)
                 {
@@ -409,40 +407,25 @@ namespace Akka.Remote.Transport.DotNetty
                 if (Settings.Ssl.RequireMutualAuthentication)
                 {
                     // Mutual TLS: Require client certificate authentication
+                    // Compose validator: either use custom validator or build from config settings
+                    // This ensures a single execution path through validation logic
+                    var validator = Settings.Ssl.CustomValidator ?? ComposeValidatorFromSettings();
+
+                    // Create adapter bridge from our CertificateValidationCallback to RemoteCertificateValidationCallback
+                    // For server-side, extract the remote peer (client address) from the channel
+                    RemoteCertificateValidationCallback validationCallback = (sender, certificate, chain, errors) =>
+                    {
+                        // Extract client address from channel
+                        var remoteAddress = channel.RemoteAddress?.ToString() ?? "unknown";
+                        var x509Cert = certificate as X509Certificate2;
+                        return validator(x509Cert, chain, remoteAddress, errors, Log);
+                    };
+
                     tlsHandler = new TlsHandler(
                         stream => new SslStream(
                             stream,
                             leaveInnerStreamOpen: true,
-                            userCertificateValidationCallback: (sender, certificate, chain, errors) =>
-                            {
-                                if (certificate == null)
-                                {
-                                    Log.Error("Mutual TLS authentication failed: Client did not provide a certificate.\n" +
-                                             "Server requires mutual TLS (require-mutual-authentication = true).\n" +
-                                             "Suggestions:\n" +
-                                             "  - Ensure client has mutual TLS enabled (require-mutual-authentication = true)\n" +
-                                             "  - Verify client certificate is properly configured and accessible\n" +
-                                             "  - Check client-side logs for certificate loading errors");
-                                    return false;
-                                }
-
-                                if (Settings.Ssl.SuppressValidation)
-                                {
-                                    // In test/dev mode, accept any client certificate
-                                    return true;
-                                }
-
-                                if (errors != SslPolicyErrors.None)
-                                {
-                                    // Build detailed error message with certificate details and suggestions
-                                    var cert = certificate as X509Certificate2;
-                                    var detailedError = TlsErrorMessageBuilder.BuildSslPolicyErrorMessage(errors, cert, chain);
-                                    Log.Error("Mutual TLS authentication failed: Client certificate validation error.\n{0}", detailedError);
-                                    return false;
-                                }
-
-                                return true;
-                            }),
+                            userCertificateValidationCallback: validationCallback),
                         new ServerTlsSettings(Settings.Ssl.Certificate, negotiateClientCertificate: true));
                 }
                 else
@@ -461,6 +444,103 @@ namespace Akka.Remote.Transport.DotNetty
             {
                 var handler = new TcpServerHandler(this, Logging.GetLogger(System, typeof(TcpServerHandler)), AssociationListenerPromise.Task);
                 pipeline.AddLast("ServerHandler", handler);
+            }
+        }
+
+        /// <summary>
+        /// Composes a certificate validation callback from the current SSL settings.
+        /// This creates a validator that respects SuppressValidation
+        /// and ValidateCertificateHostname configuration options.
+        /// </summary>
+        /// <returns>A CertificateValidationCallback composed from configuration settings.</returns>
+        private CertificateValidationCallback ComposeValidatorFromSettings()
+        {
+            // Start with chain validation, optionally ignoring CA validation errors
+            CertificateValidationCallback validator = Settings.Ssl.SuppressValidation
+                ? CertificateValidation.ChainPlusThen((cert, chain, peer) =>
+                {
+                    // In suppress mode, accept any certificate that can be parsed
+                    return cert != null;
+                }, Log)
+                : CertificateValidation.ValidateChain(Log);
+
+            // Optionally compose with hostname validation
+            if (Settings.Ssl.ValidateCertificateHostname)
+            {
+                // Hostname validation is applied via Combine which runs both validators
+                // The hostname validator will be called with the peer address extracted from the channel
+                validator = CertificateValidation.ChainPlusThen((cert, chain, peer) =>
+                {
+                    // After chain validation passes, check hostname if enabled
+                    if (Settings.Ssl.ValidateCertificateHostname && cert is X509Certificate2 x509Cert)
+                    {
+                        // Extract hostname from peer address (format is typically "akka://system@host:port")
+                        var host = peer?.Contains("://") == true
+                            ? peer.Substring(peer.LastIndexOf("@") + 1).Split(':')[0]
+                            : peer;
+
+                        // Check if certificate CN or SANs match the expected hostname
+                        return ValidateCertificateHostnameMatch(x509Cert, host);
+                    }
+                    return true;
+                }, Log);
+            }
+
+            return validator;
+        }
+
+        /// <summary>
+        /// Validates that a certificate's CN or Subject Alternative Name matches the expected hostname.
+        /// Supports wildcard certificates and IP addresses.
+        /// Uses reflection for compatibility across .NET Framework, .NET Standard 2.0, and .NET 6+
+        /// </summary>
+        private bool ValidateCertificateHostnameMatch(X509Certificate2 certificate, string expectedHostname)
+        {
+            if (certificate == null || string.IsNullOrEmpty(expectedHostname))
+                return false;
+
+            try
+            {
+                // Check CN in subject distinguished name
+                var subject = certificate.SubjectName.Name;
+                if (subject?.Contains($"CN={expectedHostname}", StringComparison.OrdinalIgnoreCase) == true)
+                    return true;
+
+                // Try to check Subject Alternative Names (SANs)
+                // Use reflection for compatibility since X509SubjectAlternativeNameExtension
+                // is only available in .NET 6+
+                try
+                {
+                    var sanExtension = certificate.Extensions["2.5.29.17"];
+                    if (sanExtension != null)
+                    {
+                        // Try using the EnumerateSubjectAlternativeNames method (NET 6+)
+                        var enumerateMethod = sanExtension.GetType().GetMethod("EnumerateSubjectAlternativeNames");
+                        if (enumerateMethod != null)
+                        {
+                            var sanNames = enumerateMethod.Invoke(sanExtension, null) as System.Collections.IEnumerable;
+                            if (sanNames != null)
+                            {
+                                foreach (var sanName in sanNames)
+                                {
+                                    if (sanName?.ToString()?.Equals(expectedHostname, StringComparison.OrdinalIgnoreCase) == true)
+                                        return true;
+                                }
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    // SAN parsing not supported on this framework version - continue with CN-only matching
+                }
+
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning("Error validating certificate hostname for {0}: {1}", expectedHostname, ex.Message);
+                return false;
             }
         }
 

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Security;
@@ -509,6 +510,25 @@ namespace Akka.Remote.Transport.DotNetty
     }
 
     /// <summary>
+    /// PUBLIC API
+    ///
+    /// Custom certificate validation callback for mTLS connections.
+    /// Invoked during TLS handshake on both client and server sides.
+    /// </summary>
+    /// <param name="certificate">The peer certificate to validate</param>
+    /// <param name="chain">The X509 chain for validation</param>
+    /// <param name="remotePeer">The remote address/peer identifier</param>
+    /// <param name="errors">SSL policy errors from standard validation</param>
+    /// <param name="log">Logger for diagnostics</param>
+    /// <returns>True to accept cert, false to reject</returns>
+    public delegate bool CertificateValidationCallback(
+        X509Certificate2 certificate,
+        X509Chain chain,
+        string remotePeer,
+        SslPolicyErrors errors,
+        ILoggingAdapter log);
+
+    /// <summary>
     /// INTERNAL API
     ///
     /// Factory for creating TLS certificate validation callbacks with different security policies.
@@ -586,6 +606,213 @@ namespace Akka.Remote.Transport.DotNetty
         /// </summary>
         public static RemoteCertificateValidationCallback AcceptAll()
             => (_, _, _, _) => true;
+    }
+
+    /// <summary>
+    /// PUBLIC API
+    ///
+    /// Factory methods for common certificate validation scenarios.
+    /// Helpers return delegates that can be composed or used standalone.
+    /// Each helper creates a CertificateValidationCallback that can be passed to DotNettySslSetup.
+    /// </summary>
+    public static class CertificateValidation
+    {
+        /// <summary>
+        /// Validate certificate chain against system CA store.
+        /// Use for: CA-signed certificates in production.
+        /// </summary>
+        public static CertificateValidationCallback ValidateChain(
+            ILoggingAdapter? log = null)
+        {
+            return (cert, chain, peer, errors, log_) =>
+            {
+                var filteredErrors = errors & ~SslPolicyErrors.RemoteCertificateNameMismatch;
+                if (filteredErrors == SslPolicyErrors.None)
+                    return true;
+
+                var cert509 = cert as X509Certificate2;
+                var detailedError = TlsErrorMessageBuilder.BuildSslPolicyErrorMessage(
+                    filteredErrors, cert509, chain);
+                (log ?? log_).Error("Certificate chain validation failed for {0}:\n{1}", peer, detailedError);
+                return false;
+            };
+        }
+
+        /// <summary>
+        /// Validate certificate hostname (CN/SAN) matches expected hostname.
+        /// Use for: Per-node certificates, FQDN-based identity.
+        /// Applies bidirectionally on both client and server.
+        /// </summary>
+        public static CertificateValidationCallback ValidateHostname(
+            string? expectedHostname = null,
+            ILoggingAdapter? log = null)
+        {
+            return (cert, chain, peer, errors, log_) =>
+            {
+                var hostname = expectedHostname ?? peer;
+
+                if ((errors & SslPolicyErrors.RemoteCertificateNameMismatch) != 0)
+                {
+                    var cn = (cert as X509Certificate2)?.GetNameInfo(X509NameType.DnsName, false);
+                    (log ?? log_).Error(
+                        "Hostname validation failed for {0}: expected '{1}', certificate CN is '{2}'",
+                        peer, hostname, cn);
+                    return false;
+                }
+
+                return true;
+            };
+        }
+
+        /// <summary>
+        /// Pin certificate by thumbprint. Only accept certs matching allowed list.
+        /// Use for: High-security scenarios, known peer certificates.
+        /// Best combined with: Certificate revocation checking.
+        /// </summary>
+        public static CertificateValidationCallback PinnedCertificate(
+            params string[] allowedThumbprints)
+        {
+            if (allowedThumbprints == null || allowedThumbprints.Length == 0)
+                throw new ArgumentException("At least one thumbprint required");
+
+            var normalizedThumbprints = new HashSet<string>(
+                allowedThumbprints!.Select(t => t.ToUpperInvariant()));
+
+            return (cert, chain, peer, errors, log) =>
+            {
+                var cert509 = cert as X509Certificate2;
+                var thumbprint = cert509?.Thumbprint?.ToUpperInvariant();
+
+                if (!normalizedThumbprints.Contains(thumbprint ?? ""))
+                {
+                    log.Error("Certificate pinning failed for {0}: thumbprint '{1}' not in allowed list",
+                        peer, thumbprint);
+                    return false;
+                }
+
+                return true;
+            };
+        }
+
+        /// <summary>
+        /// Validate certificate subject DN matches expected pattern.
+        /// Use for: Organizational CA, issuer-based identity verification.
+        /// Supports wildcards: "CN=Akka-Node-*" matches "CN=Akka-Node-001"
+        /// </summary>
+        public static CertificateValidationCallback ValidateSubject(
+            string expectedSubjectPattern,
+            ILoggingAdapter? log = null)
+        {
+            if (string.IsNullOrEmpty(expectedSubjectPattern))
+                throw new ArgumentException("Subject pattern required");
+
+            return (cert, chain, peer, errors, log_) =>
+            {
+                var cert509 = cert as X509Certificate2;
+                var subject = cert509?.Subject;
+
+                if (!SubjectMatchesPattern(subject, expectedSubjectPattern))
+                {
+                    (log ?? log_).Error(
+                        "Subject validation failed for {0}: '{1}' does not match pattern '{2}'",
+                        peer, subject, expectedSubjectPattern);
+                    return false;
+                }
+
+                return true;
+            };
+        }
+
+        /// <summary>
+        /// Validate certificate issuer matches expected DN pattern.
+        /// Use for: Verifying certificate came from trusted CA.
+        /// </summary>
+        public static CertificateValidationCallback ValidateIssuer(
+            string expectedIssuerPattern,
+            ILoggingAdapter? log = null)
+        {
+            if (string.IsNullOrEmpty(expectedIssuerPattern))
+                throw new ArgumentException("Issuer pattern required");
+
+            return (cert, chain, peer, errors, log_) =>
+            {
+                var cert509 = cert as X509Certificate2;
+                var issuer = cert509?.Issuer;
+
+                if (!SubjectMatchesPattern(issuer, expectedIssuerPattern))
+                {
+                    (log ?? log_).Error(
+                        "Issuer validation failed for {0}: '{1}' does not match pattern '{2}'",
+                        peer, issuer, expectedIssuerPattern);
+                    return false;
+                }
+
+                return true;
+            };
+        }
+
+        /// <summary>
+        /// Compose multiple validation callbacks into a single callback.
+        /// All validators must pass for certificate to be accepted.
+        /// Use for: Combining multiple validation strategies.
+        /// </summary>
+        public static CertificateValidationCallback Combine(
+            params CertificateValidationCallback[] validators)
+        {
+            if (validators == null || validators.Length == 0)
+                throw new ArgumentException("At least one validator required");
+
+            return (cert, chain, peer, errors, log) =>
+            {
+                foreach (var validator in validators!)
+                {
+                    if (!validator(cert, chain, peer, errors, log))
+                        return false;
+                }
+                return true;
+            };
+        }
+
+        /// <summary>
+        /// Chain validator with optional custom validation.
+        /// Validates certificate chain, then calls optional custom logic.
+        /// </summary>
+        public static CertificateValidationCallback ChainPlusThen(
+            Func<X509Certificate2, X509Chain, string, bool> customCheck,
+            ILoggingAdapter? log = null)
+        {
+            if (customCheck == null)
+                throw new ArgumentException("Custom check function required");
+
+            return (cert, chain, peer, errors, log_) =>
+            {
+                // First validate chain
+                var chainValidator = ValidateChain(log ?? log_);
+                if (!chainValidator(cert, chain, peer, errors, log_))
+                    return false;
+
+                // Then custom check
+                var cert509 = cert as X509Certificate2;
+                if (!customCheck(cert509, chain, peer))
+                {
+                    (log ?? log_).Error("Custom certificate validation failed for {0}", peer);
+                    return false;
+                }
+
+                return true;
+            };
+        }
+
+        private static bool SubjectMatchesPattern(string? subject, string pattern)
+        {
+            // Simple wildcard matching: CN=Akka-Node-* matches CN=Akka-Node-001
+            if (string.IsNullOrEmpty(subject))
+                return false;
+
+            var regex = "^" + System.Text.RegularExpressions.Regex.Escape(pattern)
+                .Replace("\\*", ".*") + "$";
+            return System.Text.RegularExpressions.Regex.IsMatch(subject, regex);
+        }
     }
 
     /// <summary>

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -505,52 +505,6 @@ namespace Akka.Remote.Transport.DotNetty
     }
 
     /// <summary>
-    /// INTERNAL API
-    ///
-    /// Specifies how certificate chain validation should be performed during TLS handshake.
-    /// Controls whether to validate certificates against the system CA trust store.
-    /// </summary>
-    internal enum ChainValidationMode
-    {
-        /// <summary>
-        /// Validate certificate chain against system CA trust store.
-        /// Use for production with CA-signed certificates.
-        /// Certificates must chain to a trusted root CA.
-        /// </summary>
-        ValidateChain,
-
-        /// <summary>
-        /// Ignore certificate chain validation errors.
-        /// Use for development/testing with self-signed certificates.
-        /// WARNING: Allows untrusted certificates - use only in non-production environments.
-        /// </summary>
-        IgnoreChainErrors
-    }
-
-    /// <summary>
-    /// INTERNAL API
-    ///
-    /// Specifies how hostname validation should be performed during TLS handshake.
-    /// Controls whether the certificate CN/SAN must match the connection target hostname.
-    /// </summary>
-    internal enum HostnameValidationMode
-    {
-        /// <summary>
-        /// Validate that certificate CN/SAN matches target hostname.
-        /// Use for traditional client-server TLS with DNS-based connections.
-        /// Prevents man-in-the-middle attacks by ensuring certificate matches expected server.
-        /// </summary>
-        ValidateHostname,
-
-        /// <summary>
-        /// Ignore hostname mismatch errors.
-        /// Use for: Mutual TLS with per-node certificates, IP-based connections, dynamic service discovery.
-        /// Still validates certificate chain (unless IgnoreChainErrors is also set).
-        /// </summary>
-        IgnoreHostnameMismatch
-    }
-
-    /// <summary>
     /// PUBLIC API
     ///
     /// Custom certificate validation callback for mTLS connections.
@@ -568,86 +522,6 @@ namespace Akka.Remote.Transport.DotNetty
         string remotePeer,
         SslPolicyErrors errors,
         ILoggingAdapter log);
-
-    /// <summary>
-    /// INTERNAL API
-    ///
-    /// Factory for creating TLS certificate validation callbacks with different security policies.
-    /// Provides type-safe, self-documenting methods for configuring certificate validation behavior.
-    /// </summary>
-    internal static class TlsValidationCallbacks
-    {
-        /// <summary>
-        /// Creates a configurable validation callback that filters SSL policy errors based on validation modes.
-        /// </summary>
-        /// <param name="chainValidation">Controls certificate chain/CA validation</param>
-        /// <param name="hostnameValidation">Controls hostname matching validation</param>
-        /// <param name="log">Logger for validation failures</param>
-        /// <returns>Validation callback configured according to parameters</returns>
-        public static RemoteCertificateValidationCallback Create(
-            ChainValidationMode chainValidation,
-            HostnameValidationMode hostnameValidation,
-            ILoggingAdapter log)
-        {
-            return (sender, cert, chain, errors) =>
-            {
-                var filteredErrors = errors;
-
-                // Apply chain validation filter
-                if (chainValidation == ChainValidationMode.IgnoreChainErrors)
-                {
-                    filteredErrors &= ~SslPolicyErrors.RemoteCertificateChainErrors;
-                    filteredErrors &= ~SslPolicyErrors.RemoteCertificateNotAvailable;
-                }
-
-                // Apply hostname validation filter
-                if (hostnameValidation == HostnameValidationMode.IgnoreHostnameMismatch)
-                {
-                    filteredErrors &= ~SslPolicyErrors.RemoteCertificateNameMismatch;
-                }
-
-                if (filteredErrors == SslPolicyErrors.None)
-                    return true; // Certificate is valid after applying configured filters
-
-                // Log detailed error for validation failures
-                var cert509 = cert as X509Certificate2;
-                var detailedError = TlsErrorMessageBuilder.BuildSslPolicyErrorMessage(
-                    filteredErrors, cert509, chain);
-                var mode = chainValidation == ChainValidationMode.IgnoreChainErrors ? "suppress-validation enabled" :
-                           hostnameValidation == HostnameValidationMode.ValidateHostname ? "full validation" : "hostname validation disabled";
-                log.Error("TLS certificate validation failed ({0}):\n{1}", mode, detailedError);
-                return false;
-            };
-        }
-
-        /// <summary>
-        /// Creates validation callback for full TLS validation (chain + hostname).
-        /// Use for traditional client-server TLS with CA-signed certificates and DNS names.
-        /// </summary>
-        public static RemoteCertificateValidationCallback ValidateFull(ILoggingAdapter log)
-            => Create(ChainValidationMode.ValidateChain, HostnameValidationMode.ValidateHostname, log);
-
-        /// <summary>
-        /// Creates validation callback that validates chain but ignores hostname mismatches.
-        /// Use for: Mutual TLS with per-node certificates, IP-based connections, dynamic service discovery.
-        /// </summary>
-        public static RemoteCertificateValidationCallback ValidateChainOnly(ILoggingAdapter log)
-            => Create(ChainValidationMode.ValidateChain, HostnameValidationMode.IgnoreHostnameMismatch, log);
-
-        /// <summary>
-        /// Creates validation callback that ignores chain errors but validates hostname.
-        /// Use for: Testing with self-signed certificates where hostname should still match.
-        /// </summary>
-        public static RemoteCertificateValidationCallback ValidateHostnameOnly(ILoggingAdapter log)
-            => Create(ChainValidationMode.IgnoreChainErrors, HostnameValidationMode.ValidateHostname, log);
-
-        /// <summary>
-        /// Creates validation callback that accepts all certificates without validation.
-        /// FOR TESTING ONLY. WARNING: Disables all security checks including chain, hostname, and expiration.
-        /// </summary>
-        public static RemoteCertificateValidationCallback AcceptAll()
-            => (_, _, _, _) => true;
-    }
 
     /// <summary>
     /// PUBLIC API

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -517,8 +518,8 @@ namespace Akka.Remote.Transport.DotNetty
     /// <param name="log">Logger for diagnostics</param>
     /// <returns>True to accept cert, false to reject</returns>
     public delegate bool CertificateValidationCallback(
-        X509Certificate2 certificate,
-        X509Chain chain,
+        X509Certificate2? certificate,
+        X509Chain? chain,
         string remotePeer,
         SslPolicyErrors errors,
         ILoggingAdapter log);
@@ -539,16 +540,15 @@ namespace Akka.Remote.Transport.DotNetty
         public static CertificateValidationCallback ValidateChain(
             ILoggingAdapter? log = null)
         {
-            return (cert, chain, peer, errors, log_) =>
+            return (cert, chain, peer, errors, noClosureLog) =>
             {
                 var filteredErrors = errors & ~SslPolicyErrors.RemoteCertificateNameMismatch;
                 if (filteredErrors == SslPolicyErrors.None)
                     return true;
 
-                var cert509 = cert as X509Certificate2;
                 var detailedError = TlsErrorMessageBuilder.BuildSslPolicyErrorMessage(
-                    filteredErrors, cert509, chain);
-                (log ?? log_).Error("Certificate chain validation failed for {0}:\n{1}", peer, detailedError);
+                    filteredErrors, cert, chain);
+                (log ?? noClosureLog).Error("Certificate chain validation failed for {0}:\n{1}", peer, detailedError);
                 return false;
             };
         }
@@ -693,7 +693,7 @@ namespace Akka.Remote.Transport.DotNetty
         /// Validates certificate chain, then calls optional custom logic.
         /// </summary>
         public static CertificateValidationCallback ChainPlusThen(
-            Func<X509Certificate2, X509Chain, string, bool> customCheck,
+            Func<X509Certificate2?, X509Chain?, string, bool> customCheck,
             ILoggingAdapter? log = null)
         {
             if (customCheck == null)
@@ -707,8 +707,7 @@ namespace Akka.Remote.Transport.DotNetty
                     return false;
 
                 // Then custom check
-                var cert509 = cert as X509Certificate2;
-                if (!customCheck(cert509, chain, peer))
+                if (!customCheck(cert, chain, peer))
                 {
                     (log ?? log_).Error("Custom certificate validation failed for {0}", peer);
                     return false;

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -818,7 +818,7 @@ namespace Akka.Remote.Transport.DotNetty
             message.AppendLine("TLS/SSL certificate validation failed:");
 
             // Interpret SslPolicyErrors flags
-            if ((errors & System.Net.Security.SslPolicyErrors.None) != System.Net.Security.SslPolicyErrors.None)
+            if (errors != System.Net.Security.SslPolicyErrors.None)
             {
                 if ((errors & System.Net.Security.SslPolicyErrors.RemoteCertificateNotAvailable) != 0)
                 {

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -601,7 +601,12 @@ namespace Akka.Remote.Transport.DotNetty
             if (allowedThumbprints == null || allowedThumbprints.Length == 0)
                 throw new ArgumentException("At least one thumbprint required");
 
-            // Normalize and filter out any null/empty thumbprints to prevent security issues
+            // Normalize thumbprints to uppercase for case-insensitive comparison.
+            // This is SAFE because thumbprints are hexadecimal representations of SHA hashes.
+            // "2A8B4C" and "2a8b4c" represent the same binary value - just different display conventions.
+            // Different tools display thumbprints differently (Windows=uppercase, OpenSSL=lowercase),
+            // so case-insensitive comparison improves usability without compromising security.
+            // Also filter out any null/empty thumbprints to prevent security issues.
             var normalizedThumbprints = new HashSet<string>(
                 allowedThumbprints
                     .Where(t => !string.IsNullOrWhiteSpace(t))

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -355,19 +355,25 @@ namespace Akka.Remote.Transport.DotNetty
         /// </summary>
         public readonly bool ValidateCertificateHostname;
 
+        /// <summary>
+        /// Custom certificate validation callback (overrides config-based validation when provided)
+        /// </summary>
+        public readonly CertificateValidationCallback? CustomValidator;
+
         private SslSettings()
         {
             Certificate = null;
             SuppressValidation = false;
             RequireMutualAuthentication = false;
             ValidateCertificateHostname = false;
+            CustomValidator = null;
         }
 
         /// <summary>
         /// Constructor for backward compatibility - defaults to RequireMutualAuthentication = true, ValidateCertificateHostname = false
         /// </summary>
         public SslSettings(X509Certificate2 certificate, bool suppressValidation)
-            : this(certificate, suppressValidation, requireMutualAuthentication: true, validateCertificateHostname: false)
+            : this(certificate, suppressValidation, requireMutualAuthentication: true, validateCertificateHostname: false, customValidator: null)
         {
         }
 
@@ -375,16 +381,22 @@ namespace Akka.Remote.Transport.DotNetty
         /// Constructor for backward compatibility - defaults to ValidateCertificateHostname = false
         /// </summary>
         public SslSettings(X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication)
-            : this(certificate, suppressValidation, requireMutualAuthentication, validateCertificateHostname: false)
+            : this(certificate, suppressValidation, requireMutualAuthentication, validateCertificateHostname: false, customValidator: null)
         {
         }
 
         public SslSettings(X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname)
+            : this(certificate, suppressValidation, requireMutualAuthentication, validateCertificateHostname, customValidator: null)
+        {
+        }
+
+        public SslSettings(X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname, CertificateValidationCallback? customValidator)
         {
             Certificate = certificate;
             SuppressValidation = suppressValidation;
             RequireMutualAuthentication = requireMutualAuthentication;
             ValidateCertificateHostname = validateCertificateHostname;
+            CustomValidator = customValidator;
         }
 
         /// <summary>
@@ -434,6 +446,11 @@ namespace Akka.Remote.Transport.DotNetty
         }
 
         private SslSettings(string certificateThumbprint, string storeName, StoreLocation storeLocation, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname)
+            : this(certificateThumbprint, storeName, storeLocation, suppressValidation, requireMutualAuthentication, validateCertificateHostname, customValidator: null)
+        {
+        }
+
+        private SslSettings(string certificateThumbprint, string storeName, StoreLocation storeLocation, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname, CertificateValidationCallback? customValidator)
         {
             using var store = new X509Store(storeName, storeLocation);
             store.Open(OpenFlags.ReadOnly);
@@ -449,9 +466,15 @@ namespace Akka.Remote.Transport.DotNetty
             SuppressValidation = suppressValidation;
             RequireMutualAuthentication = requireMutualAuthentication;
             ValidateCertificateHostname = validateCertificateHostname;
+            CustomValidator = customValidator;
         }
 
         private SslSettings(string certificatePath, string certificatePassword, X509KeyStorageFlags flags, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname)
+            : this(certificatePath, certificatePassword, flags, suppressValidation, requireMutualAuthentication, validateCertificateHostname, customValidator: null)
+        {
+        }
+
+        private SslSettings(string certificatePath, string certificatePassword, X509KeyStorageFlags flags, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname, CertificateValidationCallback? customValidator)
         {
             if (string.IsNullOrEmpty(certificatePath))
                 throw new ArgumentNullException(nameof(certificatePath), "Path to SSL certificate was not found (by default it can be found under `akka.remote.dot-netty.tcp.ssl.certificate.path`)");
@@ -460,6 +483,7 @@ namespace Akka.Remote.Transport.DotNetty
             SuppressValidation = suppressValidation;
             RequireMutualAuthentication = requireMutualAuthentication;
             ValidateCertificateHostname = validateCertificateHostname;
+            CustomValidator = customValidator;
         }
     }
 

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -542,6 +542,12 @@ namespace Akka.Remote.Transport.DotNetty
         {
             return (cert, chain, peer, errors, noClosureLog) =>
             {
+                if (cert == null)
+                {
+                    (log ?? noClosureLog).Error("Certificate chain validation failed for {0}: certificate is null", peer);
+                    return false;
+                }
+
                 var filteredErrors = errors & ~SslPolicyErrors.RemoteCertificateNameMismatch;
                 if (filteredErrors == SslPolicyErrors.None)
                     return true;
@@ -562,20 +568,25 @@ namespace Akka.Remote.Transport.DotNetty
             string? expectedHostname = null,
             ILoggingAdapter? log = null)
         {
-            return (cert, chain, peer, errors, log_) =>
+            return (cert, chain, peer, errors, nonClosureLog) =>
             {
-                var hostname = expectedHostname ?? peer;
-
-                if ((errors & SslPolicyErrors.RemoteCertificateNameMismatch) != 0)
+                if (cert == null)
                 {
-                    var cn = (cert as X509Certificate2)?.GetNameInfo(X509NameType.DnsName, false);
-                    (log ?? log_).Error(
-                        "Hostname validation failed for {0}: expected '{1}', certificate CN is '{2}'",
-                        peer, hostname, cn);
+                    (log ?? nonClosureLog).Error(
+                        "Hostname validation failed for {0}: certificate is null",
+                        peer);
                     return false;
                 }
 
-                return true;
+                var hostname = expectedHostname ?? peer;
+
+                if ((errors & SslPolicyErrors.RemoteCertificateNameMismatch) == 0) return true;
+                var cn = cert.GetNameInfo(X509NameType.DnsName, false);
+                (log ?? nonClosureLog).Error(
+                    "Hostname validation failed for {0}: expected '{1}', certificate CN is '{2}'",
+                    peer, hostname, cn);
+                return false;
+
             };
         }
 
@@ -590,15 +601,32 @@ namespace Akka.Remote.Transport.DotNetty
             if (allowedThumbprints == null || allowedThumbprints.Length == 0)
                 throw new ArgumentException("At least one thumbprint required");
 
+            // Normalize and filter out any null/empty thumbprints to prevent security issues
             var normalizedThumbprints = new HashSet<string>(
-                allowedThumbprints!.Select(t => t.ToUpperInvariant()));
+                allowedThumbprints
+                    .Where(t => !string.IsNullOrWhiteSpace(t))
+                    .Select(t => t.ToUpperInvariant()));
+
+            if (normalizedThumbprints.Count == 0)
+                throw new ArgumentException("At least one valid (non-empty) thumbprint required");
 
             return (cert, chain, peer, errors, log) =>
             {
-                var cert509 = cert as X509Certificate2;
-                var thumbprint = cert509?.Thumbprint?.ToUpperInvariant();
+                if (cert == null)
+                {
+                    log.Error("Certificate pinning failed for {0}: certificate is null", peer);
+                    return false;
+                }
 
-                if (!normalizedThumbprints.Contains(thumbprint ?? ""))
+                var thumbprint = cert.Thumbprint?.ToUpperInvariant();
+
+                if (string.IsNullOrEmpty(thumbprint))
+                {
+                    log.Error("Certificate pinning failed for {0}: certificate has no thumbprint", peer);
+                    return false;
+                }
+
+                if (!normalizedThumbprints.Contains(thumbprint!))
                 {
                     log.Error("Certificate pinning failed for {0}: thumbprint '{1}' not in allowed list",
                         peer, thumbprint);
@@ -618,13 +646,29 @@ namespace Akka.Remote.Transport.DotNetty
             string expectedSubjectPattern,
             ILoggingAdapter? log = null)
         {
-            if (string.IsNullOrEmpty(expectedSubjectPattern))
+            if (string.IsNullOrWhiteSpace(expectedSubjectPattern))
                 throw new ArgumentException("Subject pattern required");
 
             return (cert, chain, peer, errors, log_) =>
             {
+                if (cert == null)
+                {
+                    (log ?? log_).Error(
+                        "Subject validation failed for {0}: certificate is null",
+                        peer);
+                    return false;
+                }
+
                 var cert509 = cert as X509Certificate2;
                 var subject = cert509?.Subject;
+
+                if (string.IsNullOrEmpty(subject))
+                {
+                    (log ?? log_).Error(
+                        "Subject validation failed for {0}: certificate has no subject",
+                        peer);
+                    return false;
+                }
 
                 if (!SubjectMatchesPattern(subject, expectedSubjectPattern))
                 {
@@ -646,13 +690,29 @@ namespace Akka.Remote.Transport.DotNetty
             string expectedIssuerPattern,
             ILoggingAdapter? log = null)
         {
-            if (string.IsNullOrEmpty(expectedIssuerPattern))
+            if (string.IsNullOrWhiteSpace(expectedIssuerPattern))
                 throw new ArgumentException("Issuer pattern required");
 
             return (cert, chain, peer, errors, log_) =>
             {
+                if (cert == null)
+                {
+                    (log ?? log_).Error(
+                        "Issuer validation failed for {0}: certificate is null",
+                        peer);
+                    return false;
+                }
+
                 var cert509 = cert as X509Certificate2;
                 var issuer = cert509?.Issuer;
+
+                if (string.IsNullOrEmpty(issuer))
+                {
+                    (log ?? log_).Error(
+                        "Issuer validation failed for {0}: certificate has no issuer",
+                        peer);
+                    return false;
+                }
 
                 if (!SubjectMatchesPattern(issuer, expectedIssuerPattern))
                 {

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransportSettings.cs
@@ -144,9 +144,26 @@ namespace Akka.Remote.Transport.DotNetty
             var config = system.Settings.Config.GetConfig("akka.remote.dot-netty.tcp");
             if (config.IsNullOrEmpty())
                 throw ConfigurationException.NullOrEmptyConfig<DotNettyTransportSettings>("akka.remote.dot-netty.tcp");
-            
+
             var setup = system.Settings.Setup.Get<DotNettySslSetup>();
             var sslSettings = setup.HasValue ? setup.Value.Settings : null;
+
+            // Warn if both DotNettySslSetup and HOCON SSL are configured (DotNettySslSetup takes precedence)
+            if (sslSettings != null && config.GetBoolean("enable-ssl"))
+            {
+                var sslConfig = config.GetConfig("ssl");
+                // Only warn if HOCON has explicit certificate configuration
+                var hasCertPath = sslConfig.HasPath("certificate.path") && !string.IsNullOrWhiteSpace(sslConfig.GetString("certificate.path"));
+                var hasCertThumbprint = sslConfig.HasPath("certificate.thumbprint") && !string.IsNullOrWhiteSpace(sslConfig.GetString("certificate.thumbprint"));
+
+                if (hasCertPath || hasCertThumbprint)
+                {
+                    var log = Logging.GetLogger(system, typeof(DotNettyTransportSettings));
+                    log.Warning("Both DotNettySslSetup and HOCON SSL configuration are present. " +
+                               "DotNettySslSetup takes precedence and HOCON SSL settings will be ignored.");
+                }
+            }
+
             return Create(config, sslSettings);
         }
 


### PR DESCRIPTION
## Summary

This PR implements a comprehensive programmatic certificate validation API for Akka.NET remote TLS transport, addressing the critical asymmetric hostname validation bug and providing high-level configuration flexibility.

### Key Changes

**6 commits total:**

1. **feat(remote)**: `CertificateValidationCallback` delegate and `CertificateValidation` helper factory
   - New `CertificateValidationCallback` delegate for user-facing validation logic
   - 7 helper factory methods: `ValidateChain`, `ValidateHostname`, `PinnedCertificate`, `ValidateSubject`, `ValidateIssuer`, `Combine`, `ChainPlusThen`
   - Adapter bridge between user delegates and DotNetty's low-level validation

2. **fix(remote)**: Single execution path for validation with hostname validation asymmetry fix
   - Fixes critical bug: client-enforced hostname validation was ignored by server
   - Server now enforces hostname validation when client requires it
   - Eliminates dual branching logic via single `CustomValidator ?? ComposeValidatorFromSettings()` path

3. **fix(remote)**: Reject missing client certificates in server-side mutual TLS validation
   - Explicit null certificate rejection when mTLS required
   - Test `Mutual_TLS_should_fail_when_client_has_no_certificate` now passes

4. **docs**: Programmatic certificate validation examples and consolidated security documentation
   - Added 5 code examples to `TlsConfigurationSample.cs` with #region tags
   - Created "Validation Strategies: HOCON vs Programmatic" section with decision matrix
   - Unified "Hostname Validation" and "Mutual TLS" sections to reduce duplication

5. **fix**: Corrected compilation errors in documentation examples
   - Added `Akka.Remote` reference to `Akka.Docs.Tests` project
   - Wrapped examples with `#if NET6_0_OR_GREATER` for framework compatibility
   - Fixed API usage: params vs arrays, correct delegate signatures

6. **fix**: Wire CustomValidator through SslSettings and add comprehensive integration tests ⭐ **CRITICAL**
   - Fixed `DotNettySslSetup.Settings` to pass `CustomValidator` to `SslSettings` constructor
   - Removed unused `ValidateCertificateHostnameMatch` method (489-542 lines)
   - Added 3 integration tests that actually validate CustomValidator functionality works end-to-end

### Test Results
- All 327 unit tests passing ✓ (324 existing + 3 new)
- 5 tests skipped (expected)
- All 42 DotNetty tests pass ✓
- DocFX metadata build: 0 warnings/errors ✓
- DocFX full build: 0 warnings/errors ✓

### New Integration Tests (Commit 6)
1. **`CustomValidator_that_accepts_should_allow_connection`**
   - Verifies CustomValidator callback is invoked during TLS handshake
   - Verifies acceptance allows successful connection

2. **`CustomValidator_that_rejects_should_prevent_connection`**
   - Verifies CustomValidator rejection prevents connection
   - Verifies callback was invoked even when rejecting

3. **`DotNettySslSetup_should_pass_CustomValidator_to_SslSettings`**
   - Unit test verifying CustomValidator is properly wired through

### Files Modified
- `DotNettyTransport.cs` - Single execution path + null certificate rejection + removed unused method
- `DotNettyTransportSettings.cs` - CertificateValidationCallback + CertificateValidation factory
- `DotNettySslSetup.cs` - CustomValidator property + wiring to SslSettings
- `SslSettings.cs` - CustomValidator property
- `DotNettySslSetupSpec.cs` - 3 new integration tests for CustomValidator
- `TlsConfigurationSample.cs` - 5 programmatic examples (net6.0+)
- `Akka.Docs.Tests.csproj` - Akka.Remote reference
- `security.md` - Consolidated validation strategies + decision matrix

### Documentation
The new API provides:
- High-level programmatic control over certificate validation
- 5 usage patterns: chain validation, hostname validation, certificate pinning, subject validation, issuer validation
- Composable validators via `Combine` and `ChainPlusThen`
- Custom validation logic with `ChainPlusThen` for complex scenarios

### Backwards Compatibility
✓ Fully backwards compatible - all changes are additive
✓ Existing HOCON-based configuration unaffected
✓ New API is optional; users can continue using HOCON

## Test Plan

- [x] All unit tests pass (327/327)
- [x] Multi-node tests pass
- [x] Mutual TLS validation fixed and tested
- [x] CustomValidator wiring fixed and tested
- [x] CustomValidator acceptance/rejection tested end-to-end
- [x] Documentation builds without warnings/errors
- [x] Code examples compile correctly
- [x] API compatibility maintained