### PR TITLE
Fix timing race condition in AwaitAssertAsync causing premature timeouts

### DIFF
--- a/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
@@ -62,16 +62,19 @@ namespace Akka.TestKit
                 }
                 catch(Exception)
                 {
-                    var stopped = Now + t;
-                    if (stopped >= stop)
-                    {
-                        Sys.Log.Warning("AwaitAssert failed, timeout [{0}] is over after [{1}] attempts and [{2}] elapsed time", max, attempts, stopped - start);
-                        throw;
-                    }
-                        
+                    // Check timeout after delay to avoid check-then-act race condition
                 }
                 attempts++;
                 await Task.Delay(t, cancellationToken);
+
+                // Check if we've exceeded the timeout AFTER sleeping
+                if (Now > stop)
+                {
+                    Sys.Log.Warning("AwaitAssert failed, timeout [{0}] is over after [{1}] attempts and [{2}] elapsed time", max, attempts, Now - start);
+                    // Re-run the assertion one final time to get the actual exception
+                    assertion();
+                }
+
                 t = (stop - Now).Min(intervalValue);
             }
         }
@@ -96,9 +99,11 @@ namespace Akka.TestKit
             var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
             if(intervalValue == Timeout.InfiniteTimeSpan) intervalValue = TimeSpan.MaxValue;
             intervalValue.EnsureIsPositiveFinite("interval");
+            var start = Now;
             var max = RemainingOrDilated(duration);
             var stop = Now + max;
             var t = max.Min(intervalValue);
+            var attempts = 0;
             while(true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -109,10 +114,19 @@ namespace Akka.TestKit
                 }
                 catch(Exception)
                 {
-                    if(Now + t >= stop)
-                        throw;
+                    // Check timeout after delay to avoid check-then-act race condition
                 }
+                attempts++;
                 await Task.Delay(t, cancellationToken);
+
+                // Check if we've exceeded the timeout AFTER sleeping
+                if (Now > stop)
+                {
+                    Sys.Log.Warning("AwaitAssert failed, timeout [{0}] is over after [{1}] attempts and [{2}] elapsed time", max, attempts, Now - start);
+                    // Re-run the assertion one final time to get the actual exception
+                    await assertion();
+                }
+
                 t = (stop - Now).Min(intervalValue);
             }
         }

--- a/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
@@ -14,9 +14,6 @@ using Nito.AsyncEx.Synchronous;
 
 namespace Akka.TestKit
 {
-    /// <summary>
-    /// TBD
-    /// </summary>
     public abstract partial class TestKitBase
     {
         /// <summary>
@@ -37,7 +34,7 @@ namespace Akka.TestKit
         public void AwaitAssert(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
         {
             AwaitAssertAsync(assertion, duration, interval, cancellationToken)
-                .WaitAndUnwrapException();
+                .WaitAndUnwrapException(cancellationToken);
         }
         
         /// <inheritdoc cref="AwaitAssert(Action, TimeSpan?, TimeSpan?, CancellationToken)"/>
@@ -122,9 +119,16 @@ namespace Akka.TestKit
                 // Check if we've exceeded the timeout AFTER sleeping
                 if (Now > stop)
                 {
-                    Sys.Log.Warning("AwaitAssert failed, timeout [{0}] is over after [{1}] attempts and [{2}] elapsed time", max, attempts, Now - start);
-                    // Re-run the assertion one final time to get the actual exception
-                    await assertion();
+                    try
+                    {
+                        await assertion();
+                        return;
+                    }
+                    catch (Exception ex)
+                    {
+                        Sys.Log.Warning(ex, "AwaitAssert failed, timeout [{0}] is over after [{1}] attempts and [{2}] elapsed time", max, attempts, Now - start);
+                        throw;
+                    }
                 }
 
                 t = (stop - Now).Min(intervalValue);


### PR DESCRIPTION
## Summary

Fixed a 6-year-old check-then-act race condition in TestKit's `AwaitAssertAsync` that could cause tests to timeout prematurely with only 1 retry attempt instead of the expected number of retries within the timeout window.

## Problem

The bug was introduced in PR #4075 (Dec 2019) when async API was added to TestKit. The timeout check occurred BEFORE `Task.Delay()`, creating a timing window where thread scheduling delays, GC pauses, or system load could cause the actual elapsed time to exceed the timeout even though the pre-check indicated a retry should occur.

This manifested as flaky test failures like:
```
Expected cluster.ReadView.Members.Count(m => m.Status == MemberStatus.Up) to be 1, but found 0.
AwaitAssert failed, timeout [00:00:03] is over after [1] attempts and [00:00:04.6625130] elapsed time
```

Only 1 attempt in 4.6 seconds instead of ~30 attempts in 3 seconds.

## Changes

- Move timeout check to AFTER `Task.Delay()` in both `AwaitAssertAsync` overloads
- Changed boundary condition from `>=` to `>` to allow final retry when at exact timeout
- Re-run assertion on timeout to propagate the actual exception instead of generic timeout
- Added explanatory comments documenting the race condition

## Impact

This benefits all tests across the entire Akka.NET suite that use `AwaitAssert()`, preventing false timeout failures under load.

## Testing

Verified that `StartEntitySpec.StartEntity_while_the_entity_is_waiting_for_restart_should_restart_it_immediately` now passes with the default 3-second timeout (previously required 10 seconds as a workaround).