### PR TITLE
Backport: feat(persistence): completion callbacks via Defer

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -7,12 +7,6 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Persistence
 {
-    public sealed class AsyncHandlerInvocation : Akka.Persistence.IPendingHandlerInvocation
-    {
-        public AsyncHandlerInvocation(object evt, System.Action<object> handler) { }
-        public object Event { get; }
-        public System.Action<object> Handler { get; }
-    }
     public abstract class AtLeastOnceDeliveryActor : Akka.Persistence.PersistentActor
     {
         protected AtLeastOnceDeliveryActor() { }
@@ -246,6 +240,7 @@ namespace Akka.Persistence
         public override void AroundPreStart() { }
         protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         public void DeferAsync<TEvent>(TEvent evt, System.Action<TEvent> handler) { }
+        public void DeferAsync<TEvent>(TEvent evt, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void DeleteMessages(long toSequenceNr) { }
         public void DeleteSnapshot(long sequenceNr) { }
         public void DeleteSnapshots(Akka.Persistence.SnapshotSelectionCriteria criteria) { }
@@ -255,9 +250,21 @@ namespace Akka.Persistence
         protected virtual void OnRecoveryFailure(System.Exception reason, object message = null) { }
         protected virtual void OnReplaySuccess() { }
         public void Persist<TEvent>(TEvent @event, System.Action<TEvent> handler) { }
+        public void Persist<TEvent>(TEvent @event, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Action onComplete) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Action onComplete) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Action onComplete) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Action onComplete) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
         public void PersistAsync<TEvent>(TEvent @event, System.Action<TEvent> handler) { }
+        public void PersistAsync<TEvent>(TEvent @event, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         protected abstract bool ReceiveCommand(object message);
         protected abstract bool ReceiveRecover(object message);
         protected void RunTask(System.Func<System.Threading.Tasks.Task> action) { }
@@ -272,11 +279,6 @@ namespace Akka.Persistence
     }
     public interface IJournalRequest : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IPersistenceMessage { }
     public interface IJournalResponse : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IPersistenceMessage { }
-    public interface IPendingHandlerInvocation
-    {
-        object Event { get; }
-        System.Action<object> Handler { get; }
-    }
     public interface IPersistenceMessage : Akka.Actor.INoSerializationVerificationNeeded { }
     public interface IPersistenceRecovery
     {
@@ -675,12 +677,6 @@ namespace Akka.Persistence
         public SnapshotStoreHealthCheckResponse(Akka.Persistence.PersistenceHealthCheckResult result) { }
         public Akka.Persistence.PersistenceHealthCheckResult Result { get; }
         public override string ToString() { }
-    }
-    public sealed class StashingHandlerInvocation : Akka.Persistence.IPendingHandlerInvocation
-    {
-        public StashingHandlerInvocation(object evt, System.Action<object> handler) { }
-        public object Event { get; }
-        public System.Action<object> Handler { get; }
     }
     public sealed class ThrowExceptionConfigurator : Akka.Persistence.IStashOverflowStrategyConfigurator
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -7,12 +7,6 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Persistence
 {
-    public sealed class AsyncHandlerInvocation : Akka.Persistence.IPendingHandlerInvocation
-    {
-        public AsyncHandlerInvocation(object evt, System.Action<object> handler) { }
-        public object Event { get; }
-        public System.Action<object> Handler { get; }
-    }
     public abstract class AtLeastOnceDeliveryActor : Akka.Persistence.PersistentActor
     {
         protected AtLeastOnceDeliveryActor() { }
@@ -246,6 +240,7 @@ namespace Akka.Persistence
         public override void AroundPreStart() { }
         protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         public void DeferAsync<TEvent>(TEvent evt, System.Action<TEvent> handler) { }
+        public void DeferAsync<TEvent>(TEvent evt, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void DeleteMessages(long toSequenceNr) { }
         public void DeleteSnapshot(long sequenceNr) { }
         public void DeleteSnapshots(Akka.Persistence.SnapshotSelectionCriteria criteria) { }
@@ -255,9 +250,21 @@ namespace Akka.Persistence
         protected virtual void OnRecoveryFailure(System.Exception reason, object message = null) { }
         protected virtual void OnReplaySuccess() { }
         public void Persist<TEvent>(TEvent @event, System.Action<TEvent> handler) { }
+        public void Persist<TEvent>(TEvent @event, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Action onComplete) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Action onComplete) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Action onComplete) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Action onComplete) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
         public void PersistAsync<TEvent>(TEvent @event, System.Action<TEvent> handler) { }
+        public void PersistAsync<TEvent>(TEvent @event, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         protected abstract bool ReceiveCommand(object message);
         protected abstract bool ReceiveRecover(object message);
         protected void RunTask(System.Func<System.Threading.Tasks.Task> action) { }
@@ -272,11 +279,6 @@ namespace Akka.Persistence
     }
     public interface IJournalRequest : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IPersistenceMessage { }
     public interface IJournalResponse : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IPersistenceMessage { }
