### PR TITLE
fix: Eliminate race condition in Log_dead_letters test

### DIFF
--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -117,13 +117,24 @@ namespace Akka.Tests.Actor
 
             try
             {
+                var testKit = new TestKit.Xunit2.TestKit(sys);
+                var probe = testKit.CreateTestProbe();
                 var a = sys.ActorOf(Props.Create<Terminater>());
 
-                var eventFilter = new EventFilterFactory(new TestKit.Xunit2.TestKit(sys));
-                await eventFilter.Info(contains: "not delivered").ExpectAsync(1, () => {
+                // Watch for actor termination to ensure proper synchronization
+                await probe.WatchAsync(a);
+
+                var eventFilter = new EventFilterFactory(testKit);
+                await eventFilter.Info(contains: "not delivered").ExpectAsync(1, async () => {
+                    // Tell the actor to stop
                     a.Tell("run");
+
+                    // Wait for the actor to fully terminate - this ensures the mailbox
+                    // is swapped to DeadLetterMailbox before we send the next message
+                    await probe.ExpectTerminatedAsync(a);
+
+                    // Now send the message that should become a dead letter
                     a.Tell("boom");
-                    return Task.CompletedTask;
                 });
             }
             finally { Shutdown(sys); }


### PR DESCRIPTION
## Summary
- Fix race condition in `ActorSystemSpec.Log_dead_letters` test
- Use death watch synchronization (`WatchAsync`/`ExpectTerminatedAsync`) to ensure actor is fully terminated before sending the message expected to become a dead letter

## Test plan
- [x] Verified test passes consistently (10/10 runs)
- [x] Build succeeds with no warnings