### PR TITLE
Fix race condition in ReliableDeliveryShardingSpec multi-producer test

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/ReliableDeliveryShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/ReliableDeliveryShardingSpec.cs
@@ -569,14 +569,21 @@ public class ReliableDeliveryShardingSpec : TestKit.Xunit2.TestKit
                             _producerController.Tell(new ShardingProducerController.Start<Job>(ctx.Self));
                     }, "sendNextAdapter");
 
-            // simulate fast producer
-            Timers.StartPeriodicTimer("tick", Tick.Instance, TimeSpan.FromMilliseconds(20));
+            // Timer will start when first RequestNext arrives (see Idle method)
         }
 
         private void Idle(int n)
         {
             Receive<Tick>(_ => { }); // ignore
-            Receive<RequestNext>(next => { Become(() => Active(n + 1, next.SendNextTo)); });
+            Receive<RequestNext>(next =>
+            {
+                // Start timer on first RequestNext to avoid race condition
+                // where ticks arrive before producer is ready to send messages
+                if (!Timers.IsTimerActive("tick"))
+                    Timers.StartPeriodicTimer("tick", Tick.Instance, TimeSpan.FromMilliseconds(20));
+
+                Become(() => Active(n + 1, next.SendNextTo));
+            });
         }
 
         private void Active(int n, IActorRef sendTo)

--- a/src/core/Akka.Tests/Delivery/TestConsumer.cs
+++ b/src/core/Akka.Tests/Delivery/TestConsumer.cs
@@ -104,7 +104,7 @@ public sealed class TestConsumer : ReceiveActor, IWithTimers
             // schedule to simulate slower consumer
             Timers.StartSingleTimer(delivery, // have to use a unique-per-message key here, otherwise messages from multiple producers will cancel each other
                 new SomeAsyncJob(delivery.Msg, delivery.ConfirmTo, delivery.ProducerId, delivery.SeqNr),
-                TimeSpan.FromMilliseconds(10));
+                Delay);
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes #7943 - Flaky test: `ReliableDeliveryShardingSpec.ReliableDelivery_with_Sharding_must_illustrate_Sharding_usage_with_several_producers` times out

The test was failing intermittently in CI with a timeout, receiving **0 messages instead of expected 3** within the 5-second timeout period.

## Root Cause: Actor Lifecycle Race Condition

**TestShardingProducer** started its periodic timer (20ms ticks) in `PreStart()` before the actor was ready to process messages:

```csharp
protected override void PreStart()
{
    _sendNextAdapter = Context.ActorOf(...);
    
    // Timer starts immediately, but actor not ready
    Timers.StartPeriodicTimer("tick", Tick.Instance, TimeSpan.FromMilliseconds(20));
}
```

The initialization sequence required:
1. Child actor creation
2. Child actor's `OnPreStart` sends `Start<Job>` to ShardingProducerController
3. Controller processes Start and sends `RequestNext` back
4. Producer receives `RequestNext` and transitions from `Idle` → `Active`

**The Problem**: Timer ticks fired while the actor was stuck in `Idle` state (which ignores ticks), wasting initialization time. With 2 producers, this race was amplified, causing complete initialization failure → 0 messages.

## Changes

### 1. Fix TestShardingProducer Timer Initialization Race
**File**: `src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/ReliableDeliveryShardingSpec.cs`

Moved timer initialization from `PreStart()` to the `Idle()` state handler:

```csharp
private void Idle(int n)
{
    Receive<Tick>(_ => { }); // ignore
    Receive<RequestNext>(next =>
    {
        // Start timer on first RequestNext to avoid race condition
        if (!Timers.IsTimerActive("tick"))
            Timers.StartPeriodicTimer("tick", Tick.Instance, TimeSpan.FromMilliseconds(20));
        
        Become(() => Active(n + 1, next.SendNextTo));
    });
}
```

Now the timer only starts when the producer is fully initialized and ready to send messages.

### 2. Fix TestConsumer Hardcoded Delay Bug
**File**: `src/core/Akka.Tests/Delivery/TestConsumer.cs`

Changed hardcoded 10ms delay to use the configured `Delay` field:

```csharp
// Before:
Timers.StartSingleTimer(delivery, msg, TimeSpan.FromMilliseconds(10));

// After:
Timers.StartSingleTimer(delivery, msg, Delay);
```

This allows tests to properly configure consumer processing speed.

## Test Results

✅ **Flaky test**: `ReliableDelivery_with_Sharding_must_illustrate_Sharding_usage_with_several_producers` - **PASSED**  
✅ **All ReliableDeliveryShardingSpec tests** (8 tests) - **PASSED**  
✅ **All ConsumerControllerSpecs tests** (19 tests) - **PASSED**

The fix eliminates the race condition while maintaining backward compatibility with all existing tests.