-    public interface IPendingHandlerInvocation
-    {
-        object Event { get; }
-        System.Action<object> Handler { get; }
-    }
     public interface IPersistenceMessage : Akka.Actor.INoSerializationVerificationNeeded { }
     public interface IPersistenceRecovery
     {
@@ -674,12 +676,6 @@ namespace Akka.Persistence
         public SnapshotStoreHealthCheckResponse(Akka.Persistence.PersistenceHealthCheckResult result) { }
         public Akka.Persistence.PersistenceHealthCheckResult Result { get; }
         public override string ToString() { }
-    }
-    public sealed class StashingHandlerInvocation : Akka.Persistence.IPendingHandlerInvocation
-    {
-        public StashingHandlerInvocation(object evt, System.Action<object> handler) { }
-        public object Event { get; }
-        public System.Action<object> Handler { get; }
     }
     public sealed class ThrowExceptionConfigurator : Akka.Persistence.IStashOverflowStrategyConfigurator
     {

--- a/src/core/Akka.Persistence.Tests/PersistenceCompletionCallbackSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceCompletionCallbackSpec.cs
@@ -1,0 +1,886 @@
+//-----------------------------------------------------------------------
+// <copyright file="PersistenceCompletionCallbackSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Akka.Persistence.Tests
+{
+    /// <summary>
+    /// Tests for persistence completion callbacks and async handler support.
+    /// </summary>
+    public class PersistenceCompletionCallbackSpec : PersistenceSpec
+    {
+        public PersistenceCompletionCallbackSpec(ITestOutputHelper output)
+            : base(Configuration("PersistenceCompletionCallbackSpec"), output)
+        {
+        }
+
+        #region Test Actors
+
+        private class TestEvent
+        {
+            public string Data { get; }
+            public TestEvent(string data) => Data = data;
+        }
+
+        private class GetEvents
+        {
+            public static readonly GetEvents Instance = new();
+            private GetEvents() { }
+        }
+
+        private class GetCompletionOrder
+        {
+            public static readonly GetCompletionOrder Instance = new();
+            private GetCompletionOrder() { }
+        }
+
+        /// <summary>
+        /// Actor that tests PersistAll with sync completion callback
+        /// </summary>
+        private class PersistAllWithCompletionActor : UntypedPersistentActor
+        {
+            private readonly List<string> _events = new();
+            private readonly List<string> _completionOrder = new();
+            private readonly IActorRef _probe;
+
+            public override string PersistenceId { get; }
+
+            public PersistAllWithCompletionActor(string persistenceId, IActorRef probe)
+            {
+                PersistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override void OnRecover(object message)
+            {
+                if (message is TestEvent evt)
+                    _events.Add(evt.Data);
+            }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message)
+                {
+                    case string[] events:
+                        var testEvents = new List<TestEvent>();
+                        foreach (var e in events)
+                            testEvents.Add(new TestEvent(e));
+
+                        PersistAll(testEvents, evt =>
+                        {
+                            _events.Add(evt.Data);
+                            _completionOrder.Add($"handler:{evt.Data}");
+                        }, () =>
+                        {
+                            _completionOrder.Add("completion");
+                            _probe.Tell("completed");
+                        });
+                        break;
+
+                    case GetEvents:
+                        Sender.Tell(_events.ToArray());
+                        break;
+
+                    case GetCompletionOrder:
+                        Sender.Tell(_completionOrder.ToArray());
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Actor that tests PersistAll with async completion callback
+        /// </summary>
+        private class PersistAllWithAsyncCompletionActor : UntypedPersistentActor
+        {
+            private readonly List<string> _events = new();
+            private readonly List<string> _completionOrder = new();
+            private readonly IActorRef _probe;
+
+            public override string PersistenceId { get; }
+
+            public PersistAllWithAsyncCompletionActor(string persistenceId, IActorRef probe)
+            {
+                PersistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override void OnRecover(object message)
+            {
+                if (message is TestEvent evt)
+                    _events.Add(evt.Data);
+            }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message)
+                {
+                    case string[] events:
+                        var testEvents = new List<TestEvent>();
+                        foreach (var e in events)
+                            testEvents.Add(new TestEvent(e));
+
+                        PersistAll(testEvents, evt =>
+                        {
+                            _events.Add(evt.Data);
+                            _completionOrder.Add($"handler:{evt.Data}");
+                        }, async () =>
+                        {
+                            await Task.Delay(10);
+                            _completionOrder.Add("async-completion");
+                            _probe.Tell("completed");
+                        });
+                        break;
+
+                    case GetEvents:
+                        Sender.Tell(_events.ToArray());
+                        break;
+
+                    case GetCompletionOrder:
+                        Sender.Tell(_completionOrder.ToArray());
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Actor that tests PersistAllAsync with sync completion callback
+        /// </summary>
+        private class PersistAllAsyncWithCompletionActor : UntypedPersistentActor
+        {
+            private readonly List<string> _events = new();
+            private readonly List<string> _completionOrder = new();
+            private readonly IActorRef _probe;
+
+            public override string PersistenceId { get; }
+
+            public PersistAllAsyncWithCompletionActor(string persistenceId, IActorRef probe)
+            {
+                PersistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override void OnRecover(object message)
+            {
+                if (message is TestEvent evt)
+                    _events.Add(evt.Data);
+            }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message)
+                {
+                    case string[] events:
+                        var testEvents = new List<TestEvent>();
+                        foreach (var e in events)
+                            testEvents.Add(new TestEvent(e));
+
+                        PersistAllAsync(testEvents, evt =>
+                        {
+                            _events.Add(evt.Data);
+                            _completionOrder.Add($"handler:{evt.Data}");
+                        }, () =>
+                        {
+                            _completionOrder.Add("completion");
+                            _probe.Tell("completed");
+                        });
+                        break;
+
+                    case GetEvents:
+                        Sender.Tell(_events.ToArray());
+                        break;
+
+                    case GetCompletionOrder:
+                        Sender.Tell(_completionOrder.ToArray());
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Actor that tests Persist with async handler
+        /// </summary>
+        private class PersistWithAsyncHandlerActor : UntypedPersistentActor
+        {
+            private readonly List<string> _events = new();
+            private readonly List<string> _completionOrder = new();
+            private readonly IActorRef _probe;
+
+            public override string PersistenceId { get; }
+
+            public PersistWithAsyncHandlerActor(string persistenceId, IActorRef probe)
+            {
+                PersistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override void OnRecover(object message)
+            {
+                if (message is TestEvent evt)
+                    _events.Add(evt.Data);
+            }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message)
+                {
+                    case string eventData:
+                        Persist(new TestEvent(eventData), async evt =>
+                        {
+                            await Task.Delay(10);
+                            _events.Add(evt.Data);
+                            _completionOrder.Add($"async-handler:{evt.Data}");
+                            _probe.Tell("handled");
+                        });
+                        break;
+
+                    case GetEvents:
+                        Sender.Tell(_events.ToArray());
+                        break;
+
+                    case GetCompletionOrder:
+                        Sender.Tell(_completionOrder.ToArray());
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Actor that tests PersistAsync with async handler
+        /// </summary>
+        private class PersistAsyncWithAsyncHandlerActor : UntypedPersistentActor
+        {
+            private readonly List<string> _events = new();
+            private readonly List<string> _completionOrder = new();
+            private readonly IActorRef _probe;
+
+            public override string PersistenceId { get; }
+
+            public PersistAsyncWithAsyncHandlerActor(string persistenceId, IActorRef probe)
+            {
+                PersistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override void OnRecover(object message)
+            {
+                if (message is TestEvent evt)
+                    _events.Add(evt.Data);
+            }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message)
+                {
+                    case string eventData:
+                        PersistAsync(new TestEvent(eventData), async evt =>
+                        {
+                            await Task.Delay(10);
+                            _events.Add(evt.Data);
+                            _completionOrder.Add($"async-handler:{evt.Data}");
+                            _probe.Tell("handled");
+                        });
+                        break;
+
+                    case GetEvents:
+                        Sender.Tell(_events.ToArray());
+                        break;
+
+                    case GetCompletionOrder:
+                        Sender.Tell(_completionOrder.ToArray());
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Actor that tests DeferAsync with async handler
+        /// </summary>
+        private class DeferAsyncWithAsyncHandlerActor : UntypedPersistentActor
+        {
+            private readonly List<string> _events = new();
+            private readonly List<string> _completionOrder = new();
+            private readonly IActorRef _probe;
+
+            public override string PersistenceId { get; }
+
+            public DeferAsyncWithAsyncHandlerActor(string persistenceId, IActorRef probe)
+            {
+                PersistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override void OnRecover(object message)
+            {
+                if (message is TestEvent evt)
+                    _events.Add(evt.Data);
+            }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message)
+                {
+                    case string[] events:
+                        // First persist events, then defer async
+                        var testEvents = new List<TestEvent>();
+                        foreach (var e in events)
+                            testEvents.Add(new TestEvent(e));
+
+                        PersistAllAsync(testEvents, evt =>
+                        {
+                            _events.Add(evt.Data);
+                            _completionOrder.Add($"handler:{evt.Data}");
+                        });
+
+                        DeferAsync("deferred", async _ =>
+                        {
+                            await Task.Delay(10);
+                            _completionOrder.Add("async-deferred");
+                            _probe.Tell("deferred");
+                        });
+                        break;
+
+                    case GetEvents:
+                        Sender.Tell(_events.ToArray());
+                        break;
+
+                    case GetCompletionOrder:
+                        Sender.Tell(_completionOrder.ToArray());
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Actor that tests PersistAll with async handlers
+        /// </summary>
+        private class PersistAllWithAsyncHandlerActor : UntypedPersistentActor
+        {
+            private readonly List<string> _events = new();
+            private readonly List<string> _completionOrder = new();
+            private readonly IActorRef _probe;
+
+            public override string PersistenceId { get; }
+
+            public PersistAllWithAsyncHandlerActor(string persistenceId, IActorRef probe)
+            {
+                PersistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override void OnRecover(object message)
+            {
+                if (message is TestEvent evt)
+                    _events.Add(evt.Data);
+            }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message)
+                {
+                    case string[] events:
+                        var testEvents = new List<TestEvent>();
+                        foreach (var e in events)
+                            testEvents.Add(new TestEvent(e));
+
+                        PersistAll(testEvents, async evt =>
+                        {
+                            await Task.Delay(10);
+                            _events.Add(evt.Data);
+                            _completionOrder.Add($"async-handler:{evt.Data}");
+                        }, () =>
+                        {
+                            _completionOrder.Add("completion");
+                            _probe.Tell("completed");
+                        });
+                        break;
+
+                    case GetEvents:
+                        Sender.Tell(_events.ToArray());
+                        break;
+
+                    case GetCompletionOrder:
+                        Sender.Tell(_completionOrder.ToArray());
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Actor that tests stashing behavior - commands should be stashed during PersistAll
+        /// </summary>
+        private class StashingBehaviorTestActor : UntypedPersistentActor
+        {
+            private readonly List<string> _commandOrder = new();
+            private readonly IActorRef _probe;
+
+            public override string PersistenceId { get; }
+
+            public StashingBehaviorTestActor(string persistenceId, IActorRef probe)
+            {
+                PersistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override void OnRecover(object message) { }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message)
+                {
+                    case "persist":
+                        _commandOrder.Add("persist-start");
+                        PersistAll(new[] { new TestEvent("a"), new TestEvent("b") }, evt =>
+                        {
+                            _commandOrder.Add($"handler:{evt.Data}");
+                        }, () =>
+                        {
+                            _commandOrder.Add("completion");
+                        });
+                        _commandOrder.Add("persist-end");
+                        break;
+
+                    case "other":
+                        _commandOrder.Add("other-command");
+                        _probe.Tell("other-processed");
+                        break;
+
+                    case "get-order":
+                        Sender.Tell(_commandOrder.ToArray());
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Actor that tests sequential persist operations to verify ordering is maintained
+        /// even when empty events are involved
+        /// </summary>
+        private class SequentialPersistOrderingActor : UntypedPersistentActor
+        {
+            private readonly List<string> _executionOrder = new();
+            private readonly IActorRef _probe;
+
+            public override string PersistenceId { get; }
+
+            public SequentialPersistOrderingActor(string persistenceId, IActorRef probe)
+            {
+                PersistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override void OnRecover(object message) { }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message)
+                {
+                    // Test: Persist followed by PersistAll with empty events
+                    // The empty PersistAll completion should run AFTER the Persist handler
+                    case "persist-then-empty":
+                        Persist(new TestEvent("first"), evt =>
+                        {
+                            _executionOrder.Add($"persist-handler:{evt.Data}");
+                        });
+                        PersistAll(Array.Empty<TestEvent>(), _ => { }, () =>
+                        {
+                            _executionOrder.Add("empty-completion");
+                            _probe.Tell("done");
+                        });
+                        break;
+
+                    // Test: Multiple PersistAll calls where middle one is empty
+                    case "persist-empty-persist":
+                        PersistAll(new[] { new TestEvent("first") }, evt =>
+                        {
+                            _executionOrder.Add($"first-handler:{evt.Data}");
+                        }, () =>
+                        {
+                            _executionOrder.Add("first-completion");
+                        });
+                        PersistAll(Array.Empty<TestEvent>(), _ => { }, () =>
+                        {
+                            _executionOrder.Add("empty-completion");
+                        });
+                        PersistAll(new[] { new TestEvent("last") }, evt =>
+                        {
+                            _executionOrder.Add($"last-handler:{evt.Data}");
+                        }, () =>
+                        {
+                            _executionOrder.Add("last-completion");
+                            _probe.Tell("done");
+                        });
+                        break;
+
+                    case "get-order":
+                        Sender.Tell(_executionOrder.ToArray());
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Actor that tests empty event list with various completion callback overloads
+        /// </summary>
+        private class EmptyEventsWithCompletionActor : UntypedPersistentActor
+        {
+            private readonly IActorRef _probe;
+            private bool _completionCalled;
+
+            public override string PersistenceId { get; }
+
+            public EmptyEventsWithCompletionActor(string persistenceId, IActorRef probe)
+            {
+                PersistenceId = persistenceId;
+                _probe = probe;
+            }
+
+            protected override void OnRecover(object message) { }
+
+            protected override void OnCommand(object message)
+            {
+                switch (message)
+                {
+                    // PersistAll with sync completion callback
+                    case "persist-empty-sync":
+                        PersistAll(Array.Empty<TestEvent>(), _ => { }, () =>
+                        {
+                            _completionCalled = true;
+                            _probe.Tell("completed");
+                        });
+                        break;
+
+                    // PersistAll with async completion callback
+                    case "persist-empty-async":
+                        PersistAll(Array.Empty<TestEvent>(), _ => { }, async () =>
+                        {
+                            await Task.Yield();
+                            _completionCalled = true;
+                            _probe.Tell("completed");
+                        });
+                        break;
+
+                    // PersistAllAsync with sync completion callback
+                    case "persist-async-empty-sync":
+                        PersistAllAsync(Array.Empty<TestEvent>(), _ => { }, () =>
+                        {
+                            _completionCalled = true;
+                            _probe.Tell("completed");
+                        });
+                        break;
+
+                    // PersistAllAsync with async completion callback
+                    case "persist-async-empty-async":
+                        PersistAllAsync(Array.Empty<TestEvent>(), _ => { }, async () =>
+                        {
+                            await Task.Yield();
+                            _completionCalled = true;
+                            _probe.Tell("completed");
+                        });
+                        break;
+
+                    case "check":
+                        Sender.Tell(_completionCalled);
+                        break;
+
+                    case "reset":
+                        _completionCalled = false;
+                        Sender.Tell("reset-done");
+                        break;
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests
+
+        [Fact(DisplayName = "PersistAll with sync completion callback should invoke callback after all handlers")]
+        public async Task PersistAll_WithSyncCompletion_Should_InvokeAfterAllHandlers()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new PersistAllWithCompletionActor(Name, probe)));
+
+            actor.Tell(new[] { "event1", "event2", "event3" });
+            await probe.ExpectMsgAsync("completed");
+
+            actor.Tell(GetCompletionOrder.Instance);
+            var order = await ExpectMsgAsync<string[]>();
+
+            order.Should().BeEquivalentTo(new[]
+            {
+                "handler:event1",
+                "handler:event2",
+                "handler:event3",
+                "completion"
+            }, options => options.WithStrictOrdering());
+        }
+
+        [Fact(DisplayName = "PersistAll with async completion callback should invoke callback after all handlers")]
+        public async Task PersistAll_WithAsyncCompletion_Should_InvokeAfterAllHandlers()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new PersistAllWithAsyncCompletionActor(Name, probe)));
+
+            actor.Tell(new[] { "event1", "event2", "event3" });
+            await probe.ExpectMsgAsync("completed");
+
+            actor.Tell(GetCompletionOrder.Instance);
+            var order = await ExpectMsgAsync<string[]>();
+
+            order.Should().BeEquivalentTo(new[]
+            {
+                "handler:event1",
+                "handler:event2",
+                "handler:event3",
+                "async-completion"
+            }, options => options.WithStrictOrdering());
+        }
+
+        [Fact(DisplayName = "PersistAllAsync with sync completion callback should invoke callback after all handlers")]
+        public async Task PersistAllAsync_WithSyncCompletion_Should_InvokeAfterAllHandlers()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new PersistAllAsyncWithCompletionActor(Name, probe)));
+
+            actor.Tell(new[] { "event1", "event2", "event3" });
+            await probe.ExpectMsgAsync("completed");
+
+            actor.Tell(GetCompletionOrder.Instance);
+            var order = await ExpectMsgAsync<string[]>();
+
+            order.Should().BeEquivalentTo(new[]
+            {
+                "handler:event1",
+                "handler:event2",
+                "handler:event3",
+                "completion"
+            }, options => options.WithStrictOrdering());
+        }
+
+        [Fact(DisplayName = "Persist with async handler should execute handler asynchronously")]
+        public async Task Persist_WithAsyncHandler_Should_ExecuteAsynchronously()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new PersistWithAsyncHandlerActor(Name, probe)));
+
+            actor.Tell("event1");
+            await probe.ExpectMsgAsync("handled");
+
+            actor.Tell(GetCompletionOrder.Instance);
+            var order = await ExpectMsgAsync<string[]>();
+
+            order.Should().Contain("async-handler:event1");
+        }
+
+        [Fact(DisplayName = "PersistAsync with async handler should execute handler asynchronously")]
+        public async Task PersistAsync_WithAsyncHandler_Should_ExecuteAsynchronously()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new PersistAsyncWithAsyncHandlerActor(Name, probe)));
+
+            actor.Tell("event1");
+            await probe.ExpectMsgAsync("handled");
+
+            actor.Tell(GetCompletionOrder.Instance);
+            var order = await ExpectMsgAsync<string[]>();
+
+            order.Should().Contain("async-handler:event1");
+        }
+
+        [Fact(DisplayName = "DeferAsync with async handler should execute after pending invocations")]
+        public async Task DeferAsync_WithAsyncHandler_Should_ExecuteAfterPending()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new DeferAsyncWithAsyncHandlerActor(Name, probe)));
+
+            actor.Tell(new[] { "event1", "event2" });
+            await probe.ExpectMsgAsync("deferred");
+
+            actor.Tell(GetCompletionOrder.Instance);
+            var order = await ExpectMsgAsync<string[]>();
+
+            order.Should().BeEquivalentTo(new[]
+            {
+                "handler:event1",
+                "handler:event2",
+                "async-deferred"
+            }, options => options.WithStrictOrdering());
+        }
+
+        [Fact(DisplayName = "PersistAll with async handlers should execute handlers and completion in order")]
+        public async Task PersistAll_WithAsyncHandlers_Should_ExecuteInOrder()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new PersistAllWithAsyncHandlerActor(Name, probe)));
+
+            actor.Tell(new[] { "event1", "event2" });
+            await probe.ExpectMsgAsync("completed");
+
+            actor.Tell(GetCompletionOrder.Instance);
+            var order = await ExpectMsgAsync<string[]>();
+
+            order.Should().BeEquivalentTo(new[]
+            {
+                "async-handler:event1",
+                "async-handler:event2",
+                "completion"
+            }, options => options.WithStrictOrdering());
+        }
+
+        [Fact(DisplayName = "PersistAll should stash commands until completion callback finishes")]
+        public async Task PersistAll_Should_StashCommandsUntilCompletion()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new StashingBehaviorTestActor(Name, probe)));
+
+            // Send persist command followed immediately by another command
+            actor.Tell("persist");
+            actor.Tell("other");
+
+            // Wait for the other command to be processed (after completion)
+            await probe.ExpectMsgAsync("other-processed");
+
+            actor.Tell("get-order");
+            var order = await ExpectMsgAsync<string[]>();
+
+            // The "other" command should be processed after the completion callback
+            order.Should().BeEquivalentTo(new[]
+            {
+                "persist-start",
+                "persist-end",
+                "handler:a",
+                "handler:b",
+                "completion",
+                "other-command"
+            }, options => options.WithStrictOrdering());
+        }
+
+        [Fact(DisplayName = "PersistAll with empty events and sync completion should invoke completion callback immediately")]
+        public async Task PersistAll_WithEmptyEvents_SyncCompletion_Should_InvokeCompletionImmediately()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new EmptyEventsWithCompletionActor(Name, probe)));
+
+            actor.Tell("persist-empty-sync");
+            await probe.ExpectMsgAsync("completed");
+
+            actor.Tell("check");
+            var completionCalled = await ExpectMsgAsync<bool>();
+            completionCalled.Should().BeTrue();
+        }
+
+        [Fact(DisplayName = "PersistAll with empty events and async completion should invoke completion callback immediately")]
+        public async Task PersistAll_WithEmptyEvents_AsyncCompletion_Should_InvokeCompletionImmediately()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new EmptyEventsWithCompletionActor(Name, probe)));
+
+            actor.Tell("persist-empty-async");
+            await probe.ExpectMsgAsync("completed");
+
+            actor.Tell("check");
+            var completionCalled = await ExpectMsgAsync<bool>();
+            completionCalled.Should().BeTrue();
+        }
+
+        [Fact(DisplayName = "PersistAllAsync with empty events and sync completion should invoke completion callback immediately")]
+        public async Task PersistAllAsync_WithEmptyEvents_SyncCompletion_Should_InvokeCompletionImmediately()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new EmptyEventsWithCompletionActor(Name, probe)));
+
+            actor.Tell("persist-async-empty-sync");
+            await probe.ExpectMsgAsync("completed");
+
+            actor.Tell("check");
+            var completionCalled = await ExpectMsgAsync<bool>();
+            completionCalled.Should().BeTrue();
+        }
+
+        [Fact(DisplayName = "PersistAllAsync with empty events and async completion should invoke completion callback immediately")]
+        public async Task PersistAllAsync_WithEmptyEvents_AsyncCompletion_Should_InvokeCompletionImmediately()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new EmptyEventsWithCompletionActor(Name, probe)));
+
+            actor.Tell("persist-async-empty-async");
+            await probe.ExpectMsgAsync("completed");
+
+            actor.Tell("check");
+            var completionCalled = await ExpectMsgAsync<bool>();
+            completionCalled.Should().BeTrue();
+        }
+
+        [Fact(DisplayName = "Persist followed by PersistAll with empty events should maintain execution order")]
+        public async Task Persist_ThenEmptyPersistAll_Should_MaintainOrder()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new SequentialPersistOrderingActor(Name, probe)));
+
+            actor.Tell("persist-then-empty");
+            await probe.ExpectMsgAsync("done");
+
+            actor.Tell("get-order");
+            var order = await ExpectMsgAsync<string[]>();
+
+            // The empty PersistAll completion must run AFTER the Persist handler
+            order.Should().BeEquivalentTo(new[]
+            {
+                "persist-handler:first",
+                "empty-completion"
+            }, options => options.WithStrictOrdering());
+        }
+
+        [Fact(DisplayName = "Sequential PersistAll with empty events in middle should maintain execution order")]
+        public async Task SequentialPersistAll_WithEmptyInMiddle_Should_MaintainOrder()
+        {
+            var probe = CreateTestProbe();
+            var actor = ActorOf(Props.Create(() =>
+                new SequentialPersistOrderingActor(Name, probe)));
+
+            actor.Tell("persist-empty-persist");
+            await probe.ExpectMsgAsync("done");
+
+            actor.Tell("get-order");
+            var order = await ExpectMsgAsync<string[]>();
+
+            // All callbacks should execute in the order they were queued
+            order.Should().BeEquivalentTo(new[]
+            {
+                "first-handler:first",
+                "first-completion",
+                "empty-completion",
+                "last-handler:last",
+                "last-completion"
+            }, options => options.WithStrictOrdering());
+        }
+
+        #endregion
+    }
+}

