### PR TITLE
Fix race condition in QueueSink causing async enumerable timeout

### DIFF
--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -744,8 +744,16 @@ namespace Akka.Streams.Implementation
                 Pull(_stage.In);
             }
 
-            public override void PostStop() => 
+            public override void PostStop()
+            {
+                // Complete any pending request before shutting down to prevent orphaned Tasks
+                if (_currentRequest.HasValue)
+                {
+                    _currentRequest.Value.SetException(new StreamDetachedException());
+                    _currentRequest = Option<TaskCompletionSource<Option<T>>>.None;
+                }
                 StopCallback(promise => promise.SetException(new StreamDetachedException()));
+            }
 
             private Action<TaskCompletionSource<Option<T>>> Callback()
             {


### PR DESCRIPTION
## Summary
Fixed a timing-dependent race condition where `RunAsAsyncEnumerable` would timeout when the materializer shut down while a `PullAsync()` request was pending.

## Changes
- Modified `QueueSink.Logic.PostStop()` to properly complete any pending `TaskCompletionSource` stored in `_currentRequest` with a `StreamDetachedException` before shutting down
- This prevents orphaned Tasks that would never complete

## Issue
This resolves intermittent test failures in `AsyncEnumerableSpec.RunAsAsyncEnumerable_Throws_on_Abrupt_Stream_termination` where the test would hang waiting for an exception that never arrived.

## Root Cause
When the materializer shut down abruptly, the `PostStop()` method only set up a callback handler for future pull requests but didn't clean up already-pending requests waiting for data. The pending `TaskCompletionSource` in `_currentRequest` would remain incomplete, causing the async enumerable to hang indefinitely.

## Testing
- ✅ Previously failing test now passes consistently (10/10 runs)
- ✅ All 13 tests in AsyncEnumerableSpec suite pass
- ✅ No regressions introduced