### PR TITLE
Fix `TcpListener` to not stop from accepting further connections on transient accept errors

### DIFF
--- a/src/core/Akka/IO/TcpListener.cs
+++ b/src/core/Akka/IO/TcpListener.cs
@@ -298,22 +298,9 @@ namespace Akka.IO
                     break;
 
                 // Fatal errors - the listener socket itself is broken
-                case SocketError.OperationAborted:
-                case SocketError.NotSocket:
-                case SocketError.Shutdown:
-                case SocketError.NetworkDown:
-                case SocketError.AccessDenied:
-                case SocketError.AddressNotAvailable:
-                case SocketError.InvalidArgument:
+                default:
                     _failedCount++;
                     _log.Error("Fatal socket error in TcpListener: {0} - stopping listener", saea.SocketError);
-                    Context.Stop(Self);
-                    break;
-
-                default:
-                    // Unknown error - treat it as a fatal error and stop listener
-                    _failedCount++;
-                    _log.Error("Unexpected socket error in TcpListener: {0} - stopping listener", saea.SocketError);
                     Context.Stop(Self);
                     break;
             }

--- a/src/core/Akka/IO/TcpListener.cs
+++ b/src/core/Akka/IO/TcpListener.cs
@@ -142,7 +142,7 @@ namespace Akka.IO
                         {
                             subscriber.Tell(stats);
                         }
-                    }   
+                    }
                     return true;
 
                 case Tcp.SubscribeToTcpListenerStats subscribe:
@@ -277,6 +277,7 @@ namespace Akka.IO
                     break;
 
                 case SocketError.ConnectionReset:
+                case SocketError.ConnectionAborted:
                 case SocketError.NoBufferSpaceAvailable:
                 case SocketError.TryAgain:
                 case SocketError.TimedOut:

--- a/src/core/Akka/IO/TcpListener.cs
+++ b/src/core/Akka/IO/TcpListener.cs
@@ -282,6 +282,12 @@ namespace Akka.IO
                 case SocketError.TryAgain:
                 case SocketError.TimedOut:
                 case SocketError.WouldBlock:
+                case SocketError.Interrupted:
+                case SocketError.TooManyOpenSockets:
+                case SocketError.NetworkUnreachable:
+                case SocketError.HostDown:
+                case SocketError.HostUnreachable:
+                case SocketError.ConnectionRefused:
                     _retryCount++;
                     _log.Warning("Retriable socket error in TcpListener: {0} - retrying accept operation in 10ms",
                         saea.SocketError);
@@ -290,9 +296,24 @@ namespace Akka.IO
                     Context.System.Scheduler.ScheduleTellOnce(TimeSpan.FromMilliseconds(10), Self,
                         new RetryAccept(saea), ActorRefs.NoSender);
                     break;
-                default:
+
+                // Fatal errors - the listener socket itself is broken
+                case SocketError.OperationAborted:
+                case SocketError.NotSocket:
+                case SocketError.Shutdown:
+                case SocketError.NetworkDown:
+                case SocketError.AccessDenied:
+                case SocketError.AddressNotAvailable:
+                case SocketError.InvalidArgument:
                     _failedCount++;
-                    _log.Error("Fatal socket error in TcpListener: {0}", saea.SocketError);
+                    _log.Error("Fatal socket error in TcpListener: {0} - stopping listener", saea.SocketError);
+                    Context.Stop(Self);
+                    break;
+
+                default:
+                    // Unknown error - treat it as a fatal error and stop listener
+                    _failedCount++;
+                    _log.Error("Unexpected socket error in TcpListener: {0} - stopping listener", saea.SocketError);
                     Context.Stop(Self);
                     break;
             }


### PR DESCRIPTION
Fixes #7969

## Changes

- Handle more transient errors in the `TcpListener.HandleAccept()`. This fixes the issue of the `TcpListener` stopping accepting any further incoming connections in case of a transient error during accept.
- Be explicit about handling the known fatal errors in `TcpListener.HandleAccept()`.
- Unknown errors are still treated as fatal. Arguably, they could be treated as transient errors but there's some risk in that as well (some additional context at the end of this description).

Disclaimer: I'm not an expert in the domain got help from AI to craft this PR so a thorough review would be appreciated.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

## Additional notes

- I believe it's possible to work around the issue here by watching the `TcpListener` actor and re-binding on fatal failures, but any active TCP connections would still be terminated if the issue occurs.
- If the `TcpListener` stops on a fatal error, the `Tcp.Unbound` does not seem to be sent. I.e., this code in the `TcpEchoService.Server` sample does not trigger: `Receive<Tcp.Unbound>(_ => _stopCommander?.Tell("Done"));`
- I was not able to find the watch + re-bind pattern (to protect against unexpected termination) from any of the samples or the docs. I suspect many apps running in production might not have this and are thus susceptible.

Regarding whether the unknown errors should be treated as fatal or transient:
- If the errors are treated as fatal, it increases the likelihood of applications being affected by this. It'd make it less likely for production apps to stop accepting incoming connections.
- If the errors are treated as transient, the `TcpListener` can end up in an infinite loop of retrying what is really a fatal error. This prevents the surrounding app from seeing the issue and reacting to it.
- Perhaps a better approach would be to keep retrying on unknown errors for a few seconds and then terminate so the app can detect and handle the error. Anyway, it's outside the context of this PR.