--- a/src/core/Akka.Persistence/Eventsourced.Recovery.cs
+++ b/src/core/Akka.Persistence/Eventsourced.Recovery.cs
@@ -383,7 +383,7 @@ namespace Akka.Persistence
                     // enables an early return to `processingCommands`, because if this counter hits `0`,
                     // we know the remaining pendingInvocations are all `persistAsync` created, which
                     // means we can go back to processing commands also - and these callbacks will be called as soon as possible
-                    if (invocation is StashingHandlerInvocation)
+                    if (invocation is IStashingInvocation)
                         _pendingStashingPersistInvocations--;
 
                     if (_pendingStashingPersistInvocations == 0)
@@ -398,15 +398,54 @@ namespace Akka.Persistence
             });
         }
 
-        private void PeekApplyHandler(object payload)
+        /// <summary>
+        /// Applies the handler for the first pending invocation.
+        /// For sync handlers, invokes directly. For async handlers, uses RunTask.
+        /// </summary>
+        /// <param name="payload">The event payload to pass to the handler.</param>
+        /// <param name="onComplete">Callback invoked when the handler completes (true if error).</param>
+        private void PeekApplyHandler(object payload, Action<bool> onComplete)
         {
-            try
+            var invocation = _pendingInvocations.First.Value;
+
+            if (invocation is IAsyncHandlerInvocation asyncInv)
             {
-                _pendingInvocations.First.Value.Handler(payload);
+                // Async handler - run via RunTask
+                RunTask(async () =>
+                {
+                    try
+                    {
+                        await asyncInv.AsyncHandler(payload);
+                        onComplete(false);
+                    }
+                    catch
+                    {
+                        onComplete(true);
+                        throw;
+                    }
+                    finally
+                    {
+                        FlushBatch();
+                    }
+                });
             }
-            finally
+            else if (invocation is ISyncHandlerInvocation syncInv)
             {
-                FlushBatch();
+                // Sync handler - invoke directly
+                try
+                {
+                    syncInv.Handler(payload);
+                    onComplete(false);
+                }
+                catch
+                {
+                    onComplete(true);
+                    throw;
+                }
+                finally
+                {
+                    FlushBatch();
+                }
             }
         }
 
