### PR TITLE
Improve documentation for Sink.FromWriter isOwner parameter

### DIFF
--- a/src/core/Akka.Streams/Dsl/ChannelSink.cs
+++ b/src/core/Akka.Streams/Dsl/ChannelSink.cs
@@ -15,14 +15,19 @@ namespace Akka.Streams.Dsl
     public static class ChannelSink
     {
         /// <summary>
-        /// Creates a Sink, that will emit incoming events directly into provider <see cref="ChannelWriter{T}"/>.
-        /// It will handle problems such as backpressure and <paramref name="writer"/>. When <paramref name="isOwner"/>
-        /// is set to <c>true</c>, it will also take responsibility to complete given <paramref name="writer"/>.
+        /// Creates a Sink that will emit incoming events directly into the provided <see cref="ChannelWriter{T}"/>.
+        /// It will handle backpressure automatically by respecting the channel's capacity.
         /// </summary>
         /// <typeparam name="T">Type of events passed to <paramref name="writer"/>.</typeparam>
-        /// <param name="writer">A <see cref="ChannelWriter{T}"/> to pass events emitted from materialized graph to.</param>
-        /// <param name="isOwner">Determines materialized graph should be responsible for completing given <paramref name="writer"/>.</param>
-        /// <returns></returns>
+        /// <param name="writer">A <see cref="ChannelWriter{T}"/> to pass events emitted from the materialized graph to.</param>
+        /// <param name="isOwner">
+        /// Determines whether the materialized graph should take ownership of the <paramref name="writer"/>.
+        /// When <c>true</c>, the sink will call <see cref="ChannelWriter{T}.Complete()"/> when the stream completes normally,
+        /// and <see cref="ChannelWriter{T}.TryComplete(Exception)"/> if the stream fails.
+        /// When <c>false</c>, the sink will not complete the writer, allowing it to be used by multiple producers
+        /// or managed externally.
+        /// </param>
+        /// <returns>A <see cref="Sink{TIn,TMat}"/> that writes to the provided channel.</returns>
         public static Sink<T, NotUsed> FromWriter<T>(ChannelWriter<T> writer, bool isOwner)
         {
             if (writer is null)

--- a/src/core/Akka.Streams/Dsl/ChannelSink.cs
+++ b/src/core/Akka.Streams/Dsl/ChannelSink.cs
@@ -22,8 +22,8 @@ namespace Akka.Streams.Dsl
         /// <param name="writer">A <see cref="ChannelWriter{T}"/> to pass events emitted from the materialized graph to.</param>
         /// <param name="isOwner">
         /// Determines whether the materialized graph should take ownership of the <paramref name="writer"/>.
-        /// When <c>true</c>, the sink will call <see cref="ChannelWriter{T}.Complete()"/> when the stream completes normally,
-        /// and <see cref="ChannelWriter{T}.TryComplete(Exception)"/> if the stream fails.
+        /// When <c>true</c>, the sink will call <c>Complete()</c> when the stream completes normally,
+        /// and <c>TryComplete(Exception)</c> if the stream fails.
         /// When <c>false</c>, the sink will not complete the writer, allowing it to be used by multiple producers
         /// or managed externally.
         /// </param>

--- a/src/core/Akka.Streams/Dsl/Sink.cs
+++ b/src/core/Akka.Streams/Dsl/Sink.cs
@@ -699,8 +699,8 @@ namespace Akka.Streams.Dsl
         /// <param name="writer">A <see cref="ChannelWriter{T}"/> to pass events emitted from the materialized graph to.</param>
         /// <param name="isOwner">
         /// Determines whether the materialized graph should take ownership of the <paramref name="writer"/>.
-        /// When <c>true</c>, the sink will call <see cref="ChannelWriter{T}.Complete()"/> when the stream completes normally,
-        /// and <see cref="ChannelWriter{T}.TryComplete(Exception)"/> if the stream fails.
+        /// When <c>true</c>, the sink will call <c>Complete()</c> when the stream completes normally,
+        /// and <c>TryComplete(Exception)</c> if the stream fails.
         /// When <c>false</c>, the sink will not complete the writer, allowing it to be used by multiple producers
         /// or managed externally.
         /// </param>

--- a/src/core/Akka.Streams/Dsl/Sink.cs
+++ b/src/core/Akka.Streams/Dsl/Sink.cs
@@ -690,6 +690,21 @@ namespace Akka.Streams.Dsl
             return ChannelSink.AsReader<T>(bufferSize, singleReader, fullMode);
         }
 
+
+        /// <summary>
+        /// Creates a Sink that will emit incoming events directly into the provided <see cref="ChannelWriter{T}"/>.
+        /// It will handle backpressure automatically by respecting the channel's capacity.
+        /// </summary>
+        /// <typeparam name="T">Type of events passed to <paramref name="writer"/>.</typeparam>
+        /// <param name="writer">A <see cref="ChannelWriter{T}"/> to pass events emitted from the materialized graph to.</param>
+        /// <param name="isOwner">
+        /// Determines whether the materialized graph should take ownership of the <paramref name="writer"/>.
+        /// When <c>true</c>, the sink will call <see cref="ChannelWriter{T}.Complete()"/> when the stream completes normally,
+        /// and <see cref="ChannelWriter{T}.TryComplete(Exception)"/> if the stream fails.
+        /// When <c>false</c>, the sink will not complete the writer, allowing it to be used by multiple producers
+        /// or managed externally.
+        /// </param>
+        /// <returns>A <see cref="Sink{TIn,TMat}"/> that writes to the provided channel.</returns>
         public static Sink<T, NotUsed> FromWriter<T>(ChannelWriter<T> writer,
             bool isOwner)
         {


### PR DESCRIPTION
## Summary
This PR improves the documentation for the `Sink.FromWriter` method's `isOwner` parameter to clarify its behavior and usage.

## Background
This fix addresses a documentation gap identified in Freshdesk support ticket #557. A customer was learning to use Akka.Streams' native Channel integration and was unclear about:
- What the `isOwner` parameter means
- Whether the stream automatically completes the channel writer

While the customer eventually found the answer by inspecting the source code, this highlighted that our API documentation was incomplete and potentially confusing for new users.

## Changes
- Fixed incomplete documentation sentence in `ChannelSink.cs` that ended with "It will handle problems such as backpressure and <paramref name="writer"/>."
- Added comprehensive documentation explaining the `isOwner` parameter behavior:
  - When `true`: The sink takes ownership and calls `ChannelWriter<T>.Complete()` when the stream completes
  - When `false`: The sink does not complete the writer, allowing multiple producers or external lifecycle management
- Added matching documentation to both `Sink.cs` and `ChannelSink.cs` for consistency

## Use Cases Clarified
The documentation now clearly explains when to use each setting:
- **`isOwner = true`**: Use when the stream is the sole producer to the channel
- **`isOwner = false`**: Use when multiple streams share the same channel or when external code needs to manage the writer lifecycle

## Testing
This is a documentation-only change. No functional code was modified.

## Related Issues
- Addresses documentation gap reported in Freshdesk support ticket #557