### PR TITLE
Skip parsing PropertyNames when empty Parameters

### DIFF
--- a/src/core/Akka/Event/LogMessage.cs
+++ b/src/core/Akka/Event/LogMessage.cs
@@ -79,15 +79,7 @@ namespace Akka.Event
                 // Optimize: avoid ToArray() if Parameters() already returns IReadOnlyList
                 if (parameters is IReadOnlyList<object> readOnlyList)
                 {
-                    if (readOnlyList.Count == 0)
-                    {
-                        // Optimize: Skips parsing PropertyNames when empty Parameters()
-                        _properties = EmptyDictionary;
-                    }
-                    else
-                    {
-                        _properties = CreatePropertyDictionary(PropertyNames, readOnlyList);
-                    }
+                    _properties = CreatePropertyDictionary(PropertyNames, readOnlyList);
                 }
                 else
                 {

--- a/src/core/Akka/Event/LogMessage.cs
+++ b/src/core/Akka/Event/LogMessage.cs
@@ -75,22 +75,24 @@ namespace Akka.Event
         {
             if (_properties == null)
             {
-                var names = PropertyNames;
                 var parameters = Parameters();
-
                 // Optimize: avoid ToArray() if Parameters() already returns IReadOnlyList
                 if (parameters is IReadOnlyList<object> readOnlyList)
                 {
-                    _properties = CreatePropertyDictionary(names, readOnlyList);
-                }
-                else if (parameters is object[] array)
-                {
-                    _properties = CreatePropertyDictionary(names, array);
+                    if (readOnlyList.Count == 0)
+                    {
+                        // Optimize: Skips parsing PropertyNames when empty Parameters()
+                        _properties = EmptyDictionary;
+                    }
+                    else
+                    {
+                        _properties = CreatePropertyDictionary(PropertyNames, readOnlyList);
+                    }
                 }
                 else
                 {
                     // Fallback: convert to array
-                    _properties = CreatePropertyDictionary(names, parameters.ToArray());
+                    _properties = CreatePropertyDictionary(PropertyNames, parameters.ToArray());
                 }
             }
             return _properties;
@@ -106,33 +108,6 @@ namespace Akka.Event
 
             // Handle mismatched counts (more values than names, or vice versa)
             var count = Math.Min(names.Count, values.Count);
-            if (count == 0)
-                return EmptyDictionary;
-
-            var dict = new Dictionary<string, object>(count);
-            for (int i = 0; i < count; i++)
-            {
-                dict[names[i]] = values[i];
-            }
-
-#if NET8_0_OR_GREATER
-            // Use FrozenDictionary for optimal read performance on .NET 8+
-            return System.Collections.Frozen.FrozenDictionary.ToFrozenDictionary(dict);
-#else
-            return dict;
-#endif
-        }
-
-        private static IReadOnlyDictionary<string, object> CreatePropertyDictionary(
-            IReadOnlyList<string> names,
-            object[] values)
-        {
-            // Handle empty case
-            if (names.Count == 0)
-                return EmptyDictionary;
-
-            // Handle mismatched counts (more values than names, or vice versa)
-            var count = Math.Min(names.Count, values.Length);
             if (count == 0)
                 return EmptyDictionary;
 


### PR DESCRIPTION
Removed unnecessary casting to array, since it will automatically match `IReadOnlyList<object>`.

Curious why you also convert into FrozenDictionary (another allocation that hurt performance). Since a LogEvent is a very temporary object, that is thrown away. FrozenDictionary are "expensive" to create, because you plan to hold on to them.

https://github.com/akkadotnet/akka.net/blob/f2fe27b0bd5adf7c4f0c0963afe201e18e19dae2/src/core/Akka/Event/LogMessage.cs#L145-L150

I find it strange that when calling Akka's LogMessage.ToString() and using semantic logging, then Akka-Formatter explodes in your face (Because `string.Format` only handles positional parameters).

Also strange that Akka LogMessage only supports message-template-properties. I find message-template properties very organic and error-prone (case-sensitive, spelling, etc.) compared to explicit "building" the LogEvent.