@@ -421,16 +460,7 @@ namespace Akka.Persistence
                     if (m1.ActorInstanceId == _instanceId)
                     {
                         UpdateLastSequenceNr(m1.Persistent);
-                        try
-                        {
-                            PeekApplyHandler(m1.Persistent.Payload);
-                            onWriteMessageComplete(false);
-                        }
-                        catch
-                        {
-                            onWriteMessageComplete(true);
-                            throw;
-                        }
+                        PeekApplyHandler(m1.Persistent.Payload, onWriteMessageComplete);
                     }
 
                     break;
@@ -469,16 +499,7 @@ namespace Akka.Persistence
                 {
                     if (m.ActorInstanceId == _instanceId)
                     {
-                        try
-                        {
-                            PeekApplyHandler(m.Message);
-                            onWriteMessageComplete(false);
-                        }
-                        catch (Exception)
-                        {
-                            onWriteMessageComplete(true);
-                            throw;
-                        }
+                        PeekApplyHandler(m.Message, onWriteMessageComplete);
                     }
 
                     break;

--- a/src/core/Akka.Persistence/Eventsourced.cs
+++ b/src/core/Akka.Persistence/Eventsourced.cs
@@ -16,16 +16,43 @@ using System.Threading.Tasks;
 
 namespace Akka.Persistence
 {
-    public interface IPendingHandlerInvocation
+    /// <summary>
+    /// Base interface for pending handler invocations.
+    /// </summary>
+    internal interface IPendingHandlerInvocation
     {
         object Event { get; }
+    }
+
+    /// <summary>
+    /// Interface for invocations with synchronous handlers.
+    /// </summary>
+    internal interface ISyncHandlerInvocation : IPendingHandlerInvocation
+    {
         Action<object> Handler { get; }
     }
 
     /// <summary>
-    /// Forces actor to stash incoming commands until all invocations are handled.
+    /// Interface for invocations with asynchronous handlers.
     /// </summary>
-    public sealed class StashingHandlerInvocation : IPendingHandlerInvocation
+    internal interface IAsyncHandlerInvocation : IPendingHandlerInvocation
+    {
+        Func<object, Task> AsyncHandler { get; }
+    }
+
+    /// <summary>
+    /// Marker interface for stashing invocations that increment the stashing counter.
+    /// </summary>
+    internal interface IStashingInvocation : IPendingHandlerInvocation
+    {
+    }
+
+    /// <summary>
+    /// Forces actor to stash incoming commands until all invocations are handled.
+    /// Used by <see cref="Eventsourced.Persist{TEvent}(TEvent,Action{TEvent})"/> and
+    /// <see cref="Eventsourced.PersistAll{TEvent}(IEnumerable{TEvent},Action{TEvent})"/>.
+    /// </summary>
+    internal sealed class StashingHandlerInvocation : ISyncHandlerInvocation, IStashingInvocation
     {
         public StashingHandlerInvocation(object evt, Action<object> handler)
         {
@@ -34,16 +61,32 @@ namespace Akka.Persistence
         }
 
         public object Event { get; }
-
         public Action<object> Handler { get; }
+    }
+
+    /// <summary>
+    /// Stashing invocation with an asynchronous handler.
+    /// Used by <see cref="Eventsourced.Persist{TEvent}(TEvent,Func{TEvent,Task})"/> and
+    /// <see cref="Eventsourced.PersistAll{TEvent}(IEnumerable{TEvent},Func{TEvent,Task})"/>.
+    /// </summary>
+    internal sealed class StashingAsyncHandlerInvocation : IAsyncHandlerInvocation, IStashingInvocation
+    {
+        public StashingAsyncHandlerInvocation(object evt, Func<object, Task> asyncHandler)
+        {
+            Event = evt;
+            AsyncHandler = asyncHandler;
+        }
+
+        public object Event { get; }
+        public Func<object, Task> AsyncHandler { get; }
     }
 
     /// <summary>
     /// Unlike <see cref="StashingHandlerInvocation"/> this one does not force actor to stash commands.
     /// Originates from <see cref="Eventsourced.PersistAsync{TEvent}(TEvent,Action{TEvent})"/>
-    /// or <see cref="Eventsourced.DeferAsync{TEvent}"/> method calls.
+    /// or <see cref="Eventsourced.DeferAsync{TEvent}(TEvent,Action{TEvent})"/> method calls.
     /// </summary>
-    public sealed class AsyncHandlerInvocation : IPendingHandlerInvocation
+    internal sealed class AsyncHandlerInvocation : ISyncHandlerInvocation
     {
         public AsyncHandlerInvocation(object evt, Action<object> handler)
         {
@@ -52,8 +95,24 @@ namespace Akka.Persistence
         }
 
         public object Event { get; }
-
         public Action<object> Handler { get; }
+    }
+
+    /// <summary>
+    /// Non-stashing invocation with an asynchronous handler.
+    /// Used by <see cref="Eventsourced.PersistAsync{TEvent}(TEvent,Func{TEvent,Task})"/> and
+    /// <see cref="Eventsourced.DeferAsync{TEvent}(TEvent,Func{TEvent,Task})"/>.
+    /// </summary>
+    internal sealed class AsyncAsyncHandlerInvocation : IAsyncHandlerInvocation
+    {
+        public AsyncAsyncHandlerInvocation(object evt, Func<object, Task> asyncHandler)
+        {
+            Event = evt;
+            AsyncHandler = asyncHandler;
+        }
+
+        public object Event { get; }
+        public Func<object, Task> AsyncHandler { get; }
     }
 
     /// <summary>
@@ -311,6 +370,27 @@ namespace Akka.Persistence
         }
 
         /// <summary>
+        /// Asynchronously persists an <paramref name="event"/> with an async handler.
+        /// This method guarantees that no new commands will be received by a persistent actor
+        /// between a call to <see cref="Persist{TEvent}(TEvent,Func{TEvent,Task})"/> and execution of its handler.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="event">The event to persist.</param>
+        /// <param name="handler">The async handler to invoke after persistence.</param>
+        public void Persist<TEvent>(TEvent @event, Func<TEvent, Task> handler)
+        {
+            if (IsRecovering)
+            {
+                throw new InvalidOperationException("Cannot persist during replay. Events can be persisted when receiving RecoveryCompleted or later.");
+            }
+
+            _pendingStashingPersistInvocations++;
+            _pendingInvocations.AddLast(new StashingAsyncHandlerInvocation(@event, o => handler((TEvent)o)));
+            _eventBatch.AddLast(new AtomicWrite(new Persistent(@event, persistenceId: PersistenceId,
+                sequenceNr: NextSequenceNr(), writerGuid: _writerGuid, sender: Sender)));
+        }
+
+        /// <summary>
         /// Asynchronously persists series of <paramref name="events"/> in specified order.
         /// This is equivalent of multiple calls of <see cref="Persist{TEvent}(TEvent,System.Action{TEvent})"/> calls
         /// with the same handler, except that events are persisted atomically with this method.
@@ -339,6 +419,129 @@ namespace Akka.Persistence
 
             if (persistents.Count > 0)
                 _eventBatch.AddLast(new AtomicWrite(persistents.ToImmutable()));
+        }
+
+        /// <summary>
+        /// Asynchronously persists series of <paramref name="events"/> in specified order with a completion callback.
+        /// The <paramref name="onComplete"/> callback is invoked after all events have been persisted and their handlers executed.
+        /// This method guarantees that no new commands will be received until all handlers and the completion callback have finished.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="events">The events to persist.</param>
+        /// <param name="handler">The handler to invoke for each persisted event.</param>
+        /// <param name="onComplete">The callback to invoke after all events have been persisted and handled.</param>
+        public void PersistAll<TEvent>(IEnumerable<TEvent> events, Action<TEvent> handler, Action onComplete)
+        {
+            if (events == null || !events.Any())
+            {
+                if (onComplete != null)
+                    Defer<object>(null, _ => onComplete());
+                return;
+            }
+
+            PersistAll(events, handler);
+            if (onComplete != null)
+                Defer<object>(null, _ => onComplete());
+        }
+
+        /// <summary>
+        /// Asynchronously persists series of <paramref name="events"/> in specified order with an async completion callback.
+        /// The <paramref name="onCompleteAsync"/> callback is invoked after all events have been persisted and their handlers executed.
+        /// This method guarantees that no new commands will be received until all handlers and the completion callback have finished.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="events">The events to persist.</param>
+        /// <param name="handler">The handler to invoke for each persisted event.</param>
+        /// <param name="onCompleteAsync">The async callback to invoke after all events have been persisted and handled.</param>
+        public void PersistAll<TEvent>(IEnumerable<TEvent> events, Action<TEvent> handler, Func<Task> onCompleteAsync)
+        {
+            if (events == null || !events.Any())
+            {
+                if (onCompleteAsync != null)
+                    Defer<object>(null, async _ => await onCompleteAsync());
+                return;
+            }
+
+            PersistAll(events, handler);
+            if (onCompleteAsync != null)
+                Defer<object>(null, async _ => await onCompleteAsync());
+        }
+
+        /// <summary>
+        /// Asynchronously persists series of <paramref name="events"/> with an async handler.
+        /// This method guarantees that no new commands will be received until all handlers have finished.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="events">The events to persist.</param>
+        /// <param name="handler">The async handler to invoke for each persisted event.</param>
+        public void PersistAll<TEvent>(IEnumerable<TEvent> events, Func<TEvent, Task> handler)
+        {
+            if (IsRecovering)
+            {
+                throw new InvalidOperationException("Cannot persist during replay. Events can be persisted when receiving RecoveryCompleted or later.");
+            }
+
+            if (events == null) return;
+
+            Func<object, Task> Inv(Func<TEvent, Task> h) => o => h((TEvent)o);
+            var asyncInv = Inv(handler);
+            var persistents = ImmutableList.CreateBuilder<IPersistentRepresentation>();
+            foreach (var @event in events)
+            {
+                _pendingStashingPersistInvocations++;
+                _pendingInvocations.AddLast(new StashingAsyncHandlerInvocation(@event, asyncInv));
+                persistents.Add(new Persistent(@event, persistenceId: PersistenceId,
+                    sequenceNr: NextSequenceNr(), writerGuid: _writerGuid, sender: Sender));
+            }
+
+            if (persistents.Count > 0)
+                _eventBatch.AddLast(new AtomicWrite(persistents.ToImmutable()));
+        }
+
+        /// <summary>
+        /// Asynchronously persists series of <paramref name="events"/> with an async handler and completion callback.
+        /// The <paramref name="onComplete"/> callback is invoked after all events have been persisted and their handlers executed.
+        /// This method guarantees that no new commands will be received until all handlers and the completion callback have finished.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="events">The events to persist.</param>
+        /// <param name="handler">The async handler to invoke for each persisted event.</param>
+        /// <param name="onComplete">The callback to invoke after all events have been persisted and handled.</param>
+        public void PersistAll<TEvent>(IEnumerable<TEvent> events, Func<TEvent, Task> handler, Action onComplete)
+        {
+            if (events == null || !events.Any())
+            {
+                if (onComplete != null)
+                    Defer<object>(null, _ => onComplete());
+                return;
+            }
+
+            PersistAll(events, handler);
+            if (onComplete != null)
+                Defer<object>(null, _ => onComplete());
+        }
+
+        /// <summary>
+        /// Asynchronously persists series of <paramref name="events"/> with an async handler and async completion callback.
+        /// The <paramref name="onCompleteAsync"/> callback is invoked after all events have been persisted and their handlers executed.
+        /// This method guarantees that no new commands will be received until all handlers and the completion callback have finished.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="events">The events to persist.</param>
+        /// <param name="handler">The async handler to invoke for each persisted event.</param>
+        /// <param name="onCompleteAsync">The async callback to invoke after all events have been persisted and handled.</param>
+        public void PersistAll<TEvent>(IEnumerable<TEvent> events, Func<TEvent, Task> handler, Func<Task> onCompleteAsync)
+        {
+            if (events == null || !events.Any())
+            {
+                if (onCompleteAsync != null)
+                    Defer<object>(null, async _ => await onCompleteAsync());
+                return;
+            }
+
+            PersistAll(events, handler);
+            if (onCompleteAsync != null)
+                Defer<object>(null, async _ => await onCompleteAsync());
         }
 
         /// <summary>
@@ -382,6 +585,26 @@ namespace Akka.Persistence
         }
 
         /// <summary>
+        /// Asynchronously persists an <paramref name="event"/> with an async handler.
+        /// Unlike <see cref="Persist{TEvent}(TEvent,Func{TEvent,Task})"/>, this method allows
+        /// commands to be processed between the persist call and handler execution.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="event">The event to persist.</param>
+        /// <param name="handler">The async handler to invoke after persistence.</param>
+        public void PersistAsync<TEvent>(TEvent @event, Func<TEvent, Task> handler)
+        {
+            if (IsRecovering)
+            {
+                throw new InvalidOperationException("Cannot persist during replay. Events can be persisted when receiving RecoveryCompleted or later.");
+            }
+
+            _pendingInvocations.AddLast(new AsyncAsyncHandlerInvocation(@event, o => handler((TEvent)o)));
+            _eventBatch.AddLast(new AtomicWrite(new Persistent(@event, persistenceId: PersistenceId,
+                sequenceNr: NextSequenceNr(), writerGuid: _writerGuid, sender: Sender)));
+        }
+
+        /// <summary>
         /// Asynchronously persists series of <paramref name="events"/> in specified order.
         /// This is equivalent of multiple calls of <see cref="PersistAsync{TEvent}(TEvent,System.Action{TEvent})"/> calls
         /// with the same handler, except that events are persisted atomically with this method.
@@ -409,11 +632,135 @@ namespace Akka.Persistence
         }
 
         /// <summary>
+        /// Asynchronously persists series of <paramref name="events"/> in specified order with a completion callback.
+        /// Unlike <see cref="PersistAll{TEvent}(IEnumerable{TEvent},Action{TEvent},Action)"/>, this method allows
+        /// commands to be processed between event handler executions.
+        /// The <paramref name="onComplete"/> callback is invoked after all events have been persisted and their handlers executed.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="events">The events to persist.</param>
+        /// <param name="handler">The handler to invoke for each persisted event.</param>
+        /// <param name="onComplete">The callback to invoke after all events have been persisted and handled.</param>
+        public void PersistAllAsync<TEvent>(IEnumerable<TEvent> events, Action<TEvent> handler, Action onComplete)
+        {
+            if (events == null || !events.Any())
+            {
+                if (onComplete != null)
+                    DeferAsync<object>(null, _ => onComplete());
+                return;
+            }
+
+            PersistAllAsync(events, handler);
+            if (onComplete != null)
+                DeferAsync<object>(null, _ => onComplete());
+        }
+
+        /// <summary>
+        /// Asynchronously persists series of <paramref name="events"/> in specified order with an async completion callback.
+        /// Unlike <see cref="PersistAll{TEvent}(IEnumerable{TEvent},Action{TEvent},Func{Task})"/>, this method allows
+        /// commands to be processed between event handler executions.
+        /// The <paramref name="onCompleteAsync"/> callback is invoked after all events have been persisted and their handlers executed.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="events">The events to persist.</param>
+        /// <param name="handler">The handler to invoke for each persisted event.</param>
+        /// <param name="onCompleteAsync">The async callback to invoke after all events have been persisted and handled.</param>
+        public void PersistAllAsync<TEvent>(IEnumerable<TEvent> events, Action<TEvent> handler, Func<Task> onCompleteAsync)
+        {
+            if (events == null || !events.Any())
+            {
+                if (onCompleteAsync != null)
+                    DeferAsync<object>(null, async _ => await onCompleteAsync());
+                return;
+            }
+
+            PersistAllAsync(events, handler);
+            if (onCompleteAsync != null)
+                DeferAsync<object>(null, async _ => await onCompleteAsync());
+        }
+
+        /// <summary>
+        /// Asynchronously persists series of <paramref name="events"/> with an async handler.
+        /// Unlike <see cref="PersistAll{TEvent}(IEnumerable{TEvent},Func{TEvent,Task})"/>, this method allows
+        /// commands to be processed between event handler executions.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="events">The events to persist.</param>
+        /// <param name="handler">The async handler to invoke for each persisted event.</param>
+        public void PersistAllAsync<TEvent>(IEnumerable<TEvent> events, Func<TEvent, Task> handler)
+        {
+            if (IsRecovering)
+            {
+                throw new InvalidOperationException("Cannot persist during replay. Events can be persisted when receiving RecoveryCompleted or later.");
+            }
+
+            Func<object, Task> Inv(Func<TEvent, Task> h) => o => h((TEvent)o);
+            var asyncInv = Inv(handler);
+            var enumerable = events as TEvent[] ?? events.ToArray();
+            foreach (var @event in enumerable)
+            {
+                _pendingInvocations.AddLast(new AsyncAsyncHandlerInvocation(@event, asyncInv));
+            }
+
+            _eventBatch.AddLast(new AtomicWrite(enumerable.Select(e => new Persistent(e, persistenceId: PersistenceId,
+                    sequenceNr: NextSequenceNr(), writerGuid: _writerGuid, sender: Sender))
+                .ToImmutableList<IPersistentRepresentation>()));
+        }
+
+        /// <summary>
+        /// Asynchronously persists series of <paramref name="events"/> with an async handler and completion callback.
+        /// Unlike <see cref="PersistAll{TEvent}(IEnumerable{TEvent},Func{TEvent,Task},Action)"/>, this method allows
+        /// commands to be processed between event handler executions.
+        /// The <paramref name="onComplete"/> callback is invoked after all events have been persisted and their handlers executed.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="events">The events to persist.</param>
+        /// <param name="handler">The async handler to invoke for each persisted event.</param>
+        /// <param name="onComplete">The callback to invoke after all events have been persisted and handled.</param>
+        public void PersistAllAsync<TEvent>(IEnumerable<TEvent> events, Func<TEvent, Task> handler, Action onComplete)
+        {
+            if (events == null || !events.Any())
+            {
+                if (onComplete != null)
+                    DeferAsync<object>(null, _ => onComplete());
+                return;
+            }
+
+            PersistAllAsync(events, handler);
+            if (onComplete != null)
+                DeferAsync<object>(null, _ => onComplete());
+        }
+
+        /// <summary>
+        /// Asynchronously persists series of <paramref name="events"/> with an async handler and async completion callback.
+        /// Unlike <see cref="PersistAll{TEvent}(IEnumerable{TEvent},Func{TEvent,Task},Func{Task})"/>, this method allows
+        /// commands to be processed between event handler executions.
+        /// The <paramref name="onCompleteAsync"/> callback is invoked after all events have been persisted and their handlers executed.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="events">The events to persist.</param>
+        /// <param name="handler">The async handler to invoke for each persisted event.</param>
+        /// <param name="onCompleteAsync">The async callback to invoke after all events have been persisted and handled.</param>
+        public void PersistAllAsync<TEvent>(IEnumerable<TEvent> events, Func<TEvent, Task> handler, Func<Task> onCompleteAsync)
+        {
+            if (events == null || !events.Any())
+            {
+                if (onCompleteAsync != null)
+                    DeferAsync<object>(null, async _ => await onCompleteAsync());
+                return;
+            }
+
+            PersistAllAsync(events, handler);
+            if (onCompleteAsync != null)
+                DeferAsync<object>(null, async _ => await onCompleteAsync());
+        }
+
+        /// <summary>
         /// Defer the <paramref name="handler"/> execution until all pending handlers have been executed.
         /// Allows to define logic within the actor, which will respect the invocation-order-guarantee
         /// in respect to <see cref="PersistAsync{TEvent}(TEvent,System.Action{TEvent})"/> calls.
         /// That is, if <see cref="PersistAsync{TEvent}(TEvent,System.Action{TEvent})"/> was invoked before
-        /// <see cref="DeferAsync{TEvent}"/>, the corresponding handlers will be
+        /// <see cref="DeferAsync{TEvent}(TEvent,Action{TEvent})"/>, the corresponding handlers will be
         /// invoked in the same order as they were registered in.
         ///
         /// This call will NOT result in <paramref name="evt"/> being persisted, use
@@ -445,6 +792,79 @@ namespace Akka.Persistence
                 _pendingInvocations.AddLast(new AsyncHandlerInvocation(evt, o => handler((TEvent)o)));
                 _eventBatch.AddLast(new NonPersistentMessage(evt, Sender));
             }
+        }
+
+        /// <summary>
+        /// Defer the <paramref name="handler"/> execution until all pending handlers have been executed.
+        /// This is the async variant that accepts an async handler.
+        ///
+        /// This call will NOT result in <paramref name="evt"/> being persisted.
+        ///
+        /// If there are no pending persist handler calls, the <paramref name="handler"/> will be called immediately
+        /// via <see cref="RunTask"/>.
+        ///
+        /// If persistence of an earlier event fails, the persistent actor will stop, and the
+        /// <paramref name="handler"/> will not be run.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="evt">The event to pass to the handler.</param>
+        /// <param name="handler">The async handler to invoke.</param>
+        public void DeferAsync<TEvent>(TEvent evt, Func<TEvent, Task> handler)
+        {
+            if (IsRecovering)
+            {
+                throw new InvalidOperationException("Cannot persist during replay. Events can be persisted when receiving RecoveryCompleted or later.");
+            }
+
+            if (_pendingInvocations.Count == 0)
+            {
+                RunTask(() => handler(evt));
+            }
+            else
+            {
+                _pendingInvocations.AddLast(new AsyncAsyncHandlerInvocation(evt, o => handler((TEvent)o)));
+                _eventBatch.AddLast(new NonPersistentMessage(evt, Sender));
+            }
+        }
+
+        /// <summary>
+        /// Internal stashing variant of Defer. Increments <c>_pendingStashingPersistInvocations</c>
+        /// to ensure commands remain stashed until this handler completes.
+        /// Used internally for completion callbacks on <see cref="PersistAll{TEvent}(IEnumerable{TEvent},Action{TEvent},Action)"/>.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="evt">The event to pass to the handler.</param>
+        /// <param name="handler">The handler to invoke.</param>
+        internal void Defer<TEvent>(TEvent evt, Action<TEvent> handler)
+        {
+            if (IsRecovering)
+            {
+                throw new InvalidOperationException("Cannot persist during replay. Events can be persisted when receiving RecoveryCompleted or later.");
+            }
+
+            _pendingStashingPersistInvocations++;
+            _pendingInvocations.AddLast(new StashingHandlerInvocation(evt, o => handler((TEvent)o)));
+            _eventBatch.AddLast(new NonPersistentMessage(evt, Sender));
+        }
+
+        /// <summary>
+        /// Internal stashing variant of Defer with async handler. Increments <c>_pendingStashingPersistInvocations</c>
+        /// to ensure commands remain stashed until this handler completes.
+        /// Used internally for async completion callbacks on <see cref="PersistAll{TEvent}(IEnumerable{TEvent},Action{TEvent},Func{Task})"/>.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="evt">The event to pass to the handler.</param>
+        /// <param name="handler">The async handler to invoke.</param>
+        internal void Defer<TEvent>(TEvent evt, Func<TEvent, Task> handler)
+        {
+            if (IsRecovering)
+            {
+                throw new InvalidOperationException("Cannot persist during replay. Events can be persisted when receiving RecoveryCompleted or later.");
+            }
+
+            _pendingStashingPersistInvocations++;
+            _pendingInvocations.AddLast(new StashingAsyncHandlerInvocation(evt, o => handler((TEvent)o)));
+            _eventBatch.AddLast(new NonPersistentMessage(evt, Sender));
         }
 
         /// <summary>


### PR DESCRIPTION
Backport of #7954 to v1.5 branch.

## Original PR
#7954 - feat(persistence): completion callbacks via Defer - simplified alternative to #7937

## Summary
Adds completion callback support for persistence operations using the Defer mechanism.