### PR TITLE
Exclude compiler-generated state machine attributes from API approval tests

### DIFF
--- a/src/core/Akka.API.Tests/Akka.API.Tests.csproj
+++ b/src/core/Akka.API.Tests/Akka.API.Tests.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
-    <PackageReference Include="PublicApiGenerator" Version="9.3.0" />
+    <PackageReference Include="PublicApiGenerator" Version="11.5.0" />
     <PackageReference Include="Verify.Xunit" Version="25.0.2" />
     <PackageReference Include="Verify.DiffPlex" Version="3.0.0" />
   </ItemGroup>

--- a/src/core/Akka.API.Tests/CoreAPISpec.cs
+++ b/src/core/Akka.API.Tests/CoreAPISpec.cs
@@ -13,7 +13,7 @@ using Akka.Persistence;
 using Akka.Remote;
 using Xunit;
 using Akka.Persistence.Query;
-using static PublicApiGenerator.ApiGenerator;
+using PublicApiGenerator;
 using Akka.Cluster.Sharding;
 using Akka.Cluster.Metrics;
 using Akka.Persistence.Query.InMemory;
@@ -25,9 +25,22 @@ namespace Akka.API.Tests
 {
     public class CoreAPISpec
     {
+        // Exclude compiler-generated state machine attributes from API surface.
+        // These contain auto-generated type names (e.g., <MethodName>d__123) that change
+        // whenever code structure changes, causing unnecessary API approval churn.
+        private static readonly ApiGeneratorOptions ApiOptions = new ApiGeneratorOptions
+        {
+            ExcludeAttributes = new[]
+            {
+                "System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute",
+                "System.Runtime.CompilerServices.AsyncStateMachineAttribute",
+                "System.Runtime.CompilerServices.IteratorStateMachineAttribute"
+            }
+        };
+
         static Task VerifyAssembly<T>()
         {
-            return Verifier.Verify(GeneratePublicApi(typeof(T).Assembly));
+            return Verifier.Verify(typeof(T).Assembly.GeneratePublicApi(ApiOptions));
         }
 
         [Fact]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.DotNet.verified.txt
@@ -1,25 +1,25 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Metrics")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.Performance")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Management.Cluster.Http")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("0e3e691b-0c31-4718-9b1a-d749b93208c9")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Metrics")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests.Performance")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DistributedData")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Management.Cluster.Http")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("0e3e691b-0c31-4718-9b1a-d749b93208c9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Cluster
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class AutoDowning : Akka.Cluster.IDowningProvider
     {
         public AutoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
@@ -41,11 +41,10 @@ namespace Akka.Cluster
         public Akka.Cluster.ClusterEvent.CurrentClusterState State { get; }
         public Akka.Actor.ExtendedActorSystem System { get; }
         public void Down(Akka.Actor.Address address) { }
-        public static Akka.Cluster.Cluster Get(Akka.Actor.ActorSystem system) { }
         public void Join(Akka.Actor.Address address) { }
-        public System.Threading.Tasks.Task JoinAsync(Akka.Actor.Address address, System.Threading.CancellationToken token = null) { }
+        public System.Threading.Tasks.Task JoinAsync(Akka.Actor.Address address, System.Threading.CancellationToken token = default) { }
         public void JoinSeedNodes(System.Collections.Generic.IEnumerable<Akka.Actor.Address> seedNodes) { }
-        public System.Threading.Tasks.Task JoinSeedNodesAsync(System.Collections.Generic.IEnumerable<Akka.Actor.Address> seedNodes, System.Threading.CancellationToken token = null) { }
+        public System.Threading.Tasks.Task JoinSeedNodesAsync(System.Collections.Generic.IEnumerable<Akka.Actor.Address> seedNodes, System.Threading.CancellationToken token = default) { }
         public void Leave(Akka.Actor.Address address) { }
         public System.Threading.Tasks.Task LeaveAsync() { }
         public System.Threading.Tasks.Task LeaveAsync(System.Threading.CancellationToken cancellationToken) { }
@@ -57,8 +56,9 @@ namespace Akka.Cluster
         public void Subscribe(Akka.Actor.IActorRef subscriber, Akka.Cluster.ClusterEvent.SubscriptionInitialStateMode initialStateMode, params System.Type[] to) { }
         public void Unsubscribe(Akka.Actor.IActorRef subscriber) { }
         public void Unsubscribe(Akka.Actor.IActorRef subscriber, System.Type to) { }
+        public static Akka.Cluster.Cluster Get(Akka.Actor.ActorSystem system) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ClusterActorRefProvider : Akka.Remote.RemoteActorRefProvider, Akka.Actor.IActorRefProvider, Akka.Cluster.IClusterActorRefProvider, Akka.Remote.IRemoteActorRefProvider
     {
         public ClusterActorRefProvider(string systemName, Akka.Actor.Settings settings, Akka.Event.EventStream eventStream) { }
@@ -194,9 +194,9 @@ namespace Akka.Cluster
         public ClusterSettings(Akka.Configuration.Config config, string systemName) { }
         public bool AllowWeaklyUpMembers { get; }
         public Akka.Util.AppVersion AppVersion { get; }
-        [System.ObsoleteAttribute("Deprecated as of Akka.NET v1.5.2 - clustering defaults to using KeepMajority SBR " +
+        [System.Obsolete("Deprecated as of Akka.NET v1.5.2 - clustering defaults to using KeepMajority SBR " +
             "instead")]
-        public System.Nullable<System.TimeSpan> AutoDownUnreachableAfter { get; }
+        public System.TimeSpan? AutoDownUnreachableAfter { get; }
         public System.Type DowningProviderType { get; }
         public Akka.Configuration.Config FailureDetectorConfig { get; }
         public string FailureDetectorImplementationClass { get; }
@@ -212,16 +212,16 @@ namespace Akka.Cluster
         public System.Collections.Immutable.ImmutableDictionary<string, int> MinNrOfMembersOfRole { get; }
         public int MonitoredByNrOfMembers { get; }
         public System.TimeSpan PeriodicTasksInitialDelay { get; }
-        public System.Nullable<System.TimeSpan> PublishStatsInterval { get; }
+        public System.TimeSpan? PublishStatsInterval { get; }
         public int ReduceGossipDifferentViewProbability { get; }
-        public System.Nullable<System.TimeSpan> RetryUnsuccessfulJoinAfter { get; }
+        public System.TimeSpan? RetryUnsuccessfulJoinAfter { get; }
         public System.Collections.Immutable.ImmutableHashSet<string> Roles { get; }
         public bool RunCoordinatedShutdownWhenDown { get; }
         public System.TimeSpan SchedulerTickDuration { get; }
         public int SchedulerTicksPerWheel { get; }
         public System.TimeSpan SeedNodeTimeout { get; }
         public System.Collections.Immutable.ImmutableList<Akka.Actor.Address> SeedNodes { get; }
-        public System.Nullable<System.TimeSpan> ShutdownAfterUnsuccessfulJoinSeedNodes { get; }
+        public System.TimeSpan? ShutdownAfterUnsuccessfulJoinSeedNodes { get; }
         public System.TimeSpan UnreachableNodesReaperInterval { get; }
         public string UseDispatcher { get; }
         public bool UseLegacyHeartbeatMessage { get; }
@@ -229,7 +229,7 @@ namespace Akka.Cluster
         public bool VerboseHeartbeatLogging { get; }
         public System.TimeSpan WeaklyUpAfter { get; }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IClusterActorRefProvider : Akka.Actor.IActorRefProvider, Akka.Remote.IRemoteActorRefProvider { }
     public interface IClusterMessage { }
     public interface IDowningProvider
@@ -252,12 +252,12 @@ namespace Akka.Cluster
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public bool HasRole(string role) { }
-        public static Akka.Cluster.Member HighestPriorityOf(Akka.Cluster.Member m1, Akka.Cluster.Member m2) { }
         public bool IsOlderThan(Akka.Cluster.Member other) { }
-        public static System.Collections.Immutable.ImmutableHashSet<Akka.Cluster.Member> PickHighestPriority(System.Collections.Generic.IEnumerable<Akka.Cluster.Member> a, System.Collections.Generic.IEnumerable<Akka.Cluster.Member> b) { }
-        public static System.Collections.Immutable.ImmutableSortedSet<Akka.Cluster.Member> PickNextTransition(System.Collections.Generic.IEnumerable<Akka.Cluster.Member> a, System.Collections.Generic.IEnumerable<Akka.Cluster.Member> b) { }
-        public static Akka.Cluster.Member PickNextTransition(Akka.Cluster.Member a, Akka.Cluster.Member b) { }
         public override string ToString() { }
+        public static Akka.Cluster.Member HighestPriorityOf(Akka.Cluster.Member m1, Akka.Cluster.Member m2) { }
+        public static System.Collections.Immutable.ImmutableHashSet<Akka.Cluster.Member> PickHighestPriority(System.Collections.Generic.IEnumerable<Akka.Cluster.Member> a, System.Collections.Generic.IEnumerable<Akka.Cluster.Member> b) { }
+        public static Akka.Cluster.Member PickNextTransition(Akka.Cluster.Member a, Akka.Cluster.Member b) { }
+        public static System.Collections.Immutable.ImmutableSortedSet<Akka.Cluster.Member> PickNextTransition(System.Collections.Generic.IEnumerable<Akka.Cluster.Member> a, System.Collections.Generic.IEnumerable<Akka.Cluster.Member> b) { }
     }
     public enum MemberStatus
     {
@@ -292,15 +292,13 @@ namespace Akka.Cluster
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
-        public static bool ==(Akka.Cluster.UniqueAddress left, Akka.Cluster.UniqueAddress right) { }
-        public static bool !=(Akka.Cluster.UniqueAddress left, Akka.Cluster.UniqueAddress right) { }
+        public static bool operator !=(Akka.Cluster.UniqueAddress left, Akka.Cluster.UniqueAddress right) { }
+        public static bool operator ==(Akka.Cluster.UniqueAddress left, Akka.Cluster.UniqueAddress right) { }
     }
     public sealed class VectorClock
     {
         public System.Collections.Immutable.ImmutableSortedDictionary<Akka.Cluster.VectorClock.Node, long> Versions { get; }
         public Akka.Cluster.VectorClock.Ordering CompareTo(Akka.Cluster.VectorClock that) { }
-        public static Akka.Cluster.VectorClock Create() { }
-        public static Akka.Cluster.VectorClock Create(System.Collections.Immutable.ImmutableSortedDictionary<Akka.Cluster.VectorClock.Node, long> seedValues) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public Akka.Cluster.VectorClock Increment(Akka.Cluster.VectorClock.Node node) { }
@@ -311,19 +309,21 @@ namespace Akka.Cluster
         public Akka.Cluster.VectorClock Merge(Akka.Cluster.VectorClock that) { }
         public Akka.Cluster.VectorClock Prune(Akka.Cluster.VectorClock.Node removedNode) { }
         public override string ToString() { }
-        public static bool ==(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
-        public static bool >(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
-        public static bool !=(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
-        public static bool <(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
+        public static Akka.Cluster.VectorClock Create() { }
+        public static Akka.Cluster.VectorClock Create(System.Collections.Immutable.ImmutableSortedDictionary<Akka.Cluster.VectorClock.Node, long> seedValues) { }
+        public static bool operator !=(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
+        public static bool operator <(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
+        public static bool operator ==(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
+        public static bool operator >(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
         public class Node : System.IComparable<Akka.Cluster.VectorClock.Node>
         {
             public Node(string value) { }
             public int CompareTo(Akka.Cluster.VectorClock.Node other) { }
-            public static Akka.Cluster.VectorClock.Node Create(string name) { }
             public override bool Equals(object obj) { }
-            public static Akka.Cluster.VectorClock.Node FromHash(string hash) { }
             public override int GetHashCode() { }
             public override string ToString() { }
+            public static Akka.Cluster.VectorClock.Node Create(string name) { }
+            public static Akka.Cluster.VectorClock.Node FromHash(string hash) { }
         }
         public enum Ordering
         {
@@ -379,8 +379,8 @@ namespace Akka.Cluster.Routing
         public ClusterRouterPoolSettings(int totalInstances, int maxInstancesPerNode, bool allowLocalRoutees, string useRole = null) { }
         public int MaxInstancesPerNode { get; }
         public override bool Equals(object obj) { }
-        public static Akka.Cluster.Routing.ClusterRouterPoolSettings FromConfig(Akka.Configuration.Config config) { }
         public override int GetHashCode() { }
+        public static Akka.Cluster.Routing.ClusterRouterPoolSettings FromConfig(Akka.Configuration.Config config) { }
     }
     public abstract class ClusterRouterSettingsBase
     {
@@ -416,12 +416,12 @@ namespace Akka.Cluster.SBR
     }
     public sealed class SplitBrainResolverSettings
     {
-        public static readonly System.Collections.Immutable.ImmutableHashSet<string> AllStrategyNames;
         public const string DownAllName = "down-all";
         public const string KeepMajorityName = "keep-majority";
         public const string KeepOldestName = "keep-oldest";
         public const string LeaseMajorityName = "lease-majority";
         public const string StaticQuorumName = "static-quorum";
+        public static readonly System.Collections.Immutable.ImmutableHashSet<string> AllStrategyNames;
         public SplitBrainResolverSettings(Akka.Configuration.Config config) { }
         public System.TimeSpan DownAllWhenUnstable { get; }
         public System.TimeSpan DowningStableAfter { get; }
@@ -440,7 +440,7 @@ namespace Akka.Cluster.SBR
 }
 namespace Akka.Cluster.Serialization
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ClusterMessageSerializer : Akka.Serialization.SerializerWithStringManifest
     {
         public ClusterMessageSerializer(Akka.Actor.ExtendedActorSystem system) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCluster.Net.verified.txt
@@ -1,25 +1,25 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Metrics")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.Performance")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Management.Cluster.Http")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("0e3e691b-0c31-4718-9b1a-d749b93208c9")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Metrics")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests.Performance")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DistributedData")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Management.Cluster.Http")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("0e3e691b-0c31-4718-9b1a-d749b93208c9")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Cluster
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class AutoDowning : Akka.Cluster.IDowningProvider
     {
         public AutoDowning(Akka.Actor.ActorSystem system, Akka.Cluster.Cluster cluster) { }
@@ -41,11 +41,10 @@ namespace Akka.Cluster
         public Akka.Cluster.ClusterEvent.CurrentClusterState State { get; }
         public Akka.Actor.ExtendedActorSystem System { get; }
         public void Down(Akka.Actor.Address address) { }
-        public static Akka.Cluster.Cluster Get(Akka.Actor.ActorSystem system) { }
         public void Join(Akka.Actor.Address address) { }
-        public System.Threading.Tasks.Task JoinAsync(Akka.Actor.Address address, System.Threading.CancellationToken token = null) { }
+        public System.Threading.Tasks.Task JoinAsync(Akka.Actor.Address address, System.Threading.CancellationToken token = default) { }
         public void JoinSeedNodes(System.Collections.Generic.IEnumerable<Akka.Actor.Address> seedNodes) { }
-        public System.Threading.Tasks.Task JoinSeedNodesAsync(System.Collections.Generic.IEnumerable<Akka.Actor.Address> seedNodes, System.Threading.CancellationToken token = null) { }
+        public System.Threading.Tasks.Task JoinSeedNodesAsync(System.Collections.Generic.IEnumerable<Akka.Actor.Address> seedNodes, System.Threading.CancellationToken token = default) { }
         public void Leave(Akka.Actor.Address address) { }
         public System.Threading.Tasks.Task LeaveAsync() { }
         public System.Threading.Tasks.Task LeaveAsync(System.Threading.CancellationToken cancellationToken) { }
@@ -57,8 +56,9 @@ namespace Akka.Cluster
         public void Subscribe(Akka.Actor.IActorRef subscriber, Akka.Cluster.ClusterEvent.SubscriptionInitialStateMode initialStateMode, params System.Type[] to) { }
         public void Unsubscribe(Akka.Actor.IActorRef subscriber) { }
         public void Unsubscribe(Akka.Actor.IActorRef subscriber, System.Type to) { }
+        public static Akka.Cluster.Cluster Get(Akka.Actor.ActorSystem system) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ClusterActorRefProvider : Akka.Remote.RemoteActorRefProvider, Akka.Actor.IActorRefProvider, Akka.Cluster.IClusterActorRefProvider, Akka.Remote.IRemoteActorRefProvider
     {
         public ClusterActorRefProvider(string systemName, Akka.Actor.Settings settings, Akka.Event.EventStream eventStream) { }
@@ -194,9 +194,9 @@ namespace Akka.Cluster
         public ClusterSettings(Akka.Configuration.Config config, string systemName) { }
         public bool AllowWeaklyUpMembers { get; }
         public Akka.Util.AppVersion AppVersion { get; }
-        [System.ObsoleteAttribute("Deprecated as of Akka.NET v1.5.2 - clustering defaults to using KeepMajority SBR " +
+        [System.Obsolete("Deprecated as of Akka.NET v1.5.2 - clustering defaults to using KeepMajority SBR " +
             "instead")]
-        public System.Nullable<System.TimeSpan> AutoDownUnreachableAfter { get; }
+        public System.TimeSpan? AutoDownUnreachableAfter { get; }
         public System.Type DowningProviderType { get; }
         public Akka.Configuration.Config FailureDetectorConfig { get; }
         public string FailureDetectorImplementationClass { get; }
@@ -212,16 +212,16 @@ namespace Akka.Cluster
         public System.Collections.Immutable.ImmutableDictionary<string, int> MinNrOfMembersOfRole { get; }
         public int MonitoredByNrOfMembers { get; }
         public System.TimeSpan PeriodicTasksInitialDelay { get; }
-        public System.Nullable<System.TimeSpan> PublishStatsInterval { get; }
+        public System.TimeSpan? PublishStatsInterval { get; }
         public int ReduceGossipDifferentViewProbability { get; }
-        public System.Nullable<System.TimeSpan> RetryUnsuccessfulJoinAfter { get; }
+        public System.TimeSpan? RetryUnsuccessfulJoinAfter { get; }
         public System.Collections.Immutable.ImmutableHashSet<string> Roles { get; }
         public bool RunCoordinatedShutdownWhenDown { get; }
         public System.TimeSpan SchedulerTickDuration { get; }
         public int SchedulerTicksPerWheel { get; }
         public System.TimeSpan SeedNodeTimeout { get; }
         public System.Collections.Immutable.ImmutableList<Akka.Actor.Address> SeedNodes { get; }
-        public System.Nullable<System.TimeSpan> ShutdownAfterUnsuccessfulJoinSeedNodes { get; }
+        public System.TimeSpan? ShutdownAfterUnsuccessfulJoinSeedNodes { get; }
         public System.TimeSpan UnreachableNodesReaperInterval { get; }
         public string UseDispatcher { get; }
         public bool UseLegacyHeartbeatMessage { get; }
@@ -229,7 +229,7 @@ namespace Akka.Cluster
         public bool VerboseHeartbeatLogging { get; }
         public System.TimeSpan WeaklyUpAfter { get; }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IClusterActorRefProvider : Akka.Actor.IActorRefProvider, Akka.Remote.IRemoteActorRefProvider { }
     public interface IClusterMessage { }
     public interface IDowningProvider
@@ -252,12 +252,12 @@ namespace Akka.Cluster
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public bool HasRole(string role) { }
-        public static Akka.Cluster.Member HighestPriorityOf(Akka.Cluster.Member m1, Akka.Cluster.Member m2) { }
         public bool IsOlderThan(Akka.Cluster.Member other) { }
-        public static System.Collections.Immutable.ImmutableHashSet<Akka.Cluster.Member> PickHighestPriority(System.Collections.Generic.IEnumerable<Akka.Cluster.Member> a, System.Collections.Generic.IEnumerable<Akka.Cluster.Member> b) { }
-        public static System.Collections.Immutable.ImmutableSortedSet<Akka.Cluster.Member> PickNextTransition(System.Collections.Generic.IEnumerable<Akka.Cluster.Member> a, System.Collections.Generic.IEnumerable<Akka.Cluster.Member> b) { }
-        public static Akka.Cluster.Member PickNextTransition(Akka.Cluster.Member a, Akka.Cluster.Member b) { }
         public override string ToString() { }
+        public static Akka.Cluster.Member HighestPriorityOf(Akka.Cluster.Member m1, Akka.Cluster.Member m2) { }
+        public static System.Collections.Immutable.ImmutableHashSet<Akka.Cluster.Member> PickHighestPriority(System.Collections.Generic.IEnumerable<Akka.Cluster.Member> a, System.Collections.Generic.IEnumerable<Akka.Cluster.Member> b) { }
+        public static Akka.Cluster.Member PickNextTransition(Akka.Cluster.Member a, Akka.Cluster.Member b) { }
+        public static System.Collections.Immutable.ImmutableSortedSet<Akka.Cluster.Member> PickNextTransition(System.Collections.Generic.IEnumerable<Akka.Cluster.Member> a, System.Collections.Generic.IEnumerable<Akka.Cluster.Member> b) { }
     }
     public enum MemberStatus
     {
@@ -292,15 +292,13 @@ namespace Akka.Cluster
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
-        public static bool ==(Akka.Cluster.UniqueAddress left, Akka.Cluster.UniqueAddress right) { }
-        public static bool !=(Akka.Cluster.UniqueAddress left, Akka.Cluster.UniqueAddress right) { }
+        public static bool operator !=(Akka.Cluster.UniqueAddress left, Akka.Cluster.UniqueAddress right) { }
+        public static bool operator ==(Akka.Cluster.UniqueAddress left, Akka.Cluster.UniqueAddress right) { }
     }
     public sealed class VectorClock
     {
         public System.Collections.Immutable.ImmutableSortedDictionary<Akka.Cluster.VectorClock.Node, long> Versions { get; }
         public Akka.Cluster.VectorClock.Ordering CompareTo(Akka.Cluster.VectorClock that) { }
-        public static Akka.Cluster.VectorClock Create() { }
-        public static Akka.Cluster.VectorClock Create(System.Collections.Immutable.ImmutableSortedDictionary<Akka.Cluster.VectorClock.Node, long> seedValues) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public Akka.Cluster.VectorClock Increment(Akka.Cluster.VectorClock.Node node) { }
@@ -311,19 +309,21 @@ namespace Akka.Cluster
         public Akka.Cluster.VectorClock Merge(Akka.Cluster.VectorClock that) { }
         public Akka.Cluster.VectorClock Prune(Akka.Cluster.VectorClock.Node removedNode) { }
         public override string ToString() { }
-        public static bool ==(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
-        public static bool >(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
-        public static bool !=(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
-        public static bool <(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
+        public static Akka.Cluster.VectorClock Create() { }
+        public static Akka.Cluster.VectorClock Create(System.Collections.Immutable.ImmutableSortedDictionary<Akka.Cluster.VectorClock.Node, long> seedValues) { }
+        public static bool operator !=(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
+        public static bool operator <(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
+        public static bool operator ==(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
+        public static bool operator >(Akka.Cluster.VectorClock left, Akka.Cluster.VectorClock right) { }
         public class Node : System.IComparable<Akka.Cluster.VectorClock.Node>
         {
             public Node(string value) { }
             public int CompareTo(Akka.Cluster.VectorClock.Node other) { }
-            public static Akka.Cluster.VectorClock.Node Create(string name) { }
             public override bool Equals(object obj) { }
-            public static Akka.Cluster.VectorClock.Node FromHash(string hash) { }
             public override int GetHashCode() { }
             public override string ToString() { }
+            public static Akka.Cluster.VectorClock.Node Create(string name) { }
+            public static Akka.Cluster.VectorClock.Node FromHash(string hash) { }
         }
         public enum Ordering
         {
@@ -379,8 +379,8 @@ namespace Akka.Cluster.Routing
         public ClusterRouterPoolSettings(int totalInstances, int maxInstancesPerNode, bool allowLocalRoutees, string useRole = null) { }
         public int MaxInstancesPerNode { get; }
         public override bool Equals(object obj) { }
-        public static Akka.Cluster.Routing.ClusterRouterPoolSettings FromConfig(Akka.Configuration.Config config) { }
         public override int GetHashCode() { }
+        public static Akka.Cluster.Routing.ClusterRouterPoolSettings FromConfig(Akka.Configuration.Config config) { }
     }
     public abstract class ClusterRouterSettingsBase
     {
@@ -416,12 +416,12 @@ namespace Akka.Cluster.SBR
     }
     public sealed class SplitBrainResolverSettings
     {
-        public static readonly System.Collections.Immutable.ImmutableHashSet<string> AllStrategyNames;
         public const string DownAllName = "down-all";
         public const string KeepMajorityName = "keep-majority";
         public const string KeepOldestName = "keep-oldest";
         public const string LeaseMajorityName = "lease-majority";
         public const string StaticQuorumName = "static-quorum";
+        public static readonly System.Collections.Immutable.ImmutableHashSet<string> AllStrategyNames;
         public SplitBrainResolverSettings(Akka.Configuration.Config config) { }
         public System.TimeSpan DownAllWhenUnstable { get; }
         public System.TimeSpan DowningStableAfter { get; }
@@ -440,7 +440,7 @@ namespace Akka.Cluster.SBR
 }
 namespace Akka.Cluster.Serialization
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ClusterMessageSerializer : Akka.Serialization.SerializerWithStringManifest
     {
         public ClusterMessageSerializer(Akka.Actor.ExtendedActorSystem system) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterMetrics.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterMetrics.DotNet.verified.txt
@@ -1,12 +1,12 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Metrics.Tests")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Metrics.Tests")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Cluster.Metrics
 {
     public sealed class AdaptiveLoadBalancingGroup : Akka.Routing.Group
     {
-        public AdaptiveLoadBalancingGroup(Akka.Cluster.Metrics.IMetricsSelector metricsSelector = null, System.Collections.Generic.IEnumerable<string> paths = null, string routerDispatcher = null) { }
         public AdaptiveLoadBalancingGroup(Akka.Configuration.Config config) { }
+        public AdaptiveLoadBalancingGroup(Akka.Cluster.Metrics.IMetricsSelector metricsSelector = null, System.Collections.Generic.IEnumerable<string> paths = null, string routerDispatcher = null) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override System.Collections.Generic.IEnumerable<string> GetPaths(Akka.Actor.ActorSystem system) { }
         public override Akka.Actor.Props RoutingLogicController(Akka.Routing.RoutingLogic routingLogic) { }
@@ -21,7 +21,7 @@ namespace Akka.Cluster.Metrics
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class AdaptiveLoadBalancingMetricsListener : Akka.Actor.ActorBase
     {
         public AdaptiveLoadBalancingMetricsListener(Akka.Cluster.Metrics.IClusterMetricsRoutingLogic routingLogic) { }
@@ -31,8 +31,8 @@ namespace Akka.Cluster.Metrics
     }
     public sealed class AdaptiveLoadBalancingPool : Akka.Routing.Pool
     {
-        public AdaptiveLoadBalancingPool(Akka.Cluster.Metrics.IMetricsSelector metricsSelector = null, int nrOfInstances = 0, Akka.Actor.SupervisorStrategy supervisorStrategy = null, string routerDispatcher = null, bool usePoolDispatcher = False) { }
         public AdaptiveLoadBalancingPool(Akka.Configuration.Config config) { }
+        public AdaptiveLoadBalancingPool(Akka.Cluster.Metrics.IMetricsSelector metricsSelector = null, int nrOfInstances = 0, Akka.Actor.SupervisorStrategy supervisorStrategy = null, string routerDispatcher = null, bool usePoolDispatcher = false) { }
         public Akka.Cluster.Metrics.IMetricsSelector MetricsSelector { get; }
         public override Akka.Routing.Resizer Resizer { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
@@ -69,15 +69,15 @@ namespace Akka.Cluster.Metrics
     public class ClusterMetrics : Akka.Actor.IExtension
     {
         public Akka.Cluster.Metrics.Configuration.ClusterMetricsSettings Settings { get; }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public Akka.Cluster.Metrics.ClusterMetricsStrategy Strategy { get; }
         public Akka.Actor.IActorRef Supervisor { get; }
-        public static Akka.Configuration.Config DefaultConfig() { }
-        public static Akka.Cluster.Metrics.ClusterMetrics Get(Akka.Actor.ActorSystem system) { }
         public void Subscribe(Akka.Actor.IActorRef metricsListener) { }
         public void Unsubscribe(Akka.Actor.IActorRef metricsListener) { }
+        public static Akka.Configuration.Config DefaultConfig() { }
+        public static Akka.Cluster.Metrics.ClusterMetrics Get(Akka.Actor.ActorSystem system) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ClusterMetricsCollector : Akka.Actor.ActorBase
     {
         public ClusterMetricsCollector() { }
@@ -94,7 +94,7 @@ namespace Akka.Cluster.Metrics
     {
         public ClusterMetricsStrategy(Akka.Configuration.Config config) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ClusterMetricsSupervisor : Akka.Actor.ActorBase
     {
         public ClusterMetricsSupervisor() { }
@@ -102,8 +102,8 @@ namespace Akka.Cluster.Metrics
         protected override bool Receive(object message) { }
         protected override Akka.Actor.SupervisorStrategy SupervisorStrategy() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static ClusterMetricsSupervisorMetadata
+    [Akka.Annotations.InternalApi]
+    public static class ClusterMetricsSupervisorMetadata
     {
         public sealed class CollectionStartMessage : Akka.Cluster.Metrics.ClusterMetricsSupervisorMetadata.ICollectionControlMessage
         {
@@ -144,7 +144,7 @@ namespace Akka.Cluster.Metrics
         public MetricsCollectorBuilder() { }
         public Akka.Cluster.Metrics.IMetricsCollector Build(Akka.Actor.ActorSystem system) { }
     }
-    public class static MetricsSelectorBuilder
+    public static class MetricsSelectorBuilder
     {
         public static Akka.Cluster.Metrics.IMetricsSelector BuildFromConfig(Akka.Configuration.Config config) { }
     }
@@ -159,7 +159,7 @@ namespace Akka.Cluster.Metrics
         public System.Collections.Immutable.ImmutableArray<Akka.Cluster.Metrics.CapacityMetricsSelector> Selectors { get; }
         public override System.Collections.Immutable.IImmutableDictionary<Akka.Actor.Address, double> Capacity(System.Collections.Immutable.IImmutableSet<Akka.Cluster.Metrics.Serialization.NodeMetrics> nodeMetrics) { }
     }
-    public class static StandardMetrics
+    public static class StandardMetrics
     {
         public const string CpuProcessUsage = "CpuProcessUsage";
         public const string CpuTotalUsage = "CpuTotalUsage";
@@ -177,7 +177,7 @@ namespace Akka.Cluster.Metrics
             public int ProcessorsNumber { get; }
             public long Timestamp { get; }
             public double TotalUsage { get; }
-            [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+            [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                     "Address",
                     "Timestamp",
                     "CpuProcessUsage",
@@ -193,7 +193,7 @@ namespace Akka.Cluster.Metrics
             public Akka.Util.Option<double> MaxRecommended { get; }
             public long Timestamp { get; }
             public double Used { get; }
-            [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+            [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                     "Address",
                     "Timestamp",
                     "UsedSmoothValue",
@@ -202,7 +202,7 @@ namespace Akka.Cluster.Metrics
             public static Akka.Util.Option<System.ValueTuple<Akka.Actor.Address, long, double, double, Akka.Util.Option<double>>> Decompose(Akka.Cluster.Metrics.Serialization.NodeMetrics nodeMetrics) { }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class WeightedRoutees
     {
         public WeightedRoutees(System.Collections.Immutable.ImmutableArray<Akka.Routing.Routee> routees, Akka.Actor.Address selfAddress, System.Collections.Immutable.IImmutableDictionary<Akka.Actor.Address, int> weights) { }
@@ -215,8 +215,8 @@ namespace Akka.Cluster.Metrics.Collectors
 {
     public class DefaultCollector : Akka.Cluster.Metrics.IMetricsCollector, System.IDisposable
     {
-        public DefaultCollector(Akka.Actor.Address address) { }
         public DefaultCollector(Akka.Actor.ActorSystem system) { }
+        public DefaultCollector(Akka.Actor.Address address) { }
         public void Dispose() { }
         public Akka.Cluster.Metrics.Serialization.NodeMetrics Sample() { }
     }
@@ -251,22 +251,21 @@ namespace Akka.Cluster.Metrics.Events
 }
 namespace Akka.Cluster.Metrics.Helpers
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public struct AnyNumber
     {
+        public AnyNumber(double n) { }
+        public AnyNumber(float n) { }
         public AnyNumber(int n) { }
         public AnyNumber(long n) { }
-        public AnyNumber(float n) { }
-        public AnyNumber(double n) { }
         public double DoubleValue { get; }
         public long LongValue { get; }
-        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public Akka.Cluster.Metrics.Helpers.AnyNumber.NumberType Type { get; }
         public override string ToString() { }
+        public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(double n) { }
+        public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(float n) { }
         public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(int n) { }
         public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(long n) { }
-        public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(float n) { }
-        public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(double n) { }
         public enum NumberType
         {
             Int = 0,
@@ -285,9 +284,9 @@ namespace Akka.Cluster.Metrics.Serialization
         public override string Manifest(object o) { }
         public override byte[] ToBinary(object obj) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IClusterMetricMessage { }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class MetricsGossip
     {
         public static readonly Akka.Cluster.Metrics.Serialization.MetricsGossip Empty;
@@ -297,9 +296,9 @@ namespace Akka.Cluster.Metrics.Serialization
         public Akka.Cluster.Metrics.Serialization.MetricsGossip Merge(Akka.Cluster.Metrics.Serialization.MetricsGossip otherGossip) { }
         public Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics> NodeMetricsFor(Akka.Actor.Address address) { }
         public Akka.Cluster.Metrics.Serialization.MetricsGossip Remove(Akka.Actor.Address node) { }
-        public static Akka.Cluster.Metrics.Serialization.MetricsGossip +(Akka.Cluster.Metrics.Serialization.MetricsGossip gossip, Akka.Cluster.Metrics.Serialization.NodeMetrics newNodeMetrics) { }
+        public static Akka.Cluster.Metrics.Serialization.MetricsGossip operator +(Akka.Cluster.Metrics.Serialization.MetricsGossip gossip, Akka.Cluster.Metrics.Serialization.NodeMetrics newNodeMetrics) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class MetricsGossipEnvelope : Akka.Cluster.Metrics.Serialization.IClusterMetricMessage, Akka.Event.IDeadLetterSuppression
     {
         public MetricsGossipEnvelope(Akka.Actor.Address fromAddress, Akka.Cluster.Metrics.Serialization.MetricsGossip gossip, bool reply) { }
@@ -307,23 +306,19 @@ namespace Akka.Cluster.Metrics.Serialization
         public Akka.Cluster.Metrics.Serialization.MetricsGossip Gossip { get; }
         public bool Reply { get; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class NodeMetrics : System.IEquatable<Akka.Cluster.Metrics.Serialization.NodeMetrics>
     {
         public NodeMetrics(Akka.Actor.Address address, long timestamp, System.Collections.Generic.IEnumerable<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> metrics) { }
         public Akka.Actor.Address Address { get; }
         public System.Collections.Immutable.ImmutableHashSet<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Metrics { get; }
         public long Timestamp { get; }
-        public bool Equals(Akka.Cluster.Metrics.Serialization.NodeMetrics other) { }
+        public bool Equals(Akka.Cluster.Metrics.Serialization.NodeMetrics? other) { }
         public override int GetHashCode() { }
         public Akka.Cluster.Metrics.Serialization.NodeMetrics Merge(Akka.Cluster.Metrics.Serialization.NodeMetrics that) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
         public Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Metric(string name) { }
         public bool SameAs(Akka.Cluster.Metrics.Serialization.NodeMetrics that) { }
         public Akka.Cluster.Metrics.Serialization.NodeMetrics Update(Akka.Cluster.Metrics.Serialization.NodeMetrics that) { }
-        public class static Types
+        public static class Types
         {
             public sealed class EWMA : System.IEquatable<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA>
             {
@@ -332,50 +327,32 @@ namespace Akka.Cluster.Metrics.Serialization
                 public double Value { get; }
                 public bool Equals(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA other) { }
                 public override bool Equals(object obj) { }
-                public static double GetAlpha(System.TimeSpan halfLife, System.TimeSpan collectInterval) { }
                 public override int GetHashCode() { }
-                public static Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA +(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA current, double xn) { }
+                public static double GetAlpha(System.TimeSpan halfLife, System.TimeSpan collectInterval) { }
+                public static Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA operator +(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA current, double xn) { }
             }
-            [System.Runtime.CompilerServices.NullableAttribute(0)]
             public sealed class Metric : System.IEquatable<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric>
             {
-                public Metric(string name, Akka.Cluster.Metrics.Helpers.AnyNumber value, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})] Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA> average) { }
-                [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})]
+                public Metric(string name, Akka.Cluster.Metrics.Helpers.AnyNumber value, Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA> average) { }
                 public Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA> Average { get; }
                 public bool IsSmooth { get; }
                 public string Name { get; }
                 public double SmoothValue { get; }
                 public Akka.Cluster.Metrics.Helpers.AnyNumber Value { get; }
                 public Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric Add(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric latest) { }
-                [Akka.Annotations.InternalApiAttribute()]
-                public static Akka.Util.Either<long, double> ConvertNumber(Akka.Cluster.Metrics.Helpers.AnyNumber number) { }
-                [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})]
-                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create(string name, Akka.Cluster.Metrics.Helpers.AnyNumber value) { }
-                [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})]
-                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create([System.Runtime.CompilerServices.NullableAttribute(1)] string name, Akka.Cluster.Metrics.Helpers.AnyNumber value, Akka.Util.Option<double> decayFactor) { }
-                [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})]
-                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create(string name, Akka.Util.Try<Akka.Cluster.Metrics.Helpers.AnyNumber> value, [System.Runtime.CompilerServices.NullableAttribute(0)] Akka.Util.Option<double> decayFactor) { }
-                [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})]
-                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA> CreateEWMA(Akka.Cluster.Metrics.Helpers.AnyNumber value, Akka.Util.Option<double> decayFactor) { }
-                [Akka.Annotations.InternalApiAttribute()]
-                public static bool Defined(Akka.Cluster.Metrics.Helpers.AnyNumber value) { }
-                public bool Equals(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric other) { }
-                public override bool Equals(object obj) { }
+                public bool Equals(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric? other) { }
+                public override bool Equals(object? obj) { }
                 public override int GetHashCode() { }
                 public bool SameAs(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric that) { }
-                public static Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric +(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric m1, Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric m2) { }
+                [Akka.Annotations.InternalApi]
+                public static Akka.Util.Either<long, double> ConvertNumber(Akka.Cluster.Metrics.Helpers.AnyNumber number) { }
+                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create(string name, Akka.Cluster.Metrics.Helpers.AnyNumber value) { }
+                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create(string name, Akka.Cluster.Metrics.Helpers.AnyNumber value, Akka.Util.Option<double> decayFactor) { }
+                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create(string name, Akka.Util.Try<Akka.Cluster.Metrics.Helpers.AnyNumber> value, Akka.Util.Option<double> decayFactor) { }
+                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA> CreateEWMA(Akka.Cluster.Metrics.Helpers.AnyNumber value, Akka.Util.Option<double> decayFactor) { }
+                [Akka.Annotations.InternalApi]
+                public static bool Defined(Akka.Cluster.Metrics.Helpers.AnyNumber value) { }
+                public static Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric operator +(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric m1, Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric m2) { }
             }
         }
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterMetrics.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterMetrics.Net.verified.txt
@@ -1,12 +1,12 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Metrics.Tests")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Metrics.Tests")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Cluster.Metrics
 {
     public sealed class AdaptiveLoadBalancingGroup : Akka.Routing.Group
     {
-        public AdaptiveLoadBalancingGroup(Akka.Cluster.Metrics.IMetricsSelector metricsSelector = null, System.Collections.Generic.IEnumerable<string> paths = null, string routerDispatcher = null) { }
         public AdaptiveLoadBalancingGroup(Akka.Configuration.Config config) { }
+        public AdaptiveLoadBalancingGroup(Akka.Cluster.Metrics.IMetricsSelector metricsSelector = null, System.Collections.Generic.IEnumerable<string> paths = null, string routerDispatcher = null) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override System.Collections.Generic.IEnumerable<string> GetPaths(Akka.Actor.ActorSystem system) { }
         public override Akka.Actor.Props RoutingLogicController(Akka.Routing.RoutingLogic routingLogic) { }
@@ -21,7 +21,7 @@ namespace Akka.Cluster.Metrics
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class AdaptiveLoadBalancingMetricsListener : Akka.Actor.ActorBase
     {
         public AdaptiveLoadBalancingMetricsListener(Akka.Cluster.Metrics.IClusterMetricsRoutingLogic routingLogic) { }
@@ -31,8 +31,8 @@ namespace Akka.Cluster.Metrics
     }
     public sealed class AdaptiveLoadBalancingPool : Akka.Routing.Pool
     {
-        public AdaptiveLoadBalancingPool(Akka.Cluster.Metrics.IMetricsSelector metricsSelector = null, int nrOfInstances = 0, Akka.Actor.SupervisorStrategy supervisorStrategy = null, string routerDispatcher = null, bool usePoolDispatcher = False) { }
         public AdaptiveLoadBalancingPool(Akka.Configuration.Config config) { }
+        public AdaptiveLoadBalancingPool(Akka.Cluster.Metrics.IMetricsSelector metricsSelector = null, int nrOfInstances = 0, Akka.Actor.SupervisorStrategy supervisorStrategy = null, string routerDispatcher = null, bool usePoolDispatcher = false) { }
         public Akka.Cluster.Metrics.IMetricsSelector MetricsSelector { get; }
         public override Akka.Routing.Resizer Resizer { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
@@ -69,15 +69,15 @@ namespace Akka.Cluster.Metrics
     public class ClusterMetrics : Akka.Actor.IExtension
     {
         public Akka.Cluster.Metrics.Configuration.ClusterMetricsSettings Settings { get; }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public Akka.Cluster.Metrics.ClusterMetricsStrategy Strategy { get; }
         public Akka.Actor.IActorRef Supervisor { get; }
-        public static Akka.Configuration.Config DefaultConfig() { }
-        public static Akka.Cluster.Metrics.ClusterMetrics Get(Akka.Actor.ActorSystem system) { }
         public void Subscribe(Akka.Actor.IActorRef metricsListener) { }
         public void Unsubscribe(Akka.Actor.IActorRef metricsListener) { }
+        public static Akka.Configuration.Config DefaultConfig() { }
+        public static Akka.Cluster.Metrics.ClusterMetrics Get(Akka.Actor.ActorSystem system) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ClusterMetricsCollector : Akka.Actor.ActorBase
     {
         public ClusterMetricsCollector() { }
@@ -94,7 +94,7 @@ namespace Akka.Cluster.Metrics
     {
         public ClusterMetricsStrategy(Akka.Configuration.Config config) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ClusterMetricsSupervisor : Akka.Actor.ActorBase
     {
         public ClusterMetricsSupervisor() { }
@@ -102,8 +102,8 @@ namespace Akka.Cluster.Metrics
         protected override bool Receive(object message) { }
         protected override Akka.Actor.SupervisorStrategy SupervisorStrategy() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static ClusterMetricsSupervisorMetadata
+    [Akka.Annotations.InternalApi]
+    public static class ClusterMetricsSupervisorMetadata
     {
         public sealed class CollectionStartMessage : Akka.Cluster.Metrics.ClusterMetricsSupervisorMetadata.ICollectionControlMessage
         {
@@ -144,7 +144,7 @@ namespace Akka.Cluster.Metrics
         public MetricsCollectorBuilder() { }
         public Akka.Cluster.Metrics.IMetricsCollector Build(Akka.Actor.ActorSystem system) { }
     }
-    public class static MetricsSelectorBuilder
+    public static class MetricsSelectorBuilder
     {
         public static Akka.Cluster.Metrics.IMetricsSelector BuildFromConfig(Akka.Configuration.Config config) { }
     }
@@ -159,7 +159,7 @@ namespace Akka.Cluster.Metrics
         public System.Collections.Immutable.ImmutableArray<Akka.Cluster.Metrics.CapacityMetricsSelector> Selectors { get; }
         public override System.Collections.Immutable.IImmutableDictionary<Akka.Actor.Address, double> Capacity(System.Collections.Immutable.IImmutableSet<Akka.Cluster.Metrics.Serialization.NodeMetrics> nodeMetrics) { }
     }
-    public class static StandardMetrics
+    public static class StandardMetrics
     {
         public const string CpuProcessUsage = "CpuProcessUsage";
         public const string CpuTotalUsage = "CpuTotalUsage";
@@ -177,7 +177,7 @@ namespace Akka.Cluster.Metrics
             public int ProcessorsNumber { get; }
             public long Timestamp { get; }
             public double TotalUsage { get; }
-            [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+            [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                     "Address",
                     "Timestamp",
                     "CpuProcessUsage",
@@ -193,7 +193,7 @@ namespace Akka.Cluster.Metrics
             public Akka.Util.Option<double> MaxRecommended { get; }
             public long Timestamp { get; }
             public double Used { get; }
-            [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+            [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                     "Address",
                     "Timestamp",
                     "UsedSmoothValue",
@@ -202,7 +202,7 @@ namespace Akka.Cluster.Metrics
             public static Akka.Util.Option<System.ValueTuple<Akka.Actor.Address, long, double, double, Akka.Util.Option<double>>> Decompose(Akka.Cluster.Metrics.Serialization.NodeMetrics nodeMetrics) { }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class WeightedRoutees
     {
         public WeightedRoutees(System.Collections.Immutable.ImmutableArray<Akka.Routing.Routee> routees, Akka.Actor.Address selfAddress, System.Collections.Immutable.IImmutableDictionary<Akka.Actor.Address, int> weights) { }
@@ -215,8 +215,8 @@ namespace Akka.Cluster.Metrics.Collectors
 {
     public class DefaultCollector : Akka.Cluster.Metrics.IMetricsCollector, System.IDisposable
     {
-        public DefaultCollector(Akka.Actor.Address address) { }
         public DefaultCollector(Akka.Actor.ActorSystem system) { }
+        public DefaultCollector(Akka.Actor.Address address) { }
         public void Dispose() { }
         public Akka.Cluster.Metrics.Serialization.NodeMetrics Sample() { }
     }
@@ -251,21 +251,21 @@ namespace Akka.Cluster.Metrics.Events
 }
 namespace Akka.Cluster.Metrics.Helpers
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public struct AnyNumber
     {
+        public AnyNumber(double n) { }
+        public AnyNumber(float n) { }
         public AnyNumber(int n) { }
         public AnyNumber(long n) { }
-        public AnyNumber(float n) { }
-        public AnyNumber(double n) { }
         public double DoubleValue { get; }
         public long LongValue { get; }
         public Akka.Cluster.Metrics.Helpers.AnyNumber.NumberType Type { get; }
         public override string ToString() { }
+        public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(double n) { }
+        public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(float n) { }
         public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(int n) { }
         public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(long n) { }
-        public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(float n) { }
-        public static Akka.Cluster.Metrics.Helpers.AnyNumber op_Implicit(double n) { }
         public enum NumberType
         {
             Int = 0,
@@ -284,9 +284,9 @@ namespace Akka.Cluster.Metrics.Serialization
         public override string Manifest(object o) { }
         public override byte[] ToBinary(object obj) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IClusterMetricMessage { }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class MetricsGossip
     {
         public static readonly Akka.Cluster.Metrics.Serialization.MetricsGossip Empty;
@@ -296,9 +296,9 @@ namespace Akka.Cluster.Metrics.Serialization
         public Akka.Cluster.Metrics.Serialization.MetricsGossip Merge(Akka.Cluster.Metrics.Serialization.MetricsGossip otherGossip) { }
         public Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics> NodeMetricsFor(Akka.Actor.Address address) { }
         public Akka.Cluster.Metrics.Serialization.MetricsGossip Remove(Akka.Actor.Address node) { }
-        public static Akka.Cluster.Metrics.Serialization.MetricsGossip +(Akka.Cluster.Metrics.Serialization.MetricsGossip gossip, Akka.Cluster.Metrics.Serialization.NodeMetrics newNodeMetrics) { }
+        public static Akka.Cluster.Metrics.Serialization.MetricsGossip operator +(Akka.Cluster.Metrics.Serialization.MetricsGossip gossip, Akka.Cluster.Metrics.Serialization.NodeMetrics newNodeMetrics) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class MetricsGossipEnvelope : Akka.Cluster.Metrics.Serialization.IClusterMetricMessage, Akka.Event.IDeadLetterSuppression
     {
         public MetricsGossipEnvelope(Akka.Actor.Address fromAddress, Akka.Cluster.Metrics.Serialization.MetricsGossip gossip, bool reply) { }
@@ -306,23 +306,19 @@ namespace Akka.Cluster.Metrics.Serialization
         public Akka.Cluster.Metrics.Serialization.MetricsGossip Gossip { get; }
         public bool Reply { get; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class NodeMetrics : System.IEquatable<Akka.Cluster.Metrics.Serialization.NodeMetrics>
     {
         public NodeMetrics(Akka.Actor.Address address, long timestamp, System.Collections.Generic.IEnumerable<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> metrics) { }
         public Akka.Actor.Address Address { get; }
         public System.Collections.Immutable.ImmutableHashSet<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Metrics { get; }
         public long Timestamp { get; }
-        public bool Equals(Akka.Cluster.Metrics.Serialization.NodeMetrics other) { }
+        public bool Equals(Akka.Cluster.Metrics.Serialization.NodeMetrics? other) { }
         public override int GetHashCode() { }
         public Akka.Cluster.Metrics.Serialization.NodeMetrics Merge(Akka.Cluster.Metrics.Serialization.NodeMetrics that) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
         public Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Metric(string name) { }
         public bool SameAs(Akka.Cluster.Metrics.Serialization.NodeMetrics that) { }
         public Akka.Cluster.Metrics.Serialization.NodeMetrics Update(Akka.Cluster.Metrics.Serialization.NodeMetrics that) { }
-        public class static Types
+        public static class Types
         {
             public sealed class EWMA : System.IEquatable<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA>
             {
@@ -331,50 +327,32 @@ namespace Akka.Cluster.Metrics.Serialization
                 public double Value { get; }
                 public bool Equals(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA other) { }
                 public override bool Equals(object obj) { }
-                public static double GetAlpha(System.TimeSpan halfLife, System.TimeSpan collectInterval) { }
                 public override int GetHashCode() { }
-                public static Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA +(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA current, double xn) { }
+                public static double GetAlpha(System.TimeSpan halfLife, System.TimeSpan collectInterval) { }
+                public static Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA operator +(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA current, double xn) { }
             }
-            [System.Runtime.CompilerServices.NullableAttribute(0)]
             public sealed class Metric : System.IEquatable<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric>
             {
-                public Metric(string name, Akka.Cluster.Metrics.Helpers.AnyNumber value, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})] Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA> average) { }
-                [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})]
+                public Metric(string name, Akka.Cluster.Metrics.Helpers.AnyNumber value, Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA> average) { }
                 public Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA> Average { get; }
                 public bool IsSmooth { get; }
                 public string Name { get; }
                 public double SmoothValue { get; }
                 public Akka.Cluster.Metrics.Helpers.AnyNumber Value { get; }
                 public Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric Add(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric latest) { }
-                [Akka.Annotations.InternalApiAttribute()]
-                public static Akka.Util.Either<long, double> ConvertNumber(Akka.Cluster.Metrics.Helpers.AnyNumber number) { }
-                [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})]
-                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create(string name, Akka.Cluster.Metrics.Helpers.AnyNumber value) { }
-                [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})]
-                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create([System.Runtime.CompilerServices.NullableAttribute(1)] string name, Akka.Cluster.Metrics.Helpers.AnyNumber value, Akka.Util.Option<double> decayFactor) { }
-                [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})]
-                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create(string name, Akka.Util.Try<Akka.Cluster.Metrics.Helpers.AnyNumber> value, [System.Runtime.CompilerServices.NullableAttribute(0)] Akka.Util.Option<double> decayFactor) { }
-                [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                        0,
-                        1})]
-                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA> CreateEWMA(Akka.Cluster.Metrics.Helpers.AnyNumber value, Akka.Util.Option<double> decayFactor) { }
-                [Akka.Annotations.InternalApiAttribute()]
-                public static bool Defined(Akka.Cluster.Metrics.Helpers.AnyNumber value) { }
-                public bool Equals(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric other) { }
-                public override bool Equals(object obj) { }
+                public bool Equals(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric? other) { }
+                public override bool Equals(object? obj) { }
                 public override int GetHashCode() { }
                 public bool SameAs(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric that) { }
-                public static Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric +(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric m1, Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric m2) { }
+                [Akka.Annotations.InternalApi]
+                public static Akka.Util.Either<long, double> ConvertNumber(Akka.Cluster.Metrics.Helpers.AnyNumber number) { }
+                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create(string name, Akka.Cluster.Metrics.Helpers.AnyNumber value) { }
+                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create(string name, Akka.Cluster.Metrics.Helpers.AnyNumber value, Akka.Util.Option<double> decayFactor) { }
+                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric> Create(string name, Akka.Util.Try<Akka.Cluster.Metrics.Helpers.AnyNumber> value, Akka.Util.Option<double> decayFactor) { }
+                public static Akka.Util.Option<Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.EWMA> CreateEWMA(Akka.Cluster.Metrics.Helpers.AnyNumber value, Akka.Util.Option<double> decayFactor) { }
+                [Akka.Annotations.InternalApi]
+                public static bool Defined(Akka.Cluster.Metrics.Helpers.AnyNumber value) { }
+                public static Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric operator +(Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric m1, Akka.Cluster.Metrics.Serialization.NodeMetrics.Types.Metric m2) { }
             }
         }
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.DotNet.verified.txt
@@ -1,67 +1,64 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData.Tests")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("a05c31e8-0246-46a1-b3bc-4d6fe7a9aa49")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DistributedData.Tests")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("a05c31e8-0246-46a1-b3bc-4d6fe7a9aa49")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Cluster.Sharding
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ClusterSharding : Akka.Actor.IExtension
     {
         public ClusterSharding(Akka.Actor.ExtendedActorSystem system) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public Akka.Cluster.Sharding.IShardingBufferMessageAdapter BufferMessageAdapter { get; }
         public Akka.Cluster.Sharding.ClusterShardingSettings Settings { get; }
         public System.Collections.Immutable.ImmutableHashSet<string> ShardTypeNames { get; }
-        public static Akka.Configuration.Config DefaultConfig() { }
         public Akka.Cluster.Sharding.IShardAllocationStrategy DefaultShardAllocationStrategy(Akka.Cluster.Sharding.ClusterShardingSettings settings) { }
-        public static Akka.Cluster.Sharding.ClusterSharding Get(Akka.Actor.ActorSystem system) { }
-        [Akka.Annotations.InternalApiAttribute()]
-        public void SetShardingBufferMessageAdapter(Akka.Cluster.Sharding.IShardingBufferMessageAdapter bufferMessageAdapter) { }
+        [Akka.Annotations.InternalApi]
+        public void SetShardingBufferMessageAdapter(Akka.Cluster.Sharding.IShardingBufferMessageAdapter? bufferMessageAdapter) { }
         public Akka.Actor.IActorRef ShardRegion(string typeName) { }
         public Akka.Actor.IActorRef ShardRegionProxy(string typeName) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
-        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
         public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
-        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
         public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public Akka.Actor.IActorRef StartProxy(string typeName, string role, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
         public Akka.Actor.IActorRef StartProxy(string typeName, string role, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartProxyAsync(string typeName, string role, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public Akka.Actor.IActorRef StartProxy(string typeName, string role, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartProxyAsync(string typeName, string role, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartProxyAsync(string typeName, string role, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        public static Akka.Configuration.Config DefaultConfig() { }
+        public static Akka.Cluster.Sharding.ClusterSharding Get(Akka.Actor.ActorSystem system) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1})]
     public sealed class ClusterShardingExtensionProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Sharding.ClusterSharding>
     {
         public ClusterShardingExtensionProvider() { }
         public override Akka.Cluster.Sharding.ClusterSharding CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
+    [System.Serializable]
     public sealed class ClusterShardingSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
         public readonly Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings CoordinatorSingletonSettings;
@@ -78,10 +75,7 @@ namespace Akka.Cluster.Sharding
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings) { }
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.RememberEntitiesStore rememberEntitiesStore, System.TimeSpan shardRegionQueryTimeout, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.SupervisorStrategy SupervisorStrategy { get; }
-        public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Configuration.Config config, Akka.Configuration.Config singletonConfig) { }
+        public Akka.Actor.SupervisorStrategy? SupervisorStrategy { get; }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithCoordinatorSingletonSettings(Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithJournalPluginId(string journalPluginId) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithLeaseSettings(Akka.Coordination.LeaseUsageSettings leaseSettings) { }
@@ -92,34 +86,39 @@ namespace Akka.Cluster.Sharding
         public Akka.Cluster.Sharding.ClusterShardingSettings WithStateStoreMode(Akka.Cluster.Sharding.StateStoreMode mode) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithSupervisorStrategy(Akka.Actor.SupervisorStrategy supervisorStrategy) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithTuningParameters(Akka.Cluster.Sharding.TuningParameters tuningParameters) { }
+        public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Configuration.Config config, Akka.Configuration.Config singletonConfig) { }
     }
+    [System.Serializable]
     public sealed class ClusterShardingStats : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ClusterShardingStats>
     {
         public readonly System.Collections.Immutable.IImmutableDictionary<Akka.Actor.Address, Akka.Cluster.Sharding.ShardRegionStats> Regions;
         public ClusterShardingStats(System.Collections.Immutable.IImmutableDictionary<Akka.Actor.Address, Akka.Cluster.Sharding.ShardRegionStats> regions) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.ClusterShardingStats other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class CurrentRegions : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.CurrentRegions>
     {
         public readonly System.Collections.Immutable.IImmutableSet<Akka.Actor.Address> Regions;
         public CurrentRegions(System.Collections.Immutable.IImmutableSet<Akka.Actor.Address> regions) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.CurrentRegions other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class CurrentShardRegionState : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.CurrentShardRegionState>
     {
         public readonly System.Collections.Immutable.IImmutableSet<string> Failed;
         public readonly System.Collections.Immutable.IImmutableSet<Akka.Cluster.Sharding.ShardState> Shards;
-        [System.ObsoleteAttribute("Use constructor with `failed` argument. Obsolete since 1.5.0-alpha1")]
+        [System.Obsolete("Use constructor with `failed` argument. Obsolete since 1.5.0-alpha1")]
         public CurrentShardRegionState(System.Collections.Immutable.IImmutableSet<Akka.Cluster.Sharding.ShardState> shards) { }
         public CurrentShardRegionState(System.Collections.Immutable.IImmutableSet<Akka.Cluster.Sharding.ShardState> shards, System.Collections.Immutable.IImmutableSet<string> failed) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.CurrentShardRegionState other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -131,28 +130,25 @@ namespace Akka.Cluster.Sharding
         public string ShardId { get; }
         public Akka.Actor.Address ShardRegion { get; }
     }
-    public class static EnumerableExtensions
+    public static class EnumerableExtensions
     {
         public static System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<T>> Grouped<T>(this System.Collections.Generic.IEnumerable<T> items, int size) { }
     }
-    [System.ObsoleteAttribute("Use HashCodeMessageExtractor or IMessageExtractor instead.")]
-    [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            0,
-            1,
-            1})]
+    [System.Obsolete("Use HashCodeMessageExtractor or IMessageExtractor instead.")]
     public delegate Akka.Util.Option<System.ValueTuple<string, object>> ExtractEntityId(object message);
-    [System.ObsoleteAttribute("Use HashCodeMessageExtractor or IMessageExtractor instead.")]
+    [System.Obsolete("Use HashCodeMessageExtractor or IMessageExtractor instead.")]
     public delegate string ExtractShardId(object message);
+    [System.Serializable]
     public sealed class GetClusterShardingStats : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery, System.IEquatable<Akka.Cluster.Sharding.GetClusterShardingStats>
     {
         public readonly System.TimeSpan Timeout;
         public GetClusterShardingStats(System.TimeSpan timeout) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.GetClusterShardingStats other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class GetCurrentRegions : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery
     {
         public static readonly Akka.Cluster.Sharding.GetCurrentRegions Instance;
@@ -164,40 +160,33 @@ namespace Akka.Cluster.Sharding
         public string EntityId { get; }
         public System.TimeSpan Timeout { get; }
     }
+    [System.Serializable]
     public sealed class GetShardRegionState : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery
     {
         public static readonly Akka.Cluster.Sharding.GetShardRegionState Instance;
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class GetShardRegionStats : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery
     {
         public static readonly Akka.Cluster.Sharding.GetShardRegionStats Instance;
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class GracefulShutdown : Akka.Cluster.Sharding.IShardRegionCommand
     {
         public static readonly Akka.Cluster.Sharding.GracefulShutdown Instance;
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class HashCodeMessageExtractor : Akka.Cluster.Sharding.IMessageExtractor
     {
         public readonly int MaxNumberOfShards;
         protected HashCodeMessageExtractor(int maxNumberOfShards) { }
-        public static Akka.Cluster.Sharding.HashCodeMessageExtractor Create(int maxNumberOfShards, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                1,
-                1,
-                2})] System.Func<object, string> entityIdExtractor, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1,
-                1})] System.Func<object, object> messageExtractor = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public abstract string EntityId(object message);
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public virtual object EntityMessage(object message) { }
-        [System.ObsoleteAttribute("Use ShardId(string, object?) instead. Since v1.5.15")]
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public virtual string ShardId(object message) { }
-        public virtual string ShardId(string entityId, [System.Runtime.CompilerServices.NullableAttribute(2)] object messageHint = null) { }
+        public abstract string? EntityId(object message);
+        public virtual object? EntityMessage(object message) { }
+        [System.Obsolete("Use ShardId(string, object?) instead. Since v1.5.15")]
+        public virtual string? ShardId(object message) { }
+        public virtual string ShardId(string entityId, object? messageHint = null) { }
+        public static Akka.Cluster.Sharding.HashCodeMessageExtractor Create(int maxNumberOfShards, System.Func<object, string?> entityIdExtractor, System.Func<object, object>? messageExtractor = null) { }
     }
     public interface IActorSystemDependentAllocationStrategy : Akka.Actor.INoSerializationVerificationNeeded, Akka.Cluster.Sharding.IShardAllocationStrategy
     {
@@ -206,14 +195,11 @@ namespace Akka.Cluster.Sharding
     public interface IClusterShardingSerializable { }
     public interface IMessageExtractor
     {
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        string EntityId(object message);
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        object EntityMessage(object message);
-        [System.ObsoleteAttribute("Use ShardId(EntityId, object) instead.")]
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        string ShardId(object message);
-        string ShardId(string entityId, [System.Runtime.CompilerServices.NullableAttribute(2)] object messageHint = null);
+        string? EntityId(object message);
+        object? EntityMessage(object message);
+        [System.Obsolete("Use ShardId(EntityId, object) instead.")]
+        string? ShardId(object message);
+        string ShardId(string entityId, object? messageHint = null);
     }
     public interface IShardAllocationStrategy : Akka.Actor.INoSerializationVerificationNeeded
     {
@@ -222,7 +208,7 @@ namespace Akka.Cluster.Sharding
     }
     public interface IShardRegionCommand { }
     public interface IShardRegionQuery { }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IShardingBufferMessageAdapter
     {
         object Apply(object message, Akka.Actor.IActorContext context);
@@ -232,13 +218,15 @@ namespace Akka.Cluster.Sharding
     {
         void Start();
     }
-    [System.ObsoleteAttribute("Use ShardAllocationStrategy.LeastShardAllocationStrategy instead. This will be re" +
+    [System.Obsolete("Use ShardAllocationStrategy.LeastShardAllocationStrategy instead. This will be re" +
         "moved in v1.6.")]
+    [System.Serializable]
     public class LeastShardAllocationStrategy : Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy
     {
         public LeastShardAllocationStrategy(int rebalanceThreshold, int maxSimultaneousRebalance) { }
         public override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableSet<string>> Rebalance(System.Collections.Immutable.IImmutableDictionary<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> currentShardAllocations, System.Collections.Immutable.IImmutableSet<string> rebalanceInProgress) { }
     }
+    [System.Serializable]
     public sealed class Passivate : Akka.Cluster.Sharding.IShardRegionCommand
     {
         public Passivate(object stopMessage) { }
@@ -250,113 +238,101 @@ namespace Akka.Cluster.Sharding
         Eventsourced = 1,
         Custom = 2,
     }
-    public class static ShardAllocationStrategy
+    public static class ShardAllocationStrategy
     {
         public static Akka.Cluster.Sharding.IShardAllocationStrategy LeastShardAllocationStrategy(int absoluteLimit, double relativeLimit) { }
     }
-    [Akka.Annotations.InternalStableApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [Akka.Annotations.InternalStableApi]
     public sealed class ShardRegion : Akka.Actor.ActorBase, Akka.Actor.IWithTimers
     {
-        public ShardRegion(string typeName, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1,
-                1})] System.Func<string, Akka.Actor.Props> entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, string coordinatorPath, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, object handOffStopMessage, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Cluster.Sharding.Internal.IRememberEntitiesProvider rememberEntitiesProvider) { }
+        public ShardRegion(string typeName, System.Func<string, Akka.Actor.Props>? entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, string coordinatorPath, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, object handOffStopMessage, Akka.Cluster.Sharding.Internal.IRememberEntitiesProvider? rememberEntitiesProvider) { }
         public Akka.Actor.ITimerScheduler Timers { get; set; }
         protected override void PostStop() { }
         protected override void PreStart() { }
         protected override bool Receive(object message) { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
+        [System.Serializable]
         public sealed class StartEntity : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ShardRegion.StartEntity>
         {
             public readonly string EntityId;
             public StartEntity(string entityId) { }
-            public override bool Equals(object obj) { }
-            public bool Equals(Akka.Cluster.Sharding.ShardRegion.StartEntity other) { }
+            public bool Equals(Akka.Cluster.Sharding.ShardRegion.StartEntity? other) { }
+            public override bool Equals(object? obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
         }
     }
+    [System.Serializable]
     public sealed class ShardRegionStats : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ShardRegionStats>
     {
         public readonly System.Collections.Immutable.IImmutableSet<string> Failed;
         public readonly System.Collections.Immutable.IImmutableDictionary<string, int> Stats;
-        [System.ObsoleteAttribute("Use constructor with `failed` argument. Obsolete since 1.5.0-alpha1")]
+        [System.Obsolete("Use constructor with `failed` argument. Obsolete since 1.5.0-alpha1")]
         public ShardRegionStats(System.Collections.Immutable.IImmutableDictionary<string, int> stats) { }
         public ShardRegionStats(System.Collections.Immutable.IImmutableDictionary<string, int> stats, System.Collections.Immutable.IImmutableSet<string> failed) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.ShardRegionStats other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class ShardState : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ShardState>
     {
         public readonly System.Collections.Immutable.IImmutableSet<string> EntityIds;
         public readonly string ShardId;
         public ShardState(string shardId, System.Collections.Immutable.IImmutableSet<string> entityIds) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.ShardState other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
     public class ShardSupervisionStrategy : Akka.Actor.OneForOneStrategy
     {
-        public ShardSupervisionStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public ShardSupervisionStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, Akka.Actor.IDecider decider) { }
-        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
-        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = True) { }
-        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
-        public ShardSupervisionStrategy(Akka.Actor.IDecider decider) { }
         public ShardSupervisionStrategy() { }
+        public ShardSupervisionStrategy(Akka.Actor.IDecider decider) { }
+        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = true) { }
+        public ShardSupervisionStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, Akka.Actor.IDecider decider) { }
+        public ShardSupervisionStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = true) { }
+        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = true) { }
         public override void ProcessFailure(Akka.Actor.IActorContext context, bool restart, Akka.Actor.IActorRef child, System.Exception cause, Akka.Actor.Internal.ChildRestartStats stats, System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> children) { }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
-    [Akka.Annotations.DoNotInheritAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [Akka.Annotations.ApiMayChange]
+    [Akka.Annotations.DoNotInherit]
     public class ShardedDaemonProcess : Akka.Actor.IExtension
     {
         public ShardedDaemonProcess(Akka.Actor.ExtendedActorSystem system) { }
-        public static Akka.Cluster.Sharding.ShardedDaemonProcess Get(Akka.Actor.ActorSystem system) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, Akka.Cluster.Sharding.ShardedDaemonProcessSettings settings, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
+        public Akka.Actor.IActorRef? Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory) { }
+        public Akka.Actor.IActorRef? Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, object? stopMessage) { }
+        public Akka.Actor.IActorRef? Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, Akka.Cluster.Sharding.ShardedDaemonProcessSettings settings, object? stopMessage) { }
         public Akka.Actor.IActorRef InitProxy(string name, int numberOfInstances, string role) { }
+        public static Akka.Cluster.Sharding.ShardedDaemonProcess Get(Akka.Actor.ActorSystem system) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1})]
     public class ShardedDaemonProcessExtensionProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Sharding.ShardedDaemonProcess>
     {
         public ShardedDaemonProcessExtensionProvider() { }
         public override Akka.Cluster.Sharding.ShardedDaemonProcess CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [Akka.Annotations.ApiMayChange]
+    [System.Serializable]
     public sealed class ShardedDaemonProcessSettings
     {
         public readonly System.TimeSpan KeepAliveInterval;
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public readonly string Role;
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public readonly Akka.Cluster.Sharding.ClusterShardingSettings ShardingSettings;
-        public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings FromConfig(Akka.Configuration.Config config) { }
+        public readonly string? Role;
+        public readonly Akka.Cluster.Sharding.ClusterShardingSettings? ShardingSettings;
         public Akka.Cluster.Sharding.ShardedDaemonProcessSettings WithKeepAliveInterval(System.TimeSpan keepAliveInterval) { }
         public Akka.Cluster.Sharding.ShardedDaemonProcessSettings WithRole(string role) { }
         public Akka.Cluster.Sharding.ShardedDaemonProcessSettings WithShardingSettings(Akka.Cluster.Sharding.ClusterShardingSettings shardingSettings) { }
+        public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings FromConfig(Akka.Configuration.Config config) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ShardingEnvelope : Akka.Actor.IWrappedMessage, Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ShardingEnvelope>
     {
         public ShardingEnvelope(string entityId, object message) { }
         public string EntityId { get; }
         public object Message { get; }
-        public bool Equals(Akka.Cluster.Sharding.ShardingEnvelope other) { }
-        public override bool Equals(object obj) { }
+        public bool Equals(Akka.Cluster.Sharding.ShardingEnvelope? other) { }
+        public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -366,6 +342,7 @@ namespace Akka.Cluster.Sharding
         DData = 1,
         Custom = 2,
     }
+    [System.Serializable]
     public class TuningParameters
     {
         public readonly int BufferSize;
@@ -390,26 +367,26 @@ namespace Akka.Cluster.Sharding
         public readonly System.TimeSpan UpdatingStateTimeout;
         public readonly System.TimeSpan WaitingForStateTimeout;
         public TuningParameters(
-                    System.TimeSpan coordinatorFailureBackoff, 
-                    System.TimeSpan retryInterval, 
-                    int bufferSize, 
-                    System.TimeSpan handOffTimeout, 
-                    System.TimeSpan shardStartTimeout, 
-                    System.TimeSpan shardFailureBackoff, 
-                    System.TimeSpan entityRestartBackoff, 
-                    System.TimeSpan rebalanceInterval, 
-                    int snapshotAfter, 
-                    int keepNrOfBatches, 
-                    int leastShardAllocationRebalanceThreshold, 
-                    int leastShardAllocationMaxSimultaneousRebalance, 
-                    System.TimeSpan waitingForStateTimeout, 
-                    System.TimeSpan updatingStateTimeout, 
-                    string entityRecoveryStrategy, 
-                    System.TimeSpan entityRecoveryConstantRateStrategyFrequency, 
-                    int entityRecoveryConstantRateStrategyNumberOfEntities, 
-                    int coordinatorStateWriteMajorityPlus, 
-                    int coordinatorStateReadMajorityPlus, 
-                    int leastShardAllocationAbsoluteLimit, 
+                    System.TimeSpan coordinatorFailureBackoff,
+                    System.TimeSpan retryInterval,
+                    int bufferSize,
+                    System.TimeSpan handOffTimeout,
+                    System.TimeSpan shardStartTimeout,
+                    System.TimeSpan shardFailureBackoff,
+                    System.TimeSpan entityRestartBackoff,
+                    System.TimeSpan rebalanceInterval,
+                    int snapshotAfter,
+                    int keepNrOfBatches,
+                    int leastShardAllocationRebalanceThreshold,
+                    int leastShardAllocationMaxSimultaneousRebalance,
+                    System.TimeSpan waitingForStateTimeout,
+                    System.TimeSpan updatingStateTimeout,
+                    string entityRecoveryStrategy,
+                    System.TimeSpan entityRecoveryConstantRateStrategyFrequency,
+                    int entityRecoveryConstantRateStrategyNumberOfEntities,
+                    int coordinatorStateWriteMajorityPlus,
+                    int coordinatorStateReadMajorityPlus,
+                    int leastShardAllocationAbsoluteLimit,
                     double leastShardAllocationRelativeLimit) { }
         public Akka.Cluster.Sharding.TuningParameters WithBufferSize(int bufferSize) { }
         public Akka.Cluster.Sharding.TuningParameters WithCoordinatorFailureBackoff(System.TimeSpan coordinatorFailureBackoff) { }
@@ -436,61 +413,52 @@ namespace Akka.Cluster.Sharding
 }
 namespace Akka.Cluster.Sharding.Delivery
 {
-    [Akka.Annotations.ApiMayChangeAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static ShardingConsumerController
+    [Akka.Annotations.ApiMayChange]
+    public static class ShardingConsumerController
     {
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<Akka.Actor.IActorRef, Akka.Actor.Props> consumerProps, Akka.Cluster.Sharding.Delivery.ShardingConsumerController.Settings settings) { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
+        public static Akka.Actor.Props Create<T>(System.Func<Akka.Actor.IActorRef, Akka.Actor.Props> consumerProps, Akka.Cluster.Sharding.Delivery.ShardingConsumerController.Settings settings) { }
         public sealed class Settings : System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingConsumerController.Settings>
         {
-            public bool AllowBypass { get; set; }
-            public int BufferSize { get; set; }
-            public Akka.Delivery.ConsumerController.Settings ConsumerControllerSettings { get; set; }
-            public static Akka.Cluster.Sharding.Delivery.ShardingConsumerController.Settings Create(Akka.Actor.ActorSystem system) { }
+            public bool AllowBypass { get; init; }
+            public int BufferSize { get; init; }
+            public Akka.Delivery.ConsumerController.Settings ConsumerControllerSettings { get; init; }
             public override string ToString() { }
+            public static Akka.Cluster.Sharding.Delivery.ShardingConsumerController.Settings Create(Akka.Actor.ActorSystem system) { }
         }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static ShardingProducerController
+    [Akka.Annotations.ApiMayChange]
+    public static class ShardingProducerController
     {
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(string producerId, Akka.Actor.IActorRef shardRegion, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<Akka.Actor.Props> durableQueue, Akka.Cluster.Sharding.Delivery.ShardingProducerController.Settings settings) { }
+        public static Akka.Actor.Props Create<T>(string producerId, Akka.Actor.IActorRef shardRegion, Akka.Util.Option<Akka.Actor.Props> durableQueue, Akka.Cluster.Sharding.Delivery.ShardingProducerController.Settings settings) { }
         public interface IShardingProducerControllerCommand<T> { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class MessageWithConfirmation<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Cluster.Sharding.Delivery.ShardingProducerController.IShardingProducerControllerCommand<T>, System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingProducerController.MessageWithConfirmation<T>>
+        public sealed class MessageWithConfirmation<T> : Akka.Cluster.Sharding.Delivery.ShardingProducerController.IShardingProducerControllerCommand<T>, System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingProducerController.MessageWithConfirmation<T>>
         {
             public MessageWithConfirmation(string EntityId, T Message, Akka.Actor.IActorRef ReplyTo) { }
-            public string EntityId { get; set; }
-            public T Message { get; set; }
-            public Akka.Actor.IActorRef ReplyTo { get; set; }
+            public string EntityId { get; init; }
+            public T Message { get; init; }
+            public Akka.Actor.IActorRef ReplyTo { get; init; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class RequestNext<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingProducerController.RequestNext<T>>
+        public sealed class RequestNext<T> : System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingProducerController.RequestNext<T>>
         {
             public RequestNext(Akka.Actor.IActorRef SendNextTo, Akka.Actor.IActorRef AskNextToRef, System.Collections.Immutable.ImmutableHashSet<string> EntitiesWithDemand, System.Collections.Immutable.ImmutableDictionary<string, int> BufferedForEntitiesWithoutDemand) { }
-            public Akka.Actor.IActorRef AskNextToRef { get; set; }
-            public System.Collections.Immutable.ImmutableDictionary<string, int> BufferedForEntitiesWithoutDemand { get; set; }
-            public System.Collections.Immutable.ImmutableHashSet<string> EntitiesWithDemand { get; set; }
-            public Akka.Actor.IActorRef SendNextTo { get; set; }
-            public System.Threading.Tasks.Task<long> AskNextTo(string entityId, T msg, System.Threading.CancellationToken cancellationToken = null) { }
+            public Akka.Actor.IActorRef AskNextToRef { get; init; }
+            public System.Collections.Immutable.ImmutableDictionary<string, int> BufferedForEntitiesWithoutDemand { get; init; }
+            public System.Collections.Immutable.ImmutableHashSet<string> EntitiesWithDemand { get; init; }
+            public Akka.Actor.IActorRef SendNextTo { get; init; }
             public void AskNextTo(Akka.Cluster.Sharding.Delivery.ShardingProducerController.MessageWithConfirmation<T> msgWithConfirmation) { }
+            public System.Threading.Tasks.Task<long> AskNextTo(string entityId, T msg, System.Threading.CancellationToken cancellationToken = default) { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class Settings : System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingProducerController.Settings>
         {
-            public int BufferSize { get; set; }
-            public System.TimeSpan CleanupUnusedAfter { get; set; }
-            public System.TimeSpan InternalAskTimeout { get; set; }
-            public Akka.Delivery.ProducerController.Settings ProducerControllerSettings { get; set; }
-            public System.TimeSpan ResendFirstUnconfirmedIdleTimeout { get; set; }
+            public int BufferSize { get; init; }
+            public System.TimeSpan CleanupUnusedAfter { get; init; }
+            public System.TimeSpan InternalAskTimeout { get; init; }
+            public Akka.Delivery.ProducerController.Settings ProducerControllerSettings { get; init; }
+            public System.TimeSpan ResendFirstUnconfirmedIdleTimeout { get; init; }
             public static Akka.Cluster.Sharding.Delivery.ShardingProducerController.Settings Create(Akka.Actor.ActorSystem system) { }
             public static Akka.Cluster.Sharding.Delivery.ShardingProducerController.Settings Create(Akka.Configuration.Config config, Akka.Configuration.Config producerControllerConfig) { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class Start<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Cluster.Sharding.Delivery.ShardingProducerController.IShardingProducerControllerCommand<T>
+        public sealed class Start<T> : Akka.Cluster.Sharding.Delivery.ShardingProducerController.IShardingProducerControllerCommand<T>
         {
             public Start(Akka.Actor.IActorRef producer) { }
             public Akka.Actor.IActorRef Producer { get; }
@@ -502,8 +470,8 @@ namespace Akka.Cluster.Sharding.External
     public class ClientTimeoutException : System.Exception
     {
         public ClientTimeoutException(string message) { }
-        public ClientTimeoutException(string message, System.Exception innerEx) { }
         protected ClientTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public ClientTimeoutException(string message, System.Exception innerEx) { }
     }
     public sealed class ExternalShardAllocation : Akka.Actor.IExtension
     {
@@ -528,8 +496,8 @@ namespace Akka.Cluster.Sharding.External
         {
             public GetShardLocation(string shard) { }
             public string Shard { get; }
-            public override bool Equals(object obj) { }
             public bool Equals(Akka.Cluster.Sharding.External.ExternalShardAllocationStrategy.GetShardLocation other) { }
+            public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
         }
@@ -537,8 +505,8 @@ namespace Akka.Cluster.Sharding.External
         {
             public GetShardLocationResponse(Akka.Actor.Address address) { }
             public Akka.Actor.Address Address { get; }
-            public override bool Equals(object obj) { }
             public bool Equals(Akka.Cluster.Sharding.External.ExternalShardAllocationStrategy.GetShardLocationResponse other) { }
+            public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
         }
@@ -551,8 +519,8 @@ namespace Akka.Cluster.Sharding.External
         {
             public GetShardLocationsResponse(System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Address> desiredAllocations) { }
             public System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Address> DesiredAllocations { get; }
-            public override bool Equals(object obj) { }
             public bool Equals(Akka.Cluster.Sharding.External.ExternalShardAllocationStrategy.GetShardLocationsResponse other) { }
+            public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
         }
@@ -560,8 +528,8 @@ namespace Akka.Cluster.Sharding.External
         {
             public ShardLocation(Akka.Actor.Address address) { }
             public Akka.Actor.Address Address { get; }
-            public override bool Equals(object obj) { }
             public bool Equals(Akka.Cluster.Sharding.External.ExternalShardAllocationStrategy.ShardLocation other) { }
+            public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
         }
@@ -587,7 +555,7 @@ namespace Akka.Cluster.Sharding.Internal
         protected virtual Akka.Cluster.Member SelfMember { get; }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> AllocateShard(Akka.Actor.IActorRef requester, string shardId, System.Collections.Immutable.IImmutableDictionary<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> currentShardAllocations) { }
         protected bool IsAGoodTimeToRebalance(System.Collections.Generic.IEnumerable<Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy.RegionEntry> regionEntries) { }
-        [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "Region",
                 "Shards"})]
         protected System.ValueTuple<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> MostSuitableRegion(System.Collections.Generic.IEnumerable<Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy.RegionEntry> regionEntries) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterSharding.Net.verified.txt
@@ -1,67 +1,64 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData.Tests")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("a05c31e8-0246-46a1-b3bc-4d6fe7a9aa49")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DistributedData.Tests")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("a05c31e8-0246-46a1-b3bc-4d6fe7a9aa49")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Cluster.Sharding
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ClusterSharding : Akka.Actor.IExtension
     {
         public ClusterSharding(Akka.Actor.ExtendedActorSystem system) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public Akka.Cluster.Sharding.IShardingBufferMessageAdapter BufferMessageAdapter { get; }
         public Akka.Cluster.Sharding.ClusterShardingSettings Settings { get; }
         public System.Collections.Immutable.ImmutableHashSet<string> ShardTypeNames { get; }
-        public static Akka.Configuration.Config DefaultConfig() { }
         public Akka.Cluster.Sharding.IShardAllocationStrategy DefaultShardAllocationStrategy(Akka.Cluster.Sharding.ClusterShardingSettings settings) { }
-        public static Akka.Cluster.Sharding.ClusterSharding Get(Akka.Actor.ActorSystem system) { }
-        [Akka.Annotations.InternalApiAttribute()]
-        public void SetShardingBufferMessageAdapter(Akka.Cluster.Sharding.IShardingBufferMessageAdapter bufferMessageAdapter) { }
+        [Akka.Annotations.InternalApi]
+        public void SetShardingBufferMessageAdapter(Akka.Cluster.Sharding.IShardingBufferMessageAdapter? bufferMessageAdapter) { }
         public Akka.Actor.IActorRef ShardRegion(string typeName) { }
         public Akka.Actor.IActorRef ShardRegionProxy(string typeName) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
-        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
         public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
-        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
         public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public Akka.Actor.IActorRef Start(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public Akka.Actor.IActorRef Start(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public Akka.Actor.IActorRef StartProxy(string typeName, string role, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, Akka.Actor.Props entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartAsync(string typeName, System.Func<string, Akka.Actor.Props> entityPropsFactory, Akka.Cluster.Sharding.ClusterShardingSettings settings, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId, Akka.Cluster.Sharding.IShardAllocationStrategy allocationStrategy, object handOffStopMessage) { }
         public Akka.Actor.IActorRef StartProxy(string typeName, string role, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
-        [System.ObsoleteAttribute("Use one of the overloads that accepts an IMessageExtractor instead")]
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartProxyAsync(string typeName, string role, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public Akka.Actor.IActorRef StartProxy(string typeName, string role, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartProxyAsync(string typeName, string role, Akka.Cluster.Sharding.IMessageExtractor messageExtractor) { }
+        [System.Obsolete("Use one of the overloads that accepts an IMessageExtractor instead")]
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> StartProxyAsync(string typeName, string role, Akka.Cluster.Sharding.ExtractEntityId extractEntityId, Akka.Cluster.Sharding.ExtractShardId extractShardId) { }
+        public static Akka.Configuration.Config DefaultConfig() { }
+        public static Akka.Cluster.Sharding.ClusterSharding Get(Akka.Actor.ActorSystem system) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1})]
     public sealed class ClusterShardingExtensionProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Sharding.ClusterSharding>
     {
         public ClusterShardingExtensionProvider() { }
         public override Akka.Cluster.Sharding.ClusterSharding CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
+    [System.Serializable]
     public sealed class ClusterShardingSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
         public readonly Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings CoordinatorSingletonSettings;
@@ -78,10 +75,7 @@ namespace Akka.Cluster.Sharding
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings) { }
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
         public ClusterShardingSettings(string role, bool rememberEntities, string journalPluginId, string snapshotPluginId, System.TimeSpan passivateIdleEntityAfter, Akka.Cluster.Sharding.StateStoreMode stateStoreMode, Akka.Cluster.Sharding.RememberEntitiesStore rememberEntitiesStore, System.TimeSpan shardRegionQueryTimeout, Akka.Cluster.Sharding.TuningParameters tuningParameters, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings, Akka.Coordination.LeaseUsageSettings leaseSettings) { }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.SupervisorStrategy SupervisorStrategy { get; }
-        public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Configuration.Config config, Akka.Configuration.Config singletonConfig) { }
+        public Akka.Actor.SupervisorStrategy? SupervisorStrategy { get; }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithCoordinatorSingletonSettings(Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings coordinatorSingletonSettings) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithJournalPluginId(string journalPluginId) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithLeaseSettings(Akka.Coordination.LeaseUsageSettings leaseSettings) { }
@@ -92,34 +86,39 @@ namespace Akka.Cluster.Sharding
         public Akka.Cluster.Sharding.ClusterShardingSettings WithStateStoreMode(Akka.Cluster.Sharding.StateStoreMode mode) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithSupervisorStrategy(Akka.Actor.SupervisorStrategy supervisorStrategy) { }
         public Akka.Cluster.Sharding.ClusterShardingSettings WithTuningParameters(Akka.Cluster.Sharding.TuningParameters tuningParameters) { }
+        public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Sharding.ClusterShardingSettings Create(Akka.Configuration.Config config, Akka.Configuration.Config singletonConfig) { }
     }
+    [System.Serializable]
     public sealed class ClusterShardingStats : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ClusterShardingStats>
     {
         public readonly System.Collections.Immutable.IImmutableDictionary<Akka.Actor.Address, Akka.Cluster.Sharding.ShardRegionStats> Regions;
         public ClusterShardingStats(System.Collections.Immutable.IImmutableDictionary<Akka.Actor.Address, Akka.Cluster.Sharding.ShardRegionStats> regions) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.ClusterShardingStats other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class CurrentRegions : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.CurrentRegions>
     {
         public readonly System.Collections.Immutable.IImmutableSet<Akka.Actor.Address> Regions;
         public CurrentRegions(System.Collections.Immutable.IImmutableSet<Akka.Actor.Address> regions) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.CurrentRegions other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class CurrentShardRegionState : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.CurrentShardRegionState>
     {
         public readonly System.Collections.Immutable.IImmutableSet<string> Failed;
         public readonly System.Collections.Immutable.IImmutableSet<Akka.Cluster.Sharding.ShardState> Shards;
-        [System.ObsoleteAttribute("Use constructor with `failed` argument. Obsolete since 1.5.0-alpha1")]
+        [System.Obsolete("Use constructor with `failed` argument. Obsolete since 1.5.0-alpha1")]
         public CurrentShardRegionState(System.Collections.Immutable.IImmutableSet<Akka.Cluster.Sharding.ShardState> shards) { }
         public CurrentShardRegionState(System.Collections.Immutable.IImmutableSet<Akka.Cluster.Sharding.ShardState> shards, System.Collections.Immutable.IImmutableSet<string> failed) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.CurrentShardRegionState other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -131,28 +130,25 @@ namespace Akka.Cluster.Sharding
         public string ShardId { get; }
         public Akka.Actor.Address ShardRegion { get; }
     }
-    public class static EnumerableExtensions
+    public static class EnumerableExtensions
     {
         public static System.Collections.Generic.IEnumerable<System.Collections.Generic.IEnumerable<T>> Grouped<T>(this System.Collections.Generic.IEnumerable<T> items, int size) { }
     }
-    [System.ObsoleteAttribute("Use HashCodeMessageExtractor or IMessageExtractor instead.")]
-    [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            0,
-            1,
-            1})]
+    [System.Obsolete("Use HashCodeMessageExtractor or IMessageExtractor instead.")]
     public delegate Akka.Util.Option<System.ValueTuple<string, object>> ExtractEntityId(object message);
-    [System.ObsoleteAttribute("Use HashCodeMessageExtractor or IMessageExtractor instead.")]
+    [System.Obsolete("Use HashCodeMessageExtractor or IMessageExtractor instead.")]
     public delegate string ExtractShardId(object message);
+    [System.Serializable]
     public sealed class GetClusterShardingStats : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery, System.IEquatable<Akka.Cluster.Sharding.GetClusterShardingStats>
     {
         public readonly System.TimeSpan Timeout;
         public GetClusterShardingStats(System.TimeSpan timeout) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.GetClusterShardingStats other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class GetCurrentRegions : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery
     {
         public static readonly Akka.Cluster.Sharding.GetCurrentRegions Instance;
@@ -164,40 +160,33 @@ namespace Akka.Cluster.Sharding
         public string EntityId { get; }
         public System.TimeSpan Timeout { get; }
     }
+    [System.Serializable]
     public sealed class GetShardRegionState : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery
     {
         public static readonly Akka.Cluster.Sharding.GetShardRegionState Instance;
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class GetShardRegionStats : Akka.Cluster.Sharding.IClusterShardingSerializable, Akka.Cluster.Sharding.IShardRegionQuery
     {
         public static readonly Akka.Cluster.Sharding.GetShardRegionStats Instance;
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class GracefulShutdown : Akka.Cluster.Sharding.IShardRegionCommand
     {
         public static readonly Akka.Cluster.Sharding.GracefulShutdown Instance;
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class HashCodeMessageExtractor : Akka.Cluster.Sharding.IMessageExtractor
     {
         public readonly int MaxNumberOfShards;
         protected HashCodeMessageExtractor(int maxNumberOfShards) { }
-        public static Akka.Cluster.Sharding.HashCodeMessageExtractor Create(int maxNumberOfShards, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                1,
-                1,
-                2})] System.Func<object, string> entityIdExtractor, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1,
-                1})] System.Func<object, object> messageExtractor = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public abstract string EntityId(object message);
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public virtual object EntityMessage(object message) { }
-        [System.ObsoleteAttribute("Use ShardId(string, object?) instead. Since v1.5.15")]
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public virtual string ShardId(object message) { }
-        public virtual string ShardId(string entityId, [System.Runtime.CompilerServices.NullableAttribute(2)] object messageHint = null) { }
+        public abstract string? EntityId(object message);
+        public virtual object? EntityMessage(object message) { }
+        [System.Obsolete("Use ShardId(string, object?) instead. Since v1.5.15")]
+        public virtual string? ShardId(object message) { }
+        public virtual string ShardId(string entityId, object? messageHint = null) { }
+        public static Akka.Cluster.Sharding.HashCodeMessageExtractor Create(int maxNumberOfShards, System.Func<object, string?> entityIdExtractor, System.Func<object, object>? messageExtractor = null) { }
     }
     public interface IActorSystemDependentAllocationStrategy : Akka.Actor.INoSerializationVerificationNeeded, Akka.Cluster.Sharding.IShardAllocationStrategy
     {
@@ -206,14 +195,11 @@ namespace Akka.Cluster.Sharding
     public interface IClusterShardingSerializable { }
     public interface IMessageExtractor
     {
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        string EntityId(object message);
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        object EntityMessage(object message);
-        [System.ObsoleteAttribute("Use ShardId(EntityId, object) instead.")]
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        string ShardId(object message);
-        string ShardId(string entityId, [System.Runtime.CompilerServices.NullableAttribute(2)] object messageHint = null);
+        string? EntityId(object message);
+        object? EntityMessage(object message);
+        [System.Obsolete("Use ShardId(EntityId, object) instead.")]
+        string? ShardId(object message);
+        string ShardId(string entityId, object? messageHint = null);
     }
     public interface IShardAllocationStrategy : Akka.Actor.INoSerializationVerificationNeeded
     {
@@ -222,7 +208,7 @@ namespace Akka.Cluster.Sharding
     }
     public interface IShardRegionCommand { }
     public interface IShardRegionQuery { }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IShardingBufferMessageAdapter
     {
         object Apply(object message, Akka.Actor.IActorContext context);
@@ -232,13 +218,15 @@ namespace Akka.Cluster.Sharding
     {
         void Start();
     }
-    [System.ObsoleteAttribute("Use ShardAllocationStrategy.LeastShardAllocationStrategy instead. This will be re" +
+    [System.Obsolete("Use ShardAllocationStrategy.LeastShardAllocationStrategy instead. This will be re" +
         "moved in v1.6.")]
+    [System.Serializable]
     public class LeastShardAllocationStrategy : Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy
     {
         public LeastShardAllocationStrategy(int rebalanceThreshold, int maxSimultaneousRebalance) { }
         public override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableSet<string>> Rebalance(System.Collections.Immutable.IImmutableDictionary<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> currentShardAllocations, System.Collections.Immutable.IImmutableSet<string> rebalanceInProgress) { }
     }
+    [System.Serializable]
     public sealed class Passivate : Akka.Cluster.Sharding.IShardRegionCommand
     {
         public Passivate(object stopMessage) { }
@@ -250,113 +238,101 @@ namespace Akka.Cluster.Sharding
         Eventsourced = 1,
         Custom = 2,
     }
-    public class static ShardAllocationStrategy
+    public static class ShardAllocationStrategy
     {
         public static Akka.Cluster.Sharding.IShardAllocationStrategy LeastShardAllocationStrategy(int absoluteLimit, double relativeLimit) { }
     }
-    [Akka.Annotations.InternalStableApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [Akka.Annotations.InternalStableApi]
     public sealed class ShardRegion : Akka.Actor.ActorBase, Akka.Actor.IWithTimers
     {
-        public ShardRegion(string typeName, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1,
-                1})] System.Func<string, Akka.Actor.Props> entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, string coordinatorPath, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, object handOffStopMessage, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Cluster.Sharding.Internal.IRememberEntitiesProvider rememberEntitiesProvider) { }
+        public ShardRegion(string typeName, System.Func<string, Akka.Actor.Props>? entityProps, Akka.Cluster.Sharding.ClusterShardingSettings settings, string coordinatorPath, Akka.Cluster.Sharding.IMessageExtractor messageExtractor, object handOffStopMessage, Akka.Cluster.Sharding.Internal.IRememberEntitiesProvider? rememberEntitiesProvider) { }
         public Akka.Actor.ITimerScheduler Timers { get; set; }
         protected override void PostStop() { }
         protected override void PreStart() { }
         protected override bool Receive(object message) { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
+        [System.Serializable]
         public sealed class StartEntity : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ShardRegion.StartEntity>
         {
             public readonly string EntityId;
             public StartEntity(string entityId) { }
-            public override bool Equals(object obj) { }
-            public bool Equals(Akka.Cluster.Sharding.ShardRegion.StartEntity other) { }
+            public bool Equals(Akka.Cluster.Sharding.ShardRegion.StartEntity? other) { }
+            public override bool Equals(object? obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
         }
     }
+    [System.Serializable]
     public sealed class ShardRegionStats : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ShardRegionStats>
     {
         public readonly System.Collections.Immutable.IImmutableSet<string> Failed;
         public readonly System.Collections.Immutable.IImmutableDictionary<string, int> Stats;
-        [System.ObsoleteAttribute("Use constructor with `failed` argument. Obsolete since 1.5.0-alpha1")]
+        [System.Obsolete("Use constructor with `failed` argument. Obsolete since 1.5.0-alpha1")]
         public ShardRegionStats(System.Collections.Immutable.IImmutableDictionary<string, int> stats) { }
         public ShardRegionStats(System.Collections.Immutable.IImmutableDictionary<string, int> stats, System.Collections.Immutable.IImmutableSet<string> failed) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.ShardRegionStats other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class ShardState : Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ShardState>
     {
         public readonly System.Collections.Immutable.IImmutableSet<string> EntityIds;
         public readonly string ShardId;
         public ShardState(string shardId, System.Collections.Immutable.IImmutableSet<string> entityIds) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Cluster.Sharding.ShardState other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
     public class ShardSupervisionStrategy : Akka.Actor.OneForOneStrategy
     {
-        public ShardSupervisionStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public ShardSupervisionStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, Akka.Actor.IDecider decider) { }
-        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
-        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = True) { }
-        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
-        public ShardSupervisionStrategy(Akka.Actor.IDecider decider) { }
         public ShardSupervisionStrategy() { }
+        public ShardSupervisionStrategy(Akka.Actor.IDecider decider) { }
+        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public ShardSupervisionStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = true) { }
+        public ShardSupervisionStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, Akka.Actor.IDecider decider) { }
+        public ShardSupervisionStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = true) { }
+        public ShardSupervisionStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = true) { }
         public override void ProcessFailure(Akka.Actor.IActorContext context, bool restart, Akka.Actor.IActorRef child, System.Exception cause, Akka.Actor.Internal.ChildRestartStats stats, System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> children) { }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
-    [Akka.Annotations.DoNotInheritAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [Akka.Annotations.ApiMayChange]
+    [Akka.Annotations.DoNotInherit]
     public class ShardedDaemonProcess : Akka.Actor.IExtension
     {
         public ShardedDaemonProcess(Akka.Actor.ExtendedActorSystem system) { }
-        public static Akka.Cluster.Sharding.ShardedDaemonProcess Get(Akka.Actor.ActorSystem system) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.IActorRef Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, Akka.Cluster.Sharding.ShardedDaemonProcessSettings settings, [System.Runtime.CompilerServices.NullableAttribute(2)] object stopMessage) { }
+        public Akka.Actor.IActorRef? Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory) { }
+        public Akka.Actor.IActorRef? Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, object? stopMessage) { }
+        public Akka.Actor.IActorRef? Init(string name, int numberOfInstances, System.Func<int, Akka.Actor.Props> propsFactory, Akka.Cluster.Sharding.ShardedDaemonProcessSettings settings, object? stopMessage) { }
         public Akka.Actor.IActorRef InitProxy(string name, int numberOfInstances, string role) { }
+        public static Akka.Cluster.Sharding.ShardedDaemonProcess Get(Akka.Actor.ActorSystem system) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1})]
     public class ShardedDaemonProcessExtensionProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Sharding.ShardedDaemonProcess>
     {
         public ShardedDaemonProcessExtensionProvider() { }
         public override Akka.Cluster.Sharding.ShardedDaemonProcess CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [Akka.Annotations.ApiMayChange]
+    [System.Serializable]
     public sealed class ShardedDaemonProcessSettings
     {
         public readonly System.TimeSpan KeepAliveInterval;
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public readonly string Role;
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public readonly Akka.Cluster.Sharding.ClusterShardingSettings ShardingSettings;
-        public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings FromConfig(Akka.Configuration.Config config) { }
+        public readonly string? Role;
+        public readonly Akka.Cluster.Sharding.ClusterShardingSettings? ShardingSettings;
         public Akka.Cluster.Sharding.ShardedDaemonProcessSettings WithKeepAliveInterval(System.TimeSpan keepAliveInterval) { }
         public Akka.Cluster.Sharding.ShardedDaemonProcessSettings WithRole(string role) { }
         public Akka.Cluster.Sharding.ShardedDaemonProcessSettings WithShardingSettings(Akka.Cluster.Sharding.ClusterShardingSettings shardingSettings) { }
+        public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Sharding.ShardedDaemonProcessSettings FromConfig(Akka.Configuration.Config config) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ShardingEnvelope : Akka.Actor.IWrappedMessage, Akka.Cluster.Sharding.IClusterShardingSerializable, System.IEquatable<Akka.Cluster.Sharding.ShardingEnvelope>
     {
         public ShardingEnvelope(string entityId, object message) { }
         public string EntityId { get; }
         public object Message { get; }
-        public bool Equals(Akka.Cluster.Sharding.ShardingEnvelope other) { }
-        public override bool Equals(object obj) { }
+        public bool Equals(Akka.Cluster.Sharding.ShardingEnvelope? other) { }
+        public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -366,6 +342,7 @@ namespace Akka.Cluster.Sharding
         DData = 1,
         Custom = 2,
     }
+    [System.Serializable]
     public class TuningParameters
     {
         public readonly int BufferSize;
@@ -390,26 +367,26 @@ namespace Akka.Cluster.Sharding
         public readonly System.TimeSpan UpdatingStateTimeout;
         public readonly System.TimeSpan WaitingForStateTimeout;
         public TuningParameters(
-                    System.TimeSpan coordinatorFailureBackoff, 
-                    System.TimeSpan retryInterval, 
-                    int bufferSize, 
-                    System.TimeSpan handOffTimeout, 
-                    System.TimeSpan shardStartTimeout, 
-                    System.TimeSpan shardFailureBackoff, 
-                    System.TimeSpan entityRestartBackoff, 
-                    System.TimeSpan rebalanceInterval, 
-                    int snapshotAfter, 
-                    int keepNrOfBatches, 
-                    int leastShardAllocationRebalanceThreshold, 
-                    int leastShardAllocationMaxSimultaneousRebalance, 
-                    System.TimeSpan waitingForStateTimeout, 
-                    System.TimeSpan updatingStateTimeout, 
-                    string entityRecoveryStrategy, 
-                    System.TimeSpan entityRecoveryConstantRateStrategyFrequency, 
-                    int entityRecoveryConstantRateStrategyNumberOfEntities, 
-                    int coordinatorStateWriteMajorityPlus, 
-                    int coordinatorStateReadMajorityPlus, 
-                    int leastShardAllocationAbsoluteLimit, 
+                    System.TimeSpan coordinatorFailureBackoff,
+                    System.TimeSpan retryInterval,
+                    int bufferSize,
+                    System.TimeSpan handOffTimeout,
+                    System.TimeSpan shardStartTimeout,
+                    System.TimeSpan shardFailureBackoff,
+                    System.TimeSpan entityRestartBackoff,
+                    System.TimeSpan rebalanceInterval,
+                    int snapshotAfter,
+                    int keepNrOfBatches,
+                    int leastShardAllocationRebalanceThreshold,
+                    int leastShardAllocationMaxSimultaneousRebalance,
+                    System.TimeSpan waitingForStateTimeout,
+                    System.TimeSpan updatingStateTimeout,
+                    string entityRecoveryStrategy,
+                    System.TimeSpan entityRecoveryConstantRateStrategyFrequency,
+                    int entityRecoveryConstantRateStrategyNumberOfEntities,
+                    int coordinatorStateWriteMajorityPlus,
+                    int coordinatorStateReadMajorityPlus,
+                    int leastShardAllocationAbsoluteLimit,
                     double leastShardAllocationRelativeLimit) { }
         public Akka.Cluster.Sharding.TuningParameters WithBufferSize(int bufferSize) { }
         public Akka.Cluster.Sharding.TuningParameters WithCoordinatorFailureBackoff(System.TimeSpan coordinatorFailureBackoff) { }
@@ -436,61 +413,52 @@ namespace Akka.Cluster.Sharding
 }
 namespace Akka.Cluster.Sharding.Delivery
 {
-    [Akka.Annotations.ApiMayChangeAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static ShardingConsumerController
+    [Akka.Annotations.ApiMayChange]
+    public static class ShardingConsumerController
     {
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<Akka.Actor.IActorRef, Akka.Actor.Props> consumerProps, Akka.Cluster.Sharding.Delivery.ShardingConsumerController.Settings settings) { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
+        public static Akka.Actor.Props Create<T>(System.Func<Akka.Actor.IActorRef, Akka.Actor.Props> consumerProps, Akka.Cluster.Sharding.Delivery.ShardingConsumerController.Settings settings) { }
         public sealed class Settings : System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingConsumerController.Settings>
         {
-            public bool AllowBypass { get; set; }
-            public int BufferSize { get; set; }
-            public Akka.Delivery.ConsumerController.Settings ConsumerControllerSettings { get; set; }
-            public static Akka.Cluster.Sharding.Delivery.ShardingConsumerController.Settings Create(Akka.Actor.ActorSystem system) { }
+            public bool AllowBypass { get; init; }
+            public int BufferSize { get; init; }
+            public Akka.Delivery.ConsumerController.Settings ConsumerControllerSettings { get; init; }
             public override string ToString() { }
+            public static Akka.Cluster.Sharding.Delivery.ShardingConsumerController.Settings Create(Akka.Actor.ActorSystem system) { }
         }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static ShardingProducerController
+    [Akka.Annotations.ApiMayChange]
+    public static class ShardingProducerController
     {
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(string producerId, Akka.Actor.IActorRef shardRegion, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<Akka.Actor.Props> durableQueue, Akka.Cluster.Sharding.Delivery.ShardingProducerController.Settings settings) { }
+        public static Akka.Actor.Props Create<T>(string producerId, Akka.Actor.IActorRef shardRegion, Akka.Util.Option<Akka.Actor.Props> durableQueue, Akka.Cluster.Sharding.Delivery.ShardingProducerController.Settings settings) { }
         public interface IShardingProducerControllerCommand<T> { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class MessageWithConfirmation<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Cluster.Sharding.Delivery.ShardingProducerController.IShardingProducerControllerCommand<T>, System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingProducerController.MessageWithConfirmation<T>>
+        public sealed class MessageWithConfirmation<T> : Akka.Cluster.Sharding.Delivery.ShardingProducerController.IShardingProducerControllerCommand<T>, System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingProducerController.MessageWithConfirmation<T>>
         {
             public MessageWithConfirmation(string EntityId, T Message, Akka.Actor.IActorRef ReplyTo) { }
-            public string EntityId { get; set; }
-            public T Message { get; set; }
-            public Akka.Actor.IActorRef ReplyTo { get; set; }
+            public string EntityId { get; init; }
+            public T Message { get; init; }
+            public Akka.Actor.IActorRef ReplyTo { get; init; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class RequestNext<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingProducerController.RequestNext<T>>
+        public sealed class RequestNext<T> : System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingProducerController.RequestNext<T>>
         {
             public RequestNext(Akka.Actor.IActorRef SendNextTo, Akka.Actor.IActorRef AskNextToRef, System.Collections.Immutable.ImmutableHashSet<string> EntitiesWithDemand, System.Collections.Immutable.ImmutableDictionary<string, int> BufferedForEntitiesWithoutDemand) { }
-            public Akka.Actor.IActorRef AskNextToRef { get; set; }
-            public System.Collections.Immutable.ImmutableDictionary<string, int> BufferedForEntitiesWithoutDemand { get; set; }
-            public System.Collections.Immutable.ImmutableHashSet<string> EntitiesWithDemand { get; set; }
-            public Akka.Actor.IActorRef SendNextTo { get; set; }
-            public System.Threading.Tasks.Task<long> AskNextTo(string entityId, T msg, System.Threading.CancellationToken cancellationToken = null) { }
+            public Akka.Actor.IActorRef AskNextToRef { get; init; }
+            public System.Collections.Immutable.ImmutableDictionary<string, int> BufferedForEntitiesWithoutDemand { get; init; }
+            public System.Collections.Immutable.ImmutableHashSet<string> EntitiesWithDemand { get; init; }
+            public Akka.Actor.IActorRef SendNextTo { get; init; }
             public void AskNextTo(Akka.Cluster.Sharding.Delivery.ShardingProducerController.MessageWithConfirmation<T> msgWithConfirmation) { }
+            public System.Threading.Tasks.Task<long> AskNextTo(string entityId, T msg, System.Threading.CancellationToken cancellationToken = default) { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class Settings : System.IEquatable<Akka.Cluster.Sharding.Delivery.ShardingProducerController.Settings>
         {
-            public int BufferSize { get; set; }
-            public System.TimeSpan CleanupUnusedAfter { get; set; }
-            public System.TimeSpan InternalAskTimeout { get; set; }
-            public Akka.Delivery.ProducerController.Settings ProducerControllerSettings { get; set; }
-            public System.TimeSpan ResendFirstUnconfirmedIdleTimeout { get; set; }
+            public int BufferSize { get; init; }
+            public System.TimeSpan CleanupUnusedAfter { get; init; }
+            public System.TimeSpan InternalAskTimeout { get; init; }
+            public Akka.Delivery.ProducerController.Settings ProducerControllerSettings { get; init; }
+            public System.TimeSpan ResendFirstUnconfirmedIdleTimeout { get; init; }
             public static Akka.Cluster.Sharding.Delivery.ShardingProducerController.Settings Create(Akka.Actor.ActorSystem system) { }
             public static Akka.Cluster.Sharding.Delivery.ShardingProducerController.Settings Create(Akka.Configuration.Config config, Akka.Configuration.Config producerControllerConfig) { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class Start<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Cluster.Sharding.Delivery.ShardingProducerController.IShardingProducerControllerCommand<T>
+        public sealed class Start<T> : Akka.Cluster.Sharding.Delivery.ShardingProducerController.IShardingProducerControllerCommand<T>
         {
             public Start(Akka.Actor.IActorRef producer) { }
             public Akka.Actor.IActorRef Producer { get; }
@@ -502,8 +470,8 @@ namespace Akka.Cluster.Sharding.External
     public class ClientTimeoutException : System.Exception
     {
         public ClientTimeoutException(string message) { }
-        public ClientTimeoutException(string message, System.Exception innerEx) { }
         protected ClientTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public ClientTimeoutException(string message, System.Exception innerEx) { }
     }
     public sealed class ExternalShardAllocation : Akka.Actor.IExtension
     {
@@ -528,8 +496,8 @@ namespace Akka.Cluster.Sharding.External
         {
             public GetShardLocation(string shard) { }
             public string Shard { get; }
-            public override bool Equals(object obj) { }
             public bool Equals(Akka.Cluster.Sharding.External.ExternalShardAllocationStrategy.GetShardLocation other) { }
+            public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
         }
@@ -537,8 +505,8 @@ namespace Akka.Cluster.Sharding.External
         {
             public GetShardLocationResponse(Akka.Actor.Address address) { }
             public Akka.Actor.Address Address { get; }
-            public override bool Equals(object obj) { }
             public bool Equals(Akka.Cluster.Sharding.External.ExternalShardAllocationStrategy.GetShardLocationResponse other) { }
+            public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
         }
@@ -551,8 +519,8 @@ namespace Akka.Cluster.Sharding.External
         {
             public GetShardLocationsResponse(System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Address> desiredAllocations) { }
             public System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Address> DesiredAllocations { get; }
-            public override bool Equals(object obj) { }
             public bool Equals(Akka.Cluster.Sharding.External.ExternalShardAllocationStrategy.GetShardLocationsResponse other) { }
+            public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
         }
@@ -560,8 +528,8 @@ namespace Akka.Cluster.Sharding.External
         {
             public ShardLocation(Akka.Actor.Address address) { }
             public Akka.Actor.Address Address { get; }
-            public override bool Equals(object obj) { }
             public bool Equals(Akka.Cluster.Sharding.External.ExternalShardAllocationStrategy.ShardLocation other) { }
+            public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
         }
@@ -587,7 +555,7 @@ namespace Akka.Cluster.Sharding.Internal
         protected virtual Akka.Cluster.Member SelfMember { get; }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> AllocateShard(Akka.Actor.IActorRef requester, string shardId, System.Collections.Immutable.IImmutableDictionary<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> currentShardAllocations) { }
         protected bool IsAGoodTimeToRebalance(System.Collections.Generic.IEnumerable<Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy.RegionEntry> regionEntries) { }
-        [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "Region",
                 "Shards"})]
         protected System.ValueTuple<Akka.Actor.IActorRef, System.Collections.Immutable.IImmutableList<string>> MostSuitableRegion(System.Collections.Generic.IEnumerable<Akka.Cluster.Sharding.Internal.AbstractLeastShardAllocationStrategy.RegionEntry> regionEntries) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.DotNet.verified.txt
@@ -1,17 +1,18 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests.MultiNode")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("5cf8a8be-b634-473f-bb01-eba878746bd4")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools.Tests.MultiNode")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("5cf8a8be-b634-473f-bb01-eba878746bd4")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Cluster.Tools.Client
 {
     public sealed class ClusterClient : Akka.Actor.ActorBase
     {
         public ClusterClient(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
         protected override void PostStop() { }
-        public static Akka.Actor.Props Props(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
         protected override bool Receive(object message) { }
+        public static Akka.Actor.Props Props(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
+        [System.Serializable]
         public sealed class Publish : Akka.Cluster.Tools.Client.IClusterClientProtocolMessage, System.IEquatable<Akka.Cluster.Tools.Client.ClusterClient.Publish>
         {
             public Publish(string topic, object message) { }
@@ -21,9 +22,10 @@ namespace Akka.Cluster.Tools.Client
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }
         }
+        [System.Serializable]
         public sealed class Send : Akka.Cluster.Tools.Client.IClusterClientProtocolMessage, System.IEquatable<Akka.Cluster.Tools.Client.ClusterClient.Send>
         {
-            public Send(string path, object message, bool localAffinity = False) { }
+            public Send(string path, object message, bool localAffinity = false) { }
             public bool LocalAffinity { get; }
             public object Message { get; }
             public string Path { get; }
@@ -31,6 +33,7 @@ namespace Akka.Cluster.Tools.Client
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }
         }
+        [System.Serializable]
         public sealed class SendToAll : Akka.Cluster.Tools.Client.IClusterClientProtocolMessage, System.IEquatable<Akka.Cluster.Tools.Client.ClusterClient.SendToAll>
         {
             public SendToAll(string path, object message) { }
@@ -41,7 +44,6 @@ namespace Akka.Cluster.Tools.Client
             public override int GetHashCode() { }
         }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ClusterClientDiscovery : Akka.Actor.UntypedActor, Akka.Actor.IActorStash, Akka.Actor.IWithTimers, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         public ClusterClientDiscovery(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
@@ -51,21 +53,19 @@ namespace Akka.Cluster.Tools.Client
         protected override void PostStop() { }
         protected override void PreStart() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ClusterClientDiscoverySettings : System.IEquatable<Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings>
     {
-        [System.Runtime.CompilerServices.NullableAttribute(1)]
         public static readonly Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings Empty;
-        public ClusterClientDiscoverySettings(string DiscoveryMethod, string ServiceName, string PortName, int NumberOfContacts, System.TimeSpan Interval, double ExponentialBackoffJitter, System.TimeSpan ExponentialBackoffMax, System.TimeSpan ResolveTimeout, System.TimeSpan ProbeTimeout) { }
-        public string DiscoveryMethod { get; set; }
-        public double ExponentialBackoffJitter { get; set; }
-        public System.TimeSpan ExponentialBackoffMax { get; set; }
-        public System.TimeSpan Interval { get; set; }
-        public int NumberOfContacts { get; set; }
-        public string PortName { get; set; }
-        public System.TimeSpan ProbeTimeout { get; set; }
-        public System.TimeSpan ResolveTimeout { get; set; }
-        public string ServiceName { get; set; }
+        public ClusterClientDiscoverySettings(string? DiscoveryMethod, string? ServiceName, string? PortName, int NumberOfContacts, System.TimeSpan Interval, double ExponentialBackoffJitter, System.TimeSpan ExponentialBackoffMax, System.TimeSpan ResolveTimeout, System.TimeSpan ProbeTimeout) { }
+        public string? DiscoveryMethod { get; init; }
+        public double ExponentialBackoffJitter { get; init; }
+        public System.TimeSpan ExponentialBackoffMax { get; init; }
+        public System.TimeSpan Interval { get; init; }
+        public int NumberOfContacts { get; init; }
+        public string? PortName { get; init; }
+        public System.TimeSpan ProbeTimeout { get; init; }
+        public System.TimeSpan ResolveTimeout { get; init; }
+        public string? ServiceName { get; init; }
         public static Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings Create(Akka.Configuration.Config clusterClientConfig) { }
     }
     public sealed class ClusterClientReceptionist : Akka.Actor.IExtension
@@ -73,48 +73,47 @@ namespace Akka.Cluster.Tools.Client
         public ClusterClientReceptionist(Akka.Actor.ExtendedActorSystem system) { }
         public bool IsTerminated { get; }
         public Akka.Actor.IActorRef Underlying { get; }
-        public static Akka.Configuration.Config DefaultConfig() { }
-        public static Akka.Cluster.Tools.Client.ClusterClientReceptionist Get(Akka.Actor.ActorSystem system) { }
         public void RegisterService(Akka.Actor.IActorRef actorRef) { }
         public void RegisterSubscriber(string topic, Akka.Actor.IActorRef actorRef) { }
         public void UnregisterService(Akka.Actor.IActorRef actorRef) { }
         public void UnregisterSubscriber(string topic, Akka.Actor.IActorRef actorRef) { }
+        public static Akka.Configuration.Config DefaultConfig() { }
+        public static Akka.Cluster.Tools.Client.ClusterClientReceptionist Get(Akka.Actor.ActorSystem system) { }
     }
     public sealed class ClusterClientReceptionistExtensionProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Tools.Client.ClusterClientReceptionist>
     {
         public ClusterClientReceptionistExtensionProvider() { }
         public override Akka.Cluster.Tools.Client.ClusterClientReceptionist CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ClusterClientSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        [System.ObsoleteAttribute("Use constructor with useLegacySerialization argument instead. Since 1.5.15")]
-        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, System.Nullable<System.TimeSpan> reconnectTimeout = null) { }
-        [System.ObsoleteAttribute("Use constructor with useInitialContactsDiscovery and discoverySettings argument i" +
+        [System.Obsolete("Use constructor with useLegacySerialization argument instead. Since 1.5.15")]
+        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, System.TimeSpan? reconnectTimeout = default) { }
+        [System.Obsolete("Use constructor with useInitialContactsDiscovery and discoverySettings argument i" +
             "nstead. Since 1.5.25")]
-        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, bool useLegacySerialization, System.Nullable<System.TimeSpan> reconnectTimeout = null) { }
-        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, bool useLegacySerialization, bool useInitialContactsDiscovery, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings discoverySettings = null, System.Nullable<System.TimeSpan> reconnectTimeout = null, bool verboseLogging = False) { }
+        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, bool useLegacySerialization, System.TimeSpan? reconnectTimeout = default) { }
+        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, bool useLegacySerialization, bool useInitialContactsDiscovery, Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings? discoverySettings = null, System.TimeSpan? reconnectTimeout = default, bool verboseLogging = false) { }
         public System.TimeSpan AcceptableHeartbeatPause { get; }
         public int BufferSize { get; }
         public Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings DiscoverySettings { get; }
         public System.TimeSpan EstablishingGetContactsInterval { get; }
         public System.TimeSpan HeartbeatInterval { get; }
         public System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> InitialContacts { get; }
-        public System.Nullable<System.TimeSpan> ReconnectTimeout { get; }
+        public System.TimeSpan? ReconnectTimeout { get; }
         public System.TimeSpan RefreshContactsInterval { get; }
         public bool UseInitialContactDiscovery { get; }
         public bool UseLegacySerialization { get; }
         public bool VerboseLogging { get; }
-        public static Akka.Cluster.Tools.Client.ClusterClientSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Client.ClusterClientSettings Create(Akka.Configuration.Config config) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithBufferSize(int bufferSize) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithEstablishingGetContactsInterval(System.TimeSpan value) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithHeartbeatInterval(System.TimeSpan value) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithInitialContacts(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts) { }
-        public Akka.Cluster.Tools.Client.ClusterClientSettings WithInitialContactsDiscovery(bool useInitialContactsDiscovery, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings discoverySettings = null) { }
-        public Akka.Cluster.Tools.Client.ClusterClientSettings WithReconnectTimeout(System.Nullable<System.TimeSpan> reconnectTimeout) { }
+        public Akka.Cluster.Tools.Client.ClusterClientSettings WithInitialContactsDiscovery(bool useInitialContactsDiscovery, Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings? discoverySettings = null) { }
+        public Akka.Cluster.Tools.Client.ClusterClientSettings WithReconnectTimeout(System.TimeSpan? reconnectTimeout) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithRefreshContactsInterval(System.TimeSpan value) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithUseLegacySerialization(bool useLegacySerialization) { }
+        public static Akka.Cluster.Tools.Client.ClusterClientSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Client.ClusterClientSettings Create(Akka.Configuration.Config config) { }
     }
     public sealed class ClusterClientUnreachable : Akka.Cluster.Tools.Client.IClusterClientInteraction
     {
@@ -136,8 +135,8 @@ namespace Akka.Cluster.Tools.Client
         public ClusterReceptionist(Akka.Actor.IActorRef pubSubMediator, Akka.Cluster.Tools.Client.ClusterReceptionistSettings settings) { }
         protected override void PostStop() { }
         protected override void PreStart() { }
-        public static Akka.Actor.Props Props(Akka.Actor.IActorRef pubSubMediator, Akka.Cluster.Tools.Client.ClusterReceptionistSettings settings) { }
         protected override bool Receive(object message) { }
+        public static Akka.Actor.Props Props(Akka.Actor.IActorRef pubSubMediator, Akka.Cluster.Tools.Client.ClusterReceptionistSettings settings) { }
     }
     public sealed class ClusterReceptionistSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
@@ -148,13 +147,13 @@ namespace Akka.Cluster.Tools.Client
         public int NumberOfContacts { get; }
         public System.TimeSpan ResponseTunnelReceiveTimeout { get; }
         public string Role { get; }
-        public static Akka.Cluster.Tools.Client.ClusterReceptionistSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Client.ClusterReceptionistSettings Create(Akka.Configuration.Config config) { }
         public Akka.Cluster.Tools.Client.ClusterReceptionistSettings WithHeartbeat(System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, System.TimeSpan failureDetectionInterval) { }
         public Akka.Cluster.Tools.Client.ClusterReceptionistSettings WithNumberOfContacts(int numberOfContacts) { }
         public Akka.Cluster.Tools.Client.ClusterReceptionistSettings WithResponseTunnelReceiveTimeout(System.TimeSpan responseTunnelReceiveTimeout) { }
         public Akka.Cluster.Tools.Client.ClusterReceptionistSettings WithRole(string role) { }
         public Akka.Cluster.Tools.Client.ClusterReceptionistSettings WithoutRole() { }
+        public static Akka.Cluster.Tools.Client.ClusterReceptionistSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Client.ClusterReceptionistSettings Create(Akka.Configuration.Config config) { }
     }
     public sealed class ContactPointAdded : Akka.Cluster.Tools.Client.IContactPointChange
     {
@@ -221,6 +220,7 @@ namespace Akka.Cluster.Tools.Client.Serialization
 }
 namespace Akka.Cluster.Tools.PublishSubscribe
 {
+    [System.Serializable]
     public sealed class CurrentTopics : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.CurrentTopics>
     {
         public CurrentTopics(System.Collections.Immutable.IImmutableSet<string> topics) { }
@@ -254,7 +254,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
     }
     public sealed class DistributedPubSubSettings : Akka.Actor.INoSerializationVerificationNeeded, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings>
     {
-        [System.ObsoleteAttribute("Use .ctor that supports WaitForSubscribers instead. Since 1.4.42")]
+        [System.Obsolete("Use .ctor that supports WaitForSubscribers instead. Since 1.4.42")]
         public DistributedPubSubSettings(string role, Akka.Routing.RoutingLogic routingLogic, System.TimeSpan gossipInterval, System.TimeSpan removedTimeToLive, int maxDeltaElements, bool sendToDeadLettersWhenNoSubscribers) { }
         public DistributedPubSubSettings(string role, Akka.Routing.RoutingLogic routingLogic, System.TimeSpan gossipInterval, System.TimeSpan removedTimeToLive, int maxDeltaElements, bool sendToDeadLettersWhenNoSubscribers, int maxBufferedMessagePerTopic, System.TimeSpan bufferedMessageTimeoutCheckInterval) { }
         public System.TimeSpan BufferedMessageTimeoutCheckInterval { get; }
@@ -265,8 +265,6 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public string Role { get; }
         public Akka.Routing.RoutingLogic RoutingLogic { get; }
         public bool SendToDeadLettersWhenNoSubscribers { get; }
-        public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Configuration.Config config) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithBufferedMessageTimeoutCheckInterval(System.TimeSpan bufferedMessageTimeoutCheckInterval) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithGossipInterval(System.TimeSpan gossipInterval) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithMaxBufferedMessagePerTopic(int maxBufferedMessagePerTopic) { }
@@ -275,16 +273,20 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithRole(string role) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithRoutingLogic(Akka.Routing.RoutingLogic routingLogic) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithSendToDeadLettersWhenNoSubscribers(bool sendToDeadLetterWhenNoSubscribers) { }
+        public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Configuration.Config config) { }
     }
+    [System.Serializable]
     public sealed class GetTopics
     {
         public static Akka.Cluster.Tools.PublishSubscribe.GetTopics Instance { get; }
     }
     public interface IDistributedPubSubMessage { }
     public interface IPublishResponse { }
+    [System.Serializable]
     public sealed class Publish : Akka.Actor.IWrappedMessage, Akka.Cluster.Tools.PublishSubscribe.IDistributedPubSubMessage, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Publish>
     {
-        public Publish(string topic, object message, bool sendOneMessageToEachGroup = False) { }
+        public Publish(string topic, object message, bool sendOneMessageToEachGroup = false) { }
         public object Message { get; }
         public bool SendOneMessageToEachGroup { get; }
         public string Topic { get; }
@@ -301,22 +303,23 @@ namespace Akka.Cluster.Tools.PublishSubscribe
     public sealed class PublishFailed : Akka.Cluster.Tools.PublishSubscribe.IPublishResponse, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.PublishFailed>
     {
         public PublishFailed(Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message, Akka.Cluster.Tools.PublishSubscribe.PublishFailReason Reason) { }
-        public Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message { get; set; }
-        public Akka.Cluster.Tools.PublishSubscribe.PublishFailReason Reason { get; set; }
+        public Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message { get; init; }
+        public Akka.Cluster.Tools.PublishSubscribe.PublishFailReason Reason { get; init; }
     }
     public sealed class PublishSucceeded : Akka.Cluster.Tools.PublishSubscribe.IPublishResponse, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.PublishSucceeded>
     {
         public PublishSucceeded(Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message) { }
-        public Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message { get; set; }
+        public Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message { get; init; }
     }
     public sealed class PublishWithAck : Akka.Actor.IWrappedMessage, Akka.Cluster.Tools.PublishSubscribe.IDistributedPubSubMessage, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.PublishWithAck>
     {
-        public PublishWithAck(string topic, object message, System.TimeSpan timeout, bool sendOneMessageToEachGroup = False) { }
+        public PublishWithAck(string topic, object message, System.TimeSpan timeout, bool sendOneMessageToEachGroup = false) { }
         public object Message { get; }
         public bool SendOneMessageToEachGroup { get; }
         public System.TimeSpan Timeout { get; }
         public string Topic { get; }
     }
+    [System.Serializable]
     public sealed class Put : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Put>
     {
         public Put(Akka.Actor.IActorRef @ref) { }
@@ -326,6 +329,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Remove : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Remove>
     {
         public Remove(string path) { }
@@ -335,9 +339,10 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Send : Akka.Actor.IWrappedMessage, Akka.Cluster.Tools.PublishSubscribe.IDistributedPubSubMessage, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Send>
     {
-        public Send(string path, object message, bool localAffinity = False) { }
+        public Send(string path, object message, bool localAffinity = false) { }
         public bool LocalAffinity { get; }
         public object Message { get; }
         public string Path { get; }
@@ -346,9 +351,10 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SendToAll : Akka.Actor.IWrappedMessage, Akka.Cluster.Tools.PublishSubscribe.IDistributedPubSubMessage, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.SendToAll>
     {
-        public SendToAll(string path, object message, bool excludeSelf = False) { }
+        public SendToAll(string path, object message, bool excludeSelf = false) { }
         public bool ExcludeSelf { get; }
         public object Message { get; }
         public string Path { get; }
@@ -357,6 +363,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Subscribe : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Subscribe>
     {
         public Subscribe(string topic, Akka.Actor.IActorRef @ref, string group = null) { }
@@ -368,6 +375,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SubscribeAck : Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.SubscribeAck>
     {
         public SubscribeAck(Akka.Cluster.Tools.PublishSubscribe.Subscribe subscribe) { }
@@ -377,6 +385,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Unsubscribe : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Unsubscribe>
     {
         public Unsubscribe(string topic, Akka.Actor.IActorRef @ref, string group = null) { }
@@ -388,6 +397,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class UnsubscribeAck : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.UnsubscribeAck>
     {
         public UnsubscribeAck(Akka.Cluster.Tools.PublishSubscribe.Unsubscribe unsubscribe) { }
@@ -400,7 +410,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
 }
 namespace Akka.Cluster.Tools.PublishSubscribe.Internal
 {
-    [Akka.Annotations.ApiMayChangeAttribute()]
+    [Akka.Annotations.ApiMayChange]
     public sealed class CountSubscribers
     {
         public CountSubscribers(string topic) { }
@@ -419,53 +429,50 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
 }
 namespace Akka.Cluster.Tools.Singleton
 {
-    [Akka.Annotations.DoNotInheritAttribute()]
+    [Akka.Annotations.DoNotInherit]
     public class ClusterSingleton : Akka.Actor.IExtension
     {
         public ClusterSingleton(Akka.Actor.ExtendedActorSystem system) { }
+        [System.Obsolete(@"This convenience method is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
+        public Akka.Actor.IActorRef Init(Akka.Cluster.Tools.Singleton.SingletonActor singleton) { }
         public static Akka.Configuration.Config DefaultConfig() { }
         public static Akka.Cluster.Tools.Singleton.ClusterSingleton Get(Akka.Actor.ActorSystem system) { }
-        [System.ObsoleteAttribute(@"This convenience method is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
-        public Akka.Actor.IActorRef Init(Akka.Cluster.Tools.Singleton.SingletonActor singleton) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1})]
     public sealed class ClusterSingletonManager : Akka.Actor.FSM<Akka.Cluster.Tools.Singleton.ClusterSingletonState, Akka.Cluster.Tools.Singleton.IClusterSingletonData>
     {
         public ClusterSingletonManager(Akka.Actor.Props singletonProps, object terminationMessage, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
-        [System.ObsoleteAttribute("Deprecated and will be removed in v1.6, please use ClusterSingleton.DefaultConfig" +
-            "() instead. Since 1.5.32.")]
-        public static Akka.Configuration.Config DefaultConfig() { }
         protected override void PostStop() { }
         protected override void PreStart() { }
+        [System.Obsolete("Deprecated and will be removed in v1.6, please use ClusterSingleton.DefaultConfig" +
+            "() instead. Since 1.5.32.")]
+        public static Akka.Configuration.Config DefaultConfig() { }
         public static Akka.Actor.Props Props(Akka.Actor.Props singletonProps, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
         public static Akka.Actor.Props Props(Akka.Actor.Props singletonProps, object terminationMessage, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ClusterSingletonManagerIsStuckException : Akka.Actor.AkkaException
     {
         public ClusterSingletonManagerIsStuckException(string message) { }
         public ClusterSingletonManagerIsStuckException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.Serializable]
     public sealed class ClusterSingletonManagerSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
         public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, bool considerAppVersion) { }
         public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, Akka.Coordination.LeaseUsageSettings leaseSettings, bool considerAppVersion) { }
-        [System.ObsoleteAttribute("ConsiderAppVersion is not used anymore and will be removed in future versions.")]
+        [System.Obsolete("ConsiderAppVersion is not used anymore and will be removed in future versions.")]
         public bool ConsiderAppVersion { get; }
         public System.TimeSpan HandOverRetryInterval { get; }
         public Akka.Coordination.LeaseUsageSettings LeaseSettings { get; }
         public System.TimeSpan RemovalMargin { get; }
         public string Role { get; }
         public string SingletonName { get; }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings Create(Akka.Configuration.Config config) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithHandOverRetryInterval(System.TimeSpan handOverRetryInterval) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithLeaseSettings(Akka.Coordination.LeaseUsageSettings leaseSettings) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithRemovalMargin(System.TimeSpan removalMargin) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithRole(string role) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithSingletonName(string singletonName) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings Create(Akka.Configuration.Config config) { }
     }
     public class ClusterSingletonProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Tools.Singleton.ClusterSingleton>
     {
@@ -476,9 +483,9 @@ namespace Akka.Cluster.Tools.Singleton
     {
         public ClusterSingletonProxy(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
         public Akka.Actor.ITimerScheduler Timers { get; set; }
-        public static Akka.Configuration.Config DefaultConfig() { }
         protected override void PostStop() { }
         protected override void PreStart() { }
+        public static Akka.Configuration.Config DefaultConfig() { }
         public static Akka.Actor.Props Props(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
         public enum IdentifyResult
         {
@@ -497,7 +504,7 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public sealed class ClusterSingletonProxySettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        [System.ObsoleteAttribute("Use constructor with logSingletonIdentificationFailure and logSingletonIdentifica" +
+        [System.Obsolete("Use constructor with logSingletonIdentificationFailure and logSingletonIdentifica" +
             "tionInterval parameter instead. Since v1.5.30")]
         public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize, bool considerAppVersion) { }
         public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize, bool considerAppVersion, bool logSingletonIdentificationFailure, System.TimeSpan singletonIdentificationFailurePeriod) { }
@@ -508,16 +515,17 @@ namespace Akka.Cluster.Tools.Singleton
         public System.TimeSpan SingletonIdentificationFailurePeriod { get; }
         public System.TimeSpan SingletonIdentificationInterval { get; }
         public string SingletonName { get; }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config, bool considerAppVersion) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithBufferSize(int bufferSize) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithLogSingletonIdentificationFailure(bool logSingletonIdentificationFailure) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithRole(string role) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonIdentificationFailureDuration(System.TimeSpan singletonIdentificationFailurePeriod) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonIdentificationInterval(System.TimeSpan singletonIdentificationInterval) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonName(string singletonName) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config, bool considerAppVersion) { }
     }
-    [System.ObsoleteAttribute(@"This setting class is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
+    [System.Obsolete(@"This setting class is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
+    [System.Serializable]
     public class ClusterSingletonSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
         public int BufferSize { get; }
@@ -529,8 +537,6 @@ namespace Akka.Cluster.Tools.Singleton
         public string Role { get; }
         public System.TimeSpan SingletonIdentificationFailurePeriod { get; }
         public System.TimeSpan SingletonIdentificationInterval { get; }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Configuration.Config config) { }
         public override string ToString() { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithBufferSize(int bufferSize) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithHandOverRetryInterval(System.TimeSpan handOverRetryInterval) { }
@@ -540,7 +546,10 @@ namespace Akka.Cluster.Tools.Singleton
         public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithRole(string role) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithSingletonIdentificationFailurePeriod(System.TimeSpan singletonIdentificationFailurePeriod) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithSingletonIdentificationInterval(System.TimeSpan singletonIdentificationInterval) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Configuration.Config config) { }
     }
+    [System.Serializable]
     public enum ClusterSingletonState
     {
         Start = 0,
@@ -556,17 +565,17 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public interface IClusterSingletonData { }
     public interface IClusterSingletonMessage { }
-    [System.ObsoleteAttribute(@"This setting class is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
+    [System.Obsolete(@"This setting class is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
     public class SingletonActor
     {
         public string Name { get; }
         public Akka.Actor.Props Props { get; }
         public Akka.Util.Option<Akka.Cluster.Tools.Singleton.ClusterSingletonSettings> Settings { get; }
         public Akka.Util.Option<object> StopMessage { get; }
-        public static Akka.Cluster.Tools.Singleton.SingletonActor Create(Akka.Actor.Props props, string name) { }
         public Akka.Cluster.Tools.Singleton.SingletonActor WithProps(Akka.Actor.Props props) { }
         public Akka.Cluster.Tools.Singleton.SingletonActor WithSettings(Akka.Cluster.Tools.Singleton.ClusterSingletonSettings settings) { }
         public Akka.Cluster.Tools.Singleton.SingletonActor WithStopMessage(object stopMessage) { }
+        public static Akka.Cluster.Tools.Singleton.SingletonActor Create(Akka.Actor.Props props, string name) { }
     }
 }
 namespace Akka.Cluster.Tools.Singleton.Serialization

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveClusterTools.Net.verified.txt
@@ -1,17 +1,18 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools.Tests.MultiNode")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("5cf8a8be-b634-473f-bb01-eba878746bd4")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools.Tests.MultiNode")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("5cf8a8be-b634-473f-bb01-eba878746bd4")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Cluster.Tools.Client
 {
     public sealed class ClusterClient : Akka.Actor.ActorBase
     {
         public ClusterClient(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
         protected override void PostStop() { }
-        public static Akka.Actor.Props Props(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
         protected override bool Receive(object message) { }
+        public static Akka.Actor.Props Props(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
+        [System.Serializable]
         public sealed class Publish : Akka.Cluster.Tools.Client.IClusterClientProtocolMessage, System.IEquatable<Akka.Cluster.Tools.Client.ClusterClient.Publish>
         {
             public Publish(string topic, object message) { }
@@ -21,9 +22,10 @@ namespace Akka.Cluster.Tools.Client
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }
         }
+        [System.Serializable]
         public sealed class Send : Akka.Cluster.Tools.Client.IClusterClientProtocolMessage, System.IEquatable<Akka.Cluster.Tools.Client.ClusterClient.Send>
         {
-            public Send(string path, object message, bool localAffinity = False) { }
+            public Send(string path, object message, bool localAffinity = false) { }
             public bool LocalAffinity { get; }
             public object Message { get; }
             public string Path { get; }
@@ -31,6 +33,7 @@ namespace Akka.Cluster.Tools.Client
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }
         }
+        [System.Serializable]
         public sealed class SendToAll : Akka.Cluster.Tools.Client.IClusterClientProtocolMessage, System.IEquatable<Akka.Cluster.Tools.Client.ClusterClient.SendToAll>
         {
             public SendToAll(string path, object message) { }
@@ -41,7 +44,6 @@ namespace Akka.Cluster.Tools.Client
             public override int GetHashCode() { }
         }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ClusterClientDiscovery : Akka.Actor.UntypedActor, Akka.Actor.IActorStash, Akka.Actor.IWithTimers, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
         public ClusterClientDiscovery(Akka.Cluster.Tools.Client.ClusterClientSettings settings) { }
@@ -51,21 +53,19 @@ namespace Akka.Cluster.Tools.Client
         protected override void PostStop() { }
         protected override void PreStart() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ClusterClientDiscoverySettings : System.IEquatable<Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings>
     {
-        [System.Runtime.CompilerServices.NullableAttribute(1)]
         public static readonly Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings Empty;
-        public ClusterClientDiscoverySettings(string DiscoveryMethod, string ServiceName, string PortName, int NumberOfContacts, System.TimeSpan Interval, double ExponentialBackoffJitter, System.TimeSpan ExponentialBackoffMax, System.TimeSpan ResolveTimeout, System.TimeSpan ProbeTimeout) { }
-        public string DiscoveryMethod { get; set; }
-        public double ExponentialBackoffJitter { get; set; }
-        public System.TimeSpan ExponentialBackoffMax { get; set; }
-        public System.TimeSpan Interval { get; set; }
-        public int NumberOfContacts { get; set; }
-        public string PortName { get; set; }
-        public System.TimeSpan ProbeTimeout { get; set; }
-        public System.TimeSpan ResolveTimeout { get; set; }
-        public string ServiceName { get; set; }
+        public ClusterClientDiscoverySettings(string? DiscoveryMethod, string? ServiceName, string? PortName, int NumberOfContacts, System.TimeSpan Interval, double ExponentialBackoffJitter, System.TimeSpan ExponentialBackoffMax, System.TimeSpan ResolveTimeout, System.TimeSpan ProbeTimeout) { }
+        public string? DiscoveryMethod { get; init; }
+        public double ExponentialBackoffJitter { get; init; }
+        public System.TimeSpan ExponentialBackoffMax { get; init; }
+        public System.TimeSpan Interval { get; init; }
+        public int NumberOfContacts { get; init; }
+        public string? PortName { get; init; }
+        public System.TimeSpan ProbeTimeout { get; init; }
+        public System.TimeSpan ResolveTimeout { get; init; }
+        public string? ServiceName { get; init; }
         public static Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings Create(Akka.Configuration.Config clusterClientConfig) { }
     }
     public sealed class ClusterClientReceptionist : Akka.Actor.IExtension
@@ -73,48 +73,47 @@ namespace Akka.Cluster.Tools.Client
         public ClusterClientReceptionist(Akka.Actor.ExtendedActorSystem system) { }
         public bool IsTerminated { get; }
         public Akka.Actor.IActorRef Underlying { get; }
-        public static Akka.Configuration.Config DefaultConfig() { }
-        public static Akka.Cluster.Tools.Client.ClusterClientReceptionist Get(Akka.Actor.ActorSystem system) { }
         public void RegisterService(Akka.Actor.IActorRef actorRef) { }
         public void RegisterSubscriber(string topic, Akka.Actor.IActorRef actorRef) { }
         public void UnregisterService(Akka.Actor.IActorRef actorRef) { }
         public void UnregisterSubscriber(string topic, Akka.Actor.IActorRef actorRef) { }
+        public static Akka.Configuration.Config DefaultConfig() { }
+        public static Akka.Cluster.Tools.Client.ClusterClientReceptionist Get(Akka.Actor.ActorSystem system) { }
     }
     public sealed class ClusterClientReceptionistExtensionProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Tools.Client.ClusterClientReceptionist>
     {
         public ClusterClientReceptionistExtensionProvider() { }
         public override Akka.Cluster.Tools.Client.ClusterClientReceptionist CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ClusterClientSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        [System.ObsoleteAttribute("Use constructor with useLegacySerialization argument instead. Since 1.5.15")]
-        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, System.Nullable<System.TimeSpan> reconnectTimeout = null) { }
-        [System.ObsoleteAttribute("Use constructor with useInitialContactsDiscovery and discoverySettings argument i" +
+        [System.Obsolete("Use constructor with useLegacySerialization argument instead. Since 1.5.15")]
+        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, System.TimeSpan? reconnectTimeout = default) { }
+        [System.Obsolete("Use constructor with useInitialContactsDiscovery and discoverySettings argument i" +
             "nstead. Since 1.5.25")]
-        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, bool useLegacySerialization, System.Nullable<System.TimeSpan> reconnectTimeout = null) { }
-        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, bool useLegacySerialization, bool useInitialContactsDiscovery, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings discoverySettings = null, System.Nullable<System.TimeSpan> reconnectTimeout = null, bool verboseLogging = False) { }
+        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, bool useLegacySerialization, System.TimeSpan? reconnectTimeout = default) { }
+        public ClusterClientSettings(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts, System.TimeSpan establishingGetContactsInterval, System.TimeSpan refreshContactsInterval, System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, int bufferSize, bool useLegacySerialization, bool useInitialContactsDiscovery, Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings? discoverySettings = null, System.TimeSpan? reconnectTimeout = default, bool verboseLogging = false) { }
         public System.TimeSpan AcceptableHeartbeatPause { get; }
         public int BufferSize { get; }
         public Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings DiscoverySettings { get; }
         public System.TimeSpan EstablishingGetContactsInterval { get; }
         public System.TimeSpan HeartbeatInterval { get; }
         public System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> InitialContacts { get; }
-        public System.Nullable<System.TimeSpan> ReconnectTimeout { get; }
+        public System.TimeSpan? ReconnectTimeout { get; }
         public System.TimeSpan RefreshContactsInterval { get; }
         public bool UseInitialContactDiscovery { get; }
         public bool UseLegacySerialization { get; }
         public bool VerboseLogging { get; }
-        public static Akka.Cluster.Tools.Client.ClusterClientSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Client.ClusterClientSettings Create(Akka.Configuration.Config config) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithBufferSize(int bufferSize) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithEstablishingGetContactsInterval(System.TimeSpan value) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithHeartbeatInterval(System.TimeSpan value) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithInitialContacts(System.Collections.Immutable.IImmutableSet<Akka.Actor.ActorPath> initialContacts) { }
-        public Akka.Cluster.Tools.Client.ClusterClientSettings WithInitialContactsDiscovery(bool useInitialContactsDiscovery, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings discoverySettings = null) { }
-        public Akka.Cluster.Tools.Client.ClusterClientSettings WithReconnectTimeout(System.Nullable<System.TimeSpan> reconnectTimeout) { }
+        public Akka.Cluster.Tools.Client.ClusterClientSettings WithInitialContactsDiscovery(bool useInitialContactsDiscovery, Akka.Cluster.Tools.Client.ClusterClientDiscoverySettings? discoverySettings = null) { }
+        public Akka.Cluster.Tools.Client.ClusterClientSettings WithReconnectTimeout(System.TimeSpan? reconnectTimeout) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithRefreshContactsInterval(System.TimeSpan value) { }
         public Akka.Cluster.Tools.Client.ClusterClientSettings WithUseLegacySerialization(bool useLegacySerialization) { }
+        public static Akka.Cluster.Tools.Client.ClusterClientSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Client.ClusterClientSettings Create(Akka.Configuration.Config config) { }
     }
     public sealed class ClusterClientUnreachable : Akka.Cluster.Tools.Client.IClusterClientInteraction
     {
@@ -136,8 +135,8 @@ namespace Akka.Cluster.Tools.Client
         public ClusterReceptionist(Akka.Actor.IActorRef pubSubMediator, Akka.Cluster.Tools.Client.ClusterReceptionistSettings settings) { }
         protected override void PostStop() { }
         protected override void PreStart() { }
-        public static Akka.Actor.Props Props(Akka.Actor.IActorRef pubSubMediator, Akka.Cluster.Tools.Client.ClusterReceptionistSettings settings) { }
         protected override bool Receive(object message) { }
+        public static Akka.Actor.Props Props(Akka.Actor.IActorRef pubSubMediator, Akka.Cluster.Tools.Client.ClusterReceptionistSettings settings) { }
     }
     public sealed class ClusterReceptionistSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
@@ -148,13 +147,13 @@ namespace Akka.Cluster.Tools.Client
         public int NumberOfContacts { get; }
         public System.TimeSpan ResponseTunnelReceiveTimeout { get; }
         public string Role { get; }
-        public static Akka.Cluster.Tools.Client.ClusterReceptionistSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Client.ClusterReceptionistSettings Create(Akka.Configuration.Config config) { }
         public Akka.Cluster.Tools.Client.ClusterReceptionistSettings WithHeartbeat(System.TimeSpan heartbeatInterval, System.TimeSpan acceptableHeartbeatPause, System.TimeSpan failureDetectionInterval) { }
         public Akka.Cluster.Tools.Client.ClusterReceptionistSettings WithNumberOfContacts(int numberOfContacts) { }
         public Akka.Cluster.Tools.Client.ClusterReceptionistSettings WithResponseTunnelReceiveTimeout(System.TimeSpan responseTunnelReceiveTimeout) { }
         public Akka.Cluster.Tools.Client.ClusterReceptionistSettings WithRole(string role) { }
         public Akka.Cluster.Tools.Client.ClusterReceptionistSettings WithoutRole() { }
+        public static Akka.Cluster.Tools.Client.ClusterReceptionistSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Client.ClusterReceptionistSettings Create(Akka.Configuration.Config config) { }
     }
     public sealed class ContactPointAdded : Akka.Cluster.Tools.Client.IContactPointChange
     {
@@ -221,6 +220,7 @@ namespace Akka.Cluster.Tools.Client.Serialization
 }
 namespace Akka.Cluster.Tools.PublishSubscribe
 {
+    [System.Serializable]
     public sealed class CurrentTopics : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.CurrentTopics>
     {
         public CurrentTopics(System.Collections.Immutable.IImmutableSet<string> topics) { }
@@ -254,7 +254,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
     }
     public sealed class DistributedPubSubSettings : Akka.Actor.INoSerializationVerificationNeeded, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings>
     {
-        [System.ObsoleteAttribute("Use .ctor that supports WaitForSubscribers instead. Since 1.4.42")]
+        [System.Obsolete("Use .ctor that supports WaitForSubscribers instead. Since 1.4.42")]
         public DistributedPubSubSettings(string role, Akka.Routing.RoutingLogic routingLogic, System.TimeSpan gossipInterval, System.TimeSpan removedTimeToLive, int maxDeltaElements, bool sendToDeadLettersWhenNoSubscribers) { }
         public DistributedPubSubSettings(string role, Akka.Routing.RoutingLogic routingLogic, System.TimeSpan gossipInterval, System.TimeSpan removedTimeToLive, int maxDeltaElements, bool sendToDeadLettersWhenNoSubscribers, int maxBufferedMessagePerTopic, System.TimeSpan bufferedMessageTimeoutCheckInterval) { }
         public System.TimeSpan BufferedMessageTimeoutCheckInterval { get; }
@@ -265,8 +265,6 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public string Role { get; }
         public Akka.Routing.RoutingLogic RoutingLogic { get; }
         public bool SendToDeadLettersWhenNoSubscribers { get; }
-        public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Configuration.Config config) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithBufferedMessageTimeoutCheckInterval(System.TimeSpan bufferedMessageTimeoutCheckInterval) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithGossipInterval(System.TimeSpan gossipInterval) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithMaxBufferedMessagePerTopic(int maxBufferedMessagePerTopic) { }
@@ -275,16 +273,20 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithRole(string role) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithRoutingLogic(Akka.Routing.RoutingLogic routingLogic) { }
         public Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings WithSendToDeadLettersWhenNoSubscribers(bool sendToDeadLetterWhenNoSubscribers) { }
+        public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.PublishSubscribe.DistributedPubSubSettings Create(Akka.Configuration.Config config) { }
     }
+    [System.Serializable]
     public sealed class GetTopics
     {
         public static Akka.Cluster.Tools.PublishSubscribe.GetTopics Instance { get; }
     }
     public interface IDistributedPubSubMessage { }
     public interface IPublishResponse { }
+    [System.Serializable]
     public sealed class Publish : Akka.Actor.IWrappedMessage, Akka.Cluster.Tools.PublishSubscribe.IDistributedPubSubMessage, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Publish>
     {
-        public Publish(string topic, object message, bool sendOneMessageToEachGroup = False) { }
+        public Publish(string topic, object message, bool sendOneMessageToEachGroup = false) { }
         public object Message { get; }
         public bool SendOneMessageToEachGroup { get; }
         public string Topic { get; }
@@ -301,22 +303,23 @@ namespace Akka.Cluster.Tools.PublishSubscribe
     public sealed class PublishFailed : Akka.Cluster.Tools.PublishSubscribe.IPublishResponse, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.PublishFailed>
     {
         public PublishFailed(Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message, Akka.Cluster.Tools.PublishSubscribe.PublishFailReason Reason) { }
-        public Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message { get; set; }
-        public Akka.Cluster.Tools.PublishSubscribe.PublishFailReason Reason { get; set; }
+        public Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message { get; init; }
+        public Akka.Cluster.Tools.PublishSubscribe.PublishFailReason Reason { get; init; }
     }
     public sealed class PublishSucceeded : Akka.Cluster.Tools.PublishSubscribe.IPublishResponse, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.PublishSucceeded>
     {
         public PublishSucceeded(Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message) { }
-        public Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message { get; set; }
+        public Akka.Cluster.Tools.PublishSubscribe.PublishWithAck Message { get; init; }
     }
     public sealed class PublishWithAck : Akka.Actor.IWrappedMessage, Akka.Cluster.Tools.PublishSubscribe.IDistributedPubSubMessage, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.PublishWithAck>
     {
-        public PublishWithAck(string topic, object message, System.TimeSpan timeout, bool sendOneMessageToEachGroup = False) { }
+        public PublishWithAck(string topic, object message, System.TimeSpan timeout, bool sendOneMessageToEachGroup = false) { }
         public object Message { get; }
         public bool SendOneMessageToEachGroup { get; }
         public System.TimeSpan Timeout { get; }
         public string Topic { get; }
     }
+    [System.Serializable]
     public sealed class Put : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Put>
     {
         public Put(Akka.Actor.IActorRef @ref) { }
@@ -326,6 +329,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Remove : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Remove>
     {
         public Remove(string path) { }
@@ -335,9 +339,10 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Send : Akka.Actor.IWrappedMessage, Akka.Cluster.Tools.PublishSubscribe.IDistributedPubSubMessage, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Send>
     {
-        public Send(string path, object message, bool localAffinity = False) { }
+        public Send(string path, object message, bool localAffinity = false) { }
         public bool LocalAffinity { get; }
         public object Message { get; }
         public string Path { get; }
@@ -346,9 +351,10 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SendToAll : Akka.Actor.IWrappedMessage, Akka.Cluster.Tools.PublishSubscribe.IDistributedPubSubMessage, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.SendToAll>
     {
-        public SendToAll(string path, object message, bool excludeSelf = False) { }
+        public SendToAll(string path, object message, bool excludeSelf = false) { }
         public bool ExcludeSelf { get; }
         public object Message { get; }
         public string Path { get; }
@@ -357,6 +363,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Subscribe : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Subscribe>
     {
         public Subscribe(string topic, Akka.Actor.IActorRef @ref, string group = null) { }
@@ -368,6 +375,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SubscribeAck : Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.SubscribeAck>
     {
         public SubscribeAck(Akka.Cluster.Tools.PublishSubscribe.Subscribe subscribe) { }
@@ -377,6 +385,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Unsubscribe : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.Unsubscribe>
     {
         public Unsubscribe(string topic, Akka.Actor.IActorRef @ref, string group = null) { }
@@ -388,6 +397,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class UnsubscribeAck : System.IEquatable<Akka.Cluster.Tools.PublishSubscribe.UnsubscribeAck>
     {
         public UnsubscribeAck(Akka.Cluster.Tools.PublishSubscribe.Unsubscribe unsubscribe) { }
@@ -400,7 +410,7 @@ namespace Akka.Cluster.Tools.PublishSubscribe
 }
 namespace Akka.Cluster.Tools.PublishSubscribe.Internal
 {
-    [Akka.Annotations.ApiMayChangeAttribute()]
+    [Akka.Annotations.ApiMayChange]
     public sealed class CountSubscribers
     {
         public CountSubscribers(string topic) { }
@@ -419,53 +429,50 @@ namespace Akka.Cluster.Tools.PublishSubscribe.Serialization
 }
 namespace Akka.Cluster.Tools.Singleton
 {
-    [Akka.Annotations.DoNotInheritAttribute()]
+    [Akka.Annotations.DoNotInherit]
     public class ClusterSingleton : Akka.Actor.IExtension
     {
         public ClusterSingleton(Akka.Actor.ExtendedActorSystem system) { }
+        [System.Obsolete(@"This convenience method is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
+        public Akka.Actor.IActorRef Init(Akka.Cluster.Tools.Singleton.SingletonActor singleton) { }
         public static Akka.Configuration.Config DefaultConfig() { }
         public static Akka.Cluster.Tools.Singleton.ClusterSingleton Get(Akka.Actor.ActorSystem system) { }
-        [System.ObsoleteAttribute(@"This convenience method is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
-        public Akka.Actor.IActorRef Init(Akka.Cluster.Tools.Singleton.SingletonActor singleton) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1})]
     public sealed class ClusterSingletonManager : Akka.Actor.FSM<Akka.Cluster.Tools.Singleton.ClusterSingletonState, Akka.Cluster.Tools.Singleton.IClusterSingletonData>
     {
         public ClusterSingletonManager(Akka.Actor.Props singletonProps, object terminationMessage, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
-        [System.ObsoleteAttribute("Deprecated and will be removed in v1.6, please use ClusterSingleton.DefaultConfig" +
-            "() instead. Since 1.5.32.")]
-        public static Akka.Configuration.Config DefaultConfig() { }
         protected override void PostStop() { }
         protected override void PreStart() { }
+        [System.Obsolete("Deprecated and will be removed in v1.6, please use ClusterSingleton.DefaultConfig" +
+            "() instead. Since 1.5.32.")]
+        public static Akka.Configuration.Config DefaultConfig() { }
         public static Akka.Actor.Props Props(Akka.Actor.Props singletonProps, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
         public static Akka.Actor.Props Props(Akka.Actor.Props singletonProps, object terminationMessage, Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings settings) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ClusterSingletonManagerIsStuckException : Akka.Actor.AkkaException
     {
         public ClusterSingletonManagerIsStuckException(string message) { }
         public ClusterSingletonManagerIsStuckException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.Serializable]
     public sealed class ClusterSingletonManagerSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
         public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, bool considerAppVersion) { }
         public ClusterSingletonManagerSettings(string singletonName, string role, System.TimeSpan removalMargin, System.TimeSpan handOverRetryInterval, Akka.Coordination.LeaseUsageSettings leaseSettings, bool considerAppVersion) { }
-        [System.ObsoleteAttribute("ConsiderAppVersion is not used anymore and will be removed in future versions.")]
+        [System.Obsolete("ConsiderAppVersion is not used anymore and will be removed in future versions.")]
         public bool ConsiderAppVersion { get; }
         public System.TimeSpan HandOverRetryInterval { get; }
         public Akka.Coordination.LeaseUsageSettings LeaseSettings { get; }
         public System.TimeSpan RemovalMargin { get; }
         public string Role { get; }
         public string SingletonName { get; }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings Create(Akka.Configuration.Config config) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithHandOverRetryInterval(System.TimeSpan handOverRetryInterval) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithLeaseSettings(Akka.Coordination.LeaseUsageSettings leaseSettings) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithRemovalMargin(System.TimeSpan removalMargin) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithRole(string role) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings WithSingletonName(string singletonName) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonManagerSettings Create(Akka.Configuration.Config config) { }
     }
     public class ClusterSingletonProvider : Akka.Actor.ExtensionIdProvider<Akka.Cluster.Tools.Singleton.ClusterSingleton>
     {
@@ -476,9 +483,9 @@ namespace Akka.Cluster.Tools.Singleton
     {
         public ClusterSingletonProxy(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
         public Akka.Actor.ITimerScheduler Timers { get; set; }
-        public static Akka.Configuration.Config DefaultConfig() { }
         protected override void PostStop() { }
         protected override void PreStart() { }
+        public static Akka.Configuration.Config DefaultConfig() { }
         public static Akka.Actor.Props Props(string singletonManagerPath, Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings settings) { }
         public enum IdentifyResult
         {
@@ -497,7 +504,7 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public sealed class ClusterSingletonProxySettings : Akka.Actor.INoSerializationVerificationNeeded
     {
-        [System.ObsoleteAttribute("Use constructor with logSingletonIdentificationFailure and logSingletonIdentifica" +
+        [System.Obsolete("Use constructor with logSingletonIdentificationFailure and logSingletonIdentifica" +
             "tionInterval parameter instead. Since v1.5.30")]
         public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize, bool considerAppVersion) { }
         public ClusterSingletonProxySettings(string singletonName, string role, System.TimeSpan singletonIdentificationInterval, int bufferSize, bool considerAppVersion, bool logSingletonIdentificationFailure, System.TimeSpan singletonIdentificationFailurePeriod) { }
@@ -508,16 +515,17 @@ namespace Akka.Cluster.Tools.Singleton
         public System.TimeSpan SingletonIdentificationFailurePeriod { get; }
         public System.TimeSpan SingletonIdentificationInterval { get; }
         public string SingletonName { get; }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config, bool considerAppVersion) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithBufferSize(int bufferSize) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithLogSingletonIdentificationFailure(bool logSingletonIdentificationFailure) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithRole(string role) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonIdentificationFailureDuration(System.TimeSpan singletonIdentificationFailurePeriod) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonIdentificationInterval(System.TimeSpan singletonIdentificationInterval) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings WithSingletonName(string singletonName) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonProxySettings Create(Akka.Configuration.Config config, bool considerAppVersion) { }
     }
-    [System.ObsoleteAttribute(@"This setting class is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
+    [System.Obsolete(@"This setting class is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
+    [System.Serializable]
     public class ClusterSingletonSettings : Akka.Actor.INoSerializationVerificationNeeded
     {
         public int BufferSize { get; }
@@ -529,8 +537,6 @@ namespace Akka.Cluster.Tools.Singleton
         public string Role { get; }
         public System.TimeSpan SingletonIdentificationFailurePeriod { get; }
         public System.TimeSpan SingletonIdentificationInterval { get; }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Configuration.Config config) { }
         public override string ToString() { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithBufferSize(int bufferSize) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithHandOverRetryInterval(System.TimeSpan handOverRetryInterval) { }
@@ -540,7 +546,10 @@ namespace Akka.Cluster.Tools.Singleton
         public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithRole(string role) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithSingletonIdentificationFailurePeriod(System.TimeSpan singletonIdentificationFailurePeriod) { }
         public Akka.Cluster.Tools.Singleton.ClusterSingletonSettings WithSingletonIdentificationInterval(System.TimeSpan singletonIdentificationInterval) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.Cluster.Tools.Singleton.ClusterSingletonSettings Create(Akka.Configuration.Config config) { }
     }
+    [System.Serializable]
     public enum ClusterSingletonState
     {
         Start = 0,
@@ -556,17 +565,17 @@ namespace Akka.Cluster.Tools.Singleton
     }
     public interface IClusterSingletonData { }
     public interface IClusterSingletonMessage { }
-    [System.ObsoleteAttribute(@"This setting class is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
+    [System.Obsolete(@"This setting class is deprecated and will be removed in v1.6, please use ClusterSingletonManager.Props and ClusterSingletonProxy.Props directly instead. See https://getakka.net/community/whats-new/akkadotnet-v1.5-upgrade-advisories.html#upgrading-to-akkanet-v1532. Since 1.5.32.")]
     public class SingletonActor
     {
         public string Name { get; }
         public Akka.Actor.Props Props { get; }
         public Akka.Util.Option<Akka.Cluster.Tools.Singleton.ClusterSingletonSettings> Settings { get; }
         public Akka.Util.Option<object> StopMessage { get; }
-        public static Akka.Cluster.Tools.Singleton.SingletonActor Create(Akka.Actor.Props props, string name) { }
         public Akka.Cluster.Tools.Singleton.SingletonActor WithProps(Akka.Actor.Props props) { }
         public Akka.Cluster.Tools.Singleton.SingletonActor WithSettings(Akka.Cluster.Tools.Singleton.ClusterSingletonSettings settings) { }
         public Akka.Cluster.Tools.Singleton.SingletonActor WithStopMessage(object stopMessage) { }
+        public static Akka.Cluster.Tools.Singleton.SingletonActor Create(Akka.Actor.Props props, string name) { }
     }
 }
 namespace Akka.Cluster.Tools.Singleton.Serialization

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCoordination.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCoordination.DotNet.verified.txt
@@ -1,5 +1,5 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Coordination
 {
     public abstract class Lease
@@ -14,15 +14,15 @@ namespace Akka.Coordination
     public class LeaseException : System.Exception
     {
         public LeaseException(string message) { }
-        public LeaseException(string message, System.Exception innerEx) { }
         protected LeaseException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public LeaseException(string message, System.Exception innerEx) { }
     }
     public class LeaseProvider : Akka.Actor.IExtension
     {
         public LeaseProvider(Akka.Actor.ExtendedActorSystem system) { }
+        public Akka.Coordination.Lease GetLease(string leaseName, string configPath, string ownerName) { }
         public static Akka.Configuration.Config DefaultConfig() { }
         public static Akka.Coordination.LeaseProvider Get(Akka.Actor.ActorSystem system) { }
-        public Akka.Coordination.Lease GetLease(string leaseName, string configPath, string ownerName) { }
     }
     public class LeaseProviderExtensionProvider : Akka.Actor.ExtensionIdProvider<Akka.Coordination.LeaseProvider>
     {
@@ -36,9 +36,9 @@ namespace Akka.Coordination
         public string LeaseName { get; }
         public string OwnerName { get; }
         public Akka.Coordination.TimeoutSettings TimeoutSettings { get; }
-        public static Akka.Coordination.LeaseSettings Create(Akka.Configuration.Config config, string leaseName, string ownerName) { }
         public override string ToString() { }
         public Akka.Coordination.LeaseSettings WithTimeoutSettings(Akka.Coordination.TimeoutSettings timeoutSettings) { }
+        public static Akka.Coordination.LeaseSettings Create(Akka.Configuration.Config config, string leaseName, string ownerName) { }
     }
     public sealed class LeaseTimeoutException : Akka.Coordination.LeaseException
     {
@@ -58,10 +58,10 @@ namespace Akka.Coordination
         public System.TimeSpan HeartbeatInterval { get; }
         public System.TimeSpan HeartbeatTimeout { get; }
         public System.TimeSpan OperationTimeout { get; }
-        public static Akka.Coordination.TimeoutSettings Create(Akka.Configuration.Config config) { }
         public override string ToString() { }
         public Akka.Coordination.TimeoutSettings WithHeartbeatInterval(System.TimeSpan heartbeatInterval) { }
         public Akka.Coordination.TimeoutSettings WithHeartbeatTimeout(System.TimeSpan heartbeatTimeout) { }
         public Akka.Coordination.TimeoutSettings withOperationTimeout(System.TimeSpan operationTimeout) { }
+        public static Akka.Coordination.TimeoutSettings Create(Akka.Configuration.Config config) { }
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCoordination.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCoordination.Net.verified.txt
@@ -1,5 +1,5 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Coordination
 {
     public abstract class Lease
@@ -14,15 +14,15 @@ namespace Akka.Coordination
     public class LeaseException : System.Exception
     {
         public LeaseException(string message) { }
-        public LeaseException(string message, System.Exception innerEx) { }
         protected LeaseException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public LeaseException(string message, System.Exception innerEx) { }
     }
     public class LeaseProvider : Akka.Actor.IExtension
     {
         public LeaseProvider(Akka.Actor.ExtendedActorSystem system) { }
+        public Akka.Coordination.Lease GetLease(string leaseName, string configPath, string ownerName) { }
         public static Akka.Configuration.Config DefaultConfig() { }
         public static Akka.Coordination.LeaseProvider Get(Akka.Actor.ActorSystem system) { }
-        public Akka.Coordination.Lease GetLease(string leaseName, string configPath, string ownerName) { }
     }
     public class LeaseProviderExtensionProvider : Akka.Actor.ExtensionIdProvider<Akka.Coordination.LeaseProvider>
     {
@@ -36,9 +36,9 @@ namespace Akka.Coordination
         public string LeaseName { get; }
         public string OwnerName { get; }
         public Akka.Coordination.TimeoutSettings TimeoutSettings { get; }
-        public static Akka.Coordination.LeaseSettings Create(Akka.Configuration.Config config, string leaseName, string ownerName) { }
         public override string ToString() { }
         public Akka.Coordination.LeaseSettings WithTimeoutSettings(Akka.Coordination.TimeoutSettings timeoutSettings) { }
+        public static Akka.Coordination.LeaseSettings Create(Akka.Configuration.Config config, string leaseName, string ownerName) { }
     }
     public sealed class LeaseTimeoutException : Akka.Coordination.LeaseException
     {
@@ -58,10 +58,10 @@ namespace Akka.Coordination
         public System.TimeSpan HeartbeatInterval { get; }
         public System.TimeSpan HeartbeatTimeout { get; }
         public System.TimeSpan OperationTimeout { get; }
-        public static Akka.Coordination.TimeoutSettings Create(Akka.Configuration.Config config) { }
         public override string ToString() { }
         public Akka.Coordination.TimeoutSettings WithHeartbeatInterval(System.TimeSpan heartbeatInterval) { }
         public Akka.Coordination.TimeoutSettings WithHeartbeatTimeout(System.TimeSpan heartbeatTimeout) { }
         public Akka.Coordination.TimeoutSettings withOperationTimeout(System.TimeSpan operationTimeout) { }
+        public static Akka.Coordination.TimeoutSettings Create(Akka.Configuration.Config config) { }
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -1,48 +1,48 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.API.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DependencyInjection")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DependencyInjection.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Docs.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.MultiNodeTestRunner.Shared.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.Sql.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.TCK")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.TestKit.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.TestKit.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.TestKit.Xunit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.TestKit.Xunit2")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Tests.Performance")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("1a5cab08-b032-49ca-8db3-9428c5a9db14")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.API.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DependencyInjection")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DependencyInjection.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DistributedData")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Docs.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.MultiNodeTestRunner.Shared.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.Sql.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.TCK")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.TestKit.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Streams")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Streams.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.Xunit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.Xunit2")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Tests.Performance")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("1a5cab08-b032-49ca-8db3-9428c5a9db14")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Actor
 {
     public abstract class ActorBase : Akka.Actor.IInternalActor
     {
         protected ActorBase() { }
-        protected static Akka.Actor.IActorContext Context { get; }
-        protected static Akka.Actor.Receive EmptyReceive { get; }
         protected Akka.Actor.IActorRef Self { get; }
         protected Akka.Actor.IActorRef Sender { get; }
+        protected static Akka.Actor.IActorContext Context { get; }
+        protected static Akka.Actor.Receive EmptyReceive { get; }
         public virtual void AroundPostRestart(System.Exception cause, object message) { }
         public virtual void AroundPostStop() { }
         public virtual void AroundPreRestart(System.Exception cause, object message) { }
@@ -55,65 +55,57 @@ namespace Akka.Actor
         protected virtual void PreRestart(System.Exception reason, object message) { }
         protected virtual void PreStart() { }
         protected abstract bool Receive(object message);
-        protected void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout) { }
+        protected void SetReceiveTimeout(System.TimeSpan? timeout) { }
         protected virtual Akka.Actor.SupervisorStrategy SupervisorStrategy() { }
         protected void UnbecomeStacked() { }
         protected virtual void Unhandled(object message) { }
     }
-    [System.Diagnostics.DebuggerDisplayAttribute("{Self,nq}")]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [System.Diagnostics.DebuggerDisplay("{Self,nq}")]
     public class ActorCell : Akka.Actor.IActorContext, Akka.Actor.IActorRefFactory, Akka.Actor.ICanWatch, Akka.Actor.ICell, Akka.Actor.IUntypedActorContext
     {
         public const int UndefinedUid = 0;
         public ActorCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.IInternalActorRef self, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Actor.IInternalActorRef parent) { }
         public Akka.Actor.Internal.IChildrenContainer ChildrenContainer { get; }
         public int CurrentEnvelopeId { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public object CurrentMessage { get; }
+        public object? CurrentMessage { get; }
         public Akka.Dispatch.MessageDispatcher Dispatcher { get; }
         public bool HasMessages { get; }
         public bool IsLocal { get; }
         protected bool IsNormal { get; }
         public bool IsTerminated { get; }
         protected bool IsTerminating { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Dispatch.Mailbox Mailbox { get; }
+        public Akka.Dispatch.Mailbox? Mailbox { get; }
         public int NumberOfMessages { get; }
         public Akka.Actor.IInternalActorRef Parent { get; }
         public Akka.Actor.Props Props { get; }
-        public System.Nullable<System.TimeSpan> ReceiveTimeout { get; }
+        public System.TimeSpan? ReceiveTimeout { get; }
         public Akka.Actor.IActorRef Self { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.IActorRef Sender { get; }
+        public Akka.Actor.IActorRef? Sender { get; }
         public Akka.Actor.ActorSystem System { get; }
         public Akka.Actor.Internal.ActorSystemImpl SystemImpl { get; }
         public virtual Akka.Dispatch.ActorTaskScheduler TaskScheduler { get; }
-        public virtual Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null) { }
-        public Akka.Actor.ActorSelection ActorSelection(string path) { }
+        public virtual Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string? name = null) { }
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath path) { }
+        public Akka.Actor.ActorSelection ActorSelection(string path) { }
         protected void AddWatcher(Akka.Actor.IActorRef watchee, Akka.Actor.IActorRef watcher) { }
         protected void AddressTerminated(Akka.Actor.Address address) { }
-        public virtual Akka.Actor.IActorRef AttachChild(Akka.Actor.Props props, bool isSystemService, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null) { }
+        public virtual Akka.Actor.IActorRef AttachChild(Akka.Actor.Props props, bool isSystemService, string? name = null) { }
         protected virtual void AutoReceiveMessage(Akka.Actor.Envelope envelope) { }
         public void Become(Akka.Actor.Receive receive) { }
         public void BecomeStacked(Akka.Actor.Receive receive) { }
-        public void CheckReceiveTimeout(bool reschedule = True) { }
-        protected void ClearActor(Akka.Actor.ActorBase actor) { }
+        public void CheckReceiveTimeout(bool reschedule = true) { }
+        protected void ClearActor(Akka.Actor.ActorBase? actor) { }
         protected void ClearActorCell() { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        protected virtual Akka.Actor.ActorRestarted CreateActorRestartedEvent(System.Exception cause) { }
-        protected virtual Akka.Actor.ActorStarted CreateActorStartedEvent() { }
-        protected virtual Akka.Actor.ActorStopped CreateActorStoppedEvent() { }
+        protected virtual Akka.Actor.ActorRestarted? CreateActorRestartedEvent(System.Exception cause) { }
+        protected virtual Akka.Actor.ActorStarted? CreateActorStartedEvent() { }
+        protected virtual Akka.Actor.ActorStopped? CreateActorStoppedEvent() { }
         protected virtual Akka.Actor.ActorBase CreateNewActorInstance() { }
-        [System.ObsoleteAttribute("Use TryGetChildStatsByName [0.7.1]", true)]
+        [System.Obsolete("Use TryGetChildStatsByName [0.7.1]", true)]
         public Akka.Actor.IInternalActorRef GetChildByName(string name) { }
         public System.Collections.Generic.IEnumerable<Akka.Actor.IInternalActorRef> GetChildren() { }
-        public static Akka.Actor.IActorRef GetCurrentSelfOrNoSender() { }
-        public static Akka.Actor.IActorRef GetCurrentSenderOrNoSender() { }
         public Akka.Actor.IInternalActorRef GetSingleChild(string name) { }
         public void Init(bool sendSupervise, Akka.Dispatch.MailboxType mailboxType) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.Internal.ChildRestartStats InitChild(Akka.Actor.IInternalActorRef actor) { }
+        public Akka.Actor.Internal.ChildRestartStats? InitChild(Akka.Actor.IInternalActorRef actor) { }
         public void Invoke(Akka.Actor.Envelope envelope) { }
         protected virtual void PreStart() { }
         protected void PrepareForNewActor() { }
@@ -121,38 +113,37 @@ namespace Akka.Actor
         public void ReceiveMessageForTest(Akka.Actor.Envelope envelope) { }
         protected void ReceivedTerminated(Akka.Actor.Terminated t) { }
         protected void RemWatcher(Akka.Actor.IActorRef watchee, Akka.Actor.IActorRef watcher) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        protected Akka.Actor.Internal.SuspendReason RemoveChildAndGetStateChange(Akka.Actor.IActorRef child) { }
+        protected Akka.Actor.Internal.SuspendReason? RemoveChildAndGetStateChange(Akka.Actor.IActorRef child) { }
         public void ReserveChild(string name) { }
         public void Restart(System.Exception cause) { }
         public void Resume(System.Exception causedByFailure) { }
         public virtual void SendMessage(Akka.Actor.Envelope message) { }
         public virtual void SendMessage(Akka.Actor.IActorRef sender, object message) { }
         public virtual void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage systemMessage) { }
-        protected static void SetActorFields(Akka.Actor.ActorBase actor) { }
         protected bool SetChildrenTerminationReason(Akka.Actor.Internal.SuspendReason reason) { }
-        public void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout = null) { }
+        public void SetReceiveTimeout(System.TimeSpan? timeout = default) { }
         protected void SetTerminated() { }
         public virtual void Start() { }
         protected void Stash(Akka.Dispatch.SysMsg.SystemMessage msg) { }
-        public void Stop(Akka.Actor.IActorRef child) { }
         public void Stop() { }
+        public void Stop(Akka.Actor.IActorRef child) { }
         protected void StopFunctionRefs() { }
         public void Suspend() { }
         protected void TellWatchersWeDied() { }
-        public void TerminatedQueuedFor(Akka.Actor.IActorRef subject, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<object> customMessage) { }
+        public void TerminatedQueuedFor(Akka.Actor.IActorRef subject, Akka.Util.Option<object> customMessage) { }
         public bool TryGetChildStatsByName(string name, out Akka.Actor.Internal.IChildStats child) { }
-        protected bool TryGetChildStatsByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats child) { }
+        protected bool TryGetChildStatsByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Akka.Actor.Internal.ChildRestartStats? child) { }
         public void UnbecomeStacked() { }
         protected void UnreserveChild(string name) { }
         public Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef subject) { }
-        protected void UnwatchWatchedActors(Akka.Actor.ActorBase actor) { }
+        protected void UnwatchWatchedActors(Akka.Actor.ActorBase? actor) { }
         public void UseThreadContext(System.Action action) { }
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef subject) { }
         public Akka.Actor.IActorRef WatchWith(Akka.Actor.IActorRef subject, object message) { }
         protected void WatchedActorTerminated(Akka.Actor.IActorRef actor, bool existenceConfirmed, bool addressTerminated) { }
+        public static Akka.Actor.IActorRef? GetCurrentSelfOrNoSender() { }
+        public static Akka.Actor.IActorRef? GetCurrentSenderOrNoSender() { }
+        protected static void SetActorFields(Akka.Actor.ActorBase? actor) { }
     }
     public sealed class ActorIdentity
     {
@@ -167,17 +158,17 @@ namespace Akka.Actor
     {
         public ActorInitializationException() { }
         public ActorInitializationException(string message) { }
+        protected ActorInitializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ActorInitializationException(string message, System.Exception cause) { }
         public ActorInitializationException(Akka.Actor.IActorRef actor, string message, System.Exception cause = null) { }
-        protected ActorInitializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public Akka.Actor.IActorRef Actor { get; set; }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { }
     }
     public class ActorInterruptedException : Akka.Actor.AkkaException
     {
-        public ActorInterruptedException(string message = null, System.Exception cause = null) { }
         protected ActorInterruptedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public ActorInterruptedException(string message = null, System.Exception cause = null) { }
     }
     public class ActorKilledException : Akka.Actor.AkkaException
     {
@@ -201,18 +192,15 @@ namespace Akka.Actor
         public System.Collections.Generic.IReadOnlyList<string> Elements { get; }
         public string Name { get; }
         public Akka.Actor.ActorPath Parent { get; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        [Newtonsoft.Json.JsonIgnore]
         public Akka.Actor.ActorPath Root { get; }
         public long Uid { get; }
         public Akka.Actor.ActorPath Child(string childName) { }
         public int CompareTo(Akka.Actor.ActorPath other) { }
         public bool Equals(Akka.Actor.ActorPath other) { }
         public override bool Equals(object obj) { }
-        public static string FormatPathElements(System.Collections.Generic.IEnumerable<string> pathElements) { }
         public override int GetHashCode() { }
-        public static bool IsValidPathElement(string s) { }
         public Akka.Actor.ActorPath ParentOf(int depth) { }
-        public static Akka.Actor.ActorPath Parse(string path) { }
         public string ToSerializationFormat() { }
         public string ToSerializationFormatWithAddress(Akka.Actor.Address address) { }
         public override string ToString() { }
@@ -221,23 +209,26 @@ namespace Akka.Actor
         public string ToStringWithUid() { }
         public string ToStringWithoutAddress() { }
         public Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
+        public Akka.Actor.ActorPath WithUid(long uid) { }
+        public static string FormatPathElements(System.Collections.Generic.IEnumerable<string> pathElements) { }
+        public static bool IsValidPathElement(string s) { }
+        public static Akka.Actor.ActorPath Parse(string path) { }
         public static bool TryParse(string path, out Akka.Actor.ActorPath actorPath) { }
-        public static bool TryParse(Akka.Actor.ActorPath basePath, string absoluteUri, out Akka.Actor.ActorPath actorPath) { }
         public static bool TryParse(Akka.Actor.ActorPath basePath, System.ReadOnlySpan<char> absoluteUri, out Akka.Actor.ActorPath actorPath) { }
+        public static bool TryParse(Akka.Actor.ActorPath basePath, string absoluteUri, out Akka.Actor.ActorPath actorPath) { }
         public static bool TryParseAddress(string path, out Akka.Actor.Address address) { }
         public static bool TryParseAddress(string path, out Akka.Actor.Address address, out System.ReadOnlySpan<char> absoluteUri) { }
         public static bool TryParseParts(System.ReadOnlySpan<char> path, out System.ReadOnlySpan<char> address, out System.ReadOnlySpan<char> absoluteUri) { }
-        public Akka.Actor.ActorPath WithUid(long uid) { }
-        public static Akka.Actor.ActorPath /(Akka.Actor.ActorPath path, string name) { }
-        public static Akka.Actor.ActorPath /(Akka.Actor.ActorPath path, System.Collections.Generic.IEnumerable<string> name) { }
-        public static bool ==(Akka.Actor.ActorPath left, Akka.Actor.ActorPath right) { }
-        public static bool !=(Akka.Actor.ActorPath left, Akka.Actor.ActorPath right) { }
+        public static bool operator !=(Akka.Actor.ActorPath left, Akka.Actor.ActorPath right) { }
+        public static Akka.Actor.ActorPath operator /(Akka.Actor.ActorPath path, System.Collections.Generic.IEnumerable<string> name) { }
+        public static Akka.Actor.ActorPath operator /(Akka.Actor.ActorPath path, string name) { }
+        public static bool operator ==(Akka.Actor.ActorPath left, Akka.Actor.ActorPath right) { }
         public sealed class Surrogate : Akka.Util.ISurrogate, System.IEquatable<Akka.Actor.ActorPath.Surrogate>, System.IEquatable<Akka.Actor.ActorPath>
         {
             public Surrogate(string path) { }
             public string Path { get; }
-            public bool Equals(Akka.Actor.ActorPath.Surrogate other) { }
             public bool Equals(Akka.Actor.ActorPath other) { }
+            public bool Equals(Akka.Actor.ActorPath.Surrogate other) { }
             public override bool Equals(object obj) { }
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
             public override int GetHashCode() { }
@@ -279,10 +270,10 @@ namespace Akka.Actor
     {
         protected ActorRefBase() { }
         public abstract Akka.Actor.ActorPath Path { get; }
-        public int CompareTo(object obj) { }
         public int CompareTo(Akka.Actor.IActorRef other) { }
-        public override bool Equals(object obj) { }
+        public int CompareTo(object obj) { }
         public bool Equals(Akka.Actor.IActorRef other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public void Tell(object message, Akka.Actor.IActorRef sender) { }
         protected abstract void TellInternal(object message, Akka.Actor.IActorRef sender);
@@ -295,29 +286,29 @@ namespace Akka.Actor
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
         }
     }
-    public class static ActorRefExtensions
+    public static class ActorRefExtensions
     {
         public static Akka.Actor.IActorRef GetOrElse(this Akka.Actor.IActorRef actorRef, System.Func<Akka.Actor.IActorRef> elseValue) { }
         public static bool IsNobody(this Akka.Actor.IActorRef actorRef) { }
     }
-    public class static ActorRefFactoryExtensions
+    public static class ActorRefFactoryExtensions
     {
         public static Akka.Actor.IActorRef ActorOf<TActor>(this Akka.Actor.IActorRefFactory factory, string name = null)
             where TActor : Akka.Actor.ActorBase, new () { }
         public static Akka.Actor.ActorSelection ActorSelection(this Akka.Actor.IActorRefFactory factory, Akka.Actor.IActorRef anchorRef, string actorPath) { }
     }
-    public class static ActorRefFactoryShared
+    public static class ActorRefFactoryShared
     {
         public static Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath actorPath, Akka.Actor.ActorSystem system) { }
-        public static Akka.Actor.ActorSelection ActorSelection(string path, Akka.Actor.ActorSystem system, Akka.Actor.IActorRef lookupRoot) { }
         public static Akka.Actor.ActorSelection ActorSelection(Akka.Actor.IActorRef anchorActorRef, string path) { }
+        public static Akka.Actor.ActorSelection ActorSelection(string path, Akka.Actor.ActorSystem system, Akka.Actor.IActorRef lookupRoot) { }
     }
-    public class static ActorRefImplicitSenderExtensions
+    public static class ActorRefImplicitSenderExtensions
     {
         public static void Forward(this Akka.Actor.IActorRef receiver, object message) { }
         public static void Tell(this Akka.Actor.IActorRef receiver, object message) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class ActorRefWithCell : Akka.Actor.InternalActorRefBase
     {
         protected ActorRefWithCell() { }
@@ -325,16 +316,14 @@ namespace Akka.Actor
         public abstract Akka.Actor.ICell Underlying { get; }
         public abstract Akka.Actor.IInternalActorRef GetSingleChild(string name);
     }
-    public class static ActorRefs
+    public static class ActorRefs
     {
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public static readonly Akka.Actor.IActorRef NoSender;
+        public static readonly Akka.Actor.IActorRef? NoSender;
         public static readonly Akka.Actor.Nobody Nobody;
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ActorRestarted : Akka.Actor.IActorTelemetryEvent, Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.INotInfluenceReceiveTimeout
     {
-        public ActorRestarted(Akka.Actor.IActorRef subject, System.Type actorType, System.Exception reason, [System.Runtime.CompilerServices.NullableAttribute(2)] string actorTypeOverride = null) { }
+        public ActorRestarted(Akka.Actor.IActorRef subject, System.Type actorType, System.Exception reason, string? actorTypeOverride = null) { }
         public System.Type ActorType { get; }
         public string ActorTypeOverride { get; }
         public System.Exception Reason { get; }
@@ -344,13 +333,13 @@ namespace Akka.Actor
     {
         public ActorSelection() { }
         public ActorSelection(Akka.Actor.IActorRef anchor, Akka.Actor.SelectionPathElement[] path) { }
-        public ActorSelection(Akka.Actor.IActorRef anchor, string path) { }
         public ActorSelection(Akka.Actor.IActorRef anchor, System.Collections.Generic.IEnumerable<string> elements) { }
+        public ActorSelection(Akka.Actor.IActorRef anchor, string path) { }
         public Akka.Actor.IActorRef Anchor { get; }
         public Akka.Actor.SelectionPathElement[] Path { get; }
         public string PathString { get; }
-        public override bool Equals(object obj) { }
         protected bool Equals(Akka.Actor.ActorSelection other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ResolveOne(System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ResolveOne(System.TimeSpan timeout, System.Threading.CancellationToken ct) { }
@@ -359,17 +348,16 @@ namespace Akka.Actor
     }
     public class ActorSelectionMessage : Akka.Actor.IAutoReceivedMessage, Akka.Actor.IPossiblyHarmful, Akka.Actor.IWrappedMessage
     {
-        public ActorSelectionMessage(object message, Akka.Actor.SelectionPathElement[] elements, bool wildCardFanOut = False) { }
+        public ActorSelectionMessage(object message, Akka.Actor.SelectionPathElement[] elements, bool wildCardFanOut = false) { }
         public Akka.Actor.SelectionPathElement[] Elements { get; }
         public object Message { get; }
         public bool WildCardFanOut { get; }
-        public Akka.Actor.ActorSelectionMessage Copy(object message = null, Akka.Actor.SelectionPathElement[] elements = null, System.Nullable<bool> wildCardFanOut = null) { }
+        public Akka.Actor.ActorSelectionMessage Copy(object message = null, Akka.Actor.SelectionPathElement[] elements = null, bool? wildCardFanOut = default) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ActorStarted : Akka.Actor.IActorTelemetryEvent, Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.INotInfluenceReceiveTimeout
     {
-        public ActorStarted(Akka.Actor.IActorRef subject, System.Type actorType, [System.Runtime.CompilerServices.NullableAttribute(2)] string actorTypeOverride = null) { }
+        public ActorStarted(Akka.Actor.IActorRef subject, System.Type actorType, string? actorTypeOverride = null) { }
         public System.Type ActorType { get; }
         public string ActorTypeOverride { get; }
         public Akka.Actor.IActorRef Subject { get; }
@@ -381,10 +369,9 @@ namespace Akka.Actor
         public override void BeforeIncarnated(Akka.Actor.ActorBase actor, Akka.Actor.IActorContext context) { }
         public override bool CanBeAppliedTo(System.Type actorType) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ActorStopped : Akka.Actor.IActorTelemetryEvent, Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.INotInfluenceReceiveTimeout
     {
-        public ActorStopped(Akka.Actor.IActorRef subject, System.Type actorType, [System.Runtime.CompilerServices.NullableAttribute(2)] string actorTypeOverride = null) { }
+        public ActorStopped(Akka.Actor.IActorRef subject, System.Type actorType, string? actorTypeOverride = null) { }
         public System.Type ActorType { get; }
         public string ActorTypeOverride { get; }
         public Akka.Actor.IActorRef Subject { get; }
@@ -408,10 +395,6 @@ namespace Akka.Actor
         public abstract Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string name = null);
         public abstract Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath actorPath);
         public abstract Akka.Actor.ActorSelection ActorSelection(string actorPath);
-        public static Akka.Actor.ActorSystem Create(string name, Akka.Configuration.Config config) { }
-        public static Akka.Actor.ActorSystem Create(string name, Akka.Actor.BootstrapSetup setup) { }
-        public static Akka.Actor.ActorSystem Create(string name, Akka.Actor.Setup.ActorSystemSetup setup) { }
-        public static Akka.Actor.ActorSystem Create(string name) { }
         public void Dispose() { }
         public abstract object GetExtension(Akka.Actor.IExtensionId extensionId);
         public abstract T GetExtension<T>()
@@ -426,8 +409,12 @@ namespace Akka.Actor
         public abstract bool TryGetExtension(System.Type extensionType, out object extension);
         public abstract bool TryGetExtension<T>(out T extension)
             where T :  class, Akka.Actor.IExtension;
+        public static Akka.Actor.ActorSystem Create(string name) { }
+        public static Akka.Actor.ActorSystem Create(string name, Akka.Actor.BootstrapSetup setup) { }
+        public static Akka.Actor.ActorSystem Create(string name, Akka.Actor.Setup.ActorSystemSetup setup) { }
+        public static Akka.Actor.ActorSystem Create(string name, Akka.Configuration.Config config) { }
     }
-    public class static ActorSystemWithExtensions
+    public static class ActorSystemWithExtensions
     {
         public static T WithExtension<T>(this Akka.Actor.ActorSystem system)
             where T :  class, Akka.Actor.IExtension { }
@@ -441,11 +428,11 @@ namespace Akka.Actor
     {
         public static readonly Akka.Actor.Address AllSystems;
         public static readonly System.Collections.Generic.IComparer<Akka.Actor.Address> Comparer;
-        public Address(string protocol, string system, string host = null, System.Nullable<int> port = null) { }
+        public Address(string protocol, string system, string host = null, int? port = default) { }
         public bool HasGlobalScope { get; }
         public bool HasLocalScope { get; }
         public string Host { get; }
-        public System.Nullable<int> Port { get; }
+        public int? Port { get; }
         public string Protocol { get; }
         public string System { get; }
         public object Clone() { }
@@ -454,24 +441,24 @@ namespace Akka.Actor
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public string HostPort() { }
-        public static Akka.Actor.Address Parse(string address) { }
         public override string ToString() { }
         public Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
-        public static bool TryParse(string path, out Akka.Actor.Address address) { }
-        public static bool TryParse(string path, out Akka.Actor.Address address, out string absolutUri) { }
-        public static bool TryParse(System.ReadOnlySpan<char> span, out Akka.Actor.Address address) { }
-        public static bool TryParse(System.ReadOnlySpan<char> span, out Akka.Actor.Address address, out System.ReadOnlySpan<char> absolutUri) { }
         public Akka.Actor.Address WithHost(string host = null) { }
-        public Akka.Actor.Address WithPort(System.Nullable<int> port = null) { }
+        public Akka.Actor.Address WithPort(int? port = default) { }
         public Akka.Actor.Address WithProtocol(string protocol) { }
         public Akka.Actor.Address WithSystem(string system) { }
-        public static bool ==(Akka.Actor.Address left, Akka.Actor.Address right) { }
-        public static bool !=(Akka.Actor.Address left, Akka.Actor.Address right) { }
+        public static Akka.Actor.Address Parse(string address) { }
+        public static bool TryParse(System.ReadOnlySpan<char> span, out Akka.Actor.Address address) { }
+        public static bool TryParse(string path, out Akka.Actor.Address address) { }
+        public static bool TryParse(System.ReadOnlySpan<char> span, out Akka.Actor.Address address, out System.ReadOnlySpan<char> absolutUri) { }
+        public static bool TryParse(string path, out Akka.Actor.Address address, out string absolutUri) { }
+        public static bool operator !=(Akka.Actor.Address left, Akka.Actor.Address right) { }
+        public static bool operator ==(Akka.Actor.Address left, Akka.Actor.Address right) { }
         public sealed class AddressSurrogate : Akka.Util.ISurrogate
         {
             public AddressSurrogate() { }
             public string Host { get; set; }
-            public System.Nullable<int> Port { get; set; }
+            public int? Port { get; set; }
             public string Protocol { get; set; }
             public string System { get; set; }
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
@@ -480,19 +467,19 @@ namespace Akka.Actor
     public abstract class AkkaException : System.Exception
     {
         protected AkkaException() { }
-        protected AkkaException(string message, System.Exception cause = null) { }
         protected AkkaException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected AkkaException(string message, System.Exception cause = null) { }
         protected System.Exception Cause { get; }
     }
     public class AllForOneStrategy : Akka.Actor.SupervisorStrategy, System.IEquatable<Akka.Actor.AllForOneStrategy>
     {
-        public AllForOneStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public AllForOneStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, Akka.Actor.IDecider decider) { }
-        public AllForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
-        public AllForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = True) { }
-        public AllForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public AllForOneStrategy(Akka.Actor.IDecider decider) { }
         protected AllForOneStrategy() { }
+        public AllForOneStrategy(Akka.Actor.IDecider decider) { }
+        public AllForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public AllForOneStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, Akka.Actor.IDecider decider) { }
+        public AllForOneStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public AllForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = true) { }
+        public AllForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = true) { }
         public override Akka.Actor.IDecider Decider { get; }
         public int MaxNumberOfRetries { get; }
         public int WithinTimeRangeMilliseconds { get; }
@@ -522,18 +509,18 @@ namespace Akka.Actor
     {
         public Akka.Util.Option<Akka.Actor.ProviderSelection> ActorRefProvider { get; }
         public Akka.Util.Option<Akka.Configuration.Config> Config { get; }
-        public static Akka.Actor.BootstrapSetup Create() { }
         public Akka.Actor.BootstrapSetup WithActorRefProvider(Akka.Actor.ProviderSelection name) { }
         public Akka.Actor.BootstrapSetup WithConfig(Akka.Configuration.Config config) { }
         public Akka.Actor.BootstrapSetup WithConfigFallback(Akka.Configuration.Config config) { }
+        public static Akka.Actor.BootstrapSetup Create() { }
     }
     public class Cancelable : Akka.Actor.ICancelable, System.IDisposable
     {
+        public Cancelable(Akka.Actor.IActionScheduler scheduler) { }
+        public Cancelable(Akka.Actor.IScheduler scheduler) { }
         public Cancelable(Akka.Actor.IActionScheduler scheduler, System.TimeSpan delay) { }
         public Cancelable(Akka.Actor.IScheduler scheduler, System.TimeSpan delay) { }
         public Cancelable(Akka.Actor.IScheduler scheduler, int millisecondsDelay) { }
-        public Cancelable(Akka.Actor.IScheduler scheduler) { }
-        public Cancelable(Akka.Actor.IActionScheduler scheduler) { }
         public bool IsCancellationRequested { get; }
         public bool IsDisposed { get; }
         public System.Threading.CancellationToken Token { get; }
@@ -541,15 +528,15 @@ namespace Akka.Actor
         public void Cancel(bool throwOnFirstException) { }
         public void CancelAfter(System.TimeSpan delay) { }
         public void CancelAfter(int millisecondsDelay) { }
-        public static Akka.Actor.ICancelable CreateCanceled() { }
-        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IScheduler scheduler, params Akka.Actor.ICancelable[] cancelables) { }
-        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IActionScheduler scheduler, params Akka.Actor.ICancelable[] cancelables) { }
-        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IScheduler scheduler, params System.Threading.CancellationToken[] cancellationTokens) { }
-        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IActionScheduler scheduler, params System.Threading.CancellationToken[] cancellationTokens) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+        public static Akka.Actor.ICancelable CreateCanceled() { }
+        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IActionScheduler scheduler, params Akka.Actor.ICancelable[] cancelables) { }
+        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IActionScheduler scheduler, params System.Threading.CancellationToken[] cancellationTokens) { }
+        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IScheduler scheduler, params Akka.Actor.ICancelable[] cancelables) { }
+        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IScheduler scheduler, params System.Threading.CancellationToken[] cancellationTokens) { }
     }
-    public class static CancelableExtensions
+    public static class CancelableExtensions
     {
         public static void CancelIfNotNull(this Akka.Actor.ICancelable cancelable) { }
     }
@@ -575,9 +562,9 @@ namespace Akka.Actor
         public Akka.Actor.ExtendedActorSystem System { get; }
         public System.TimeSpan TotalTimeout { get; }
         public void AddTask(string phase, string taskName, System.Func<System.Threading.Tasks.Task<Akka.Done>> task) { }
-        public static Akka.Actor.CoordinatedShutdown Get(Akka.Actor.ActorSystem sys) { }
         public System.Threading.Tasks.Task<Akka.Done> Run(Akka.Actor.CoordinatedShutdown.Reason reason, string fromPhase = null) { }
         public System.TimeSpan Timeout(string phase) { }
+        public static Akka.Actor.CoordinatedShutdown Get(Akka.Actor.ActorSystem sys) { }
         public class ActorSystemTerminateReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
@@ -619,13 +606,13 @@ namespace Akka.Actor
         public CoordinatedShutdownExtension() { }
         public override Akka.Actor.CoordinatedShutdown CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
-    [System.ObsoleteAttribute("This class will be removed in Akka.NET v1.6.0 - use the IScheduler instead.")]
+    [System.Obsolete("This class will be removed in Akka.NET v1.6.0 - use the IScheduler instead.")]
     public class DateTimeOffsetNowTimeProvider : Akka.Actor.IDateTimeOffsetNowTimeProvider, Akka.Actor.ITimeProvider
     {
         public System.TimeSpan HighResMonotonicClock { get; }
-        public static Akka.Actor.DateTimeOffsetNowTimeProvider Instance { get; }
         public System.TimeSpan MonotonicClock { get; }
         public System.DateTimeOffset Now { get; }
+        public static Akka.Actor.DateTimeOffsetNowTimeProvider Instance { get; }
     }
     public class DeadLetterActorRef : Akka.Actor.EmptyLocalActorRef
     {
@@ -633,7 +620,7 @@ namespace Akka.Actor
         protected override bool SpecialHandle(object message, Akka.Actor.IActorRef sender) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class DeadLetterMailbox : Akka.Dispatch.Mailbox
     {
         public DeadLetterMailbox(Akka.Actor.IActorRef deadLetters) { }
@@ -645,11 +632,11 @@ namespace Akka.Actor
         public Akka.Actor.IActorRef DeadActor { get; }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static Decider
+    public static class Decider
     {
-        public static Akka.Actor.DeployableDecider From(Akka.Actor.Directive defaultDirective, params System.Collections.Generic.KeyValuePair<, >[] pairs) { }
-        public static Akka.Actor.DeployableDecider From(Akka.Actor.Directive defaultDirective, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>> pairs) { }
         public static Akka.Actor.LocalOnlyDecider From(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public static Akka.Actor.DeployableDecider From(Akka.Actor.Directive defaultDirective, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>> pairs) { }
+        public static Akka.Actor.DeployableDecider From(Akka.Actor.Directive defaultDirective, params System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>[] pairs) { }
     }
     public class DefaultSupervisorStrategy : Akka.Actor.SupervisorStrategyConfigurator
     {
@@ -658,17 +645,17 @@ namespace Akka.Actor
     }
     public class Deploy : Akka.Util.ISurrogated, System.IEquatable<Akka.Actor.Deploy>
     {
+        public const int NoStashSize = -1;
         public static readonly Akka.Actor.Deploy Local;
         public static readonly string NoDispatcherGiven;
         public static readonly string NoMailboxGiven;
         public static readonly Akka.Actor.Scope NoScopeGiven;
-        public const int NoStashSize = -1;
         public static readonly Akka.Actor.Deploy None;
         public Deploy() { }
-        public Deploy(string path, Akka.Actor.Scope scope) { }
         public Deploy(Akka.Actor.Scope scope) { }
-        public Deploy(Akka.Routing.RouterConfig routerConfig, Akka.Actor.Scope scope) { }
         public Deploy(Akka.Routing.RouterConfig routerConfig) { }
+        public Deploy(Akka.Routing.RouterConfig routerConfig, Akka.Actor.Scope scope) { }
+        public Deploy(string path, Akka.Actor.Scope scope) { }
         public Deploy(string path, Akka.Configuration.Config config, Akka.Routing.RouterConfig routerConfig, Akka.Actor.Scope scope, string dispatcher) { }
         public Deploy(string path, Akka.Configuration.Config config, Akka.Routing.RouterConfig routerConfig, Akka.Actor.Scope scope, string dispatcher, string mailbox) { }
         public Deploy(string path, Akka.Configuration.Config config, Akka.Routing.RouterConfig routerConfig, Akka.Actor.Scope scope, string dispatcher, string mailbox, int stashCapacity) { }
@@ -704,9 +691,9 @@ namespace Akka.Actor
     {
         protected DeployableDecider() { }
         public DeployableDecider(Akka.Actor.Directive defaultDirective, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>> pairs) { }
-        public DeployableDecider(Akka.Actor.Directive defaultDirective, params System.Collections.Generic.KeyValuePair<, >[] pairs) { }
+        public DeployableDecider(Akka.Actor.Directive defaultDirective, params System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>[] pairs) { }
         public Akka.Actor.Directive DefaultDirective { get; }
-        public System.Collections.Generic.KeyValuePair<, >[] Pairs { get; }
+        public System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>[] Pairs { get; }
         public Akka.Actor.Directive Decide(System.Exception cause) { }
         public bool Equals(Akka.Actor.DeployableDecider other) { }
         public override bool Equals(object obj) { }
@@ -728,7 +715,7 @@ namespace Akka.Actor
         Escalate = 2,
         Stop = 3,
     }
-    public class static DirectiveExtensions
+    public static class DirectiveExtensions
     {
         public static System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive> When<TException>(this Akka.Actor.Directive self)
             where TException : System.Exception { }
@@ -736,7 +723,7 @@ namespace Akka.Actor
     public class EmptyLocalActorRef : Akka.Actor.MinimalActorRef
     {
         public EmptyLocalActorRef(Akka.Actor.IActorRefProvider provider, Akka.Actor.ActorPath path, Akka.Event.EventStream eventStream) { }
-        [System.ObsoleteAttribute("Use Context.Watch and Receive<Terminated> [1.1.0]")]
+        [System.Obsolete("Use Context.Watch and Receive<Terminated> [1.1.0]")]
         public override bool IsTerminated { get; }
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
@@ -744,11 +731,10 @@ namespace Akka.Actor
         protected virtual bool SpecialHandle(object message, Akka.Actor.IActorRef sender) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
-    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-    public struct Envelope
+    public readonly struct Envelope
     {
-        public Envelope(object message, Akka.Actor.IActorRef sender, Akka.Actor.ActorSystem system) { }
         public Envelope(object message, Akka.Actor.IActorRef sender) { }
+        public Envelope(object message, Akka.Actor.IActorRef sender, Akka.Actor.ActorSystem system) { }
         public object Message { get; }
         public Akka.Actor.IActorRef Sender { get; }
         public override string ToString() { }
@@ -795,8 +781,7 @@ namespace Akka.Actor
             public override int GetHashCode() { }
             public override string ToString() { }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct Event<TD> : Akka.Actor.INoSerializationVerificationNeeded
+        public readonly struct Event<TD> : Akka.Actor.INoSerializationVerificationNeeded
         {
             public Event(object fsmEvent, TD stateData) { }
             public object FsmEvent { get; }
@@ -829,18 +814,14 @@ namespace Akka.Actor
         {
             public static Akka.Actor.FSMBase.Shutdown Instance { get; }
         }
-        public sealed class StateTimeout
-        {
-            public static Akka.Actor.FSMBase.StateTimeout Instance { get; }
-        }
         public sealed class State<TS, TD> : System.IEquatable<Akka.Actor.FSMBase.State<TS, TD>>
         {
-            public State(TS stateName, TD stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, bool notifies = True) { }
+            public State(TS stateName, TD stateData, System.TimeSpan? timeout = default, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, bool notifies = true) { }
             public System.Collections.Generic.IReadOnlyList<object> Replies { get; }
             public TD StateData { get; }
             public TS StateName { get; }
             public Akka.Actor.FSMBase.Reason StopReason { get; }
-            public System.Nullable<System.TimeSpan> Timeout { get; }
+            public System.TimeSpan? Timeout { get; }
             public bool Equals(Akka.Actor.FSMBase.State<TS, TD> other) { }
             public override bool Equals(object obj) { }
             public Akka.Actor.FSMBase.State<TS, TD> ForMax(System.TimeSpan timeout) { }
@@ -848,6 +829,10 @@ namespace Akka.Actor
             public Akka.Actor.FSMBase.State<TS, TD> Replying(object replyValue) { }
             public override string ToString() { }
             public Akka.Actor.FSMBase.State<TS, TD> Using(TD nextStateData) { }
+        }
+        public sealed class StateTimeout
+        {
+            public static Akka.Actor.FSMBase.StateTimeout Instance { get; }
         }
         public sealed class StopEvent<TS, TD> : Akka.Actor.INoSerializationVerificationNeeded
         {
@@ -888,7 +873,7 @@ namespace Akka.Actor
         public TState StateName { get; }
         public void CancelTimer(string name) { }
         public Akka.Actor.FSMBase.State<TState, TData> GoTo(TState nextStateName) { }
-        [System.ObsoleteAttribute("This method is obsoleted. Use GoTo(nextStateName).Using(newStateData) [1.2.0]")]
+        [System.Obsolete("This method is obsoleted. Use GoTo(nextStateName).Using(newStateData) [1.2.0]")]
         public Akka.Actor.FSMBase.State<TState, TData> GoTo(TState nextStateName, TData stateData) { }
         public void Initialize() { }
         public bool IsTimerActive(string name) { }
@@ -897,33 +882,33 @@ namespace Akka.Actor
         public void OnTransition(Akka.Actor.FSM<TState, TData>.TransitionHandler transitionHandler) { }
         protected override void PostStop() { }
         protected override bool Receive(object message) { }
-        public void SetStateTimeout(TState state, System.Nullable<System.TimeSpan> timeout) { }
-        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = False) { }
-        public void StartWith(TState stateName, TData stateData, System.Nullable<System.TimeSpan> timeout = null) { }
+        public void SetStateTimeout(TState state, System.TimeSpan? timeout) { }
+        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = false) { }
+        public void StartWith(TState stateName, TData stateData, System.TimeSpan? timeout = default) { }
         public Akka.Actor.FSMBase.State<TState, TData> Stay() { }
         public Akka.Actor.FSMBase.State<TState, TData> Stop() { }
         public Akka.Actor.FSMBase.State<TState, TData> Stop(Akka.Actor.FSMBase.Reason reason) { }
         public Akka.Actor.FSMBase.State<TState, TData> Stop(Akka.Actor.FSMBase.Reason reason, TData stateData) { }
         public Akka.Actor.FSM<TState, TData>.TransformHelper Transform(Akka.Actor.FSM<TState, TData>.StateFunction func) { }
-        public void When(TState stateName, Akka.Actor.FSM<TState, TData>.StateFunction func, System.Nullable<System.TimeSpan> timeout = null) { }
+        public void When(TState stateName, Akka.Actor.FSM<TState, TData>.StateFunction func, System.TimeSpan? timeout = default) { }
         public void WhenUnhandled(Akka.Actor.FSM<TState, TData>.StateFunction stateFunction) { }
-        public delegate Akka.Actor.FSMBase.State<TState, TData> StateFunction<TState, TData>(Akka.Actor.FSMBase.Event<TData> fsmEvent);
-        public sealed class TransformHelper<TState, TData>
+        public sealed class TransformHelper
         {
             public TransformHelper(Akka.Actor.FSM<TState, TData>.StateFunction func) { }
             public Akka.Actor.FSM<TState, TData>.StateFunction Func { get; }
             public Akka.Actor.FSM<TState, TData>.StateFunction Using(System.Func<Akka.Actor.FSMBase.State<TState, TData>, Akka.Actor.FSMBase.State<TState, TData>> andThen) { }
         }
+        public delegate Akka.Actor.FSMBase.State<TState, TData> StateFunction<TState, TData>(Akka.Actor.FSMBase.Event<TData> fsmEvent);
         public delegate void TransitionHandler<TState, TData>(TState initialState, TState nextState);
     }
-    [System.ObsoleteAttribute("Use Akka.Actor.Status.Failure. Will be removed in v1.6")]
+    [System.Obsolete("Use Akka.Actor.Status.Failure. Will be removed in v1.6")]
     public class Failure
     {
         public Failure() { }
         public System.Exception Exception { get; set; }
         public System.DateTime Timestamp { get; set; }
     }
-    [System.ObsoleteAttribute("Use List of Akka.Actor.Status.Failure. Will be removed in v1.6")]
+    [System.Obsolete("Use List of Akka.Actor.Status.Failure. Will be removed in v1.6")]
     public class Failures
     {
         public Failures() { }
@@ -938,17 +923,17 @@ namespace Akka.Actor
         public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
-    public class static Futures
+    public static class Futures
     {
-        public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout = null) { }
         public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.Threading.CancellationToken cancellationToken) { }
-        public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
-        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout = null) { }
+        public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.TimeSpan? timeout = default) { }
+        public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.TimeSpan? timeout, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Threading.CancellationToken cancellationToken) { }
-        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
-        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, System.Func<Akka.Actor.IActorRef, object> messageFactory, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.TimeSpan? timeout = default) { }
+        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, System.Func<Akka.Actor.IActorRef, object> messageFactory, System.TimeSpan? timeout, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.TimeSpan? timeout, System.Threading.CancellationToken cancellationToken) { }
     }
-    public class static GracefulStopSupport
+    public static class GracefulStopSupport
     {
         public static System.Threading.Tasks.Task<bool> GracefulStop(this Akka.Actor.IActorRef target, System.TimeSpan timeout) { }
         public static System.Threading.Tasks.Task<bool> GracefulStop(this Akka.Actor.IActorRef target, System.TimeSpan timeout, object stopMessage) { }
@@ -959,7 +944,6 @@ namespace Akka.Actor
         protected override void PreStart() { }
         protected override bool Receive(object message) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class HashedWheelTimerScheduler : Akka.Actor.SchedulerBase, Akka.Actor.IDateTimeOffsetNowTimeProvider, Akka.Actor.ITimeProvider, System.IDisposable
     {
         public HashedWheelTimerScheduler(Akka.Configuration.Config scheduler, Akka.Event.ILoggingAdapter log) { }
@@ -967,26 +951,26 @@ namespace Akka.Actor
         public override System.TimeSpan MonotonicClock { get; }
         protected override System.DateTimeOffset TimeNow { get; }
         public void Dispose() { }
-        protected override void InternalScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable) { }
         protected override void InternalScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
-        protected override void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable) { }
+        protected override void InternalScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable) { }
         protected override void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
+        protected override void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable) { }
         protected override void InternalScheduleTellOnce(System.TimeSpan delay, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable) { }
         protected override void InternalScheduleTellRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable) { }
     }
     public interface IActionScheduler : Akka.Actor.IRunnableScheduler
     {
-        void ScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable);
         void ScheduleOnce(System.TimeSpan delay, System.Action action);
-        void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable);
+        void ScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable);
         void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action);
+        void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable);
     }
     public interface IActorContext : Akka.Actor.IActorRefFactory, Akka.Actor.ICanWatch
     {
         Akka.Dispatch.MessageDispatcher Dispatcher { get; }
         Akka.Actor.IActorRef Parent { get; }
         Akka.Actor.Props Props { get; }
-        System.Nullable<System.TimeSpan> ReceiveTimeout { get; }
+        System.TimeSpan? ReceiveTimeout { get; }
         Akka.Actor.IActorRef Self { get; }
         Akka.Actor.IActorRef Sender { get; }
         Akka.Actor.ActorSystem System { get; }
@@ -994,7 +978,7 @@ namespace Akka.Actor
         void BecomeStacked(Akka.Actor.Receive receive);
         Akka.Actor.IActorRef Child(string name);
         System.Collections.Generic.IEnumerable<Akka.Actor.IActorRef> GetChildren();
-        void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout);
+        void SetReceiveTimeout(System.TimeSpan? timeout);
         void Stop(Akka.Actor.IActorRef child);
         void UnbecomeStacked();
     }
@@ -1023,25 +1007,25 @@ namespace Akka.Actor
         Akka.Actor.IActorRef IgnoreRef { get; }
         Akka.Actor.IInternalActorRef RootGuardian { get; }
         Akka.Actor.ActorPath RootPath { get; }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         Akka.Serialization.Information SerializationInformation { get; }
         Akka.Actor.Settings Settings { get; }
         Akka.Actor.LocalActorRef SystemGuardian { get; }
         Akka.Actor.IInternalActorRef TempContainer { get; }
         System.Threading.Tasks.Task TerminationTask { get; }
         Akka.Actor.IInternalActorRef ActorOf(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.Props props, Akka.Actor.IInternalActorRef supervisor, Akka.Actor.ActorPath path, bool systemService, Akka.Actor.Deploy deploy, bool lookupDeploy, bool async);
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         Akka.Actor.FutureActorRef<T> CreateFutureRef<T>(System.Threading.Tasks.TaskCompletionSource<T> tcs);
         Akka.Actor.Address GetExternalAddressFor(Akka.Actor.Address address);
         void Init(Akka.Actor.Internal.ActorSystemImpl system);
         void RegisterTempActor(Akka.Actor.IInternalActorRef actorRef, Akka.Actor.ActorPath path);
-        Akka.Actor.IActorRef ResolveActorRef(string path);
         Akka.Actor.IActorRef ResolveActorRef(Akka.Actor.ActorPath actorPath);
+        Akka.Actor.IActorRef ResolveActorRef(string path);
         Akka.Actor.IActorRef RootGuardianAt(Akka.Actor.Address address);
         Akka.Actor.ActorPath TempPath();
         void UnregisterTempActor(Akka.Actor.ActorPath path);
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IActorRefScope
     {
         bool IsLocal { get; }
@@ -1077,7 +1061,7 @@ namespace Akka.Actor
         void CancelAfter(System.TimeSpan delay);
         void CancelAfter(int millisecondsDelay);
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface ICell
     {
         Akka.Actor.Internal.IChildrenContainer ChildrenContainer { get; }
@@ -1091,7 +1075,7 @@ namespace Akka.Actor
         Akka.Actor.ActorSystem System { get; }
         Akka.Actor.Internal.ActorSystemImpl SystemImpl { get; }
         Akka.Actor.IInternalActorRef GetChildByName(string name);
-        [System.ObsoleteAttribute("Used ChildrenRefs instead [1.1.0]")]
+        [System.Obsolete("Used ChildrenRefs instead [1.1.0]")]
         System.Collections.Generic.IEnumerable<Akka.Actor.IInternalActorRef> GetChildren();
         Akka.Actor.IInternalActorRef GetSingleChild(string name);
         void Restart(System.Exception cause);
@@ -1144,19 +1128,19 @@ namespace Akka.Actor
     {
         Akka.Actor.IActorContext ActorContext { get; }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IInternalActorRef : Akka.Actor.IActorRef, Akka.Actor.IActorRefScope, Akka.Actor.ICanTell, Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.IActorRef>, System.IEquatable<Akka.Actor.IActorRef>
     {
-        [System.ObsoleteAttribute("Use Context.Watch and Receive<Terminated> [1.1.0]")]
+        [System.Obsolete("Use Context.Watch and Receive<Terminated> [1.1.0]")]
         bool IsTerminated { get; }
         Akka.Actor.IInternalActorRef Parent { get; }
         Akka.Actor.IActorRefProvider Provider { get; }
         Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name);
         void Restart(System.Exception cause);
         void Resume(System.Exception causedByFailure = null);
-        [System.ObsoleteAttribute("Use SendSystemMessage(message) [1.1.0]")]
-        void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender);
         void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message);
+        [System.Obsolete("Use SendSystemMessage(message) [1.1.0]")]
+        void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender);
         void Start();
         void Stop();
         void Suspend();
@@ -1172,10 +1156,10 @@ namespace Akka.Actor
     }
     public interface IRunnableScheduler
     {
-        void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
         void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action);
-        void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
+        void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
         void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action);
+        void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
     }
     public interface IScheduler : Akka.Actor.ITellScheduler, Akka.Actor.ITimeProvider
     {
@@ -1215,8 +1199,8 @@ namespace Akka.Actor
         void CancelAll();
         bool IsTimerActive(object key);
         void StartPeriodicTimer(object key, object msg, System.TimeSpan interval);
-        void StartPeriodicTimer(object key, object msg, System.TimeSpan interval, Akka.Actor.IActorRef sender);
         void StartPeriodicTimer(object key, object msg, System.TimeSpan initialDelay, System.TimeSpan interval);
+        void StartPeriodicTimer(object key, object msg, System.TimeSpan interval, Akka.Actor.IActorRef sender);
         void StartPeriodicTimer(object key, object msg, System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.IActorRef sender);
         void StartSingleTimer(object key, object msg, System.TimeSpan timeout);
         void StartSingleTimer(object key, object msg, System.TimeSpan timeout, Akka.Actor.IActorRef sender);
@@ -1226,7 +1210,7 @@ namespace Akka.Actor
         void Become(Akka.Actor.UntypedReceive receive);
         void BecomeStacked(Akka.Actor.UntypedReceive receive);
     }
-    [System.ObsoleteAttribute("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
+    [System.Obsolete("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
     public interface IWithBoundedStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics> { }
     public interface IWithStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IDequeBasedMessageQueueSemantics> { }
     public interface IWithTimers
@@ -1260,7 +1244,6 @@ namespace Akka.Actor
     public class Inbox : Akka.Actor.ICanWatch, Akka.Actor.IInboxable, System.IDisposable
     {
         public Akka.Actor.IActorRef Receiver { get; }
-        public static Akka.Actor.Inbox Create(Akka.Actor.ActorSystem system) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public object Receive() { }
@@ -1273,6 +1256,7 @@ namespace Akka.Actor
         public Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef subject) { }
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef subject) { }
         public Akka.Actor.IActorRef WatchWith(Akka.Actor.IActorRef subject, object message) { }
+        public static Akka.Actor.Inbox Create(Akka.Actor.ActorSystem system) { }
     }
     public sealed class IntentionalActorRestartException : Akka.Actor.AkkaException
     {
@@ -1283,7 +1267,7 @@ namespace Akka.Actor
         public static Akka.Actor.IntentionalRestart Instance { get; }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class InternalActorRefBase : Akka.Actor.ActorRefBase, Akka.Actor.IActorRef, Akka.Actor.IActorRefScope, Akka.Actor.ICanTell, Akka.Actor.IInternalActorRef, Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.IActorRef>, System.IEquatable<Akka.Actor.IActorRef>
     {
         protected InternalActorRefBase() { }
@@ -1294,9 +1278,9 @@ namespace Akka.Actor
         public abstract Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name);
         public abstract void Restart(System.Exception cause);
         public abstract void Resume(System.Exception causedByFailure = null);
-        [System.ObsoleteAttribute("Use SendSystemMessage(message) instead [1.1.0]")]
-        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public abstract void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message);
+        [System.Obsolete("Use SendSystemMessage(message) instead [1.1.0]")]
+        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public abstract void Start();
         public abstract void Stop();
         public abstract void Suspend();
@@ -1304,8 +1288,8 @@ namespace Akka.Actor
     public class InvalidActorNameException : Akka.Actor.AkkaException
     {
         public InvalidActorNameException(string message) { }
-        public InvalidActorNameException(string message, System.Exception innerException) { }
         protected InvalidActorNameException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public InvalidActorNameException(string message, System.Exception innerException) { }
     }
     public class InvalidMessageException : Akka.Actor.AkkaException
     {
@@ -1369,8 +1353,8 @@ namespace Akka.Actor
         public void Init(Akka.Actor.Internal.ActorSystemImpl system) { }
         public void RegisterExtraName(string name, Akka.Actor.IInternalActorRef actor) { }
         public void RegisterTempActor(Akka.Actor.IInternalActorRef actorRef, Akka.Actor.ActorPath path) { }
-        public Akka.Actor.IActorRef ResolveActorRef(string path) { }
         public Akka.Actor.IActorRef ResolveActorRef(Akka.Actor.ActorPath path) { }
+        public Akka.Actor.IActorRef ResolveActorRef(string path) { }
         public Akka.Actor.IActorRef RootGuardianAt(Akka.Actor.Address address) { }
         public Akka.Actor.ActorPath TempPath() { }
         public void UnregisterTempActor(Akka.Actor.ActorPath path) { }
@@ -1396,15 +1380,15 @@ namespace Akka.Actor
     {
         public LoggerInitializationException() { }
         public LoggerInitializationException(string message) { }
-        public LoggerInitializationException(string message, System.Exception cause = null) { }
         protected LoggerInitializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public LoggerInitializationException(string message, System.Exception cause = null) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class MinimalActorRef : Akka.Actor.InternalActorRefBase, Akka.Actor.IActorRefScope
     {
         protected MinimalActorRef() { }
         public override bool IsLocal { get; }
-        [System.ObsoleteAttribute("Use Context.Watch and Receive<Terminated> [1.1.0]")]
+        [System.Obsolete("Use Context.Watch and Receive<Terminated> [1.1.0]")]
         public override bool IsTerminated { get; }
         public override Akka.Actor.IInternalActorRef Parent { get; }
         public override Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name) { }
@@ -1430,14 +1414,14 @@ namespace Akka.Actor
     }
     public class OneForOneStrategy : Akka.Actor.SupervisorStrategy, System.IEquatable<Akka.Actor.OneForOneStrategy>
     {
-        public OneForOneStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public OneForOneStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, Akka.Actor.IDecider decider) { }
-        public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
-        public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = True) { }
-        public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
-        public OneForOneStrategy(Akka.Actor.IDecider decider) { }
         protected OneForOneStrategy() { }
+        public OneForOneStrategy(Akka.Actor.IDecider decider) { }
+        public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = true) { }
+        public OneForOneStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, Akka.Actor.IDecider decider) { }
+        public OneForOneStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = true) { }
+        public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = true) { }
         public override Akka.Actor.IDecider Decider { get; }
         public int MaxNumberOfRetries { get; }
         public int WithinTimeRangeMilliseconds { get; }
@@ -1459,16 +1443,16 @@ namespace Akka.Actor
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
         }
     }
-    public class static PipeToSupport
+    public static class PipeToSupport
     {
-        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.Task<T> taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
-        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.ValueTask<T> taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
-        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.Task<T> taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
-        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.ValueTask<T> taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
         public static System.Threading.Tasks.Task PipeTo(this System.Threading.Tasks.Task taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<object> success = null, System.Func<System.Exception, object> failure = null) { }
         public static System.Threading.Tasks.Task PipeTo(this System.Threading.Tasks.ValueTask taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<object> success = null, System.Func<System.Exception, object> failure = null) { }
         public static System.Threading.Tasks.Task PipeTo(this System.Threading.Tasks.Task taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<object> success = null, System.Func<System.Exception, object> failure = null) { }
         public static System.Threading.Tasks.Task PipeTo(this System.Threading.Tasks.ValueTask taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<object> success = null, System.Func<System.Exception, object> failure = null) { }
+        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.Task<T> taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
+        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.ValueTask<T> taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
+        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.Task<T> taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
+        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.ValueTask<T> taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
     }
     public sealed class PoisonPill : Akka.Actor.IAutoReceivedMessage, Akka.Actor.IPossiblyHarmful, Akka.Event.IDeadLetterSuppression
     {
@@ -1477,15 +1461,15 @@ namespace Akka.Actor
     }
     public class PostRestartException : Akka.Actor.ActorInitializationException
     {
-        public PostRestartException(Akka.Actor.IActorRef actor, System.Exception cause, System.Exception originalCause) { }
         protected PostRestartException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public PostRestartException(Akka.Actor.IActorRef actor, System.Exception cause, System.Exception originalCause) { }
         public System.Exception OriginalCause { get; }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class PreRestartException : Akka.Actor.ActorInitializationException
     {
-        public PreRestartException(Akka.Actor.IActorRef actor, System.Exception restartException, System.Exception cause, object optionalMessage) { }
         protected PreRestartException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public PreRestartException(Akka.Actor.IActorRef actor, System.Exception restartException, System.Exception cause, object optionalMessage) { }
         public object OptionalMessage { get; }
         public System.Exception RestartException { get; }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
@@ -1495,38 +1479,26 @@ namespace Akka.Actor
         public static readonly Akka.Actor.Props None;
         protected Props() { }
         protected Props(Akka.Actor.Props copy) { }
-        public Props(System.Type type, object[] args) { }
         public Props(System.Type type) { }
-        public Props(System.Type type, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Collections.Generic.IEnumerable<object> args) { }
-        public Props(System.Type type, Akka.Actor.SupervisorStrategy supervisorStrategy, params object[] args) { }
+        public Props(System.Type type, object[] args) { }
         public Props(Akka.Actor.Deploy deploy, System.Type type, System.Collections.Generic.IEnumerable<object> args) { }
         public Props(Akka.Actor.Deploy deploy, System.Type type, params object[] args) { }
+        public Props(System.Type type, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Collections.Generic.IEnumerable<object> args) { }
+        public Props(System.Type type, Akka.Actor.SupervisorStrategy supervisorStrategy, params object[] args) { }
         public object[] Arguments { get; }
-        public Akka.Actor.Deploy Deploy { get; set; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        public Akka.Actor.Deploy Deploy { get; protected set; }
+        [Newtonsoft.Json.JsonIgnore]
         public string Dispatcher { get; }
-        public static Akka.Actor.Props Empty { get; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        [Newtonsoft.Json.JsonIgnore]
         public string Mailbox { get; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        [Newtonsoft.Json.JsonIgnore]
         public Akka.Routing.RouterConfig RouterConfig { get; }
-        public Akka.Actor.SupervisorStrategy SupervisorStrategy { get; set; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        public Akka.Actor.SupervisorStrategy SupervisorStrategy { get; protected set; }
+        [Newtonsoft.Json.JsonIgnore]
         public System.Type Type { get; }
         public string TypeName { get; }
+        public static Akka.Actor.Props Empty { get; }
         protected virtual Akka.Actor.Props Copy() { }
-        public static Akka.Actor.Props Create<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, Akka.Actor.SupervisorStrategy supervisorStrategy = null)
-            where TActor : Akka.Actor.ActorBase { }
-        public static Akka.Actor.Props Create<TActor>(params object[] args)
-            where TActor : Akka.Actor.ActorBase { }
-        public static Akka.Actor.Props Create<TActor>(Akka.Actor.SupervisorStrategy supervisorStrategy)
-            where TActor : Akka.Actor.ActorBase, new () { }
-        public static Akka.Actor.Props Create(System.Type type, params object[] args) { }
-        [System.ObsoleteAttribute("Do not use this method. Call CreateBy(IIndirectActorProducer, params object[] arg" +
-            "s) instead")]
-        public static Akka.Actor.Props CreateBy<TProducer>(params object[] args)
-            where TProducer :  class, Akka.Actor.IIndirectActorProducer { }
-        public static Akka.Actor.Props CreateBy(Akka.Actor.IIndirectActorProducer producer, params object[] args) { }
         public bool Equals(Akka.Actor.Props other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
@@ -1538,6 +1510,18 @@ namespace Akka.Actor
         public Akka.Actor.Props WithRouter(Akka.Routing.RouterConfig routerConfig) { }
         public Akka.Actor.Props WithStashCapacity(int stashCapacity) { }
         public Akka.Actor.Props WithSupervisorStrategy(Akka.Actor.SupervisorStrategy supervisorStrategy) { }
+        public static Akka.Actor.Props Create(System.Type type, params object[] args) { }
+        public static Akka.Actor.Props Create<TActor>(Akka.Actor.SupervisorStrategy supervisorStrategy)
+            where TActor : Akka.Actor.ActorBase, new () { }
+        public static Akka.Actor.Props Create<TActor>(params object[] args)
+            where TActor : Akka.Actor.ActorBase { }
+        public static Akka.Actor.Props Create<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, Akka.Actor.SupervisorStrategy supervisorStrategy = null)
+            where TActor : Akka.Actor.ActorBase { }
+        public static Akka.Actor.Props CreateBy(Akka.Actor.IIndirectActorProducer producer, params object[] args) { }
+        [System.Obsolete("Do not use this method. Call CreateBy(IIndirectActorProducer, params object[] arg" +
+            "s) instead")]
+        public static Akka.Actor.Props CreateBy<TProducer>(params object[] args)
+            where TProducer :  class, Akka.Actor.IIndirectActorProducer { }
         public class PropsSurrogate : Akka.Util.ISurrogate
         {
             public PropsSurrogate() { }
@@ -1555,7 +1539,7 @@ namespace Akka.Actor
         }
         public sealed class Custom : Akka.Actor.ProviderSelection
         {
-            public Custom(string fqn, string identifier = null, bool hasCluster = False) { }
+            public Custom(string fqn, string identifier = null, bool hasCluster = false) { }
         }
         public sealed class Local : Akka.Actor.ProviderSelection
         {
@@ -1567,39 +1551,30 @@ namespace Akka.Actor
         }
     }
     public delegate bool Receive(object message);
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class ReceiveActor : Akka.Actor.UntypedActor, Akka.Actor.Internal.IInitializableActor
     {
         protected ReceiveActor() { }
         protected void Become(System.Action configure) { }
         protected void BecomeStacked(System.Action configure) { }
-        protected virtual void OnReceive(object message) { }
-        protected void Receive<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Action<T> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<T> shouldHandle = null) { }
-        protected void Receive<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
-        protected void Receive(System.Type messageType, System.Action<object> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<object> shouldHandle = null) { }
-        protected void Receive(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
-        protected void Receive<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T, bool> handler) { }
+        protected override sealed void OnReceive(object message) { }
         protected void Receive(System.Type messageType, System.Func<object, bool> handler) { }
+        protected void Receive(System.Type messageType, System.Action<object> handler, System.Predicate<object>? shouldHandle = null) { }
+        protected void Receive(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
+        protected void Receive<T>(System.Func<T, bool> handler) { }
+        protected void Receive<T>(System.Action<T> handler, System.Predicate<T>? shouldHandle = null) { }
+        protected void Receive<T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
         protected void ReceiveAny(System.Action<object> handler) { }
         protected void ReceiveAnyAsync(System.Func<object, System.Threading.Tasks.Task> handler) { }
-        protected void ReceiveAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T, System.Threading.Tasks.Task> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<T> shouldHandle = null) { }
-        protected void ReceiveAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Predicate<T> shouldHandle, System.Func<T, System.Threading.Tasks.Task> handler) { }
-        protected void ReceiveAsync(System.Type messageType, System.Func<object, System.Threading.Tasks.Task> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<object> shouldHandle = null) { }
+        protected void ReceiveAsync(System.Type messageType, System.Func<object, System.Threading.Tasks.Task> handler, System.Predicate<object>? shouldHandle = null) { }
         protected void ReceiveAsync(System.Type messageType, System.Predicate<object> shouldHandle, System.Func<object, System.Threading.Tasks.Task> handler) { }
+        protected void ReceiveAsync<T>(System.Func<T, System.Threading.Tasks.Task> handler, System.Predicate<T>? shouldHandle = null) { }
+        protected void ReceiveAsync<T>(System.Predicate<T> shouldHandle, System.Func<T, System.Threading.Tasks.Task> handler) { }
     }
     public class ReceiveTimeout : Akka.Actor.IPossiblyHarmful
     {
         public static Akka.Actor.ReceiveTimeout Instance { get; }
     }
-    public class static RelativeActorPath
+    public static class RelativeActorPath
     {
         public static System.Collections.Generic.IEnumerable<string> Unapply(string addr) { }
     }
@@ -1649,7 +1624,7 @@ namespace Akka.Actor
     {
         public RootActorPath(Akka.Actor.Address address, string name = "") { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class RootGuardianActorRef : Akka.Actor.LocalActorRef
     {
         public RootGuardianActorRef(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Dispatch.MailboxType mailboxType, Akka.Actor.IInternalActorRef supervisor, Akka.Actor.ActorPath path, Akka.Actor.IInternalActorRef deadLetters, System.Collections.Generic.IReadOnlyDictionary<string, Akka.Actor.IInternalActorRef> extraNames) { }
@@ -1675,16 +1650,16 @@ namespace Akka.Actor
         public abstract System.TimeSpan HighResMonotonicClock { get; }
         public abstract System.TimeSpan MonotonicClock { get; }
         protected abstract System.DateTimeOffset TimeNow { get; }
-        protected abstract void InternalScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable);
         protected abstract void InternalScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
-        protected abstract void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable);
+        protected abstract void InternalScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable);
         protected abstract void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
+        protected abstract void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable);
         protected abstract void InternalScheduleTellOnce(System.TimeSpan delay, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable);
         protected abstract void InternalScheduleTellRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable);
-        public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
         public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action) { }
-        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
+        public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
         public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action) { }
+        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
         protected static void ValidateDelay(System.TimeSpan delay, string parameterName) { }
         protected static void ValidateInterval(System.TimeSpan interval, string parameterName) { }
     }
@@ -1693,7 +1668,7 @@ namespace Akka.Actor
         public SchedulerException(string message) { }
         public SchedulerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static SchedulerExtensions
+    public static class SchedulerExtensions
     {
         public static void ScheduleOnce(this Akka.Actor.IActionScheduler scheduler, int millisecondsDelay, System.Action action, Akka.Actor.ICancelable cancelable = null) { }
         public static Akka.Actor.ICancelable ScheduleOnceCancelable(this Akka.Actor.IActionScheduler scheduler, System.TimeSpan delay, System.Action action) { }
@@ -1803,17 +1778,17 @@ namespace Akka.Actor
         public void InjectTopLevelFallback(Akka.Configuration.Config config) { }
         public override string ToString() { }
     }
-    public class static StashFactory
+    public static class StashFactory
     {
-        public static Akka.Actor.IStash CreateStash<T>(this Akka.Actor.IActorContext context)
-            where T : Akka.Actor.ActorBase { }
         public static Akka.Actor.IStash CreateStash(this Akka.Actor.IActorContext context, Akka.Actor.IActorStash actorInstance) { }
         public static Akka.Actor.IStash CreateStash(this Akka.Actor.IActorContext context, System.Type actorType) { }
+        public static Akka.Actor.IStash CreateStash<T>(this Akka.Actor.IActorContext context)
+            where T : Akka.Actor.ActorBase { }
     }
     public class StashOverflowException : Akka.Actor.AkkaException
     {
-        public StashOverflowException(string message, System.Exception cause = null) { }
         protected StashOverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public StashOverflowException(string message, System.Exception cause = null) { }
     }
     public abstract class Status
     {
@@ -1828,8 +1803,8 @@ namespace Akka.Actor
         }
         public sealed class Success : Akka.Actor.Status
         {
-            public static readonly Akka.Actor.Status.Success Instance;
             public readonly object Status;
+            public static readonly Akka.Actor.Status.Success Instance;
             public Success(object status) { }
             public override string ToString() { }
         }
@@ -1884,7 +1859,7 @@ namespace Akka.Actor
         public TerminatedProps() { }
         public override Akka.Actor.ActorBase NewActor() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class UnstartedCell : Akka.Actor.ICell
     {
         public UnstartedCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.RepointableActorRef self, Akka.Actor.Props props, Akka.Actor.IInternalActorRef supervisor) { }
@@ -1914,11 +1889,11 @@ namespace Akka.Actor
     public abstract class UntypedActor : Akka.Actor.ActorBase
     {
         protected UntypedActor() { }
-        protected static Akka.Actor.IUntypedActorContext Context { get; }
+        protected new static Akka.Actor.IUntypedActorContext Context { get; }
         protected void Become(Akka.Actor.UntypedReceive receive) { }
         protected void BecomeStacked(Akka.Actor.UntypedReceive receive) { }
         protected abstract void OnReceive(object message);
-        protected virtual bool Receive(object message) { }
+        protected override sealed bool Receive(object message) { }
         protected void RunTask(System.Action action) { }
         protected void RunTask(System.Func<System.Threading.Tasks.Task> action) { }
     }
@@ -1938,11 +1913,11 @@ namespace Akka.Actor
         public Akka.Actor.IStash Stash { get; set; }
     }
     public delegate void UntypedReceive(object message);
-    public class static WatchAsyncSupport
+    public static class WatchAsyncSupport
     {
-        public static System.Threading.Tasks.Task<bool> WatchAsync(this Akka.Actor.IActorRef target, System.Threading.CancellationToken token = null) { }
+        public static System.Threading.Tasks.Task<bool> WatchAsync(this Akka.Actor.IActorRef target, System.Threading.CancellationToken token = default) { }
     }
-    public class static WrappedMessage
+    public static class WrappedMessage
     {
         public static object Unwrap(object message) { }
     }
@@ -1978,7 +1953,7 @@ namespace Akka.Actor.Dsl
         public void ReceiveAsync<T>(System.Predicate<T> shouldHandle, System.Func<T, Akka.Actor.IActorContext, System.Threading.Tasks.Task> handler) { }
         protected override Akka.Actor.SupervisorStrategy SupervisorStrategy() { }
     }
-    public class static ActExtensions
+    public static class ActExtensions
     {
         public static Akka.Actor.IActorRef ActorOf(this Akka.Actor.IActorRefFactory factory, System.Action<Akka.Actor.Dsl.IActorDsl> config, string name = null) { }
         public static Akka.Actor.IActorRef ActorOf(this Akka.Actor.IActorRefFactory factory, System.Action<Akka.Actor.Dsl.IActorDsl, Akka.Actor.IActorContext> config, string name = null) { }
@@ -1998,8 +1973,8 @@ namespace Akka.Actor.Dsl
         void DefaultPreRestart(System.Exception reason, object message);
         void DefaultPreStart();
         void Receive<T>(System.Action<T, Akka.Actor.IActorContext> handler);
-        void Receive<T>(System.Predicate<T> shouldHandle, System.Action<T, Akka.Actor.IActorContext> handler);
         void Receive<T>(System.Action<T, Akka.Actor.IActorContext> handler, System.Predicate<T> shouldHandle);
+        void Receive<T>(System.Predicate<T> shouldHandle, System.Action<T, Akka.Actor.IActorContext> handler);
         void ReceiveAny(System.Action<object, Akka.Actor.IActorContext> handler);
         void ReceiveAnyAsync(System.Func<object, Akka.Actor.IActorContext, System.Threading.Tasks.Task> handler);
         void ReceiveAsync<T>(System.Func<T, Akka.Actor.IActorContext, System.Threading.Tasks.Task> handler, System.Predicate<T> shouldHandle = null);
@@ -2027,7 +2002,7 @@ namespace Akka.Actor.Internal
     public class ActorSystemImpl : Akka.Actor.ExtendedActorSystem
     {
         public ActorSystemImpl(string name) { }
-        public ActorSystemImpl(string name, Akka.Configuration.Config config, Akka.Actor.Setup.ActorSystemSetup setup, System.Nullable<Akka.Util.Option<Akka.Actor.Props>> guardianProps = null) { }
+        public ActorSystemImpl(string name, Akka.Configuration.Config config, Akka.Actor.Setup.ActorSystemSetup setup, Akka.Util.Option<Akka.Actor.Props>? guardianProps = default) { }
         public override Akka.Actor.ActorProducerPipelineResolver ActorPipelineResolver { get; }
         public override Akka.Actor.IActorRef DeadLetters { get; }
         public override Akka.Dispatch.Dispatchers Dispatchers { get; }
@@ -2101,17 +2076,17 @@ namespace Akka.Actor.Internal
         public abstract Akka.Actor.Internal.IChildrenContainer Reserve(string name);
         public abstract Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor);
         public bool TryGetByName(string name, out Akka.Actor.Internal.IChildStats stats) { }
-        public bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats childRestartStats) { }
+        public bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Akka.Actor.Internal.ChildRestartStats? childRestartStats) { }
         public abstract Akka.Actor.Internal.IChildrenContainer Unreserve(string name);
     }
     public class EmptyChildrenContainer : Akka.Actor.Internal.IChildrenContainer
     {
         protected EmptyChildrenContainer() { }
         public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.IInternalActorRef> Children { get; }
-        public static Akka.Actor.Internal.IChildrenContainer Instance { get; }
         public virtual bool IsNormal { get; }
         public virtual bool IsTerminating { get; }
         public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> Stats { get; }
+        public static Akka.Actor.Internal.IChildrenContainer Instance { get; }
         public virtual Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats) { }
         public bool Contains(Akka.Actor.IActorRef actor) { }
         public Akka.Actor.Internal.IChildrenContainer Remove(Akka.Actor.IActorRef child) { }
@@ -2135,38 +2110,37 @@ namespace Akka.Actor.Internal
         Akka.Actor.Internal.IChildrenContainer Reserve(string name);
         Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor);
         bool TryGetByName(string name, out Akka.Actor.Internal.IChildStats stats);
-        bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats stats);
+        bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Akka.Actor.Internal.ChildRestartStats? stats);
         Akka.Actor.Internal.IChildrenContainer Unreserve(string name);
     }
     public interface IInitializableActor
     {
         void Init();
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IInternalSupportsTestFSMRef<TState, TData>
     {
         bool IsStateTimerActive { get; }
         void ApplyState(Akka.Actor.FSMBase.State<TState, TData> upcomingState);
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class InternalActivateFsmLogging
     {
         public static Akka.Actor.Internal.InternalActivateFsmLogging Instance { get; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static InternalCurrentActorCellKeeper
+    public static class InternalCurrentActorCellKeeper
     {
-        public static Akka.Actor.ActorCell Current { get; set; }
+        public static Akka.Actor.ActorCell? Current { get; set; }
     }
     public class NormalChildrenContainer : Akka.Actor.Internal.ChildrenContainerBase
     {
         public override Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats) { }
-        public static Akka.Actor.Internal.IChildrenContainer Create(System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children) { }
         public override Akka.Actor.Internal.IChildrenContainer Remove(Akka.Actor.IActorRef child) { }
         public override Akka.Actor.Internal.IChildrenContainer Reserve(string name) { }
         public override Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor) { }
         public override string ToString() { }
         public override Akka.Actor.Internal.IChildrenContainer Unreserve(string name) { }
+        public static Akka.Actor.Internal.IChildrenContainer Create(System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children) { }
     }
     public abstract class SuspendReason
     {
@@ -2192,9 +2166,9 @@ namespace Akka.Actor.Internal
     }
     public class TerminatedChildrenContainer : Akka.Actor.Internal.EmptyChildrenContainer
     {
-        public new static Akka.Actor.Internal.IChildrenContainer Instance { get; }
         public override bool IsNormal { get; }
         public override bool IsTerminating { get; }
+        public new static Akka.Actor.Internal.IChildrenContainer Instance { get; }
         public override Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats) { }
         public override Akka.Actor.Internal.IChildrenContainer Reserve(string name) { }
         public override string ToString() { }
@@ -2223,7 +2197,7 @@ namespace Akka.Actor.Internal
 }
 namespace Akka.Actor.Scheduler
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IScheduledTellMsg : Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.IWrappedMessage { }
 }
 namespace Akka.Actor.Setup
@@ -2233,12 +2207,12 @@ namespace Akka.Actor.Setup
         public static readonly Akka.Actor.Setup.ActorSystemSetup Empty;
         public Akka.Actor.Setup.ActorSystemSetup And<T>(T setup)
             where T : Akka.Actor.Setup.Setup { }
-        public static Akka.Actor.Setup.ActorSystemSetup Create(params Akka.Actor.Setup.Setup[] setup) { }
         public Akka.Util.Option<T> Get<T>()
             where T : Akka.Actor.Setup.Setup { }
         public override string ToString() { }
         public Akka.Actor.Setup.ActorSystemSetup WithSetup<T>(T setup)
             where T : Akka.Actor.Setup.Setup { }
+        public static Akka.Actor.Setup.ActorSystemSetup Create(params Akka.Actor.Setup.Setup[] setup) { }
     }
     public abstract class Setup
     {
@@ -2248,22 +2222,22 @@ namespace Akka.Actor.Setup
 }
 namespace Akka.Annotations
 {
-    [System.AttributeUsageAttribute(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsage(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface, AllowMultiple=false, Inherited=true)]
     public sealed class ApiMayChangeAttribute : System.Attribute
     {
         public ApiMayChangeAttribute() { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple=false, Inherited=true)]
     public sealed class DoNotInheritAttribute : System.Attribute
     {
         public DoNotInheritAttribute() { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsage(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface, AllowMultiple=false, Inherited=true)]
     public sealed class InternalApiAttribute : System.Attribute
     {
         public InternalApiAttribute() { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsage(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface, AllowMultiple=false, Inherited=true)]
     public sealed class InternalStableApiAttribute : System.Attribute
     {
         public InternalStableApiAttribute() { }
@@ -2283,14 +2257,14 @@ namespace Akka.Configuration
         public System.Collections.Generic.IEnumerable<Akka.Configuration.Hocon.HoconSubstitution> Substitutions { get; set; }
         public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Akka.Configuration.Hocon.HoconValue>> AsEnumerable() { }
         protected Akka.Configuration.Config Copy(Akka.Configuration.Config fallback = null) { }
-        public virtual bool GetBoolean(string path, bool default = False) { }
+        public virtual bool GetBoolean(string path, bool default = false) { }
         public virtual System.Collections.Generic.IList<bool> GetBooleanList(string path) { }
         public virtual System.Collections.Generic.IList<byte> GetByteList(string path) { }
-        public virtual System.Nullable<long> GetByteSize(string path) { }
-        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("def")]
-        public virtual System.Nullable<long> GetByteSize(string path, System.Nullable<long> def = null) { }
+        public virtual long? GetByteSize(string path) { }
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("def")]
+        public virtual long? GetByteSize(string path, long? def = default) { }
         public virtual Akka.Configuration.Config GetConfig(string path) { }
-        public virtual decimal GetDecimal(string path, [System.Runtime.CompilerServices.DecimalConstantAttribute(0, 0, 0u, 0u, 0u)] decimal @default) { }
+        public virtual decimal GetDecimal(string path, [System.Runtime.CompilerServices.DecimalConstant(0, 0, 0u, 0u, 0u)] decimal @default) { }
         public virtual System.Collections.Generic.IList<decimal> GetDecimalList(string path) { }
         public virtual double GetDouble(string path, double default = 0) { }
         public virtual System.Collections.Generic.IList<double> GetDoubleList(string path) { }
@@ -2303,17 +2277,17 @@ namespace Akka.Configuration
         public virtual string GetString(string path, string default = null) { }
         public virtual System.Collections.Generic.IList<string> GetStringList(string path) { }
         public virtual System.Collections.Generic.IList<string> GetStringList(string path, string[] defaultPaths) { }
-        public virtual System.TimeSpan GetTimeSpan(string path, System.Nullable<System.TimeSpan> default = null, bool allowInfinite = True) { }
+        public virtual System.TimeSpan GetTimeSpan(string path, System.TimeSpan? default = default, bool allowInfinite = true) { }
         public Akka.Configuration.Hocon.HoconValue GetValue(string path) { }
         public virtual bool HasPath(string path) { }
         public override string ToString() { }
         public string ToString(bool includeFallback) { }
         public virtual Akka.Configuration.Config WithFallback(Akka.Configuration.Config fallback) { }
-        public static Akka.Configuration.Config +(Akka.Configuration.Config config, string fallback) { }
-        public static Akka.Configuration.Config +(string configHocon, Akka.Configuration.Config fallbackConfig) { }
         public static Akka.Configuration.Config op_Implicit(string str) { }
+        public static Akka.Configuration.Config operator +(Akka.Configuration.Config config, string fallback) { }
+        public static Akka.Configuration.Config operator +(string configHocon, Akka.Configuration.Config fallbackConfig) { }
     }
-    public class static ConfigExtensions
+    public static class ConfigExtensions
     {
         public static bool IsNullOrEmpty(this Akka.Configuration.Config config) { }
         public static Akka.Configuration.Config SafeWithFallback(this Akka.Configuration.Config config, Akka.Configuration.Config fallback) { }
@@ -2321,8 +2295,8 @@ namespace Akka.Configuration
     public class ConfigurationException : Akka.Actor.AkkaException
     {
         public ConfigurationException(string message) { }
-        public ConfigurationException(string message, System.Exception exception) { }
         protected ConfigurationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public ConfigurationException(string message, System.Exception exception) { }
         public static Akka.Configuration.ConfigurationException NullOrEmptyConfig<T>(string path = null) { }
     }
     public class ConfigurationFactory
@@ -2331,11 +2305,11 @@ namespace Akka.Configuration
         public static Akka.Configuration.Config Empty { get; }
         public static Akka.Configuration.Config Default() { }
         public static Akka.Configuration.Config FromObject(object source) { }
+        public static Akka.Configuration.Config FromResource(string resourceName, System.Reflection.Assembly assembly) { }
         public static Akka.Configuration.Config FromResource(string resourceName, object instanceInAssembly) { }
         public static Akka.Configuration.Config FromResource<TAssembly>(string resourceName) { }
-        public static Akka.Configuration.Config FromResource(string resourceName, System.Reflection.Assembly assembly) { }
-        public static Akka.Configuration.Config ParseString(string hocon, System.Func<string, Akka.Configuration.Hocon.HoconRoot> includeCallback) { }
         public static Akka.Configuration.Config ParseString(string hocon) { }
+        public static Akka.Configuration.Config ParseString(string hocon, System.Func<string, Akka.Configuration.Hocon.HoconRoot> includeCallback) { }
     }
 }
 namespace Akka.Configuration.Hocon
@@ -2363,7 +2337,7 @@ namespace Akka.Configuration.Hocon
     {
         public HoconObject() { }
         public System.Collections.Generic.Dictionary<string, Akka.Configuration.Hocon.HoconValue> Items { get; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        [Newtonsoft.Json.JsonIgnore]
         public System.Collections.Generic.IDictionary<string, object> Unwrapped { get; }
         public System.Collections.Generic.IList<Akka.Configuration.Hocon.HoconValue> GetArray() { }
         public Akka.Configuration.Hocon.HoconValue GetKey(string key) { }
@@ -2378,8 +2352,8 @@ namespace Akka.Configuration.Hocon
     public class HoconRoot
     {
         protected HoconRoot() { }
-        public HoconRoot(Akka.Configuration.Hocon.HoconValue value, System.Collections.Generic.IEnumerable<Akka.Configuration.Hocon.HoconSubstitution> substitutions) { }
         public HoconRoot(Akka.Configuration.Hocon.HoconValue value) { }
+        public HoconRoot(Akka.Configuration.Hocon.HoconValue value, System.Collections.Generic.IEnumerable<Akka.Configuration.Hocon.HoconSubstitution> substitutions) { }
         public System.Collections.Generic.IEnumerable<Akka.Configuration.Hocon.HoconSubstitution> Substitutions { get; }
         public Akka.Configuration.Hocon.HoconValue Value { get; }
     }
@@ -2441,7 +2415,7 @@ namespace Akka.Configuration.Hocon
     public class HoconValue : Akka.Configuration.Hocon.IMightBeAHoconObject
     {
         public HoconValue() { }
-        public HoconValue(System.Collections.Generic.List<Akka.Configuration.Hocon.IHoconElement> values, bool adoptedFromFallback = True) { }
+        public HoconValue(System.Collections.Generic.List<Akka.Configuration.Hocon.IHoconElement> values, bool adoptedFromFallback = true) { }
         public bool IsEmpty { get; }
         public System.Collections.Generic.List<Akka.Configuration.Hocon.IHoconElement> Values { get; }
         public void AppendValue(Akka.Configuration.Hocon.IHoconElement value) { }
@@ -2452,7 +2426,7 @@ namespace Akka.Configuration.Hocon
         public System.Collections.Generic.IList<bool> GetBooleanList() { }
         public byte GetByte() { }
         public System.Collections.Generic.IList<byte> GetByteList() { }
-        public System.Nullable<long> GetByteSize() { }
+        public long? GetByteSize() { }
         public Akka.Configuration.Hocon.HoconValue GetChildObject(string key) { }
         public decimal GetDecimal() { }
         public System.Collections.Generic.IList<decimal> GetDecimalList() { }
@@ -2467,7 +2441,7 @@ namespace Akka.Configuration.Hocon
         public Akka.Configuration.Hocon.HoconObject GetObject() { }
         public string GetString() { }
         public System.Collections.Generic.IList<string> GetStringList() { }
-        public System.TimeSpan GetTimeSpan(bool allowInfinite = True) { }
+        public System.TimeSpan GetTimeSpan(bool allowInfinite = true) { }
         public bool IsArray() { }
         public bool IsObject() { }
         public bool IsString() { }
@@ -2491,9 +2465,9 @@ namespace Akka.Configuration.Hocon
     public class Parser
     {
         public Parser() { }
-        public static Akka.Configuration.Hocon.HoconRoot Parse(string text, System.Func<string, Akka.Configuration.Hocon.HoconRoot> includeCallback) { }
         public Akka.Configuration.Hocon.HoconArray ParseArray(string currentPath) { }
         public void ParseValue(Akka.Configuration.Hocon.HoconValue owner, string currentPath) { }
+        public static Akka.Configuration.Hocon.HoconRoot Parse(string text, System.Func<string, Akka.Configuration.Hocon.HoconRoot> includeCallback) { }
     }
     public class Token
     {
@@ -2533,241 +2507,165 @@ namespace Akka.Configuration.Hocon
         public void Pop() { }
         public void PullWhitespace() { }
         public void Push() { }
-        public string Take(int length) { }
         public char Take() { }
+        public string Take(int length) { }
     }
 }
 namespace Akka.Delivery
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static ConsumerController
+    public static class ConsumerController
     {
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(Akka.Actor.IActorRefFactory actorRefFactory, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<Akka.Actor.IActorRef> producerControllerReference, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Delivery.ConsumerController.Settings settings = null) { }
-        [Akka.Annotations.InternalApiAttribute()]
-        public static Akka.Actor.Props CreateWithFuzzing<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(Akka.Actor.IActorRefFactory actorRefFactory, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<Akka.Actor.IActorRef> producerControllerReference, System.Func<object, double> fuzzing, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Delivery.ConsumerController.Settings settings = null) { }
+        public static Akka.Actor.Props Create<T>(Akka.Actor.IActorRefFactory actorRefFactory, Akka.Util.Option<Akka.Actor.IActorRef> producerControllerReference, Akka.Delivery.ConsumerController.Settings? settings = null) { }
+        [Akka.Annotations.InternalApi]
+        public static Akka.Actor.Props CreateWithFuzzing<T>(Akka.Actor.IActorRefFactory actorRefFactory, Akka.Util.Option<Akka.Actor.IActorRef> producerControllerReference, System.Func<object, double> fuzzing, Akka.Delivery.ConsumerController.Settings? settings = null) { }
         public sealed class Confirmed
         {
-            [System.Runtime.CompilerServices.NullableAttribute(1)]
             public static readonly Akka.Delivery.ConsumerController.Confirmed Instance;
         }
-        public sealed class DeliverThenStop<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
+        public sealed class DeliverThenStop<T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
         {
-            [System.Runtime.CompilerServices.NullableAttribute(1)]
             public static readonly Akka.Delivery.ConsumerController.DeliverThenStop<T> Instance;
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class Delivery<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>, Akka.Delivery.Internal.IDeliverySerializable, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Delivery.ConsumerController.Delivery<T>>
+        public sealed class Delivery<T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>, Akka.Delivery.Internal.IDeliverySerializable, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Delivery.ConsumerController.Delivery<T>>
         {
             public Delivery(T Message, Akka.Actor.IActorRef ConfirmTo, string ProducerId, long SeqNr) { }
-            public Akka.Actor.IActorRef ConfirmTo { get; set; }
-            public T Message { get; set; }
-            public string ProducerId { get; set; }
-            public long SeqNr { get; set; }
+            public Akka.Actor.IActorRef ConfirmTo { get; init; }
+            public T Message { get; init; }
+            public string ProducerId { get; init; }
+            public long SeqNr { get; init; }
             public override string ToString() { }
         }
         public interface IConsumerCommand<T> { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class RegisterToProducerController<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
+        public sealed class RegisterToProducerController<T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
         {
             public RegisterToProducerController(Akka.Actor.IActorRef producerController) { }
             public Akka.Actor.IActorRef ProducerController { get; }
         }
-        [Akka.Annotations.InternalApiAttribute()]
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class SequencedMessage<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>, Akka.Delivery.Internal.IDeliverySerializable, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Delivery.ConsumerController.SequencedMessage<T>>
+        [Akka.Annotations.InternalApi]
+        public sealed class SequencedMessage<T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>, Akka.Delivery.Internal.IDeliverySerializable, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Delivery.ConsumerController.SequencedMessage<T>>
         {
-            public SequencedMessage(string ProducerId, long SeqNr, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})] Akka.Delivery.Internal.MessageOrChunk<T> Message, bool First, bool Ack) { }
-            public bool Ack { get; set; }
-            public bool First { get; set; }
-            [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
-            public Akka.Delivery.Internal.MessageOrChunk<T> Message { get; set; }
-            public string ProducerId { get; set; }
-            public long SeqNr { get; set; }
-            public bool Equals([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    2,
-                    1})] Akka.Delivery.ConsumerController.SequencedMessage<T> other) { }
+            public SequencedMessage(string ProducerId, long SeqNr, Akka.Delivery.Internal.MessageOrChunk<T> Message, bool First, bool Ack) { }
+            public bool Ack { get; init; }
+            public bool First { get; init; }
+            public Akka.Delivery.Internal.MessageOrChunk<T> Message { get; init; }
+            public string ProducerId { get; init; }
+            public long SeqNr { get; init; }
+            public bool Equals(Akka.Delivery.ConsumerController.SequencedMessage<T>? other) { }
             public override int GetHashCode() { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class Settings : System.IEquatable<Akka.Delivery.ConsumerController.Settings>
         {
-            public int FlowControlWindow { get; set; }
-            public bool OnlyFlowControl { get; set; }
-            public System.TimeSpan ResendIntervalMax { get; set; }
-            public System.TimeSpan ResendIntervalMin { get; set; }
+            public int FlowControlWindow { get; init; }
+            public bool OnlyFlowControl { get; init; }
+            public System.TimeSpan ResendIntervalMax { get; init; }
+            public System.TimeSpan ResendIntervalMin { get; init; }
+            public override string ToString() { }
             public static Akka.Delivery.ConsumerController.Settings Create(Akka.Actor.ActorSystem actorSystem) { }
             public static Akka.Delivery.ConsumerController.Settings Create(Akka.Configuration.Config config) { }
-            public override string ToString() { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class Start<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
+        public sealed class Start<T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
         {
             public Start(Akka.Actor.IActorRef deliverTo) { }
             public Akka.Actor.IActorRef DeliverTo { get; }
         }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static DurableProducerQueue
+    public static class DurableProducerQueue
     {
         public const string NoQualifier = "";
         public interface IDurableProducerQueueCommand { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class LoadState : Akka.Delivery.DurableProducerQueue.IDurableProducerQueueCommand, System.IEquatable<Akka.Delivery.DurableProducerQueue.LoadState>
         {
             public LoadState(Akka.Actor.IActorRef ReplyTo) { }
-            public Akka.Actor.IActorRef ReplyTo { get; set; }
+            public Akka.Actor.IActorRef ReplyTo { get; init; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class MessageSent<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.Internal.IDeliverySerializable, System.IEquatable<Akka.Delivery.DurableProducerQueue.MessageSent<T>>
+        public sealed class MessageSent<T> : Akka.Delivery.Internal.IDeliverySerializable, System.IEquatable<Akka.Delivery.DurableProducerQueue.MessageSent<T>>
         {
-            public MessageSent(long SeqNr, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})] Akka.Delivery.Internal.MessageOrChunk<T> Message, bool Ack, string ConfirmationQualifier, long Timestamp) { }
-            public bool Ack { get; set; }
-            public string ConfirmationQualifier { get; set; }
-            [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
-            public Akka.Delivery.Internal.MessageOrChunk<T> Message { get; set; }
-            public long SeqNr { get; set; }
-            public long Timestamp { get; set; }
-            public bool Equals([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    2,
-                    1})] Akka.Delivery.DurableProducerQueue.MessageSent<T> other) { }
-            public static Akka.Delivery.DurableProducerQueue.MessageSent<T> FromChunked(long seqNo, Akka.Delivery.Internal.ChunkedMessage chunkedMessage, bool ack, string confirmationQualifier, long timestamp) { }
-            public static Akka.Delivery.DurableProducerQueue.MessageSent<T> FromMessageOrChunked(long seqNo, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})] Akka.Delivery.Internal.MessageOrChunk<T> messageOrChunk, bool ack, string confirmationQualifier, long timestamp) { }
+            public MessageSent(long SeqNr, Akka.Delivery.Internal.MessageOrChunk<T> Message, bool Ack, string ConfirmationQualifier, long Timestamp) { }
+            public bool Ack { get; init; }
+            public string ConfirmationQualifier { get; init; }
+            public Akka.Delivery.Internal.MessageOrChunk<T> Message { get; init; }
+            public long SeqNr { get; init; }
+            public long Timestamp { get; init; }
+            public bool Equals(Akka.Delivery.DurableProducerQueue.MessageSent<T>? other) { }
             public override int GetHashCode() { }
             public override string ToString() { }
             public Akka.Delivery.DurableProducerQueue.MessageSent<T> WithQualifier(string qualifier) { }
             public Akka.Delivery.DurableProducerQueue.MessageSent<T> WithTimestamp(long timestamp) { }
+            public static Akka.Delivery.DurableProducerQueue.MessageSent<T> FromChunked(long seqNo, Akka.Delivery.Internal.ChunkedMessage chunkedMessage, bool ack, string confirmationQualifier, long timestamp) { }
+            public static Akka.Delivery.DurableProducerQueue.MessageSent<T> FromMessageOrChunked(long seqNo, Akka.Delivery.Internal.MessageOrChunk<T> messageOrChunk, bool ack, string confirmationQualifier, long timestamp) { }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public struct State<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.Internal.IDeliverySerializable, System.IEquatable<Akka.Delivery.DurableProducerQueue.State<T>>
+        public readonly struct State<T> : Akka.Delivery.Internal.IDeliverySerializable, System.IEquatable<Akka.Delivery.DurableProducerQueue.State<T>>
         {
-            public State(long CurrentSeqNr, long HighestConfirmedSeqNr, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    1,
-                    1,
-                    0})] System.Collections.Immutable.ImmutableDictionary<string, System.ValueTuple<long, long>> ConfirmedSeqNr, System.Collections.Immutable.ImmutableList<Akka.Delivery.DurableProducerQueue.MessageSent<T>> Unconfirmed) { }
-            [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    1,
-                    1,
-                    0})]
-            public System.Collections.Immutable.ImmutableDictionary<string, System.ValueTuple<long, long>> ConfirmedSeqNr { get; set; }
-            public long CurrentSeqNr { get; set; }
-            [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
+            public State(long CurrentSeqNr, long HighestConfirmedSeqNr, System.Collections.Immutable.ImmutableDictionary<string, System.ValueTuple<long, long>> ConfirmedSeqNr, System.Collections.Immutable.ImmutableList<Akka.Delivery.DurableProducerQueue.MessageSent<T>> Unconfirmed) { }
+            public System.Collections.Immutable.ImmutableDictionary<string, System.ValueTuple<long, long>> ConfirmedSeqNr { get; init; }
+            public long CurrentSeqNr { get; init; }
+            public long HighestConfirmedSeqNr { get; init; }
+            public System.Collections.Immutable.ImmutableList<Akka.Delivery.DurableProducerQueue.MessageSent<T>> Unconfirmed { get; init; }
             public static Akka.Delivery.DurableProducerQueue.State<T> Empty { get; }
-            public long HighestConfirmedSeqNr { get; set; }
-            public System.Collections.Immutable.ImmutableList<Akka.Delivery.DurableProducerQueue.MessageSent<T>> Unconfirmed { get; set; }
-            [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
             public Akka.Delivery.DurableProducerQueue.State<T> AddConfirmed(long seqNr, string qualifier, long timestamp) { }
-            [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
             public Akka.Delivery.DurableProducerQueue.State<T> AddMessageSent(Akka.Delivery.DurableProducerQueue.MessageSent<T> messageSent) { }
-            [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
             public Akka.Delivery.DurableProducerQueue.State<T> CleanUp(System.Collections.Generic.ISet<string> confirmationQualifiers) { }
-            [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
             public Akka.Delivery.DurableProducerQueue.State<T> CleanUpPartialChunkedMessages() { }
-            public bool Equals([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})] Akka.Delivery.DurableProducerQueue.State<T> other) { }
+            public bool Equals(Akka.Delivery.DurableProducerQueue.State<T> other) { }
             public override int GetHashCode() { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class StoreMessageConfirmed : Akka.Delivery.DurableProducerQueue.IDurableProducerQueueCommand, System.IEquatable<Akka.Delivery.DurableProducerQueue.StoreMessageConfirmed>
         {
             public StoreMessageConfirmed(long SeqNr, string ConfirmationQualifier, long Timestamp) { }
-            public string ConfirmationQualifier { get; set; }
-            public long SeqNr { get; set; }
-            public long Timestamp { get; set; }
+            public string ConfirmationQualifier { get; init; }
+            public long SeqNr { get; init; }
+            public long Timestamp { get; init; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
+        public sealed class StoreMessageSent<T> : Akka.Delivery.DurableProducerQueue.IDurableProducerQueueCommand, System.IEquatable<Akka.Delivery.DurableProducerQueue.StoreMessageSent<T>>
+        {
+            public StoreMessageSent(Akka.Delivery.DurableProducerQueue.MessageSent<T> MessageSent, Akka.Actor.IActorRef ReplyTo) { }
+            public Akka.Delivery.DurableProducerQueue.MessageSent<T> MessageSent { get; init; }
+            public Akka.Actor.IActorRef ReplyTo { get; init; }
+        }
         public sealed class StoreMessageSentAck : System.IEquatable<Akka.Delivery.DurableProducerQueue.StoreMessageSentAck>
         {
             public StoreMessageSentAck(long StoredSeqNo) { }
-            public long StoredSeqNo { get; set; }
-        }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class StoreMessageSent<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.DurableProducerQueue.IDurableProducerQueueCommand, System.IEquatable<Akka.Delivery.DurableProducerQueue.StoreMessageSent<T>>
-        {
-            public StoreMessageSent(Akka.Delivery.DurableProducerQueue.MessageSent<T> MessageSent, Akka.Actor.IActorRef ReplyTo) { }
-            public Akka.Delivery.DurableProducerQueue.MessageSent<T> MessageSent { get; set; }
-            public Akka.Actor.IActorRef ReplyTo { get; set; }
+            public long StoredSeqNo { get; init; }
         }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static ProducerController
+    public static class ProducerController
     {
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(Akka.Actor.IActorRefFactory actorRefFactory, string producerId, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<Akka.Actor.Props> durableProducerQueue, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Delivery.ProducerController.Settings settings = null, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1,
-                1})] System.Action<Akka.Delivery.ConsumerController.SequencedMessage<T>> sendAdapter = null) { }
-        [Akka.Annotations.InternalApiAttribute()]
-        public static Akka.Actor.Props CreateWithFuzzing<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(Akka.Actor.IActorRefFactory actorRefFactory, string producerId, System.Func<object, double> fuzzing, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<Akka.Actor.Props> durableProducerQueue, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Delivery.ProducerController.Settings settings = null, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1,
-                1})] System.Action<Akka.Delivery.ConsumerController.SequencedMessage<T>> sendAdapter = null) { }
+        public static Akka.Actor.Props Create<T>(Akka.Actor.IActorRefFactory actorRefFactory, string producerId, Akka.Util.Option<Akka.Actor.Props> durableProducerQueue, Akka.Delivery.ProducerController.Settings? settings = null, System.Action<Akka.Delivery.ConsumerController.SequencedMessage<T>>? sendAdapter = null) { }
+        [Akka.Annotations.InternalApi]
+        public static Akka.Actor.Props CreateWithFuzzing<T>(Akka.Actor.IActorRefFactory actorRefFactory, string producerId, System.Func<object, double> fuzzing, Akka.Util.Option<Akka.Actor.Props> durableProducerQueue, Akka.Delivery.ProducerController.Settings? settings = null, System.Action<Akka.Delivery.ConsumerController.SequencedMessage<T>>? sendAdapter = null) { }
         public interface IProducerCommand<T> { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class MessageWithConfirmation<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ProducerController.IProducerCommand<T>
+        public sealed class MessageWithConfirmation<T> : Akka.Delivery.ProducerController.IProducerCommand<T>
         {
             public MessageWithConfirmation(T message, Akka.Actor.IActorRef replyTo) { }
             public T Message { get; }
             public Akka.Actor.IActorRef ReplyTo { get; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class RegisterConsumer<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.Internal.IDeliverySerializable, Akka.Delivery.ProducerController.IProducerCommand<T>, System.IEquatable<Akka.Delivery.ProducerController.RegisterConsumer<T>>
+        public sealed class RegisterConsumer<T> : Akka.Delivery.Internal.IDeliverySerializable, Akka.Delivery.ProducerController.IProducerCommand<T>, System.IEquatable<Akka.Delivery.ProducerController.RegisterConsumer<T>>
         {
             public RegisterConsumer(Akka.Actor.IActorRef ConsumerController) { }
-            public Akka.Actor.IActorRef ConsumerController { get; set; }
+            public Akka.Actor.IActorRef ConsumerController { get; init; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class RequestNext<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Actor.INoSerializationVerificationNeeded, Akka.Delivery.ProducerController.IProducerCommand<T>
+        public sealed class RequestNext<T> : Akka.Actor.INoSerializationVerificationNeeded, Akka.Delivery.ProducerController.IProducerCommand<T>
         {
             public RequestNext(string producerId, long currentSeqNr, long confirmedSeqNr, Akka.Actor.IActorRef sendNextTo) { }
             public long ConfirmedSeqNr { get; }
             public long CurrentSeqNr { get; }
             public string ProducerId { get; }
             public Akka.Actor.IActorRef SendNextTo { get; }
-            public System.Threading.Tasks.Task<long> AskNextTo(T msg, System.Threading.CancellationToken cancellationToken = null) { }
             public void AskNextTo(Akka.Delivery.ProducerController.MessageWithConfirmation<T> msgWithConfirmation) { }
+            public System.Threading.Tasks.Task<long> AskNextTo(T msg, System.Threading.CancellationToken cancellationToken = default) { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class Settings : System.IEquatable<Akka.Delivery.ProducerController.Settings>
         {
             public const int DefaultDeliveryBufferSize = 128;
-            public System.Nullable<int> ChunkLargeMessagesBytes { get; set; }
-            public System.TimeSpan DurableQueueRequestTimeout { get; set; }
-            public System.TimeSpan DurableQueueResendFirstInterval { get; set; }
-            public int DurableQueueRetryAttempts { get; set; }
+            public int? ChunkLargeMessagesBytes { get; init; }
+            public System.TimeSpan DurableQueueRequestTimeout { get; init; }
+            public System.TimeSpan DurableQueueResendFirstInterval { get; init; }
+            public int DurableQueueRetryAttempts { get; init; }
             public static Akka.Delivery.ProducerController.Settings Create(Akka.Actor.ActorSystem actorSystem) { }
             public static Akka.Delivery.ProducerController.Settings Create(Akka.Configuration.Config config) { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class Start<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ProducerController.IProducerCommand<T>
+        public sealed class Start<T> : Akka.Delivery.ProducerController.IProducerCommand<T>
         {
             public Start(Akka.Actor.IActorRef producer) { }
             public Akka.Actor.IActorRef Producer { get; }
@@ -2776,10 +2674,8 @@ namespace Akka.Delivery
 }
 namespace Akka.Delivery.Internal
 {
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public struct ChunkedMessage
+    [Akka.Annotations.InternalApi]
+    public readonly struct ChunkedMessage
     {
         public ChunkedMessage(Akka.IO.ByteString serializedMessage, bool firstChunk, bool lastChunk, int serializerId, string manifest) { }
         public bool FirstChunk { get; }
@@ -2789,38 +2685,24 @@ namespace Akka.Delivery.Internal
         public int SerializerId { get; }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IDeliverySerializable { }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public struct MessageOrChunk<T> : System.IEquatable<Akka.Delivery.Internal.MessageOrChunk<T>>
+    [Akka.Annotations.InternalApi]
+    public readonly struct MessageOrChunk<T> : System.IEquatable<Akka.Delivery.Internal.MessageOrChunk<T>>
     {
-        public MessageOrChunk(T message) { }
         public MessageOrChunk(Akka.Delivery.Internal.ChunkedMessage chunkedMessage) { }
-        public System.Nullable<Akka.Delivery.Internal.ChunkedMessage> Chunk { get; }
+        public MessageOrChunk(T message) { }
+        public Akka.Delivery.Internal.ChunkedMessage? Chunk { get; }
         public bool IsMessage { get; }
         public T Message { get; }
-        public bool Equals([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Delivery.Internal.MessageOrChunk<T> other) { }
-        public override bool Equals(object obj) { }
+        public bool Equals(Akka.Delivery.Internal.MessageOrChunk<T> other) { }
+        public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
-        public static Akka.Delivery.Internal.MessageOrChunk<T> op_Implicit(T message) { }
-        public static T op_Implicit([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Delivery.Internal.MessageOrChunk<T> message) { }
-        public static Akka.Delivery.Internal.ChunkedMessage op_Implicit([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Delivery.Internal.MessageOrChunk<T> message) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
         public static Akka.Delivery.Internal.MessageOrChunk<T> op_Implicit(Akka.Delivery.Internal.ChunkedMessage chunkedMessage) { }
+        public static T op_Implicit(Akka.Delivery.Internal.MessageOrChunk<T> message) { }
+        public static Akka.Delivery.Internal.ChunkedMessage op_Implicit(Akka.Delivery.Internal.MessageOrChunk<T> message) { }
+        public static Akka.Delivery.Internal.MessageOrChunk<T> op_Implicit(T message) { }
     }
 }
 namespace Akka.Dispatch
@@ -2845,9 +2727,9 @@ namespace Akka.Dispatch
         protected virtual void OnAfterTaskCompleted() { }
         protected virtual void OnBeforeTaskStarted() { }
         protected override void QueueTask(System.Threading.Tasks.Task task) { }
+        protected override bool TryExecuteTaskInline(System.Threading.Tasks.Task task, bool taskWasPreviouslyQueued) { }
         public static void RunTask(System.Action action) { }
         public static void RunTask(System.Func<System.Threading.Tasks.Task> asyncAction) { }
-        protected override bool TryExecuteTaskInline(System.Threading.Tasks.Task task, bool taskWasPreviouslyQueued) { }
     }
     public class BoundedDequeBasedMailbox : Akka.Dispatch.MailboxType, Akka.Dispatch.IProducesMessageQueue<Akka.Dispatch.MessageQueues.BoundedDequeMessageQueue>, Akka.Dispatch.IProducesPushTimeoutSemanticsMailbox
     {
@@ -2871,8 +2753,8 @@ namespace Akka.Dispatch
         public System.Threading.Tasks.TaskScheduler Low { get; }
         public System.Threading.Tasks.TaskScheduler Normal { get; }
         public void Dispose() { }
-        public static Akka.Dispatch.ChannelTaskScheduler Get(Akka.Actor.ActorSystem system) { }
         public System.Threading.Tasks.TaskScheduler GetScheduler(Akka.Dispatch.TaskSchedulerPriority priority) { }
+        public static Akka.Dispatch.ChannelTaskScheduler Get(Akka.Actor.ActorSystem system) { }
     }
     public sealed class ChannelTaskSchedulerProvider : Akka.Actor.ExtensionIdProvider<Akka.Dispatch.ChannelTaskScheduler>
     {
@@ -2881,7 +2763,7 @@ namespace Akka.Dispatch
     }
     public sealed class CurrentSynchronizationContextDispatcher : Akka.Dispatch.Dispatcher
     {
-        public CurrentSynchronizationContextDispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, System.Nullable<long> throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
+        public CurrentSynchronizationContextDispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, long? throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
     }
     public sealed class DefaultDispatcherPrerequisites : Akka.Dispatch.IDispatcherPrerequisites
     {
@@ -2893,9 +2775,9 @@ namespace Akka.Dispatch
     }
     public class Dispatcher : Akka.Dispatch.MessageDispatcher
     {
-        public Dispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, System.Nullable<long> throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
+        public Dispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, long? throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
         protected override void ExecuteTask(Akka.Dispatch.IRunnable run) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected override void Shutdown() { }
     }
     public sealed class DispatcherConfigurator : Akka.Dispatch.MessageDispatcherConfigurator
@@ -2912,11 +2794,11 @@ namespace Akka.Dispatch
         public Akka.Configuration.Config DefaultDispatcherConfig { get; }
         public Akka.Dispatch.MessageDispatcher DefaultGlobalDispatcher { get; }
         public Akka.Dispatch.IDispatcherPrerequisites Prerequisites { get; }
-        [Akka.Annotations.InternalApiAttribute()]
-        public static Akka.Configuration.Config GetConfig(Akka.Configuration.Config config, string id, int depth = 0) { }
         public bool HasDispatcher(string id) { }
         public Akka.Dispatch.MessageDispatcher Lookup(string dispatcherName) { }
         public bool RegisterConfigurator(string id, Akka.Dispatch.MessageDispatcherConfigurator configurator) { }
+        [Akka.Annotations.InternalApi]
+        public static Akka.Configuration.Config GetConfig(Akka.Configuration.Config config, string id, int depth = 0) { }
     }
     public abstract class ExecutorService
     {
@@ -2925,14 +2807,14 @@ namespace Akka.Dispatch
         public abstract void Execute(Akka.Dispatch.IRunnable run);
         public abstract void Shutdown();
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class ExecutorServiceConfigurator : Akka.Dispatch.ExecutorServiceFactory
     {
         protected ExecutorServiceConfigurator(Akka.Configuration.Config config, Akka.Dispatch.IDispatcherPrerequisites prerequisites) { }
         public Akka.Configuration.Config Config { get; }
         public Akka.Dispatch.IDispatcherPrerequisites Prerequisites { get; }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class ExecutorServiceFactory
     {
         protected ExecutorServiceFactory() { }
@@ -2986,11 +2868,11 @@ namespace Akka.Dispatch
         public Akka.Dispatch.MessageDispatcher Dispatcher { get; }
         public Akka.Dispatch.MessageQueues.IMessageQueue MessageQueue { get; }
         public virtual void CleanUp() { }
-        [System.Diagnostics.ConditionalAttribute("MAILBOXDEBUG")]
-        public static void DebugPrint(string message, params object[] args) { }
         public void Execute() { }
         public void Run() { }
         public virtual void SetActor(Akka.Actor.ActorCell actorCell) { }
+        [System.Diagnostics.Conditional("MAILBOXDEBUG")]
+        public static void DebugPrint(string message, params object[] args) { }
     }
     public abstract class MailboxType
     {
@@ -3011,7 +2893,7 @@ namespace Akka.Dispatch
         public Akka.Dispatch.MailboxType Lookup(string id) { }
         public Akka.Dispatch.MailboxType LookupByQueueType(System.Type queueType) { }
         public bool ProducesMessageQueue(System.Type mailboxType) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public int StashCapacity(string dispatcher, string mailbox) { }
     }
     public abstract class MessageDispatcher
@@ -3020,21 +2902,21 @@ namespace Akka.Dispatch
         protected MessageDispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator) { }
         public Akka.Dispatch.MessageDispatcherConfigurator Configurator { get; }
         public Akka.Event.EventStream EventStream { get; }
-        public string Id { get; set; }
+        public string Id { get; protected set; }
         protected long Inhabitants { get; }
         public Akka.Dispatch.Mailboxes Mailboxes { get; }
-        [Akka.Annotations.InternalApiAttribute()]
-        public System.TimeSpan ShutdownTimeout { get; set; }
+        [Akka.Annotations.InternalApi]
+        public System.TimeSpan ShutdownTimeout { get; protected set; }
         public int Throughput { get; set; }
-        public System.Nullable<long> ThroughputDeadlineTime { get; set; }
+        public long? ThroughputDeadlineTime { get; protected set; }
         public virtual void Attach(Akka.Actor.ActorCell cell) { }
         public virtual void Detach(Akka.Actor.ActorCell cell) { }
         public virtual void Dispatch(Akka.Actor.ActorCell cell, Akka.Actor.Envelope envelope) { }
         protected abstract void ExecuteTask(Akka.Dispatch.IRunnable run);
         protected void ReportFailure(System.Exception ex) { }
-        public void Schedule(System.Action run) { }
         public void Schedule(Akka.Dispatch.IRunnable run) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        public void Schedule(System.Action run) { }
+        [Akka.Annotations.InternalApi]
         protected abstract void Shutdown();
         public virtual void SystemDispatch(Akka.Actor.ActorCell cell, Akka.Dispatch.SysMsg.SystemMessage message) { }
     }
@@ -3048,12 +2930,12 @@ namespace Akka.Dispatch
     }
     public sealed class PinnedDispatcher : Akka.Dispatch.Dispatcher
     {
-        public PinnedDispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, System.Nullable<long> throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
+        public PinnedDispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, long? throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
     }
     public class RejectedExecutionException : Akka.Actor.AkkaException
     {
-        public RejectedExecutionException(string message = null, System.Exception inner = null) { }
         protected RejectedExecutionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public RejectedExecutionException(string message = null, System.Exception inner = null) { }
     }
     public enum TaskSchedulerPriority
     {
@@ -3091,7 +2973,7 @@ namespace Akka.Dispatch
         public const int DefaultCapacity = 11;
         protected UnboundedPriorityMailbox(Akka.Actor.Settings settings, Akka.Configuration.Config config) { }
         public int InitialCapacity { get; }
-        public virtual Akka.Dispatch.MessageQueues.IMessageQueue Create(Akka.Actor.IActorRef owner, Akka.Actor.ActorSystem system) { }
+        public override sealed Akka.Dispatch.MessageQueues.IMessageQueue Create(Akka.Actor.IActorRef owner, Akka.Actor.ActorSystem system) { }
         protected abstract int PriorityGenerator(object message);
     }
     public abstract class UnboundedStablePriorityMailbox : Akka.Dispatch.MailboxType, Akka.Dispatch.IProducesMessageQueue<Akka.Dispatch.MessageQueues.UnboundedStablePriorityMessageQueue>
@@ -3099,7 +2981,7 @@ namespace Akka.Dispatch
         public const int DefaultCapacity = 11;
         protected UnboundedStablePriorityMailbox(Akka.Actor.Settings settings, Akka.Configuration.Config config) { }
         public int InitialCapacity { get; }
-        public virtual Akka.Dispatch.MessageQueues.IMessageQueue Create(Akka.Actor.IActorRef owner, Akka.Actor.ActorSystem system) { }
+        public override sealed Akka.Dispatch.MessageQueues.IMessageQueue Create(Akka.Actor.IActorRef owner, Akka.Actor.ActorSystem system) { }
         protected abstract int PriorityGenerator(object message);
     }
 }
@@ -3212,7 +3094,7 @@ namespace Akka.Dispatch.SysMsg
         public System.Exception Reason { get; }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Failed : Akka.Dispatch.SysMsg.SystemMessage
     {
         public Failed(Akka.Actor.IActorRef child, System.Exception cause, long uid) { }
@@ -3267,7 +3149,7 @@ namespace Akka.Dispatch.SysMsg
         public Suspend() { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalStableApiAttribute()]
+    [Akka.Annotations.InternalStableApi]
     public abstract class SystemMessage : Akka.Actor.INoSerializationVerificationNeeded, Akka.Dispatch.SysMsg.ISystemMessage
     {
         protected SystemMessage() { }
@@ -3315,12 +3197,13 @@ namespace Akka
     {
         public static readonly Akka.Done Instance;
     }
+    [System.Serializable]
     public sealed class NotUsed : System.IComparable<Akka.NotUsed>, System.IEquatable<Akka.NotUsed>
     {
         public static readonly Akka.NotUsed Instance;
         public int CompareTo(Akka.NotUsed other) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.NotUsed other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -3373,8 +3256,8 @@ namespace Akka.Event
     public class DefaultLogMessageFormatter : Akka.Event.ILogMessageFormatter
     {
         public static readonly Akka.Event.DefaultLogMessageFormatter Instance;
-        public string Format(string format, params object[] args) { }
         public string Format(string format, System.Collections.Generic.IEnumerable<object> args) { }
+        public string Format(string format, params object[] args) { }
     }
     public class DefaultLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>
     {
@@ -3384,8 +3267,8 @@ namespace Akka.Event
     }
     public sealed class Dropped : Akka.Event.AllDeadLetters
     {
-        public Dropped(object message, string reason, Akka.Actor.IActorRef sender, Akka.Actor.IActorRef recipient) { }
         public Dropped(object message, string reason, Akka.Actor.IActorRef recipient) { }
+        public Dropped(object message, string reason, Akka.Actor.IActorRef sender, Akka.Actor.IActorRef recipient) { }
         public string Reason { get; }
     }
     public class DummyClassForStringSources
@@ -3403,10 +3286,10 @@ namespace Akka.Event
         protected abstract bool Classify(TEvent @event, TClassifier classifier);
         protected abstract TClassifier GetClassifier(TEvent @event);
         protected abstract bool IsSubClassification(TClassifier parent, TClassifier child);
-        protected abstract void Publish(TEvent @event, TSubscriber subscriber);
         public virtual void Publish(TEvent @event) { }
-        protected string SimpleName(object source) { }
+        protected abstract void Publish(TEvent @event, TSubscriber subscriber);
         protected string SimpleName(System.Type source) { }
+        protected string SimpleName(object source) { }
         public virtual bool Subscribe(TSubscriber subscriber, TClassifier classifier) { }
         public virtual bool Unsubscribe(TSubscriber subscriber) { }
         public virtual bool Unsubscribe(TSubscriber subscriber, TClassifier classifier) { }
@@ -3416,26 +3299,25 @@ namespace Akka.Event
         public EventStream(bool debug) { }
         public void StartUnsubscriber(Akka.Actor.Internal.ActorSystemImpl system) { }
         public override bool Subscribe(Akka.Actor.IActorRef subscriber, System.Type channel) { }
-        public override bool Unsubscribe(Akka.Actor.IActorRef subscriber, System.Type channel) { }
         public override bool Unsubscribe(Akka.Actor.IActorRef subscriber) { }
+        public override bool Unsubscribe(Akka.Actor.IActorRef subscriber, System.Type channel) { }
     }
-    public class static EventStreamExtensions
+    public static class EventStreamExtensions
     {
         public static bool Subscribe<TChannel>(this Akka.Event.EventStream eventStream, Akka.Actor.IActorRef subscriber) { }
         public static bool Unsubscribe<TChannel>(this Akka.Event.EventStream eventStream, Akka.Actor.IActorRef subscriber) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ExactMatchLogSourceFilter : Akka.Event.LogFilterBase
     {
         public ExactMatchLogSourceFilter(string source, System.StringComparison comparison = 5) { }
         public override Akka.Event.LogFilterType FilterType { get; }
-        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, [System.Runtime.CompilerServices.NullableAttribute(2)] string expandedMessage = null) { }
+        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, string? expandedMessage = null) { }
     }
     public interface IDeadLetterSuppression { }
     public interface ILogMessageFormatter
     {
-        string Format(string format, params object[] args);
         string Format(string format, System.Collections.Generic.IEnumerable<object> args);
+        string Format(string format, params object[] args);
     }
     public interface ILoggerMessageQueueSemantics : Akka.Dispatch.ISemantics { }
     public interface ILoggingAdapter
@@ -3446,8 +3328,8 @@ namespace Akka.Event
         bool IsInfoEnabled { get; }
         bool IsWarningEnabled { get; }
         bool IsEnabled(Akka.Event.LogLevel logLevel);
-        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format);
         void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message);
+        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format);
     }
     public class Info : Akka.Event.LogEvent
     {
@@ -3463,33 +3345,28 @@ namespace Akka.Event
     public abstract class LogEvent : Akka.Actor.INoSerializationVerificationNeeded
     {
         protected LogEvent() { }
-        public System.Exception Cause { get; set; }
-        public System.Type LogClass { get; set; }
-        public string LogSource { get; set; }
-        public object Message { get; set; }
+        public System.Exception Cause { get; protected set; }
+        public System.Type LogClass { get; protected set; }
+        public string LogSource { get; protected set; }
+        public object Message { get; protected set; }
         public System.Threading.Thread Thread { get; }
         public System.DateTime Timestamp { get; }
         public abstract Akka.Event.LogLevel LogLevel();
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static LogEventExtensions
+    public static class LogEventExtensions
     {
         public static System.Collections.Generic.IEnumerable<object> GetParameters(this Akka.Event.LogEvent evt) { }
         public static System.Collections.Generic.IReadOnlyList<string> GetPropertyNames(this Akka.Event.LogEvent evt) { }
         public static string GetTemplate(this Akka.Event.LogEvent evt) { }
-        public static bool TryGetProperties(this Akka.Event.LogEvent evt, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1,
-                1})] out System.Collections.Generic.IReadOnlyDictionary<string, object> properties) { }
+        public static bool TryGetProperties(this Akka.Event.LogEvent evt, out System.Collections.Generic.IReadOnlyDictionary<string, object>? properties) { }
     }
     public abstract class LogFilterBase : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
     {
         protected LogFilterBase() { }
         public abstract Akka.Event.LogFilterType FilterType { get; }
-        public abstract Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, [System.Runtime.CompilerServices.NullableAttribute(2)] string expandedMessage = null);
+        public abstract Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, string? expandedMessage = null);
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class LogFilterBuilder
     {
         public LogFilterBuilder() { }
@@ -3510,7 +3387,6 @@ namespace Akka.Event
         Drop = 1,
         NoDecision = 2,
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class LogFilterEvaluator
     {
         public static readonly Akka.Event.LogFilterEvaluator NoFilters;
@@ -3518,7 +3394,6 @@ namespace Akka.Event
         public bool EvaluatesLogSourcesOnly { get; }
         public virtual bool ShouldTryKeepMessage(Akka.Event.LogEvent evt, out string expandedLogMessage) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class LogFilterSetup : Akka.Actor.Setup.Setup
     {
         public LogFilterSetup(Akka.Event.LogFilterBase[] filters) { }
@@ -3544,17 +3419,15 @@ namespace Akka.Event
         public string Format { get; }
         public System.Collections.Generic.IReadOnlyList<string> PropertyNames { get; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object> GetProperties() { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public abstract System.Collections.Generic.IEnumerable<object> Parameters();
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public abstract string Unformatted();
     }
-    public class static LogMessageExtensions { }
+    public static class LogMessageExtensions { }
     public struct LogSource
     {
-        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public string Source { get; }
-        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public System.Type Type { get; }
         public static Akka.Event.LogSource Create(object o) { }
         public static Akka.Event.LogSource Create(object o, Akka.Actor.ActorSystem system) { }
@@ -3573,7 +3446,7 @@ namespace Akka.Event
     {
         public LoggerMailbox(Akka.Actor.IActorRef owner, Akka.Actor.ActorSystem system) { }
     }
-    public class static Logging
+    public static class Logging
     {
         public static System.Type ClassFor(this Akka.Event.LogLevel logLevel) { }
         public static Akka.Event.ILoggingAdapter GetLogger(this Akka.Actor.IActorContext context, Akka.Event.ILogMessageFormatter logMessageFormatter = null) { }
@@ -3582,8 +3455,8 @@ namespace Akka.Event
         public static Akka.Event.LogLevel LogLevelFor(string logLevel) { }
         public static Akka.Event.LogLevel LogLevelFor<T>()
             where T : Akka.Event.LogEvent { }
-        public static string SimpleName(object o) { }
         public static string SimpleName(System.Type t) { }
+        public static string SimpleName(object o) { }
         public static string StringFor(this Akka.Event.LogLevel logLevel) { }
     }
     public abstract class LoggingAdapterBase : Akka.Event.ILoggingAdapter
@@ -3610,10 +3483,12 @@ namespace Akka.Event
         public void SetLogLevel(Akka.Event.LogLevel logLevel) { }
         public void StartStdoutLogger(Akka.Actor.Settings config) { }
     }
-    public class static LoggingExtensions
+    public static class LoggingExtensions
     {
         public static void Debug(this Akka.Event.ILoggingAdapter log, string format) { }
         public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
         public static void Debug<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
         public static void Debug<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
         public static void Debug<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
@@ -3626,10 +3501,10 @@ namespace Akka.Event
         public static void Debug<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
         public static void Debug<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
         public static void Debug<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
-        public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
-        public static void Debug(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
         public static void Error(this Akka.Event.ILoggingAdapter log, string format) { }
         public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
         public static void Error<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
         public static void Error<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
         public static void Error<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
@@ -3642,10 +3517,10 @@ namespace Akka.Event
         public static void Error<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
         public static void Error<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
         public static void Error<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
-        public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
-        public static void Error(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
         public static void Info(this Akka.Event.ILoggingAdapter log, string format) { }
         public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
         public static void Info<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
         public static void Info<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
         public static void Info<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
@@ -3658,8 +3533,6 @@ namespace Akka.Event
         public static void Info<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
         public static void Info<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
         public static void Info<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
-        public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
-        public static void Info(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
         public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, string format) { }
         public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, string format, object[] args) { }
         public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, System.Exception cause, string format, object[] args) { }
@@ -3671,6 +3544,8 @@ namespace Akka.Event
         public static void Log<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
         public static void Warning(this Akka.Event.ILoggingAdapter log, string format) { }
         public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
         public static void Warning<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
         public static void Warning<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
         public static void Warning<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
@@ -3683,17 +3558,15 @@ namespace Akka.Event
         public static void Warning<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
         public static void Warning<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
         public static void Warning<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
-        public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
-        public static void Warning(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
     }
     public abstract class MinimalLogger : Akka.Actor.MinimalActorRef
     {
         protected MinimalLogger() { }
         public Akka.Event.LogFilterEvaluator Filter { get; }
-        public virtual Akka.Actor.ActorPath Path { get; }
-        public virtual Akka.Actor.IActorRefProvider Provider { get; }
+        public override sealed Akka.Actor.ActorPath Path { get; }
+        public override sealed Akka.Actor.IActorRefProvider Provider { get; }
         protected abstract void Log(object message);
-        protected virtual void TellInternal(object message, Akka.Actor.IActorRef sender) { }
+        protected override sealed void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
     public sealed class NoLogger : Akka.Event.ILoggingAdapter
     {
@@ -3704,28 +3577,26 @@ namespace Akka.Event
         public bool IsInfoEnabled { get; }
         public bool IsWarningEnabled { get; }
         public bool IsEnabled(Akka.Event.LogLevel logLevel) { }
-        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format) { }
         public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class RegexLogMessageFilter : Akka.Event.LogFilterBase
     {
         public RegexLogMessageFilter(System.Text.RegularExpressions.Regex messageRegex) { }
         public override Akka.Event.LogFilterType FilterType { get; }
-        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, [System.Runtime.CompilerServices.NullableAttribute(2)] string expandedMessage = null) { }
+        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, string? expandedMessage = null) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class RegexLogSourceFilter : Akka.Event.LogFilterBase
     {
         public RegexLogSourceFilter(System.Text.RegularExpressions.Regex sourceRegex) { }
         public override Akka.Event.LogFilterType FilterType { get; }
-        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, [System.Runtime.CompilerServices.NullableAttribute(2)] string expandedMessage = null) { }
+        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, string? expandedMessage = null) { }
     }
     public sealed class SemanticLogMessageFormatter : Akka.Event.ILogMessageFormatter
     {
         public static readonly Akka.Event.SemanticLogMessageFormatter Instance;
-        public string Format(string format, params object[] args) { }
         public string Format(string format, System.Collections.Generic.IEnumerable<object> args) { }
+        public string Format(string format, params object[] args) { }
     }
     public class StandardOutLogger : Akka.Event.MinimalLogger
     {
@@ -3739,8 +3610,8 @@ namespace Akka.Event
     }
     public class Subscription<TSubscriber, TClassifier>
     {
-        public Subscription(TSubscriber subscriber, System.Collections.Generic.IEnumerable<TClassifier> unsubscriptions) { }
         public Subscription(TSubscriber subscriber) { }
+        public Subscription(TSubscriber subscriber, System.Collections.Generic.IEnumerable<TClassifier> unsubscriptions) { }
         public TSubscriber Subscriber { get; }
         public System.Collections.Generic.ISet<TClassifier> Unsubscriptions { get; }
     }
@@ -3795,37 +3666,23 @@ namespace Akka.IO
         BigEndian = 0,
         LittleEndian = 1,
     }
-    [System.Diagnostics.DebuggerDisplayAttribute("(Count = {_count}, Buffers = {_buffers})")]
+    [System.Diagnostics.DebuggerDisplay("(Count = {_count}, Buffers = {_buffers})")]
     public sealed class ByteString : System.Collections.Generic.IEnumerable<byte>, System.Collections.IEnumerable, System.IEquatable<Akka.IO.ByteString>
     {
         public int Count { get; }
-        public static Akka.IO.ByteString Empty { get; }
         public bool IsCompact { get; }
         public bool IsEmpty { get; }
         public byte this[int index] { get; }
+        public static Akka.IO.ByteString Empty { get; }
         public Akka.IO.ByteString Compact() { }
         public Akka.IO.ByteString Concat(Akka.IO.ByteString other) { }
-        public static Akka.IO.ByteString CopyFrom(byte[] array) { }
-        public static Akka.IO.ByteString CopyFrom(System.ArraySegment<byte> buffer) { }
-        public static Akka.IO.ByteString CopyFrom(byte[] array, int offset, int count) { }
-        public static Akka.IO.ByteString CopyFrom(System.Memory<byte> memory) { }
-        public static Akka.IO.ByteString CopyFrom(System.Memory<byte> memory, int offset, int count) { }
-        public static Akka.IO.ByteString CopyFrom(System.Span<byte> span) { }
-        public static Akka.IO.ByteString CopyFrom(System.Span<byte> span, int offset, int count) { }
-        public static Akka.IO.ByteString CopyFrom(System.Collections.Generic.IEnumerable<System.ArraySegment<byte>> buffers) { }
-        public int CopyTo(byte[] buffer, int index, int count) { }
         public int CopyTo(ref System.Memory<byte> buffer) { }
-        public int CopyTo(ref System.Memory<byte> buffer, int index, int count) { }
         public int CopyTo(ref System.Span<byte> buffer) { }
+        public int CopyTo(ref System.Memory<byte> buffer, int index, int count) { }
         public int CopyTo(ref System.Span<byte> buffer, int index, int count) { }
-        public override bool Equals(object obj) { }
+        public int CopyTo(byte[] buffer, int index, int count) { }
         public bool Equals(Akka.IO.ByteString other) { }
-        public static Akka.IO.ByteString FromBytes(byte[] array) { }
-        public static Akka.IO.ByteString FromBytes(System.ArraySegment<byte> buffer) { }
-        public static Akka.IO.ByteString FromBytes(byte[] array, int offset, int count) { }
-        public static Akka.IO.ByteString FromBytes(System.Collections.Generic.IEnumerable<System.ArraySegment<byte>> buffers) { }
-        public static Akka.IO.ByteString FromString(string str) { }
-        public static Akka.IO.ByteString FromString(string str, System.Text.Encoding encoding) { }
+        public override bool Equals(object obj) { }
         public System.Collections.Generic.IEnumerator<byte> GetEnumerator() { }
         public override int GetHashCode() { }
         public bool HasSubstring(Akka.IO.ByteString other, int index) { }
@@ -3839,13 +3696,27 @@ namespace Akka.IO
         public string ToString(System.Text.Encoding encoding) { }
         public void WriteTo(System.IO.Stream stream) { }
         public System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream) { }
-        public static Akka.IO.ByteString +(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
-        public static bool ==(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
-        public static Akka.IO.ByteString op_Explicit(byte[] bytes) { }
+        public static Akka.IO.ByteString CopyFrom(System.ArraySegment<byte> buffer) { }
+        public static Akka.IO.ByteString CopyFrom(System.Collections.Generic.IEnumerable<System.ArraySegment<byte>> buffers) { }
+        public static Akka.IO.ByteString CopyFrom(System.Memory<byte> memory) { }
+        public static Akka.IO.ByteString CopyFrom(System.Span<byte> span) { }
+        public static Akka.IO.ByteString CopyFrom(byte[] array) { }
+        public static Akka.IO.ByteString CopyFrom(System.Memory<byte> memory, int offset, int count) { }
+        public static Akka.IO.ByteString CopyFrom(System.Span<byte> span, int offset, int count) { }
+        public static Akka.IO.ByteString CopyFrom(byte[] array, int offset, int count) { }
+        public static Akka.IO.ByteString FromBytes(System.ArraySegment<byte> buffer) { }
+        public static Akka.IO.ByteString FromBytes(System.Collections.Generic.IEnumerable<System.ArraySegment<byte>> buffers) { }
+        public static Akka.IO.ByteString FromBytes(byte[] array) { }
+        public static Akka.IO.ByteString FromBytes(byte[] array, int offset, int count) { }
+        public static Akka.IO.ByteString FromString(string str) { }
+        public static Akka.IO.ByteString FromString(string str, System.Text.Encoding encoding) { }
         public static byte[] op_Explicit(Akka.IO.ByteString byteString) { }
-        public static bool !=(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
+        public static Akka.IO.ByteString op_Explicit(byte[] bytes) { }
+        public static bool operator !=(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
+        public static Akka.IO.ByteString operator +(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
+        public static bool operator ==(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ConnectException : System.Exception
     {
         public ConnectException(string message) { }
@@ -3854,8 +3725,8 @@ namespace Akka.IO
     {
         public static readonly Akka.IO.Dns Instance;
         public Dns() { }
-        public static Akka.IO.Dns.Resolved Cached(string name, Akka.Actor.ActorSystem system) { }
         public override Akka.IO.DnsExt CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
+        public static Akka.IO.Dns.Resolved Cached(string name, Akka.Actor.ActorSystem system) { }
         public static Akka.IO.Dns.Resolved ResolveName(string name, Akka.Actor.ActorSystem system, Akka.Actor.IActorRef sender) { }
         public abstract class Command : Akka.Actor.INoSerializationVerificationNeeded
         {
@@ -3936,7 +3807,7 @@ namespace Akka.IO
             public DatagramChannelCreator() { }
             public virtual System.Net.Sockets.Socket Create(System.Net.Sockets.AddressFamily addressFamily) { }
         }
-        public class static SO
+        public static class SO
         {
             public class ReceiveBufferSize : Akka.IO.Inet.SocketOption
             {
@@ -4024,14 +3895,13 @@ namespace Akka.IO
         }
         public class Bind : Akka.IO.Tcp.Command
         {
-            public Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint localAddress, int backlog = 1024, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, bool pullMode = False) { }
+            public Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint localAddress, int backlog = 1024, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, bool pullMode = false) { }
             public int Backlog { get; }
             public Akka.Actor.IActorRef Handler { get; }
             public System.Net.EndPoint LocalAddress { get; }
             public System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> Options { get; }
             public bool PullMode { get; }
-            [System.Runtime.CompilerServices.NullableAttribute(2)]
-            public Akka.IO.TcpSettings TcpSettings { get; set; }
+            public Akka.IO.TcpSettings? TcpSettings { get; set; }
             public override string ToString() { }
         }
         public sealed class Bound : Akka.IO.Tcp.Event
@@ -4061,14 +3931,14 @@ namespace Akka.IO
         }
         public sealed class CommandFailed : Akka.IO.Tcp.Event
         {
-            public CommandFailed(Akka.IO.Tcp.Command cmd, Akka.Util.Option<System.Exception> ex) { }
             public CommandFailed(Akka.IO.Tcp.Command cmd) { }
+            public CommandFailed(Akka.IO.Tcp.Command cmd, Akka.Util.Option<System.Exception> ex) { }
             public Akka.Util.Option<System.Exception> Cause { get; }
-            [Akka.Annotations.InternalApiAttribute()]
+            [Akka.Annotations.InternalApi]
             public string CauseString { get; }
             public Akka.IO.Tcp.Command Cmd { get; }
             public override string ToString() { }
-            [Akka.Annotations.InternalApiAttribute()]
+            [Akka.Annotations.InternalApi]
             public Akka.IO.Tcp.CommandFailed WithCause(System.Exception cause) { }
         }
         public sealed class CompoundWrite : Akka.IO.Tcp.WriteCommand, System.Collections.Generic.IEnumerable<Akka.IO.Tcp.SimpleWriteCommand>, System.Collections.IEnumerable
@@ -4092,14 +3962,13 @@ namespace Akka.IO
         }
         public sealed class Connect : Akka.IO.Tcp.Command
         {
-            public Connect(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress = null, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, System.Nullable<System.TimeSpan> timeout = null, bool pullMode = False) { }
+            public Connect(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress = null, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, System.TimeSpan? timeout = default, bool pullMode = false) { }
             public System.Net.EndPoint LocalAddress { get; }
             public System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> Options { get; }
             public bool PullMode { get; }
             public System.Net.EndPoint RemoteAddress { get; }
-            [System.Runtime.CompilerServices.NullableAttribute(2)]
-            public Akka.IO.TcpSettings TcpSettings { get; set; }
-            public System.Nullable<System.TimeSpan> Timeout { get; }
+            public Akka.IO.TcpSettings? TcpSettings { get; set; }
+            public System.TimeSpan? Timeout { get; }
             public override string ToString() { }
         }
         public sealed class Connected : Akka.IO.Tcp.Event
@@ -4112,18 +3981,16 @@ namespace Akka.IO
         public class ConnectionClosed : Akka.IO.Tcp.Event, Akka.Event.IDeadLetterSuppression
         {
             public ConnectionClosed() { }
-            [System.Runtime.CompilerServices.NullableAttribute(2)]
-            public virtual string Cause { get; }
+            public virtual string? Cause { get; }
             public virtual bool IsAborted { get; }
             public virtual bool IsConfirmed { get; }
             public virtual bool IsErrorClosed { get; }
             public virtual bool IsPeerClosed { get; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class ErrorClosed : Akka.IO.Tcp.ConnectionClosed
         {
-            public ErrorClosed(string cause) { }
-            public override string Cause { get; }
+            public ErrorClosed(string? cause) { }
+            public override string? Cause { get; }
             public override bool IsErrorClosed { get; }
             public override string ToString() { }
         }
@@ -4156,7 +4023,7 @@ namespace Akka.IO
         }
         public class Register : Akka.IO.Tcp.Command
         {
-            public Register(Akka.Actor.IActorRef handler, bool keepOpenOnPeerClosed = False, bool useResumeWriting = True) { }
+            public Register(Akka.Actor.IActorRef handler, bool keepOpenOnPeerClosed = false, bool useResumeWriting = true) { }
             public Akka.Actor.IActorRef Handler { get; }
             public bool KeepOpenOnPeerClosed { get; }
             public bool UseResumeWriting { get; }
@@ -4186,20 +4053,19 @@ namespace Akka.IO
         public sealed class SubscribeToTcpListenerStats : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.SubscribeToTcpListenerStats>
         {
             public SubscribeToTcpListenerStats(Akka.Actor.IActorRef Subscriber) { }
-            public Akka.Actor.IActorRef Subscriber { get; set; }
+            public Akka.Actor.IActorRef Subscriber { get; init; }
         }
         public sealed class SuspendReading : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.SuspendReading Instance;
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class TcpListenerStatistics : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.TcpListenerStatistics>
         {
             public TcpListenerStatistics() { }
-            public long AcceptedIncomingConnections { get; set; }
-            public long FailedIncomingConnections { get; set; }
-            public long IncomingConnectionsClosed { get; set; }
-            public long RetriedIncomingConnections { get; set; }
+            public long AcceptedIncomingConnections { get; init; }
+            public long FailedIncomingConnections { get; init; }
+            public long IncomingConnectionsClosed { get; init; }
+            public long RetriedIncomingConnections { get; init; }
         }
         public class Unbind : Akka.IO.Tcp.Command
         {
@@ -4212,7 +4078,7 @@ namespace Akka.IO
         public sealed class UnsubscribeFromTcpListenerStats : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.UnsubscribeFromTcpListenerStats>
         {
             public UnsubscribeFromTcpListenerStats(Akka.Actor.IActorRef Subscriber) { }
-            public Akka.Actor.IActorRef Subscriber { get; set; }
+            public Akka.Actor.IActorRef Subscriber { get; init; }
         }
         public sealed class Write : Akka.IO.Tcp.SimpleWriteCommand
         {
@@ -4220,18 +4086,18 @@ namespace Akka.IO
             public override Akka.IO.Tcp.Event Ack { get; }
             public override long Bytes { get; }
             public Akka.IO.ByteString Data { get; }
+            public override string ToString() { }
             public static Akka.IO.Tcp.Write Create(Akka.IO.ByteString data) { }
             public static Akka.IO.Tcp.Write Create(Akka.IO.ByteString data, Akka.IO.Tcp.Event ack) { }
-            public override string ToString() { }
         }
         public abstract class WriteCommand : Akka.IO.Tcp.Command
         {
             protected WriteCommand() { }
             public abstract long Bytes { get; }
-            public static Akka.IO.Tcp.WriteCommand Create(System.Collections.Generic.IEnumerable<Akka.IO.Tcp.WriteCommand> writes) { }
-            public static Akka.IO.Tcp.WriteCommand Create(params WriteCommand[] writes) { }
             public Akka.IO.Tcp.CompoundWrite Prepend(Akka.IO.Tcp.SimpleWriteCommand other) { }
             public Akka.IO.Tcp.WriteCommand Prepend(System.Collections.Generic.IEnumerable<Akka.IO.Tcp.WriteCommand> writes) { }
+            public static Akka.IO.Tcp.WriteCommand Create(params Akka.IO.Tcp.WriteCommand[] writes) { }
+            public static Akka.IO.Tcp.WriteCommand Create(System.Collections.Generic.IEnumerable<Akka.IO.Tcp.WriteCommand> writes) { }
         }
         public sealed class WritingResumed : Akka.IO.Tcp.Event
         {
@@ -4244,21 +4110,21 @@ namespace Akka.IO
         public override Akka.Actor.IActorRef Manager { get; }
         public Akka.IO.TcpSettings Settings { get; }
     }
-    public class static TcpExtensions
+    public static class TcpExtensions
     {
         public static Akka.Actor.IActorRef Tcp(this Akka.Actor.ActorSystem system) { }
     }
-    public class static TcpMessage
+    public static class TcpMessage
     {
         public static Akka.IO.Tcp.Command Abort() { }
-        public static Akka.IO.Tcp.Command Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint endpoint, int backlog, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, bool pullMode) { }
         public static Akka.IO.Tcp.Command Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint endpoint, int backlog) { }
+        public static Akka.IO.Tcp.Command Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint endpoint, int backlog, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, bool pullMode) { }
         public static Akka.IO.Tcp.Command Close() { }
         public static Akka.IO.Tcp.Command ConfirmedClose() { }
-        public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress, [System.Runtime.CompilerServices.NullableAttribute(2)] System.Net.EndPoint localAddress, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, System.Nullable<System.TimeSpan> timeout, bool pullMode) { }
         public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress) { }
+        public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress, System.Net.EndPoint? localAddress, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, System.TimeSpan? timeout, bool pullMode) { }
         public static Akka.IO.Tcp.NoAck NoAck(object token = null) { }
-        public static Akka.IO.Tcp.Command Register(Akka.Actor.IActorRef handler, bool keepOpenOnPeerClosed = False, bool useResumeWriting = True) { }
+        public static Akka.IO.Tcp.Command Register(Akka.Actor.IActorRef handler, bool keepOpenOnPeerClosed = false, bool useResumeWriting = true) { }
         public static Akka.IO.Tcp.Command ResumeAccepting(int batchSize) { }
         public static Akka.IO.Tcp.Command ResumeReading() { }
         public static Akka.IO.Tcp.Command ResumeWriting() { }
@@ -4268,29 +4134,29 @@ namespace Akka.IO
     }
     public sealed class TcpSettings : System.IEquatable<Akka.IO.TcpSettings>
     {
-        [System.ObsoleteAttribute("Many of these options are no longer used. Use the TcpSettings.Create method inste" +
+        [System.Obsolete("Many of these options are no longer used. Use the TcpSettings.Create method inste" +
             "ad.")]
-        public TcpSettings(string bufferPoolConfigPath, int initialSocketAsyncEventArgs, bool traceLogging, int batchAcceptLimit, System.Nullable<System.TimeSpan> registerTimeout, int receivedMessageSizeLimit, string managementDispatcher, string fileIoDispatcher, int transferToLimit, int finishConnectRetries, bool outgoingSocketForceIpv4, int writeCommandsQueueMaxSize) { }
-        public int BatchAcceptLimit { get; set; }
-        [System.ObsoleteAttribute("This property is unused")]
+        public TcpSettings(string bufferPoolConfigPath, int initialSocketAsyncEventArgs, bool traceLogging, int batchAcceptLimit, System.TimeSpan? registerTimeout, int receivedMessageSizeLimit, string managementDispatcher, string fileIoDispatcher, int transferToLimit, int finishConnectRetries, bool outgoingSocketForceIpv4, int writeCommandsQueueMaxSize) { }
+        public int BatchAcceptLimit { get; init; }
+        [System.Obsolete("This property is unused")]
         public string BufferPoolConfigPath { get; }
-        [System.ObsoleteAttribute("This property is unused")]
+        [System.Obsolete("This property is unused")]
         public string FileIODispatcher { get; }
-        public int FinishConnectRetries { get; set; }
-        [System.ObsoleteAttribute("This property is unused")]
+        public int FinishConnectRetries { get; init; }
+        [System.Obsolete("This property is unused")]
         public int InitialSocketAsyncEventArgs { get; }
         public string ManagementDispatcher { get; }
-        public int MaxFrameSizeBytes { get; set; }
-        public bool OutgoingSocketForceIpv4 { get; set; }
-        public int ReceiveBufferSize { get; set; }
-        [System.ObsoleteAttribute("This property is now MaxFrameSizeBytes")]
+        public int MaxFrameSizeBytes { get; init; }
+        public bool OutgoingSocketForceIpv4 { get; init; }
+        public int ReceiveBufferSize { get; init; }
+        [System.Obsolete("This property is now MaxFrameSizeBytes")]
         public long ReceivedMessageSizeLimit { get; }
-        public System.Nullable<System.TimeSpan> RegisterTimeout { get; set; }
-        public int SendBufferSize { get; set; }
-        public bool TraceLogging { get; set; }
-        [System.ObsoleteAttribute("This property is unused")]
+        public System.TimeSpan? RegisterTimeout { get; init; }
+        public int SendBufferSize { get; init; }
+        public bool TraceLogging { get; init; }
+        [System.Obsolete("This property is unused")]
         public int TransferToLimit { get; set; }
-        public int WriteCommandsQueueMaxSize { get; set; }
+        public int WriteCommandsQueueMaxSize { get; init; }
         public static Akka.IO.TcpSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.IO.TcpSettings Create(Akka.Configuration.Config config) { }
     }
@@ -4368,8 +4234,8 @@ namespace Akka.IO
             public Akka.IO.ByteString Payload { get; }
             public System.Net.EndPoint Target { get; }
             public bool WantsAck { get; }
-            public static Akka.IO.Udp.Send Create(Akka.IO.ByteString data, System.Net.EndPoint target) { }
             public override string ToString() { }
+            public static Akka.IO.Udp.Send Create(Akka.IO.ByteString data, System.Net.EndPoint target) { }
         }
         public sealed class SimpleSender : Akka.IO.Udp.Command
         {
@@ -4477,7 +4343,7 @@ namespace Akka.IO
         public UdpExt(Akka.Actor.ExtendedActorSystem system, Akka.IO.UdpSettings settings) { }
         public override Akka.Actor.IActorRef Manager { get; }
     }
-    public class static UdpExtensions
+    public static class UdpExtensions
     {
         public static Akka.Actor.IActorRef Udp(this Akka.Actor.ActorSystem system) { }
     }
@@ -4496,12 +4362,12 @@ namespace Akka.IO
 }
 namespace Akka.Pattern
 {
-    public class static Backoff
+    public static class Backoff
     {
-        [System.ObsoleteAttribute("Use the overloaded one which accepts maxNrOfRetries instead.")]
+        [System.Obsolete("Use the overloaded one which accepts maxNrOfRetries instead.")]
         public static Akka.Pattern.BackoffOptions OnFailure(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public static Akka.Pattern.BackoffOptions OnFailure(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
-        [System.ObsoleteAttribute("Use the overloaded one which accepts maxNrOfRetries instead.")]
+        [System.Obsolete("Use the overloaded one which accepts maxNrOfRetries instead.")]
         public static Akka.Pattern.BackoffOptions OnStop(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public static Akka.Pattern.BackoffOptions OnStop(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
     }
@@ -4520,39 +4386,46 @@ namespace Akka.Pattern
     {
         public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, Akka.Pattern.IBackoffReset reset, double randomFactor, Akka.Actor.SupervisorStrategy strategy, object replyWhileStopped = null, System.Func<object, bool> finalStopMessage = null) { }
-        public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
-        public static Akka.Actor.Props Props(Akka.Pattern.BackoffOptions options) { }
-        public static Akka.Actor.Props PropsWithSupervisorStrategy(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, Akka.Actor.SupervisorStrategy strategy) { }
         protected override bool Receive(object message) { }
         protected override Akka.Actor.SupervisorStrategy SupervisorStrategy() { }
+        public static Akka.Actor.Props Props(Akka.Pattern.BackoffOptions options) { }
+        public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
+        public static Akka.Actor.Props PropsWithSupervisorStrategy(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, Akka.Actor.SupervisorStrategy strategy) { }
+        [System.Serializable]
         public sealed class CurrentChild
         {
             public CurrentChild(Akka.Actor.IActorRef @ref) { }
             public Akka.Actor.IActorRef Ref { get; }
         }
+        [System.Serializable]
         public sealed class GetCurrentChild
         {
             public static readonly Akka.Pattern.BackoffSupervisor.GetCurrentChild Instance;
         }
+        [System.Serializable]
         public sealed class GetRestartCount
         {
             public static readonly Akka.Pattern.BackoffSupervisor.GetRestartCount Instance;
         }
+        [System.Serializable]
         public sealed class Reset
         {
             public static readonly Akka.Pattern.BackoffSupervisor.Reset Instance;
         }
+        [System.Serializable]
         public sealed class ResetRestartCount : Akka.Event.IDeadLetterSuppression
         {
             public ResetRestartCount(int current) { }
             public int Current { get; }
         }
+        [System.Serializable]
         public sealed class RestartCount
         {
             public RestartCount(int count) { }
             public int Count { get; }
         }
+        [System.Serializable]
         public sealed class StartChild : Akka.Event.IDeadLetterSuppression
         {
             public static readonly Akka.Pattern.BackoffSupervisor.StartChild Instance;
@@ -4588,34 +4461,34 @@ namespace Akka.Pattern
         public double RandomFactor { get; }
         public System.TimeSpan ResetTimeout { get; }
         public Akka.Actor.IScheduler Scheduler { get; }
-        public static Akka.Pattern.CircuitBreaker Create(Akka.Actor.IScheduler scheduler, int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
         public void Fail() { }
         public Akka.Pattern.CircuitBreaker OnClose(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
         public void Succeed() { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
-            " Since 1.5.42")]
-        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
-        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
-            " Since 1.5.42")]
-        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.Tasks.Task<T>> body) { }
-        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+        [System.Obsolete("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
             " Since 1.5.42")]
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+        [System.Obsolete("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
+        [System.Obsolete("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
             " Since 1.5.42")]
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.Tasks.Task> body) { }
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
+        [System.Obsolete("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
         public Akka.Pattern.CircuitBreaker WithExponentialBackoff(System.TimeSpan maxResetTimeout) { }
         public Akka.Pattern.CircuitBreaker WithRandomFactor(double randomFactor) { }
         public void WithSyncCircuitBreaker(System.Action body) { }
         public T WithSyncCircuitBreaker<T>(System.Func<T> body) { }
+        public static Akka.Pattern.CircuitBreaker Create(Akka.Actor.IScheduler scheduler, int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
     }
-    public class static FutureTimeoutSupport
+    public static class FutureTimeoutSupport
     {
         public static System.Threading.Tasks.Task<T> After<T>(System.TimeSpan duration, Akka.Actor.IScheduler scheduler, System.Func<System.Threading.Tasks.Task<T>> value) { }
     }
@@ -4623,28 +4496,28 @@ namespace Akka.Pattern
     public class IllegalStateException : Akka.Actor.AkkaException
     {
         public IllegalStateException(string message) { }
-        public IllegalStateException(string message, System.Exception innerEx) { }
         protected IllegalStateException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public IllegalStateException(string message, System.Exception innerEx) { }
     }
     public class OpenCircuitException : Akka.Actor.AkkaException
     {
         public OpenCircuitException() { }
-        public OpenCircuitException(string message) { }
-        public OpenCircuitException(string message, System.TimeSpan remainingDuration) { }
-        public OpenCircuitException(string message, System.Exception cause) { }
-        public OpenCircuitException(string message, System.Exception cause, System.TimeSpan remainingDuration) { }
         public OpenCircuitException(System.Exception cause) { }
+        public OpenCircuitException(string message) { }
         public OpenCircuitException(System.Exception cause, System.TimeSpan remainingDuration) { }
         protected OpenCircuitException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public OpenCircuitException(string message, System.Exception cause) { }
+        public OpenCircuitException(string message, System.TimeSpan remainingDuration) { }
+        public OpenCircuitException(string message, System.Exception cause, System.TimeSpan remainingDuration) { }
         public System.TimeSpan RemainingDuration { get; }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static RetrySupport
+    public static class RetrySupport
     {
         public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts) { }
-        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, int randomFactor, Akka.Actor.IScheduler scheduler) { }
-        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan delay, Akka.Actor.IScheduler scheduler) { }
         public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.Func<int, Akka.Util.Option<System.TimeSpan>> delayFunction, Akka.Actor.IScheduler scheduler) { }
+        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan delay, Akka.Actor.IScheduler scheduler) { }
+        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, int randomFactor, Akka.Actor.IScheduler scheduler) { }
     }
     public class UserCalledFailException : Akka.Actor.AkkaException
     {
@@ -4658,9 +4531,9 @@ namespace Akka.Routing
     {
         public ActorRefRoutee(Akka.Actor.IActorRef actor) { }
         public Akka.Actor.IActorRef Actor { get; }
-        public override System.Threading.Tasks.Task<object> Ask(object message, System.Nullable<System.TimeSpan> timeout) { }
-        public override bool Equals(object obj) { }
+        public override System.Threading.Tasks.Task<object> Ask(object message, System.TimeSpan? timeout) { }
         protected bool Equals(Akka.Routing.ActorRefRoutee other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override void Send(object message, Akka.Actor.IActorRef sender) { }
     }
@@ -4668,9 +4541,9 @@ namespace Akka.Routing
     {
         public ActorSelectionRoutee(Akka.Actor.ActorSelection actor) { }
         public Akka.Actor.ActorSelection Selection { get; }
-        public override System.Threading.Tasks.Task<object> Ask(object message, System.Nullable<System.TimeSpan> timeout) { }
-        public override bool Equals(object obj) { }
+        public override System.Threading.Tasks.Task<object> Ask(object message, System.TimeSpan? timeout) { }
         protected bool Equals(Akka.Routing.ActorSelectionRoutee other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override void Send(object message, Akka.Actor.IActorRef sender) { }
     }
@@ -4691,8 +4564,8 @@ namespace Akka.Routing
     public sealed class BroadcastGroup : Akka.Routing.Group
     {
         public BroadcastGroup(Akka.Configuration.Config config) { }
-        public BroadcastGroup(params string[] paths) { }
         public BroadcastGroup(System.Collections.Generic.IEnumerable<string> paths) { }
+        public BroadcastGroup(params string[] paths) { }
         public BroadcastGroup(System.Collections.Generic.IEnumerable<string> paths, string routerDispatcher) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override System.Collections.Generic.IEnumerable<string> GetPaths(Akka.Actor.ActorSystem system) { }
@@ -4708,9 +4581,9 @@ namespace Akka.Routing
     }
     public sealed class BroadcastPool : Akka.Routing.Pool
     {
-        public BroadcastPool(int nrOfInstances) { }
         public BroadcastPool(Akka.Configuration.Config config) { }
-        public BroadcastPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False) { }
+        public BroadcastPool(int nrOfInstances) { }
+        public BroadcastPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem system) { }
         public override Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
@@ -4734,7 +4607,7 @@ namespace Akka.Routing
         public BroadcastRoutingLogic() { }
         public override Akka.Routing.Routee Select(object message, Akka.Routing.Routee[] routees) { }
     }
-    public class static ConsistentHash
+    public static class ConsistentHash
     {
         public static Akka.Routing.ConsistentHash<T> Create<T>(System.Collections.Generic.IEnumerable<T> nodes, int virtualNodesFactor) { }
         public class ConsistentHashingPoolSurrogate : Akka.Util.ISurrogate
@@ -4757,9 +4630,9 @@ namespace Akka.Routing
         public T NodeFor(byte[] key) { }
         public T NodeFor(string key) { }
         public Akka.Routing.ConsistentHash<T> Remove(T node) { }
-        public static Akka.Routing.ConsistentHash<T> +(Akka.Routing.ConsistentHash<T> hash, T node) { }
-        public static Akka.Routing.ConsistentHash<T> -(Akka.Routing.ConsistentHash<T> hash, T node) { }
-        public class ConsistentHashingGroupSurrogate<T> : Akka.Util.ISurrogate
+        public static Akka.Routing.ConsistentHash<T> operator +(Akka.Routing.ConsistentHash<T> hash, T node) { }
+        public static Akka.Routing.ConsistentHash<T> operator -(Akka.Routing.ConsistentHash<T> hash, T node) { }
+        public class ConsistentHashingGroupSurrogate : Akka.Util.ISurrogate
         {
             public ConsistentHashingGroupSurrogate() { }
             public string[] Paths { get; set; }
@@ -4775,8 +4648,8 @@ namespace Akka.Routing
     public sealed class ConsistentHashingGroup : Akka.Routing.Group
     {
         public ConsistentHashingGroup(Akka.Configuration.Config config) { }
-        public ConsistentHashingGroup(params string[] paths) { }
         public ConsistentHashingGroup(System.Collections.Generic.IEnumerable<string> paths) { }
+        public ConsistentHashingGroup(params string[] paths) { }
         public ConsistentHashingGroup(System.Collections.Generic.IEnumerable<string> paths, Akka.Routing.ConsistentHashMapping hashMapping) { }
         public ConsistentHashingGroup(System.Collections.Generic.IEnumerable<string> paths, int virtualNodesFactor, Akka.Routing.ConsistentHashMapping hashMapping, string routerDispatcher) { }
         public int VirtualNodesFactor { get; }
@@ -4797,10 +4670,10 @@ namespace Akka.Routing
     }
     public sealed class ConsistentHashingPool : Akka.Routing.Pool
     {
-        public ConsistentHashingPool(int nrOfInstances) { }
         public ConsistentHashingPool(Akka.Configuration.Config config) { }
+        public ConsistentHashingPool(int nrOfInstances) { }
         public ConsistentHashingPool(int nrOfInstances, Akka.Routing.ConsistentHashMapping hashMapping) { }
-        public ConsistentHashingPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False, int virtualNodesFactor = 0, Akka.Routing.ConsistentHashMapping hashMapping = null) { }
+        public ConsistentHashingPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false, int virtualNodesFactor = 0, Akka.Routing.ConsistentHashMapping hashMapping = null) { }
         public int VirtualNodesFactor { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem system) { }
@@ -4855,12 +4728,12 @@ namespace Akka.Routing
         public bool Equals(Akka.Routing.DefaultResizer other) { }
         public override bool Equals(object obj) { }
         public int Filter(int pressure, int capacity) { }
-        public static Akka.Routing.DefaultResizer FromConfig(Akka.Configuration.Config resizerConfig) { }
         public override int GetHashCode() { }
         public override bool IsTimeForResize(long messageCounter) { }
         public int Pressure(System.Collections.Generic.IEnumerable<Akka.Routing.Routee> currentRoutees) { }
         public int Rampup(int pressure, int capacity) { }
         public override int Resize(System.Collections.Generic.IEnumerable<Akka.Routing.Routee> currentRoutees) { }
+        public new static Akka.Routing.DefaultResizer FromConfig(Akka.Configuration.Config resizerConfig) { }
     }
     public class FromConfig : Akka.Routing.Pool
     {
@@ -4928,8 +4801,8 @@ namespace Akka.Routing
     public class NoRouter : Akka.Routing.RouterConfig
     {
         protected NoRouter() { }
-        public static Akka.Routing.NoRouter Instance { get; }
         public override string RouterDispatcher { get; }
+        public static Akka.Routing.NoRouter Instance { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override Akka.Actor.ActorBase CreateRouterActor() { }
         public Akka.Actor.Props Props(Akka.Actor.Props routeeProps) { }
@@ -4944,12 +4817,12 @@ namespace Akka.Routing
     public abstract class Pool : Akka.Routing.RouterConfig, System.IEquatable<Akka.Routing.Pool>
     {
         protected Pool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher) { }
-        public static Akka.Actor.SupervisorStrategy DefaultSupervisorStrategy { get; }
         public int NrOfInstances { get; }
         public virtual Akka.Routing.Resizer Resizer { get; }
         public override bool StopRouterWhenAllRouteesRemoved { get; }
         public virtual Akka.Actor.SupervisorStrategy SupervisorStrategy { get; }
         public virtual bool UsePoolDispatcher { get; }
+        public static Akka.Actor.SupervisorStrategy DefaultSupervisorStrategy { get; }
         public override Akka.Actor.ActorBase CreateRouterActor() { }
         public bool Equals(Akka.Routing.Pool other) { }
         public override bool Equals(object obj) { }
@@ -4960,8 +4833,8 @@ namespace Akka.Routing
     public sealed class RandomGroup : Akka.Routing.Group
     {
         public RandomGroup(Akka.Configuration.Config config) { }
-        public RandomGroup(params string[] paths) { }
         public RandomGroup(System.Collections.Generic.IEnumerable<string> paths) { }
+        public RandomGroup(params string[] paths) { }
         public RandomGroup(System.Collections.Generic.IEnumerable<string> paths, string routerDispatcher) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override System.Collections.Generic.IEnumerable<string> GetPaths(Akka.Actor.ActorSystem system) { }
@@ -4984,7 +4857,7 @@ namespace Akka.Routing
     {
         public RandomPool(Akka.Configuration.Config config) { }
         public RandomPool(int nrOfInstances) { }
-        public RandomPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False) { }
+        public RandomPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem system) { }
         public override Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
@@ -5015,15 +4888,15 @@ namespace Akka.Routing
     public abstract class Resizer
     {
         protected Resizer() { }
-        public static Akka.Routing.Resizer FromConfig(Akka.Configuration.Config parentConfig) { }
         public abstract bool IsTimeForResize(long messageCounter);
         public abstract int Resize(System.Collections.Generic.IEnumerable<Akka.Routing.Routee> currentRoutees);
+        public static Akka.Routing.Resizer FromConfig(Akka.Configuration.Config parentConfig) { }
     }
     public sealed class RoundRobinGroup : Akka.Routing.Group
     {
         public RoundRobinGroup(Akka.Configuration.Config config) { }
-        public RoundRobinGroup(params string[] paths) { }
         public RoundRobinGroup(System.Collections.Generic.IEnumerable<string> paths) { }
+        public RoundRobinGroup(params string[] paths) { }
         public RoundRobinGroup(System.Collections.Generic.IEnumerable<string> paths, string routerDispatcher) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override System.Collections.Generic.IEnumerable<string> GetPaths(Akka.Actor.ActorSystem system) { }
@@ -5042,7 +4915,7 @@ namespace Akka.Routing
         public RoundRobinPool(Akka.Configuration.Config config) { }
         public RoundRobinPool(int nrOfInstances) { }
         public RoundRobinPool(int nrOfInstances, Akka.Routing.Resizer resizer) { }
-        public RoundRobinPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False) { }
+        public RoundRobinPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem sys) { }
         public override Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
@@ -5071,9 +4944,9 @@ namespace Akka.Routing
     {
         public static readonly Akka.Routing.Routee NoRoutee;
         public Routee() { }
-        public virtual System.Threading.Tasks.Task<object> Ask(object message, System.Nullable<System.TimeSpan> timeout) { }
-        public static Akka.Routing.Routee FromActorRef(Akka.Actor.IActorRef actorRef) { }
+        public virtual System.Threading.Tasks.Task<object> Ask(object message, System.TimeSpan? timeout) { }
         public virtual void Send(object message, Akka.Actor.IActorRef sender) { }
+        public static Akka.Routing.Routee FromActorRef(Akka.Actor.IActorRef actorRef) { }
     }
     public sealed class Routees
     {
@@ -5082,17 +4955,17 @@ namespace Akka.Routing
     }
     public class Router
     {
-        [Akka.Annotations.InternalApiAttribute()]
-        public Router(Akka.Routing.RoutingLogic logic, Akka.Actor.IActorRef routee, params Akka.Actor.IActorRef[] routees) { }
         public Router(Akka.Routing.RoutingLogic logic, params Akka.Routing.Routee[] routees) { }
+        [Akka.Annotations.InternalApi]
+        public Router(Akka.Routing.RoutingLogic logic, Akka.Actor.IActorRef routee, params Akka.Actor.IActorRef[] routees) { }
         public System.Collections.Generic.IEnumerable<Akka.Routing.Routee> Routees { get; }
         public Akka.Routing.RoutingLogic RoutingLogic { get; }
-        public virtual Akka.Routing.Router AddRoutee(Akka.Routing.Routee routee) { }
-        public Akka.Routing.Router AddRoutee(Akka.Actor.IActorRef routee) { }
         public Akka.Routing.Router AddRoutee(Akka.Actor.ActorSelection routee) { }
-        public virtual Akka.Routing.Router RemoveRoutee(Akka.Routing.Routee routee) { }
-        public Akka.Routing.Router RemoveRoutee(Akka.Actor.IActorRef routee) { }
+        public Akka.Routing.Router AddRoutee(Akka.Actor.IActorRef routee) { }
+        public virtual Akka.Routing.Router AddRoutee(Akka.Routing.Routee routee) { }
         public Akka.Routing.Router RemoveRoutee(Akka.Actor.ActorSelection routee) { }
+        public Akka.Routing.Router RemoveRoutee(Akka.Actor.IActorRef routee) { }
+        public virtual Akka.Routing.Router RemoveRoutee(Akka.Routing.Routee routee) { }
         public virtual void Route(object message, Akka.Actor.IActorRef sender) { }
         protected virtual void Send(Akka.Routing.Routee routee, object message, Akka.Actor.IActorRef sender) { }
         protected object UnWrap(object message) { }
@@ -5105,7 +4978,7 @@ namespace Akka.Routing
         public virtual string RouterDispatcher { get; }
         public virtual bool StopRouterWhenAllRouteesRemoved { get; }
         public abstract Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system);
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public abstract Akka.Actor.ActorBase CreateRouterActor();
         public bool Equals(Akka.Routing.RouterConfig other) { }
         public override bool Equals(object obj) { }
@@ -5125,7 +4998,7 @@ namespace Akka.Routing
     {
         protected RouterManagementMessage() { }
     }
-    public class static RouterMessage
+    public static class RouterMessage
     {
         public static readonly Akka.Routing.GetRoutees GetRoutees;
     }
@@ -5137,8 +5010,8 @@ namespace Akka.Routing
     public sealed class ScatterGatherFirstCompletedGroup : Akka.Routing.Group
     {
         public ScatterGatherFirstCompletedGroup(Akka.Configuration.Config config) { }
-        public ScatterGatherFirstCompletedGroup(System.TimeSpan within, params string[] paths) { }
         public ScatterGatherFirstCompletedGroup(System.Collections.Generic.IEnumerable<string> paths, System.TimeSpan within) { }
+        public ScatterGatherFirstCompletedGroup(System.TimeSpan within, params string[] paths) { }
         public ScatterGatherFirstCompletedGroup(System.Collections.Generic.IEnumerable<string> paths, System.TimeSpan within, string routerDispatcher) { }
         public System.TimeSpan Within { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
@@ -5159,7 +5032,7 @@ namespace Akka.Routing
         public ScatterGatherFirstCompletedPool(Akka.Configuration.Config config) { }
         public ScatterGatherFirstCompletedPool(int nrOfInstances) { }
         public ScatterGatherFirstCompletedPool(int nrOfInstances, System.TimeSpan within) { }
-        public ScatterGatherFirstCompletedPool(int nrOfInstances, Akka.Routing.Resizer resizer, System.TimeSpan within, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False) { }
+        public ScatterGatherFirstCompletedPool(int nrOfInstances, Akka.Routing.Resizer resizer, System.TimeSpan within, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false) { }
         public System.TimeSpan Within { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem system) { }
@@ -5194,7 +5067,7 @@ namespace Akka.Routing
     {
         public SmallestMailboxPool(Akka.Configuration.Config config) { }
         public SmallestMailboxPool(int nrOfInstances) { }
-        public SmallestMailboxPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False) { }
+        public SmallestMailboxPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem system) { }
         public override Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
@@ -5249,7 +5122,7 @@ namespace Akka.Routing
     {
         public TailChoppingPool(Akka.Configuration.Config config) { }
         public TailChoppingPool(int nrOfInstances, System.TimeSpan within, System.TimeSpan interval) { }
-        public TailChoppingPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, System.TimeSpan within, System.TimeSpan interval, bool usePoolDispatcher = False) { }
+        public TailChoppingPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, System.TimeSpan within, System.TimeSpan interval, bool usePoolDispatcher = false) { }
         public System.TimeSpan Interval { get; }
         public System.TimeSpan Within { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
@@ -5287,7 +5160,7 @@ namespace Akka.Serialization
         public override object FromBinary(byte[] bytes, System.Type type) { }
         public override byte[] ToBinary(object obj) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Information : System.IEquatable<Akka.Serialization.Information>
     {
         public Information(Akka.Actor.Address address, Akka.Actor.ActorSystem system) { }
@@ -5296,8 +5169,8 @@ namespace Akka.Serialization
         public bool Equals(Akka.Serialization.Information other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public static bool ==(Akka.Serialization.Information left, Akka.Serialization.Information right) { }
-        public static bool !=(Akka.Serialization.Information left, Akka.Serialization.Information right) { }
+        public static bool operator !=(Akka.Serialization.Information left, Akka.Serialization.Information right) { }
+        public static bool operator ==(Akka.Serialization.Information left, Akka.Serialization.Information right) { }
     }
     public class NewtonSoftJsonSerializer : Akka.Serialization.Serializer
     {
@@ -5340,7 +5213,7 @@ namespace Akka.Serialization
         public Serialization(Akka.Actor.ExtendedActorSystem system) { }
         public Akka.Actor.ExtendedActorSystem System { get; }
         public void AddSerializationMap(System.Type type, Akka.Serialization.Serializer serializer) { }
-        [System.ObsoleteAttribute("No longer supported. Use the AddSerializer(name, serializer) overload instead.", true)]
+        [System.Obsolete("No longer supported. Use the AddSerializer(name, serializer) overload instead.", true)]
         public void AddSerializer(Akka.Serialization.Serializer serializer) { }
         public void AddSerializer(string name, Akka.Serialization.Serializer serializer) { }
         public object Deserialize(byte[] bytes, int serializerId, System.Type type) { }
@@ -5348,13 +5221,13 @@ namespace Akka.Serialization
         public Akka.Actor.IActorRef DeserializeActorRef(string path) { }
         public Akka.Serialization.Serializer FindSerializerFor(object obj, string defaultSerializerName = null) { }
         public Akka.Serialization.Serializer FindSerializerForType(System.Type objectType, string defaultSerializerName = null) { }
+        public byte[] Serialize(object o) { }
         public static Akka.Serialization.Information GetCurrentTransportInformation() { }
         public static string ManifestFor(Akka.Serialization.Serializer s, object msg) { }
-        public byte[] Serialize(object o) { }
         public static string SerializedActorPath(Akka.Actor.IActorRef actorRef) { }
-        [System.ObsoleteAttribute("Obsolete. Use the SerializeWithTransport<T>(ExtendedActorSystem) method instead.")]
-        public static T WithTransport<T>(Akka.Actor.ActorSystem system, Akka.Actor.Address address, System.Func<T> action) { }
         public static T WithTransport<T>(Akka.Actor.ExtendedActorSystem system, System.Func<T> action) { }
+        [System.Obsolete("Obsolete. Use the SerializeWithTransport<T>(ExtendedActorSystem) method instead.")]
+        public static T WithTransport<T>(Akka.Actor.ActorSystem system, Akka.Actor.Address address, System.Func<T> action) { }
         public static T WithTransport<TState, T>(Akka.Actor.ExtendedActorSystem system, TState state, System.Func<TState, T> action) { }
     }
     public sealed class SerializationSetup : Akka.Actor.Setup.Setup
@@ -5380,16 +5253,16 @@ namespace Akka.Serialization
         public System.Collections.Immutable.ImmutableHashSet<System.Type> UseFor { get; }
         public static Akka.Serialization.SerializerDetails Create(string alias, Akka.Serialization.Serializer serializer, System.Collections.Immutable.ImmutableHashSet<System.Type> useFor) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static SerializerIdentifierHelper
+    [Akka.Annotations.InternalApi]
+    public static class SerializerIdentifierHelper
     {
         public static int GetSerializerIdentifierFromConfig(System.Type type, Akka.Actor.ExtendedActorSystem system) { }
     }
     public abstract class SerializerWithStringManifest : Akka.Serialization.Serializer
     {
         protected SerializerWithStringManifest(Akka.Actor.ExtendedActorSystem system) { }
-        public virtual bool IncludeManifest { get; }
-        public virtual object FromBinary(byte[] bytes, System.Type type) { }
+        public override sealed bool IncludeManifest { get; }
+        public override sealed object FromBinary(byte[] bytes, System.Type type) { }
         public abstract object FromBinary(byte[] bytes, string manifest);
         public abstract string Manifest(object o);
     }
@@ -5401,17 +5274,17 @@ namespace Akka.Util
         public static readonly Akka.Util.AppVersion Zero;
         public string Version { get; }
         public int CompareTo(Akka.Util.AppVersion other) { }
-        public static Akka.Util.AppVersion Create(string version) { }
         public bool Equals(Akka.Util.AppVersion other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
-        public static bool ==(Akka.Util.AppVersion first, Akka.Util.AppVersion second) { }
-        public static bool !=(Akka.Util.AppVersion first, Akka.Util.AppVersion second) { }
+        public static Akka.Util.AppVersion Create(string version) { }
+        public static bool operator !=(Akka.Util.AppVersion first, Akka.Util.AppVersion second) { }
+        public static bool operator ==(Akka.Util.AppVersion first, Akka.Util.AppVersion second) { }
     }
     public class AtomicBoolean
     {
-        public AtomicBoolean(bool initialValue = False) { }
+        public AtomicBoolean(bool initialValue = false) { }
         public bool Value { get; set; }
         public bool CompareAndSet(bool expected, bool newValue) { }
         public bool GetAndSet(bool newValue) { }
@@ -5421,19 +5294,19 @@ namespace Akka.Util
         where T :  class
     {
         protected T atomicValue;
-        public AtomicReference(T originalValue) { }
         public AtomicReference() { }
+        public AtomicReference(T originalValue) { }
         public T Value { get; set; }
         public bool CompareAndSet(T expected, T newValue) { }
         public T CompareExchange(T expected, T newValue) { }
         public T GetAndSet(T newValue) { }
         public static T op_Implicit(Akka.Util.AtomicReference<T> atomicReference) { }
     }
-    public class static BitArrayHelpers
+    public static class BitArrayHelpers
     {
         public static byte[] ToBytes(this System.Collections.BitArray arr) { }
     }
-    public class static ByteHelpers
+    public static class ByteHelpers
     {
         public static byte[] PutInt(this byte[] target, int x, int offset = 0, Akka.IO.ByteOrder order = 0) { }
     }
@@ -5453,14 +5326,14 @@ namespace Akka.Util
         public bool TryAdd(T item) { }
         public bool TryRemove(T item) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static DynamicAccess
+    [Akka.Annotations.InternalApi]
+    public static class DynamicAccess
     {
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public static Akka.Util.Try<TResult> CreateInstanceFor<TResult>(string typeName, params object[] args)
             where TResult :  class { }
     }
-    public class static Either
+    public static class Either
     {
         public static Akka.Util.Left<T> Left<T>(T value) { }
         public static Akka.Util.Right<T> Right<T>(T value) { }
@@ -5508,8 +5381,8 @@ namespace Akka.Util
         public TValue FindValue(TKey key, System.Func<TValue, bool> predicate) { }
         public void ForEach(System.Action<TKey, TValue> fun) { }
         public bool Put(TKey key, TValue value) { }
-        public bool Remove(TKey key, TValue value) { }
         public System.Collections.Generic.IEnumerable<TValue> Remove(TKey key) { }
+        public bool Remove(TKey key, TValue value) { }
         public void RemoveValue(TValue value) { }
     }
     public class Left<T>
@@ -5524,7 +5397,7 @@ namespace Akka.Util
         public Left(TA a) { }
         public override bool IsLeft { get; }
         public override bool IsRight { get; }
-        public TA Value { get; }
+        public new TA Value { get; }
     }
     public sealed class ListPriorityQueue
     {
@@ -5536,7 +5409,7 @@ namespace Akka.Util
         public Akka.Actor.Envelope Peek() { }
         public override string ToString() { }
     }
-    public class static MurmurHash
+    public static class MurmurHash
     {
         public const uint StartMagicA = 2505324423u;
         public const uint StartMagicB = 718793509u;
@@ -5550,17 +5423,15 @@ namespace Akka.Util
         public static int StringHash(string s) { }
         public static int SymmetricHash<T>(System.Collections.Generic.IEnumerable<T> xs, uint seed) { }
     }
-    [Akka.Annotations.InternalStableApiAttribute()]
-    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-    public struct Option<T>
+    [Akka.Annotations.InternalStableApi]
+    public readonly struct Option<T>
     {
         public static readonly Akka.Util.Option<T> None;
-        [System.ObsoleteAttribute("Use Option<T>.Create() instead")]
+        [System.Obsolete("Use Option<T>.Create() instead")]
         public Option(T value) { }
         public bool HasValue { get; }
         public bool IsEmpty { get; }
         public T Value { get; }
-        public static Akka.Util.Option<T> Create(T value) { }
         public bool Equals(Akka.Util.Option<T> other) { }
         public override bool Equals(object obj) { }
         public Akka.Util.Option<TNew> FlatSelect<TNew>(System.Func<T, Akka.Util.Option<TNew>> mapper) { }
@@ -5569,40 +5440,25 @@ namespace Akka.Util
         public void OnSuccess(System.Action<T> action) { }
         public Akka.Util.Option<TNew> Select<TNew>(System.Func<T, TNew> selector) { }
         public override string ToString() { }
-        public static bool ==(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
+        public static Akka.Util.Option<T> Create(T value) { }
         public static Akka.Util.Option<T> op_Implicit(T value) { }
-        public static bool !=(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
+        public static bool operator !=(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
+        public static bool operator ==(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static Result
+    public static class Result
     {
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
-        public static Akka.Util.Result<T> Failure<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Exception exception) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
-        public static Akka.Util.Result<T> From<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
-        public static Akka.Util.Result<T> FromTask<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Threading.Tasks.Task<T> task) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
-        public static Akka.Util.Result<T> Success<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(T value) { }
+        public static Akka.Util.Result<T> Failure<T>(System.Exception exception) { }
+        public static Akka.Util.Result<T> From<T>(System.Func<T> func) { }
+        public static Akka.Util.Result<T> FromTask<T>(System.Threading.Tasks.Task<T> task) { }
+        public static Akka.Util.Result<T> Success<T>(T value) { }
     }
-    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-    public struct Result<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : System.IEquatable<Akka.Util.Result<T>>
+    public readonly struct Result<T> : System.IEquatable<Akka.Util.Result<T>>
     {
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public readonly System.Exception Exception;
+        public readonly System.Exception? Exception;
         public readonly bool IsSuccess;
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public readonly T Value;
-        public Result(T value) { }
+        public readonly T? Value;
         public Result(System.Exception exception) { }
+        public Result(T value) { }
         public override string ToString() { }
     }
     public class Right<T>
@@ -5617,9 +5473,9 @@ namespace Akka.Util
         public Right(TB b) { }
         public override bool IsLeft { get; }
         public override bool IsRight { get; }
-        public TB Value { get; }
+        public new TB Value { get; }
     }
-    public class static RuntimeDetector
+    public static class RuntimeDetector
     {
         public static readonly bool IsMono;
         public static readonly bool IsWindows;
@@ -5634,32 +5490,32 @@ namespace Akka.Util
         public Akka.Actor.Envelope Peek() { }
         public override string ToString() { }
     }
-    public class static StandardOutWriter
+    public static class StandardOutWriter
     {
-        public static void Write(string message, System.Nullable<System.ConsoleColor> foregroundColor = null, System.Nullable<System.ConsoleColor> backgroundColor = null) { }
-        public static void WriteLine(string message, System.Nullable<System.ConsoleColor> foregroundColor = null, System.Nullable<System.ConsoleColor> backgroundColor = null) { }
+        public static void Write(string message, System.ConsoleColor? foregroundColor = default, System.ConsoleColor? backgroundColor = default) { }
+        public static void WriteLine(string message, System.ConsoleColor? foregroundColor = default, System.ConsoleColor? backgroundColor = default) { }
     }
-    public class static StringFormat
+    public static class StringFormat
     {
         public static string SafeJoin(string separator, params object[] args) { }
     }
     public class Switch
     {
-        public Switch(bool startAsOn = False) { }
+        public Switch(bool startAsOn = false) { }
         public bool IsOff { get; }
         public bool IsOn { get; }
         public bool IfOff(System.Action action) { }
         public bool IfOn(System.Action action) { }
         public void Locked(System.Action action) { }
-        public bool SwitchOff(System.Action action) { }
         public bool SwitchOff() { }
-        public bool SwitchOn(System.Action action) { }
+        public bool SwitchOff(System.Action action) { }
         public bool SwitchOn() { }
+        public bool SwitchOn(System.Action action) { }
         protected bool TranscendFrom(bool from, System.Action action) { }
         public bool WhileOff(System.Action action) { }
         public bool WhileOn(System.Action action) { }
     }
-    public class static ThreadLocalRandom
+    public static class ThreadLocalRandom
     {
         public static System.Random Current { get; }
     }
@@ -5668,7 +5524,7 @@ namespace Akka.Util
         public TickTimeTokenBucket(long capacity, long period) { }
         public override long CurrentTime { get; }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class TokenBucket
     {
         protected TokenBucket(long capacity, long ticksBetweenTokens) { }
@@ -5678,38 +5534,38 @@ namespace Akka.Util
     }
     public class Try<T>
     {
-        public Try(T success) { }
         public Try(System.Exception failure) { }
+        public Try(T success) { }
         public Akka.Util.Option<System.Exception> Failure { get; }
         public bool IsSuccess { get; }
         public Akka.Util.Option<T> Success { get; }
-        public static Akka.Util.Try<T> From(System.Func<T> func) { }
         public T Get() { }
         public Akka.Util.Try<T> GetOrElse(System.Func<T> fallback) { }
         public Akka.Util.Try<T> OrElse(Akka.Util.Try<T> @default) { }
         public Akka.Util.Try<T> Recover(System.Action<System.Exception> failureHandler) { }
         public Akka.Util.Try<T> RecoverWith(System.Func<System.Exception, Akka.Util.Try<T>> failureHandler) { }
+        public static Akka.Util.Try<T> From(System.Func<T> func) { }
         public static Akka.Util.Try<T> op_Implicit(T value) { }
     }
-    public class static TypeExtensions
+    public static class TypeExtensions
     {
-        public static bool Implements<T>(this System.Type type) { }
         public static bool Implements(this System.Type type, System.Type moreGeneralType) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        public static bool Implements<T>(this System.Type type) { }
+        [Akka.Annotations.InternalApi]
         public static string TypeQualifiedName(this System.Type type) { }
     }
-    public class static Vector
+    public static class Vector
     {
         public static System.Func<System.Func<T>, System.Collections.Generic.IList<T>> Fill<T>(int number) { }
     }
-    public class static WildcardMatch
+    public static class WildcardMatch
     {
-        public static bool Like(this string text, string pattern, bool caseSensitive = False) { }
+        public static bool Like(this string text, string pattern, bool caseSensitive = false) { }
     }
 }
 namespace Akka.Util.Extensions
 {
-    public class static ObjectExtensions
+    public static class ObjectExtensions
     {
         public static Akka.Util.Option<T> AsOption<T>(this T obj) { }
     }
@@ -5718,8 +5574,8 @@ namespace Akka.Util.Internal
 {
     public class AtomicCounter : Akka.Util.Internal.IAtomicCounter<int>
     {
-        public AtomicCounter(int initialValue) { }
         public AtomicCounter() { }
+        public AtomicCounter(int initialValue) { }
         public int Current { get; }
         public int AddAndGet(int amount) { }
         public bool CompareAndSet(int expected, int newValue) { }
@@ -5735,8 +5591,8 @@ namespace Akka.Util.Internal
     }
     public class AtomicCounterLong : Akka.Util.Internal.IAtomicCounter<long>
     {
-        public AtomicCounterLong(long value) { }
         public AtomicCounterLong() { }
+        public AtomicCounterLong(long value) { }
         public long Current { get; }
         public long AddAndGet(long amount) { }
         public bool CompareAndSet(long expected, long newValue) { }
@@ -5749,14 +5605,12 @@ namespace Akka.Util.Internal
         public void Reset() { }
         public override string ToString() { }
     }
-    public class static Extensions
+    public static class Extensions
     {
         public static System.Collections.Generic.IDictionary<TKey, TValue> AddAndReturn<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> hash, TKey key, TValue value) { }
         public static T AsInstanceOf<T>(this object self) { }
         public static string BetweenDoubleQuotes(this string self) { }
-        public static System.Collections.Generic.IEnumerable<T> Concat<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] this System.Collections.Generic.IEnumerable<T> enumerable, T item) { }
+        public static System.Collections.Generic.IEnumerable<T> Concat<T>(this System.Collections.Generic.IEnumerable<T>? enumerable, T item) { }
         public static System.Collections.Generic.IEnumerable<T> Drop<T>(this System.Collections.Generic.IEnumerable<T> self, int count) { }
         public static void ForEach<T>(this System.Collections.Generic.IEnumerable<T> source, System.Action<T> action) { }
         public static TValue GetOrElse<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> hash, TKey key, TValue elseValue) { }
@@ -5784,7 +5638,7 @@ namespace Akka.Util.Internal
         void Enter();
         System.Threading.Tasks.Task<T> Invoke<T>(System.Func<System.Threading.Tasks.Task<T>> body);
     }
-    public class static InterlockedSpin
+    public static class InterlockedSpin
     {
         public static TReturn ConditionallySwap<T, TReturn>(ref T reference, System.Func<T, System.ValueTuple<bool, T, TReturn>> updateIfTrue)
             where T :  class { }
@@ -5794,11 +5648,11 @@ namespace Akka.Util.Internal
 }
 namespace Akka.Util.Reflection
 {
-    public class static ExpressionExtensions
+    public static class ExpressionExtensions
     {
         public static object[] GetArguments(this System.Linq.Expressions.NewExpression newExpression) { }
     }
-    public class static TypeCache
+    public static class TypeCache
     {
         public static System.Type GetType(string typeName) { }
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -1,48 +1,48 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.API.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DependencyInjection")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DependencyInjection.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Docs.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.MultiNodeTestRunner.Shared.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.Sql.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.TCK")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.TestKit.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.TestKit.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.TestKit.Xunit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.TestKit.Xunit2")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Tests.Performance")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("1a5cab08-b032-49ca-8db3-9428c5a9db14")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.API.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DependencyInjection")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DependencyInjection.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DistributedData")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Docs.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.MultiNodeTestRunner.Shared.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.Sql.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.TCK")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.TestKit.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Streams")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Streams.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.Xunit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.Xunit2")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Tests.Performance")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("1a5cab08-b032-49ca-8db3-9428c5a9db14")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Actor
 {
     public abstract class ActorBase : Akka.Actor.IInternalActor
     {
         protected ActorBase() { }
-        protected static Akka.Actor.IActorContext Context { get; }
-        protected static Akka.Actor.Receive EmptyReceive { get; }
         protected Akka.Actor.IActorRef Self { get; }
         protected Akka.Actor.IActorRef Sender { get; }
+        protected static Akka.Actor.IActorContext Context { get; }
+        protected static Akka.Actor.Receive EmptyReceive { get; }
         public virtual void AroundPostRestart(System.Exception cause, object message) { }
         public virtual void AroundPostStop() { }
         public virtual void AroundPreRestart(System.Exception cause, object message) { }
@@ -55,65 +55,57 @@ namespace Akka.Actor
         protected virtual void PreRestart(System.Exception reason, object message) { }
         protected virtual void PreStart() { }
         protected abstract bool Receive(object message);
-        protected void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout) { }
+        protected void SetReceiveTimeout(System.TimeSpan? timeout) { }
         protected virtual Akka.Actor.SupervisorStrategy SupervisorStrategy() { }
         protected void UnbecomeStacked() { }
         protected virtual void Unhandled(object message) { }
     }
-    [System.Diagnostics.DebuggerDisplayAttribute("{Self,nq}")]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [System.Diagnostics.DebuggerDisplay("{Self,nq}")]
     public class ActorCell : Akka.Actor.IActorContext, Akka.Actor.IActorRefFactory, Akka.Actor.ICanWatch, Akka.Actor.ICell, Akka.Actor.IUntypedActorContext
     {
         public const int UndefinedUid = 0;
         public ActorCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.IInternalActorRef self, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Actor.IInternalActorRef parent) { }
         public Akka.Actor.Internal.IChildrenContainer ChildrenContainer { get; }
         public int CurrentEnvelopeId { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public object CurrentMessage { get; }
+        public object? CurrentMessage { get; }
         public Akka.Dispatch.MessageDispatcher Dispatcher { get; }
         public bool HasMessages { get; }
         public bool IsLocal { get; }
         protected bool IsNormal { get; }
         public bool IsTerminated { get; }
         protected bool IsTerminating { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Dispatch.Mailbox Mailbox { get; }
+        public Akka.Dispatch.Mailbox? Mailbox { get; }
         public int NumberOfMessages { get; }
         public Akka.Actor.IInternalActorRef Parent { get; }
         public Akka.Actor.Props Props { get; }
-        public System.Nullable<System.TimeSpan> ReceiveTimeout { get; }
+        public System.TimeSpan? ReceiveTimeout { get; }
         public Akka.Actor.IActorRef Self { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.IActorRef Sender { get; }
+        public Akka.Actor.IActorRef? Sender { get; }
         public Akka.Actor.ActorSystem System { get; }
         public Akka.Actor.Internal.ActorSystemImpl SystemImpl { get; }
         public virtual Akka.Dispatch.ActorTaskScheduler TaskScheduler { get; }
-        public virtual Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null) { }
-        public Akka.Actor.ActorSelection ActorSelection(string path) { }
+        public virtual Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string? name = null) { }
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath path) { }
+        public Akka.Actor.ActorSelection ActorSelection(string path) { }
         protected void AddWatcher(Akka.Actor.IActorRef watchee, Akka.Actor.IActorRef watcher) { }
         protected void AddressTerminated(Akka.Actor.Address address) { }
-        public virtual Akka.Actor.IActorRef AttachChild(Akka.Actor.Props props, bool isSystemService, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null) { }
+        public virtual Akka.Actor.IActorRef AttachChild(Akka.Actor.Props props, bool isSystemService, string? name = null) { }
         protected virtual void AutoReceiveMessage(Akka.Actor.Envelope envelope) { }
         public void Become(Akka.Actor.Receive receive) { }
         public void BecomeStacked(Akka.Actor.Receive receive) { }
-        public void CheckReceiveTimeout(bool reschedule = True) { }
-        protected void ClearActor(Akka.Actor.ActorBase actor) { }
+        public void CheckReceiveTimeout(bool reschedule = true) { }
+        protected void ClearActor(Akka.Actor.ActorBase? actor) { }
         protected void ClearActorCell() { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        protected virtual Akka.Actor.ActorRestarted CreateActorRestartedEvent(System.Exception cause) { }
-        protected virtual Akka.Actor.ActorStarted CreateActorStartedEvent() { }
-        protected virtual Akka.Actor.ActorStopped CreateActorStoppedEvent() { }
+        protected virtual Akka.Actor.ActorRestarted? CreateActorRestartedEvent(System.Exception cause) { }
+        protected virtual Akka.Actor.ActorStarted? CreateActorStartedEvent() { }
+        protected virtual Akka.Actor.ActorStopped? CreateActorStoppedEvent() { }
         protected virtual Akka.Actor.ActorBase CreateNewActorInstance() { }
-        [System.ObsoleteAttribute("Use TryGetChildStatsByName [0.7.1]", true)]
+        [System.Obsolete("Use TryGetChildStatsByName [0.7.1]", true)]
         public Akka.Actor.IInternalActorRef GetChildByName(string name) { }
         public System.Collections.Generic.IEnumerable<Akka.Actor.IInternalActorRef> GetChildren() { }
-        public static Akka.Actor.IActorRef GetCurrentSelfOrNoSender() { }
-        public static Akka.Actor.IActorRef GetCurrentSenderOrNoSender() { }
         public Akka.Actor.IInternalActorRef GetSingleChild(string name) { }
         public void Init(bool sendSupervise, Akka.Dispatch.MailboxType mailboxType) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Actor.Internal.ChildRestartStats InitChild(Akka.Actor.IInternalActorRef actor) { }
+        public Akka.Actor.Internal.ChildRestartStats? InitChild(Akka.Actor.IInternalActorRef actor) { }
         public void Invoke(Akka.Actor.Envelope envelope) { }
         protected virtual void PreStart() { }
         protected void PrepareForNewActor() { }
@@ -121,38 +113,37 @@ namespace Akka.Actor
         public void ReceiveMessageForTest(Akka.Actor.Envelope envelope) { }
         protected void ReceivedTerminated(Akka.Actor.Terminated t) { }
         protected void RemWatcher(Akka.Actor.IActorRef watchee, Akka.Actor.IActorRef watcher) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        protected Akka.Actor.Internal.SuspendReason RemoveChildAndGetStateChange(Akka.Actor.IActorRef child) { }
+        protected Akka.Actor.Internal.SuspendReason? RemoveChildAndGetStateChange(Akka.Actor.IActorRef child) { }
         public void ReserveChild(string name) { }
         public void Restart(System.Exception cause) { }
         public void Resume(System.Exception causedByFailure) { }
         public virtual void SendMessage(Akka.Actor.Envelope message) { }
         public virtual void SendMessage(Akka.Actor.IActorRef sender, object message) { }
         public virtual void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage systemMessage) { }
-        protected static void SetActorFields(Akka.Actor.ActorBase actor) { }
         protected bool SetChildrenTerminationReason(Akka.Actor.Internal.SuspendReason reason) { }
-        public void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout = null) { }
+        public void SetReceiveTimeout(System.TimeSpan? timeout = default) { }
         protected void SetTerminated() { }
         public virtual void Start() { }
         protected void Stash(Akka.Dispatch.SysMsg.SystemMessage msg) { }
-        public void Stop(Akka.Actor.IActorRef child) { }
         public void Stop() { }
+        public void Stop(Akka.Actor.IActorRef child) { }
         protected void StopFunctionRefs() { }
         public void Suspend() { }
         protected void TellWatchersWeDied() { }
-        public void TerminatedQueuedFor(Akka.Actor.IActorRef subject, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<object> customMessage) { }
+        public void TerminatedQueuedFor(Akka.Actor.IActorRef subject, Akka.Util.Option<object> customMessage) { }
         public bool TryGetChildStatsByName(string name, out Akka.Actor.Internal.IChildStats child) { }
-        protected bool TryGetChildStatsByRef(Akka.Actor.IActorRef actor, [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats child) { }
+        protected bool TryGetChildStatsByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Akka.Actor.Internal.ChildRestartStats? child) { }
         public void UnbecomeStacked() { }
         protected void UnreserveChild(string name) { }
         public Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef subject) { }
-        protected void UnwatchWatchedActors(Akka.Actor.ActorBase actor) { }
+        protected void UnwatchWatchedActors(Akka.Actor.ActorBase? actor) { }
         public void UseThreadContext(System.Action action) { }
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef subject) { }
         public Akka.Actor.IActorRef WatchWith(Akka.Actor.IActorRef subject, object message) { }
         protected void WatchedActorTerminated(Akka.Actor.IActorRef actor, bool existenceConfirmed, bool addressTerminated) { }
+        public static Akka.Actor.IActorRef? GetCurrentSelfOrNoSender() { }
+        public static Akka.Actor.IActorRef? GetCurrentSenderOrNoSender() { }
+        protected static void SetActorFields(Akka.Actor.ActorBase? actor) { }
     }
     public sealed class ActorIdentity
     {
@@ -167,17 +158,17 @@ namespace Akka.Actor
     {
         public ActorInitializationException() { }
         public ActorInitializationException(string message) { }
+        protected ActorInitializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public ActorInitializationException(string message, System.Exception cause) { }
         public ActorInitializationException(Akka.Actor.IActorRef actor, string message, System.Exception cause = null) { }
-        protected ActorInitializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public Akka.Actor.IActorRef Actor { get; set; }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { }
     }
     public class ActorInterruptedException : Akka.Actor.AkkaException
     {
-        public ActorInterruptedException(string message = null, System.Exception cause = null) { }
         protected ActorInterruptedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public ActorInterruptedException(string message = null, System.Exception cause = null) { }
     }
     public class ActorKilledException : Akka.Actor.AkkaException
     {
@@ -201,18 +192,15 @@ namespace Akka.Actor
         public System.Collections.Generic.IReadOnlyList<string> Elements { get; }
         public string Name { get; }
         public Akka.Actor.ActorPath Parent { get; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        [Newtonsoft.Json.JsonIgnore]
         public Akka.Actor.ActorPath Root { get; }
         public long Uid { get; }
         public Akka.Actor.ActorPath Child(string childName) { }
         public int CompareTo(Akka.Actor.ActorPath other) { }
         public bool Equals(Akka.Actor.ActorPath other) { }
         public override bool Equals(object obj) { }
-        public static string FormatPathElements(System.Collections.Generic.IEnumerable<string> pathElements) { }
         public override int GetHashCode() { }
-        public static bool IsValidPathElement(string s) { }
         public Akka.Actor.ActorPath ParentOf(int depth) { }
-        public static Akka.Actor.ActorPath Parse(string path) { }
         public string ToSerializationFormat() { }
         public string ToSerializationFormatWithAddress(Akka.Actor.Address address) { }
         public override string ToString() { }
@@ -221,23 +209,26 @@ namespace Akka.Actor
         public string ToStringWithUid() { }
         public string ToStringWithoutAddress() { }
         public Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
+        public Akka.Actor.ActorPath WithUid(long uid) { }
+        public static string FormatPathElements(System.Collections.Generic.IEnumerable<string> pathElements) { }
+        public static bool IsValidPathElement(string s) { }
+        public static Akka.Actor.ActorPath Parse(string path) { }
         public static bool TryParse(string path, out Akka.Actor.ActorPath actorPath) { }
-        public static bool TryParse(Akka.Actor.ActorPath basePath, string absoluteUri, out Akka.Actor.ActorPath actorPath) { }
         public static bool TryParse(Akka.Actor.ActorPath basePath, System.ReadOnlySpan<char> absoluteUri, out Akka.Actor.ActorPath actorPath) { }
+        public static bool TryParse(Akka.Actor.ActorPath basePath, string absoluteUri, out Akka.Actor.ActorPath actorPath) { }
         public static bool TryParseAddress(string path, out Akka.Actor.Address address) { }
         public static bool TryParseAddress(string path, out Akka.Actor.Address address, out System.ReadOnlySpan<char> absoluteUri) { }
         public static bool TryParseParts(System.ReadOnlySpan<char> path, out System.ReadOnlySpan<char> address, out System.ReadOnlySpan<char> absoluteUri) { }
-        public Akka.Actor.ActorPath WithUid(long uid) { }
-        public static Akka.Actor.ActorPath /(Akka.Actor.ActorPath path, string name) { }
-        public static Akka.Actor.ActorPath /(Akka.Actor.ActorPath path, System.Collections.Generic.IEnumerable<string> name) { }
-        public static bool ==(Akka.Actor.ActorPath left, Akka.Actor.ActorPath right) { }
-        public static bool !=(Akka.Actor.ActorPath left, Akka.Actor.ActorPath right) { }
+        public static bool operator !=(Akka.Actor.ActorPath left, Akka.Actor.ActorPath right) { }
+        public static Akka.Actor.ActorPath operator /(Akka.Actor.ActorPath path, System.Collections.Generic.IEnumerable<string> name) { }
+        public static Akka.Actor.ActorPath operator /(Akka.Actor.ActorPath path, string name) { }
+        public static bool operator ==(Akka.Actor.ActorPath left, Akka.Actor.ActorPath right) { }
         public sealed class Surrogate : Akka.Util.ISurrogate, System.IEquatable<Akka.Actor.ActorPath.Surrogate>, System.IEquatable<Akka.Actor.ActorPath>
         {
             public Surrogate(string path) { }
             public string Path { get; }
-            public bool Equals(Akka.Actor.ActorPath.Surrogate other) { }
             public bool Equals(Akka.Actor.ActorPath other) { }
+            public bool Equals(Akka.Actor.ActorPath.Surrogate other) { }
             public override bool Equals(object obj) { }
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
             public override int GetHashCode() { }
@@ -279,10 +270,10 @@ namespace Akka.Actor
     {
         protected ActorRefBase() { }
         public abstract Akka.Actor.ActorPath Path { get; }
-        public int CompareTo(object obj) { }
         public int CompareTo(Akka.Actor.IActorRef other) { }
-        public override bool Equals(object obj) { }
+        public int CompareTo(object obj) { }
         public bool Equals(Akka.Actor.IActorRef other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public void Tell(object message, Akka.Actor.IActorRef sender) { }
         protected abstract void TellInternal(object message, Akka.Actor.IActorRef sender);
@@ -295,29 +286,29 @@ namespace Akka.Actor
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
         }
     }
-    public class static ActorRefExtensions
+    public static class ActorRefExtensions
     {
         public static Akka.Actor.IActorRef GetOrElse(this Akka.Actor.IActorRef actorRef, System.Func<Akka.Actor.IActorRef> elseValue) { }
         public static bool IsNobody(this Akka.Actor.IActorRef actorRef) { }
     }
-    public class static ActorRefFactoryExtensions
+    public static class ActorRefFactoryExtensions
     {
         public static Akka.Actor.IActorRef ActorOf<TActor>(this Akka.Actor.IActorRefFactory factory, string name = null)
             where TActor : Akka.Actor.ActorBase, new () { }
         public static Akka.Actor.ActorSelection ActorSelection(this Akka.Actor.IActorRefFactory factory, Akka.Actor.IActorRef anchorRef, string actorPath) { }
     }
-    public class static ActorRefFactoryShared
+    public static class ActorRefFactoryShared
     {
         public static Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath actorPath, Akka.Actor.ActorSystem system) { }
-        public static Akka.Actor.ActorSelection ActorSelection(string path, Akka.Actor.ActorSystem system, Akka.Actor.IActorRef lookupRoot) { }
         public static Akka.Actor.ActorSelection ActorSelection(Akka.Actor.IActorRef anchorActorRef, string path) { }
+        public static Akka.Actor.ActorSelection ActorSelection(string path, Akka.Actor.ActorSystem system, Akka.Actor.IActorRef lookupRoot) { }
     }
-    public class static ActorRefImplicitSenderExtensions
+    public static class ActorRefImplicitSenderExtensions
     {
         public static void Forward(this Akka.Actor.IActorRef receiver, object message) { }
         public static void Tell(this Akka.Actor.IActorRef receiver, object message) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class ActorRefWithCell : Akka.Actor.InternalActorRefBase
     {
         protected ActorRefWithCell() { }
@@ -325,16 +316,14 @@ namespace Akka.Actor
         public abstract Akka.Actor.ICell Underlying { get; }
         public abstract Akka.Actor.IInternalActorRef GetSingleChild(string name);
     }
-    public class static ActorRefs
+    public static class ActorRefs
     {
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public static readonly Akka.Actor.IActorRef NoSender;
+        public static readonly Akka.Actor.IActorRef? NoSender;
         public static readonly Akka.Actor.Nobody Nobody;
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ActorRestarted : Akka.Actor.IActorTelemetryEvent, Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.INotInfluenceReceiveTimeout
     {
-        public ActorRestarted(Akka.Actor.IActorRef subject, System.Type actorType, System.Exception reason, [System.Runtime.CompilerServices.NullableAttribute(2)] string actorTypeOverride = null) { }
+        public ActorRestarted(Akka.Actor.IActorRef subject, System.Type actorType, System.Exception reason, string? actorTypeOverride = null) { }
         public System.Type ActorType { get; }
         public string ActorTypeOverride { get; }
         public System.Exception Reason { get; }
@@ -344,13 +333,13 @@ namespace Akka.Actor
     {
         public ActorSelection() { }
         public ActorSelection(Akka.Actor.IActorRef anchor, Akka.Actor.SelectionPathElement[] path) { }
-        public ActorSelection(Akka.Actor.IActorRef anchor, string path) { }
         public ActorSelection(Akka.Actor.IActorRef anchor, System.Collections.Generic.IEnumerable<string> elements) { }
+        public ActorSelection(Akka.Actor.IActorRef anchor, string path) { }
         public Akka.Actor.IActorRef Anchor { get; }
         public Akka.Actor.SelectionPathElement[] Path { get; }
         public string PathString { get; }
-        public override bool Equals(object obj) { }
         protected bool Equals(Akka.Actor.ActorSelection other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ResolveOne(System.TimeSpan timeout) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ResolveOne(System.TimeSpan timeout, System.Threading.CancellationToken ct) { }
@@ -359,17 +348,16 @@ namespace Akka.Actor
     }
     public class ActorSelectionMessage : Akka.Actor.IAutoReceivedMessage, Akka.Actor.IPossiblyHarmful, Akka.Actor.IWrappedMessage
     {
-        public ActorSelectionMessage(object message, Akka.Actor.SelectionPathElement[] elements, bool wildCardFanOut = False) { }
+        public ActorSelectionMessage(object message, Akka.Actor.SelectionPathElement[] elements, bool wildCardFanOut = false) { }
         public Akka.Actor.SelectionPathElement[] Elements { get; }
         public object Message { get; }
         public bool WildCardFanOut { get; }
-        public Akka.Actor.ActorSelectionMessage Copy(object message = null, Akka.Actor.SelectionPathElement[] elements = null, System.Nullable<bool> wildCardFanOut = null) { }
+        public Akka.Actor.ActorSelectionMessage Copy(object message = null, Akka.Actor.SelectionPathElement[] elements = null, bool? wildCardFanOut = default) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ActorStarted : Akka.Actor.IActorTelemetryEvent, Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.INotInfluenceReceiveTimeout
     {
-        public ActorStarted(Akka.Actor.IActorRef subject, System.Type actorType, [System.Runtime.CompilerServices.NullableAttribute(2)] string actorTypeOverride = null) { }
+        public ActorStarted(Akka.Actor.IActorRef subject, System.Type actorType, string? actorTypeOverride = null) { }
         public System.Type ActorType { get; }
         public string ActorTypeOverride { get; }
         public Akka.Actor.IActorRef Subject { get; }
@@ -381,10 +369,9 @@ namespace Akka.Actor
         public override void BeforeIncarnated(Akka.Actor.ActorBase actor, Akka.Actor.IActorContext context) { }
         public override bool CanBeAppliedTo(System.Type actorType) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ActorStopped : Akka.Actor.IActorTelemetryEvent, Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.INotInfluenceReceiveTimeout
     {
-        public ActorStopped(Akka.Actor.IActorRef subject, System.Type actorType, [System.Runtime.CompilerServices.NullableAttribute(2)] string actorTypeOverride = null) { }
+        public ActorStopped(Akka.Actor.IActorRef subject, System.Type actorType, string? actorTypeOverride = null) { }
         public System.Type ActorType { get; }
         public string ActorTypeOverride { get; }
         public Akka.Actor.IActorRef Subject { get; }
@@ -408,10 +395,6 @@ namespace Akka.Actor
         public abstract Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string name = null);
         public abstract Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath actorPath);
         public abstract Akka.Actor.ActorSelection ActorSelection(string actorPath);
-        public static Akka.Actor.ActorSystem Create(string name, Akka.Configuration.Config config) { }
-        public static Akka.Actor.ActorSystem Create(string name, Akka.Actor.BootstrapSetup setup) { }
-        public static Akka.Actor.ActorSystem Create(string name, Akka.Actor.Setup.ActorSystemSetup setup) { }
-        public static Akka.Actor.ActorSystem Create(string name) { }
         public void Dispose() { }
         public abstract object GetExtension(Akka.Actor.IExtensionId extensionId);
         public abstract T GetExtension<T>()
@@ -426,8 +409,12 @@ namespace Akka.Actor
         public abstract bool TryGetExtension(System.Type extensionType, out object extension);
         public abstract bool TryGetExtension<T>(out T extension)
             where T :  class, Akka.Actor.IExtension;
+        public static Akka.Actor.ActorSystem Create(string name) { }
+        public static Akka.Actor.ActorSystem Create(string name, Akka.Actor.BootstrapSetup setup) { }
+        public static Akka.Actor.ActorSystem Create(string name, Akka.Actor.Setup.ActorSystemSetup setup) { }
+        public static Akka.Actor.ActorSystem Create(string name, Akka.Configuration.Config config) { }
     }
-    public class static ActorSystemWithExtensions
+    public static class ActorSystemWithExtensions
     {
         public static T WithExtension<T>(this Akka.Actor.ActorSystem system)
             where T :  class, Akka.Actor.IExtension { }
@@ -441,11 +428,11 @@ namespace Akka.Actor
     {
         public static readonly Akka.Actor.Address AllSystems;
         public static readonly System.Collections.Generic.IComparer<Akka.Actor.Address> Comparer;
-        public Address(string protocol, string system, string host = null, System.Nullable<int> port = null) { }
+        public Address(string protocol, string system, string host = null, int? port = default) { }
         public bool HasGlobalScope { get; }
         public bool HasLocalScope { get; }
         public string Host { get; }
-        public System.Nullable<int> Port { get; }
+        public int? Port { get; }
         public string Protocol { get; }
         public string System { get; }
         public object Clone() { }
@@ -454,24 +441,24 @@ namespace Akka.Actor
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public string HostPort() { }
-        public static Akka.Actor.Address Parse(string address) { }
         public override string ToString() { }
         public Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
-        public static bool TryParse(string path, out Akka.Actor.Address address) { }
-        public static bool TryParse(string path, out Akka.Actor.Address address, out string absolutUri) { }
-        public static bool TryParse(System.ReadOnlySpan<char> span, out Akka.Actor.Address address) { }
-        public static bool TryParse(System.ReadOnlySpan<char> span, out Akka.Actor.Address address, out System.ReadOnlySpan<char> absolutUri) { }
         public Akka.Actor.Address WithHost(string host = null) { }
-        public Akka.Actor.Address WithPort(System.Nullable<int> port = null) { }
+        public Akka.Actor.Address WithPort(int? port = default) { }
         public Akka.Actor.Address WithProtocol(string protocol) { }
         public Akka.Actor.Address WithSystem(string system) { }
-        public static bool ==(Akka.Actor.Address left, Akka.Actor.Address right) { }
-        public static bool !=(Akka.Actor.Address left, Akka.Actor.Address right) { }
+        public static Akka.Actor.Address Parse(string address) { }
+        public static bool TryParse(System.ReadOnlySpan<char> span, out Akka.Actor.Address address) { }
+        public static bool TryParse(string path, out Akka.Actor.Address address) { }
+        public static bool TryParse(System.ReadOnlySpan<char> span, out Akka.Actor.Address address, out System.ReadOnlySpan<char> absolutUri) { }
+        public static bool TryParse(string path, out Akka.Actor.Address address, out string absolutUri) { }
+        public static bool operator !=(Akka.Actor.Address left, Akka.Actor.Address right) { }
+        public static bool operator ==(Akka.Actor.Address left, Akka.Actor.Address right) { }
         public sealed class AddressSurrogate : Akka.Util.ISurrogate
         {
             public AddressSurrogate() { }
             public string Host { get; set; }
-            public System.Nullable<int> Port { get; set; }
+            public int? Port { get; set; }
             public string Protocol { get; set; }
             public string System { get; set; }
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
@@ -480,19 +467,19 @@ namespace Akka.Actor
     public abstract class AkkaException : System.Exception
     {
         protected AkkaException() { }
-        protected AkkaException(string message, System.Exception cause = null) { }
         protected AkkaException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        protected AkkaException(string message, System.Exception cause = null) { }
         protected System.Exception Cause { get; }
     }
     public class AllForOneStrategy : Akka.Actor.SupervisorStrategy, System.IEquatable<Akka.Actor.AllForOneStrategy>
     {
-        public AllForOneStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public AllForOneStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, Akka.Actor.IDecider decider) { }
-        public AllForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
-        public AllForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = True) { }
-        public AllForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public AllForOneStrategy(Akka.Actor.IDecider decider) { }
         protected AllForOneStrategy() { }
+        public AllForOneStrategy(Akka.Actor.IDecider decider) { }
+        public AllForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public AllForOneStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, Akka.Actor.IDecider decider) { }
+        public AllForOneStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public AllForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = true) { }
+        public AllForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = true) { }
         public override Akka.Actor.IDecider Decider { get; }
         public int MaxNumberOfRetries { get; }
         public int WithinTimeRangeMilliseconds { get; }
@@ -522,18 +509,18 @@ namespace Akka.Actor
     {
         public Akka.Util.Option<Akka.Actor.ProviderSelection> ActorRefProvider { get; }
         public Akka.Util.Option<Akka.Configuration.Config> Config { get; }
-        public static Akka.Actor.BootstrapSetup Create() { }
         public Akka.Actor.BootstrapSetup WithActorRefProvider(Akka.Actor.ProviderSelection name) { }
         public Akka.Actor.BootstrapSetup WithConfig(Akka.Configuration.Config config) { }
         public Akka.Actor.BootstrapSetup WithConfigFallback(Akka.Configuration.Config config) { }
+        public static Akka.Actor.BootstrapSetup Create() { }
     }
     public class Cancelable : Akka.Actor.ICancelable, System.IDisposable
     {
+        public Cancelable(Akka.Actor.IActionScheduler scheduler) { }
+        public Cancelable(Akka.Actor.IScheduler scheduler) { }
         public Cancelable(Akka.Actor.IActionScheduler scheduler, System.TimeSpan delay) { }
         public Cancelable(Akka.Actor.IScheduler scheduler, System.TimeSpan delay) { }
         public Cancelable(Akka.Actor.IScheduler scheduler, int millisecondsDelay) { }
-        public Cancelable(Akka.Actor.IScheduler scheduler) { }
-        public Cancelable(Akka.Actor.IActionScheduler scheduler) { }
         public bool IsCancellationRequested { get; }
         public bool IsDisposed { get; }
         public System.Threading.CancellationToken Token { get; }
@@ -541,15 +528,15 @@ namespace Akka.Actor
         public void Cancel(bool throwOnFirstException) { }
         public void CancelAfter(System.TimeSpan delay) { }
         public void CancelAfter(int millisecondsDelay) { }
-        public static Akka.Actor.ICancelable CreateCanceled() { }
-        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IScheduler scheduler, params Akka.Actor.ICancelable[] cancelables) { }
-        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IActionScheduler scheduler, params Akka.Actor.ICancelable[] cancelables) { }
-        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IScheduler scheduler, params System.Threading.CancellationToken[] cancellationTokens) { }
-        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IActionScheduler scheduler, params System.Threading.CancellationToken[] cancellationTokens) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
+        public static Akka.Actor.ICancelable CreateCanceled() { }
+        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IActionScheduler scheduler, params Akka.Actor.ICancelable[] cancelables) { }
+        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IActionScheduler scheduler, params System.Threading.CancellationToken[] cancellationTokens) { }
+        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IScheduler scheduler, params Akka.Actor.ICancelable[] cancelables) { }
+        public static Akka.Actor.ICancelable CreateLinkedCancelable(Akka.Actor.IScheduler scheduler, params System.Threading.CancellationToken[] cancellationTokens) { }
     }
-    public class static CancelableExtensions
+    public static class CancelableExtensions
     {
         public static void CancelIfNotNull(this Akka.Actor.ICancelable cancelable) { }
     }
@@ -575,9 +562,9 @@ namespace Akka.Actor
         public Akka.Actor.ExtendedActorSystem System { get; }
         public System.TimeSpan TotalTimeout { get; }
         public void AddTask(string phase, string taskName, System.Func<System.Threading.Tasks.Task<Akka.Done>> task) { }
-        public static Akka.Actor.CoordinatedShutdown Get(Akka.Actor.ActorSystem sys) { }
         public System.Threading.Tasks.Task<Akka.Done> Run(Akka.Actor.CoordinatedShutdown.Reason reason, string fromPhase = null) { }
         public System.TimeSpan Timeout(string phase) { }
+        public static Akka.Actor.CoordinatedShutdown Get(Akka.Actor.ActorSystem sys) { }
         public class ActorSystemTerminateReason : Akka.Actor.CoordinatedShutdown.Reason
         {
             public static readonly Akka.Actor.CoordinatedShutdown.Reason Instance;
@@ -619,13 +606,13 @@ namespace Akka.Actor
         public CoordinatedShutdownExtension() { }
         public override Akka.Actor.CoordinatedShutdown CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
-    [System.ObsoleteAttribute("This class will be removed in Akka.NET v1.6.0 - use the IScheduler instead.")]
+    [System.Obsolete("This class will be removed in Akka.NET v1.6.0 - use the IScheduler instead.")]
     public class DateTimeOffsetNowTimeProvider : Akka.Actor.IDateTimeOffsetNowTimeProvider, Akka.Actor.ITimeProvider
     {
         public System.TimeSpan HighResMonotonicClock { get; }
-        public static Akka.Actor.DateTimeOffsetNowTimeProvider Instance { get; }
         public System.TimeSpan MonotonicClock { get; }
         public System.DateTimeOffset Now { get; }
+        public static Akka.Actor.DateTimeOffsetNowTimeProvider Instance { get; }
     }
     public class DeadLetterActorRef : Akka.Actor.EmptyLocalActorRef
     {
@@ -633,7 +620,7 @@ namespace Akka.Actor
         protected override bool SpecialHandle(object message, Akka.Actor.IActorRef sender) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class DeadLetterMailbox : Akka.Dispatch.Mailbox
     {
         public DeadLetterMailbox(Akka.Actor.IActorRef deadLetters) { }
@@ -645,11 +632,11 @@ namespace Akka.Actor
         public Akka.Actor.IActorRef DeadActor { get; }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static Decider
+    public static class Decider
     {
-        public static Akka.Actor.DeployableDecider From(Akka.Actor.Directive defaultDirective, params System.Collections.Generic.KeyValuePair<, >[] pairs) { }
-        public static Akka.Actor.DeployableDecider From(Akka.Actor.Directive defaultDirective, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>> pairs) { }
         public static Akka.Actor.LocalOnlyDecider From(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public static Akka.Actor.DeployableDecider From(Akka.Actor.Directive defaultDirective, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>> pairs) { }
+        public static Akka.Actor.DeployableDecider From(Akka.Actor.Directive defaultDirective, params System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>[] pairs) { }
     }
     public class DefaultSupervisorStrategy : Akka.Actor.SupervisorStrategyConfigurator
     {
@@ -658,17 +645,17 @@ namespace Akka.Actor
     }
     public class Deploy : Akka.Util.ISurrogated, System.IEquatable<Akka.Actor.Deploy>
     {
+        public const int NoStashSize = -1;
         public static readonly Akka.Actor.Deploy Local;
         public static readonly string NoDispatcherGiven;
         public static readonly string NoMailboxGiven;
         public static readonly Akka.Actor.Scope NoScopeGiven;
-        public const int NoStashSize = -1;
         public static readonly Akka.Actor.Deploy None;
         public Deploy() { }
-        public Deploy(string path, Akka.Actor.Scope scope) { }
         public Deploy(Akka.Actor.Scope scope) { }
-        public Deploy(Akka.Routing.RouterConfig routerConfig, Akka.Actor.Scope scope) { }
         public Deploy(Akka.Routing.RouterConfig routerConfig) { }
+        public Deploy(Akka.Routing.RouterConfig routerConfig, Akka.Actor.Scope scope) { }
+        public Deploy(string path, Akka.Actor.Scope scope) { }
         public Deploy(string path, Akka.Configuration.Config config, Akka.Routing.RouterConfig routerConfig, Akka.Actor.Scope scope, string dispatcher) { }
         public Deploy(string path, Akka.Configuration.Config config, Akka.Routing.RouterConfig routerConfig, Akka.Actor.Scope scope, string dispatcher, string mailbox) { }
         public Deploy(string path, Akka.Configuration.Config config, Akka.Routing.RouterConfig routerConfig, Akka.Actor.Scope scope, string dispatcher, string mailbox, int stashCapacity) { }
@@ -704,9 +691,9 @@ namespace Akka.Actor
     {
         protected DeployableDecider() { }
         public DeployableDecider(Akka.Actor.Directive defaultDirective, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>> pairs) { }
-        public DeployableDecider(Akka.Actor.Directive defaultDirective, params System.Collections.Generic.KeyValuePair<, >[] pairs) { }
+        public DeployableDecider(Akka.Actor.Directive defaultDirective, params System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>[] pairs) { }
         public Akka.Actor.Directive DefaultDirective { get; }
-        public System.Collections.Generic.KeyValuePair<, >[] Pairs { get; }
+        public System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive>[] Pairs { get; }
         public Akka.Actor.Directive Decide(System.Exception cause) { }
         public bool Equals(Akka.Actor.DeployableDecider other) { }
         public override bool Equals(object obj) { }
@@ -728,7 +715,7 @@ namespace Akka.Actor
         Escalate = 2,
         Stop = 3,
     }
-    public class static DirectiveExtensions
+    public static class DirectiveExtensions
     {
         public static System.Collections.Generic.KeyValuePair<System.Type, Akka.Actor.Directive> When<TException>(this Akka.Actor.Directive self)
             where TException : System.Exception { }
@@ -736,7 +723,7 @@ namespace Akka.Actor
     public class EmptyLocalActorRef : Akka.Actor.MinimalActorRef
     {
         public EmptyLocalActorRef(Akka.Actor.IActorRefProvider provider, Akka.Actor.ActorPath path, Akka.Event.EventStream eventStream) { }
-        [System.ObsoleteAttribute("Use Context.Watch and Receive<Terminated> [1.1.0]")]
+        [System.Obsolete("Use Context.Watch and Receive<Terminated> [1.1.0]")]
         public override bool IsTerminated { get; }
         public override Akka.Actor.ActorPath Path { get; }
         public override Akka.Actor.IActorRefProvider Provider { get; }
@@ -744,10 +731,10 @@ namespace Akka.Actor
         protected virtual bool SpecialHandle(object message, Akka.Actor.IActorRef sender) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
-    public struct Envelope
+    public readonly struct Envelope
     {
-        public Envelope(object message, Akka.Actor.IActorRef sender, Akka.Actor.ActorSystem system) { }
         public Envelope(object message, Akka.Actor.IActorRef sender) { }
+        public Envelope(object message, Akka.Actor.IActorRef sender, Akka.Actor.ActorSystem system) { }
         public object Message { get; }
         public Akka.Actor.IActorRef Sender { get; }
         public override string ToString() { }
@@ -794,7 +781,7 @@ namespace Akka.Actor
             public override int GetHashCode() { }
             public override string ToString() { }
         }
-        public struct Event<TD> : Akka.Actor.INoSerializationVerificationNeeded
+        public readonly struct Event<TD> : Akka.Actor.INoSerializationVerificationNeeded
         {
             public Event(object fsmEvent, TD stateData) { }
             public object FsmEvent { get; }
@@ -827,18 +814,14 @@ namespace Akka.Actor
         {
             public static Akka.Actor.FSMBase.Shutdown Instance { get; }
         }
-        public sealed class StateTimeout
-        {
-            public static Akka.Actor.FSMBase.StateTimeout Instance { get; }
-        }
         public sealed class State<TS, TD> : System.IEquatable<Akka.Actor.FSMBase.State<TS, TD>>
         {
-            public State(TS stateName, TD stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, bool notifies = True) { }
+            public State(TS stateName, TD stateData, System.TimeSpan? timeout = default, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, bool notifies = true) { }
             public System.Collections.Generic.IReadOnlyList<object> Replies { get; }
             public TD StateData { get; }
             public TS StateName { get; }
             public Akka.Actor.FSMBase.Reason StopReason { get; }
-            public System.Nullable<System.TimeSpan> Timeout { get; }
+            public System.TimeSpan? Timeout { get; }
             public bool Equals(Akka.Actor.FSMBase.State<TS, TD> other) { }
             public override bool Equals(object obj) { }
             public Akka.Actor.FSMBase.State<TS, TD> ForMax(System.TimeSpan timeout) { }
@@ -846,6 +829,10 @@ namespace Akka.Actor
             public Akka.Actor.FSMBase.State<TS, TD> Replying(object replyValue) { }
             public override string ToString() { }
             public Akka.Actor.FSMBase.State<TS, TD> Using(TD nextStateData) { }
+        }
+        public sealed class StateTimeout
+        {
+            public static Akka.Actor.FSMBase.StateTimeout Instance { get; }
         }
         public sealed class StopEvent<TS, TD> : Akka.Actor.INoSerializationVerificationNeeded
         {
@@ -886,7 +873,7 @@ namespace Akka.Actor
         public TState StateName { get; }
         public void CancelTimer(string name) { }
         public Akka.Actor.FSMBase.State<TState, TData> GoTo(TState nextStateName) { }
-        [System.ObsoleteAttribute("This method is obsoleted. Use GoTo(nextStateName).Using(newStateData) [1.2.0]")]
+        [System.Obsolete("This method is obsoleted. Use GoTo(nextStateName).Using(newStateData) [1.2.0]")]
         public Akka.Actor.FSMBase.State<TState, TData> GoTo(TState nextStateName, TData stateData) { }
         public void Initialize() { }
         public bool IsTimerActive(string name) { }
@@ -895,33 +882,33 @@ namespace Akka.Actor
         public void OnTransition(Akka.Actor.FSM<TState, TData>.TransitionHandler transitionHandler) { }
         protected override void PostStop() { }
         protected override bool Receive(object message) { }
-        public void SetStateTimeout(TState state, System.Nullable<System.TimeSpan> timeout) { }
-        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = False) { }
-        public void StartWith(TState stateName, TData stateData, System.Nullable<System.TimeSpan> timeout = null) { }
+        public void SetStateTimeout(TState state, System.TimeSpan? timeout) { }
+        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = false) { }
+        public void StartWith(TState stateName, TData stateData, System.TimeSpan? timeout = default) { }
         public Akka.Actor.FSMBase.State<TState, TData> Stay() { }
         public Akka.Actor.FSMBase.State<TState, TData> Stop() { }
         public Akka.Actor.FSMBase.State<TState, TData> Stop(Akka.Actor.FSMBase.Reason reason) { }
         public Akka.Actor.FSMBase.State<TState, TData> Stop(Akka.Actor.FSMBase.Reason reason, TData stateData) { }
         public Akka.Actor.FSM<TState, TData>.TransformHelper Transform(Akka.Actor.FSM<TState, TData>.StateFunction func) { }
-        public void When(TState stateName, Akka.Actor.FSM<TState, TData>.StateFunction func, System.Nullable<System.TimeSpan> timeout = null) { }
+        public void When(TState stateName, Akka.Actor.FSM<TState, TData>.StateFunction func, System.TimeSpan? timeout = default) { }
         public void WhenUnhandled(Akka.Actor.FSM<TState, TData>.StateFunction stateFunction) { }
-        public delegate Akka.Actor.FSMBase.State<TState, TData> StateFunction<TState, TData>(Akka.Actor.FSMBase.Event<TData> fsmEvent);
-        public sealed class TransformHelper<TState, TData>
+        public sealed class TransformHelper
         {
             public TransformHelper(Akka.Actor.FSM<TState, TData>.StateFunction func) { }
             public Akka.Actor.FSM<TState, TData>.StateFunction Func { get; }
             public Akka.Actor.FSM<TState, TData>.StateFunction Using(System.Func<Akka.Actor.FSMBase.State<TState, TData>, Akka.Actor.FSMBase.State<TState, TData>> andThen) { }
         }
+        public delegate Akka.Actor.FSMBase.State<TState, TData> StateFunction<TState, TData>(Akka.Actor.FSMBase.Event<TData> fsmEvent);
         public delegate void TransitionHandler<TState, TData>(TState initialState, TState nextState);
     }
-    [System.ObsoleteAttribute("Use Akka.Actor.Status.Failure. Will be removed in v1.6")]
+    [System.Obsolete("Use Akka.Actor.Status.Failure. Will be removed in v1.6")]
     public class Failure
     {
         public Failure() { }
         public System.Exception Exception { get; set; }
         public System.DateTime Timestamp { get; set; }
     }
-    [System.ObsoleteAttribute("Use List of Akka.Actor.Status.Failure. Will be removed in v1.6")]
+    [System.Obsolete("Use List of Akka.Actor.Status.Failure. Will be removed in v1.6")]
     public class Failures
     {
         public Failures() { }
@@ -936,17 +923,17 @@ namespace Akka.Actor
         public override void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
-    public class static Futures
+    public static class Futures
     {
-        public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout = null) { }
         public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.Threading.CancellationToken cancellationToken) { }
-        public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
-        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout = null) { }
+        public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.TimeSpan? timeout = default) { }
+        public static System.Threading.Tasks.Task<object> Ask(this Akka.Actor.ICanTell self, object message, System.TimeSpan? timeout, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Threading.CancellationToken cancellationToken) { }
-        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
-        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, System.Func<Akka.Actor.IActorRef, object> messageFactory, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.TimeSpan? timeout = default) { }
+        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, System.Func<Akka.Actor.IActorRef, object> messageFactory, System.TimeSpan? timeout, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Threading.Tasks.Task<T> Ask<T>(this Akka.Actor.ICanTell self, object message, System.TimeSpan? timeout, System.Threading.CancellationToken cancellationToken) { }
     }
-    public class static GracefulStopSupport
+    public static class GracefulStopSupport
     {
         public static System.Threading.Tasks.Task<bool> GracefulStop(this Akka.Actor.IActorRef target, System.TimeSpan timeout) { }
         public static System.Threading.Tasks.Task<bool> GracefulStop(this Akka.Actor.IActorRef target, System.TimeSpan timeout, object stopMessage) { }
@@ -957,7 +944,6 @@ namespace Akka.Actor
         protected override void PreStart() { }
         protected override bool Receive(object message) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class HashedWheelTimerScheduler : Akka.Actor.SchedulerBase, Akka.Actor.IDateTimeOffsetNowTimeProvider, Akka.Actor.ITimeProvider, System.IDisposable
     {
         public HashedWheelTimerScheduler(Akka.Configuration.Config scheduler, Akka.Event.ILoggingAdapter log) { }
@@ -965,26 +951,26 @@ namespace Akka.Actor
         public override System.TimeSpan MonotonicClock { get; }
         protected override System.DateTimeOffset TimeNow { get; }
         public void Dispose() { }
-        protected override void InternalScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable) { }
         protected override void InternalScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
-        protected override void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable) { }
+        protected override void InternalScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable) { }
         protected override void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
+        protected override void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable) { }
         protected override void InternalScheduleTellOnce(System.TimeSpan delay, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable) { }
         protected override void InternalScheduleTellRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable) { }
     }
     public interface IActionScheduler : Akka.Actor.IRunnableScheduler
     {
-        void ScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable);
         void ScheduleOnce(System.TimeSpan delay, System.Action action);
-        void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable);
+        void ScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable);
         void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action);
+        void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable);
     }
     public interface IActorContext : Akka.Actor.IActorRefFactory, Akka.Actor.ICanWatch
     {
         Akka.Dispatch.MessageDispatcher Dispatcher { get; }
         Akka.Actor.IActorRef Parent { get; }
         Akka.Actor.Props Props { get; }
-        System.Nullable<System.TimeSpan> ReceiveTimeout { get; }
+        System.TimeSpan? ReceiveTimeout { get; }
         Akka.Actor.IActorRef Self { get; }
         Akka.Actor.IActorRef Sender { get; }
         Akka.Actor.ActorSystem System { get; }
@@ -992,7 +978,7 @@ namespace Akka.Actor
         void BecomeStacked(Akka.Actor.Receive receive);
         Akka.Actor.IActorRef Child(string name);
         System.Collections.Generic.IEnumerable<Akka.Actor.IActorRef> GetChildren();
-        void SetReceiveTimeout(System.Nullable<System.TimeSpan> timeout);
+        void SetReceiveTimeout(System.TimeSpan? timeout);
         void Stop(Akka.Actor.IActorRef child);
         void UnbecomeStacked();
     }
@@ -1021,25 +1007,25 @@ namespace Akka.Actor
         Akka.Actor.IActorRef IgnoreRef { get; }
         Akka.Actor.IInternalActorRef RootGuardian { get; }
         Akka.Actor.ActorPath RootPath { get; }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         Akka.Serialization.Information SerializationInformation { get; }
         Akka.Actor.Settings Settings { get; }
         Akka.Actor.LocalActorRef SystemGuardian { get; }
         Akka.Actor.IInternalActorRef TempContainer { get; }
         System.Threading.Tasks.Task TerminationTask { get; }
         Akka.Actor.IInternalActorRef ActorOf(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.Props props, Akka.Actor.IInternalActorRef supervisor, Akka.Actor.ActorPath path, bool systemService, Akka.Actor.Deploy deploy, bool lookupDeploy, bool async);
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         Akka.Actor.FutureActorRef<T> CreateFutureRef<T>(System.Threading.Tasks.TaskCompletionSource<T> tcs);
         Akka.Actor.Address GetExternalAddressFor(Akka.Actor.Address address);
         void Init(Akka.Actor.Internal.ActorSystemImpl system);
         void RegisterTempActor(Akka.Actor.IInternalActorRef actorRef, Akka.Actor.ActorPath path);
-        Akka.Actor.IActorRef ResolveActorRef(string path);
         Akka.Actor.IActorRef ResolveActorRef(Akka.Actor.ActorPath actorPath);
+        Akka.Actor.IActorRef ResolveActorRef(string path);
         Akka.Actor.IActorRef RootGuardianAt(Akka.Actor.Address address);
         Akka.Actor.ActorPath TempPath();
         void UnregisterTempActor(Akka.Actor.ActorPath path);
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IActorRefScope
     {
         bool IsLocal { get; }
@@ -1075,7 +1061,7 @@ namespace Akka.Actor
         void CancelAfter(System.TimeSpan delay);
         void CancelAfter(int millisecondsDelay);
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface ICell
     {
         Akka.Actor.Internal.IChildrenContainer ChildrenContainer { get; }
@@ -1089,7 +1075,7 @@ namespace Akka.Actor
         Akka.Actor.ActorSystem System { get; }
         Akka.Actor.Internal.ActorSystemImpl SystemImpl { get; }
         Akka.Actor.IInternalActorRef GetChildByName(string name);
-        [System.ObsoleteAttribute("Used ChildrenRefs instead [1.1.0]")]
+        [System.Obsolete("Used ChildrenRefs instead [1.1.0]")]
         System.Collections.Generic.IEnumerable<Akka.Actor.IInternalActorRef> GetChildren();
         Akka.Actor.IInternalActorRef GetSingleChild(string name);
         void Restart(System.Exception cause);
@@ -1142,19 +1128,19 @@ namespace Akka.Actor
     {
         Akka.Actor.IActorContext ActorContext { get; }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IInternalActorRef : Akka.Actor.IActorRef, Akka.Actor.IActorRefScope, Akka.Actor.ICanTell, Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.IActorRef>, System.IEquatable<Akka.Actor.IActorRef>
     {
-        [System.ObsoleteAttribute("Use Context.Watch and Receive<Terminated> [1.1.0]")]
+        [System.Obsolete("Use Context.Watch and Receive<Terminated> [1.1.0]")]
         bool IsTerminated { get; }
         Akka.Actor.IInternalActorRef Parent { get; }
         Akka.Actor.IActorRefProvider Provider { get; }
         Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name);
         void Restart(System.Exception cause);
         void Resume(System.Exception causedByFailure = null);
-        [System.ObsoleteAttribute("Use SendSystemMessage(message) [1.1.0]")]
-        void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender);
         void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message);
+        [System.Obsolete("Use SendSystemMessage(message) [1.1.0]")]
+        void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender);
         void Start();
         void Stop();
         void Suspend();
@@ -1170,10 +1156,10 @@ namespace Akka.Actor
     }
     public interface IRunnableScheduler
     {
-        void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
         void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action);
-        void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
+        void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
         void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action);
+        void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
     }
     public interface IScheduler : Akka.Actor.ITellScheduler, Akka.Actor.ITimeProvider
     {
@@ -1213,8 +1199,8 @@ namespace Akka.Actor
         void CancelAll();
         bool IsTimerActive(object key);
         void StartPeriodicTimer(object key, object msg, System.TimeSpan interval);
-        void StartPeriodicTimer(object key, object msg, System.TimeSpan interval, Akka.Actor.IActorRef sender);
         void StartPeriodicTimer(object key, object msg, System.TimeSpan initialDelay, System.TimeSpan interval);
+        void StartPeriodicTimer(object key, object msg, System.TimeSpan interval, Akka.Actor.IActorRef sender);
         void StartPeriodicTimer(object key, object msg, System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.IActorRef sender);
         void StartSingleTimer(object key, object msg, System.TimeSpan timeout);
         void StartSingleTimer(object key, object msg, System.TimeSpan timeout, Akka.Actor.IActorRef sender);
@@ -1224,7 +1210,7 @@ namespace Akka.Actor
         void Become(Akka.Actor.UntypedReceive receive);
         void BecomeStacked(Akka.Actor.UntypedReceive receive);
     }
-    [System.ObsoleteAttribute("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
+    [System.Obsolete("Use `IWithStash` with a configured BoundedDeque-based mailbox instead.")]
     public interface IWithBoundedStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IBoundedDequeBasedMessageQueueSemantics> { }
     public interface IWithStash : Akka.Actor.IActorStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IDequeBasedMessageQueueSemantics> { }
     public interface IWithTimers
@@ -1258,7 +1244,6 @@ namespace Akka.Actor
     public class Inbox : Akka.Actor.ICanWatch, Akka.Actor.IInboxable, System.IDisposable
     {
         public Akka.Actor.IActorRef Receiver { get; }
-        public static Akka.Actor.Inbox Create(Akka.Actor.ActorSystem system) { }
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public object Receive() { }
@@ -1271,6 +1256,7 @@ namespace Akka.Actor
         public Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef subject) { }
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef subject) { }
         public Akka.Actor.IActorRef WatchWith(Akka.Actor.IActorRef subject, object message) { }
+        public static Akka.Actor.Inbox Create(Akka.Actor.ActorSystem system) { }
     }
     public sealed class IntentionalActorRestartException : Akka.Actor.AkkaException
     {
@@ -1281,7 +1267,7 @@ namespace Akka.Actor
         public static Akka.Actor.IntentionalRestart Instance { get; }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class InternalActorRefBase : Akka.Actor.ActorRefBase, Akka.Actor.IActorRef, Akka.Actor.IActorRefScope, Akka.Actor.ICanTell, Akka.Actor.IInternalActorRef, Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.IActorRef>, System.IEquatable<Akka.Actor.IActorRef>
     {
         protected InternalActorRefBase() { }
@@ -1292,9 +1278,9 @@ namespace Akka.Actor
         public abstract Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name);
         public abstract void Restart(System.Exception cause);
         public abstract void Resume(System.Exception causedByFailure = null);
-        [System.ObsoleteAttribute("Use SendSystemMessage(message) instead [1.1.0]")]
-        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public abstract void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message);
+        [System.Obsolete("Use SendSystemMessage(message) instead [1.1.0]")]
+        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public abstract void Start();
         public abstract void Stop();
         public abstract void Suspend();
@@ -1302,8 +1288,8 @@ namespace Akka.Actor
     public class InvalidActorNameException : Akka.Actor.AkkaException
     {
         public InvalidActorNameException(string message) { }
-        public InvalidActorNameException(string message, System.Exception innerException) { }
         protected InvalidActorNameException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public InvalidActorNameException(string message, System.Exception innerException) { }
     }
     public class InvalidMessageException : Akka.Actor.AkkaException
     {
@@ -1367,8 +1353,8 @@ namespace Akka.Actor
         public void Init(Akka.Actor.Internal.ActorSystemImpl system) { }
         public void RegisterExtraName(string name, Akka.Actor.IInternalActorRef actor) { }
         public void RegisterTempActor(Akka.Actor.IInternalActorRef actorRef, Akka.Actor.ActorPath path) { }
-        public Akka.Actor.IActorRef ResolveActorRef(string path) { }
         public Akka.Actor.IActorRef ResolveActorRef(Akka.Actor.ActorPath path) { }
+        public Akka.Actor.IActorRef ResolveActorRef(string path) { }
         public Akka.Actor.IActorRef RootGuardianAt(Akka.Actor.Address address) { }
         public Akka.Actor.ActorPath TempPath() { }
         public void UnregisterTempActor(Akka.Actor.ActorPath path) { }
@@ -1394,15 +1380,15 @@ namespace Akka.Actor
     {
         public LoggerInitializationException() { }
         public LoggerInitializationException(string message) { }
-        public LoggerInitializationException(string message, System.Exception cause = null) { }
         protected LoggerInitializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public LoggerInitializationException(string message, System.Exception cause = null) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class MinimalActorRef : Akka.Actor.InternalActorRefBase, Akka.Actor.IActorRefScope
     {
         protected MinimalActorRef() { }
         public override bool IsLocal { get; }
-        [System.ObsoleteAttribute("Use Context.Watch and Receive<Terminated> [1.1.0]")]
+        [System.Obsolete("Use Context.Watch and Receive<Terminated> [1.1.0]")]
         public override bool IsTerminated { get; }
         public override Akka.Actor.IInternalActorRef Parent { get; }
         public override Akka.Actor.IActorRef GetChild(System.Collections.Generic.IReadOnlyList<string> name) { }
@@ -1428,14 +1414,14 @@ namespace Akka.Actor
     }
     public class OneForOneStrategy : Akka.Actor.SupervisorStrategy, System.IEquatable<Akka.Actor.OneForOneStrategy>
     {
-        public OneForOneStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public OneForOneStrategy(System.Nullable<int> maxNrOfRetries, System.Nullable<System.TimeSpan> withinTimeRange, Akka.Actor.IDecider decider) { }
-        public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
-        public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = True) { }
-        public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
-        public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = True) { }
-        public OneForOneStrategy(Akka.Actor.IDecider decider) { }
         protected OneForOneStrategy() { }
+        public OneForOneStrategy(Akka.Actor.IDecider decider) { }
+        public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public OneForOneStrategy(System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = true) { }
+        public OneForOneStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, Akka.Actor.IDecider decider) { }
+        public OneForOneStrategy(int? maxNrOfRetries, System.TimeSpan? withinTimeRange, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider) { }
+        public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, Akka.Actor.IDecider decider, bool loggingEnabled = true) { }
+        public OneForOneStrategy(int maxNrOfRetries, int withinTimeMilliseconds, System.Func<System.Exception, Akka.Actor.Directive> localOnlyDecider, bool loggingEnabled = true) { }
         public override Akka.Actor.IDecider Decider { get; }
         public int MaxNumberOfRetries { get; }
         public int WithinTimeRangeMilliseconds { get; }
@@ -1457,16 +1443,16 @@ namespace Akka.Actor
             public Akka.Util.ISurrogated FromSurrogate(Akka.Actor.ActorSystem system) { }
         }
     }
-    public class static PipeToSupport
+    public static class PipeToSupport
     {
-        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.Task<T> taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
-        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.ValueTask<T> taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
-        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.Task<T> taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
-        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.ValueTask<T> taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
         public static System.Threading.Tasks.Task PipeTo(this System.Threading.Tasks.Task taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<object> success = null, System.Func<System.Exception, object> failure = null) { }
         public static System.Threading.Tasks.Task PipeTo(this System.Threading.Tasks.ValueTask taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<object> success = null, System.Func<System.Exception, object> failure = null) { }
         public static System.Threading.Tasks.Task PipeTo(this System.Threading.Tasks.Task taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<object> success = null, System.Func<System.Exception, object> failure = null) { }
         public static System.Threading.Tasks.Task PipeTo(this System.Threading.Tasks.ValueTask taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<object> success = null, System.Func<System.Exception, object> failure = null) { }
+        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.Task<T> taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
+        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.ValueTask<T> taskToPipe, Akka.Actor.ICanTell recipient, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
+        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.Task<T> taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
+        public static System.Threading.Tasks.Task PipeTo<T>(this System.Threading.Tasks.ValueTask<T> taskToPipe, Akka.Actor.ICanTell recipient, bool useConfigureAwait, Akka.Actor.IActorRef sender = null, System.Func<T, object> success = null, System.Func<System.Exception, object> failure = null) { }
     }
     public sealed class PoisonPill : Akka.Actor.IAutoReceivedMessage, Akka.Actor.IPossiblyHarmful, Akka.Event.IDeadLetterSuppression
     {
@@ -1475,15 +1461,15 @@ namespace Akka.Actor
     }
     public class PostRestartException : Akka.Actor.ActorInitializationException
     {
-        public PostRestartException(Akka.Actor.IActorRef actor, System.Exception cause, System.Exception originalCause) { }
         protected PostRestartException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public PostRestartException(Akka.Actor.IActorRef actor, System.Exception cause, System.Exception originalCause) { }
         public System.Exception OriginalCause { get; }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class PreRestartException : Akka.Actor.ActorInitializationException
     {
-        public PreRestartException(Akka.Actor.IActorRef actor, System.Exception restartException, System.Exception cause, object optionalMessage) { }
         protected PreRestartException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public PreRestartException(Akka.Actor.IActorRef actor, System.Exception restartException, System.Exception cause, object optionalMessage) { }
         public object OptionalMessage { get; }
         public System.Exception RestartException { get; }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
@@ -1493,38 +1479,26 @@ namespace Akka.Actor
         public static readonly Akka.Actor.Props None;
         protected Props() { }
         protected Props(Akka.Actor.Props copy) { }
-        public Props(System.Type type, object[] args) { }
         public Props(System.Type type) { }
-        public Props(System.Type type, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Collections.Generic.IEnumerable<object> args) { }
-        public Props(System.Type type, Akka.Actor.SupervisorStrategy supervisorStrategy, params object[] args) { }
+        public Props(System.Type type, object[] args) { }
         public Props(Akka.Actor.Deploy deploy, System.Type type, System.Collections.Generic.IEnumerable<object> args) { }
         public Props(Akka.Actor.Deploy deploy, System.Type type, params object[] args) { }
+        public Props(System.Type type, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Collections.Generic.IEnumerable<object> args) { }
+        public Props(System.Type type, Akka.Actor.SupervisorStrategy supervisorStrategy, params object[] args) { }
         public object[] Arguments { get; }
-        public Akka.Actor.Deploy Deploy { get; set; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        public Akka.Actor.Deploy Deploy { get; protected set; }
+        [Newtonsoft.Json.JsonIgnore]
         public string Dispatcher { get; }
-        public static Akka.Actor.Props Empty { get; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        [Newtonsoft.Json.JsonIgnore]
         public string Mailbox { get; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        [Newtonsoft.Json.JsonIgnore]
         public Akka.Routing.RouterConfig RouterConfig { get; }
-        public Akka.Actor.SupervisorStrategy SupervisorStrategy { get; set; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        public Akka.Actor.SupervisorStrategy SupervisorStrategy { get; protected set; }
+        [Newtonsoft.Json.JsonIgnore]
         public System.Type Type { get; }
         public string TypeName { get; }
+        public static Akka.Actor.Props Empty { get; }
         protected virtual Akka.Actor.Props Copy() { }
-        public static Akka.Actor.Props Create<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, Akka.Actor.SupervisorStrategy supervisorStrategy = null)
-            where TActor : Akka.Actor.ActorBase { }
-        public static Akka.Actor.Props Create<TActor>(params object[] args)
-            where TActor : Akka.Actor.ActorBase { }
-        public static Akka.Actor.Props Create<TActor>(Akka.Actor.SupervisorStrategy supervisorStrategy)
-            where TActor : Akka.Actor.ActorBase, new () { }
-        public static Akka.Actor.Props Create(System.Type type, params object[] args) { }
-        [System.ObsoleteAttribute("Do not use this method. Call CreateBy(IIndirectActorProducer, params object[] arg" +
-            "s) instead")]
-        public static Akka.Actor.Props CreateBy<TProducer>(params object[] args)
-            where TProducer :  class, Akka.Actor.IIndirectActorProducer { }
-        public static Akka.Actor.Props CreateBy(Akka.Actor.IIndirectActorProducer producer, params object[] args) { }
         public bool Equals(Akka.Actor.Props other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
@@ -1536,6 +1510,18 @@ namespace Akka.Actor
         public Akka.Actor.Props WithRouter(Akka.Routing.RouterConfig routerConfig) { }
         public Akka.Actor.Props WithStashCapacity(int stashCapacity) { }
         public Akka.Actor.Props WithSupervisorStrategy(Akka.Actor.SupervisorStrategy supervisorStrategy) { }
+        public static Akka.Actor.Props Create(System.Type type, params object[] args) { }
+        public static Akka.Actor.Props Create<TActor>(Akka.Actor.SupervisorStrategy supervisorStrategy)
+            where TActor : Akka.Actor.ActorBase, new () { }
+        public static Akka.Actor.Props Create<TActor>(params object[] args)
+            where TActor : Akka.Actor.ActorBase { }
+        public static Akka.Actor.Props Create<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, Akka.Actor.SupervisorStrategy supervisorStrategy = null)
+            where TActor : Akka.Actor.ActorBase { }
+        public static Akka.Actor.Props CreateBy(Akka.Actor.IIndirectActorProducer producer, params object[] args) { }
+        [System.Obsolete("Do not use this method. Call CreateBy(IIndirectActorProducer, params object[] arg" +
+            "s) instead")]
+        public static Akka.Actor.Props CreateBy<TProducer>(params object[] args)
+            where TProducer :  class, Akka.Actor.IIndirectActorProducer { }
         public class PropsSurrogate : Akka.Util.ISurrogate
         {
             public PropsSurrogate() { }
@@ -1553,7 +1539,7 @@ namespace Akka.Actor
         }
         public sealed class Custom : Akka.Actor.ProviderSelection
         {
-            public Custom(string fqn, string identifier = null, bool hasCluster = False) { }
+            public Custom(string fqn, string identifier = null, bool hasCluster = false) { }
         }
         public sealed class Local : Akka.Actor.ProviderSelection
         {
@@ -1565,39 +1551,30 @@ namespace Akka.Actor
         }
     }
     public delegate bool Receive(object message);
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class ReceiveActor : Akka.Actor.UntypedActor, Akka.Actor.Internal.IInitializableActor
     {
         protected ReceiveActor() { }
         protected void Become(System.Action configure) { }
         protected void BecomeStacked(System.Action configure) { }
-        protected virtual void OnReceive(object message) { }
-        protected void Receive<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Action<T> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<T> shouldHandle = null) { }
-        protected void Receive<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
-        protected void Receive(System.Type messageType, System.Action<object> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<object> shouldHandle = null) { }
-        protected void Receive(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
-        protected void Receive<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T, bool> handler) { }
+        protected override sealed void OnReceive(object message) { }
         protected void Receive(System.Type messageType, System.Func<object, bool> handler) { }
+        protected void Receive(System.Type messageType, System.Action<object> handler, System.Predicate<object>? shouldHandle = null) { }
+        protected void Receive(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
+        protected void Receive<T>(System.Func<T, bool> handler) { }
+        protected void Receive<T>(System.Action<T> handler, System.Predicate<T>? shouldHandle = null) { }
+        protected void Receive<T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
         protected void ReceiveAny(System.Action<object> handler) { }
         protected void ReceiveAnyAsync(System.Func<object, System.Threading.Tasks.Task> handler) { }
-        protected void ReceiveAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T, System.Threading.Tasks.Task> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<T> shouldHandle = null) { }
-        protected void ReceiveAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Predicate<T> shouldHandle, System.Func<T, System.Threading.Tasks.Task> handler) { }
-        protected void ReceiveAsync(System.Type messageType, System.Func<object, System.Threading.Tasks.Task> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<object> shouldHandle = null) { }
+        protected void ReceiveAsync(System.Type messageType, System.Func<object, System.Threading.Tasks.Task> handler, System.Predicate<object>? shouldHandle = null) { }
         protected void ReceiveAsync(System.Type messageType, System.Predicate<object> shouldHandle, System.Func<object, System.Threading.Tasks.Task> handler) { }
+        protected void ReceiveAsync<T>(System.Func<T, System.Threading.Tasks.Task> handler, System.Predicate<T>? shouldHandle = null) { }
+        protected void ReceiveAsync<T>(System.Predicate<T> shouldHandle, System.Func<T, System.Threading.Tasks.Task> handler) { }
     }
     public class ReceiveTimeout : Akka.Actor.IPossiblyHarmful
     {
         public static Akka.Actor.ReceiveTimeout Instance { get; }
     }
-    public class static RelativeActorPath
+    public static class RelativeActorPath
     {
         public static System.Collections.Generic.IEnumerable<string> Unapply(string addr) { }
     }
@@ -1647,7 +1624,7 @@ namespace Akka.Actor
     {
         public RootActorPath(Akka.Actor.Address address, string name = "") { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class RootGuardianActorRef : Akka.Actor.LocalActorRef
     {
         public RootGuardianActorRef(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Dispatch.MailboxType mailboxType, Akka.Actor.IInternalActorRef supervisor, Akka.Actor.ActorPath path, Akka.Actor.IInternalActorRef deadLetters, System.Collections.Generic.IReadOnlyDictionary<string, Akka.Actor.IInternalActorRef> extraNames) { }
@@ -1673,16 +1650,16 @@ namespace Akka.Actor
         public abstract System.TimeSpan HighResMonotonicClock { get; }
         public abstract System.TimeSpan MonotonicClock { get; }
         protected abstract System.DateTimeOffset TimeNow { get; }
-        protected abstract void InternalScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable);
         protected abstract void InternalScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
-        protected abstract void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable);
+        protected abstract void InternalScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable);
         protected abstract void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable);
+        protected abstract void InternalScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable);
         protected abstract void InternalScheduleTellOnce(System.TimeSpan delay, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable);
         protected abstract void InternalScheduleTellRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable);
-        public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
         public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action) { }
-        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
+        public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
         public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action) { }
+        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
         protected static void ValidateDelay(System.TimeSpan delay, string parameterName) { }
         protected static void ValidateInterval(System.TimeSpan interval, string parameterName) { }
     }
@@ -1691,7 +1668,7 @@ namespace Akka.Actor
         public SchedulerException(string message) { }
         public SchedulerException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static SchedulerExtensions
+    public static class SchedulerExtensions
     {
         public static void ScheduleOnce(this Akka.Actor.IActionScheduler scheduler, int millisecondsDelay, System.Action action, Akka.Actor.ICancelable cancelable = null) { }
         public static Akka.Actor.ICancelable ScheduleOnceCancelable(this Akka.Actor.IActionScheduler scheduler, System.TimeSpan delay, System.Action action) { }
@@ -1801,17 +1778,17 @@ namespace Akka.Actor
         public void InjectTopLevelFallback(Akka.Configuration.Config config) { }
         public override string ToString() { }
     }
-    public class static StashFactory
+    public static class StashFactory
     {
-        public static Akka.Actor.IStash CreateStash<T>(this Akka.Actor.IActorContext context)
-            where T : Akka.Actor.ActorBase { }
         public static Akka.Actor.IStash CreateStash(this Akka.Actor.IActorContext context, Akka.Actor.IActorStash actorInstance) { }
         public static Akka.Actor.IStash CreateStash(this Akka.Actor.IActorContext context, System.Type actorType) { }
+        public static Akka.Actor.IStash CreateStash<T>(this Akka.Actor.IActorContext context)
+            where T : Akka.Actor.ActorBase { }
     }
     public class StashOverflowException : Akka.Actor.AkkaException
     {
-        public StashOverflowException(string message, System.Exception cause = null) { }
         protected StashOverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public StashOverflowException(string message, System.Exception cause = null) { }
     }
     public abstract class Status
     {
@@ -1826,8 +1803,8 @@ namespace Akka.Actor
         }
         public sealed class Success : Akka.Actor.Status
         {
-            public static readonly Akka.Actor.Status.Success Instance;
             public readonly object Status;
+            public static readonly Akka.Actor.Status.Success Instance;
             public Success(object status) { }
             public override string ToString() { }
         }
@@ -1882,7 +1859,7 @@ namespace Akka.Actor
         public TerminatedProps() { }
         public override Akka.Actor.ActorBase NewActor() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class UnstartedCell : Akka.Actor.ICell
     {
         public UnstartedCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.RepointableActorRef self, Akka.Actor.Props props, Akka.Actor.IInternalActorRef supervisor) { }
@@ -1912,11 +1889,11 @@ namespace Akka.Actor
     public abstract class UntypedActor : Akka.Actor.ActorBase
     {
         protected UntypedActor() { }
-        protected static Akka.Actor.IUntypedActorContext Context { get; }
+        protected new static Akka.Actor.IUntypedActorContext Context { get; }
         protected void Become(Akka.Actor.UntypedReceive receive) { }
         protected void BecomeStacked(Akka.Actor.UntypedReceive receive) { }
         protected abstract void OnReceive(object message);
-        protected virtual bool Receive(object message) { }
+        protected override sealed bool Receive(object message) { }
         protected void RunTask(System.Action action) { }
         protected void RunTask(System.Func<System.Threading.Tasks.Task> action) { }
     }
@@ -1936,11 +1913,11 @@ namespace Akka.Actor
         public Akka.Actor.IStash Stash { get; set; }
     }
     public delegate void UntypedReceive(object message);
-    public class static WatchAsyncSupport
+    public static class WatchAsyncSupport
     {
-        public static System.Threading.Tasks.Task<bool> WatchAsync(this Akka.Actor.IActorRef target, System.Threading.CancellationToken token = null) { }
+        public static System.Threading.Tasks.Task<bool> WatchAsync(this Akka.Actor.IActorRef target, System.Threading.CancellationToken token = default) { }
     }
-    public class static WrappedMessage
+    public static class WrappedMessage
     {
         public static object Unwrap(object message) { }
     }
@@ -1976,7 +1953,7 @@ namespace Akka.Actor.Dsl
         public void ReceiveAsync<T>(System.Predicate<T> shouldHandle, System.Func<T, Akka.Actor.IActorContext, System.Threading.Tasks.Task> handler) { }
         protected override Akka.Actor.SupervisorStrategy SupervisorStrategy() { }
     }
-    public class static ActExtensions
+    public static class ActExtensions
     {
         public static Akka.Actor.IActorRef ActorOf(this Akka.Actor.IActorRefFactory factory, System.Action<Akka.Actor.Dsl.IActorDsl> config, string name = null) { }
         public static Akka.Actor.IActorRef ActorOf(this Akka.Actor.IActorRefFactory factory, System.Action<Akka.Actor.Dsl.IActorDsl, Akka.Actor.IActorContext> config, string name = null) { }
@@ -1996,8 +1973,8 @@ namespace Akka.Actor.Dsl
         void DefaultPreRestart(System.Exception reason, object message);
         void DefaultPreStart();
         void Receive<T>(System.Action<T, Akka.Actor.IActorContext> handler);
-        void Receive<T>(System.Predicate<T> shouldHandle, System.Action<T, Akka.Actor.IActorContext> handler);
         void Receive<T>(System.Action<T, Akka.Actor.IActorContext> handler, System.Predicate<T> shouldHandle);
+        void Receive<T>(System.Predicate<T> shouldHandle, System.Action<T, Akka.Actor.IActorContext> handler);
         void ReceiveAny(System.Action<object, Akka.Actor.IActorContext> handler);
         void ReceiveAnyAsync(System.Func<object, Akka.Actor.IActorContext, System.Threading.Tasks.Task> handler);
         void ReceiveAsync<T>(System.Func<T, Akka.Actor.IActorContext, System.Threading.Tasks.Task> handler, System.Predicate<T> shouldHandle = null);
@@ -2025,7 +2002,7 @@ namespace Akka.Actor.Internal
     public class ActorSystemImpl : Akka.Actor.ExtendedActorSystem
     {
         public ActorSystemImpl(string name) { }
-        public ActorSystemImpl(string name, Akka.Configuration.Config config, Akka.Actor.Setup.ActorSystemSetup setup, System.Nullable<Akka.Util.Option<Akka.Actor.Props>> guardianProps = null) { }
+        public ActorSystemImpl(string name, Akka.Configuration.Config config, Akka.Actor.Setup.ActorSystemSetup setup, Akka.Util.Option<Akka.Actor.Props>? guardianProps = default) { }
         public override Akka.Actor.ActorProducerPipelineResolver ActorPipelineResolver { get; }
         public override Akka.Actor.IActorRef DeadLetters { get; }
         public override Akka.Dispatch.Dispatchers Dispatchers { get; }
@@ -2099,17 +2076,17 @@ namespace Akka.Actor.Internal
         public abstract Akka.Actor.Internal.IChildrenContainer Reserve(string name);
         public abstract Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor);
         public bool TryGetByName(string name, out Akka.Actor.Internal.IChildStats stats) { }
-        public bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats childRestartStats) { }
+        public bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Akka.Actor.Internal.ChildRestartStats? childRestartStats) { }
         public abstract Akka.Actor.Internal.IChildrenContainer Unreserve(string name);
     }
     public class EmptyChildrenContainer : Akka.Actor.Internal.IChildrenContainer
     {
         protected EmptyChildrenContainer() { }
         public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.IInternalActorRef> Children { get; }
-        public static Akka.Actor.Internal.IChildrenContainer Instance { get; }
         public virtual bool IsNormal { get; }
         public virtual bool IsTerminating { get; }
         public System.Collections.Generic.IReadOnlyCollection<Akka.Actor.Internal.ChildRestartStats> Stats { get; }
+        public static Akka.Actor.Internal.IChildrenContainer Instance { get; }
         public virtual Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats) { }
         public bool Contains(Akka.Actor.IActorRef actor) { }
         public Akka.Actor.Internal.IChildrenContainer Remove(Akka.Actor.IActorRef child) { }
@@ -2133,38 +2110,37 @@ namespace Akka.Actor.Internal
         Akka.Actor.Internal.IChildrenContainer Reserve(string name);
         Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor);
         bool TryGetByName(string name, out Akka.Actor.Internal.IChildStats stats);
-        bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats stats);
+        bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Akka.Actor.Internal.ChildRestartStats? stats);
         Akka.Actor.Internal.IChildrenContainer Unreserve(string name);
     }
     public interface IInitializableActor
     {
         void Init();
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IInternalSupportsTestFSMRef<TState, TData>
     {
         bool IsStateTimerActive { get; }
         void ApplyState(Akka.Actor.FSMBase.State<TState, TData> upcomingState);
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class InternalActivateFsmLogging
     {
         public static Akka.Actor.Internal.InternalActivateFsmLogging Instance { get; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static InternalCurrentActorCellKeeper
+    public static class InternalCurrentActorCellKeeper
     {
-        public static Akka.Actor.ActorCell Current { get; set; }
+        public static Akka.Actor.ActorCell? Current { get; set; }
     }
     public class NormalChildrenContainer : Akka.Actor.Internal.ChildrenContainerBase
     {
         public override Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats) { }
-        public static Akka.Actor.Internal.IChildrenContainer Create(System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children) { }
         public override Akka.Actor.Internal.IChildrenContainer Remove(Akka.Actor.IActorRef child) { }
         public override Akka.Actor.Internal.IChildrenContainer Reserve(string name) { }
         public override Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor) { }
         public override string ToString() { }
         public override Akka.Actor.Internal.IChildrenContainer Unreserve(string name) { }
+        public static Akka.Actor.Internal.IChildrenContainer Create(System.Collections.Immutable.IImmutableDictionary<string, Akka.Actor.Internal.IChildStats> children) { }
     }
     public abstract class SuspendReason
     {
@@ -2190,9 +2166,9 @@ namespace Akka.Actor.Internal
     }
     public class TerminatedChildrenContainer : Akka.Actor.Internal.EmptyChildrenContainer
     {
-        public new static Akka.Actor.Internal.IChildrenContainer Instance { get; }
         public override bool IsNormal { get; }
         public override bool IsTerminating { get; }
+        public new static Akka.Actor.Internal.IChildrenContainer Instance { get; }
         public override Akka.Actor.Internal.IChildrenContainer Add(string name, Akka.Actor.Internal.ChildRestartStats stats) { }
         public override Akka.Actor.Internal.IChildrenContainer Reserve(string name) { }
         public override string ToString() { }
@@ -2221,7 +2197,7 @@ namespace Akka.Actor.Internal
 }
 namespace Akka.Actor.Scheduler
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IScheduledTellMsg : Akka.Actor.INoSerializationVerificationNeeded, Akka.Actor.IWrappedMessage { }
 }
 namespace Akka.Actor.Setup
@@ -2231,12 +2207,12 @@ namespace Akka.Actor.Setup
         public static readonly Akka.Actor.Setup.ActorSystemSetup Empty;
         public Akka.Actor.Setup.ActorSystemSetup And<T>(T setup)
             where T : Akka.Actor.Setup.Setup { }
-        public static Akka.Actor.Setup.ActorSystemSetup Create(params Akka.Actor.Setup.Setup[] setup) { }
         public Akka.Util.Option<T> Get<T>()
             where T : Akka.Actor.Setup.Setup { }
         public override string ToString() { }
         public Akka.Actor.Setup.ActorSystemSetup WithSetup<T>(T setup)
             where T : Akka.Actor.Setup.Setup { }
+        public static Akka.Actor.Setup.ActorSystemSetup Create(params Akka.Actor.Setup.Setup[] setup) { }
     }
     public abstract class Setup
     {
@@ -2246,22 +2222,22 @@ namespace Akka.Actor.Setup
 }
 namespace Akka.Annotations
 {
-    [System.AttributeUsageAttribute(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsage(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface, AllowMultiple=false, Inherited=true)]
     public sealed class ApiMayChangeAttribute : System.Attribute
     {
         public ApiMayChangeAttribute() { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface, AllowMultiple=false, Inherited=true)]
     public sealed class DoNotInheritAttribute : System.Attribute
     {
         public DoNotInheritAttribute() { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsage(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface, AllowMultiple=false, Inherited=true)]
     public sealed class InternalApiAttribute : System.Attribute
     {
         public InternalApiAttribute() { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface | System.AttributeTargets.All, AllowMultiple=false, Inherited=true)]
+    [System.AttributeUsage(System.AttributeTargets.Module | System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Enum | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.Interface, AllowMultiple=false, Inherited=true)]
     public sealed class InternalStableApiAttribute : System.Attribute
     {
         public InternalStableApiAttribute() { }
@@ -2281,13 +2257,14 @@ namespace Akka.Configuration
         public System.Collections.Generic.IEnumerable<Akka.Configuration.Hocon.HoconSubstitution> Substitutions { get; set; }
         public virtual System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, Akka.Configuration.Hocon.HoconValue>> AsEnumerable() { }
         protected Akka.Configuration.Config Copy(Akka.Configuration.Config fallback = null) { }
-        public virtual bool GetBoolean(string path, bool default = False) { }
+        public virtual bool GetBoolean(string path, bool default = false) { }
         public virtual System.Collections.Generic.IList<bool> GetBooleanList(string path) { }
         public virtual System.Collections.Generic.IList<byte> GetByteList(string path) { }
-        public virtual System.Nullable<long> GetByteSize(string path) { }
-        public virtual System.Nullable<long> GetByteSize(string path, System.Nullable<long> def = null) { }
+        public virtual long? GetByteSize(string path) { }
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("def")]
+        public virtual long? GetByteSize(string path, long? def = default) { }
         public virtual Akka.Configuration.Config GetConfig(string path) { }
-        public virtual decimal GetDecimal(string path, [System.Runtime.CompilerServices.DecimalConstantAttribute(0, 0, 0u, 0u, 0u)] decimal @default) { }
+        public virtual decimal GetDecimal(string path, [System.Runtime.CompilerServices.DecimalConstant(0, 0, 0u, 0u, 0u)] decimal @default) { }
         public virtual System.Collections.Generic.IList<decimal> GetDecimalList(string path) { }
         public virtual double GetDouble(string path, double default = 0) { }
         public virtual System.Collections.Generic.IList<double> GetDoubleList(string path) { }
@@ -2300,17 +2277,17 @@ namespace Akka.Configuration
         public virtual string GetString(string path, string default = null) { }
         public virtual System.Collections.Generic.IList<string> GetStringList(string path) { }
         public virtual System.Collections.Generic.IList<string> GetStringList(string path, string[] defaultPaths) { }
-        public virtual System.TimeSpan GetTimeSpan(string path, System.Nullable<System.TimeSpan> default = null, bool allowInfinite = True) { }
+        public virtual System.TimeSpan GetTimeSpan(string path, System.TimeSpan? default = default, bool allowInfinite = true) { }
         public Akka.Configuration.Hocon.HoconValue GetValue(string path) { }
         public virtual bool HasPath(string path) { }
         public override string ToString() { }
         public string ToString(bool includeFallback) { }
         public virtual Akka.Configuration.Config WithFallback(Akka.Configuration.Config fallback) { }
-        public static Akka.Configuration.Config +(Akka.Configuration.Config config, string fallback) { }
-        public static Akka.Configuration.Config +(string configHocon, Akka.Configuration.Config fallbackConfig) { }
         public static Akka.Configuration.Config op_Implicit(string str) { }
+        public static Akka.Configuration.Config operator +(Akka.Configuration.Config config, string fallback) { }
+        public static Akka.Configuration.Config operator +(string configHocon, Akka.Configuration.Config fallbackConfig) { }
     }
-    public class static ConfigExtensions
+    public static class ConfigExtensions
     {
         public static bool IsNullOrEmpty(this Akka.Configuration.Config config) { }
         public static Akka.Configuration.Config SafeWithFallback(this Akka.Configuration.Config config, Akka.Configuration.Config fallback) { }
@@ -2318,8 +2295,8 @@ namespace Akka.Configuration
     public class ConfigurationException : Akka.Actor.AkkaException
     {
         public ConfigurationException(string message) { }
-        public ConfigurationException(string message, System.Exception exception) { }
         protected ConfigurationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public ConfigurationException(string message, System.Exception exception) { }
         public static Akka.Configuration.ConfigurationException NullOrEmptyConfig<T>(string path = null) { }
     }
     public class ConfigurationFactory
@@ -2328,12 +2305,12 @@ namespace Akka.Configuration
         public static Akka.Configuration.Config Empty { get; }
         public static Akka.Configuration.Config Default() { }
         public static Akka.Configuration.Config FromObject(object source) { }
+        public static Akka.Configuration.Config FromResource(string resourceName, System.Reflection.Assembly assembly) { }
         public static Akka.Configuration.Config FromResource(string resourceName, object instanceInAssembly) { }
         public static Akka.Configuration.Config FromResource<TAssembly>(string resourceName) { }
-        public static Akka.Configuration.Config FromResource(string resourceName, System.Reflection.Assembly assembly) { }
         public static Akka.Configuration.Config Load() { }
-        public static Akka.Configuration.Config ParseString(string hocon, System.Func<string, Akka.Configuration.Hocon.HoconRoot> includeCallback) { }
         public static Akka.Configuration.Config ParseString(string hocon) { }
+        public static Akka.Configuration.Config ParseString(string hocon, System.Func<string, Akka.Configuration.Hocon.HoconRoot> includeCallback) { }
     }
 }
 namespace Akka.Configuration.Hocon
@@ -2342,7 +2319,7 @@ namespace Akka.Configuration.Hocon
     {
         public AkkaConfigurationSection() { }
         public Akka.Configuration.Config AkkaConfig { get; }
-        [System.Configuration.ConfigurationPropertyAttribute("hocon", IsRequired=true)]
+        [System.Configuration.ConfigurationProperty("hocon", IsRequired=true)]
         public Akka.Configuration.Hocon.HoconConfigurationElement Hocon { get; set; }
     }
     public abstract class CDataConfigurationElement : System.Configuration.ConfigurationElement
@@ -2363,7 +2340,7 @@ namespace Akka.Configuration.Hocon
     public class HoconConfigurationElement : Akka.Configuration.Hocon.CDataConfigurationElement
     {
         public HoconConfigurationElement() { }
-        [System.Configuration.ConfigurationPropertyAttribute("content", IsKey=true, IsRequired=true)]
+        [System.Configuration.ConfigurationProperty("content", IsKey=true, IsRequired=true)]
         public string Content { get; set; }
     }
     public class HoconLiteral : Akka.Configuration.Hocon.IHoconElement
@@ -2380,7 +2357,7 @@ namespace Akka.Configuration.Hocon
     {
         public HoconObject() { }
         public System.Collections.Generic.Dictionary<string, Akka.Configuration.Hocon.HoconValue> Items { get; }
-        [Newtonsoft.Json.JsonIgnoreAttribute()]
+        [Newtonsoft.Json.JsonIgnore]
         public System.Collections.Generic.IDictionary<string, object> Unwrapped { get; }
         public System.Collections.Generic.IList<Akka.Configuration.Hocon.HoconValue> GetArray() { }
         public Akka.Configuration.Hocon.HoconValue GetKey(string key) { }
@@ -2395,8 +2372,8 @@ namespace Akka.Configuration.Hocon
     public class HoconRoot
     {
         protected HoconRoot() { }
-        public HoconRoot(Akka.Configuration.Hocon.HoconValue value, System.Collections.Generic.IEnumerable<Akka.Configuration.Hocon.HoconSubstitution> substitutions) { }
         public HoconRoot(Akka.Configuration.Hocon.HoconValue value) { }
+        public HoconRoot(Akka.Configuration.Hocon.HoconValue value, System.Collections.Generic.IEnumerable<Akka.Configuration.Hocon.HoconSubstitution> substitutions) { }
         public System.Collections.Generic.IEnumerable<Akka.Configuration.Hocon.HoconSubstitution> Substitutions { get; }
         public Akka.Configuration.Hocon.HoconValue Value { get; }
     }
@@ -2458,7 +2435,7 @@ namespace Akka.Configuration.Hocon
     public class HoconValue : Akka.Configuration.Hocon.IMightBeAHoconObject
     {
         public HoconValue() { }
-        public HoconValue(System.Collections.Generic.List<Akka.Configuration.Hocon.IHoconElement> values, bool adoptedFromFallback = True) { }
+        public HoconValue(System.Collections.Generic.List<Akka.Configuration.Hocon.IHoconElement> values, bool adoptedFromFallback = true) { }
         public bool IsEmpty { get; }
         public System.Collections.Generic.List<Akka.Configuration.Hocon.IHoconElement> Values { get; }
         public void AppendValue(Akka.Configuration.Hocon.IHoconElement value) { }
@@ -2469,7 +2446,7 @@ namespace Akka.Configuration.Hocon
         public System.Collections.Generic.IList<bool> GetBooleanList() { }
         public byte GetByte() { }
         public System.Collections.Generic.IList<byte> GetByteList() { }
-        public System.Nullable<long> GetByteSize() { }
+        public long? GetByteSize() { }
         public Akka.Configuration.Hocon.HoconValue GetChildObject(string key) { }
         public decimal GetDecimal() { }
         public System.Collections.Generic.IList<decimal> GetDecimalList() { }
@@ -2484,7 +2461,7 @@ namespace Akka.Configuration.Hocon
         public Akka.Configuration.Hocon.HoconObject GetObject() { }
         public string GetString() { }
         public System.Collections.Generic.IList<string> GetStringList() { }
-        public System.TimeSpan GetTimeSpan(bool allowInfinite = True) { }
+        public System.TimeSpan GetTimeSpan(bool allowInfinite = true) { }
         public bool IsArray() { }
         public bool IsObject() { }
         public bool IsString() { }
@@ -2508,9 +2485,9 @@ namespace Akka.Configuration.Hocon
     public class Parser
     {
         public Parser() { }
-        public static Akka.Configuration.Hocon.HoconRoot Parse(string text, System.Func<string, Akka.Configuration.Hocon.HoconRoot> includeCallback) { }
         public Akka.Configuration.Hocon.HoconArray ParseArray(string currentPath) { }
         public void ParseValue(Akka.Configuration.Hocon.HoconValue owner, string currentPath) { }
+        public static Akka.Configuration.Hocon.HoconRoot Parse(string text, System.Func<string, Akka.Configuration.Hocon.HoconRoot> includeCallback) { }
     }
     public class Token
     {
@@ -2550,240 +2527,165 @@ namespace Akka.Configuration.Hocon
         public void Pop() { }
         public void PullWhitespace() { }
         public void Push() { }
-        public string Take(int length) { }
         public char Take() { }
+        public string Take(int length) { }
     }
 }
 namespace Akka.Delivery
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static ConsumerController
+    public static class ConsumerController
     {
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(Akka.Actor.IActorRefFactory actorRefFactory, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<Akka.Actor.IActorRef> producerControllerReference, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Delivery.ConsumerController.Settings settings = null) { }
-        [Akka.Annotations.InternalApiAttribute()]
-        public static Akka.Actor.Props CreateWithFuzzing<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(Akka.Actor.IActorRefFactory actorRefFactory, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<Akka.Actor.IActorRef> producerControllerReference, System.Func<object, double> fuzzing, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Delivery.ConsumerController.Settings settings = null) { }
+        public static Akka.Actor.Props Create<T>(Akka.Actor.IActorRefFactory actorRefFactory, Akka.Util.Option<Akka.Actor.IActorRef> producerControllerReference, Akka.Delivery.ConsumerController.Settings? settings = null) { }
+        [Akka.Annotations.InternalApi]
+        public static Akka.Actor.Props CreateWithFuzzing<T>(Akka.Actor.IActorRefFactory actorRefFactory, Akka.Util.Option<Akka.Actor.IActorRef> producerControllerReference, System.Func<object, double> fuzzing, Akka.Delivery.ConsumerController.Settings? settings = null) { }
         public sealed class Confirmed
         {
-            [System.Runtime.CompilerServices.NullableAttribute(1)]
             public static readonly Akka.Delivery.ConsumerController.Confirmed Instance;
         }
-        public sealed class DeliverThenStop<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
+        public sealed class DeliverThenStop<T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
         {
-            [System.Runtime.CompilerServices.NullableAttribute(1)]
             public static readonly Akka.Delivery.ConsumerController.DeliverThenStop<T> Instance;
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class Delivery<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>, Akka.Delivery.Internal.IDeliverySerializable, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Delivery.ConsumerController.Delivery<T>>
+        public sealed class Delivery<T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>, Akka.Delivery.Internal.IDeliverySerializable, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Delivery.ConsumerController.Delivery<T>>
         {
             public Delivery(T Message, Akka.Actor.IActorRef ConfirmTo, string ProducerId, long SeqNr) { }
-            public Akka.Actor.IActorRef ConfirmTo { get; set; }
-            public T Message { get; set; }
-            public string ProducerId { get; set; }
-            public long SeqNr { get; set; }
+            public Akka.Actor.IActorRef ConfirmTo { get; init; }
+            public T Message { get; init; }
+            public string ProducerId { get; init; }
+            public long SeqNr { get; init; }
             public override string ToString() { }
         }
         public interface IConsumerCommand<T> { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class RegisterToProducerController<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
+        public sealed class RegisterToProducerController<T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
         {
             public RegisterToProducerController(Akka.Actor.IActorRef producerController) { }
             public Akka.Actor.IActorRef ProducerController { get; }
         }
-        [Akka.Annotations.InternalApiAttribute()]
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class SequencedMessage<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>, Akka.Delivery.Internal.IDeliverySerializable, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Delivery.ConsumerController.SequencedMessage<T>>
+        [Akka.Annotations.InternalApi]
+        public sealed class SequencedMessage<T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>, Akka.Delivery.Internal.IDeliverySerializable, Akka.Event.IDeadLetterSuppression, System.IEquatable<Akka.Delivery.ConsumerController.SequencedMessage<T>>
         {
-            public SequencedMessage(string ProducerId, long SeqNr, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})] Akka.Delivery.Internal.MessageOrChunk<T> Message, bool First, bool Ack) { }
-            public bool Ack { get; set; }
-            public bool First { get; set; }
-            [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
-            public Akka.Delivery.Internal.MessageOrChunk<T> Message { get; set; }
-            public string ProducerId { get; set; }
-            public long SeqNr { get; set; }
-            public bool Equals([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    2,
-                    1})] Akka.Delivery.ConsumerController.SequencedMessage<T> other) { }
+            public SequencedMessage(string ProducerId, long SeqNr, Akka.Delivery.Internal.MessageOrChunk<T> Message, bool First, bool Ack) { }
+            public bool Ack { get; init; }
+            public bool First { get; init; }
+            public Akka.Delivery.Internal.MessageOrChunk<T> Message { get; init; }
+            public string ProducerId { get; init; }
+            public long SeqNr { get; init; }
+            public bool Equals(Akka.Delivery.ConsumerController.SequencedMessage<T>? other) { }
             public override int GetHashCode() { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class Settings : System.IEquatable<Akka.Delivery.ConsumerController.Settings>
         {
-            public int FlowControlWindow { get; set; }
-            public bool OnlyFlowControl { get; set; }
-            public System.TimeSpan ResendIntervalMax { get; set; }
-            public System.TimeSpan ResendIntervalMin { get; set; }
+            public int FlowControlWindow { get; init; }
+            public bool OnlyFlowControl { get; init; }
+            public System.TimeSpan ResendIntervalMax { get; init; }
+            public System.TimeSpan ResendIntervalMin { get; init; }
+            public override string ToString() { }
             public static Akka.Delivery.ConsumerController.Settings Create(Akka.Actor.ActorSystem actorSystem) { }
             public static Akka.Delivery.ConsumerController.Settings Create(Akka.Configuration.Config config) { }
-            public override string ToString() { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class Start<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
+        public sealed class Start<T> : Akka.Delivery.ConsumerController.IConsumerCommand<T>
         {
             public Start(Akka.Actor.IActorRef deliverTo) { }
             public Akka.Actor.IActorRef DeliverTo { get; }
         }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static DurableProducerQueue
+    public static class DurableProducerQueue
     {
         public const string NoQualifier = "";
         public interface IDurableProducerQueueCommand { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class LoadState : Akka.Delivery.DurableProducerQueue.IDurableProducerQueueCommand, System.IEquatable<Akka.Delivery.DurableProducerQueue.LoadState>
         {
             public LoadState(Akka.Actor.IActorRef ReplyTo) { }
-            public Akka.Actor.IActorRef ReplyTo { get; set; }
+            public Akka.Actor.IActorRef ReplyTo { get; init; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class MessageSent<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.Internal.IDeliverySerializable, System.IEquatable<Akka.Delivery.DurableProducerQueue.MessageSent<T>>
+        public sealed class MessageSent<T> : Akka.Delivery.Internal.IDeliverySerializable, System.IEquatable<Akka.Delivery.DurableProducerQueue.MessageSent<T>>
         {
-            public MessageSent(long SeqNr, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})] Akka.Delivery.Internal.MessageOrChunk<T> Message, bool Ack, string ConfirmationQualifier, long Timestamp) { }
-            public bool Ack { get; set; }
-            public string ConfirmationQualifier { get; set; }
-            [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
-            public Akka.Delivery.Internal.MessageOrChunk<T> Message { get; set; }
-            public long SeqNr { get; set; }
-            public long Timestamp { get; set; }
-            public bool Equals([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    2,
-                    1})] Akka.Delivery.DurableProducerQueue.MessageSent<T> other) { }
-            public static Akka.Delivery.DurableProducerQueue.MessageSent<T> FromChunked(long seqNo, Akka.Delivery.Internal.ChunkedMessage chunkedMessage, bool ack, string confirmationQualifier, long timestamp) { }
-            public static Akka.Delivery.DurableProducerQueue.MessageSent<T> FromMessageOrChunked(long seqNo, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})] Akka.Delivery.Internal.MessageOrChunk<T> messageOrChunk, bool ack, string confirmationQualifier, long timestamp) { }
+            public MessageSent(long SeqNr, Akka.Delivery.Internal.MessageOrChunk<T> Message, bool Ack, string ConfirmationQualifier, long Timestamp) { }
+            public bool Ack { get; init; }
+            public string ConfirmationQualifier { get; init; }
+            public Akka.Delivery.Internal.MessageOrChunk<T> Message { get; init; }
+            public long SeqNr { get; init; }
+            public long Timestamp { get; init; }
+            public bool Equals(Akka.Delivery.DurableProducerQueue.MessageSent<T>? other) { }
             public override int GetHashCode() { }
             public override string ToString() { }
             public Akka.Delivery.DurableProducerQueue.MessageSent<T> WithQualifier(string qualifier) { }
             public Akka.Delivery.DurableProducerQueue.MessageSent<T> WithTimestamp(long timestamp) { }
+            public static Akka.Delivery.DurableProducerQueue.MessageSent<T> FromChunked(long seqNo, Akka.Delivery.Internal.ChunkedMessage chunkedMessage, bool ack, string confirmationQualifier, long timestamp) { }
+            public static Akka.Delivery.DurableProducerQueue.MessageSent<T> FromMessageOrChunked(long seqNo, Akka.Delivery.Internal.MessageOrChunk<T> messageOrChunk, bool ack, string confirmationQualifier, long timestamp) { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public struct State<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.Internal.IDeliverySerializable, System.IEquatable<Akka.Delivery.DurableProducerQueue.State<T>>
+        public readonly struct State<T> : Akka.Delivery.Internal.IDeliverySerializable, System.IEquatable<Akka.Delivery.DurableProducerQueue.State<T>>
         {
-            public State(long CurrentSeqNr, long HighestConfirmedSeqNr, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    1,
-                    1,
-                    0})] System.Collections.Immutable.ImmutableDictionary<string, System.ValueTuple<long, long>> ConfirmedSeqNr, System.Collections.Immutable.ImmutableList<Akka.Delivery.DurableProducerQueue.MessageSent<T>> Unconfirmed) { }
-            [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    1,
-                    1,
-                    0})]
-            public System.Collections.Immutable.ImmutableDictionary<string, System.ValueTuple<long, long>> ConfirmedSeqNr { get; set; }
-            public long CurrentSeqNr { get; set; }
-            [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
+            public State(long CurrentSeqNr, long HighestConfirmedSeqNr, System.Collections.Immutable.ImmutableDictionary<string, System.ValueTuple<long, long>> ConfirmedSeqNr, System.Collections.Immutable.ImmutableList<Akka.Delivery.DurableProducerQueue.MessageSent<T>> Unconfirmed) { }
+            public System.Collections.Immutable.ImmutableDictionary<string, System.ValueTuple<long, long>> ConfirmedSeqNr { get; init; }
+            public long CurrentSeqNr { get; init; }
+            public long HighestConfirmedSeqNr { get; init; }
+            public System.Collections.Immutable.ImmutableList<Akka.Delivery.DurableProducerQueue.MessageSent<T>> Unconfirmed { get; init; }
             public static Akka.Delivery.DurableProducerQueue.State<T> Empty { get; }
-            public long HighestConfirmedSeqNr { get; set; }
-            public System.Collections.Immutable.ImmutableList<Akka.Delivery.DurableProducerQueue.MessageSent<T>> Unconfirmed { get; set; }
-            [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
             public Akka.Delivery.DurableProducerQueue.State<T> AddConfirmed(long seqNr, string qualifier, long timestamp) { }
-            [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
             public Akka.Delivery.DurableProducerQueue.State<T> AddMessageSent(Akka.Delivery.DurableProducerQueue.MessageSent<T> messageSent) { }
-            [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
             public Akka.Delivery.DurableProducerQueue.State<T> CleanUp(System.Collections.Generic.ISet<string> confirmationQualifiers) { }
-            [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})]
             public Akka.Delivery.DurableProducerQueue.State<T> CleanUpPartialChunkedMessages() { }
-            public bool Equals([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    0,
-                    1})] Akka.Delivery.DurableProducerQueue.State<T> other) { }
+            public bool Equals(Akka.Delivery.DurableProducerQueue.State<T> other) { }
             public override int GetHashCode() { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class StoreMessageConfirmed : Akka.Delivery.DurableProducerQueue.IDurableProducerQueueCommand, System.IEquatable<Akka.Delivery.DurableProducerQueue.StoreMessageConfirmed>
         {
             public StoreMessageConfirmed(long SeqNr, string ConfirmationQualifier, long Timestamp) { }
-            public string ConfirmationQualifier { get; set; }
-            public long SeqNr { get; set; }
-            public long Timestamp { get; set; }
+            public string ConfirmationQualifier { get; init; }
+            public long SeqNr { get; init; }
+            public long Timestamp { get; init; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
+        public sealed class StoreMessageSent<T> : Akka.Delivery.DurableProducerQueue.IDurableProducerQueueCommand, System.IEquatable<Akka.Delivery.DurableProducerQueue.StoreMessageSent<T>>
+        {
+            public StoreMessageSent(Akka.Delivery.DurableProducerQueue.MessageSent<T> MessageSent, Akka.Actor.IActorRef ReplyTo) { }
+            public Akka.Delivery.DurableProducerQueue.MessageSent<T> MessageSent { get; init; }
+            public Akka.Actor.IActorRef ReplyTo { get; init; }
+        }
         public sealed class StoreMessageSentAck : System.IEquatable<Akka.Delivery.DurableProducerQueue.StoreMessageSentAck>
         {
             public StoreMessageSentAck(long StoredSeqNo) { }
-            public long StoredSeqNo { get; set; }
-        }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class StoreMessageSent<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.DurableProducerQueue.IDurableProducerQueueCommand, System.IEquatable<Akka.Delivery.DurableProducerQueue.StoreMessageSent<T>>
-        {
-            public StoreMessageSent(Akka.Delivery.DurableProducerQueue.MessageSent<T> MessageSent, Akka.Actor.IActorRef ReplyTo) { }
-            public Akka.Delivery.DurableProducerQueue.MessageSent<T> MessageSent { get; set; }
-            public Akka.Actor.IActorRef ReplyTo { get; set; }
+            public long StoredSeqNo { get; init; }
         }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static ProducerController
+    public static class ProducerController
     {
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(Akka.Actor.IActorRefFactory actorRefFactory, string producerId, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<Akka.Actor.Props> durableProducerQueue, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Delivery.ProducerController.Settings settings = null, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1,
-                1})] System.Action<Akka.Delivery.ConsumerController.SequencedMessage<T>> sendAdapter = null) { }
-        [Akka.Annotations.InternalApiAttribute()]
-        public static Akka.Actor.Props CreateWithFuzzing<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(Akka.Actor.IActorRefFactory actorRefFactory, string producerId, System.Func<object, double> fuzzing, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Util.Option<Akka.Actor.Props> durableProducerQueue, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Delivery.ProducerController.Settings settings = null, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1,
-                1})] System.Action<Akka.Delivery.ConsumerController.SequencedMessage<T>> sendAdapter = null) { }
+        public static Akka.Actor.Props Create<T>(Akka.Actor.IActorRefFactory actorRefFactory, string producerId, Akka.Util.Option<Akka.Actor.Props> durableProducerQueue, Akka.Delivery.ProducerController.Settings? settings = null, System.Action<Akka.Delivery.ConsumerController.SequencedMessage<T>>? sendAdapter = null) { }
+        [Akka.Annotations.InternalApi]
+        public static Akka.Actor.Props CreateWithFuzzing<T>(Akka.Actor.IActorRefFactory actorRefFactory, string producerId, System.Func<object, double> fuzzing, Akka.Util.Option<Akka.Actor.Props> durableProducerQueue, Akka.Delivery.ProducerController.Settings? settings = null, System.Action<Akka.Delivery.ConsumerController.SequencedMessage<T>>? sendAdapter = null) { }
         public interface IProducerCommand<T> { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class MessageWithConfirmation<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ProducerController.IProducerCommand<T>
+        public sealed class MessageWithConfirmation<T> : Akka.Delivery.ProducerController.IProducerCommand<T>
         {
             public MessageWithConfirmation(T message, Akka.Actor.IActorRef replyTo) { }
             public T Message { get; }
             public Akka.Actor.IActorRef ReplyTo { get; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class RegisterConsumer<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.Internal.IDeliverySerializable, Akka.Delivery.ProducerController.IProducerCommand<T>, System.IEquatable<Akka.Delivery.ProducerController.RegisterConsumer<T>>
+        public sealed class RegisterConsumer<T> : Akka.Delivery.Internal.IDeliverySerializable, Akka.Delivery.ProducerController.IProducerCommand<T>, System.IEquatable<Akka.Delivery.ProducerController.RegisterConsumer<T>>
         {
             public RegisterConsumer(Akka.Actor.IActorRef ConsumerController) { }
-            public Akka.Actor.IActorRef ConsumerController { get; set; }
+            public Akka.Actor.IActorRef ConsumerController { get; init; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class RequestNext<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Actor.INoSerializationVerificationNeeded, Akka.Delivery.ProducerController.IProducerCommand<T>
+        public sealed class RequestNext<T> : Akka.Actor.INoSerializationVerificationNeeded, Akka.Delivery.ProducerController.IProducerCommand<T>
         {
             public RequestNext(string producerId, long currentSeqNr, long confirmedSeqNr, Akka.Actor.IActorRef sendNextTo) { }
             public long ConfirmedSeqNr { get; }
             public long CurrentSeqNr { get; }
             public string ProducerId { get; }
             public Akka.Actor.IActorRef SendNextTo { get; }
-            public System.Threading.Tasks.Task<long> AskNextTo(T msg, System.Threading.CancellationToken cancellationToken = null) { }
             public void AskNextTo(Akka.Delivery.ProducerController.MessageWithConfirmation<T> msgWithConfirmation) { }
+            public System.Threading.Tasks.Task<long> AskNextTo(T msg, System.Threading.CancellationToken cancellationToken = default) { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class Settings : System.IEquatable<Akka.Delivery.ProducerController.Settings>
         {
             public const int DefaultDeliveryBufferSize = 128;
-            public System.Nullable<int> ChunkLargeMessagesBytes { get; set; }
-            public System.TimeSpan DurableQueueRequestTimeout { get; set; }
-            public System.TimeSpan DurableQueueResendFirstInterval { get; set; }
-            public int DurableQueueRetryAttempts { get; set; }
+            public int? ChunkLargeMessagesBytes { get; init; }
+            public System.TimeSpan DurableQueueRequestTimeout { get; init; }
+            public System.TimeSpan DurableQueueResendFirstInterval { get; init; }
+            public int DurableQueueRetryAttempts { get; init; }
             public static Akka.Delivery.ProducerController.Settings Create(Akka.Actor.ActorSystem actorSystem) { }
             public static Akka.Delivery.ProducerController.Settings Create(Akka.Configuration.Config config) { }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class Start<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.ProducerController.IProducerCommand<T>
+        public sealed class Start<T> : Akka.Delivery.ProducerController.IProducerCommand<T>
         {
             public Start(Akka.Actor.IActorRef producer) { }
             public Akka.Actor.IActorRef Producer { get; }
@@ -2792,9 +2694,8 @@ namespace Akka.Delivery
 }
 namespace Akka.Delivery.Internal
 {
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public struct ChunkedMessage
+    [Akka.Annotations.InternalApi]
+    public readonly struct ChunkedMessage
     {
         public ChunkedMessage(Akka.IO.ByteString serializedMessage, bool firstChunk, bool lastChunk, int serializerId, string manifest) { }
         public bool FirstChunk { get; }
@@ -2804,37 +2705,24 @@ namespace Akka.Delivery.Internal
         public int SerializerId { get; }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IDeliverySerializable { }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public struct MessageOrChunk<T> : System.IEquatable<Akka.Delivery.Internal.MessageOrChunk<T>>
+    [Akka.Annotations.InternalApi]
+    public readonly struct MessageOrChunk<T> : System.IEquatable<Akka.Delivery.Internal.MessageOrChunk<T>>
     {
-        public MessageOrChunk(T message) { }
         public MessageOrChunk(Akka.Delivery.Internal.ChunkedMessage chunkedMessage) { }
-        public System.Nullable<Akka.Delivery.Internal.ChunkedMessage> Chunk { get; }
+        public MessageOrChunk(T message) { }
+        public Akka.Delivery.Internal.ChunkedMessage? Chunk { get; }
         public bool IsMessage { get; }
         public T Message { get; }
-        public bool Equals([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Delivery.Internal.MessageOrChunk<T> other) { }
-        public override bool Equals(object obj) { }
+        public bool Equals(Akka.Delivery.Internal.MessageOrChunk<T> other) { }
+        public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
-        public static Akka.Delivery.Internal.MessageOrChunk<T> op_Implicit(T message) { }
-        public static T op_Implicit([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Delivery.Internal.MessageOrChunk<T> message) { }
-        public static Akka.Delivery.Internal.ChunkedMessage op_Implicit([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})] Akka.Delivery.Internal.MessageOrChunk<T> message) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
         public static Akka.Delivery.Internal.MessageOrChunk<T> op_Implicit(Akka.Delivery.Internal.ChunkedMessage chunkedMessage) { }
+        public static T op_Implicit(Akka.Delivery.Internal.MessageOrChunk<T> message) { }
+        public static Akka.Delivery.Internal.ChunkedMessage op_Implicit(Akka.Delivery.Internal.MessageOrChunk<T> message) { }
+        public static Akka.Delivery.Internal.MessageOrChunk<T> op_Implicit(T message) { }
     }
 }
 namespace Akka.Dispatch
@@ -2857,9 +2745,9 @@ namespace Akka.Dispatch
         protected virtual void OnAfterTaskCompleted() { }
         protected virtual void OnBeforeTaskStarted() { }
         protected override void QueueTask(System.Threading.Tasks.Task task) { }
+        protected override bool TryExecuteTaskInline(System.Threading.Tasks.Task task, bool taskWasPreviouslyQueued) { }
         public static void RunTask(System.Action action) { }
         public static void RunTask(System.Func<System.Threading.Tasks.Task> asyncAction) { }
-        protected override bool TryExecuteTaskInline(System.Threading.Tasks.Task task, bool taskWasPreviouslyQueued) { }
     }
     public class BoundedDequeBasedMailbox : Akka.Dispatch.MailboxType, Akka.Dispatch.IProducesMessageQueue<Akka.Dispatch.MessageQueues.BoundedDequeMessageQueue>, Akka.Dispatch.IProducesPushTimeoutSemanticsMailbox
     {
@@ -2883,8 +2771,8 @@ namespace Akka.Dispatch
         public System.Threading.Tasks.TaskScheduler Low { get; }
         public System.Threading.Tasks.TaskScheduler Normal { get; }
         public void Dispose() { }
-        public static Akka.Dispatch.ChannelTaskScheduler Get(Akka.Actor.ActorSystem system) { }
         public System.Threading.Tasks.TaskScheduler GetScheduler(Akka.Dispatch.TaskSchedulerPriority priority) { }
+        public static Akka.Dispatch.ChannelTaskScheduler Get(Akka.Actor.ActorSystem system) { }
     }
     public sealed class ChannelTaskSchedulerProvider : Akka.Actor.ExtensionIdProvider<Akka.Dispatch.ChannelTaskScheduler>
     {
@@ -2893,7 +2781,7 @@ namespace Akka.Dispatch
     }
     public sealed class CurrentSynchronizationContextDispatcher : Akka.Dispatch.Dispatcher
     {
-        public CurrentSynchronizationContextDispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, System.Nullable<long> throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
+        public CurrentSynchronizationContextDispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, long? throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
     }
     public sealed class DefaultDispatcherPrerequisites : Akka.Dispatch.IDispatcherPrerequisites
     {
@@ -2905,9 +2793,9 @@ namespace Akka.Dispatch
     }
     public class Dispatcher : Akka.Dispatch.MessageDispatcher
     {
-        public Dispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, System.Nullable<long> throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
+        public Dispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, long? throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
         protected override void ExecuteTask(Akka.Dispatch.IRunnable run) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected override void Shutdown() { }
     }
     public sealed class DispatcherConfigurator : Akka.Dispatch.MessageDispatcherConfigurator
@@ -2924,11 +2812,11 @@ namespace Akka.Dispatch
         public Akka.Configuration.Config DefaultDispatcherConfig { get; }
         public Akka.Dispatch.MessageDispatcher DefaultGlobalDispatcher { get; }
         public Akka.Dispatch.IDispatcherPrerequisites Prerequisites { get; }
-        [Akka.Annotations.InternalApiAttribute()]
-        public static Akka.Configuration.Config GetConfig(Akka.Configuration.Config config, string id, int depth = 0) { }
         public bool HasDispatcher(string id) { }
         public Akka.Dispatch.MessageDispatcher Lookup(string dispatcherName) { }
         public bool RegisterConfigurator(string id, Akka.Dispatch.MessageDispatcherConfigurator configurator) { }
+        [Akka.Annotations.InternalApi]
+        public static Akka.Configuration.Config GetConfig(Akka.Configuration.Config config, string id, int depth = 0) { }
     }
     public abstract class ExecutorService
     {
@@ -2937,14 +2825,14 @@ namespace Akka.Dispatch
         public abstract void Execute(Akka.Dispatch.IRunnable run);
         public abstract void Shutdown();
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class ExecutorServiceConfigurator : Akka.Dispatch.ExecutorServiceFactory
     {
         protected ExecutorServiceConfigurator(Akka.Configuration.Config config, Akka.Dispatch.IDispatcherPrerequisites prerequisites) { }
         public Akka.Configuration.Config Config { get; }
         public Akka.Dispatch.IDispatcherPrerequisites Prerequisites { get; }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class ExecutorServiceFactory
     {
         protected ExecutorServiceFactory() { }
@@ -2998,10 +2886,10 @@ namespace Akka.Dispatch
         public Akka.Dispatch.MessageDispatcher Dispatcher { get; }
         public Akka.Dispatch.MessageQueues.IMessageQueue MessageQueue { get; }
         public virtual void CleanUp() { }
-        [System.Diagnostics.ConditionalAttribute("MAILBOXDEBUG")]
-        public static void DebugPrint(string message, params object[] args) { }
         public void Run() { }
         public virtual void SetActor(Akka.Actor.ActorCell actorCell) { }
+        [System.Diagnostics.Conditional("MAILBOXDEBUG")]
+        public static void DebugPrint(string message, params object[] args) { }
     }
     public abstract class MailboxType
     {
@@ -3022,7 +2910,7 @@ namespace Akka.Dispatch
         public Akka.Dispatch.MailboxType Lookup(string id) { }
         public Akka.Dispatch.MailboxType LookupByQueueType(System.Type queueType) { }
         public bool ProducesMessageQueue(System.Type mailboxType) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public int StashCapacity(string dispatcher, string mailbox) { }
     }
     public abstract class MessageDispatcher
@@ -3031,21 +2919,21 @@ namespace Akka.Dispatch
         protected MessageDispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator) { }
         public Akka.Dispatch.MessageDispatcherConfigurator Configurator { get; }
         public Akka.Event.EventStream EventStream { get; }
-        public string Id { get; set; }
+        public string Id { get; protected set; }
         protected long Inhabitants { get; }
         public Akka.Dispatch.Mailboxes Mailboxes { get; }
-        [Akka.Annotations.InternalApiAttribute()]
-        public System.TimeSpan ShutdownTimeout { get; set; }
+        [Akka.Annotations.InternalApi]
+        public System.TimeSpan ShutdownTimeout { get; protected set; }
         public int Throughput { get; set; }
-        public System.Nullable<long> ThroughputDeadlineTime { get; set; }
+        public long? ThroughputDeadlineTime { get; protected set; }
         public virtual void Attach(Akka.Actor.ActorCell cell) { }
         public virtual void Detach(Akka.Actor.ActorCell cell) { }
         public virtual void Dispatch(Akka.Actor.ActorCell cell, Akka.Actor.Envelope envelope) { }
         protected abstract void ExecuteTask(Akka.Dispatch.IRunnable run);
         protected void ReportFailure(System.Exception ex) { }
-        public void Schedule(System.Action run) { }
         public void Schedule(Akka.Dispatch.IRunnable run) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        public void Schedule(System.Action run) { }
+        [Akka.Annotations.InternalApi]
         protected abstract void Shutdown();
         public virtual void SystemDispatch(Akka.Actor.ActorCell cell, Akka.Dispatch.SysMsg.SystemMessage message) { }
     }
@@ -3059,12 +2947,12 @@ namespace Akka.Dispatch
     }
     public sealed class PinnedDispatcher : Akka.Dispatch.Dispatcher
     {
-        public PinnedDispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, System.Nullable<long> throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
+        public PinnedDispatcher(Akka.Dispatch.MessageDispatcherConfigurator configurator, string id, int throughput, long? throughputDeadlineTime, Akka.Dispatch.ExecutorServiceFactory executorServiceFactory, System.TimeSpan shutdownTimeout) { }
     }
     public class RejectedExecutionException : Akka.Actor.AkkaException
     {
-        public RejectedExecutionException(string message = null, System.Exception inner = null) { }
         protected RejectedExecutionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public RejectedExecutionException(string message = null, System.Exception inner = null) { }
     }
     public enum TaskSchedulerPriority
     {
@@ -3102,7 +2990,7 @@ namespace Akka.Dispatch
         public const int DefaultCapacity = 11;
         protected UnboundedPriorityMailbox(Akka.Actor.Settings settings, Akka.Configuration.Config config) { }
         public int InitialCapacity { get; }
-        public virtual Akka.Dispatch.MessageQueues.IMessageQueue Create(Akka.Actor.IActorRef owner, Akka.Actor.ActorSystem system) { }
+        public override sealed Akka.Dispatch.MessageQueues.IMessageQueue Create(Akka.Actor.IActorRef owner, Akka.Actor.ActorSystem system) { }
         protected abstract int PriorityGenerator(object message);
     }
     public abstract class UnboundedStablePriorityMailbox : Akka.Dispatch.MailboxType, Akka.Dispatch.IProducesMessageQueue<Akka.Dispatch.MessageQueues.UnboundedStablePriorityMessageQueue>
@@ -3110,7 +2998,7 @@ namespace Akka.Dispatch
         public const int DefaultCapacity = 11;
         protected UnboundedStablePriorityMailbox(Akka.Actor.Settings settings, Akka.Configuration.Config config) { }
         public int InitialCapacity { get; }
-        public virtual Akka.Dispatch.MessageQueues.IMessageQueue Create(Akka.Actor.IActorRef owner, Akka.Actor.ActorSystem system) { }
+        public override sealed Akka.Dispatch.MessageQueues.IMessageQueue Create(Akka.Actor.IActorRef owner, Akka.Actor.ActorSystem system) { }
         protected abstract int PriorityGenerator(object message);
     }
 }
@@ -3223,7 +3111,7 @@ namespace Akka.Dispatch.SysMsg
         public System.Exception Reason { get; }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Failed : Akka.Dispatch.SysMsg.SystemMessage
     {
         public Failed(Akka.Actor.IActorRef child, System.Exception cause, long uid) { }
@@ -3278,7 +3166,7 @@ namespace Akka.Dispatch.SysMsg
         public Suspend() { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalStableApiAttribute()]
+    [Akka.Annotations.InternalStableApi]
     public abstract class SystemMessage : Akka.Actor.INoSerializationVerificationNeeded, Akka.Dispatch.SysMsg.ISystemMessage
     {
         protected SystemMessage() { }
@@ -3326,12 +3214,13 @@ namespace Akka
     {
         public static readonly Akka.Done Instance;
     }
+    [System.Serializable]
     public sealed class NotUsed : System.IComparable<Akka.NotUsed>, System.IEquatable<Akka.NotUsed>
     {
         public static readonly Akka.NotUsed Instance;
         public int CompareTo(Akka.NotUsed other) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.NotUsed other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -3384,8 +3273,8 @@ namespace Akka.Event
     public class DefaultLogMessageFormatter : Akka.Event.ILogMessageFormatter
     {
         public static readonly Akka.Event.DefaultLogMessageFormatter Instance;
-        public string Format(string format, params object[] args) { }
         public string Format(string format, System.Collections.Generic.IEnumerable<object> args) { }
+        public string Format(string format, params object[] args) { }
     }
     public class DefaultLogger : Akka.Actor.ActorBase, Akka.Dispatch.IRequiresMessageQueue<Akka.Event.ILoggerMessageQueueSemantics>
     {
@@ -3395,8 +3284,8 @@ namespace Akka.Event
     }
     public sealed class Dropped : Akka.Event.AllDeadLetters
     {
-        public Dropped(object message, string reason, Akka.Actor.IActorRef sender, Akka.Actor.IActorRef recipient) { }
         public Dropped(object message, string reason, Akka.Actor.IActorRef recipient) { }
+        public Dropped(object message, string reason, Akka.Actor.IActorRef sender, Akka.Actor.IActorRef recipient) { }
         public string Reason { get; }
     }
     public class DummyClassForStringSources
@@ -3414,10 +3303,10 @@ namespace Akka.Event
         protected abstract bool Classify(TEvent @event, TClassifier classifier);
         protected abstract TClassifier GetClassifier(TEvent @event);
         protected abstract bool IsSubClassification(TClassifier parent, TClassifier child);
-        protected abstract void Publish(TEvent @event, TSubscriber subscriber);
         public virtual void Publish(TEvent @event) { }
-        protected string SimpleName(object source) { }
+        protected abstract void Publish(TEvent @event, TSubscriber subscriber);
         protected string SimpleName(System.Type source) { }
+        protected string SimpleName(object source) { }
         public virtual bool Subscribe(TSubscriber subscriber, TClassifier classifier) { }
         public virtual bool Unsubscribe(TSubscriber subscriber) { }
         public virtual bool Unsubscribe(TSubscriber subscriber, TClassifier classifier) { }
@@ -3427,26 +3316,25 @@ namespace Akka.Event
         public EventStream(bool debug) { }
         public void StartUnsubscriber(Akka.Actor.Internal.ActorSystemImpl system) { }
         public override bool Subscribe(Akka.Actor.IActorRef subscriber, System.Type channel) { }
-        public override bool Unsubscribe(Akka.Actor.IActorRef subscriber, System.Type channel) { }
         public override bool Unsubscribe(Akka.Actor.IActorRef subscriber) { }
+        public override bool Unsubscribe(Akka.Actor.IActorRef subscriber, System.Type channel) { }
     }
-    public class static EventStreamExtensions
+    public static class EventStreamExtensions
     {
         public static bool Subscribe<TChannel>(this Akka.Event.EventStream eventStream, Akka.Actor.IActorRef subscriber) { }
         public static bool Unsubscribe<TChannel>(this Akka.Event.EventStream eventStream, Akka.Actor.IActorRef subscriber) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ExactMatchLogSourceFilter : Akka.Event.LogFilterBase
     {
         public ExactMatchLogSourceFilter(string source, System.StringComparison comparison = 5) { }
         public override Akka.Event.LogFilterType FilterType { get; }
-        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, [System.Runtime.CompilerServices.NullableAttribute(2)] string expandedMessage = null) { }
+        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, string? expandedMessage = null) { }
     }
     public interface IDeadLetterSuppression { }
     public interface ILogMessageFormatter
     {
-        string Format(string format, params object[] args);
         string Format(string format, System.Collections.Generic.IEnumerable<object> args);
+        string Format(string format, params object[] args);
     }
     public interface ILoggerMessageQueueSemantics : Akka.Dispatch.ISemantics { }
     public interface ILoggingAdapter
@@ -3457,8 +3345,8 @@ namespace Akka.Event
         bool IsInfoEnabled { get; }
         bool IsWarningEnabled { get; }
         bool IsEnabled(Akka.Event.LogLevel logLevel);
-        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format);
         void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message);
+        void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format);
     }
     public class Info : Akka.Event.LogEvent
     {
@@ -3474,33 +3362,28 @@ namespace Akka.Event
     public abstract class LogEvent : Akka.Actor.INoSerializationVerificationNeeded
     {
         protected LogEvent() { }
-        public System.Exception Cause { get; set; }
-        public System.Type LogClass { get; set; }
-        public string LogSource { get; set; }
-        public object Message { get; set; }
+        public System.Exception Cause { get; protected set; }
+        public System.Type LogClass { get; protected set; }
+        public string LogSource { get; protected set; }
+        public object Message { get; protected set; }
         public System.Threading.Thread Thread { get; }
         public System.DateTime Timestamp { get; }
         public abstract Akka.Event.LogLevel LogLevel();
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static LogEventExtensions
+    public static class LogEventExtensions
     {
         public static System.Collections.Generic.IEnumerable<object> GetParameters(this Akka.Event.LogEvent evt) { }
         public static System.Collections.Generic.IReadOnlyList<string> GetPropertyNames(this Akka.Event.LogEvent evt) { }
         public static string GetTemplate(this Akka.Event.LogEvent evt) { }
-        public static bool TryGetProperties(this Akka.Event.LogEvent evt, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1,
-                1})] out System.Collections.Generic.IReadOnlyDictionary<string, object> properties) { }
+        public static bool TryGetProperties(this Akka.Event.LogEvent evt, out System.Collections.Generic.IReadOnlyDictionary<string, object>? properties) { }
     }
     public abstract class LogFilterBase : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
     {
         protected LogFilterBase() { }
         public abstract Akka.Event.LogFilterType FilterType { get; }
-        public abstract Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, [System.Runtime.CompilerServices.NullableAttribute(2)] string expandedMessage = null);
+        public abstract Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, string? expandedMessage = null);
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class LogFilterBuilder
     {
         public LogFilterBuilder() { }
@@ -3521,7 +3404,6 @@ namespace Akka.Event
         Drop = 1,
         NoDecision = 2,
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class LogFilterEvaluator
     {
         public static readonly Akka.Event.LogFilterEvaluator NoFilters;
@@ -3529,7 +3411,6 @@ namespace Akka.Event
         public bool EvaluatesLogSourcesOnly { get; }
         public virtual bool ShouldTryKeepMessage(Akka.Event.LogEvent evt, out string expandedLogMessage) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class LogFilterSetup : Akka.Actor.Setup.Setup
     {
         public LogFilterSetup(Akka.Event.LogFilterBase[] filters) { }
@@ -3555,12 +3436,12 @@ namespace Akka.Event
         public string Format { get; }
         public System.Collections.Generic.IReadOnlyList<string> PropertyNames { get; }
         public System.Collections.Generic.IReadOnlyDictionary<string, object> GetProperties() { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public abstract System.Collections.Generic.IEnumerable<object> Parameters();
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public abstract string Unformatted();
     }
-    public class static LogMessageExtensions { }
+    public static class LogMessageExtensions { }
     public struct LogSource
     {
         public string Source { get; }
@@ -3582,7 +3463,7 @@ namespace Akka.Event
     {
         public LoggerMailbox(Akka.Actor.IActorRef owner, Akka.Actor.ActorSystem system) { }
     }
-    public class static Logging
+    public static class Logging
     {
         public static System.Type ClassFor(this Akka.Event.LogLevel logLevel) { }
         public static Akka.Event.ILoggingAdapter GetLogger(this Akka.Actor.IActorContext context, Akka.Event.ILogMessageFormatter logMessageFormatter = null) { }
@@ -3591,8 +3472,8 @@ namespace Akka.Event
         public static Akka.Event.LogLevel LogLevelFor(string logLevel) { }
         public static Akka.Event.LogLevel LogLevelFor<T>()
             where T : Akka.Event.LogEvent { }
-        public static string SimpleName(object o) { }
         public static string SimpleName(System.Type t) { }
+        public static string SimpleName(object o) { }
         public static string StringFor(this Akka.Event.LogLevel logLevel) { }
     }
     public abstract class LoggingAdapterBase : Akka.Event.ILoggingAdapter
@@ -3619,10 +3500,12 @@ namespace Akka.Event
         public void SetLogLevel(Akka.Event.LogLevel logLevel) { }
         public void StartStdoutLogger(Akka.Actor.Settings config) { }
     }
-    public class static LoggingExtensions
+    public static class LoggingExtensions
     {
         public static void Debug(this Akka.Event.ILoggingAdapter log, string format) { }
         public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
         public static void Debug<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
         public static void Debug<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
         public static void Debug<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
@@ -3635,10 +3518,10 @@ namespace Akka.Event
         public static void Debug<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
         public static void Debug<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
         public static void Debug<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
-        public static void Debug(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
-        public static void Debug(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
         public static void Error(this Akka.Event.ILoggingAdapter log, string format) { }
         public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
         public static void Error<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
         public static void Error<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
         public static void Error<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
@@ -3651,10 +3534,10 @@ namespace Akka.Event
         public static void Error<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
         public static void Error<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
         public static void Error<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
-        public static void Error(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
-        public static void Error(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
         public static void Info(this Akka.Event.ILoggingAdapter log, string format) { }
         public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
         public static void Info<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
         public static void Info<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
         public static void Info<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
@@ -3667,8 +3550,6 @@ namespace Akka.Event
         public static void Info<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
         public static void Info<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
         public static void Info<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
-        public static void Info(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
-        public static void Info(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
         public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, string format) { }
         public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, string format, object[] args) { }
         public static void Log(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel level, System.Exception cause, string format, object[] args) { }
@@ -3680,6 +3561,8 @@ namespace Akka.Event
         public static void Log<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, Akka.Event.LogLevel logLevel, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
         public static void Warning(this Akka.Event.ILoggingAdapter log, string format) { }
         public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
+        public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
         public static void Warning<T1>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1) { }
         public static void Warning<T1>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1) { }
         public static void Warning<T1, T2>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2) { }
@@ -3692,17 +3575,15 @@ namespace Akka.Event
         public static void Warning<T1, T2, T3, T4, T5>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) { }
         public static void Warning<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
         public static void Warning<T1, T2, T3, T4, T5, T6>(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) { }
-        public static void Warning(this Akka.Event.ILoggingAdapter log, System.Exception cause, string format, object[] args) { }
-        public static void Warning(this Akka.Event.ILoggingAdapter log, string format, object[] args) { }
     }
     public abstract class MinimalLogger : Akka.Actor.MinimalActorRef
     {
         protected MinimalLogger() { }
         public Akka.Event.LogFilterEvaluator Filter { get; }
-        public virtual Akka.Actor.ActorPath Path { get; }
-        public virtual Akka.Actor.IActorRefProvider Provider { get; }
+        public override sealed Akka.Actor.ActorPath Path { get; }
+        public override sealed Akka.Actor.IActorRefProvider Provider { get; }
         protected abstract void Log(object message);
-        protected virtual void TellInternal(object message, Akka.Actor.IActorRef sender) { }
+        protected override sealed void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
     public sealed class NoLogger : Akka.Event.ILoggingAdapter
     {
@@ -3713,28 +3594,26 @@ namespace Akka.Event
         public bool IsInfoEnabled { get; }
         public bool IsWarningEnabled { get; }
         public bool IsEnabled(Akka.Event.LogLevel logLevel) { }
-        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format) { }
         public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, Akka.Event.LogMessage message) { }
+        public void Log(Akka.Event.LogLevel logLevel, System.Exception cause, string format) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class RegexLogMessageFilter : Akka.Event.LogFilterBase
     {
         public RegexLogMessageFilter(System.Text.RegularExpressions.Regex messageRegex) { }
         public override Akka.Event.LogFilterType FilterType { get; }
-        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, [System.Runtime.CompilerServices.NullableAttribute(2)] string expandedMessage = null) { }
+        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, string? expandedMessage = null) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class RegexLogSourceFilter : Akka.Event.LogFilterBase
     {
         public RegexLogSourceFilter(System.Text.RegularExpressions.Regex sourceRegex) { }
         public override Akka.Event.LogFilterType FilterType { get; }
-        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, [System.Runtime.CompilerServices.NullableAttribute(2)] string expandedMessage = null) { }
+        public override Akka.Event.LogFilterDecision ShouldKeepMessage(Akka.Event.LogEvent content, string? expandedMessage = null) { }
     }
     public sealed class SemanticLogMessageFormatter : Akka.Event.ILogMessageFormatter
     {
         public static readonly Akka.Event.SemanticLogMessageFormatter Instance;
-        public string Format(string format, params object[] args) { }
         public string Format(string format, System.Collections.Generic.IEnumerable<object> args) { }
+        public string Format(string format, params object[] args) { }
     }
     public class StandardOutLogger : Akka.Event.MinimalLogger
     {
@@ -3748,8 +3627,8 @@ namespace Akka.Event
     }
     public class Subscription<TSubscriber, TClassifier>
     {
-        public Subscription(TSubscriber subscriber, System.Collections.Generic.IEnumerable<TClassifier> unsubscriptions) { }
         public Subscription(TSubscriber subscriber) { }
+        public Subscription(TSubscriber subscriber, System.Collections.Generic.IEnumerable<TClassifier> unsubscriptions) { }
         public TSubscriber Subscriber { get; }
         public System.Collections.Generic.ISet<TClassifier> Unsubscriptions { get; }
     }
@@ -3804,37 +3683,23 @@ namespace Akka.IO
         BigEndian = 0,
         LittleEndian = 1,
     }
-    [System.Diagnostics.DebuggerDisplayAttribute("(Count = {_count}, Buffers = {_buffers})")]
+    [System.Diagnostics.DebuggerDisplay("(Count = {_count}, Buffers = {_buffers})")]
     public sealed class ByteString : System.Collections.Generic.IEnumerable<byte>, System.Collections.IEnumerable, System.IEquatable<Akka.IO.ByteString>
     {
         public int Count { get; }
-        public static Akka.IO.ByteString Empty { get; }
         public bool IsCompact { get; }
         public bool IsEmpty { get; }
         public byte this[int index] { get; }
+        public static Akka.IO.ByteString Empty { get; }
         public Akka.IO.ByteString Compact() { }
         public Akka.IO.ByteString Concat(Akka.IO.ByteString other) { }
-        public static Akka.IO.ByteString CopyFrom(byte[] array) { }
-        public static Akka.IO.ByteString CopyFrom(System.ArraySegment<byte> buffer) { }
-        public static Akka.IO.ByteString CopyFrom(byte[] array, int offset, int count) { }
-        public static Akka.IO.ByteString CopyFrom(System.Memory<byte> memory) { }
-        public static Akka.IO.ByteString CopyFrom(System.Memory<byte> memory, int offset, int count) { }
-        public static Akka.IO.ByteString CopyFrom(System.Span<byte> span) { }
-        public static Akka.IO.ByteString CopyFrom(System.Span<byte> span, int offset, int count) { }
-        public static Akka.IO.ByteString CopyFrom(System.Collections.Generic.IEnumerable<System.ArraySegment<byte>> buffers) { }
-        public int CopyTo(byte[] buffer, int index, int count) { }
         public int CopyTo(ref System.Memory<byte> buffer) { }
-        public int CopyTo(ref System.Memory<byte> buffer, int index, int count) { }
         public int CopyTo(ref System.Span<byte> buffer) { }
+        public int CopyTo(ref System.Memory<byte> buffer, int index, int count) { }
         public int CopyTo(ref System.Span<byte> buffer, int index, int count) { }
-        public override bool Equals(object obj) { }
+        public int CopyTo(byte[] buffer, int index, int count) { }
         public bool Equals(Akka.IO.ByteString other) { }
-        public static Akka.IO.ByteString FromBytes(byte[] array) { }
-        public static Akka.IO.ByteString FromBytes(System.ArraySegment<byte> buffer) { }
-        public static Akka.IO.ByteString FromBytes(byte[] array, int offset, int count) { }
-        public static Akka.IO.ByteString FromBytes(System.Collections.Generic.IEnumerable<System.ArraySegment<byte>> buffers) { }
-        public static Akka.IO.ByteString FromString(string str) { }
-        public static Akka.IO.ByteString FromString(string str, System.Text.Encoding encoding) { }
+        public override bool Equals(object obj) { }
         public System.Collections.Generic.IEnumerator<byte> GetEnumerator() { }
         public override int GetHashCode() { }
         public bool HasSubstring(Akka.IO.ByteString other, int index) { }
@@ -3848,13 +3713,27 @@ namespace Akka.IO
         public string ToString(System.Text.Encoding encoding) { }
         public void WriteTo(System.IO.Stream stream) { }
         public System.Threading.Tasks.Task WriteToAsync(System.IO.Stream stream) { }
-        public static Akka.IO.ByteString +(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
-        public static bool ==(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
-        public static Akka.IO.ByteString op_Explicit(byte[] bytes) { }
+        public static Akka.IO.ByteString CopyFrom(System.ArraySegment<byte> buffer) { }
+        public static Akka.IO.ByteString CopyFrom(System.Collections.Generic.IEnumerable<System.ArraySegment<byte>> buffers) { }
+        public static Akka.IO.ByteString CopyFrom(System.Memory<byte> memory) { }
+        public static Akka.IO.ByteString CopyFrom(System.Span<byte> span) { }
+        public static Akka.IO.ByteString CopyFrom(byte[] array) { }
+        public static Akka.IO.ByteString CopyFrom(System.Memory<byte> memory, int offset, int count) { }
+        public static Akka.IO.ByteString CopyFrom(System.Span<byte> span, int offset, int count) { }
+        public static Akka.IO.ByteString CopyFrom(byte[] array, int offset, int count) { }
+        public static Akka.IO.ByteString FromBytes(System.ArraySegment<byte> buffer) { }
+        public static Akka.IO.ByteString FromBytes(System.Collections.Generic.IEnumerable<System.ArraySegment<byte>> buffers) { }
+        public static Akka.IO.ByteString FromBytes(byte[] array) { }
+        public static Akka.IO.ByteString FromBytes(byte[] array, int offset, int count) { }
+        public static Akka.IO.ByteString FromString(string str) { }
+        public static Akka.IO.ByteString FromString(string str, System.Text.Encoding encoding) { }
         public static byte[] op_Explicit(Akka.IO.ByteString byteString) { }
-        public static bool !=(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
+        public static Akka.IO.ByteString op_Explicit(byte[] bytes) { }
+        public static bool operator !=(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
+        public static Akka.IO.ByteString operator +(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
+        public static bool operator ==(Akka.IO.ByteString x, Akka.IO.ByteString y) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ConnectException : System.Exception
     {
         public ConnectException(string message) { }
@@ -3863,8 +3742,8 @@ namespace Akka.IO
     {
         public static readonly Akka.IO.Dns Instance;
         public Dns() { }
-        public static Akka.IO.Dns.Resolved Cached(string name, Akka.Actor.ActorSystem system) { }
         public override Akka.IO.DnsExt CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
+        public static Akka.IO.Dns.Resolved Cached(string name, Akka.Actor.ActorSystem system) { }
         public static Akka.IO.Dns.Resolved ResolveName(string name, Akka.Actor.ActorSystem system, Akka.Actor.IActorRef sender) { }
         public abstract class Command : Akka.Actor.INoSerializationVerificationNeeded
         {
@@ -3945,7 +3824,7 @@ namespace Akka.IO
             public DatagramChannelCreator() { }
             public virtual System.Net.Sockets.Socket Create(System.Net.Sockets.AddressFamily addressFamily) { }
         }
-        public class static SO
+        public static class SO
         {
             public class ReceiveBufferSize : Akka.IO.Inet.SocketOption
             {
@@ -4033,14 +3912,13 @@ namespace Akka.IO
         }
         public class Bind : Akka.IO.Tcp.Command
         {
-            public Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint localAddress, int backlog = 1024, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, bool pullMode = False) { }
+            public Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint localAddress, int backlog = 1024, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, bool pullMode = false) { }
             public int Backlog { get; }
             public Akka.Actor.IActorRef Handler { get; }
             public System.Net.EndPoint LocalAddress { get; }
             public System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> Options { get; }
             public bool PullMode { get; }
-            [System.Runtime.CompilerServices.NullableAttribute(2)]
-            public Akka.IO.TcpSettings TcpSettings { get; set; }
+            public Akka.IO.TcpSettings? TcpSettings { get; set; }
             public override string ToString() { }
         }
         public sealed class Bound : Akka.IO.Tcp.Event
@@ -4070,14 +3948,14 @@ namespace Akka.IO
         }
         public sealed class CommandFailed : Akka.IO.Tcp.Event
         {
-            public CommandFailed(Akka.IO.Tcp.Command cmd, Akka.Util.Option<System.Exception> ex) { }
             public CommandFailed(Akka.IO.Tcp.Command cmd) { }
+            public CommandFailed(Akka.IO.Tcp.Command cmd, Akka.Util.Option<System.Exception> ex) { }
             public Akka.Util.Option<System.Exception> Cause { get; }
-            [Akka.Annotations.InternalApiAttribute()]
+            [Akka.Annotations.InternalApi]
             public string CauseString { get; }
             public Akka.IO.Tcp.Command Cmd { get; }
             public override string ToString() { }
-            [Akka.Annotations.InternalApiAttribute()]
+            [Akka.Annotations.InternalApi]
             public Akka.IO.Tcp.CommandFailed WithCause(System.Exception cause) { }
         }
         public sealed class CompoundWrite : Akka.IO.Tcp.WriteCommand, System.Collections.Generic.IEnumerable<Akka.IO.Tcp.SimpleWriteCommand>, System.Collections.IEnumerable
@@ -4101,14 +3979,13 @@ namespace Akka.IO
         }
         public sealed class Connect : Akka.IO.Tcp.Command
         {
-            public Connect(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress = null, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, System.Nullable<System.TimeSpan> timeout = null, bool pullMode = False) { }
+            public Connect(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress = null, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options = null, System.TimeSpan? timeout = default, bool pullMode = false) { }
             public System.Net.EndPoint LocalAddress { get; }
             public System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> Options { get; }
             public bool PullMode { get; }
             public System.Net.EndPoint RemoteAddress { get; }
-            [System.Runtime.CompilerServices.NullableAttribute(2)]
-            public Akka.IO.TcpSettings TcpSettings { get; set; }
-            public System.Nullable<System.TimeSpan> Timeout { get; }
+            public Akka.IO.TcpSettings? TcpSettings { get; set; }
+            public System.TimeSpan? Timeout { get; }
             public override string ToString() { }
         }
         public sealed class Connected : Akka.IO.Tcp.Event
@@ -4121,18 +3998,16 @@ namespace Akka.IO
         public class ConnectionClosed : Akka.IO.Tcp.Event, Akka.Event.IDeadLetterSuppression
         {
             public ConnectionClosed() { }
-            [System.Runtime.CompilerServices.NullableAttribute(2)]
-            public virtual string Cause { get; }
+            public virtual string? Cause { get; }
             public virtual bool IsAborted { get; }
             public virtual bool IsConfirmed { get; }
             public virtual bool IsErrorClosed { get; }
             public virtual bool IsPeerClosed { get; }
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class ErrorClosed : Akka.IO.Tcp.ConnectionClosed
         {
-            public ErrorClosed(string cause) { }
-            public override string Cause { get; }
+            public ErrorClosed(string? cause) { }
+            public override string? Cause { get; }
             public override bool IsErrorClosed { get; }
             public override string ToString() { }
         }
@@ -4165,7 +4040,7 @@ namespace Akka.IO
         }
         public class Register : Akka.IO.Tcp.Command
         {
-            public Register(Akka.Actor.IActorRef handler, bool keepOpenOnPeerClosed = False, bool useResumeWriting = True) { }
+            public Register(Akka.Actor.IActorRef handler, bool keepOpenOnPeerClosed = false, bool useResumeWriting = true) { }
             public Akka.Actor.IActorRef Handler { get; }
             public bool KeepOpenOnPeerClosed { get; }
             public bool UseResumeWriting { get; }
@@ -4195,20 +4070,19 @@ namespace Akka.IO
         public sealed class SubscribeToTcpListenerStats : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.SubscribeToTcpListenerStats>
         {
             public SubscribeToTcpListenerStats(Akka.Actor.IActorRef Subscriber) { }
-            public Akka.Actor.IActorRef Subscriber { get; set; }
+            public Akka.Actor.IActorRef Subscriber { get; init; }
         }
         public sealed class SuspendReading : Akka.IO.Tcp.Command
         {
             public static readonly Akka.IO.Tcp.SuspendReading Instance;
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         public sealed class TcpListenerStatistics : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.TcpListenerStatistics>
         {
             public TcpListenerStatistics() { }
-            public long AcceptedIncomingConnections { get; set; }
-            public long FailedIncomingConnections { get; set; }
-            public long IncomingConnectionsClosed { get; set; }
-            public long RetriedIncomingConnections { get; set; }
+            public long AcceptedIncomingConnections { get; init; }
+            public long FailedIncomingConnections { get; init; }
+            public long IncomingConnectionsClosed { get; init; }
+            public long RetriedIncomingConnections { get; init; }
         }
         public class Unbind : Akka.IO.Tcp.Command
         {
@@ -4221,7 +4095,7 @@ namespace Akka.IO
         public sealed class UnsubscribeFromTcpListenerStats : Akka.Actor.INoSerializationVerificationNeeded, Akka.IO.Tcp.ITcpQuery, System.IEquatable<Akka.IO.Tcp.UnsubscribeFromTcpListenerStats>
         {
             public UnsubscribeFromTcpListenerStats(Akka.Actor.IActorRef Subscriber) { }
-            public Akka.Actor.IActorRef Subscriber { get; set; }
+            public Akka.Actor.IActorRef Subscriber { get; init; }
         }
         public sealed class Write : Akka.IO.Tcp.SimpleWriteCommand
         {
@@ -4229,18 +4103,18 @@ namespace Akka.IO
             public override Akka.IO.Tcp.Event Ack { get; }
             public override long Bytes { get; }
             public Akka.IO.ByteString Data { get; }
+            public override string ToString() { }
             public static Akka.IO.Tcp.Write Create(Akka.IO.ByteString data) { }
             public static Akka.IO.Tcp.Write Create(Akka.IO.ByteString data, Akka.IO.Tcp.Event ack) { }
-            public override string ToString() { }
         }
         public abstract class WriteCommand : Akka.IO.Tcp.Command
         {
             protected WriteCommand() { }
             public abstract long Bytes { get; }
-            public static Akka.IO.Tcp.WriteCommand Create(System.Collections.Generic.IEnumerable<Akka.IO.Tcp.WriteCommand> writes) { }
-            public static Akka.IO.Tcp.WriteCommand Create(params WriteCommand[] writes) { }
             public Akka.IO.Tcp.CompoundWrite Prepend(Akka.IO.Tcp.SimpleWriteCommand other) { }
             public Akka.IO.Tcp.WriteCommand Prepend(System.Collections.Generic.IEnumerable<Akka.IO.Tcp.WriteCommand> writes) { }
+            public static Akka.IO.Tcp.WriteCommand Create(params Akka.IO.Tcp.WriteCommand[] writes) { }
+            public static Akka.IO.Tcp.WriteCommand Create(System.Collections.Generic.IEnumerable<Akka.IO.Tcp.WriteCommand> writes) { }
         }
         public sealed class WritingResumed : Akka.IO.Tcp.Event
         {
@@ -4253,21 +4127,21 @@ namespace Akka.IO
         public override Akka.Actor.IActorRef Manager { get; }
         public Akka.IO.TcpSettings Settings { get; }
     }
-    public class static TcpExtensions
+    public static class TcpExtensions
     {
         public static Akka.Actor.IActorRef Tcp(this Akka.Actor.ActorSystem system) { }
     }
-    public class static TcpMessage
+    public static class TcpMessage
     {
         public static Akka.IO.Tcp.Command Abort() { }
-        public static Akka.IO.Tcp.Command Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint endpoint, int backlog, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, bool pullMode) { }
         public static Akka.IO.Tcp.Command Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint endpoint, int backlog) { }
+        public static Akka.IO.Tcp.Command Bind(Akka.Actor.IActorRef handler, System.Net.EndPoint endpoint, int backlog, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, bool pullMode) { }
         public static Akka.IO.Tcp.Command Close() { }
         public static Akka.IO.Tcp.Command ConfirmedClose() { }
-        public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress, [System.Runtime.CompilerServices.NullableAttribute(2)] System.Net.EndPoint localAddress, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, System.Nullable<System.TimeSpan> timeout, bool pullMode) { }
         public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress) { }
+        public static Akka.IO.Tcp.Command Connect(System.Net.EndPoint remoteAddress, System.Net.EndPoint? localAddress, System.Collections.Generic.IEnumerable<Akka.IO.Inet.SocketOption> options, System.TimeSpan? timeout, bool pullMode) { }
         public static Akka.IO.Tcp.NoAck NoAck(object token = null) { }
-        public static Akka.IO.Tcp.Command Register(Akka.Actor.IActorRef handler, bool keepOpenOnPeerClosed = False, bool useResumeWriting = True) { }
+        public static Akka.IO.Tcp.Command Register(Akka.Actor.IActorRef handler, bool keepOpenOnPeerClosed = false, bool useResumeWriting = true) { }
         public static Akka.IO.Tcp.Command ResumeAccepting(int batchSize) { }
         public static Akka.IO.Tcp.Command ResumeReading() { }
         public static Akka.IO.Tcp.Command ResumeWriting() { }
@@ -4277,29 +4151,29 @@ namespace Akka.IO
     }
     public sealed class TcpSettings : System.IEquatable<Akka.IO.TcpSettings>
     {
-        [System.ObsoleteAttribute("Many of these options are no longer used. Use the TcpSettings.Create method inste" +
+        [System.Obsolete("Many of these options are no longer used. Use the TcpSettings.Create method inste" +
             "ad.")]
-        public TcpSettings(string bufferPoolConfigPath, int initialSocketAsyncEventArgs, bool traceLogging, int batchAcceptLimit, System.Nullable<System.TimeSpan> registerTimeout, int receivedMessageSizeLimit, string managementDispatcher, string fileIoDispatcher, int transferToLimit, int finishConnectRetries, bool outgoingSocketForceIpv4, int writeCommandsQueueMaxSize) { }
-        public int BatchAcceptLimit { get; set; }
-        [System.ObsoleteAttribute("This property is unused")]
+        public TcpSettings(string bufferPoolConfigPath, int initialSocketAsyncEventArgs, bool traceLogging, int batchAcceptLimit, System.TimeSpan? registerTimeout, int receivedMessageSizeLimit, string managementDispatcher, string fileIoDispatcher, int transferToLimit, int finishConnectRetries, bool outgoingSocketForceIpv4, int writeCommandsQueueMaxSize) { }
+        public int BatchAcceptLimit { get; init; }
+        [System.Obsolete("This property is unused")]
         public string BufferPoolConfigPath { get; }
-        [System.ObsoleteAttribute("This property is unused")]
+        [System.Obsolete("This property is unused")]
         public string FileIODispatcher { get; }
-        public int FinishConnectRetries { get; set; }
-        [System.ObsoleteAttribute("This property is unused")]
+        public int FinishConnectRetries { get; init; }
+        [System.Obsolete("This property is unused")]
         public int InitialSocketAsyncEventArgs { get; }
         public string ManagementDispatcher { get; }
-        public int MaxFrameSizeBytes { get; set; }
-        public bool OutgoingSocketForceIpv4 { get; set; }
-        public int ReceiveBufferSize { get; set; }
-        [System.ObsoleteAttribute("This property is now MaxFrameSizeBytes")]
+        public int MaxFrameSizeBytes { get; init; }
+        public bool OutgoingSocketForceIpv4 { get; init; }
+        public int ReceiveBufferSize { get; init; }
+        [System.Obsolete("This property is now MaxFrameSizeBytes")]
         public long ReceivedMessageSizeLimit { get; }
-        public System.Nullable<System.TimeSpan> RegisterTimeout { get; set; }
-        public int SendBufferSize { get; set; }
-        public bool TraceLogging { get; set; }
-        [System.ObsoleteAttribute("This property is unused")]
+        public System.TimeSpan? RegisterTimeout { get; init; }
+        public int SendBufferSize { get; init; }
+        public bool TraceLogging { get; init; }
+        [System.Obsolete("This property is unused")]
         public int TransferToLimit { get; set; }
-        public int WriteCommandsQueueMaxSize { get; set; }
+        public int WriteCommandsQueueMaxSize { get; init; }
         public static Akka.IO.TcpSettings Create(Akka.Actor.ActorSystem system) { }
         public static Akka.IO.TcpSettings Create(Akka.Configuration.Config config) { }
     }
@@ -4377,8 +4251,8 @@ namespace Akka.IO
             public Akka.IO.ByteString Payload { get; }
             public System.Net.EndPoint Target { get; }
             public bool WantsAck { get; }
-            public static Akka.IO.Udp.Send Create(Akka.IO.ByteString data, System.Net.EndPoint target) { }
             public override string ToString() { }
+            public static Akka.IO.Udp.Send Create(Akka.IO.ByteString data, System.Net.EndPoint target) { }
         }
         public sealed class SimpleSender : Akka.IO.Udp.Command
         {
@@ -4486,7 +4360,7 @@ namespace Akka.IO
         public UdpExt(Akka.Actor.ExtendedActorSystem system, Akka.IO.UdpSettings settings) { }
         public override Akka.Actor.IActorRef Manager { get; }
     }
-    public class static UdpExtensions
+    public static class UdpExtensions
     {
         public static Akka.Actor.IActorRef Udp(this Akka.Actor.ActorSystem system) { }
     }
@@ -4505,12 +4379,12 @@ namespace Akka.IO
 }
 namespace Akka.Pattern
 {
-    public class static Backoff
+    public static class Backoff
     {
-        [System.ObsoleteAttribute("Use the overloaded one which accepts maxNrOfRetries instead.")]
+        [System.Obsolete("Use the overloaded one which accepts maxNrOfRetries instead.")]
         public static Akka.Pattern.BackoffOptions OnFailure(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public static Akka.Pattern.BackoffOptions OnFailure(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
-        [System.ObsoleteAttribute("Use the overloaded one which accepts maxNrOfRetries instead.")]
+        [System.Obsolete("Use the overloaded one which accepts maxNrOfRetries instead.")]
         public static Akka.Pattern.BackoffOptions OnStop(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public static Akka.Pattern.BackoffOptions OnStop(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
     }
@@ -4529,39 +4403,46 @@ namespace Akka.Pattern
     {
         public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public BackoffSupervisor(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, Akka.Pattern.IBackoffReset reset, double randomFactor, Akka.Actor.SupervisorStrategy strategy, object replyWhileStopped = null, System.Func<object, bool> finalStopMessage = null) { }
-        public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
-        public static Akka.Actor.Props Props(Akka.Pattern.BackoffOptions options) { }
-        public static Akka.Actor.Props PropsWithSupervisorStrategy(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, Akka.Actor.SupervisorStrategy strategy) { }
         protected override bool Receive(object message) { }
         protected override Akka.Actor.SupervisorStrategy SupervisorStrategy() { }
+        public static Akka.Actor.Props Props(Akka.Pattern.BackoffOptions options) { }
+        public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        public static Akka.Actor.Props Props(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxNrOfRetries) { }
+        public static Akka.Actor.Props PropsWithSupervisorStrategy(Akka.Actor.Props childProps, string childName, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, Akka.Actor.SupervisorStrategy strategy) { }
+        [System.Serializable]
         public sealed class CurrentChild
         {
             public CurrentChild(Akka.Actor.IActorRef @ref) { }
             public Akka.Actor.IActorRef Ref { get; }
         }
+        [System.Serializable]
         public sealed class GetCurrentChild
         {
             public static readonly Akka.Pattern.BackoffSupervisor.GetCurrentChild Instance;
         }
+        [System.Serializable]
         public sealed class GetRestartCount
         {
             public static readonly Akka.Pattern.BackoffSupervisor.GetRestartCount Instance;
         }
+        [System.Serializable]
         public sealed class Reset
         {
             public static readonly Akka.Pattern.BackoffSupervisor.Reset Instance;
         }
+        [System.Serializable]
         public sealed class ResetRestartCount : Akka.Event.IDeadLetterSuppression
         {
             public ResetRestartCount(int current) { }
             public int Current { get; }
         }
+        [System.Serializable]
         public sealed class RestartCount
         {
             public RestartCount(int count) { }
             public int Count { get; }
         }
+        [System.Serializable]
         public sealed class StartChild : Akka.Event.IDeadLetterSuppression
         {
             public static readonly Akka.Pattern.BackoffSupervisor.StartChild Instance;
@@ -4597,34 +4478,34 @@ namespace Akka.Pattern
         public double RandomFactor { get; }
         public System.TimeSpan ResetTimeout { get; }
         public Akka.Actor.IScheduler Scheduler { get; }
-        public static Akka.Pattern.CircuitBreaker Create(Akka.Actor.IScheduler scheduler, int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
         public void Fail() { }
         public Akka.Pattern.CircuitBreaker OnClose(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnHalfOpen(System.Action callback) { }
         public Akka.Pattern.CircuitBreaker OnOpen(System.Action callback) { }
         public void Succeed() { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
-            " Since 1.5.42")]
-        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
-        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
-            " Since 1.5.42")]
-        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.Tasks.Task<T>> body) { }
-        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+        [System.Obsolete("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
             " Since 1.5.42")]
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.Tasks.Task> body) { }
         public System.Threading.Tasks.Task WithCircuitBreaker(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
-        [System.ObsoleteAttribute("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+        [System.Obsolete("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T>(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
+        [System.Obsolete("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
             " Since 1.5.42")]
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.Tasks.Task> body) { }
         public System.Threading.Tasks.Task WithCircuitBreaker<TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task> body) { }
+        [System.Obsolete("Use WithCircuitBreaker() that accepts functions with CancellationToken parameter." +
+            " Since 1.5.42")]
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.Tasks.Task<T>> body) { }
+        public System.Threading.Tasks.Task<T> WithCircuitBreaker<T, TState>(TState state, System.Func<TState, System.Threading.CancellationToken, System.Threading.Tasks.Task<T>> body) { }
         public Akka.Pattern.CircuitBreaker WithExponentialBackoff(System.TimeSpan maxResetTimeout) { }
         public Akka.Pattern.CircuitBreaker WithRandomFactor(double randomFactor) { }
         public void WithSyncCircuitBreaker(System.Action body) { }
         public T WithSyncCircuitBreaker<T>(System.Func<T> body) { }
+        public static Akka.Pattern.CircuitBreaker Create(Akka.Actor.IScheduler scheduler, int maxFailures, System.TimeSpan callTimeout, System.TimeSpan resetTimeout) { }
     }
-    public class static FutureTimeoutSupport
+    public static class FutureTimeoutSupport
     {
         public static System.Threading.Tasks.Task<T> After<T>(System.TimeSpan duration, Akka.Actor.IScheduler scheduler, System.Func<System.Threading.Tasks.Task<T>> value) { }
     }
@@ -4632,28 +4513,28 @@ namespace Akka.Pattern
     public class IllegalStateException : Akka.Actor.AkkaException
     {
         public IllegalStateException(string message) { }
-        public IllegalStateException(string message, System.Exception innerEx) { }
         protected IllegalStateException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public IllegalStateException(string message, System.Exception innerEx) { }
     }
     public class OpenCircuitException : Akka.Actor.AkkaException
     {
         public OpenCircuitException() { }
-        public OpenCircuitException(string message) { }
-        public OpenCircuitException(string message, System.TimeSpan remainingDuration) { }
-        public OpenCircuitException(string message, System.Exception cause) { }
-        public OpenCircuitException(string message, System.Exception cause, System.TimeSpan remainingDuration) { }
         public OpenCircuitException(System.Exception cause) { }
+        public OpenCircuitException(string message) { }
         public OpenCircuitException(System.Exception cause, System.TimeSpan remainingDuration) { }
         protected OpenCircuitException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public OpenCircuitException(string message, System.Exception cause) { }
+        public OpenCircuitException(string message, System.TimeSpan remainingDuration) { }
+        public OpenCircuitException(string message, System.Exception cause, System.TimeSpan remainingDuration) { }
         public System.TimeSpan RemainingDuration { get; }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static RetrySupport
+    public static class RetrySupport
     {
         public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts) { }
-        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, int randomFactor, Akka.Actor.IScheduler scheduler) { }
-        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan delay, Akka.Actor.IScheduler scheduler) { }
         public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.Func<int, Akka.Util.Option<System.TimeSpan>> delayFunction, Akka.Actor.IScheduler scheduler) { }
+        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan delay, Akka.Actor.IScheduler scheduler) { }
+        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, int randomFactor, Akka.Actor.IScheduler scheduler) { }
     }
     public class UserCalledFailException : Akka.Actor.AkkaException
     {
@@ -4667,9 +4548,9 @@ namespace Akka.Routing
     {
         public ActorRefRoutee(Akka.Actor.IActorRef actor) { }
         public Akka.Actor.IActorRef Actor { get; }
-        public override System.Threading.Tasks.Task<object> Ask(object message, System.Nullable<System.TimeSpan> timeout) { }
-        public override bool Equals(object obj) { }
+        public override System.Threading.Tasks.Task<object> Ask(object message, System.TimeSpan? timeout) { }
         protected bool Equals(Akka.Routing.ActorRefRoutee other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override void Send(object message, Akka.Actor.IActorRef sender) { }
     }
@@ -4677,9 +4558,9 @@ namespace Akka.Routing
     {
         public ActorSelectionRoutee(Akka.Actor.ActorSelection actor) { }
         public Akka.Actor.ActorSelection Selection { get; }
-        public override System.Threading.Tasks.Task<object> Ask(object message, System.Nullable<System.TimeSpan> timeout) { }
-        public override bool Equals(object obj) { }
+        public override System.Threading.Tasks.Task<object> Ask(object message, System.TimeSpan? timeout) { }
         protected bool Equals(Akka.Routing.ActorSelectionRoutee other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override void Send(object message, Akka.Actor.IActorRef sender) { }
     }
@@ -4700,8 +4581,8 @@ namespace Akka.Routing
     public sealed class BroadcastGroup : Akka.Routing.Group
     {
         public BroadcastGroup(Akka.Configuration.Config config) { }
-        public BroadcastGroup(params string[] paths) { }
         public BroadcastGroup(System.Collections.Generic.IEnumerable<string> paths) { }
+        public BroadcastGroup(params string[] paths) { }
         public BroadcastGroup(System.Collections.Generic.IEnumerable<string> paths, string routerDispatcher) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override System.Collections.Generic.IEnumerable<string> GetPaths(Akka.Actor.ActorSystem system) { }
@@ -4717,9 +4598,9 @@ namespace Akka.Routing
     }
     public sealed class BroadcastPool : Akka.Routing.Pool
     {
-        public BroadcastPool(int nrOfInstances) { }
         public BroadcastPool(Akka.Configuration.Config config) { }
-        public BroadcastPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False) { }
+        public BroadcastPool(int nrOfInstances) { }
+        public BroadcastPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem system) { }
         public override Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
@@ -4743,7 +4624,7 @@ namespace Akka.Routing
         public BroadcastRoutingLogic() { }
         public override Akka.Routing.Routee Select(object message, Akka.Routing.Routee[] routees) { }
     }
-    public class static ConsistentHash
+    public static class ConsistentHash
     {
         public static Akka.Routing.ConsistentHash<T> Create<T>(System.Collections.Generic.IEnumerable<T> nodes, int virtualNodesFactor) { }
         public class ConsistentHashingPoolSurrogate : Akka.Util.ISurrogate
@@ -4766,9 +4647,9 @@ namespace Akka.Routing
         public T NodeFor(byte[] key) { }
         public T NodeFor(string key) { }
         public Akka.Routing.ConsistentHash<T> Remove(T node) { }
-        public static Akka.Routing.ConsistentHash<T> +(Akka.Routing.ConsistentHash<T> hash, T node) { }
-        public static Akka.Routing.ConsistentHash<T> -(Akka.Routing.ConsistentHash<T> hash, T node) { }
-        public class ConsistentHashingGroupSurrogate<T> : Akka.Util.ISurrogate
+        public static Akka.Routing.ConsistentHash<T> operator +(Akka.Routing.ConsistentHash<T> hash, T node) { }
+        public static Akka.Routing.ConsistentHash<T> operator -(Akka.Routing.ConsistentHash<T> hash, T node) { }
+        public class ConsistentHashingGroupSurrogate : Akka.Util.ISurrogate
         {
             public ConsistentHashingGroupSurrogate() { }
             public string[] Paths { get; set; }
@@ -4784,8 +4665,8 @@ namespace Akka.Routing
     public sealed class ConsistentHashingGroup : Akka.Routing.Group
     {
         public ConsistentHashingGroup(Akka.Configuration.Config config) { }
-        public ConsistentHashingGroup(params string[] paths) { }
         public ConsistentHashingGroup(System.Collections.Generic.IEnumerable<string> paths) { }
+        public ConsistentHashingGroup(params string[] paths) { }
         public ConsistentHashingGroup(System.Collections.Generic.IEnumerable<string> paths, Akka.Routing.ConsistentHashMapping hashMapping) { }
         public ConsistentHashingGroup(System.Collections.Generic.IEnumerable<string> paths, int virtualNodesFactor, Akka.Routing.ConsistentHashMapping hashMapping, string routerDispatcher) { }
         public int VirtualNodesFactor { get; }
@@ -4806,10 +4687,10 @@ namespace Akka.Routing
     }
     public sealed class ConsistentHashingPool : Akka.Routing.Pool
     {
-        public ConsistentHashingPool(int nrOfInstances) { }
         public ConsistentHashingPool(Akka.Configuration.Config config) { }
+        public ConsistentHashingPool(int nrOfInstances) { }
         public ConsistentHashingPool(int nrOfInstances, Akka.Routing.ConsistentHashMapping hashMapping) { }
-        public ConsistentHashingPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False, int virtualNodesFactor = 0, Akka.Routing.ConsistentHashMapping hashMapping = null) { }
+        public ConsistentHashingPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false, int virtualNodesFactor = 0, Akka.Routing.ConsistentHashMapping hashMapping = null) { }
         public int VirtualNodesFactor { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem system) { }
@@ -4864,12 +4745,12 @@ namespace Akka.Routing
         public bool Equals(Akka.Routing.DefaultResizer other) { }
         public override bool Equals(object obj) { }
         public int Filter(int pressure, int capacity) { }
-        public static Akka.Routing.DefaultResizer FromConfig(Akka.Configuration.Config resizerConfig) { }
         public override int GetHashCode() { }
         public override bool IsTimeForResize(long messageCounter) { }
         public int Pressure(System.Collections.Generic.IEnumerable<Akka.Routing.Routee> currentRoutees) { }
         public int Rampup(int pressure, int capacity) { }
         public override int Resize(System.Collections.Generic.IEnumerable<Akka.Routing.Routee> currentRoutees) { }
+        public new static Akka.Routing.DefaultResizer FromConfig(Akka.Configuration.Config resizerConfig) { }
     }
     public class FromConfig : Akka.Routing.Pool
     {
@@ -4937,8 +4818,8 @@ namespace Akka.Routing
     public class NoRouter : Akka.Routing.RouterConfig
     {
         protected NoRouter() { }
-        public static Akka.Routing.NoRouter Instance { get; }
         public override string RouterDispatcher { get; }
+        public static Akka.Routing.NoRouter Instance { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override Akka.Actor.ActorBase CreateRouterActor() { }
         public Akka.Actor.Props Props(Akka.Actor.Props routeeProps) { }
@@ -4953,12 +4834,12 @@ namespace Akka.Routing
     public abstract class Pool : Akka.Routing.RouterConfig, System.IEquatable<Akka.Routing.Pool>
     {
         protected Pool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher) { }
-        public static Akka.Actor.SupervisorStrategy DefaultSupervisorStrategy { get; }
         public int NrOfInstances { get; }
         public virtual Akka.Routing.Resizer Resizer { get; }
         public override bool StopRouterWhenAllRouteesRemoved { get; }
         public virtual Akka.Actor.SupervisorStrategy SupervisorStrategy { get; }
         public virtual bool UsePoolDispatcher { get; }
+        public static Akka.Actor.SupervisorStrategy DefaultSupervisorStrategy { get; }
         public override Akka.Actor.ActorBase CreateRouterActor() { }
         public bool Equals(Akka.Routing.Pool other) { }
         public override bool Equals(object obj) { }
@@ -4969,8 +4850,8 @@ namespace Akka.Routing
     public sealed class RandomGroup : Akka.Routing.Group
     {
         public RandomGroup(Akka.Configuration.Config config) { }
-        public RandomGroup(params string[] paths) { }
         public RandomGroup(System.Collections.Generic.IEnumerable<string> paths) { }
+        public RandomGroup(params string[] paths) { }
         public RandomGroup(System.Collections.Generic.IEnumerable<string> paths, string routerDispatcher) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override System.Collections.Generic.IEnumerable<string> GetPaths(Akka.Actor.ActorSystem system) { }
@@ -4993,7 +4874,7 @@ namespace Akka.Routing
     {
         public RandomPool(Akka.Configuration.Config config) { }
         public RandomPool(int nrOfInstances) { }
-        public RandomPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False) { }
+        public RandomPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem system) { }
         public override Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
@@ -5024,15 +4905,15 @@ namespace Akka.Routing
     public abstract class Resizer
     {
         protected Resizer() { }
-        public static Akka.Routing.Resizer FromConfig(Akka.Configuration.Config parentConfig) { }
         public abstract bool IsTimeForResize(long messageCounter);
         public abstract int Resize(System.Collections.Generic.IEnumerable<Akka.Routing.Routee> currentRoutees);
+        public static Akka.Routing.Resizer FromConfig(Akka.Configuration.Config parentConfig) { }
     }
     public sealed class RoundRobinGroup : Akka.Routing.Group
     {
         public RoundRobinGroup(Akka.Configuration.Config config) { }
-        public RoundRobinGroup(params string[] paths) { }
         public RoundRobinGroup(System.Collections.Generic.IEnumerable<string> paths) { }
+        public RoundRobinGroup(params string[] paths) { }
         public RoundRobinGroup(System.Collections.Generic.IEnumerable<string> paths, string routerDispatcher) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override System.Collections.Generic.IEnumerable<string> GetPaths(Akka.Actor.ActorSystem system) { }
@@ -5051,7 +4932,7 @@ namespace Akka.Routing
         public RoundRobinPool(Akka.Configuration.Config config) { }
         public RoundRobinPool(int nrOfInstances) { }
         public RoundRobinPool(int nrOfInstances, Akka.Routing.Resizer resizer) { }
-        public RoundRobinPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False) { }
+        public RoundRobinPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem sys) { }
         public override Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
@@ -5080,9 +4961,9 @@ namespace Akka.Routing
     {
         public static readonly Akka.Routing.Routee NoRoutee;
         public Routee() { }
-        public virtual System.Threading.Tasks.Task<object> Ask(object message, System.Nullable<System.TimeSpan> timeout) { }
-        public static Akka.Routing.Routee FromActorRef(Akka.Actor.IActorRef actorRef) { }
+        public virtual System.Threading.Tasks.Task<object> Ask(object message, System.TimeSpan? timeout) { }
         public virtual void Send(object message, Akka.Actor.IActorRef sender) { }
+        public static Akka.Routing.Routee FromActorRef(Akka.Actor.IActorRef actorRef) { }
     }
     public sealed class Routees
     {
@@ -5091,17 +4972,17 @@ namespace Akka.Routing
     }
     public class Router
     {
-        [Akka.Annotations.InternalApiAttribute()]
-        public Router(Akka.Routing.RoutingLogic logic, Akka.Actor.IActorRef routee, params Akka.Actor.IActorRef[] routees) { }
         public Router(Akka.Routing.RoutingLogic logic, params Akka.Routing.Routee[] routees) { }
+        [Akka.Annotations.InternalApi]
+        public Router(Akka.Routing.RoutingLogic logic, Akka.Actor.IActorRef routee, params Akka.Actor.IActorRef[] routees) { }
         public System.Collections.Generic.IEnumerable<Akka.Routing.Routee> Routees { get; }
         public Akka.Routing.RoutingLogic RoutingLogic { get; }
-        public virtual Akka.Routing.Router AddRoutee(Akka.Routing.Routee routee) { }
-        public Akka.Routing.Router AddRoutee(Akka.Actor.IActorRef routee) { }
         public Akka.Routing.Router AddRoutee(Akka.Actor.ActorSelection routee) { }
-        public virtual Akka.Routing.Router RemoveRoutee(Akka.Routing.Routee routee) { }
-        public Akka.Routing.Router RemoveRoutee(Akka.Actor.IActorRef routee) { }
+        public Akka.Routing.Router AddRoutee(Akka.Actor.IActorRef routee) { }
+        public virtual Akka.Routing.Router AddRoutee(Akka.Routing.Routee routee) { }
         public Akka.Routing.Router RemoveRoutee(Akka.Actor.ActorSelection routee) { }
+        public Akka.Routing.Router RemoveRoutee(Akka.Actor.IActorRef routee) { }
+        public virtual Akka.Routing.Router RemoveRoutee(Akka.Routing.Routee routee) { }
         public virtual void Route(object message, Akka.Actor.IActorRef sender) { }
         protected virtual void Send(Akka.Routing.Routee routee, object message, Akka.Actor.IActorRef sender) { }
         protected object UnWrap(object message) { }
@@ -5114,7 +4995,7 @@ namespace Akka.Routing
         public virtual string RouterDispatcher { get; }
         public virtual bool StopRouterWhenAllRouteesRemoved { get; }
         public abstract Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system);
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public abstract Akka.Actor.ActorBase CreateRouterActor();
         public bool Equals(Akka.Routing.RouterConfig other) { }
         public override bool Equals(object obj) { }
@@ -5134,7 +5015,7 @@ namespace Akka.Routing
     {
         protected RouterManagementMessage() { }
     }
-    public class static RouterMessage
+    public static class RouterMessage
     {
         public static readonly Akka.Routing.GetRoutees GetRoutees;
     }
@@ -5146,8 +5027,8 @@ namespace Akka.Routing
     public sealed class ScatterGatherFirstCompletedGroup : Akka.Routing.Group
     {
         public ScatterGatherFirstCompletedGroup(Akka.Configuration.Config config) { }
-        public ScatterGatherFirstCompletedGroup(System.TimeSpan within, params string[] paths) { }
         public ScatterGatherFirstCompletedGroup(System.Collections.Generic.IEnumerable<string> paths, System.TimeSpan within) { }
+        public ScatterGatherFirstCompletedGroup(System.TimeSpan within, params string[] paths) { }
         public ScatterGatherFirstCompletedGroup(System.Collections.Generic.IEnumerable<string> paths, System.TimeSpan within, string routerDispatcher) { }
         public System.TimeSpan Within { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
@@ -5168,7 +5049,7 @@ namespace Akka.Routing
         public ScatterGatherFirstCompletedPool(Akka.Configuration.Config config) { }
         public ScatterGatherFirstCompletedPool(int nrOfInstances) { }
         public ScatterGatherFirstCompletedPool(int nrOfInstances, System.TimeSpan within) { }
-        public ScatterGatherFirstCompletedPool(int nrOfInstances, Akka.Routing.Resizer resizer, System.TimeSpan within, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False) { }
+        public ScatterGatherFirstCompletedPool(int nrOfInstances, Akka.Routing.Resizer resizer, System.TimeSpan within, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false) { }
         public System.TimeSpan Within { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem system) { }
@@ -5203,7 +5084,7 @@ namespace Akka.Routing
     {
         public SmallestMailboxPool(Akka.Configuration.Config config) { }
         public SmallestMailboxPool(int nrOfInstances) { }
-        public SmallestMailboxPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = False) { }
+        public SmallestMailboxPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, bool usePoolDispatcher = false) { }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
         public override int GetNrOfInstances(Akka.Actor.ActorSystem system) { }
         public override Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
@@ -5258,7 +5139,7 @@ namespace Akka.Routing
     {
         public TailChoppingPool(Akka.Configuration.Config config) { }
         public TailChoppingPool(int nrOfInstances, System.TimeSpan within, System.TimeSpan interval) { }
-        public TailChoppingPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, System.TimeSpan within, System.TimeSpan interval, bool usePoolDispatcher = False) { }
+        public TailChoppingPool(int nrOfInstances, Akka.Routing.Resizer resizer, Akka.Actor.SupervisorStrategy supervisorStrategy, string routerDispatcher, System.TimeSpan within, System.TimeSpan interval, bool usePoolDispatcher = false) { }
         public System.TimeSpan Interval { get; }
         public System.TimeSpan Within { get; }
         public override Akka.Routing.Router CreateRouter(Akka.Actor.ActorSystem system) { }
@@ -5296,7 +5177,7 @@ namespace Akka.Serialization
         public override object FromBinary(byte[] bytes, System.Type type) { }
         public override byte[] ToBinary(object obj) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Information : System.IEquatable<Akka.Serialization.Information>
     {
         public Information(Akka.Actor.Address address, Akka.Actor.ActorSystem system) { }
@@ -5305,8 +5186,8 @@ namespace Akka.Serialization
         public bool Equals(Akka.Serialization.Information other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public static bool ==(Akka.Serialization.Information left, Akka.Serialization.Information right) { }
-        public static bool !=(Akka.Serialization.Information left, Akka.Serialization.Information right) { }
+        public static bool operator !=(Akka.Serialization.Information left, Akka.Serialization.Information right) { }
+        public static bool operator ==(Akka.Serialization.Information left, Akka.Serialization.Information right) { }
     }
     public class NewtonSoftJsonSerializer : Akka.Serialization.Serializer
     {
@@ -5349,7 +5230,7 @@ namespace Akka.Serialization
         public Serialization(Akka.Actor.ExtendedActorSystem system) { }
         public Akka.Actor.ExtendedActorSystem System { get; }
         public void AddSerializationMap(System.Type type, Akka.Serialization.Serializer serializer) { }
-        [System.ObsoleteAttribute("No longer supported. Use the AddSerializer(name, serializer) overload instead.", true)]
+        [System.Obsolete("No longer supported. Use the AddSerializer(name, serializer) overload instead.", true)]
         public void AddSerializer(Akka.Serialization.Serializer serializer) { }
         public void AddSerializer(string name, Akka.Serialization.Serializer serializer) { }
         public object Deserialize(byte[] bytes, int serializerId, System.Type type) { }
@@ -5357,13 +5238,13 @@ namespace Akka.Serialization
         public Akka.Actor.IActorRef DeserializeActorRef(string path) { }
         public Akka.Serialization.Serializer FindSerializerFor(object obj, string defaultSerializerName = null) { }
         public Akka.Serialization.Serializer FindSerializerForType(System.Type objectType, string defaultSerializerName = null) { }
+        public byte[] Serialize(object o) { }
         public static Akka.Serialization.Information GetCurrentTransportInformation() { }
         public static string ManifestFor(Akka.Serialization.Serializer s, object msg) { }
-        public byte[] Serialize(object o) { }
         public static string SerializedActorPath(Akka.Actor.IActorRef actorRef) { }
-        [System.ObsoleteAttribute("Obsolete. Use the SerializeWithTransport<T>(ExtendedActorSystem) method instead.")]
-        public static T WithTransport<T>(Akka.Actor.ActorSystem system, Akka.Actor.Address address, System.Func<T> action) { }
         public static T WithTransport<T>(Akka.Actor.ExtendedActorSystem system, System.Func<T> action) { }
+        [System.Obsolete("Obsolete. Use the SerializeWithTransport<T>(ExtendedActorSystem) method instead.")]
+        public static T WithTransport<T>(Akka.Actor.ActorSystem system, Akka.Actor.Address address, System.Func<T> action) { }
         public static T WithTransport<TState, T>(Akka.Actor.ExtendedActorSystem system, TState state, System.Func<TState, T> action) { }
     }
     public sealed class SerializationSetup : Akka.Actor.Setup.Setup
@@ -5389,16 +5270,16 @@ namespace Akka.Serialization
         public System.Collections.Immutable.ImmutableHashSet<System.Type> UseFor { get; }
         public static Akka.Serialization.SerializerDetails Create(string alias, Akka.Serialization.Serializer serializer, System.Collections.Immutable.ImmutableHashSet<System.Type> useFor) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static SerializerIdentifierHelper
+    [Akka.Annotations.InternalApi]
+    public static class SerializerIdentifierHelper
     {
         public static int GetSerializerIdentifierFromConfig(System.Type type, Akka.Actor.ExtendedActorSystem system) { }
     }
     public abstract class SerializerWithStringManifest : Akka.Serialization.Serializer
     {
         protected SerializerWithStringManifest(Akka.Actor.ExtendedActorSystem system) { }
-        public virtual bool IncludeManifest { get; }
-        public virtual object FromBinary(byte[] bytes, System.Type type) { }
+        public override sealed bool IncludeManifest { get; }
+        public override sealed object FromBinary(byte[] bytes, System.Type type) { }
         public abstract object FromBinary(byte[] bytes, string manifest);
         public abstract string Manifest(object o);
     }
@@ -5410,17 +5291,17 @@ namespace Akka.Util
         public static readonly Akka.Util.AppVersion Zero;
         public string Version { get; }
         public int CompareTo(Akka.Util.AppVersion other) { }
-        public static Akka.Util.AppVersion Create(string version) { }
         public bool Equals(Akka.Util.AppVersion other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
-        public static bool ==(Akka.Util.AppVersion first, Akka.Util.AppVersion second) { }
-        public static bool !=(Akka.Util.AppVersion first, Akka.Util.AppVersion second) { }
+        public static Akka.Util.AppVersion Create(string version) { }
+        public static bool operator !=(Akka.Util.AppVersion first, Akka.Util.AppVersion second) { }
+        public static bool operator ==(Akka.Util.AppVersion first, Akka.Util.AppVersion second) { }
     }
     public class AtomicBoolean
     {
-        public AtomicBoolean(bool initialValue = False) { }
+        public AtomicBoolean(bool initialValue = false) { }
         public bool Value { get; set; }
         public bool CompareAndSet(bool expected, bool newValue) { }
         public bool GetAndSet(bool newValue) { }
@@ -5430,19 +5311,19 @@ namespace Akka.Util
         where T :  class
     {
         protected T atomicValue;
-        public AtomicReference(T originalValue) { }
         public AtomicReference() { }
+        public AtomicReference(T originalValue) { }
         public T Value { get; set; }
         public bool CompareAndSet(T expected, T newValue) { }
         public T CompareExchange(T expected, T newValue) { }
         public T GetAndSet(T newValue) { }
         public static T op_Implicit(Akka.Util.AtomicReference<T> atomicReference) { }
     }
-    public class static BitArrayHelpers
+    public static class BitArrayHelpers
     {
         public static byte[] ToBytes(this System.Collections.BitArray arr) { }
     }
-    public class static ByteHelpers
+    public static class ByteHelpers
     {
         public static byte[] PutInt(this byte[] target, int x, int offset = 0, Akka.IO.ByteOrder order = 0) { }
     }
@@ -5462,14 +5343,14 @@ namespace Akka.Util
         public bool TryAdd(T item) { }
         public bool TryRemove(T item) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static DynamicAccess
+    [Akka.Annotations.InternalApi]
+    public static class DynamicAccess
     {
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public static Akka.Util.Try<TResult> CreateInstanceFor<TResult>(string typeName, params object[] args)
             where TResult :  class { }
     }
-    public class static Either
+    public static class Either
     {
         public static Akka.Util.Left<T> Left<T>(T value) { }
         public static Akka.Util.Right<T> Right<T>(T value) { }
@@ -5517,8 +5398,8 @@ namespace Akka.Util
         public TValue FindValue(TKey key, System.Func<TValue, bool> predicate) { }
         public void ForEach(System.Action<TKey, TValue> fun) { }
         public bool Put(TKey key, TValue value) { }
-        public bool Remove(TKey key, TValue value) { }
         public System.Collections.Generic.IEnumerable<TValue> Remove(TKey key) { }
+        public bool Remove(TKey key, TValue value) { }
         public void RemoveValue(TValue value) { }
     }
     public class Left<T>
@@ -5533,7 +5414,7 @@ namespace Akka.Util
         public Left(TA a) { }
         public override bool IsLeft { get; }
         public override bool IsRight { get; }
-        public TA Value { get; }
+        public new TA Value { get; }
     }
     public sealed class ListPriorityQueue
     {
@@ -5545,7 +5426,7 @@ namespace Akka.Util
         public Akka.Actor.Envelope Peek() { }
         public override string ToString() { }
     }
-    public class static MurmurHash
+    public static class MurmurHash
     {
         public const uint StartMagicA = 2505324423u;
         public const uint StartMagicB = 718793509u;
@@ -5559,16 +5440,15 @@ namespace Akka.Util
         public static int StringHash(string s) { }
         public static int SymmetricHash<T>(System.Collections.Generic.IEnumerable<T> xs, uint seed) { }
     }
-    [Akka.Annotations.InternalStableApiAttribute()]
-    public struct Option<T>
+    [Akka.Annotations.InternalStableApi]
+    public readonly struct Option<T>
     {
         public static readonly Akka.Util.Option<T> None;
-        [System.ObsoleteAttribute("Use Option<T>.Create() instead")]
+        [System.Obsolete("Use Option<T>.Create() instead")]
         public Option(T value) { }
         public bool HasValue { get; }
         public bool IsEmpty { get; }
         public T Value { get; }
-        public static Akka.Util.Option<T> Create(T value) { }
         public bool Equals(Akka.Util.Option<T> other) { }
         public override bool Equals(object obj) { }
         public Akka.Util.Option<TNew> FlatSelect<TNew>(System.Func<T, Akka.Util.Option<TNew>> mapper) { }
@@ -5577,39 +5457,25 @@ namespace Akka.Util
         public void OnSuccess(System.Action<T> action) { }
         public Akka.Util.Option<TNew> Select<TNew>(System.Func<T, TNew> selector) { }
         public override string ToString() { }
-        public static bool ==(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
+        public static Akka.Util.Option<T> Create(T value) { }
         public static Akka.Util.Option<T> op_Implicit(T value) { }
-        public static bool !=(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
+        public static bool operator !=(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
+        public static bool operator ==(Akka.Util.Option<T> left, Akka.Util.Option<T> right) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static Result
+    public static class Result
     {
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
-        public static Akka.Util.Result<T> Failure<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Exception exception) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
-        public static Akka.Util.Result<T> From<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
-        public static Akka.Util.Result<T> FromTask<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Threading.Tasks.Task<T> task) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                0,
-                1})]
-        public static Akka.Util.Result<T> Success<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(T value) { }
+        public static Akka.Util.Result<T> Failure<T>(System.Exception exception) { }
+        public static Akka.Util.Result<T> From<T>(System.Func<T> func) { }
+        public static Akka.Util.Result<T> FromTask<T>(System.Threading.Tasks.Task<T> task) { }
+        public static Akka.Util.Result<T> Success<T>(T value) { }
     }
-    public struct Result<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : System.IEquatable<Akka.Util.Result<T>>
+    public readonly struct Result<T> : System.IEquatable<Akka.Util.Result<T>>
     {
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public readonly System.Exception Exception;
+        public readonly System.Exception? Exception;
         public readonly bool IsSuccess;
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public readonly T Value;
-        public Result(T value) { }
+        public readonly T? Value;
         public Result(System.Exception exception) { }
+        public Result(T value) { }
         public override string ToString() { }
     }
     public class Right<T>
@@ -5624,9 +5490,9 @@ namespace Akka.Util
         public Right(TB b) { }
         public override bool IsLeft { get; }
         public override bool IsRight { get; }
-        public TB Value { get; }
+        public new TB Value { get; }
     }
-    public class static RuntimeDetector
+    public static class RuntimeDetector
     {
         public static readonly bool IsMono;
         public static readonly bool IsWindows;
@@ -5641,32 +5507,32 @@ namespace Akka.Util
         public Akka.Actor.Envelope Peek() { }
         public override string ToString() { }
     }
-    public class static StandardOutWriter
+    public static class StandardOutWriter
     {
-        public static void Write(string message, System.Nullable<System.ConsoleColor> foregroundColor = null, System.Nullable<System.ConsoleColor> backgroundColor = null) { }
-        public static void WriteLine(string message, System.Nullable<System.ConsoleColor> foregroundColor = null, System.Nullable<System.ConsoleColor> backgroundColor = null) { }
+        public static void Write(string message, System.ConsoleColor? foregroundColor = default, System.ConsoleColor? backgroundColor = default) { }
+        public static void WriteLine(string message, System.ConsoleColor? foregroundColor = default, System.ConsoleColor? backgroundColor = default) { }
     }
-    public class static StringFormat
+    public static class StringFormat
     {
         public static string SafeJoin(string separator, params object[] args) { }
     }
     public class Switch
     {
-        public Switch(bool startAsOn = False) { }
+        public Switch(bool startAsOn = false) { }
         public bool IsOff { get; }
         public bool IsOn { get; }
         public bool IfOff(System.Action action) { }
         public bool IfOn(System.Action action) { }
         public void Locked(System.Action action) { }
-        public bool SwitchOff(System.Action action) { }
         public bool SwitchOff() { }
-        public bool SwitchOn(System.Action action) { }
+        public bool SwitchOff(System.Action action) { }
         public bool SwitchOn() { }
+        public bool SwitchOn(System.Action action) { }
         protected bool TranscendFrom(bool from, System.Action action) { }
         public bool WhileOff(System.Action action) { }
         public bool WhileOn(System.Action action) { }
     }
-    public class static ThreadLocalRandom
+    public static class ThreadLocalRandom
     {
         public static System.Random Current { get; }
     }
@@ -5675,7 +5541,7 @@ namespace Akka.Util
         public TickTimeTokenBucket(long capacity, long period) { }
         public override long CurrentTime { get; }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class TokenBucket
     {
         protected TokenBucket(long capacity, long ticksBetweenTokens) { }
@@ -5685,38 +5551,38 @@ namespace Akka.Util
     }
     public class Try<T>
     {
-        public Try(T success) { }
         public Try(System.Exception failure) { }
+        public Try(T success) { }
         public Akka.Util.Option<System.Exception> Failure { get; }
         public bool IsSuccess { get; }
         public Akka.Util.Option<T> Success { get; }
-        public static Akka.Util.Try<T> From(System.Func<T> func) { }
         public T Get() { }
         public Akka.Util.Try<T> GetOrElse(System.Func<T> fallback) { }
         public Akka.Util.Try<T> OrElse(Akka.Util.Try<T> @default) { }
         public Akka.Util.Try<T> Recover(System.Action<System.Exception> failureHandler) { }
         public Akka.Util.Try<T> RecoverWith(System.Func<System.Exception, Akka.Util.Try<T>> failureHandler) { }
+        public static Akka.Util.Try<T> From(System.Func<T> func) { }
         public static Akka.Util.Try<T> op_Implicit(T value) { }
     }
-    public class static TypeExtensions
+    public static class TypeExtensions
     {
-        public static bool Implements<T>(this System.Type type) { }
         public static bool Implements(this System.Type type, System.Type moreGeneralType) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        public static bool Implements<T>(this System.Type type) { }
+        [Akka.Annotations.InternalApi]
         public static string TypeQualifiedName(this System.Type type) { }
     }
-    public class static Vector
+    public static class Vector
     {
         public static System.Func<System.Func<T>, System.Collections.Generic.IList<T>> Fill<T>(int number) { }
     }
-    public class static WildcardMatch
+    public static class WildcardMatch
     {
-        public static bool Like(this string text, string pattern, bool caseSensitive = False) { }
+        public static bool Like(this string text, string pattern, bool caseSensitive = false) { }
     }
 }
 namespace Akka.Util.Extensions
 {
-    public class static ObjectExtensions
+    public static class ObjectExtensions
     {
         public static Akka.Util.Option<T> AsOption<T>(this T obj) { }
     }
@@ -5725,8 +5591,8 @@ namespace Akka.Util.Internal
 {
     public class AtomicCounter : Akka.Util.Internal.IAtomicCounter<int>
     {
-        public AtomicCounter(int initialValue) { }
         public AtomicCounter() { }
+        public AtomicCounter(int initialValue) { }
         public int Current { get; }
         public int AddAndGet(int amount) { }
         public bool CompareAndSet(int expected, int newValue) { }
@@ -5742,8 +5608,8 @@ namespace Akka.Util.Internal
     }
     public class AtomicCounterLong : Akka.Util.Internal.IAtomicCounter<long>
     {
-        public AtomicCounterLong(long value) { }
         public AtomicCounterLong() { }
+        public AtomicCounterLong(long value) { }
         public long Current { get; }
         public long AddAndGet(long amount) { }
         public bool CompareAndSet(long expected, long newValue) { }
@@ -5756,14 +5622,12 @@ namespace Akka.Util.Internal
         public void Reset() { }
         public override string ToString() { }
     }
-    public class static Extensions
+    public static class Extensions
     {
         public static System.Collections.Generic.IDictionary<TKey, TValue> AddAndReturn<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> hash, TKey key, TValue value) { }
         public static T AsInstanceOf<T>(this object self) { }
         public static string BetweenDoubleQuotes(this string self) { }
-        public static System.Collections.Generic.IEnumerable<T> Concat<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] this System.Collections.Generic.IEnumerable<T> enumerable, T item) { }
+        public static System.Collections.Generic.IEnumerable<T> Concat<T>(this System.Collections.Generic.IEnumerable<T>? enumerable, T item) { }
         public static System.Collections.Generic.IEnumerable<T> Drop<T>(this System.Collections.Generic.IEnumerable<T> self, int count) { }
         public static void ForEach<T>(this System.Collections.Generic.IEnumerable<T> source, System.Action<T> action) { }
         public static TValue GetOrElse<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> hash, TKey key, TValue elseValue) { }
@@ -5791,7 +5655,7 @@ namespace Akka.Util.Internal
         void Enter();
         System.Threading.Tasks.Task<T> Invoke<T>(System.Func<System.Threading.Tasks.Task<T>> body);
     }
-    public class static InterlockedSpin
+    public static class InterlockedSpin
     {
         public static TReturn ConditionallySwap<T, TReturn>(ref T reference, System.Func<T, System.ValueTuple<bool, T, TReturn>> updateIfTrue)
             where T :  class { }
@@ -5801,11 +5665,11 @@ namespace Akka.Util.Internal
 }
 namespace Akka.Util.Reflection
 {
-    public class static ExpressionExtensions
+    public static class ExpressionExtensions
     {
         public static object[] GetArguments(this System.Linq.Expressions.NewExpression newExpression) { }
     }
-    public class static TypeCache
+    public static class TypeCache
     {
         public static System.Type GetType(string typeName) { }
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDiscovery.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDiscovery.DotNet.verified.txt
@@ -1,14 +1,14 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Discovery.Aggregate
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class AggregateServiceDiscovery : Akka.Discovery.ServiceDiscovery
     {
         public AggregateServiceDiscovery(Akka.Actor.ExtendedActorSystem system) { }
         public override System.Threading.Tasks.Task<Akka.Discovery.ServiceDiscovery.Resolved> Lookup(Akka.Discovery.Lookup query, System.TimeSpan resolveTimeout) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class AggregateServiceDiscoverySettings
     {
         public AggregateServiceDiscoverySettings(Akka.Configuration.Config config) { }
@@ -17,19 +17,19 @@ namespace Akka.Discovery.Aggregate
 }
 namespace Akka.Discovery.Config
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ConfigServiceDiscovery : Akka.Discovery.ServiceDiscovery
     {
         public ConfigServiceDiscovery(Akka.Actor.ExtendedActorSystem system) { }
         public ConfigServiceDiscovery(Akka.Actor.ExtendedActorSystem system, Akka.Configuration.Config config) { }
         public override System.Threading.Tasks.Task<Akka.Discovery.ServiceDiscovery.Resolved> Lookup(Akka.Discovery.Lookup lookup, System.TimeSpan resolveTimeout) { }
-        [Akka.Annotations.InternalStableApiAttribute()]
+        [Akka.Annotations.InternalStableApi]
         public bool TryAddEndpoint(string serviceName, Akka.Discovery.ServiceDiscovery.ResolvedTarget target) { }
-        [Akka.Annotations.InternalStableApiAttribute()]
+        [Akka.Annotations.InternalStableApi]
         public bool TryRemoveEndpoint(string serviceName, Akka.Discovery.ServiceDiscovery.ResolvedTarget target) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static ConfigServicesParser
+    [Akka.Annotations.InternalApi]
+    public static class ConfigServicesParser
     {
         public static System.Collections.Generic.Dictionary<string, Akka.Discovery.ServiceDiscovery.Resolved> Parse(Akka.Configuration.Config config) { }
     }
@@ -40,8 +40,8 @@ namespace Akka.Discovery
     {
         public Discovery(Akka.Actor.ExtendedActorSystem system) { }
         public Akka.Discovery.ServiceDiscovery Default { get; }
-        public static Akka.Discovery.Discovery Get(Akka.Actor.ActorSystem system) { }
         public Akka.Discovery.ServiceDiscovery LoadServiceDiscovery(string method) { }
+        public static Akka.Discovery.Discovery Get(Akka.Actor.ActorSystem system) { }
     }
     public class DiscoveryProvider : Akka.Actor.ExtensionIdProvider<Akka.Discovery.Discovery>
     {
@@ -59,11 +59,11 @@ namespace Akka.Discovery
         public bool Equals(Akka.Discovery.Lookup other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public static bool IsValid(string srv) { }
-        public static Akka.Discovery.Lookup ParseSrv(string srv) { }
         public override string ToString() { }
         public Akka.Discovery.Lookup WithPortName(string portName) { }
         public Akka.Discovery.Lookup WithProtocol(string protocol) { }
+        public static bool IsValid(string srv) { }
+        public static Akka.Discovery.Lookup ParseSrv(string srv) { }
     }
     public abstract class ServiceDiscovery
     {
@@ -83,10 +83,10 @@ namespace Akka.Discovery
         }
         public class ResolvedTarget : Akka.Actor.INoSerializationVerificationNeeded, System.IEquatable<Akka.Discovery.ServiceDiscovery.ResolvedTarget>
         {
-            public ResolvedTarget(string host, System.Nullable<int> port = null, System.Net.IPAddress address = null) { }
+            public ResolvedTarget(string host, int? port = default, System.Net.IPAddress address = null) { }
             public System.Net.IPAddress Address { get; }
             public string Host { get; }
-            public System.Nullable<int> Port { get; }
+            public int? Port { get; }
             public bool Equals(Akka.Discovery.ServiceDiscovery.ResolvedTarget other) { }
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDiscovery.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDiscovery.Net.verified.txt
@@ -1,14 +1,14 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Discovery.Aggregate
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class AggregateServiceDiscovery : Akka.Discovery.ServiceDiscovery
     {
         public AggregateServiceDiscovery(Akka.Actor.ExtendedActorSystem system) { }
         public override System.Threading.Tasks.Task<Akka.Discovery.ServiceDiscovery.Resolved> Lookup(Akka.Discovery.Lookup query, System.TimeSpan resolveTimeout) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class AggregateServiceDiscoverySettings
     {
         public AggregateServiceDiscoverySettings(Akka.Configuration.Config config) { }
@@ -17,19 +17,19 @@ namespace Akka.Discovery.Aggregate
 }
 namespace Akka.Discovery.Config
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ConfigServiceDiscovery : Akka.Discovery.ServiceDiscovery
     {
         public ConfigServiceDiscovery(Akka.Actor.ExtendedActorSystem system) { }
         public ConfigServiceDiscovery(Akka.Actor.ExtendedActorSystem system, Akka.Configuration.Config config) { }
         public override System.Threading.Tasks.Task<Akka.Discovery.ServiceDiscovery.Resolved> Lookup(Akka.Discovery.Lookup lookup, System.TimeSpan resolveTimeout) { }
-        [Akka.Annotations.InternalStableApiAttribute()]
+        [Akka.Annotations.InternalStableApi]
         public bool TryAddEndpoint(string serviceName, Akka.Discovery.ServiceDiscovery.ResolvedTarget target) { }
-        [Akka.Annotations.InternalStableApiAttribute()]
+        [Akka.Annotations.InternalStableApi]
         public bool TryRemoveEndpoint(string serviceName, Akka.Discovery.ServiceDiscovery.ResolvedTarget target) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static ConfigServicesParser
+    [Akka.Annotations.InternalApi]
+    public static class ConfigServicesParser
     {
         public static System.Collections.Generic.Dictionary<string, Akka.Discovery.ServiceDiscovery.Resolved> Parse(Akka.Configuration.Config config) { }
     }
@@ -40,8 +40,8 @@ namespace Akka.Discovery
     {
         public Discovery(Akka.Actor.ExtendedActorSystem system) { }
         public Akka.Discovery.ServiceDiscovery Default { get; }
-        public static Akka.Discovery.Discovery Get(Akka.Actor.ActorSystem system) { }
         public Akka.Discovery.ServiceDiscovery LoadServiceDiscovery(string method) { }
+        public static Akka.Discovery.Discovery Get(Akka.Actor.ActorSystem system) { }
     }
     public class DiscoveryProvider : Akka.Actor.ExtensionIdProvider<Akka.Discovery.Discovery>
     {
@@ -59,11 +59,11 @@ namespace Akka.Discovery
         public bool Equals(Akka.Discovery.Lookup other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public static bool IsValid(string srv) { }
-        public static Akka.Discovery.Lookup ParseSrv(string srv) { }
         public override string ToString() { }
         public Akka.Discovery.Lookup WithPortName(string portName) { }
         public Akka.Discovery.Lookup WithProtocol(string protocol) { }
+        public static bool IsValid(string srv) { }
+        public static Akka.Discovery.Lookup ParseSrv(string srv) { }
     }
     public abstract class ServiceDiscovery
     {
@@ -83,10 +83,10 @@ namespace Akka.Discovery
         }
         public class ResolvedTarget : Akka.Actor.INoSerializationVerificationNeeded, System.IEquatable<Akka.Discovery.ServiceDiscovery.ResolvedTarget>
         {
-            public ResolvedTarget(string host, System.Nullable<int> port = null, System.Net.IPAddress address = null) { }
+            public ResolvedTarget(string host, int? port = default, System.Net.IPAddress address = null) { }
             public System.Net.IPAddress Address { get; }
             public string Host { get; }
-            public System.Nullable<int> Port { get; }
+            public int? Port { get; }
             public bool Equals(Akka.Discovery.ServiceDiscovery.ResolvedTarget other) { }
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDistributedData.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDistributedData.DotNet.verified.txt
@@ -1,15 +1,16 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData.Tests.MultiNode")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("f22db348-9ab3-4c6a-b1e8-9b835308d367")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DistributedData.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DistributedData.Tests.MultiNode")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("f22db348-9ab3-4c6a-b1e8-9b835308d367")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.DistributedData
 {
+    [System.Serializable]
     public sealed class Changed : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Changed>
     {
         public Changed(Akka.DistributedData.IKey key, object data) { }
@@ -23,6 +24,7 @@ namespace Akka.DistributedData
         public override string ToString() { }
     }
     public delegate long Clock<in T>(long currentTimestamp, T value);
+    [System.Serializable]
     public sealed class DataDeleted : System.Exception, Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IDeleteResponse, Akka.DistributedData.IGetResponse, Akka.DistributedData.IUpdateResponse, System.IEquatable<Akka.DistributedData.DataDeleted>
     {
         public DataDeleted(Akka.DistributedData.IKey key, object request = null) { }
@@ -40,11 +42,13 @@ namespace Akka.DistributedData
         public void ThrowOnFailure() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public class DataDeletedException : System.Exception
     {
         public DataDeletedException(string message) { }
         protected DataDeletedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.Serializable]
     public sealed class Delete : Akka.Actor.INoSerializationVerificationNeeded, System.IEquatable<Akka.DistributedData.Delete>
     {
         public Delete(Akka.DistributedData.IKey key, Akka.DistributedData.IWriteConsistency consistency, object request = null) { }
@@ -56,6 +60,7 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IDeleteResponse, System.IEquatable<Akka.DistributedData.DeleteSuccess>
     {
         public DeleteSuccess(Akka.DistributedData.IKey key, object request = null) { }
@@ -74,17 +79,17 @@ namespace Akka.DistributedData
         public bool IsDurable { get; }
         public bool IsTerminated { get; }
         public Akka.Actor.IActorRef Replicator { get; }
-        public static Akka.Configuration.Config DefaultConfig() { }
-        public System.Threading.Tasks.Task DeleteAsync<T>(Akka.DistributedData.IKey<T> key, Akka.DistributedData.IWriteConsistency consistency = null, System.Threading.CancellationToken cancellation = null)
+        public System.Threading.Tasks.Task DeleteAsync<T>(Akka.DistributedData.IKey<T> key, Akka.DistributedData.IWriteConsistency consistency = null, System.Threading.CancellationToken cancellation = default)
             where T : Akka.DistributedData.IReplicatedData<T> { }
-        public static Akka.DistributedData.DistributedData Get(Akka.Actor.ActorSystem system) { }
-        public System.Threading.Tasks.Task<T> GetAsync<T>(Akka.DistributedData.IKey<T> key, Akka.DistributedData.IReadConsistency consistency = null, System.Threading.CancellationToken cancellation = null)
+        public System.Threading.Tasks.Task<T> GetAsync<T>(Akka.DistributedData.IKey<T> key, Akka.DistributedData.IReadConsistency consistency = null, System.Threading.CancellationToken cancellation = default)
             where T :  class, Akka.DistributedData.IReplicatedData<T> { }
-        public System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableSet<string>> GetKeysAsync(System.Threading.CancellationToken cancellation = null) { }
-        public System.Threading.Tasks.Task UpdateAsync<T>(Akka.DistributedData.IKey<T> key, T replica, Akka.DistributedData.IWriteConsistency consistency = null, System.Threading.CancellationToken cancellation = null)
+        public System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableSet<string>> GetKeysAsync(System.Threading.CancellationToken cancellation = default) { }
+        public System.Threading.Tasks.Task UpdateAsync<T>(Akka.DistributedData.IKey<T> key, T replica, Akka.DistributedData.IWriteConsistency consistency = null, System.Threading.CancellationToken cancellation = default)
             where T : Akka.DistributedData.IReplicatedData<T> { }
+        public static Akka.Configuration.Config DefaultConfig() { }
+        public static Akka.DistributedData.DistributedData Get(Akka.Actor.ActorSystem system) { }
     }
-    public class static DistributedDataExtensions
+    public static class DistributedDataExtensions
     {
         public static Akka.DistributedData.DistributedData DistributedData(this Akka.Actor.ActorSystem system) { }
     }
@@ -93,7 +98,7 @@ namespace Akka.DistributedData
         public DistributedDataProvider() { }
         public override Akka.DistributedData.DistributedData CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
-    public class static Dsl
+    public static class Dsl
     {
         public static Akka.DistributedData.GetKeyIds GetKeyIds { get; }
         public static Akka.DistributedData.GetReplicaCount GetReplicaCount { get; }
@@ -107,29 +112,30 @@ namespace Akka.DistributedData
             where T : Akka.DistributedData.IReplicatedData { }
         public static Akka.DistributedData.Unsubscribe Unsubscribe<T>(Akka.DistributedData.IKey<T> key, Akka.Actor.IActorRef subscriber)
             where T : Akka.DistributedData.IReplicatedData { }
-        public static Akka.DistributedData.Update Update<T>(Akka.DistributedData.IKey<T> key, T value, Akka.DistributedData.IWriteConsistency consistency = null)
-            where T : Akka.DistributedData.IReplicatedData<T> { }
         public static Akka.DistributedData.Update Update<T>(Akka.DistributedData.IKey<T> key, Akka.DistributedData.IWriteConsistency consistency, System.Func<T, T> modify)
             where T : Akka.DistributedData.IReplicatedData { }
+        public static Akka.DistributedData.Update Update<T>(Akka.DistributedData.IKey<T> key, T value, Akka.DistributedData.IWriteConsistency consistency = null)
+            where T : Akka.DistributedData.IReplicatedData<T> { }
         public static Akka.DistributedData.Update Update<T>(Akka.DistributedData.IKey<T> key, T initial, Akka.DistributedData.IWriteConsistency consistency, System.Func<T, T> modify)
             where T : Akka.DistributedData.IReplicatedData { }
         public static Akka.DistributedData.Update Update<T>(Akka.DistributedData.IKey<T> key, T initial, Akka.DistributedData.IWriteConsistency consistency, object request, System.Func<T, T> modify)
             where T : Akka.DistributedData.IReplicatedData { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class FastMerge<T> : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedData<T>
         where T : Akka.DistributedData.FastMerge<T>
     {
         protected FastMerge() { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected T AssignAncestor(T newData) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected T ClearAncestor() { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected bool IsAncestorOf(T newData) { }
-        public abstract T Merge(T other);
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public abstract T Merge(T other);
     }
+    [System.Serializable]
     public sealed class Flag : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.Flag>, System.IComparable, System.IComparable<Akka.DistributedData.Flag>, System.IEquatable<Akka.DistributedData.Flag>
     {
         public static readonly Akka.DistributedData.Flag False;
@@ -137,8 +143,8 @@ namespace Akka.DistributedData
         public Flag() { }
         public Flag(bool enabled) { }
         public bool Enabled { get; }
-        public int CompareTo(object obj) { }
         public int CompareTo(Akka.DistributedData.Flag other) { }
+        public int CompareTo(object obj) { }
         public bool Equals(Akka.DistributedData.Flag other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
@@ -147,24 +153,27 @@ namespace Akka.DistributedData
         public override string ToString() { }
         public static bool op_Implicit(Akka.DistributedData.Flag flag) { }
     }
+    [System.Serializable]
     public sealed class FlagKey : Akka.DistributedData.Key<Akka.DistributedData.Flag>
     {
         public FlagKey(string id) { }
     }
+    [System.Serializable]
     public sealed class FlushChanges
     {
         public static readonly Akka.DistributedData.FlushChanges Instance;
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
+    [System.Serializable]
     public sealed class GCounter : Akka.DistributedData.FastMerge<Akka.DistributedData.GCounter>, Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.GCounter, Akka.DistributedData.GCounter>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.GCounter>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.GCounter>, Akka.DistributedData.IReplicatedDelta, System.IEquatable<Akka.DistributedData.GCounter>
     {
         public GCounter() { }
         public Akka.DistributedData.GCounter Delta { get; }
-        public static Akka.DistributedData.GCounter Empty { get; }
         public System.Collections.Immutable.ImmutableHashSet<Akka.Cluster.UniqueAddress> ModifiedByNodes { get; }
         public System.Collections.Immutable.ImmutableDictionary<Akka.Cluster.UniqueAddress, ulong> State { get; }
         public ulong Value { get; }
+        public static Akka.DistributedData.GCounter Empty { get; }
         public bool Equals(Akka.DistributedData.GCounter other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
@@ -179,20 +188,22 @@ namespace Akka.DistributedData
         public override string ToString() { }
         public static ulong op_Implicit(Akka.DistributedData.GCounter counter) { }
     }
+    [System.Serializable]
     public sealed class GCounterKey : Akka.DistributedData.Key<Akka.DistributedData.GCounter>
     {
         public GCounterKey(string id) { }
     }
-    public class static GSet
+    public static class GSet
     {
-        public static Akka.DistributedData.GSet<T> Create<T>(params T[] elements) { }
         public static Akka.DistributedData.GSet<T> Create<T>(System.Collections.Immutable.IImmutableSet<T> elements) { }
+        public static Akka.DistributedData.GSet<T> Create<T>(params T[] elements) { }
     }
     public sealed class GSetKey<T> : Akka.DistributedData.Key<Akka.DistributedData.GSet<T>>, Akka.DistributedData.IReplicatedDataSerialization
     {
         public GSetKey(string id) { }
         public System.Type SetType { get; }
     }
+    [System.Serializable]
     public sealed class GSet<T> : Akka.DistributedData.FastMerge<Akka.DistributedData.GSet<T>>, Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.GSet<T>, Akka.DistributedData.GSet<T>>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.GSet<T>>, Akka.DistributedData.IReplicatedDelta, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.IEquatable<Akka.DistributedData.GSet<T>>
     {
         public static readonly Akka.DistributedData.GSet<T> Empty;
@@ -215,6 +226,7 @@ namespace Akka.DistributedData
         public Akka.DistributedData.GSet<T> ResetDelta() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Get : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Get>
     {
         public Get(Akka.DistributedData.IKey key, Akka.DistributedData.IReadConsistency consistency, object request = null) { }
@@ -226,6 +238,7 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class GetFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IGetResponse, Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.GetFailure>
     {
         public GetFailure(Akka.DistributedData.IKey key, object request) { }
@@ -241,25 +254,29 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public class GetKeyIds
     {
         public static readonly Akka.DistributedData.GetKeyIds Instance;
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
+    [System.Serializable]
     public sealed class GetKeysIdsResult : System.IEquatable<Akka.DistributedData.GetKeysIdsResult>
     {
         public GetKeysIdsResult(System.Collections.Immutable.IImmutableSet<string> keys) { }
         public System.Collections.Immutable.IImmutableSet<string> Keys { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.GetKeysIdsResult other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class GetReplicaCount
     {
         public static readonly Akka.DistributedData.GetReplicaCount Instance;
     }
+    [System.Serializable]
     public sealed class GetSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IGetResponse, Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.GetSuccess>
     {
         public GetSuccess(Akka.DistributedData.IKey key, object request, Akka.DistributedData.IReplicatedData data) { }
@@ -375,23 +392,25 @@ namespace Akka.DistributedData
         protected Key(string id) { }
         public string Id { get; }
         public bool Equals(Akka.DistributedData.IKey key) { }
-        public virtual bool Equals(object obj) { }
+        public override sealed bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public static string op_Implicit(Akka.DistributedData.Key<T> key) { }
     }
-    public class static LWWDictionary
+    public static class LWWDictionary
     {
-        public static Akka.DistributedData.LWWDictionary<TKey, TValue> Create<TKey, TValue>(Akka.Cluster.UniqueAddress node, TKey key, TValue value, Akka.DistributedData.Clock<TValue> clock = null) { }
-        public static Akka.DistributedData.LWWDictionary<TKey, TValue> Create<TKey, TValue>(params System.ValueTuple<, , >[] elements) { }
+        public static Akka.DistributedData.LWWDictionary<TKey, TValue> Create<TKey, TValue>(params System.ValueTuple<Akka.Cluster.UniqueAddress, TKey, TValue>[] elements) { }
         public static Akka.DistributedData.LWWDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEnumerable<System.ValueTuple<Akka.Cluster.UniqueAddress, TKey, TValue>> elements, Akka.DistributedData.Clock<TValue> clock = null) { }
+        public static Akka.DistributedData.LWWDictionary<TKey, TValue> Create<TKey, TValue>(Akka.Cluster.UniqueAddress node, TKey key, TValue value, Akka.DistributedData.Clock<TValue> clock = null) { }
     }
+    [System.Serializable]
     public sealed class LWWDictionaryKey<TKey, TValue> : Akka.DistributedData.Key<Akka.DistributedData.LWWDictionary<TKey, TValue>>
     {
         public LWWDictionaryKey(string id) { }
         public System.Type KeyType { get; }
         public System.Type ValueType { get; }
     }
+    [System.Serializable]
     public sealed class LWWDictionary<TKey, TValue> : Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.LWWDictionary<TKey, TValue>, Akka.DistributedData.ORDictionary<TKey, Akka.DistributedData.LWWRegister<TValue>>.IDeltaOperation>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.LWWDictionary<TKey, TValue>>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.LWWDictionary<TKey, TValue>>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerable, System.IEquatable<Akka.DistributedData.LWWDictionary<TKey, TValue>>
     {
         public static readonly Akka.DistributedData.LWWDictionary<TKey, TValue> Empty;
@@ -411,8 +430,8 @@ namespace Akka.DistributedData
         public override bool Equals(object obj) { }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { }
         public override int GetHashCode() { }
-        public Akka.DistributedData.LWWDictionary<TKey, TValue> Merge(Akka.DistributedData.LWWDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.LWWDictionary<TKey, TValue> Merge(Akka.DistributedData.LWWDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.LWWDictionary<TKey, TValue> MergeDelta(Akka.DistributedData.ORDictionary<TKey, Akka.DistributedData.LWWRegister<TValue>>.IDeltaOperation delta) { }
         public bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode) { }
         public Akka.DistributedData.LWWDictionary<TKey, TValue> Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto) { }
@@ -425,18 +444,20 @@ namespace Akka.DistributedData
         public override string ToString() { }
         public bool TryGetValue(TKey key, out TValue value) { }
     }
+    [System.Serializable]
     public sealed class LWWRegisterKey<T> : Akka.DistributedData.Key<Akka.DistributedData.LWWRegister<T>>
     {
         public LWWRegisterKey(string id) { }
         public System.Type RegisterType { get; }
     }
+    [System.Serializable]
     public sealed class LWWRegister<T> : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.LWWRegister<T>>, System.IEquatable<Akka.DistributedData.LWWRegister<T>>
     {
         public static readonly Akka.DistributedData.Clock<T> DefaultClock;
         public static readonly Akka.DistributedData.Clock<T> ReverseClock;
         public LWWRegister(Akka.Cluster.UniqueAddress node, T initial) { }
-        public LWWRegister(Akka.Cluster.UniqueAddress node, T value, long timestamp) { }
         public LWWRegister(Akka.Cluster.UniqueAddress node, T initial, Akka.DistributedData.Clock<T> clock) { }
+        public LWWRegister(Akka.Cluster.UniqueAddress node, T value, long timestamp) { }
         public System.Type RegisterType { get; }
         public long Timestamp { get; }
         public Akka.Cluster.UniqueAddress UpdatedBy { get; }
@@ -444,11 +465,12 @@ namespace Akka.DistributedData
         public bool Equals(Akka.DistributedData.LWWRegister<T> other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public Akka.DistributedData.LWWRegister<T> Merge(Akka.DistributedData.LWWRegister<T> other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.LWWRegister<T> Merge(Akka.DistributedData.LWWRegister<T> other) { }
         public override string ToString() { }
         public Akka.DistributedData.LWWRegister<T> WithValue(Akka.Cluster.UniqueAddress node, T value, Akka.DistributedData.Clock<T> clock = null) { }
     }
+    [System.Serializable]
     public sealed class ModifyFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IUpdateFailure, Akka.DistributedData.IUpdateResponse
     {
         public ModifyFailure(Akka.DistributedData.IKey key, string errorMessage, System.Exception cause, object request) { }
@@ -460,10 +482,11 @@ namespace Akka.DistributedData
         public void ThrowOnFailure() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class MultiVersionVector : Akka.DistributedData.VersionVector
     {
-        public MultiVersionVector(params System.Collections.Generic.KeyValuePair<, >[] nodeVersions) { }
         public MultiVersionVector(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<Akka.Cluster.UniqueAddress, long>> versions) { }
+        public MultiVersionVector(params System.Collections.Generic.KeyValuePair<Akka.Cluster.UniqueAddress, long>[] nodeVersions) { }
         public MultiVersionVector(System.Collections.Immutable.ImmutableDictionary<Akka.Cluster.UniqueAddress, long> nodeVersions) { }
         public override int Count { get; }
         public override bool IsEmpty { get; }
@@ -479,6 +502,7 @@ namespace Akka.DistributedData
         public override string ToString() { }
         public override long VersionAt(Akka.Cluster.UniqueAddress node) { }
     }
+    [System.Serializable]
     public sealed class NotFound : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IGetResponse, Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.NotFound>
     {
         public NotFound(Akka.DistributedData.IKey key, object request) { }
@@ -494,15 +518,16 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
-    public class static ORDictionary
+    public static class ORDictionary
     {
-        public static Akka.DistributedData.ORDictionary<TKey, TValue> Create<TKey, TValue>(Akka.Cluster.UniqueAddress node, TKey key, TValue value)
-            where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
-        public static Akka.DistributedData.ORDictionary<TKey, TValue> Create<TKey, TValue>(params System.ValueTuple<, , >[] elements)
-            where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
         public static Akka.DistributedData.ORDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEnumerable<System.ValueTuple<Akka.Cluster.UniqueAddress, TKey, TValue>> elements)
             where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
+        public static Akka.DistributedData.ORDictionary<TKey, TValue> Create<TKey, TValue>(params System.ValueTuple<Akka.Cluster.UniqueAddress, TKey, TValue>[] elements)
+            where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
+        public static Akka.DistributedData.ORDictionary<TKey, TValue> Create<TKey, TValue>(Akka.Cluster.UniqueAddress node, TKey key, TValue value)
+            where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
     }
+    [System.Serializable]
     public sealed class ORDictionaryKey<TKey, TValue> : Akka.DistributedData.Key<Akka.DistributedData.ORDictionary<TKey, TValue>>
         where TValue : Akka.DistributedData.IReplicatedData<TValue>
     {
@@ -510,6 +535,7 @@ namespace Akka.DistributedData
         public System.Type KeyType { get; }
         public System.Type ValueType { get; }
     }
+    [System.Serializable]
     public sealed class ORDictionary<TKey, TValue> : Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.ORDictionary<TKey, TValue>, Akka.DistributedData.ORDictionary<TKey, TValue>.IDeltaOperation>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.ORDictionary<TKey, TValue>>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.ORDictionary<TKey, TValue>>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerable, System.IEquatable<Akka.DistributedData.ORDictionary<TKey, TValue>>
         where TValue : Akka.DistributedData.IReplicatedData<TValue>
     {
@@ -532,8 +558,8 @@ namespace Akka.DistributedData
         public override bool Equals(object obj) { }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { }
         public override int GetHashCode() { }
-        public Akka.DistributedData.ORDictionary<TKey, TValue> Merge(Akka.DistributedData.ORDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.ORDictionary<TKey, TValue> Merge(Akka.DistributedData.ORDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.ORDictionary<TKey, TValue> MergeDelta(Akka.DistributedData.ORDictionary<TKey, TValue>.IDeltaOperation delta) { }
         public bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode) { }
         public Akka.DistributedData.ORDictionary<TKey, TValue> Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto) { }
@@ -545,15 +571,16 @@ namespace Akka.DistributedData
         public Akka.DistributedData.ORDictionary<TKey, TValue> SetItem(Akka.Cluster.UniqueAddress node, TKey key, TValue value) { }
         public override string ToString() { }
         public bool TryGetValue(TKey key, out TValue value) { }
-        public interface IDeltaOperation<TKey, TValue> : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedDelta, Akka.DistributedData.IRequireCausualDeliveryOfDeltas, System.IEquatable<Akka.DistributedData.ORDictionary<TKey, TValue>.IDeltaOperation>
-            where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
+        public interface IDeltaOperation : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedDelta, Akka.DistributedData.IRequireCausualDeliveryOfDeltas, System.IEquatable<Akka.DistributedData.ORDictionary<TKey, TValue>.IDeltaOperation> { }
     }
+    [System.Serializable]
     public sealed class ORMultiValueDictionaryKey<TKey, TValue> : Akka.DistributedData.Key<Akka.DistributedData.ORMultiValueDictionary<TKey, TValue>>
     {
         public ORMultiValueDictionaryKey(string id) { }
         public System.Type KeyType { get; }
         public System.Type ValueType { get; }
     }
+    [System.Serializable]
     public sealed class ORMultiValueDictionary<TKey, TValue> : Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.ORMultiValueDictionary<TKey, TValue>, Akka.DistributedData.ORDictionary<TKey, Akka.DistributedData.ORSet<TValue>>.IDeltaOperation>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.ORMultiValueDictionary<TKey, TValue>>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.ORMultiValueDictionary<TKey, TValue>>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, System.Collections.Immutable.IImmutableSet<TValue>>>, System.Collections.IEnumerable, System.IEquatable<Akka.DistributedData.ORMultiValueDictionary<TKey, TValue>>
     {
         public static readonly Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> Empty;
@@ -576,8 +603,8 @@ namespace Akka.DistributedData
         public override bool Equals(object obj) { }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, System.Collections.Immutable.IImmutableSet<TValue>>> GetEnumerator() { }
         public override int GetHashCode() { }
-        public Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> Merge(Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> Merge(Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> MergeDelta(Akka.DistributedData.ORDictionary<TKey, Akka.DistributedData.ORSet<TValue>>.IDeltaOperation delta) { }
         public bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode) { }
         public Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto) { }
@@ -594,17 +621,19 @@ namespace Akka.DistributedData
         public override string ToString() { }
         public bool TryGetValue(TKey key, out System.Collections.Immutable.IImmutableSet<TValue> value) { }
     }
-    public class static ORSet
+    public static class ORSet
     {
-        public static Akka.DistributedData.ORSet<T> Create<T>(Akka.Cluster.UniqueAddress node, T element) { }
-        public static Akka.DistributedData.ORSet<T> Create<T>(params System.Collections.Generic.KeyValuePair<, >[] elements) { }
         public static Akka.DistributedData.ORSet<T> Create<T>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<Akka.Cluster.UniqueAddress, T>> elements) { }
+        public static Akka.DistributedData.ORSet<T> Create<T>(params System.Collections.Generic.KeyValuePair<Akka.Cluster.UniqueAddress, T>[] elements) { }
+        public static Akka.DistributedData.ORSet<T> Create<T>(Akka.Cluster.UniqueAddress node, T element) { }
     }
+    [System.Serializable]
     public sealed class ORSetKey<T> : Akka.DistributedData.Key<Akka.DistributedData.ORSet<T>>
     {
         public ORSetKey(string id) { }
         public System.Type SetType { get; }
     }
+    [System.Serializable]
     public sealed class ORSet<T> : Akka.DistributedData.FastMerge<Akka.DistributedData.ORSet<T>>, Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.ORSet<T>, Akka.DistributedData.ORSet<T>.IDeltaOperation>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.ORSet<T>>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.ORSet<T>>, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.IEquatable<Akka.DistributedData.ORSet<T>>
     {
         public static readonly Akka.DistributedData.ORSet<T> Empty;
@@ -634,8 +663,9 @@ namespace Akka.DistributedData
         public Akka.DistributedData.ORSet<T> Remove(Akka.Cluster.UniqueAddress node, T element) { }
         public Akka.DistributedData.ORSet<T> ResetDelta() { }
         public override string ToString() { }
-        public interface IDeltaOperation<T> : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedDelta, Akka.DistributedData.IRequireCausualDeliveryOfDeltas, System.IEquatable<Akka.DistributedData.ORSet<T>.IDeltaOperation> { }
+        public interface IDeltaOperation : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedDelta, Akka.DistributedData.IRequireCausualDeliveryOfDeltas, System.IEquatable<Akka.DistributedData.ORSet<T>.IDeltaOperation> { }
     }
+    [System.Serializable]
     public sealed class PNCounter : Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.PNCounter, Akka.DistributedData.PNCounter>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.PNCounter>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.PNCounter>, Akka.DistributedData.IReplicatedDelta, System.IEquatable<Akka.DistributedData.PNCounter>
     {
         public static readonly Akka.DistributedData.PNCounter Empty;
@@ -653,8 +683,8 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public Akka.DistributedData.PNCounter Increment(Akka.Cluster.Cluster node, long delta = 1) { }
         public Akka.DistributedData.PNCounter Increment(Akka.Cluster.UniqueAddress address, long delta = 1) { }
-        public Akka.DistributedData.PNCounter Merge(Akka.DistributedData.PNCounter other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.PNCounter Merge(Akka.DistributedData.PNCounter other) { }
         public Akka.DistributedData.PNCounter MergeDelta(Akka.DistributedData.PNCounter delta) { }
         public bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode) { }
         public Akka.DistributedData.PNCounter Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto) { }
@@ -689,8 +719,8 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public Akka.DistributedData.PNCounterDictionary<TKey> Increment(Akka.Cluster.Cluster node, TKey key, long delta = 1) { }
         public Akka.DistributedData.PNCounterDictionary<TKey> Increment(Akka.Cluster.UniqueAddress node, TKey key, long delta = 1) { }
-        public Akka.DistributedData.PNCounterDictionary<TKey> Merge(Akka.DistributedData.PNCounterDictionary<TKey> other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.PNCounterDictionary<TKey> Merge(Akka.DistributedData.PNCounterDictionary<TKey> other) { }
         public Akka.DistributedData.PNCounterDictionary<TKey> MergeDelta(Akka.DistributedData.ORDictionary<TKey, Akka.DistributedData.PNCounter>.IDeltaOperation delta) { }
         public bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode) { }
         public Akka.DistributedData.PNCounterDictionary<TKey> Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto) { }
@@ -709,8 +739,8 @@ namespace Akka.DistributedData
     {
         public ReadAll(System.TimeSpan timeout) { }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.ReadAll other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -719,8 +749,8 @@ namespace Akka.DistributedData
         public ReadFrom(int n, System.TimeSpan timeout) { }
         public int N { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.ReadFrom other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -737,8 +767,8 @@ namespace Akka.DistributedData
         public ReadMajority(System.TimeSpan timeout, int minCapacity = 0) { }
         public int MinCapacity { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.ReadMajority other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -748,11 +778,12 @@ namespace Akka.DistributedData
         public int Additional { get; }
         public int MinCapacity { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.ReadMajorityPlus other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class ReplicaCount : System.IEquatable<Akka.DistributedData.ReplicaCount>
     {
         public ReplicaCount(int n) { }
@@ -762,6 +793,7 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class ReplicationDeleteFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IDeleteResponse, System.IEquatable<Akka.DistributedData.ReplicationDeleteFailure>
     {
         public ReplicationDeleteFailure(Akka.DistributedData.IKey key) { }
@@ -775,8 +807,7 @@ namespace Akka.DistributedData
     }
     public sealed class ReplicatorSettings
     {
-        [System.ObsoleteAttribute("Use constructor with `verboseDebugLogging` argument. Obsolete since v1.5.0-alpha2" +
-            "")]
+        [System.Obsolete("Use constructor with `verboseDebugLogging` argument. Obsolete since v1.5.0-alpha2")]
         public ReplicatorSettings(string role, System.TimeSpan gossipInterval, System.TimeSpan notifySubscribersInterval, int maxDeltaElements, string dispatcher, System.TimeSpan pruningInterval, System.TimeSpan maxPruningDissemination, System.Collections.Immutable.IImmutableSet<string> durableKeys, Akka.Actor.Props durableStoreProps, System.TimeSpan pruningMarkerTimeToLive, System.TimeSpan durablePruningMarkerTimeToLive, int maxDeltaSize, bool restartReplicatorOnFailure, bool preferOldest) { }
         public ReplicatorSettings(string role, System.TimeSpan gossipInterval, System.TimeSpan notifySubscribersInterval, int maxDeltaElements, string dispatcher, System.TimeSpan pruningInterval, System.TimeSpan maxPruningDissemination, System.Collections.Immutable.IImmutableSet<string> durableKeys, Akka.Actor.Props durableStoreProps, System.TimeSpan pruningMarkerTimeToLive, System.TimeSpan durablePruningMarkerTimeToLive, int maxDeltaSize, bool restartReplicatorOnFailure, bool preferOldest, bool verboseDebugLogging) { }
         public string Dispatcher { get; }
@@ -795,8 +826,6 @@ namespace Akka.DistributedData
         public bool RestartReplicatorOnFailure { get; }
         public string Role { get; }
         public bool VerboseDebugLogging { get; }
-        public static Akka.DistributedData.ReplicatorSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.DistributedData.ReplicatorSettings Create(Akka.Configuration.Config config) { }
         public Akka.DistributedData.ReplicatorSettings WithDispatcher(string dispatcher) { }
         public Akka.DistributedData.ReplicatorSettings WithDurableKeys(System.Collections.Immutable.IImmutableSet<string> durableKeys) { }
         public Akka.DistributedData.ReplicatorSettings WithDurableStoreProps(Akka.Actor.Props durableStoreProps) { }
@@ -810,8 +839,10 @@ namespace Akka.DistributedData
         public Akka.DistributedData.ReplicatorSettings WithRestartReplicatorOnFailure(bool restart) { }
         public Akka.DistributedData.ReplicatorSettings WithRole(string role) { }
         public Akka.DistributedData.ReplicatorSettings WithVerboseDebugLogging(bool verboseDebugLogging) { }
+        public static Akka.DistributedData.ReplicatorSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.DistributedData.ReplicatorSettings Create(Akka.Configuration.Config config) { }
     }
-    [System.Diagnostics.DebuggerDisplayAttribute("VersionVector({Node}->{Version})")]
+    [System.Diagnostics.DebuggerDisplay("VersionVector({Node}->{Version})")]
     public sealed class SingleVersionVector : Akka.DistributedData.VersionVector
     {
         public SingleVersionVector(Akka.Cluster.UniqueAddress node, long version) { }
@@ -841,6 +872,7 @@ namespace Akka.DistributedData
         public void ThrowOnFailure() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Subscribe : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Subscribe>
     {
         public Subscribe(Akka.DistributedData.IKey key, Akka.Actor.IActorRef subscriber) { }
@@ -851,6 +883,7 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Unsubscribe : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Unsubscribe>
     {
         public Unsubscribe(Akka.DistributedData.IKey key, Akka.Actor.IActorRef subscriber) { }
@@ -861,6 +894,7 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Update : Akka.Actor.INoSerializationVerificationNeeded
     {
         public Update(Akka.DistributedData.IKey key, Akka.DistributedData.IWriteConsistency consistency, System.Func<Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedData> modify, object request = null) { }
@@ -871,6 +905,7 @@ namespace Akka.DistributedData
         public object Request { get; }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class UpdateSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IUpdateResponse, System.IEquatable<Akka.DistributedData.UpdateSuccess>
     {
         public UpdateSuccess(Akka.DistributedData.IKey key, object request) { }
@@ -883,6 +918,7 @@ namespace Akka.DistributedData
         public void ThrowOnFailure() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class UpdateTimeout : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IUpdateFailure, Akka.DistributedData.IUpdateResponse, System.IEquatable<Akka.DistributedData.UpdateTimeout>
     {
         public UpdateTimeout(Akka.DistributedData.IKey key, object request) { }
@@ -896,6 +932,7 @@ namespace Akka.DistributedData
         public void ThrowOnFailure() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public abstract class VersionVector : Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.VersionVector>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.VersionVector>, System.IEquatable<Akka.DistributedData.VersionVector>
     {
         protected static readonly Akka.Util.Internal.AtomicCounterLong Counter;
@@ -907,8 +944,6 @@ namespace Akka.DistributedData
         public abstract System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<Akka.Cluster.UniqueAddress, long>> VersionEnumerator { get; }
         public Akka.DistributedData.VersionVector.Ordering Compare(Akka.DistributedData.VersionVector other) { }
         public abstract bool Contains(Akka.Cluster.UniqueAddress node);
-        public static Akka.DistributedData.VersionVector Create(Akka.Cluster.UniqueAddress node, long version) { }
-        public static Akka.DistributedData.VersionVector Create(System.Collections.Immutable.ImmutableDictionary<Akka.Cluster.UniqueAddress, long> versions) { }
         public bool Equals(Akka.DistributedData.VersionVector other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
@@ -917,16 +952,18 @@ namespace Akka.DistributedData
         public bool IsBefore(Akka.DistributedData.VersionVector y) { }
         public bool IsConcurrent(Akka.DistributedData.VersionVector y) { }
         public bool IsSame(Akka.DistributedData.VersionVector y) { }
-        public abstract Akka.DistributedData.VersionVector Merge(Akka.DistributedData.VersionVector other);
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public abstract Akka.DistributedData.VersionVector Merge(Akka.DistributedData.VersionVector other);
         public abstract bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode);
         public abstract Akka.DistributedData.VersionVector Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto);
         public abstract Akka.DistributedData.VersionVector PruningCleanup(Akka.Cluster.UniqueAddress removedNode);
         public abstract long VersionAt(Akka.Cluster.UniqueAddress node);
-        public static bool ==(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
-        public static bool >(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
-        public static bool !=(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
-        public static bool <(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
+        public static Akka.DistributedData.VersionVector Create(System.Collections.Immutable.ImmutableDictionary<Akka.Cluster.UniqueAddress, long> versions) { }
+        public static Akka.DistributedData.VersionVector Create(Akka.Cluster.UniqueAddress node, long version) { }
+        public static bool operator !=(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
+        public static bool operator <(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
+        public static bool operator ==(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
+        public static bool operator >(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
         public enum Ordering
         {
             After = 0,
@@ -940,8 +977,8 @@ namespace Akka.DistributedData
     {
         public WriteAll(System.TimeSpan timeout) { }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.WriteAll other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -958,8 +995,8 @@ namespace Akka.DistributedData
         public WriteMajority(System.TimeSpan timeout, int minCapacity = 0) { }
         public int MinCapacity { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.WriteMajority other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -969,8 +1006,8 @@ namespace Akka.DistributedData
         public int Additional { get; }
         public int MinCapacity { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.WriteMajorityPlus other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -979,8 +1016,8 @@ namespace Akka.DistributedData
         public WriteTo(int count, System.TimeSpan timeout) { }
         public int Count { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.WriteTo other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -989,8 +1026,8 @@ namespace Akka.DistributedData.Durable
 {
     public sealed class DurableDataEnvelope : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Durable.DurableDataEnvelope>
     {
-        public DurableDataEnvelope(Akka.DistributedData.Internal.DataEnvelope dataEnvelope) { }
         public DurableDataEnvelope(Akka.DistributedData.IReplicatedData data) { }
+        public DurableDataEnvelope(Akka.DistributedData.Internal.DataEnvelope dataEnvelope) { }
         public Akka.DistributedData.IReplicatedData Data { get; }
         public bool Equals(Akka.DistributedData.Durable.DurableDataEnvelope other) { }
         public override bool Equals(object obj) { }
@@ -1018,8 +1055,8 @@ namespace Akka.DistributedData.Durable
     public sealed class LoadFailedException : Akka.Actor.AkkaException
     {
         public LoadFailedException(string message) { }
-        public LoadFailedException(string message, System.Exception cause) { }
         public LoadFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public LoadFailedException(string message, System.Exception cause) { }
     }
     public sealed class Store
     {
@@ -1038,12 +1075,13 @@ namespace Akka.DistributedData.Durable
 }
 namespace Akka.DistributedData.Internal
 {
+    [System.Serializable]
     public sealed class DataEnvelope : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Internal.DataEnvelope>
     {
         public Akka.DistributedData.IReplicatedData Data { get; }
-        public static Akka.DistributedData.Internal.DataEnvelope DeletedEnvelope { get; }
         public Akka.DistributedData.VersionVector DeltaVersions { get; }
         public System.Collections.Immutable.ImmutableDictionary<Akka.Cluster.UniqueAddress, Akka.DistributedData.IPruningState> Pruning { get; }
+        public static Akka.DistributedData.Internal.DataEnvelope DeletedEnvelope { get; }
         public bool Equals(Akka.DistributedData.Internal.DataEnvelope other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDistributedData.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveDistributedData.Net.verified.txt
@@ -1,15 +1,16 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.DistributedData.Tests.MultiNode")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("f22db348-9ab3-4c6a-b1e8-9b835308d367")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DistributedData.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.DistributedData.Tests.MultiNode")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("f22db348-9ab3-4c6a-b1e8-9b835308d367")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.DistributedData
 {
+    [System.Serializable]
     public sealed class Changed : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Changed>
     {
         public Changed(Akka.DistributedData.IKey key, object data) { }
@@ -23,6 +24,7 @@ namespace Akka.DistributedData
         public override string ToString() { }
     }
     public delegate long Clock<in T>(long currentTimestamp, T value);
+    [System.Serializable]
     public sealed class DataDeleted : System.Exception, Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IDeleteResponse, Akka.DistributedData.IGetResponse, Akka.DistributedData.IUpdateResponse, System.IEquatable<Akka.DistributedData.DataDeleted>
     {
         public DataDeleted(Akka.DistributedData.IKey key, object request = null) { }
@@ -40,11 +42,13 @@ namespace Akka.DistributedData
         public void ThrowOnFailure() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public class DataDeletedException : System.Exception
     {
         public DataDeletedException(string message) { }
         protected DataDeletedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.Serializable]
     public sealed class Delete : Akka.Actor.INoSerializationVerificationNeeded, System.IEquatable<Akka.DistributedData.Delete>
     {
         public Delete(Akka.DistributedData.IKey key, Akka.DistributedData.IWriteConsistency consistency, object request = null) { }
@@ -56,6 +60,7 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IDeleteResponse, System.IEquatable<Akka.DistributedData.DeleteSuccess>
     {
         public DeleteSuccess(Akka.DistributedData.IKey key, object request = null) { }
@@ -74,17 +79,17 @@ namespace Akka.DistributedData
         public bool IsDurable { get; }
         public bool IsTerminated { get; }
         public Akka.Actor.IActorRef Replicator { get; }
-        public static Akka.Configuration.Config DefaultConfig() { }
-        public System.Threading.Tasks.Task DeleteAsync<T>(Akka.DistributedData.IKey<T> key, Akka.DistributedData.IWriteConsistency consistency = null, System.Threading.CancellationToken cancellation = null)
+        public System.Threading.Tasks.Task DeleteAsync<T>(Akka.DistributedData.IKey<T> key, Akka.DistributedData.IWriteConsistency consistency = null, System.Threading.CancellationToken cancellation = default)
             where T : Akka.DistributedData.IReplicatedData<T> { }
-        public static Akka.DistributedData.DistributedData Get(Akka.Actor.ActorSystem system) { }
-        public System.Threading.Tasks.Task<T> GetAsync<T>(Akka.DistributedData.IKey<T> key, Akka.DistributedData.IReadConsistency consistency = null, System.Threading.CancellationToken cancellation = null)
+        public System.Threading.Tasks.Task<T> GetAsync<T>(Akka.DistributedData.IKey<T> key, Akka.DistributedData.IReadConsistency consistency = null, System.Threading.CancellationToken cancellation = default)
             where T :  class, Akka.DistributedData.IReplicatedData<T> { }
-        public System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableSet<string>> GetKeysAsync(System.Threading.CancellationToken cancellation = null) { }
-        public System.Threading.Tasks.Task UpdateAsync<T>(Akka.DistributedData.IKey<T> key, T replica, Akka.DistributedData.IWriteConsistency consistency = null, System.Threading.CancellationToken cancellation = null)
+        public System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableSet<string>> GetKeysAsync(System.Threading.CancellationToken cancellation = default) { }
+        public System.Threading.Tasks.Task UpdateAsync<T>(Akka.DistributedData.IKey<T> key, T replica, Akka.DistributedData.IWriteConsistency consistency = null, System.Threading.CancellationToken cancellation = default)
             where T : Akka.DistributedData.IReplicatedData<T> { }
+        public static Akka.Configuration.Config DefaultConfig() { }
+        public static Akka.DistributedData.DistributedData Get(Akka.Actor.ActorSystem system) { }
     }
-    public class static DistributedDataExtensions
+    public static class DistributedDataExtensions
     {
         public static Akka.DistributedData.DistributedData DistributedData(this Akka.Actor.ActorSystem system) { }
     }
@@ -93,7 +98,7 @@ namespace Akka.DistributedData
         public DistributedDataProvider() { }
         public override Akka.DistributedData.DistributedData CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
     }
-    public class static Dsl
+    public static class Dsl
     {
         public static Akka.DistributedData.GetKeyIds GetKeyIds { get; }
         public static Akka.DistributedData.GetReplicaCount GetReplicaCount { get; }
@@ -107,29 +112,30 @@ namespace Akka.DistributedData
             where T : Akka.DistributedData.IReplicatedData { }
         public static Akka.DistributedData.Unsubscribe Unsubscribe<T>(Akka.DistributedData.IKey<T> key, Akka.Actor.IActorRef subscriber)
             where T : Akka.DistributedData.IReplicatedData { }
-        public static Akka.DistributedData.Update Update<T>(Akka.DistributedData.IKey<T> key, T value, Akka.DistributedData.IWriteConsistency consistency = null)
-            where T : Akka.DistributedData.IReplicatedData<T> { }
         public static Akka.DistributedData.Update Update<T>(Akka.DistributedData.IKey<T> key, Akka.DistributedData.IWriteConsistency consistency, System.Func<T, T> modify)
             where T : Akka.DistributedData.IReplicatedData { }
+        public static Akka.DistributedData.Update Update<T>(Akka.DistributedData.IKey<T> key, T value, Akka.DistributedData.IWriteConsistency consistency = null)
+            where T : Akka.DistributedData.IReplicatedData<T> { }
         public static Akka.DistributedData.Update Update<T>(Akka.DistributedData.IKey<T> key, T initial, Akka.DistributedData.IWriteConsistency consistency, System.Func<T, T> modify)
             where T : Akka.DistributedData.IReplicatedData { }
         public static Akka.DistributedData.Update Update<T>(Akka.DistributedData.IKey<T> key, T initial, Akka.DistributedData.IWriteConsistency consistency, object request, System.Func<T, T> modify)
             where T : Akka.DistributedData.IReplicatedData { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class FastMerge<T> : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedData<T>
         where T : Akka.DistributedData.FastMerge<T>
     {
         protected FastMerge() { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected T AssignAncestor(T newData) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected T ClearAncestor() { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected bool IsAncestorOf(T newData) { }
-        public abstract T Merge(T other);
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public abstract T Merge(T other);
     }
+    [System.Serializable]
     public sealed class Flag : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.Flag>, System.IComparable, System.IComparable<Akka.DistributedData.Flag>, System.IEquatable<Akka.DistributedData.Flag>
     {
         public static readonly Akka.DistributedData.Flag False;
@@ -137,8 +143,8 @@ namespace Akka.DistributedData
         public Flag() { }
         public Flag(bool enabled) { }
         public bool Enabled { get; }
-        public int CompareTo(object obj) { }
         public int CompareTo(Akka.DistributedData.Flag other) { }
+        public int CompareTo(object obj) { }
         public bool Equals(Akka.DistributedData.Flag other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
@@ -147,24 +153,27 @@ namespace Akka.DistributedData
         public override string ToString() { }
         public static bool op_Implicit(Akka.DistributedData.Flag flag) { }
     }
+    [System.Serializable]
     public sealed class FlagKey : Akka.DistributedData.Key<Akka.DistributedData.Flag>
     {
         public FlagKey(string id) { }
     }
+    [System.Serializable]
     public sealed class FlushChanges
     {
         public static readonly Akka.DistributedData.FlushChanges Instance;
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
+    [System.Serializable]
     public sealed class GCounter : Akka.DistributedData.FastMerge<Akka.DistributedData.GCounter>, Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.GCounter, Akka.DistributedData.GCounter>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.GCounter>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.GCounter>, Akka.DistributedData.IReplicatedDelta, System.IEquatable<Akka.DistributedData.GCounter>
     {
         public GCounter() { }
         public Akka.DistributedData.GCounter Delta { get; }
-        public static Akka.DistributedData.GCounter Empty { get; }
         public System.Collections.Immutable.ImmutableHashSet<Akka.Cluster.UniqueAddress> ModifiedByNodes { get; }
         public System.Collections.Immutable.ImmutableDictionary<Akka.Cluster.UniqueAddress, ulong> State { get; }
         public ulong Value { get; }
+        public static Akka.DistributedData.GCounter Empty { get; }
         public bool Equals(Akka.DistributedData.GCounter other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
@@ -179,20 +188,22 @@ namespace Akka.DistributedData
         public override string ToString() { }
         public static ulong op_Implicit(Akka.DistributedData.GCounter counter) { }
     }
+    [System.Serializable]
     public sealed class GCounterKey : Akka.DistributedData.Key<Akka.DistributedData.GCounter>
     {
         public GCounterKey(string id) { }
     }
-    public class static GSet
+    public static class GSet
     {
-        public static Akka.DistributedData.GSet<T> Create<T>(params T[] elements) { }
         public static Akka.DistributedData.GSet<T> Create<T>(System.Collections.Immutable.IImmutableSet<T> elements) { }
+        public static Akka.DistributedData.GSet<T> Create<T>(params T[] elements) { }
     }
     public sealed class GSetKey<T> : Akka.DistributedData.Key<Akka.DistributedData.GSet<T>>, Akka.DistributedData.IReplicatedDataSerialization
     {
         public GSetKey(string id) { }
         public System.Type SetType { get; }
     }
+    [System.Serializable]
     public sealed class GSet<T> : Akka.DistributedData.FastMerge<Akka.DistributedData.GSet<T>>, Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.GSet<T>, Akka.DistributedData.GSet<T>>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.GSet<T>>, Akka.DistributedData.IReplicatedDelta, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.IEquatable<Akka.DistributedData.GSet<T>>
     {
         public static readonly Akka.DistributedData.GSet<T> Empty;
@@ -215,6 +226,7 @@ namespace Akka.DistributedData
         public Akka.DistributedData.GSet<T> ResetDelta() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Get : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Get>
     {
         public Get(Akka.DistributedData.IKey key, Akka.DistributedData.IReadConsistency consistency, object request = null) { }
@@ -226,6 +238,7 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class GetFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IGetResponse, Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.GetFailure>
     {
         public GetFailure(Akka.DistributedData.IKey key, object request) { }
@@ -241,25 +254,29 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public class GetKeyIds
     {
         public static readonly Akka.DistributedData.GetKeyIds Instance;
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }
+    [System.Serializable]
     public sealed class GetKeysIdsResult : System.IEquatable<Akka.DistributedData.GetKeysIdsResult>
     {
         public GetKeysIdsResult(System.Collections.Immutable.IImmutableSet<string> keys) { }
         public System.Collections.Immutable.IImmutableSet<string> Keys { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.GetKeysIdsResult other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class GetReplicaCount
     {
         public static readonly Akka.DistributedData.GetReplicaCount Instance;
     }
+    [System.Serializable]
     public sealed class GetSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IGetResponse, Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.GetSuccess>
     {
         public GetSuccess(Akka.DistributedData.IKey key, object request, Akka.DistributedData.IReplicatedData data) { }
@@ -375,23 +392,25 @@ namespace Akka.DistributedData
         protected Key(string id) { }
         public string Id { get; }
         public bool Equals(Akka.DistributedData.IKey key) { }
-        public virtual bool Equals(object obj) { }
+        public override sealed bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public static string op_Implicit(Akka.DistributedData.Key<T> key) { }
     }
-    public class static LWWDictionary
+    public static class LWWDictionary
     {
-        public static Akka.DistributedData.LWWDictionary<TKey, TValue> Create<TKey, TValue>(Akka.Cluster.UniqueAddress node, TKey key, TValue value, Akka.DistributedData.Clock<TValue> clock = null) { }
-        public static Akka.DistributedData.LWWDictionary<TKey, TValue> Create<TKey, TValue>(params System.ValueTuple<, , >[] elements) { }
+        public static Akka.DistributedData.LWWDictionary<TKey, TValue> Create<TKey, TValue>(params System.ValueTuple<Akka.Cluster.UniqueAddress, TKey, TValue>[] elements) { }
         public static Akka.DistributedData.LWWDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEnumerable<System.ValueTuple<Akka.Cluster.UniqueAddress, TKey, TValue>> elements, Akka.DistributedData.Clock<TValue> clock = null) { }
+        public static Akka.DistributedData.LWWDictionary<TKey, TValue> Create<TKey, TValue>(Akka.Cluster.UniqueAddress node, TKey key, TValue value, Akka.DistributedData.Clock<TValue> clock = null) { }
     }
+    [System.Serializable]
     public sealed class LWWDictionaryKey<TKey, TValue> : Akka.DistributedData.Key<Akka.DistributedData.LWWDictionary<TKey, TValue>>
     {
         public LWWDictionaryKey(string id) { }
         public System.Type KeyType { get; }
         public System.Type ValueType { get; }
     }
+    [System.Serializable]
     public sealed class LWWDictionary<TKey, TValue> : Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.LWWDictionary<TKey, TValue>, Akka.DistributedData.ORDictionary<TKey, Akka.DistributedData.LWWRegister<TValue>>.IDeltaOperation>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.LWWDictionary<TKey, TValue>>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.LWWDictionary<TKey, TValue>>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerable, System.IEquatable<Akka.DistributedData.LWWDictionary<TKey, TValue>>
     {
         public static readonly Akka.DistributedData.LWWDictionary<TKey, TValue> Empty;
@@ -411,8 +430,8 @@ namespace Akka.DistributedData
         public override bool Equals(object obj) { }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { }
         public override int GetHashCode() { }
-        public Akka.DistributedData.LWWDictionary<TKey, TValue> Merge(Akka.DistributedData.LWWDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.LWWDictionary<TKey, TValue> Merge(Akka.DistributedData.LWWDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.LWWDictionary<TKey, TValue> MergeDelta(Akka.DistributedData.ORDictionary<TKey, Akka.DistributedData.LWWRegister<TValue>>.IDeltaOperation delta) { }
         public bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode) { }
         public Akka.DistributedData.LWWDictionary<TKey, TValue> Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto) { }
@@ -425,18 +444,20 @@ namespace Akka.DistributedData
         public override string ToString() { }
         public bool TryGetValue(TKey key, out TValue value) { }
     }
+    [System.Serializable]
     public sealed class LWWRegisterKey<T> : Akka.DistributedData.Key<Akka.DistributedData.LWWRegister<T>>
     {
         public LWWRegisterKey(string id) { }
         public System.Type RegisterType { get; }
     }
+    [System.Serializable]
     public sealed class LWWRegister<T> : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.LWWRegister<T>>, System.IEquatable<Akka.DistributedData.LWWRegister<T>>
     {
         public static readonly Akka.DistributedData.Clock<T> DefaultClock;
         public static readonly Akka.DistributedData.Clock<T> ReverseClock;
         public LWWRegister(Akka.Cluster.UniqueAddress node, T initial) { }
-        public LWWRegister(Akka.Cluster.UniqueAddress node, T value, long timestamp) { }
         public LWWRegister(Akka.Cluster.UniqueAddress node, T initial, Akka.DistributedData.Clock<T> clock) { }
+        public LWWRegister(Akka.Cluster.UniqueAddress node, T value, long timestamp) { }
         public System.Type RegisterType { get; }
         public long Timestamp { get; }
         public Akka.Cluster.UniqueAddress UpdatedBy { get; }
@@ -444,11 +465,12 @@ namespace Akka.DistributedData
         public bool Equals(Akka.DistributedData.LWWRegister<T> other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public Akka.DistributedData.LWWRegister<T> Merge(Akka.DistributedData.LWWRegister<T> other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.LWWRegister<T> Merge(Akka.DistributedData.LWWRegister<T> other) { }
         public override string ToString() { }
         public Akka.DistributedData.LWWRegister<T> WithValue(Akka.Cluster.UniqueAddress node, T value, Akka.DistributedData.Clock<T> clock = null) { }
     }
+    [System.Serializable]
     public sealed class ModifyFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IUpdateFailure, Akka.DistributedData.IUpdateResponse
     {
         public ModifyFailure(Akka.DistributedData.IKey key, string errorMessage, System.Exception cause, object request) { }
@@ -460,10 +482,11 @@ namespace Akka.DistributedData
         public void ThrowOnFailure() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class MultiVersionVector : Akka.DistributedData.VersionVector
     {
-        public MultiVersionVector(params System.Collections.Generic.KeyValuePair<, >[] nodeVersions) { }
         public MultiVersionVector(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<Akka.Cluster.UniqueAddress, long>> versions) { }
+        public MultiVersionVector(params System.Collections.Generic.KeyValuePair<Akka.Cluster.UniqueAddress, long>[] nodeVersions) { }
         public MultiVersionVector(System.Collections.Immutable.ImmutableDictionary<Akka.Cluster.UniqueAddress, long> nodeVersions) { }
         public override int Count { get; }
         public override bool IsEmpty { get; }
@@ -479,6 +502,7 @@ namespace Akka.DistributedData
         public override string ToString() { }
         public override long VersionAt(Akka.Cluster.UniqueAddress node) { }
     }
+    [System.Serializable]
     public sealed class NotFound : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IGetResponse, Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.NotFound>
     {
         public NotFound(Akka.DistributedData.IKey key, object request) { }
@@ -494,15 +518,16 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
-    public class static ORDictionary
+    public static class ORDictionary
     {
-        public static Akka.DistributedData.ORDictionary<TKey, TValue> Create<TKey, TValue>(Akka.Cluster.UniqueAddress node, TKey key, TValue value)
-            where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
-        public static Akka.DistributedData.ORDictionary<TKey, TValue> Create<TKey, TValue>(params System.ValueTuple<, , >[] elements)
-            where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
         public static Akka.DistributedData.ORDictionary<TKey, TValue> Create<TKey, TValue>(System.Collections.Generic.IEnumerable<System.ValueTuple<Akka.Cluster.UniqueAddress, TKey, TValue>> elements)
             where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
+        public static Akka.DistributedData.ORDictionary<TKey, TValue> Create<TKey, TValue>(params System.ValueTuple<Akka.Cluster.UniqueAddress, TKey, TValue>[] elements)
+            where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
+        public static Akka.DistributedData.ORDictionary<TKey, TValue> Create<TKey, TValue>(Akka.Cluster.UniqueAddress node, TKey key, TValue value)
+            where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
     }
+    [System.Serializable]
     public sealed class ORDictionaryKey<TKey, TValue> : Akka.DistributedData.Key<Akka.DistributedData.ORDictionary<TKey, TValue>>
         where TValue : Akka.DistributedData.IReplicatedData<TValue>
     {
@@ -510,6 +535,7 @@ namespace Akka.DistributedData
         public System.Type KeyType { get; }
         public System.Type ValueType { get; }
     }
+    [System.Serializable]
     public sealed class ORDictionary<TKey, TValue> : Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.ORDictionary<TKey, TValue>, Akka.DistributedData.ORDictionary<TKey, TValue>.IDeltaOperation>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.ORDictionary<TKey, TValue>>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.ORDictionary<TKey, TValue>>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>>, System.Collections.IEnumerable, System.IEquatable<Akka.DistributedData.ORDictionary<TKey, TValue>>
         where TValue : Akka.DistributedData.IReplicatedData<TValue>
     {
@@ -532,8 +558,8 @@ namespace Akka.DistributedData
         public override bool Equals(object obj) { }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, TValue>> GetEnumerator() { }
         public override int GetHashCode() { }
-        public Akka.DistributedData.ORDictionary<TKey, TValue> Merge(Akka.DistributedData.ORDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.ORDictionary<TKey, TValue> Merge(Akka.DistributedData.ORDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.ORDictionary<TKey, TValue> MergeDelta(Akka.DistributedData.ORDictionary<TKey, TValue>.IDeltaOperation delta) { }
         public bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode) { }
         public Akka.DistributedData.ORDictionary<TKey, TValue> Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto) { }
@@ -545,15 +571,16 @@ namespace Akka.DistributedData
         public Akka.DistributedData.ORDictionary<TKey, TValue> SetItem(Akka.Cluster.UniqueAddress node, TKey key, TValue value) { }
         public override string ToString() { }
         public bool TryGetValue(TKey key, out TValue value) { }
-        public interface IDeltaOperation<TKey, TValue> : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedDelta, Akka.DistributedData.IRequireCausualDeliveryOfDeltas, System.IEquatable<Akka.DistributedData.ORDictionary<TKey, TValue>.IDeltaOperation>
-            where TValue : Akka.DistributedData.IReplicatedData<TValue> { }
+        public interface IDeltaOperation : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedDelta, Akka.DistributedData.IRequireCausualDeliveryOfDeltas, System.IEquatable<Akka.DistributedData.ORDictionary<TKey, TValue>.IDeltaOperation> { }
     }
+    [System.Serializable]
     public sealed class ORMultiValueDictionaryKey<TKey, TValue> : Akka.DistributedData.Key<Akka.DistributedData.ORMultiValueDictionary<TKey, TValue>>
     {
         public ORMultiValueDictionaryKey(string id) { }
         public System.Type KeyType { get; }
         public System.Type ValueType { get; }
     }
+    [System.Serializable]
     public sealed class ORMultiValueDictionary<TKey, TValue> : Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.ORMultiValueDictionary<TKey, TValue>, Akka.DistributedData.ORDictionary<TKey, Akka.DistributedData.ORSet<TValue>>.IDeltaOperation>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.ORMultiValueDictionary<TKey, TValue>>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.ORMultiValueDictionary<TKey, TValue>>, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, System.Collections.Immutable.IImmutableSet<TValue>>>, System.Collections.IEnumerable, System.IEquatable<Akka.DistributedData.ORMultiValueDictionary<TKey, TValue>>
     {
         public static readonly Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> Empty;
@@ -576,8 +603,8 @@ namespace Akka.DistributedData
         public override bool Equals(object obj) { }
         public System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<TKey, System.Collections.Immutable.IImmutableSet<TValue>>> GetEnumerator() { }
         public override int GetHashCode() { }
-        public Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> Merge(Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> Merge(Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> other) { }
         public Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> MergeDelta(Akka.DistributedData.ORDictionary<TKey, Akka.DistributedData.ORSet<TValue>>.IDeltaOperation delta) { }
         public bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode) { }
         public Akka.DistributedData.ORMultiValueDictionary<TKey, TValue> Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto) { }
@@ -594,17 +621,19 @@ namespace Akka.DistributedData
         public override string ToString() { }
         public bool TryGetValue(TKey key, out System.Collections.Immutable.IImmutableSet<TValue> value) { }
     }
-    public class static ORSet
+    public static class ORSet
     {
-        public static Akka.DistributedData.ORSet<T> Create<T>(Akka.Cluster.UniqueAddress node, T element) { }
-        public static Akka.DistributedData.ORSet<T> Create<T>(params System.Collections.Generic.KeyValuePair<, >[] elements) { }
         public static Akka.DistributedData.ORSet<T> Create<T>(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<Akka.Cluster.UniqueAddress, T>> elements) { }
+        public static Akka.DistributedData.ORSet<T> Create<T>(params System.Collections.Generic.KeyValuePair<Akka.Cluster.UniqueAddress, T>[] elements) { }
+        public static Akka.DistributedData.ORSet<T> Create<T>(Akka.Cluster.UniqueAddress node, T element) { }
     }
+    [System.Serializable]
     public sealed class ORSetKey<T> : Akka.DistributedData.Key<Akka.DistributedData.ORSet<T>>
     {
         public ORSetKey(string id) { }
         public System.Type SetType { get; }
     }
+    [System.Serializable]
     public sealed class ORSet<T> : Akka.DistributedData.FastMerge<Akka.DistributedData.ORSet<T>>, Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.ORSet<T>, Akka.DistributedData.ORSet<T>.IDeltaOperation>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.ORSet<T>>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.ORSet<T>>, System.Collections.Generic.IEnumerable<T>, System.Collections.IEnumerable, System.IEquatable<Akka.DistributedData.ORSet<T>>
     {
         public static readonly Akka.DistributedData.ORSet<T> Empty;
@@ -634,8 +663,9 @@ namespace Akka.DistributedData
         public Akka.DistributedData.ORSet<T> Remove(Akka.Cluster.UniqueAddress node, T element) { }
         public Akka.DistributedData.ORSet<T> ResetDelta() { }
         public override string ToString() { }
-        public interface IDeltaOperation<T> : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedDelta, Akka.DistributedData.IRequireCausualDeliveryOfDeltas, System.IEquatable<Akka.DistributedData.ORSet<T>.IDeltaOperation> { }
+        public interface IDeltaOperation : Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedDelta, Akka.DistributedData.IRequireCausualDeliveryOfDeltas, System.IEquatable<Akka.DistributedData.ORSet<T>.IDeltaOperation> { }
     }
+    [System.Serializable]
     public sealed class PNCounter : Akka.DistributedData.IDeltaReplicatedData, Akka.DistributedData.IDeltaReplicatedData<Akka.DistributedData.PNCounter, Akka.DistributedData.PNCounter>, Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.PNCounter>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.PNCounter>, Akka.DistributedData.IReplicatedDelta, System.IEquatable<Akka.DistributedData.PNCounter>
     {
         public static readonly Akka.DistributedData.PNCounter Empty;
@@ -653,8 +683,8 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public Akka.DistributedData.PNCounter Increment(Akka.Cluster.Cluster node, long delta = 1) { }
         public Akka.DistributedData.PNCounter Increment(Akka.Cluster.UniqueAddress address, long delta = 1) { }
-        public Akka.DistributedData.PNCounter Merge(Akka.DistributedData.PNCounter other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.PNCounter Merge(Akka.DistributedData.PNCounter other) { }
         public Akka.DistributedData.PNCounter MergeDelta(Akka.DistributedData.PNCounter delta) { }
         public bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode) { }
         public Akka.DistributedData.PNCounter Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto) { }
@@ -689,8 +719,8 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public Akka.DistributedData.PNCounterDictionary<TKey> Increment(Akka.Cluster.Cluster node, TKey key, long delta = 1) { }
         public Akka.DistributedData.PNCounterDictionary<TKey> Increment(Akka.Cluster.UniqueAddress node, TKey key, long delta = 1) { }
-        public Akka.DistributedData.PNCounterDictionary<TKey> Merge(Akka.DistributedData.PNCounterDictionary<TKey> other) { }
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public Akka.DistributedData.PNCounterDictionary<TKey> Merge(Akka.DistributedData.PNCounterDictionary<TKey> other) { }
         public Akka.DistributedData.PNCounterDictionary<TKey> MergeDelta(Akka.DistributedData.ORDictionary<TKey, Akka.DistributedData.PNCounter>.IDeltaOperation delta) { }
         public bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode) { }
         public Akka.DistributedData.PNCounterDictionary<TKey> Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto) { }
@@ -709,8 +739,8 @@ namespace Akka.DistributedData
     {
         public ReadAll(System.TimeSpan timeout) { }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.ReadAll other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -719,8 +749,8 @@ namespace Akka.DistributedData
         public ReadFrom(int n, System.TimeSpan timeout) { }
         public int N { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.ReadFrom other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -737,8 +767,8 @@ namespace Akka.DistributedData
         public ReadMajority(System.TimeSpan timeout, int minCapacity = 0) { }
         public int MinCapacity { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.ReadMajority other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -748,11 +778,12 @@ namespace Akka.DistributedData
         public int Additional { get; }
         public int MinCapacity { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.ReadMajorityPlus other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class ReplicaCount : System.IEquatable<Akka.DistributedData.ReplicaCount>
     {
         public ReplicaCount(int n) { }
@@ -762,6 +793,7 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class ReplicationDeleteFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IDeleteResponse, System.IEquatable<Akka.DistributedData.ReplicationDeleteFailure>
     {
         public ReplicationDeleteFailure(Akka.DistributedData.IKey key) { }
@@ -775,8 +807,7 @@ namespace Akka.DistributedData
     }
     public sealed class ReplicatorSettings
     {
-        [System.ObsoleteAttribute("Use constructor with `verboseDebugLogging` argument. Obsolete since v1.5.0-alpha2" +
-            "")]
+        [System.Obsolete("Use constructor with `verboseDebugLogging` argument. Obsolete since v1.5.0-alpha2")]
         public ReplicatorSettings(string role, System.TimeSpan gossipInterval, System.TimeSpan notifySubscribersInterval, int maxDeltaElements, string dispatcher, System.TimeSpan pruningInterval, System.TimeSpan maxPruningDissemination, System.Collections.Immutable.IImmutableSet<string> durableKeys, Akka.Actor.Props durableStoreProps, System.TimeSpan pruningMarkerTimeToLive, System.TimeSpan durablePruningMarkerTimeToLive, int maxDeltaSize, bool restartReplicatorOnFailure, bool preferOldest) { }
         public ReplicatorSettings(string role, System.TimeSpan gossipInterval, System.TimeSpan notifySubscribersInterval, int maxDeltaElements, string dispatcher, System.TimeSpan pruningInterval, System.TimeSpan maxPruningDissemination, System.Collections.Immutable.IImmutableSet<string> durableKeys, Akka.Actor.Props durableStoreProps, System.TimeSpan pruningMarkerTimeToLive, System.TimeSpan durablePruningMarkerTimeToLive, int maxDeltaSize, bool restartReplicatorOnFailure, bool preferOldest, bool verboseDebugLogging) { }
         public string Dispatcher { get; }
@@ -795,8 +826,6 @@ namespace Akka.DistributedData
         public bool RestartReplicatorOnFailure { get; }
         public string Role { get; }
         public bool VerboseDebugLogging { get; }
-        public static Akka.DistributedData.ReplicatorSettings Create(Akka.Actor.ActorSystem system) { }
-        public static Akka.DistributedData.ReplicatorSettings Create(Akka.Configuration.Config config) { }
         public Akka.DistributedData.ReplicatorSettings WithDispatcher(string dispatcher) { }
         public Akka.DistributedData.ReplicatorSettings WithDurableKeys(System.Collections.Immutable.IImmutableSet<string> durableKeys) { }
         public Akka.DistributedData.ReplicatorSettings WithDurableStoreProps(Akka.Actor.Props durableStoreProps) { }
@@ -810,8 +839,10 @@ namespace Akka.DistributedData
         public Akka.DistributedData.ReplicatorSettings WithRestartReplicatorOnFailure(bool restart) { }
         public Akka.DistributedData.ReplicatorSettings WithRole(string role) { }
         public Akka.DistributedData.ReplicatorSettings WithVerboseDebugLogging(bool verboseDebugLogging) { }
+        public static Akka.DistributedData.ReplicatorSettings Create(Akka.Actor.ActorSystem system) { }
+        public static Akka.DistributedData.ReplicatorSettings Create(Akka.Configuration.Config config) { }
     }
-    [System.Diagnostics.DebuggerDisplayAttribute("VersionVector({Node}->{Version})")]
+    [System.Diagnostics.DebuggerDisplay("VersionVector({Node}->{Version})")]
     public sealed class SingleVersionVector : Akka.DistributedData.VersionVector
     {
         public SingleVersionVector(Akka.Cluster.UniqueAddress node, long version) { }
@@ -841,6 +872,7 @@ namespace Akka.DistributedData
         public void ThrowOnFailure() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Subscribe : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Subscribe>
     {
         public Subscribe(Akka.DistributedData.IKey key, Akka.Actor.IActorRef subscriber) { }
@@ -851,6 +883,7 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Unsubscribe : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Unsubscribe>
     {
         public Unsubscribe(Akka.DistributedData.IKey key, Akka.Actor.IActorRef subscriber) { }
@@ -861,6 +894,7 @@ namespace Akka.DistributedData
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class Update : Akka.Actor.INoSerializationVerificationNeeded
     {
         public Update(Akka.DistributedData.IKey key, Akka.DistributedData.IWriteConsistency consistency, System.Func<Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedData> modify, object request = null) { }
@@ -871,6 +905,7 @@ namespace Akka.DistributedData
         public object Request { get; }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class UpdateSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IUpdateResponse, System.IEquatable<Akka.DistributedData.UpdateSuccess>
     {
         public UpdateSuccess(Akka.DistributedData.IKey key, object request) { }
@@ -883,6 +918,7 @@ namespace Akka.DistributedData
         public void ThrowOnFailure() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class UpdateTimeout : Akka.Actor.INoSerializationVerificationNeeded, Akka.DistributedData.IUpdateFailure, Akka.DistributedData.IUpdateResponse, System.IEquatable<Akka.DistributedData.UpdateTimeout>
     {
         public UpdateTimeout(Akka.DistributedData.IKey key, object request) { }
@@ -896,6 +932,7 @@ namespace Akka.DistributedData
         public void ThrowOnFailure() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public abstract class VersionVector : Akka.DistributedData.IRemovedNodePruning, Akka.DistributedData.IRemovedNodePruning<Akka.DistributedData.VersionVector>, Akka.DistributedData.IReplicatedData, Akka.DistributedData.IReplicatedDataSerialization, Akka.DistributedData.IReplicatedData<Akka.DistributedData.VersionVector>, System.IEquatable<Akka.DistributedData.VersionVector>
     {
         protected static readonly Akka.Util.Internal.AtomicCounterLong Counter;
@@ -907,8 +944,6 @@ namespace Akka.DistributedData
         public abstract System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<Akka.Cluster.UniqueAddress, long>> VersionEnumerator { get; }
         public Akka.DistributedData.VersionVector.Ordering Compare(Akka.DistributedData.VersionVector other) { }
         public abstract bool Contains(Akka.Cluster.UniqueAddress node);
-        public static Akka.DistributedData.VersionVector Create(Akka.Cluster.UniqueAddress node, long version) { }
-        public static Akka.DistributedData.VersionVector Create(System.Collections.Immutable.ImmutableDictionary<Akka.Cluster.UniqueAddress, long> versions) { }
         public bool Equals(Akka.DistributedData.VersionVector other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
@@ -917,16 +952,18 @@ namespace Akka.DistributedData
         public bool IsBefore(Akka.DistributedData.VersionVector y) { }
         public bool IsConcurrent(Akka.DistributedData.VersionVector y) { }
         public bool IsSame(Akka.DistributedData.VersionVector y) { }
-        public abstract Akka.DistributedData.VersionVector Merge(Akka.DistributedData.VersionVector other);
         public Akka.DistributedData.IReplicatedData Merge(Akka.DistributedData.IReplicatedData other) { }
+        public abstract Akka.DistributedData.VersionVector Merge(Akka.DistributedData.VersionVector other);
         public abstract bool NeedPruningFrom(Akka.Cluster.UniqueAddress removedNode);
         public abstract Akka.DistributedData.VersionVector Prune(Akka.Cluster.UniqueAddress removedNode, Akka.Cluster.UniqueAddress collapseInto);
         public abstract Akka.DistributedData.VersionVector PruningCleanup(Akka.Cluster.UniqueAddress removedNode);
         public abstract long VersionAt(Akka.Cluster.UniqueAddress node);
-        public static bool ==(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
-        public static bool >(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
-        public static bool !=(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
-        public static bool <(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
+        public static Akka.DistributedData.VersionVector Create(System.Collections.Immutable.ImmutableDictionary<Akka.Cluster.UniqueAddress, long> versions) { }
+        public static Akka.DistributedData.VersionVector Create(Akka.Cluster.UniqueAddress node, long version) { }
+        public static bool operator !=(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
+        public static bool operator <(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
+        public static bool operator ==(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
+        public static bool operator >(Akka.DistributedData.VersionVector x, Akka.DistributedData.VersionVector y) { }
         public enum Ordering
         {
             After = 0,
@@ -940,8 +977,8 @@ namespace Akka.DistributedData
     {
         public WriteAll(System.TimeSpan timeout) { }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.WriteAll other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -958,8 +995,8 @@ namespace Akka.DistributedData
         public WriteMajority(System.TimeSpan timeout, int minCapacity = 0) { }
         public int MinCapacity { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.WriteMajority other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -969,8 +1006,8 @@ namespace Akka.DistributedData
         public int Additional { get; }
         public int MinCapacity { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.WriteMajorityPlus other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -979,8 +1016,8 @@ namespace Akka.DistributedData
         public WriteTo(int count, System.TimeSpan timeout) { }
         public int Count { get; }
         public System.TimeSpan Timeout { get; }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.DistributedData.WriteTo other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -989,8 +1026,8 @@ namespace Akka.DistributedData.Durable
 {
     public sealed class DurableDataEnvelope : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Durable.DurableDataEnvelope>
     {
-        public DurableDataEnvelope(Akka.DistributedData.Internal.DataEnvelope dataEnvelope) { }
         public DurableDataEnvelope(Akka.DistributedData.IReplicatedData data) { }
+        public DurableDataEnvelope(Akka.DistributedData.Internal.DataEnvelope dataEnvelope) { }
         public Akka.DistributedData.IReplicatedData Data { get; }
         public bool Equals(Akka.DistributedData.Durable.DurableDataEnvelope other) { }
         public override bool Equals(object obj) { }
@@ -1018,8 +1055,8 @@ namespace Akka.DistributedData.Durable
     public sealed class LoadFailedException : Akka.Actor.AkkaException
     {
         public LoadFailedException(string message) { }
-        public LoadFailedException(string message, System.Exception cause) { }
         public LoadFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public LoadFailedException(string message, System.Exception cause) { }
     }
     public sealed class Store
     {
@@ -1038,12 +1075,13 @@ namespace Akka.DistributedData.Durable
 }
 namespace Akka.DistributedData.Internal
 {
+    [System.Serializable]
     public sealed class DataEnvelope : Akka.DistributedData.IReplicatorMessage, System.IEquatable<Akka.DistributedData.Internal.DataEnvelope>
     {
         public Akka.DistributedData.IReplicatedData Data { get; }
-        public static Akka.DistributedData.Internal.DataEnvelope DeletedEnvelope { get; }
         public Akka.DistributedData.VersionVector DeltaVersions { get; }
         public System.Collections.Immutable.ImmutableDictionary<Akka.Cluster.UniqueAddress, Akka.DistributedData.IPruningState> Pruning { get; }
+        public static Akka.DistributedData.Internal.DataEnvelope DeletedEnvelope { get; }
         public bool Equals(Akka.DistributedData.Internal.DataEnvelope other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -1,10 +1,10 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.TCK")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.Tests")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("e3bcba88-003c-4cda-8a60-f0c2553fe3c8")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.TCK")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.Tests")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("e3bcba88-003c-4cda-8a60-f0c2553fe3c8")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Persistence
 {
     public abstract class AtLeastOnceDeliveryActor : Akka.Persistence.PersistentActor
@@ -62,6 +62,7 @@ namespace Akka.Persistence
         public Akka.Persistence.AtLeastOnceDeliverySnapshot GetDeliverySnapshot() { }
         public void OnReplaySuccess() { }
         public void SetDeliverySnapshot(Akka.Persistence.AtLeastOnceDeliverySnapshot snapshot) { }
+        [System.Serializable]
         public sealed class Delivery : System.IEquatable<Akka.Persistence.AtLeastOnceDeliverySemantic.Delivery>
         {
             public Delivery(Akka.Actor.ActorPath destination, object message, System.DateTime timestamp, int attempt) { }
@@ -75,6 +76,7 @@ namespace Akka.Persistence
             public Akka.Persistence.AtLeastOnceDeliverySemantic.Delivery IncrementedCopy() { }
             public override string ToString() { }
         }
+        [System.Serializable]
         public sealed class RedeliveryTick : Akka.Actor.INotInfluenceReceiveTimeout, Akka.Event.IDeadLetterSuppression
         {
             public static Akka.Persistence.AtLeastOnceDeliverySemantic.RedeliveryTick Instance { get; }
@@ -119,6 +121,7 @@ namespace Akka.Persistence
         public System.Threading.CancellationToken CancellationToken { get; }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteMessagesFailure : Akka.Actor.INoSerializationVerificationNeeded, System.IEquatable<Akka.Persistence.DeleteMessagesFailure>
     {
         public DeleteMessagesFailure(System.Exception cause, long toSequenceNr) { }
@@ -129,6 +132,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteMessagesSuccess : System.IEquatable<Akka.Persistence.DeleteMessagesSuccess>
     {
         public DeleteMessagesSuccess(long toSequenceNr) { }
@@ -138,6 +142,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteMessagesTo : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.DeleteMessagesTo>
     {
         public DeleteMessagesTo(string persistenceId, long toSequenceNr, Akka.Actor.IActorRef persistentActor) { }
@@ -149,6 +154,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshot : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotRequest, System.IEquatable<Akka.Persistence.DeleteSnapshot>
     {
         public DeleteSnapshot(Akka.Persistence.SnapshotMetadata metadata) { }
@@ -158,6 +164,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshotFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.DeleteSnapshotFailure>
     {
         public DeleteSnapshotFailure(Akka.Persistence.SnapshotMetadata metadata, System.Exception cause) { }
@@ -168,6 +175,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshotSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.DeleteSnapshotSuccess>
     {
         public DeleteSnapshotSuccess(Akka.Persistence.SnapshotMetadata metadata) { }
@@ -177,6 +185,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshots : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotRequest, System.IEquatable<Akka.Persistence.DeleteSnapshots>
     {
         public DeleteSnapshots(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
@@ -187,6 +196,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshotsFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.DeleteSnapshotsFailure>
     {
         public DeleteSnapshotsFailure(Akka.Persistence.SnapshotSelectionCriteria criteria, System.Exception cause) { }
@@ -197,6 +207,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshotsSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.DeleteSnapshotsSuccess>
     {
         public DeleteSnapshotsSuccess(Akka.Persistence.SnapshotSelectionCriteria criteria) { }
@@ -211,7 +222,6 @@ namespace Akka.Persistence
         public DiscardConfigurator() { }
         public Akka.Persistence.IStashOverflowStrategy Create(Akka.Configuration.Config config) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class DiscardToDeadLetterStrategy : Akka.Persistence.IStashOverflowStrategy
     {
         public static Akka.Persistence.DiscardToDeadLetterStrategy Instance { get; }
@@ -225,12 +235,12 @@ namespace Akka.Persistence
         public bool IsRecovering { get; }
         public bool IsRecoveryFinished { get; }
         public Akka.Actor.IActorRef Journal { get; }
-        public string JournalPluginId { get; set; }
+        public string JournalPluginId { get; protected set; }
         public long LastSequenceNr { get; }
         protected virtual Akka.Event.ILoggingAdapter Log { get; }
         public abstract string PersistenceId { get; }
         public virtual Akka.Persistence.Recovery Recovery { get; }
-        public string SnapshotPluginId { get; set; }
+        public string SnapshotPluginId { get; protected set; }
         public long SnapshotSequenceNr { get; }
         public Akka.Actor.IActorRef SnapshotStore { get; }
         public string SnapshotterId { get; }
@@ -253,15 +263,15 @@ namespace Akka.Persistence
         public void Persist<TEvent>(TEvent @event, System.Action<TEvent> handler) { }
         public void Persist<TEvent>(TEvent @event, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Action onComplete) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
-        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Action onComplete) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Action onComplete) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
-        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Action onComplete) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
         public void PersistAsync<TEvent>(TEvent @event, System.Action<TEvent> handler) { }
@@ -339,6 +349,7 @@ namespace Akka.Persistence
         public Akka.Persistence.PersistenceHealthCheckResult Result { get; }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class LoadSnapshot : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotRequest, System.IEquatable<Akka.Persistence.LoadSnapshot>
     {
         public LoadSnapshot(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, long toSequenceNr) { }
@@ -358,6 +369,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class LoadSnapshotResult : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.LoadSnapshotResult>
     {
         public LoadSnapshotResult(Akka.Persistence.SelectedSnapshot snapshot, long toSequenceNr) { }
@@ -368,6 +380,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class LoopMessageSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.LoopMessageSuccess>
     {
         public LoopMessageSuccess(object message, int actorInstanceId) { }
@@ -382,8 +395,8 @@ namespace Akka.Persistence
     {
         public MaxUnconfirmedMessagesExceededException() { }
         public MaxUnconfirmedMessagesExceededException(string message) { }
-        public MaxUnconfirmedMessagesExceededException(string message, System.Exception innerException) { }
         protected MaxUnconfirmedMessagesExceededException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public MaxUnconfirmedMessagesExceededException(string message, System.Exception innerException) { }
     }
     public class Persistence : Akka.Actor.ExtensionIdProvider<Akka.Persistence.PersistenceExtension>
     {
@@ -398,30 +411,21 @@ namespace Akka.Persistence
         public Akka.Persistence.IStashOverflowStrategy DefaultInternalStashOverflowStrategy { get; }
         public Akka.Persistence.PersistenceSettings Settings { get; }
         public Akka.Persistence.Journal.EventAdapters AdaptersFor(string journalPluginId) { }
-        public System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckJournalHealthAsync(string journalPluginId, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckSnapshotStoreHealthAsync(string snapshotStorePluginId, System.Threading.CancellationToken cancellationToken = null) { }
-        [Akka.Annotations.InternalStableApiAttribute()]
+        public System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckJournalHealthAsync(string journalPluginId, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckSnapshotStoreHealthAsync(string snapshotStorePluginId, System.Threading.CancellationToken cancellationToken = default) { }
+        [Akka.Annotations.InternalStableApi]
         public Akka.Actor.IActorRef JournalFor(string journalPluginId) { }
         public string PersistenceId(Akka.Actor.IActorRef actor) { }
-        [Akka.Annotations.InternalStableApiAttribute()]
+        [Akka.Annotations.InternalStableApi]
         public Akka.Actor.IActorRef SnapshotStoreFor(string snapshotPluginId) { }
     }
-    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public struct PersistenceHealthCheckResult : System.IEquatable<Akka.Persistence.PersistenceHealthCheckResult>
+    public readonly struct PersistenceHealthCheckResult : System.IEquatable<Akka.Persistence.PersistenceHealthCheckResult>
     {
-        public PersistenceHealthCheckResult(Akka.Persistence.PersistenceHealthStatus Status, string Description = null, System.Exception Exception = null, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                0,
-                0})] System.Collections.Generic.IReadOnlyDictionary<string, object> Data = null) { }
-        [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                0,
-                0})]
-        public System.Collections.Generic.IReadOnlyDictionary<string, object> Data { get; set; }
-        public string Description { get; set; }
-        public System.Exception Exception { get; set; }
-        public Akka.Persistence.PersistenceHealthStatus Status { get; set; }
+        public PersistenceHealthCheckResult(Akka.Persistence.PersistenceHealthStatus Status, string? Description = null, System.Exception? Exception = null, System.Collections.Generic.IReadOnlyDictionary<string, object>? Data = null) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object>? Data { get; init; }
+        public string? Description { get; init; }
+        public System.Exception? Exception { get; init; }
+        public Akka.Persistence.PersistenceHealthStatus Status { get; init; }
     }
     public enum PersistenceHealthStatus
     {
@@ -437,8 +441,8 @@ namespace Akka.Persistence
         public Akka.Persistence.PersistenceSettings.ViewSettings View { get; }
         public sealed class AtLeastOnceDeliverySettings
         {
-            public AtLeastOnceDeliverySettings(System.TimeSpan redeliverInterval, int redeliveryBurstLimit, int warnAfterNumberOfUnconfirmedAttempts, int maxUnconfirmedMessages) { }
             public AtLeastOnceDeliverySettings(Akka.Configuration.Config config) { }
+            public AtLeastOnceDeliverySettings(System.TimeSpan redeliverInterval, int redeliveryBurstLimit, int warnAfterNumberOfUnconfirmedAttempts, int maxUnconfirmedMessages) { }
             public int MaxUnconfirmedMessages { get; }
             public System.TimeSpan RedeliverInterval { get; }
             public int RedeliveryBurstLimit { get; }
@@ -462,10 +466,11 @@ namespace Akka.Persistence
             public long AutoUpdateReplayMax { get; }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
+    [System.Serializable]
     public class Persistent : Akka.Persistence.IPersistentRepresentation, Akka.Persistence.Serialization.IMessage, System.IEquatable<Akka.Persistence.IPersistentRepresentation>
     {
-        public Persistent(object payload, long sequenceNr = 0, string persistenceId = null, string manifest = null, bool isDeleted = False, Akka.Actor.IActorRef sender = null, string writerGuid = null, long timestamp = 0) { }
+        public Persistent(object payload, long sequenceNr = 0, string persistenceId = null, string manifest = null, bool isDeleted = false, Akka.Actor.IActorRef sender = null, string writerGuid = null, long timestamp = 0) { }
         public bool IsDeleted { get; }
         public string Manifest { get; }
         public object Payload { get; }
@@ -473,11 +478,11 @@ namespace Akka.Persistence
         public Akka.Actor.IActorRef Sender { get; }
         public long SequenceNr { get; }
         public long Timestamp { get; }
-        public static string Undefined { get; }
         public string WriterGuid { get; }
+        public static string Undefined { get; }
         public bool Equals(Akka.Persistence.IPersistentRepresentation other) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Persistence.Persistent other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public Akka.Persistence.IPersistentRepresentation Update(long sequenceNr, string persistenceId, bool isDeleted, Akka.Actor.IActorRef sender, string writerGuid) { }
@@ -490,67 +495,55 @@ namespace Akka.Persistence
         protected PersistentActor() { }
         protected override bool Receive(object message) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class ReceivePersistentActor : Akka.Persistence.UntypedPersistentActor, Akka.Actor.Internal.IInitializableActor
     {
         protected ReceivePersistentActor() { }
         protected void Become(System.Action configure) { }
         protected void BecomeStacked(System.Action configure) { }
-        protected void Command<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Action<T> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<T> shouldHandle = null) { }
-        protected void Command<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
-        protected void Command(System.Type messageType, System.Action<object> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<object> shouldHandle = null) { }
-        protected void Command(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
-        protected void Command<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T, bool> handler) { }
-        protected void Command(System.Type messageType, System.Func<object, bool> handler) { }
         protected void Command(System.Action<object> handler) { }
+        protected void Command(System.Type messageType, System.Func<object, bool> handler) { }
+        protected void Command(System.Type messageType, System.Action<object> handler, System.Predicate<object>? shouldHandle = null) { }
+        protected void Command(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
+        protected void Command<T>(System.Func<T, bool> handler) { }
+        protected void Command<T>(System.Action<T> handler, System.Predicate<T>? shouldHandle = null) { }
+        protected void Command<T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
         protected void CommandAny(System.Action<object> handler) { }
         protected void CommandAnyAsync(System.Func<object, System.Threading.Tasks.Task> handler) { }
-        protected void CommandAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T, System.Threading.Tasks.Task> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<T> shouldHandle = null) { }
-        protected void CommandAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Predicate<T> shouldHandle, System.Func<T, System.Threading.Tasks.Task> handler) { }
-        protected void CommandAsync(System.Type messageType, System.Func<object, System.Threading.Tasks.Task> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<object> shouldHandle = null) { }
+        protected void CommandAsync(System.Type messageType, System.Func<object, System.Threading.Tasks.Task> handler, System.Predicate<object>? shouldHandle = null) { }
         protected void CommandAsync(System.Type messageType, System.Predicate<object> shouldHandle, System.Func<object, System.Threading.Tasks.Task> handler) { }
-        protected virtual void OnCommand(object message) { }
-        protected virtual void OnRecover(object message) { }
-        protected void Recover<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Action<T> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<T> shouldHandle = null) { }
-        protected void Recover<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
-        protected void Recover(System.Type messageType, System.Action<object> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<object> shouldHandle = null) { }
-        protected void Recover(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
-        protected void Recover<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T, bool> handler) { }
+        protected void CommandAsync<T>(System.Func<T, System.Threading.Tasks.Task> handler, System.Predicate<T>? shouldHandle = null) { }
+        protected void CommandAsync<T>(System.Predicate<T> shouldHandle, System.Func<T, System.Threading.Tasks.Task> handler) { }
+        protected override sealed void OnCommand(object message) { }
+        protected override sealed void OnRecover(object message) { }
         protected void Recover(System.Type messageType, System.Func<object, bool> handler) { }
+        protected void Recover(System.Type messageType, System.Action<object> handler, System.Predicate<object>? shouldHandle = null) { }
+        protected void Recover(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
+        protected void Recover<T>(System.Func<T, bool> handler) { }
+        protected void Recover<T>(System.Action<T> handler, System.Predicate<T>? shouldHandle = null) { }
+        protected void Recover<T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
         protected void RecoverAny(System.Action<object> handler) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [System.Serializable]
     public sealed class Recovery
     {
         public Recovery() { }
         public Recovery(Akka.Persistence.SnapshotSelectionCriteria fromSnapshot) { }
         public Recovery(Akka.Persistence.SnapshotSelectionCriteria fromSnapshot, long toSequenceNr) { }
-        public Recovery(Akka.Persistence.SnapshotSelectionCriteria fromSnapshot = null, long toSequenceNr = 9223372036854775807, long replayMax = 9223372036854775807) { }
-        public static Akka.Persistence.Recovery Default { get; }
+        public Recovery(Akka.Persistence.SnapshotSelectionCriteria? fromSnapshot = null, long toSequenceNr = 9223372036854775807, long replayMax = 9223372036854775807) { }
         public Akka.Persistence.SnapshotSelectionCriteria FromSnapshot { get; }
-        public static Akka.Persistence.Recovery None { get; }
         public long ReplayMax { get; }
         public long ToSequenceNr { get; }
+        public static Akka.Persistence.Recovery Default { get; }
+        public static Akka.Persistence.Recovery None { get; }
     }
+    [System.Serializable]
     public sealed class RecoveryCompleted
     {
-        [System.Runtime.CompilerServices.NullableAttribute(1)]
         public static readonly Akka.Persistence.RecoveryCompleted Instance;
-        public override bool Equals(object obj) { }
+        public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
     }
+    [System.Serializable]
     public sealed class RecoverySuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.RecoverySuccess>
     {
         public RecoverySuccess(long highestSequenceNr) { }
@@ -565,13 +558,13 @@ namespace Akka.Persistence
         public RecoveryTick(bool snapshot) { }
         public bool Snapshot { get; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class RecoveryTimedOutException : Akka.Actor.AkkaException
     {
         public RecoveryTimedOutException() { }
-        public RecoveryTimedOutException(string message, [System.Runtime.CompilerServices.NullableAttribute(2)] System.Exception cause = null) { }
         public RecoveryTimedOutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public RecoveryTimedOutException(string message, System.Exception? cause = null) { }
     }
+    [System.Serializable]
     public sealed class ReplayMessages : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.ReplayMessages>
     {
         public ReplayMessages(long fromSequenceNr, long toSequenceNr, long max, string persistenceId, Akka.Actor.IActorRef persistentActor) { }
@@ -585,6 +578,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class ReplayMessagesFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.ReplayMessagesFailure>
     {
         public ReplayMessagesFailure(System.Exception cause) { }
@@ -594,6 +588,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class ReplayedMessage : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.ReplayedMessage>
     {
         public ReplayedMessage(Akka.Persistence.IPersistentRepresentation persistent) { }
@@ -603,12 +598,12 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ReplyToStrategy : Akka.Persistence.IStashOverflowStrategy
     {
         public ReplyToStrategy(object response) { }
         public object Response { get; }
     }
+    [System.Serializable]
     public sealed class SaveSnapshot : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotRequest, System.IEquatable<Akka.Persistence.SaveSnapshot>
     {
         public SaveSnapshot(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
@@ -619,6 +614,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SaveSnapshotFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.SaveSnapshotFailure>
     {
         public SaveSnapshotFailure(Akka.Persistence.SnapshotMetadata metadata, System.Exception cause) { }
@@ -629,6 +625,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SaveSnapshotSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.SaveSnapshotSuccess>
     {
         public SaveSnapshotSuccess(Akka.Persistence.SnapshotMetadata metadata) { }
@@ -638,6 +635,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SelectedSnapshot : System.IEquatable<Akka.Persistence.SelectedSnapshot>
     {
         public SelectedSnapshot(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
@@ -648,22 +646,24 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SnapshotMetadata : System.IEquatable<Akka.Persistence.SnapshotMetadata>
     {
-        [System.ObsoleteAttribute("This constructor is deprecated and will be removed in v1.6. Use the constructor w" +
+        [System.Obsolete("This constructor is deprecated and will be removed in v1.6. Use the constructor w" +
             "ith the timestamp parameter instead. Since v1.5.28", true)]
         public SnapshotMetadata(string persistenceId, long sequenceNr) { }
-        [Newtonsoft.Json.JsonConstructorAttribute()]
+        [Newtonsoft.Json.JsonConstructor]
         public SnapshotMetadata(string persistenceId, long sequenceNr, System.DateTime timestamp) { }
-        public static System.Collections.Generic.IComparer<Akka.Persistence.SnapshotMetadata> Comparer { get; }
         public string PersistenceId { get; }
         public long SequenceNr { get; }
         public System.DateTime Timestamp { get; }
-        public override bool Equals(object obj) { }
+        public static System.Collections.Generic.IComparer<Akka.Persistence.SnapshotMetadata> Comparer { get; }
         public bool Equals(Akka.Persistence.SnapshotMetadata other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SnapshotOffer : System.IEquatable<Akka.Persistence.SnapshotOffer>
     {
         public SnapshotOffer(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
@@ -674,16 +674,17 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SnapshotSelectionCriteria : System.IEquatable<Akka.Persistence.SnapshotSelectionCriteria>
     {
-        [Newtonsoft.Json.JsonConstructorAttribute()]
-        public SnapshotSelectionCriteria(long maxSequenceNr, System.DateTime maxTimeStamp, long minSequenceNr = 0, System.Nullable<System.DateTime> minTimestamp = null) { }
         public SnapshotSelectionCriteria(long maxSequenceNr) { }
-        public static Akka.Persistence.SnapshotSelectionCriteria Latest { get; }
+        [Newtonsoft.Json.JsonConstructor]
+        public SnapshotSelectionCriteria(long maxSequenceNr, System.DateTime maxTimeStamp, long minSequenceNr = 0, System.DateTime? minTimestamp = default) { }
         public long MaxSequenceNr { get; }
         public System.DateTime MaxTimeStamp { get; }
         public long MinSequenceNr { get; }
-        public System.Nullable<System.DateTime> MinTimestamp { get; }
+        public System.DateTime? MinTimestamp { get; }
+        public static Akka.Persistence.SnapshotSelectionCriteria Latest { get; }
         public static Akka.Persistence.SnapshotSelectionCriteria None { get; }
         public bool Equals(Akka.Persistence.SnapshotSelectionCriteria other) { }
         public override bool Equals(object obj) { }
@@ -701,11 +702,11 @@ namespace Akka.Persistence
         public ThrowExceptionConfigurator() { }
         public Akka.Persistence.IStashOverflowStrategy Create(Akka.Configuration.Config config) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ThrowOverflowExceptionStrategy : Akka.Persistence.IStashOverflowStrategy
     {
         public static Akka.Persistence.ThrowOverflowExceptionStrategy Instance { get; }
     }
+    [System.Serializable]
     public sealed class UnconfirmedDelivery : System.IEquatable<Akka.Persistence.UnconfirmedDelivery>
     {
         public UnconfirmedDelivery(long deliveryId, Akka.Actor.ActorPath destination, object message) { }
@@ -717,6 +718,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class UnconfirmedWarning : System.IEquatable<Akka.Persistence.UnconfirmedWarning>
     {
         public UnconfirmedWarning(Akka.Persistence.UnconfirmedDelivery[] unconfirmedDeliveries) { }
@@ -726,7 +728,6 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class UntypedPersistentActor : Akka.Persistence.Eventsourced
     {
         protected UntypedPersistentActor() { }
@@ -736,9 +737,10 @@ namespace Akka.Persistence
         protected abstract void OnCommand(object message);
         protected abstract void OnRecover(object message);
         protected override bool Receive(object message) { }
-        protected virtual bool ReceiveCommand(object message) { }
-        protected virtual bool ReceiveRecover(object message) { }
+        protected override sealed bool ReceiveCommand(object message) { }
+        protected override sealed bool ReceiveRecover(object message) { }
     }
+    [System.Serializable]
     public sealed class WriteMessageFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.WriteMessageFailure>
     {
         public WriteMessageFailure(Akka.Persistence.IPersistentRepresentation persistent, System.Exception cause, int actorInstanceId) { }
@@ -750,6 +752,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class WriteMessageRejected : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.WriteMessageRejected>
     {
         public WriteMessageRejected(Akka.Persistence.IPersistentRepresentation persistent, System.Exception cause, int actorInstanceId) { }
@@ -761,6 +764,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class WriteMessageSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.WriteMessageSuccess>
     {
         public WriteMessageSuccess(Akka.Persistence.IPersistentRepresentation persistent, int actorInstanceId) { }
@@ -771,6 +775,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class WriteMessages : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.WriteMessages>
     {
         public WriteMessages(System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentEnvelope> messages, Akka.Actor.IActorRef persistentActor, int actorInstanceId) { }
@@ -782,6 +787,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class WriteMessagesFailed : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.WriteMessagesFailed>
     {
         public WriteMessagesFailed(System.Exception cause, int writeCount) { }
@@ -792,6 +798,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class WriteMessagesSuccessful : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage
     {
         public static Akka.Persistence.WriteMessagesSuccessful Instance { get; }
@@ -799,21 +806,19 @@ namespace Akka.Persistence
 }
 namespace Akka.Persistence.Delivery
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static EventSourcedProducerQueue
+    public static class EventSourcedProducerQueue
     {
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(string persistentId, Akka.Persistence.Delivery.EventSourcedProducerQueue.Settings settings) { }
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(string persistentId, Akka.Actor.IActorRefFactory system) { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
+        public static Akka.Actor.Props Create<T>(string persistentId, Akka.Actor.IActorRefFactory system) { }
+        public static Akka.Actor.Props Create<T>(string persistentId, Akka.Persistence.Delivery.EventSourcedProducerQueue.Settings settings) { }
         public class Settings : System.IEquatable<Akka.Persistence.Delivery.EventSourcedProducerQueue.Settings>
         {
-            public System.TimeSpan CleanupUnusedAfter { get; set; }
-            public bool DeleteEvents { get; set; }
-            public string JournalPluginId { get; set; }
-            public int KeepNSnapshots { get; set; }
-            public System.TimeSpan RestartMaxBackoff { get; set; }
-            public int SnapshotEvery { get; set; }
-            public string SnapshotPluginId { get; set; }
+            public System.TimeSpan CleanupUnusedAfter { get; init; }
+            public bool DeleteEvents { get; init; }
+            public string JournalPluginId { get; init; }
+            public int KeepNSnapshots { get; init; }
+            public System.TimeSpan RestartMaxBackoff { get; init; }
+            public int SnapshotEvery { get; init; }
+            public string SnapshotPluginId { get; init; }
             public static Akka.Persistence.Delivery.EventSourcedProducerQueue.Settings Create(Akka.Actor.ActorSystem sys) { }
             public static Akka.Persistence.Delivery.EventSourcedProducerQueue.Settings Create(Akka.Configuration.Config config) { }
         }
@@ -821,7 +826,7 @@ namespace Akka.Persistence.Delivery
 }
 namespace Akka.Persistence.Fsm
 {
-    public class static PersistentFSM
+    public static class PersistentFSM
     {
         public interface IFsmState
         {
@@ -829,38 +834,38 @@ namespace Akka.Persistence.Fsm
         }
         public class PersistentFSMSnapshot<TD> : Akka.Persistence.Serialization.IMessage
         {
-            public PersistentFSMSnapshot(string stateIdentifier, TD data, System.Nullable<System.TimeSpan> timeout) { }
+            public PersistentFSMSnapshot(string stateIdentifier, TD data, System.TimeSpan? timeout) { }
             public TD Data { get; }
             public string StateIdentifier { get; }
-            public System.Nullable<System.TimeSpan> Timeout { get; }
+            public System.TimeSpan? Timeout { get; }
             protected bool Equals(Akka.Persistence.Fsm.PersistentFSM.PersistentFSMSnapshot<TD> other) { }
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }
         }
-        public class StateChangeEvent : Akka.Persistence.Serialization.IMessage
-        {
-            public StateChangeEvent(string stateIdentifier, System.Nullable<System.TimeSpan> timeout) { }
-            public string StateIdentifier { get; }
-            public System.Nullable<System.TimeSpan> Timeout { get; }
-        }
         public class State<TS, TD, TE>
         {
-            public State(TS stateName, TD stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, System.Collections.Generic.IReadOnlyList<TE> domainEvents = null, System.Action<TD> afterTransitionDo = null, bool notifies = True) { }
+            public State(TS stateName, TD stateData, System.TimeSpan? timeout = default, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, System.Collections.Generic.IReadOnlyList<TE> domainEvents = null, System.Action<TD> afterTransitionDo = null, bool notifies = true) { }
             public System.Action<TD> AfterTransitionDo { get; }
             public System.Collections.Generic.IReadOnlyList<TE> DomainEvents { get; }
-            public System.Collections.Generic.IReadOnlyList<object> Replies { get; set; }
+            public System.Collections.Generic.IReadOnlyList<object> Replies { get; protected set; }
             public TD StateData { get; }
             public TS StateName { get; }
             public Akka.Actor.FSMBase.Reason StopReason { get; }
-            public System.Nullable<System.TimeSpan> Timeout { get; }
+            public System.TimeSpan? Timeout { get; }
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> AndThen(System.Action<TD> handler) { }
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> Applying(params TE[] events) { }
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> ForMax(System.TimeSpan timeout) { }
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> Replying(object replyValue) { }
             public override string ToString() { }
-            [System.ObsoleteAttribute("Internal API easily to be confused with regular FSM\'s using. Use regular events (" +
+            [System.Obsolete("Internal API easily to be confused with regular FSM\'s using. Use regular events (" +
                 "`Applying`). Internally, `copy` can be used instead.")]
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> Using(TD nextStateData) { }
+        }
+        public class StateChangeEvent : Akka.Persistence.Serialization.IMessage
+        {
+            public StateChangeEvent(string stateIdentifier, System.TimeSpan? timeout) { }
+            public string StateIdentifier { get; }
+            public System.TimeSpan? Timeout { get; }
         }
     }
     public abstract class PersistentFSMBase<TState, TData, TEvent> : Akka.Persistence.PersistentActor, Akka.Routing.IListeners
@@ -880,23 +885,23 @@ namespace Akka.Persistence.Fsm
         public void OnTransition(Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.TransitionHandler transitionHandler) { }
         protected override void PostStop() { }
         protected override bool ReceiveCommand(object message) { }
-        public void SetStateTimeout(TState state, System.Nullable<System.TimeSpan> timeout) { }
-        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = False) { }
-        public void StartWith(TState stateName, TData stateData, System.Nullable<System.TimeSpan> timeout = null) { }
+        public void SetStateTimeout(TState state, System.TimeSpan? timeout) { }
+        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = false) { }
+        public void StartWith(TState stateName, TData stateData, System.TimeSpan? timeout = default) { }
         public Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> Stay() { }
         public Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> Stop() { }
         public Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> Stop(Akka.Actor.FSMBase.Reason reason) { }
         public Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> Stop(Akka.Actor.FSMBase.Reason reason, TData stateData) { }
         public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.TransformHelper Transform(Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction func) { }
-        public void When(TState stateName, Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction func, System.Nullable<System.TimeSpan> timeout = null) { }
+        public void When(TState stateName, Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction func, System.TimeSpan? timeout = default) { }
         public void WhenUnhandled(Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction stateFunction) { }
-        public delegate Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> StateFunction<TState, TData, TEvent>(Akka.Actor.FSMBase.Event<TData> fsmEvent, Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> state = null);
-        public sealed class TransformHelper<TState, TData, TEvent>
+        public sealed class TransformHelper
         {
             public TransformHelper(Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction func) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction Func { get; }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction Using(System.Func<Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent>, Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent>> andThen) { }
         }
+        public delegate Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> StateFunction<TState, TData, TEvent>(Akka.Actor.FSMBase.Event<TData> fsmEvent, Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> state = null);
         public delegate void TransitionHandler<TState, TData, TEvent>(TState initialState, TState nextState);
     }
     public abstract class PersistentFSM<TState, TData, TEvent> : Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>
@@ -912,6 +917,7 @@ namespace Akka.Persistence.Fsm
 }
 namespace Akka.Persistence.Journal
 {
+    [System.Serializable]
     public class AsyncReplayTimeoutException : Akka.Actor.AkkaException
     {
         public AsyncReplayTimeoutException() { }
@@ -922,15 +928,15 @@ namespace Akka.Persistence.Journal
     {
         protected readonly bool CanPublish;
         protected AsyncWriteJournal() { }
-        public virtual System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckHealthAsync(System.Threading.CancellationToken cancellationToken = null) { }
+        public virtual System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckHealthAsync(System.Threading.CancellationToken cancellationToken = default) { }
         protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken);
         public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
-        protected virtual bool Receive(object message) { }
+        protected override sealed bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected bool ReceiveWriteJournal(object message) { }
         public abstract System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
-        protected static System.Exception TryUnwrapException(System.Exception e) { }
         protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken);
+        protected static System.Exception TryUnwrapException(System.Exception e) { }
     }
     public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithTimers, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
@@ -949,8 +955,9 @@ namespace Akka.Persistence.Journal
             public static Akka.Persistence.Journal.AsyncWriteProxy.InitTimeout Instance { get; }
         }
     }
-    public class static AsyncWriteTarget
+    public static class AsyncWriteTarget
     {
+        [System.Serializable]
         public sealed class DeleteMessagesTo : System.IEquatable<Akka.Persistence.Journal.AsyncWriteTarget.DeleteMessagesTo>
         {
             public DeleteMessagesTo(string persistenceId, long toSequenceNr) { }
@@ -958,11 +965,13 @@ namespace Akka.Persistence.Journal
             public long ToSequenceNr { get; }
             public bool Equals(Akka.Persistence.Journal.AsyncWriteTarget.DeleteMessagesTo other) { }
         }
+        [System.Serializable]
         public sealed class ReplayFailure
         {
             public ReplayFailure(System.Exception cause) { }
             public System.Exception Cause { get; }
         }
+        [System.Serializable]
         public sealed class ReplayMessages : System.IEquatable<Akka.Persistence.Journal.AsyncWriteTarget.ReplayMessages>
         {
             public ReplayMessages(string persistenceId, long fromSequenceNr, long toSequenceNr, long max) { }
@@ -972,18 +981,21 @@ namespace Akka.Persistence.Journal
             public long ToSequenceNr { get; }
             public bool Equals(Akka.Persistence.Journal.AsyncWriteTarget.ReplayMessages other) { }
         }
+        [System.Serializable]
         public sealed class ReplaySuccess : System.IEquatable<Akka.Persistence.Journal.AsyncWriteTarget.ReplaySuccess>
         {
             public ReplaySuccess(long highestSequenceNr) { }
             public long HighestSequenceNr { get; }
             public bool Equals(Akka.Persistence.Journal.AsyncWriteTarget.ReplaySuccess other) { }
         }
+        [System.Serializable]
         public sealed class WriteMessages
         {
             public WriteMessages(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
             public Akka.Persistence.AtomicWrite[] Messages { get; }
         }
     }
+    [System.Serializable]
     public sealed class CombinedReadEventAdapter : Akka.Persistence.Journal.IEventAdapter, Akka.Persistence.Journal.IReadEventAdapter, Akka.Persistence.Journal.IWriteEventAdapter
     {
         public CombinedReadEventAdapter(System.Collections.Generic.IEnumerable<Akka.Persistence.Journal.IEventAdapter> adapters) { }
@@ -992,6 +1004,7 @@ namespace Akka.Persistence.Journal
         public string Manifest(object evt) { }
         public object ToJournal(object evt) { }
     }
+    [System.Serializable]
     public sealed class EmptyEventSequence : Akka.Persistence.Journal.IEmptyEventSequence, Akka.Persistence.Journal.IEventSequence, System.IEquatable<Akka.Persistence.Journal.IEventSequence>
     {
         public static readonly Akka.Persistence.Journal.EmptyEventSequence Instance;
@@ -1003,17 +1016,18 @@ namespace Akka.Persistence.Journal
     public class EventAdapters
     {
         protected EventAdapters(System.Collections.Concurrent.ConcurrentDictionary<System.Type, Akka.Persistence.Journal.IEventAdapter> map, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, Akka.Persistence.Journal.IEventAdapter>> bindings, Akka.Event.ILoggingAdapter log) { }
-        public static Akka.Persistence.Journal.EventAdapters Create(Akka.Actor.ExtendedActorSystem system, Akka.Configuration.Config config) { }
-        public Akka.Persistence.Journal.IEventAdapter Get<T>() { }
         public virtual Akka.Persistence.Journal.IEventAdapter Get(System.Type type) { }
+        public Akka.Persistence.Journal.IEventAdapter Get<T>() { }
+        public static Akka.Persistence.Journal.EventAdapters Create(Akka.Actor.ExtendedActorSystem system, Akka.Configuration.Config config) { }
     }
-    public class static EventSequence
+    public static class EventSequence
     {
         public static Akka.Persistence.Journal.IEventSequence Empty;
-        public static Akka.Persistence.Journal.IEventSequence Create(params object[] events) { }
         public static Akka.Persistence.Journal.IEventSequence Create(System.Collections.Generic.IEnumerable<object> events) { }
+        public static Akka.Persistence.Journal.IEventSequence Create(params object[] events) { }
         public static Akka.Persistence.Journal.IEventSequence Single(object e) { }
     }
+    [System.Serializable]
     public class EventSequence<T> : Akka.Persistence.Journal.IEventSequence, System.IEquatable<Akka.Persistence.Journal.IEventSequence>
     {
         public EventSequence(System.Collections.Generic.IEnumerable<object> events) { }
@@ -1042,6 +1056,7 @@ namespace Akka.Persistence.Journal
         string Manifest(object evt);
         object ToJournal(object evt);
     }
+    [System.Serializable]
     public sealed class IdentityEventAdapter : Akka.Persistence.Journal.IEventAdapter, Akka.Persistence.Journal.IReadEventAdapter, Akka.Persistence.Journal.IWriteEventAdapter
     {
         public static Akka.Persistence.Journal.IdentityEventAdapter Instance { get; }
@@ -1065,6 +1080,7 @@ namespace Akka.Persistence.Journal
         protected override bool ReceivePluginInternal(object message) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken) { }
+        [System.Serializable]
         public sealed class CurrentPersistenceIds : Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Collections.Generic.IEnumerable<string> AllPersistenceIds;
@@ -1080,6 +1096,7 @@ namespace Akka.Persistence.Journal
             public override int GetHashCode() { }
             public override string ToString() { }
         }
+        [System.Serializable]
         public sealed class EventReplaySuccess
         {
             public EventReplaySuccess(int highestSequenceNr) { }
@@ -1089,6 +1106,7 @@ namespace Akka.Persistence.Journal
             public override int GetHashCode() { }
             public override string ToString() { }
         }
+        [System.Serializable]
         public sealed class ReplayAllEvents : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
         {
             public readonly int FromOffset;
@@ -1097,6 +1115,7 @@ namespace Akka.Persistence.Journal
             public readonly int ToOffset;
             public ReplayAllEvents(int fromOffset, int toOffset, long max, Akka.Actor.IActorRef replyTo) { }
         }
+        [System.Serializable]
         public sealed class ReplayTaggedMessages : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
         {
             public readonly int FromOffset;
@@ -1106,25 +1125,29 @@ namespace Akka.Persistence.Journal
             public readonly int ToOffset;
             public ReplayTaggedMessages(int fromOffset, int toOffset, int max, string tag, Akka.Actor.IActorRef replyTo) { }
         }
+        [System.Serializable]
         public sealed class ReplayTaggedMessagesSuccess
         {
             public ReplayTaggedMessagesSuccess(int highestSequenceNr) { }
             public int HighestSequenceNr { get; }
         }
+        [System.Serializable]
         public sealed class ReplayedEvent : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Offset;
             public readonly Akka.Persistence.IPersistentRepresentation Persistent;
             public ReplayedEvent(Akka.Persistence.IPersistentRepresentation persistent, int offset) { }
         }
+        [System.Serializable]
         public sealed class ReplayedTaggedMessage : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Offset;
             public readonly Akka.Persistence.IPersistentRepresentation Persistent;
-            [System.ObsoleteAttribute("If there are tags, they will be stored in the PersistentRepresentation")]
+            [System.Obsolete("If there are tags, they will be stored in the PersistentRepresentation")]
             public readonly string Tag;
             public ReplayedTaggedMessage(Akka.Persistence.IPersistentRepresentation persistent, string tag, int offset) { }
         }
+        [System.Serializable]
         public sealed class SelectCurrentPersistenceIds : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
         {
             public SelectCurrentPersistenceIds(int offset, Akka.Actor.IActorRef replyTo) { }
@@ -1160,8 +1183,8 @@ namespace Akka.Persistence.Journal
         public Akka.Persistence.Journal.ReplayFilterMode Mode { get; }
         public Akka.Actor.IActorRef PersistentActor { get; }
         public int WindowSize { get; }
-        public static Akka.Actor.Props Props(Akka.Actor.IActorRef persistentActor, Akka.Persistence.Journal.ReplayFilterMode mode, int windowSize, int maxOldWriters, bool debugEnabled) { }
         protected override bool Receive(object message) { }
+        public static Akka.Actor.Props Props(Akka.Actor.IActorRef persistentActor, Akka.Persistence.Journal.ReplayFilterMode mode, int windowSize, int maxOldWriters, bool debugEnabled) { }
     }
     public enum ReplayFilterMode
     {
@@ -1170,6 +1193,7 @@ namespace Akka.Persistence.Journal
         RepairByDiscardOld = 2,
         Disabled = 3,
     }
+    [System.Serializable]
     public sealed class SetStore
     {
         public readonly Akka.Actor.IActorRef Store;
@@ -1183,6 +1207,7 @@ namespace Akka.Persistence.Journal
         protected override System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId { get; }
         protected override System.Threading.ReaderWriterLockSlim Lock { get; }
     }
+    [System.Serializable]
     public struct SingleEventSequence : Akka.Persistence.Journal.IEventSequence, System.IEquatable<Akka.Persistence.Journal.IEventSequence>
     {
         public SingleEventSequence(object e) { }
@@ -1195,15 +1220,13 @@ namespace Akka.Persistence.Journal
     {
         public Tagged(object payload, System.Collections.Generic.IEnumerable<string> tags) { }
         public Tagged(object payload, System.Collections.Immutable.IImmutableSet<string> tags) { }
-        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public object Payload { get; }
-        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public System.Collections.Immutable.IImmutableSet<string> Tags { get; }
     }
     public abstract class WriteJournalBase : Akka.Actor.ActorBase
     {
         protected WriteJournalBase() { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentRepresentation> AdaptFromJournal(Akka.Persistence.IPersistentRepresentation representation) { }
         protected Akka.Persistence.IPersistentRepresentation AdaptToJournal(Akka.Persistence.IPersistentRepresentation representation) { }
         protected System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> PreparePersistentBatch(System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentEnvelope> resequenceables) { }
@@ -1270,8 +1293,8 @@ namespace Akka.Persistence.Snapshot
         {
             public NoSnapshotStoreException() { }
             public NoSnapshotStoreException(string message) { }
-            public NoSnapshotStoreException(string message, System.Exception innerException) { }
             protected NoSnapshotStoreException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+            public NoSnapshotStoreException(string message, System.Exception innerException) { }
         }
     }
     public class SnapshotEntry
@@ -1286,11 +1309,11 @@ namespace Akka.Persistence.Snapshot
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {
         protected SnapshotStore() { }
-        public virtual System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckHealthAsync(System.Threading.CancellationToken cancellationToken = null) { }
+        public virtual System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckHealthAsync(System.Threading.CancellationToken cancellationToken = default) { }
         protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken);
         protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
         protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
-        protected virtual bool Receive(object message) { }
+        protected override sealed bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken);
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -1,10 +1,10 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.TCK")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.Tests")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("e3bcba88-003c-4cda-8a60-f0c2553fe3c8")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.TCK")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.Tests")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("e3bcba88-003c-4cda-8a60-f0c2553fe3c8")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Persistence
 {
     public abstract class AtLeastOnceDeliveryActor : Akka.Persistence.PersistentActor
@@ -62,6 +62,7 @@ namespace Akka.Persistence
         public Akka.Persistence.AtLeastOnceDeliverySnapshot GetDeliverySnapshot() { }
         public void OnReplaySuccess() { }
         public void SetDeliverySnapshot(Akka.Persistence.AtLeastOnceDeliverySnapshot snapshot) { }
+        [System.Serializable]
         public sealed class Delivery : System.IEquatable<Akka.Persistence.AtLeastOnceDeliverySemantic.Delivery>
         {
             public Delivery(Akka.Actor.ActorPath destination, object message, System.DateTime timestamp, int attempt) { }
@@ -75,6 +76,7 @@ namespace Akka.Persistence
             public Akka.Persistence.AtLeastOnceDeliverySemantic.Delivery IncrementedCopy() { }
             public override string ToString() { }
         }
+        [System.Serializable]
         public sealed class RedeliveryTick : Akka.Actor.INotInfluenceReceiveTimeout, Akka.Event.IDeadLetterSuppression
         {
             public static Akka.Persistence.AtLeastOnceDeliverySemantic.RedeliveryTick Instance { get; }
@@ -119,6 +121,7 @@ namespace Akka.Persistence
         public System.Threading.CancellationToken CancellationToken { get; }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteMessagesFailure : Akka.Actor.INoSerializationVerificationNeeded, System.IEquatable<Akka.Persistence.DeleteMessagesFailure>
     {
         public DeleteMessagesFailure(System.Exception cause, long toSequenceNr) { }
@@ -129,6 +132,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteMessagesSuccess : System.IEquatable<Akka.Persistence.DeleteMessagesSuccess>
     {
         public DeleteMessagesSuccess(long toSequenceNr) { }
@@ -138,6 +142,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteMessagesTo : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.DeleteMessagesTo>
     {
         public DeleteMessagesTo(string persistenceId, long toSequenceNr, Akka.Actor.IActorRef persistentActor) { }
@@ -149,6 +154,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshot : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotRequest, System.IEquatable<Akka.Persistence.DeleteSnapshot>
     {
         public DeleteSnapshot(Akka.Persistence.SnapshotMetadata metadata) { }
@@ -158,6 +164,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshotFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.DeleteSnapshotFailure>
     {
         public DeleteSnapshotFailure(Akka.Persistence.SnapshotMetadata metadata, System.Exception cause) { }
@@ -168,6 +175,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshotSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.DeleteSnapshotSuccess>
     {
         public DeleteSnapshotSuccess(Akka.Persistence.SnapshotMetadata metadata) { }
@@ -177,6 +185,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshots : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotRequest, System.IEquatable<Akka.Persistence.DeleteSnapshots>
     {
         public DeleteSnapshots(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria) { }
@@ -187,6 +196,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshotsFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.DeleteSnapshotsFailure>
     {
         public DeleteSnapshotsFailure(Akka.Persistence.SnapshotSelectionCriteria criteria, System.Exception cause) { }
@@ -197,6 +207,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class DeleteSnapshotsSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.DeleteSnapshotsSuccess>
     {
         public DeleteSnapshotsSuccess(Akka.Persistence.SnapshotSelectionCriteria criteria) { }
@@ -211,7 +222,6 @@ namespace Akka.Persistence
         public DiscardConfigurator() { }
         public Akka.Persistence.IStashOverflowStrategy Create(Akka.Configuration.Config config) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class DiscardToDeadLetterStrategy : Akka.Persistence.IStashOverflowStrategy
     {
         public static Akka.Persistence.DiscardToDeadLetterStrategy Instance { get; }
@@ -225,12 +235,12 @@ namespace Akka.Persistence
         public bool IsRecovering { get; }
         public bool IsRecoveryFinished { get; }
         public Akka.Actor.IActorRef Journal { get; }
-        public string JournalPluginId { get; set; }
+        public string JournalPluginId { get; protected set; }
         public long LastSequenceNr { get; }
         protected virtual Akka.Event.ILoggingAdapter Log { get; }
         public abstract string PersistenceId { get; }
         public virtual Akka.Persistence.Recovery Recovery { get; }
-        public string SnapshotPluginId { get; set; }
+        public string SnapshotPluginId { get; protected set; }
         public long SnapshotSequenceNr { get; }
         public Akka.Actor.IActorRef SnapshotStore { get; }
         public string SnapshotterId { get; }
@@ -253,15 +263,15 @@ namespace Akka.Persistence
         public void Persist<TEvent>(TEvent @event, System.Action<TEvent> handler) { }
         public void Persist<TEvent>(TEvent @event, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler) { }
+        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Action onComplete) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
-        public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Action onComplete) { }
         public void PersistAll<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler) { }
+        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Action onComplete) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Action<TEvent> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
-        public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Action onComplete) { }
         public void PersistAllAsync<TEvent>(System.Collections.Generic.IEnumerable<TEvent> events, System.Func<TEvent, System.Threading.Tasks.Task> handler, System.Func<System.Threading.Tasks.Task> onCompleteAsync) { }
         public void PersistAsync<TEvent>(TEvent @event, System.Action<TEvent> handler) { }
@@ -339,6 +349,7 @@ namespace Akka.Persistence
         public Akka.Persistence.PersistenceHealthCheckResult Result { get; }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class LoadSnapshot : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotRequest, System.IEquatable<Akka.Persistence.LoadSnapshot>
     {
         public LoadSnapshot(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, long toSequenceNr) { }
@@ -358,6 +369,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class LoadSnapshotResult : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.LoadSnapshotResult>
     {
         public LoadSnapshotResult(Akka.Persistence.SelectedSnapshot snapshot, long toSequenceNr) { }
@@ -368,6 +380,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class LoopMessageSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.LoopMessageSuccess>
     {
         public LoopMessageSuccess(object message, int actorInstanceId) { }
@@ -382,8 +395,8 @@ namespace Akka.Persistence
     {
         public MaxUnconfirmedMessagesExceededException() { }
         public MaxUnconfirmedMessagesExceededException(string message) { }
-        public MaxUnconfirmedMessagesExceededException(string message, System.Exception innerException) { }
         protected MaxUnconfirmedMessagesExceededException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public MaxUnconfirmedMessagesExceededException(string message, System.Exception innerException) { }
     }
     public class Persistence : Akka.Actor.ExtensionIdProvider<Akka.Persistence.PersistenceExtension>
     {
@@ -398,29 +411,21 @@ namespace Akka.Persistence
         public Akka.Persistence.IStashOverflowStrategy DefaultInternalStashOverflowStrategy { get; }
         public Akka.Persistence.PersistenceSettings Settings { get; }
         public Akka.Persistence.Journal.EventAdapters AdaptersFor(string journalPluginId) { }
-        public System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckJournalHealthAsync(string journalPluginId, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckSnapshotStoreHealthAsync(string snapshotStorePluginId, System.Threading.CancellationToken cancellationToken = null) { }
-        [Akka.Annotations.InternalStableApiAttribute()]
+        public System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckJournalHealthAsync(string journalPluginId, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckSnapshotStoreHealthAsync(string snapshotStorePluginId, System.Threading.CancellationToken cancellationToken = default) { }
+        [Akka.Annotations.InternalStableApi]
         public Akka.Actor.IActorRef JournalFor(string journalPluginId) { }
         public string PersistenceId(Akka.Actor.IActorRef actor) { }
-        [Akka.Annotations.InternalStableApiAttribute()]
+        [Akka.Annotations.InternalStableApi]
         public Akka.Actor.IActorRef SnapshotStoreFor(string snapshotPluginId) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public struct PersistenceHealthCheckResult : System.IEquatable<Akka.Persistence.PersistenceHealthCheckResult>
+    public readonly struct PersistenceHealthCheckResult : System.IEquatable<Akka.Persistence.PersistenceHealthCheckResult>
     {
-        public PersistenceHealthCheckResult(Akka.Persistence.PersistenceHealthStatus Status, string Description = null, System.Exception Exception = null, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                0,
-                0})] System.Collections.Generic.IReadOnlyDictionary<string, object> Data = null) { }
-        [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                0,
-                0})]
-        public System.Collections.Generic.IReadOnlyDictionary<string, object> Data { get; set; }
-        public string Description { get; set; }
-        public System.Exception Exception { get; set; }
-        public Akka.Persistence.PersistenceHealthStatus Status { get; set; }
+        public PersistenceHealthCheckResult(Akka.Persistence.PersistenceHealthStatus Status, string? Description = null, System.Exception? Exception = null, System.Collections.Generic.IReadOnlyDictionary<string, object>? Data = null) { }
+        public System.Collections.Generic.IReadOnlyDictionary<string, object>? Data { get; init; }
+        public string? Description { get; init; }
+        public System.Exception? Exception { get; init; }
+        public Akka.Persistence.PersistenceHealthStatus Status { get; init; }
     }
     public enum PersistenceHealthStatus
     {
@@ -436,8 +441,8 @@ namespace Akka.Persistence
         public Akka.Persistence.PersistenceSettings.ViewSettings View { get; }
         public sealed class AtLeastOnceDeliverySettings
         {
-            public AtLeastOnceDeliverySettings(System.TimeSpan redeliverInterval, int redeliveryBurstLimit, int warnAfterNumberOfUnconfirmedAttempts, int maxUnconfirmedMessages) { }
             public AtLeastOnceDeliverySettings(Akka.Configuration.Config config) { }
+            public AtLeastOnceDeliverySettings(System.TimeSpan redeliverInterval, int redeliveryBurstLimit, int warnAfterNumberOfUnconfirmedAttempts, int maxUnconfirmedMessages) { }
             public int MaxUnconfirmedMessages { get; }
             public System.TimeSpan RedeliverInterval { get; }
             public int RedeliveryBurstLimit { get; }
@@ -461,10 +466,11 @@ namespace Akka.Persistence
             public long AutoUpdateReplayMax { get; }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
+    [System.Serializable]
     public class Persistent : Akka.Persistence.IPersistentRepresentation, Akka.Persistence.Serialization.IMessage, System.IEquatable<Akka.Persistence.IPersistentRepresentation>
     {
-        public Persistent(object payload, long sequenceNr = 0, string persistenceId = null, string manifest = null, bool isDeleted = False, Akka.Actor.IActorRef sender = null, string writerGuid = null, long timestamp = 0) { }
+        public Persistent(object payload, long sequenceNr = 0, string persistenceId = null, string manifest = null, bool isDeleted = false, Akka.Actor.IActorRef sender = null, string writerGuid = null, long timestamp = 0) { }
         public bool IsDeleted { get; }
         public string Manifest { get; }
         public object Payload { get; }
@@ -472,11 +478,11 @@ namespace Akka.Persistence
         public Akka.Actor.IActorRef Sender { get; }
         public long SequenceNr { get; }
         public long Timestamp { get; }
-        public static string Undefined { get; }
         public string WriterGuid { get; }
+        public static string Undefined { get; }
         public bool Equals(Akka.Persistence.IPersistentRepresentation other) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Persistence.Persistent other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
         public Akka.Persistence.IPersistentRepresentation Update(long sequenceNr, string persistenceId, bool isDeleted, Akka.Actor.IActorRef sender, string writerGuid) { }
@@ -489,67 +495,55 @@ namespace Akka.Persistence
         protected PersistentActor() { }
         protected override bool Receive(object message) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class ReceivePersistentActor : Akka.Persistence.UntypedPersistentActor, Akka.Actor.Internal.IInitializableActor
     {
         protected ReceivePersistentActor() { }
         protected void Become(System.Action configure) { }
         protected void BecomeStacked(System.Action configure) { }
-        protected void Command<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Action<T> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<T> shouldHandle = null) { }
-        protected void Command<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
-        protected void Command(System.Type messageType, System.Action<object> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<object> shouldHandle = null) { }
-        protected void Command(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
-        protected void Command<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T, bool> handler) { }
-        protected void Command(System.Type messageType, System.Func<object, bool> handler) { }
         protected void Command(System.Action<object> handler) { }
+        protected void Command(System.Type messageType, System.Func<object, bool> handler) { }
+        protected void Command(System.Type messageType, System.Action<object> handler, System.Predicate<object>? shouldHandle = null) { }
+        protected void Command(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
+        protected void Command<T>(System.Func<T, bool> handler) { }
+        protected void Command<T>(System.Action<T> handler, System.Predicate<T>? shouldHandle = null) { }
+        protected void Command<T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
         protected void CommandAny(System.Action<object> handler) { }
         protected void CommandAnyAsync(System.Func<object, System.Threading.Tasks.Task> handler) { }
-        protected void CommandAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T, System.Threading.Tasks.Task> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<T> shouldHandle = null) { }
-        protected void CommandAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Predicate<T> shouldHandle, System.Func<T, System.Threading.Tasks.Task> handler) { }
-        protected void CommandAsync(System.Type messageType, System.Func<object, System.Threading.Tasks.Task> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<object> shouldHandle = null) { }
+        protected void CommandAsync(System.Type messageType, System.Func<object, System.Threading.Tasks.Task> handler, System.Predicate<object>? shouldHandle = null) { }
         protected void CommandAsync(System.Type messageType, System.Predicate<object> shouldHandle, System.Func<object, System.Threading.Tasks.Task> handler) { }
-        protected virtual void OnCommand(object message) { }
-        protected virtual void OnRecover(object message) { }
-        protected void Recover<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Action<T> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<T> shouldHandle = null) { }
-        protected void Recover<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
-        protected void Recover(System.Type messageType, System.Action<object> handler, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<object> shouldHandle = null) { }
-        protected void Recover(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
-        protected void Recover<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T, bool> handler) { }
+        protected void CommandAsync<T>(System.Func<T, System.Threading.Tasks.Task> handler, System.Predicate<T>? shouldHandle = null) { }
+        protected void CommandAsync<T>(System.Predicate<T> shouldHandle, System.Func<T, System.Threading.Tasks.Task> handler) { }
+        protected override sealed void OnCommand(object message) { }
+        protected override sealed void OnRecover(object message) { }
         protected void Recover(System.Type messageType, System.Func<object, bool> handler) { }
+        protected void Recover(System.Type messageType, System.Action<object> handler, System.Predicate<object>? shouldHandle = null) { }
+        protected void Recover(System.Type messageType, System.Predicate<object> shouldHandle, System.Action<object> handler) { }
+        protected void Recover<T>(System.Func<T, bool> handler) { }
+        protected void Recover<T>(System.Action<T> handler, System.Predicate<T>? shouldHandle = null) { }
+        protected void Recover<T>(System.Predicate<T> shouldHandle, System.Action<T> handler) { }
         protected void RecoverAny(System.Action<object> handler) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [System.Serializable]
     public sealed class Recovery
     {
         public Recovery() { }
         public Recovery(Akka.Persistence.SnapshotSelectionCriteria fromSnapshot) { }
         public Recovery(Akka.Persistence.SnapshotSelectionCriteria fromSnapshot, long toSequenceNr) { }
-        public Recovery(Akka.Persistence.SnapshotSelectionCriteria fromSnapshot = null, long toSequenceNr = 9223372036854775807, long replayMax = 9223372036854775807) { }
-        public static Akka.Persistence.Recovery Default { get; }
+        public Recovery(Akka.Persistence.SnapshotSelectionCriteria? fromSnapshot = null, long toSequenceNr = 9223372036854775807, long replayMax = 9223372036854775807) { }
         public Akka.Persistence.SnapshotSelectionCriteria FromSnapshot { get; }
-        public static Akka.Persistence.Recovery None { get; }
         public long ReplayMax { get; }
         public long ToSequenceNr { get; }
+        public static Akka.Persistence.Recovery Default { get; }
+        public static Akka.Persistence.Recovery None { get; }
     }
+    [System.Serializable]
     public sealed class RecoveryCompleted
     {
-        [System.Runtime.CompilerServices.NullableAttribute(1)]
         public static readonly Akka.Persistence.RecoveryCompleted Instance;
-        public override bool Equals(object obj) { }
+        public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
     }
+    [System.Serializable]
     public sealed class RecoverySuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.RecoverySuccess>
     {
         public RecoverySuccess(long highestSequenceNr) { }
@@ -564,13 +558,13 @@ namespace Akka.Persistence
         public RecoveryTick(bool snapshot) { }
         public bool Snapshot { get; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class RecoveryTimedOutException : Akka.Actor.AkkaException
     {
         public RecoveryTimedOutException() { }
-        public RecoveryTimedOutException(string message, [System.Runtime.CompilerServices.NullableAttribute(2)] System.Exception cause = null) { }
         public RecoveryTimedOutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public RecoveryTimedOutException(string message, System.Exception? cause = null) { }
     }
+    [System.Serializable]
     public sealed class ReplayMessages : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.ReplayMessages>
     {
         public ReplayMessages(long fromSequenceNr, long toSequenceNr, long max, string persistenceId, Akka.Actor.IActorRef persistentActor) { }
@@ -584,6 +578,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class ReplayMessagesFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.ReplayMessagesFailure>
     {
         public ReplayMessagesFailure(System.Exception cause) { }
@@ -593,6 +588,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class ReplayedMessage : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.ReplayedMessage>
     {
         public ReplayedMessage(Akka.Persistence.IPersistentRepresentation persistent) { }
@@ -602,12 +598,12 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class ReplyToStrategy : Akka.Persistence.IStashOverflowStrategy
     {
         public ReplyToStrategy(object response) { }
         public object Response { get; }
     }
+    [System.Serializable]
     public sealed class SaveSnapshot : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotRequest, System.IEquatable<Akka.Persistence.SaveSnapshot>
     {
         public SaveSnapshot(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
@@ -618,6 +614,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SaveSnapshotFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.SaveSnapshotFailure>
     {
         public SaveSnapshotFailure(Akka.Persistence.SnapshotMetadata metadata, System.Exception cause) { }
@@ -628,6 +625,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SaveSnapshotSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IPersistenceMessage, Akka.Persistence.ISnapshotMessage, Akka.Persistence.ISnapshotResponse, System.IEquatable<Akka.Persistence.SaveSnapshotSuccess>
     {
         public SaveSnapshotSuccess(Akka.Persistence.SnapshotMetadata metadata) { }
@@ -637,6 +635,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SelectedSnapshot : System.IEquatable<Akka.Persistence.SelectedSnapshot>
     {
         public SelectedSnapshot(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
@@ -647,22 +646,24 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SnapshotMetadata : System.IEquatable<Akka.Persistence.SnapshotMetadata>
     {
-        [System.ObsoleteAttribute("This constructor is deprecated and will be removed in v1.6. Use the constructor w" +
+        [System.Obsolete("This constructor is deprecated and will be removed in v1.6. Use the constructor w" +
             "ith the timestamp parameter instead. Since v1.5.28", true)]
         public SnapshotMetadata(string persistenceId, long sequenceNr) { }
-        [Newtonsoft.Json.JsonConstructorAttribute()]
+        [Newtonsoft.Json.JsonConstructor]
         public SnapshotMetadata(string persistenceId, long sequenceNr, System.DateTime timestamp) { }
-        public static System.Collections.Generic.IComparer<Akka.Persistence.SnapshotMetadata> Comparer { get; }
         public string PersistenceId { get; }
         public long SequenceNr { get; }
         public System.DateTime Timestamp { get; }
-        public override bool Equals(object obj) { }
+        public static System.Collections.Generic.IComparer<Akka.Persistence.SnapshotMetadata> Comparer { get; }
         public bool Equals(Akka.Persistence.SnapshotMetadata other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SnapshotOffer : System.IEquatable<Akka.Persistence.SnapshotOffer>
     {
         public SnapshotOffer(Akka.Persistence.SnapshotMetadata metadata, object snapshot) { }
@@ -673,16 +674,17 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class SnapshotSelectionCriteria : System.IEquatable<Akka.Persistence.SnapshotSelectionCriteria>
     {
-        [Newtonsoft.Json.JsonConstructorAttribute()]
-        public SnapshotSelectionCriteria(long maxSequenceNr, System.DateTime maxTimeStamp, long minSequenceNr = 0, System.Nullable<System.DateTime> minTimestamp = null) { }
         public SnapshotSelectionCriteria(long maxSequenceNr) { }
-        public static Akka.Persistence.SnapshotSelectionCriteria Latest { get; }
+        [Newtonsoft.Json.JsonConstructor]
+        public SnapshotSelectionCriteria(long maxSequenceNr, System.DateTime maxTimeStamp, long minSequenceNr = 0, System.DateTime? minTimestamp = default) { }
         public long MaxSequenceNr { get; }
         public System.DateTime MaxTimeStamp { get; }
         public long MinSequenceNr { get; }
-        public System.Nullable<System.DateTime> MinTimestamp { get; }
+        public System.DateTime? MinTimestamp { get; }
+        public static Akka.Persistence.SnapshotSelectionCriteria Latest { get; }
         public static Akka.Persistence.SnapshotSelectionCriteria None { get; }
         public bool Equals(Akka.Persistence.SnapshotSelectionCriteria other) { }
         public override bool Equals(object obj) { }
@@ -700,11 +702,11 @@ namespace Akka.Persistence
         public ThrowExceptionConfigurator() { }
         public Akka.Persistence.IStashOverflowStrategy Create(Akka.Configuration.Config config) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ThrowOverflowExceptionStrategy : Akka.Persistence.IStashOverflowStrategy
     {
         public static Akka.Persistence.ThrowOverflowExceptionStrategy Instance { get; }
     }
+    [System.Serializable]
     public sealed class UnconfirmedDelivery : System.IEquatable<Akka.Persistence.UnconfirmedDelivery>
     {
         public UnconfirmedDelivery(long deliveryId, Akka.Actor.ActorPath destination, object message) { }
@@ -716,6 +718,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class UnconfirmedWarning : System.IEquatable<Akka.Persistence.UnconfirmedWarning>
     {
         public UnconfirmedWarning(Akka.Persistence.UnconfirmedDelivery[] unconfirmedDeliveries) { }
@@ -725,7 +728,6 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class UntypedPersistentActor : Akka.Persistence.Eventsourced
     {
         protected UntypedPersistentActor() { }
@@ -735,9 +737,10 @@ namespace Akka.Persistence
         protected abstract void OnCommand(object message);
         protected abstract void OnRecover(object message);
         protected override bool Receive(object message) { }
-        protected virtual bool ReceiveCommand(object message) { }
-        protected virtual bool ReceiveRecover(object message) { }
+        protected override sealed bool ReceiveCommand(object message) { }
+        protected override sealed bool ReceiveRecover(object message) { }
     }
+    [System.Serializable]
     public sealed class WriteMessageFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.WriteMessageFailure>
     {
         public WriteMessageFailure(Akka.Persistence.IPersistentRepresentation persistent, System.Exception cause, int actorInstanceId) { }
@@ -749,6 +752,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class WriteMessageRejected : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.WriteMessageRejected>
     {
         public WriteMessageRejected(Akka.Persistence.IPersistentRepresentation persistent, System.Exception cause, int actorInstanceId) { }
@@ -760,6 +764,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class WriteMessageSuccess : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.WriteMessageSuccess>
     {
         public WriteMessageSuccess(Akka.Persistence.IPersistentRepresentation persistent, int actorInstanceId) { }
@@ -770,6 +775,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class WriteMessages : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.WriteMessages>
     {
         public WriteMessages(System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentEnvelope> messages, Akka.Actor.IActorRef persistentActor, int actorInstanceId) { }
@@ -781,6 +787,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class WriteMessagesFailed : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage, System.IEquatable<Akka.Persistence.WriteMessagesFailed>
     {
         public WriteMessagesFailed(System.Exception cause, int writeCount) { }
@@ -791,6 +798,7 @@ namespace Akka.Persistence
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    [System.Serializable]
     public sealed class WriteMessagesSuccessful : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalResponse, Akka.Persistence.IPersistenceMessage
     {
         public static Akka.Persistence.WriteMessagesSuccessful Instance { get; }
@@ -798,21 +806,19 @@ namespace Akka.Persistence
 }
 namespace Akka.Persistence.Delivery
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static EventSourcedProducerQueue
+    public static class EventSourcedProducerQueue
     {
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(string persistentId, Akka.Persistence.Delivery.EventSourcedProducerQueue.Settings settings) { }
-        public static Akka.Actor.Props Create<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(string persistentId, Akka.Actor.IActorRefFactory system) { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
+        public static Akka.Actor.Props Create<T>(string persistentId, Akka.Actor.IActorRefFactory system) { }
+        public static Akka.Actor.Props Create<T>(string persistentId, Akka.Persistence.Delivery.EventSourcedProducerQueue.Settings settings) { }
         public class Settings : System.IEquatable<Akka.Persistence.Delivery.EventSourcedProducerQueue.Settings>
         {
-            public System.TimeSpan CleanupUnusedAfter { get; set; }
-            public bool DeleteEvents { get; set; }
-            public string JournalPluginId { get; set; }
-            public int KeepNSnapshots { get; set; }
-            public System.TimeSpan RestartMaxBackoff { get; set; }
-            public int SnapshotEvery { get; set; }
-            public string SnapshotPluginId { get; set; }
+            public System.TimeSpan CleanupUnusedAfter { get; init; }
+            public bool DeleteEvents { get; init; }
+            public string JournalPluginId { get; init; }
+            public int KeepNSnapshots { get; init; }
+            public System.TimeSpan RestartMaxBackoff { get; init; }
+            public int SnapshotEvery { get; init; }
+            public string SnapshotPluginId { get; init; }
             public static Akka.Persistence.Delivery.EventSourcedProducerQueue.Settings Create(Akka.Actor.ActorSystem sys) { }
             public static Akka.Persistence.Delivery.EventSourcedProducerQueue.Settings Create(Akka.Configuration.Config config) { }
         }
@@ -820,7 +826,7 @@ namespace Akka.Persistence.Delivery
 }
 namespace Akka.Persistence.Fsm
 {
-    public class static PersistentFSM
+    public static class PersistentFSM
     {
         public interface IFsmState
         {
@@ -828,38 +834,38 @@ namespace Akka.Persistence.Fsm
         }
         public class PersistentFSMSnapshot<TD> : Akka.Persistence.Serialization.IMessage
         {
-            public PersistentFSMSnapshot(string stateIdentifier, TD data, System.Nullable<System.TimeSpan> timeout) { }
+            public PersistentFSMSnapshot(string stateIdentifier, TD data, System.TimeSpan? timeout) { }
             public TD Data { get; }
             public string StateIdentifier { get; }
-            public System.Nullable<System.TimeSpan> Timeout { get; }
+            public System.TimeSpan? Timeout { get; }
             protected bool Equals(Akka.Persistence.Fsm.PersistentFSM.PersistentFSMSnapshot<TD> other) { }
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }
         }
-        public class StateChangeEvent : Akka.Persistence.Serialization.IMessage
-        {
-            public StateChangeEvent(string stateIdentifier, System.Nullable<System.TimeSpan> timeout) { }
-            public string StateIdentifier { get; }
-            public System.Nullable<System.TimeSpan> Timeout { get; }
-        }
         public class State<TS, TD, TE>
         {
-            public State(TS stateName, TD stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, System.Collections.Generic.IReadOnlyList<TE> domainEvents = null, System.Action<TD> afterTransitionDo = null, bool notifies = True) { }
+            public State(TS stateName, TD stateData, System.TimeSpan? timeout = default, Akka.Actor.FSMBase.Reason stopReason = null, System.Collections.Generic.IReadOnlyList<object> replies = null, System.Collections.Generic.IReadOnlyList<TE> domainEvents = null, System.Action<TD> afterTransitionDo = null, bool notifies = true) { }
             public System.Action<TD> AfterTransitionDo { get; }
             public System.Collections.Generic.IReadOnlyList<TE> DomainEvents { get; }
-            public System.Collections.Generic.IReadOnlyList<object> Replies { get; set; }
+            public System.Collections.Generic.IReadOnlyList<object> Replies { get; protected set; }
             public TD StateData { get; }
             public TS StateName { get; }
             public Akka.Actor.FSMBase.Reason StopReason { get; }
-            public System.Nullable<System.TimeSpan> Timeout { get; }
+            public System.TimeSpan? Timeout { get; }
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> AndThen(System.Action<TD> handler) { }
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> Applying(params TE[] events) { }
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> ForMax(System.TimeSpan timeout) { }
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> Replying(object replyValue) { }
             public override string ToString() { }
-            [System.ObsoleteAttribute("Internal API easily to be confused with regular FSM\'s using. Use regular events (" +
+            [System.Obsolete("Internal API easily to be confused with regular FSM\'s using. Use regular events (" +
                 "`Applying`). Internally, `copy` can be used instead.")]
             public Akka.Persistence.Fsm.PersistentFSM.State<TS, TD, TE> Using(TD nextStateData) { }
+        }
+        public class StateChangeEvent : Akka.Persistence.Serialization.IMessage
+        {
+            public StateChangeEvent(string stateIdentifier, System.TimeSpan? timeout) { }
+            public string StateIdentifier { get; }
+            public System.TimeSpan? Timeout { get; }
         }
     }
     public abstract class PersistentFSMBase<TState, TData, TEvent> : Akka.Persistence.PersistentActor, Akka.Routing.IListeners
@@ -879,23 +885,23 @@ namespace Akka.Persistence.Fsm
         public void OnTransition(Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.TransitionHandler transitionHandler) { }
         protected override void PostStop() { }
         protected override bool ReceiveCommand(object message) { }
-        public void SetStateTimeout(TState state, System.Nullable<System.TimeSpan> timeout) { }
-        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = False) { }
-        public void StartWith(TState stateName, TData stateData, System.Nullable<System.TimeSpan> timeout = null) { }
+        public void SetStateTimeout(TState state, System.TimeSpan? timeout) { }
+        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = false) { }
+        public void StartWith(TState stateName, TData stateData, System.TimeSpan? timeout = default) { }
         public Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> Stay() { }
         public Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> Stop() { }
         public Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> Stop(Akka.Actor.FSMBase.Reason reason) { }
         public Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> Stop(Akka.Actor.FSMBase.Reason reason, TData stateData) { }
         public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.TransformHelper Transform(Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction func) { }
-        public void When(TState stateName, Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction func, System.Nullable<System.TimeSpan> timeout = null) { }
+        public void When(TState stateName, Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction func, System.TimeSpan? timeout = default) { }
         public void WhenUnhandled(Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction stateFunction) { }
-        public delegate Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> StateFunction<TState, TData, TEvent>(Akka.Actor.FSMBase.Event<TData> fsmEvent, Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> state = null);
-        public sealed class TransformHelper<TState, TData, TEvent>
+        public sealed class TransformHelper
         {
             public TransformHelper(Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction func) { }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction Func { get; }
             public Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>.StateFunction Using(System.Func<Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent>, Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent>> andThen) { }
         }
+        public delegate Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> StateFunction<TState, TData, TEvent>(Akka.Actor.FSMBase.Event<TData> fsmEvent, Akka.Persistence.Fsm.PersistentFSM.State<TState, TData, TEvent> state = null);
         public delegate void TransitionHandler<TState, TData, TEvent>(TState initialState, TState nextState);
     }
     public abstract class PersistentFSM<TState, TData, TEvent> : Akka.Persistence.Fsm.PersistentFSMBase<TState, TData, TEvent>
@@ -911,6 +917,7 @@ namespace Akka.Persistence.Fsm
 }
 namespace Akka.Persistence.Journal
 {
+    [System.Serializable]
     public class AsyncReplayTimeoutException : Akka.Actor.AkkaException
     {
         public AsyncReplayTimeoutException() { }
@@ -921,15 +928,15 @@ namespace Akka.Persistence.Journal
     {
         protected readonly bool CanPublish;
         protected AsyncWriteJournal() { }
-        public virtual System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckHealthAsync(System.Threading.CancellationToken cancellationToken = null) { }
+        public virtual System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckHealthAsync(System.Threading.CancellationToken cancellationToken = default) { }
         protected abstract System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken);
         public abstract System.Threading.Tasks.Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, System.Threading.CancellationToken cancellationToken);
-        protected virtual bool Receive(object message) { }
+        protected override sealed bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected bool ReceiveWriteJournal(object message) { }
         public abstract System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback);
-        protected static System.Exception TryUnwrapException(System.Exception e) { }
         protected abstract System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken);
+        protected static System.Exception TryUnwrapException(System.Exception e) { }
     }
     public abstract class AsyncWriteProxy : Akka.Persistence.Journal.AsyncWriteJournal, Akka.Actor.IActorStash, Akka.Actor.IWithTimers, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>
     {
@@ -948,8 +955,9 @@ namespace Akka.Persistence.Journal
             public static Akka.Persistence.Journal.AsyncWriteProxy.InitTimeout Instance { get; }
         }
     }
-    public class static AsyncWriteTarget
+    public static class AsyncWriteTarget
     {
+        [System.Serializable]
         public sealed class DeleteMessagesTo : System.IEquatable<Akka.Persistence.Journal.AsyncWriteTarget.DeleteMessagesTo>
         {
             public DeleteMessagesTo(string persistenceId, long toSequenceNr) { }
@@ -957,11 +965,13 @@ namespace Akka.Persistence.Journal
             public long ToSequenceNr { get; }
             public bool Equals(Akka.Persistence.Journal.AsyncWriteTarget.DeleteMessagesTo other) { }
         }
+        [System.Serializable]
         public sealed class ReplayFailure
         {
             public ReplayFailure(System.Exception cause) { }
             public System.Exception Cause { get; }
         }
+        [System.Serializable]
         public sealed class ReplayMessages : System.IEquatable<Akka.Persistence.Journal.AsyncWriteTarget.ReplayMessages>
         {
             public ReplayMessages(string persistenceId, long fromSequenceNr, long toSequenceNr, long max) { }
@@ -971,18 +981,21 @@ namespace Akka.Persistence.Journal
             public long ToSequenceNr { get; }
             public bool Equals(Akka.Persistence.Journal.AsyncWriteTarget.ReplayMessages other) { }
         }
+        [System.Serializable]
         public sealed class ReplaySuccess : System.IEquatable<Akka.Persistence.Journal.AsyncWriteTarget.ReplaySuccess>
         {
             public ReplaySuccess(long highestSequenceNr) { }
             public long HighestSequenceNr { get; }
             public bool Equals(Akka.Persistence.Journal.AsyncWriteTarget.ReplaySuccess other) { }
         }
+        [System.Serializable]
         public sealed class WriteMessages
         {
             public WriteMessages(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages) { }
             public Akka.Persistence.AtomicWrite[] Messages { get; }
         }
     }
+    [System.Serializable]
     public sealed class CombinedReadEventAdapter : Akka.Persistence.Journal.IEventAdapter, Akka.Persistence.Journal.IReadEventAdapter, Akka.Persistence.Journal.IWriteEventAdapter
     {
         public CombinedReadEventAdapter(System.Collections.Generic.IEnumerable<Akka.Persistence.Journal.IEventAdapter> adapters) { }
@@ -991,6 +1004,7 @@ namespace Akka.Persistence.Journal
         public string Manifest(object evt) { }
         public object ToJournal(object evt) { }
     }
+    [System.Serializable]
     public sealed class EmptyEventSequence : Akka.Persistence.Journal.IEmptyEventSequence, Akka.Persistence.Journal.IEventSequence, System.IEquatable<Akka.Persistence.Journal.IEventSequence>
     {
         public static readonly Akka.Persistence.Journal.EmptyEventSequence Instance;
@@ -1002,17 +1016,18 @@ namespace Akka.Persistence.Journal
     public class EventAdapters
     {
         protected EventAdapters(System.Collections.Concurrent.ConcurrentDictionary<System.Type, Akka.Persistence.Journal.IEventAdapter> map, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<System.Type, Akka.Persistence.Journal.IEventAdapter>> bindings, Akka.Event.ILoggingAdapter log) { }
-        public static Akka.Persistence.Journal.EventAdapters Create(Akka.Actor.ExtendedActorSystem system, Akka.Configuration.Config config) { }
-        public Akka.Persistence.Journal.IEventAdapter Get<T>() { }
         public virtual Akka.Persistence.Journal.IEventAdapter Get(System.Type type) { }
+        public Akka.Persistence.Journal.IEventAdapter Get<T>() { }
+        public static Akka.Persistence.Journal.EventAdapters Create(Akka.Actor.ExtendedActorSystem system, Akka.Configuration.Config config) { }
     }
-    public class static EventSequence
+    public static class EventSequence
     {
         public static Akka.Persistence.Journal.IEventSequence Empty;
-        public static Akka.Persistence.Journal.IEventSequence Create(params object[] events) { }
         public static Akka.Persistence.Journal.IEventSequence Create(System.Collections.Generic.IEnumerable<object> events) { }
+        public static Akka.Persistence.Journal.IEventSequence Create(params object[] events) { }
         public static Akka.Persistence.Journal.IEventSequence Single(object e) { }
     }
+    [System.Serializable]
     public class EventSequence<T> : Akka.Persistence.Journal.IEventSequence, System.IEquatable<Akka.Persistence.Journal.IEventSequence>
     {
         public EventSequence(System.Collections.Generic.IEnumerable<object> events) { }
@@ -1041,6 +1056,7 @@ namespace Akka.Persistence.Journal
         string Manifest(object evt);
         object ToJournal(object evt);
     }
+    [System.Serializable]
     public sealed class IdentityEventAdapter : Akka.Persistence.Journal.IEventAdapter, Akka.Persistence.Journal.IReadEventAdapter, Akka.Persistence.Journal.IWriteEventAdapter
     {
         public static Akka.Persistence.Journal.IdentityEventAdapter Instance { get; }
@@ -1064,6 +1080,7 @@ namespace Akka.Persistence.Journal
         protected override bool ReceivePluginInternal(object message) { }
         public override System.Threading.Tasks.Task ReplayMessagesAsync(Akka.Actor.IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max, System.Action<Akka.Persistence.IPersistentRepresentation> recoveryCallback) { }
         protected override System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<System.Exception>> WriteMessagesAsync(System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> messages, System.Threading.CancellationToken cancellationToken) { }
+        [System.Serializable]
         public sealed class CurrentPersistenceIds : Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Collections.Generic.IEnumerable<string> AllPersistenceIds;
@@ -1079,6 +1096,7 @@ namespace Akka.Persistence.Journal
             public override int GetHashCode() { }
             public override string ToString() { }
         }
+        [System.Serializable]
         public sealed class EventReplaySuccess
         {
             public EventReplaySuccess(int highestSequenceNr) { }
@@ -1088,6 +1106,7 @@ namespace Akka.Persistence.Journal
             public override int GetHashCode() { }
             public override string ToString() { }
         }
+        [System.Serializable]
         public sealed class ReplayAllEvents : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
         {
             public readonly int FromOffset;
@@ -1096,6 +1115,7 @@ namespace Akka.Persistence.Journal
             public readonly int ToOffset;
             public ReplayAllEvents(int fromOffset, int toOffset, long max, Akka.Actor.IActorRef replyTo) { }
         }
+        [System.Serializable]
         public sealed class ReplayTaggedMessages : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
         {
             public readonly int FromOffset;
@@ -1105,25 +1125,29 @@ namespace Akka.Persistence.Journal
             public readonly int ToOffset;
             public ReplayTaggedMessages(int fromOffset, int toOffset, int max, string tag, Akka.Actor.IActorRef replyTo) { }
         }
+        [System.Serializable]
         public sealed class ReplayTaggedMessagesSuccess
         {
             public ReplayTaggedMessagesSuccess(int highestSequenceNr) { }
             public int HighestSequenceNr { get; }
         }
+        [System.Serializable]
         public sealed class ReplayedEvent : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Offset;
             public readonly Akka.Persistence.IPersistentRepresentation Persistent;
             public ReplayedEvent(Akka.Persistence.IPersistentRepresentation persistent, int offset) { }
         }
+        [System.Serializable]
         public sealed class ReplayedTaggedMessage : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Offset;
             public readonly Akka.Persistence.IPersistentRepresentation Persistent;
-            [System.ObsoleteAttribute("If there are tags, they will be stored in the PersistentRepresentation")]
+            [System.Obsolete("If there are tags, they will be stored in the PersistentRepresentation")]
             public readonly string Tag;
             public ReplayedTaggedMessage(Akka.Persistence.IPersistentRepresentation persistent, string tag, int offset) { }
         }
+        [System.Serializable]
         public sealed class SelectCurrentPersistenceIds : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
         {
             public SelectCurrentPersistenceIds(int offset, Akka.Actor.IActorRef replyTo) { }
@@ -1159,8 +1183,8 @@ namespace Akka.Persistence.Journal
         public Akka.Persistence.Journal.ReplayFilterMode Mode { get; }
         public Akka.Actor.IActorRef PersistentActor { get; }
         public int WindowSize { get; }
-        public static Akka.Actor.Props Props(Akka.Actor.IActorRef persistentActor, Akka.Persistence.Journal.ReplayFilterMode mode, int windowSize, int maxOldWriters, bool debugEnabled) { }
         protected override bool Receive(object message) { }
+        public static Akka.Actor.Props Props(Akka.Actor.IActorRef persistentActor, Akka.Persistence.Journal.ReplayFilterMode mode, int windowSize, int maxOldWriters, bool debugEnabled) { }
     }
     public enum ReplayFilterMode
     {
@@ -1169,6 +1193,7 @@ namespace Akka.Persistence.Journal
         RepairByDiscardOld = 2,
         Disabled = 3,
     }
+    [System.Serializable]
     public sealed class SetStore
     {
         public readonly Akka.Actor.IActorRef Store;
@@ -1182,6 +1207,7 @@ namespace Akka.Persistence.Journal
         protected override System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId { get; }
         protected override System.Threading.ReaderWriterLockSlim Lock { get; }
     }
+    [System.Serializable]
     public struct SingleEventSequence : Akka.Persistence.Journal.IEventSequence, System.IEquatable<Akka.Persistence.Journal.IEventSequence>
     {
         public SingleEventSequence(object e) { }
@@ -1200,7 +1226,7 @@ namespace Akka.Persistence.Journal
     public abstract class WriteJournalBase : Akka.Actor.ActorBase
     {
         protected WriteJournalBase() { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentRepresentation> AdaptFromJournal(Akka.Persistence.IPersistentRepresentation representation) { }
         protected Akka.Persistence.IPersistentRepresentation AdaptToJournal(Akka.Persistence.IPersistentRepresentation representation) { }
         protected System.Collections.Generic.IEnumerable<Akka.Persistence.AtomicWrite> PreparePersistentBatch(System.Collections.Generic.IEnumerable<Akka.Persistence.IPersistentEnvelope> resequenceables) { }
@@ -1267,8 +1293,8 @@ namespace Akka.Persistence.Snapshot
         {
             public NoSnapshotStoreException() { }
             public NoSnapshotStoreException(string message) { }
-            public NoSnapshotStoreException(string message, System.Exception innerException) { }
             protected NoSnapshotStoreException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+            public NoSnapshotStoreException(string message, System.Exception innerException) { }
         }
     }
     public class SnapshotEntry
@@ -1283,11 +1309,11 @@ namespace Akka.Persistence.Snapshot
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {
         protected SnapshotStore() { }
-        public virtual System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckHealthAsync(System.Threading.CancellationToken cancellationToken = null) { }
+        public virtual System.Threading.Tasks.Task<Akka.Persistence.PersistenceHealthCheckResult> CheckHealthAsync(System.Threading.CancellationToken cancellationToken = default) { }
         protected abstract System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken);
         protected abstract System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
         protected abstract System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken);
-        protected virtual bool Receive(object message) { }
+        protected override sealed bool Receive(object message) { }
         protected virtual bool ReceivePluginInternal(object message) { }
         protected abstract System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken);
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceInMemoryQuery.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceInMemoryQuery.DotNet.verified.txt
@@ -1,5 +1,5 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Persistence.Query.InMemory
 {
     public class InMemoryReadJournal : Akka.Persistence.Query.IAllEventsQuery, Akka.Persistence.Query.ICurrentAllEventsQuery, Akka.Persistence.Query.ICurrentEventsByPersistenceIdQuery, Akka.Persistence.Query.ICurrentEventsByTagQuery, Akka.Persistence.Query.ICurrentPersistenceIdsQuery, Akka.Persistence.Query.IEventsByPersistenceIdQuery, Akka.Persistence.Query.IEventsByTagQuery, Akka.Persistence.Query.IPersistenceIdsQuery, Akka.Persistence.Query.IReadJournal
@@ -11,10 +11,10 @@ namespace Akka.Persistence.Query.InMemory
         public Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> CurrentEventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr) { }
         public Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> CurrentEventsByTag(string tag, Akka.Persistence.Query.Offset offset) { }
         public Akka.Streams.Dsl.Source<string, Akka.NotUsed> CurrentPersistenceIds() { }
-        public static Akka.Configuration.Config DefaultConfiguration() { }
         public Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> EventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr) { }
         public Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> EventsByTag(string tag, Akka.Persistence.Query.Offset offset) { }
         public Akka.Streams.Dsl.Source<string, Akka.NotUsed> PersistenceIds() { }
+        public static Akka.Configuration.Config DefaultConfiguration() { }
     }
     public class InMemoryReadJournalProvider : Akka.Persistence.Query.IReadJournalProvider
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceInMemoryQuery.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceInMemoryQuery.Net.verified.txt
@@ -1,5 +1,5 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Persistence.Query.InMemory
 {
     public class InMemoryReadJournal : Akka.Persistence.Query.IAllEventsQuery, Akka.Persistence.Query.ICurrentAllEventsQuery, Akka.Persistence.Query.ICurrentEventsByPersistenceIdQuery, Akka.Persistence.Query.ICurrentEventsByTagQuery, Akka.Persistence.Query.ICurrentPersistenceIdsQuery, Akka.Persistence.Query.IEventsByPersistenceIdQuery, Akka.Persistence.Query.IEventsByTagQuery, Akka.Persistence.Query.IPersistenceIdsQuery, Akka.Persistence.Query.IReadJournal
@@ -11,10 +11,10 @@ namespace Akka.Persistence.Query.InMemory
         public Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> CurrentEventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr) { }
         public Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> CurrentEventsByTag(string tag, Akka.Persistence.Query.Offset offset) { }
         public Akka.Streams.Dsl.Source<string, Akka.NotUsed> CurrentPersistenceIds() { }
-        public static Akka.Configuration.Config DefaultConfiguration() { }
         public Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> EventsByPersistenceId(string persistenceId, long fromSequenceNr, long toSequenceNr) { }
         public Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> EventsByTag(string tag, Akka.Persistence.Query.Offset offset) { }
         public Akka.Streams.Dsl.Source<string, Akka.NotUsed> PersistenceIds() { }
+        public static Akka.Configuration.Config DefaultConfiguration() { }
     }
     public class InMemoryReadJournalProvider : Akka.Persistence.Query.IReadJournalProvider
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
@@ -1,15 +1,14 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("92ab2788-e008-40d0-8b54-0c95b3cf3404")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("92ab2788-e008-40d0-8b54-0c95b3cf3404")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Persistence.Query
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class EventEnvelope : System.IEquatable<Akka.Persistence.Query.EventEnvelope>
     {
-        [System.ObsoleteAttribute("For binary compatibility with previous releases. Since 1.4.14")]
+        [System.Obsolete("For binary compatibility with previous releases. Since 1.4.14")]
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event) { }
-        [System.ObsoleteAttribute("For binary compatibility with previous releases. Since 1.5.11")]
+        [System.Obsolete("For binary compatibility with previous releases. Since 1.5.11")]
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp) { }
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp, string[] tags) { }
         public object Event { get; }
@@ -18,8 +17,8 @@ namespace Akka.Persistence.Query
         public long SequenceNr { get; }
         public string[] Tags { get; }
         public long Timestamp { get; }
-        public bool Equals(Akka.Persistence.Query.EventEnvelope other) { }
-        public override bool Equals(object obj) { }
+        public bool Equals(Akka.Persistence.Query.EventEnvelope? other) { }
+        public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -70,23 +69,23 @@ namespace Akka.Persistence.Query
     {
         protected Offset() { }
         public abstract int CompareTo(Akka.Persistence.Query.Offset other);
+        public abstract override string ToString() { }
         public static Akka.Persistence.Query.Offset NoOffset() { }
         public static Akka.Persistence.Query.Offset Sequence(long value) { }
         public static Akka.Persistence.Query.Offset TimeBasedUuid(System.Guid value) { }
-        public virtual string ToString() { }
     }
     public sealed class PersistenceQuery : Akka.Actor.IExtension
     {
         public PersistenceQuery(Akka.Actor.ExtendedActorSystem system) { }
         public Akka.Event.ILoggingAdapter Log { get; }
-        public static Akka.Persistence.Query.PersistenceQuery Get(Akka.Actor.ActorSystem system) { }
-        public static Akka.Configuration.Config GetDefaultConfig<TJournal>() { }
-        public static Akka.Configuration.Config GetDefaultConfig(System.Type journalType) { }
+        public Akka.Persistence.Query.IReadJournal ReadJournalFor(System.Type readJournalType, string readJournalPluginId) { }
         public TJournal ReadJournalFor<TJournal>(string readJournalPluginId)
             where TJournal : Akka.Persistence.Query.IReadJournal { }
-        public Akka.Persistence.Query.IReadJournal ReadJournalFor(System.Type readJournalType, string readJournalPluginId) { }
+        public static Akka.Persistence.Query.PersistenceQuery Get(Akka.Actor.ActorSystem system) { }
+        public static Akka.Configuration.Config GetDefaultConfig(System.Type journalType) { }
+        public static Akka.Configuration.Config GetDefaultConfig<TJournal>() { }
     }
-    public class static PersistenceQueryExtensions
+    public static class PersistenceQueryExtensions
     {
         public static TJournal ReadJournalFor<TJournal>(this Akka.Actor.ActorSystem system, string readJournalPluginId)
             where TJournal : Akka.Persistence.Query.IReadJournal { }
@@ -100,8 +99,8 @@ namespace Akka.Persistence.Query
     {
         public Sequence(long value) { }
         public long Value { get; }
-        public int CompareTo(Akka.Persistence.Query.Sequence other) { }
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
+        public int CompareTo(Akka.Persistence.Query.Sequence other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
@@ -110,8 +109,8 @@ namespace Akka.Persistence.Query
     {
         public TimeBasedUuid(System.Guid value) { }
         public System.Guid Value { get; }
-        public int CompareTo(Akka.Persistence.Query.TimeBasedUuid other) { }
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
+        public int CompareTo(Akka.Persistence.Query.TimeBasedUuid other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
@@ -1,15 +1,14 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("92ab2788-e008-40d0-8b54-0c95b3cf3404")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("92ab2788-e008-40d0-8b54-0c95b3cf3404")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Persistence.Query
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class EventEnvelope : System.IEquatable<Akka.Persistence.Query.EventEnvelope>
     {
-        [System.ObsoleteAttribute("For binary compatibility with previous releases. Since 1.4.14")]
+        [System.Obsolete("For binary compatibility with previous releases. Since 1.4.14")]
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event) { }
-        [System.ObsoleteAttribute("For binary compatibility with previous releases. Since 1.5.11")]
+        [System.Obsolete("For binary compatibility with previous releases. Since 1.5.11")]
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp) { }
         public EventEnvelope(Akka.Persistence.Query.Offset offset, string persistenceId, long sequenceNr, object @event, long timestamp, string[] tags) { }
         public object Event { get; }
@@ -18,8 +17,8 @@ namespace Akka.Persistence.Query
         public long SequenceNr { get; }
         public string[] Tags { get; }
         public long Timestamp { get; }
-        public bool Equals(Akka.Persistence.Query.EventEnvelope other) { }
-        public override bool Equals(object obj) { }
+        public bool Equals(Akka.Persistence.Query.EventEnvelope? other) { }
+        public override bool Equals(object? obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
     }
@@ -70,23 +69,23 @@ namespace Akka.Persistence.Query
     {
         protected Offset() { }
         public abstract int CompareTo(Akka.Persistence.Query.Offset other);
+        public abstract override string ToString() { }
         public static Akka.Persistence.Query.Offset NoOffset() { }
         public static Akka.Persistence.Query.Offset Sequence(long value) { }
         public static Akka.Persistence.Query.Offset TimeBasedUuid(System.Guid value) { }
-        public virtual string ToString() { }
     }
     public sealed class PersistenceQuery : Akka.Actor.IExtension
     {
         public PersistenceQuery(Akka.Actor.ExtendedActorSystem system) { }
         public Akka.Event.ILoggingAdapter Log { get; }
-        public static Akka.Persistence.Query.PersistenceQuery Get(Akka.Actor.ActorSystem system) { }
-        public static Akka.Configuration.Config GetDefaultConfig<TJournal>() { }
-        public static Akka.Configuration.Config GetDefaultConfig(System.Type journalType) { }
+        public Akka.Persistence.Query.IReadJournal ReadJournalFor(System.Type readJournalType, string readJournalPluginId) { }
         public TJournal ReadJournalFor<TJournal>(string readJournalPluginId)
             where TJournal : Akka.Persistence.Query.IReadJournal { }
-        public Akka.Persistence.Query.IReadJournal ReadJournalFor(System.Type readJournalType, string readJournalPluginId) { }
+        public static Akka.Persistence.Query.PersistenceQuery Get(Akka.Actor.ActorSystem system) { }
+        public static Akka.Configuration.Config GetDefaultConfig(System.Type journalType) { }
+        public static Akka.Configuration.Config GetDefaultConfig<TJournal>() { }
     }
-    public class static PersistenceQueryExtensions
+    public static class PersistenceQueryExtensions
     {
         public static TJournal ReadJournalFor<TJournal>(this Akka.Actor.ActorSystem system, string readJournalPluginId)
             where TJournal : Akka.Persistence.Query.IReadJournal { }
@@ -100,8 +99,8 @@ namespace Akka.Persistence.Query
     {
         public Sequence(long value) { }
         public long Value { get; }
-        public int CompareTo(Akka.Persistence.Query.Sequence other) { }
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
+        public int CompareTo(Akka.Persistence.Query.Sequence other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
@@ -110,8 +109,8 @@ namespace Akka.Persistence.Query
     {
         public TimeBasedUuid(System.Guid value) { }
         public System.Guid Value { get; }
-        public int CompareTo(Akka.Persistence.Query.TimeBasedUuid other) { }
         public override int CompareTo(Akka.Persistence.Query.Offset other) { }
+        public int CompareTo(Akka.Persistence.Query.TimeBasedUuid other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.DotNet.verified.txt
@@ -1,21 +1,21 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Metrics")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.TestKit.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests.Performance")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("78986bdb-73f7-4532-8e03-1c9ccbe8148e")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Metrics")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.TestKit.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.Tests.Performance")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("78986bdb-73f7-4532-8e03-1c9ccbe8148e")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Remote
 {
     public class AddressUid : Akka.Actor.IExtension
@@ -40,18 +40,18 @@ namespace Akka.Remote
     public sealed class AssociatedEvent : Akka.Remote.AssociationEvent
     {
         public AssociatedEvent(Akka.Actor.Address localAddress, Akka.Actor.Address remoteAddress, bool inbound) { }
-        public override bool IsInbound { get; set; }
-        public override Akka.Actor.Address LocalAddress { get; set; }
-        public override Akka.Actor.Address RemoteAddress { get; set; }
+        public override bool IsInbound { get; protected set; }
+        public override Akka.Actor.Address LocalAddress { get; protected set; }
+        public override Akka.Actor.Address RemoteAddress { get; protected set; }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public sealed class AssociationErrorEvent : Akka.Remote.AssociationEvent
     {
         public AssociationErrorEvent(System.Exception cause, Akka.Actor.Address localAddress, Akka.Actor.Address remoteAddress, bool inbound, Akka.Event.LogLevel level) { }
         public System.Exception Cause { get; }
-        public override bool IsInbound { get; set; }
-        public override Akka.Actor.Address LocalAddress { get; set; }
-        public override Akka.Actor.Address RemoteAddress { get; set; }
+        public override bool IsInbound { get; protected set; }
+        public override Akka.Actor.Address LocalAddress { get; protected set; }
+        public override Akka.Actor.Address RemoteAddress { get; protected set; }
         public override Akka.Event.LogLevel LogLevel() { }
         public override string ToString() { }
     }
@@ -59,9 +59,9 @@ namespace Akka.Remote
     {
         protected string EventName;
         protected AssociationEvent() { }
-        public abstract bool IsInbound { get; set; }
-        public abstract Akka.Actor.Address LocalAddress { get; set; }
-        public abstract Akka.Actor.Address RemoteAddress { get; set; }
+        public abstract bool IsInbound { get; protected set; }
+        public abstract Akka.Actor.Address LocalAddress { get; protected set; }
+        public abstract Akka.Actor.Address RemoteAddress { get; protected set; }
         public override string ToString() { }
     }
     public delegate long Clock();
@@ -70,21 +70,21 @@ namespace Akka.Remote
         public Deadline(System.DateTime when) { }
         public bool HasTimeLeft { get; }
         public bool IsOverdue { get; }
-        public static Akka.Remote.Deadline Now { get; }
         public System.TimeSpan TimeLeft { get; }
         public System.DateTime When { get; }
+        public static Akka.Remote.Deadline Now { get; }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public static Akka.Remote.Deadline +(Akka.Remote.Deadline deadline, System.TimeSpan duration) { }
-        public static Akka.Remote.Deadline +(Akka.Remote.Deadline deadline, System.Nullable<System.TimeSpan> duration) { }
+        public static Akka.Remote.Deadline operator +(Akka.Remote.Deadline deadline, System.TimeSpan duration) { }
+        public static Akka.Remote.Deadline operator +(Akka.Remote.Deadline deadline, System.TimeSpan? duration) { }
     }
     public class DeadlineFailureDetector : Akka.Remote.FailureDetector
     {
-        [System.ObsoleteAttribute("Use DeadlineFailureDetector(acceptableHeartbeatPause, heartbeatInterval, clock) i" +
+        public DeadlineFailureDetector(Akka.Configuration.Config config, Akka.Event.EventStream eventStream) { }
+        [System.Obsolete("Use DeadlineFailureDetector(acceptableHeartbeatPause, heartbeatInterval, clock) i" +
             "nstead. [1.1.2]")]
         public DeadlineFailureDetector(System.TimeSpan acceptableHeartbeatPause, Akka.Remote.Clock clock = null) { }
         public DeadlineFailureDetector(System.TimeSpan acceptableHeartbeatPause, System.TimeSpan heartbeatInterval, Akka.Remote.Clock clock = null) { }
-        public DeadlineFailureDetector(Akka.Configuration.Config config, Akka.Event.EventStream eventStream) { }
         public override bool IsAvailable { get; }
         public override bool IsMonitoring { get; }
         public override void HeartBeat() { }
@@ -101,9 +101,9 @@ namespace Akka.Remote
     public sealed class DisassociatedEvent : Akka.Remote.AssociationEvent
     {
         public DisassociatedEvent(Akka.Actor.Address localAddress, Akka.Actor.Address remoteAddress, bool inbound) { }
-        public override bool IsInbound { get; set; }
-        public override Akka.Actor.Address LocalAddress { get; set; }
-        public override Akka.Actor.Address RemoteAddress { get; set; }
+        public override bool IsInbound { get; protected set; }
+        public override Akka.Actor.Address LocalAddress { get; protected set; }
+        public override Akka.Actor.Address RemoteAddress { get; protected set; }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public abstract class FailureDetector
@@ -114,8 +114,8 @@ namespace Akka.Remote
         public abstract bool IsMonitoring { get; }
         public abstract void HeartBeat();
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static FailureDetectorLoader
+    [Akka.Annotations.InternalApi]
+    public static class FailureDetectorLoader
     {
         public static Akka.Remote.FailureDetector Load(string fqcn, Akka.Configuration.Config config, Akka.Actor.ActorSystem system) { }
         public static Akka.Remote.FailureDetector LoadFailureDetector(this Akka.Actor.IActorContext context, string fqcn, Akka.Configuration.Config config) { }
@@ -128,9 +128,9 @@ namespace Akka.Remote
         void Remove(T resource);
         void Reset();
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IInternalRemotingMessage { }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IRemoteActorRefProvider : Akka.Actor.IActorRefProvider
     {
         Akka.Actor.IInternalActorRef RemoteDaemon { get; }
@@ -140,17 +140,17 @@ namespace Akka.Remote
         bool HasAddress(Akka.Actor.Address address);
         Akka.Actor.IActorRef InternalResolveActorRef(string path);
         Akka.Actor.Deploy LookUpRemotes(System.Collections.Generic.IEnumerable<string> p);
-        void Quarantine(Akka.Actor.Address address, System.Nullable<int> uid);
+        void Quarantine(Akka.Actor.Address address, int? uid);
         Akka.Actor.IInternalActorRef ResolveActorRefWithLocalAddress(string path, Akka.Actor.Address localAddress);
         void UseActorOnNode(Akka.Remote.RemoteActorRef actor, Akka.Actor.Props props, Akka.Actor.Deploy deploy, Akka.Actor.IInternalActorRef supervisor);
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IRemoteRef : Akka.Actor.IActorRefScope { }
     public class PhiAccrualFailureDetector : Akka.Remote.FailureDetector
     {
-        public PhiAccrualFailureDetector(double threshold, int maxSampleSize, System.TimeSpan minStdDeviation, System.TimeSpan acceptableHeartbeatPause, System.TimeSpan firstHeartbeatEstimate, Akka.Remote.Clock clock = null) { }
-        public PhiAccrualFailureDetector(Akka.Configuration.Config config, Akka.Event.EventStream ev) { }
         protected PhiAccrualFailureDetector(Akka.Remote.Clock clock) { }
+        public PhiAccrualFailureDetector(Akka.Configuration.Config config, Akka.Event.EventStream ev) { }
+        public PhiAccrualFailureDetector(double threshold, int maxSampleSize, System.TimeSpan minStdDeviation, System.TimeSpan acceptableHeartbeatPause, System.TimeSpan firstHeartbeatEstimate, Akka.Remote.Clock clock = null) { }
         public string Address { get; set; }
         public override bool IsAvailable { get; }
         public override bool IsMonitoring { get; }
@@ -168,7 +168,7 @@ namespace Akka.Remote
     {
         public RemoteActorRef(Akka.Remote.RemoteTransport remote, Akka.Actor.Address localAddressToUse, Akka.Actor.ActorPath path, Akka.Actor.IInternalActorRef parent, Akka.Actor.Props props, Akka.Actor.Deploy deploy) { }
         public override bool IsLocal { get; }
-        [System.ObsoleteAttribute("Use Context.Watch and Receive<Terminated> [1.1.0]")]
+        [System.Obsolete("Use Context.Watch and Receive<Terminated> [1.1.0]")]
         public override bool IsTerminated { get; }
         public Akka.Actor.Address LocalAddressToUse { get; }
         public override Akka.Actor.IInternalActorRef Parent { get; }
@@ -184,13 +184,13 @@ namespace Akka.Remote
         public override void Suspend() { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class RemoteActorRefProvider : Akka.Actor.IActorRefProvider, Akka.Remote.IRemoteActorRefProvider
     {
         public RemoteActorRefProvider(string systemName, Akka.Actor.Settings settings, Akka.Event.EventStream eventStream) { }
         public Akka.Actor.IActorRef DeadLetters { get; }
         public Akka.Actor.Address DefaultAddress { get; }
-        public Akka.Actor.Deployer Deployer { get; set; }
+        public Akka.Actor.Deployer Deployer { get; protected set; }
         public Akka.Actor.LocalActorRef Guardian { get; }
         public Akka.Actor.IActorRef IgnoreRef { get; }
         public Akka.Actor.IInternalActorRef RemoteDaemon { get; }
@@ -216,10 +216,10 @@ namespace Akka.Remote
         public virtual void Init(Akka.Actor.Internal.ActorSystemImpl system) { }
         public Akka.Actor.IActorRef InternalResolveActorRef(string path) { }
         public Akka.Actor.Deploy LookUpRemotes(System.Collections.Generic.IEnumerable<string> p) { }
-        public void Quarantine(Akka.Actor.Address address, System.Nullable<int> uid) { }
+        public void Quarantine(Akka.Actor.Address address, int? uid) { }
         public void RegisterTempActor(Akka.Actor.IInternalActorRef actorRef, Akka.Actor.ActorPath path) { }
-        public Akka.Actor.IActorRef ResolveActorRef(string path) { }
         public Akka.Actor.IActorRef ResolveActorRef(Akka.Actor.ActorPath actorPath) { }
+        public Akka.Actor.IActorRef ResolveActorRef(string path) { }
         public Akka.Actor.IInternalActorRef ResolveActorRefWithLocalAddress(string path, Akka.Actor.Address localAddress) { }
         public Akka.Actor.IActorRef RootGuardianAt(Akka.Actor.Address address) { }
         public Akka.Actor.ActorPath TempPath() { }
@@ -240,7 +240,7 @@ namespace Akka.Remote
         public int LogBufferSizeExceeding { get; set; }
         public bool LogReceive { get; set; }
         public bool LogSend { get; set; }
-        public System.Nullable<System.TimeSpan> QuarantineDuration { get; set; }
+        public System.TimeSpan? QuarantineDuration { get; set; }
         public System.TimeSpan QuarantineSilentSystemTimeout { get; set; }
         public string RemoteLifecycleEventsLogLevel { get; set; }
         public System.TimeSpan RetryGateClosedFor { get; set; }
@@ -251,7 +251,7 @@ namespace Akka.Remote
         public int SysResendLimit { get; set; }
         public System.TimeSpan SysResendTimeout { get; set; }
         public System.Collections.Generic.IList<string> TransportNames { get; set; }
-        public TransportSettings[] Transports { get; set; }
+        public Akka.Remote.RemoteSettings.TransportSettings[] Transports { get; set; }
         public System.Collections.Generic.HashSet<string> TrustedSelectionPaths { get; set; }
         public bool UntrustedMode { get; set; }
         public bool UsePassiveConnections { get; set; }
@@ -269,29 +269,29 @@ namespace Akka.Remote
             public string TransportClass { get; set; }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class RemoteTransport
     {
         protected RemoteTransport(Akka.Actor.ExtendedActorSystem system, Akka.Remote.RemoteActorRefProvider provider) { }
         public abstract System.Collections.Generic.ISet<Akka.Actor.Address> Addresses { get; }
         public abstract Akka.Actor.Address DefaultAddress { get; }
-        public Akka.Event.ILoggingAdapter Log { get; set; }
+        public Akka.Event.ILoggingAdapter Log { get; protected set; }
         public Akka.Remote.RemoteActorRefProvider Provider { get; }
         public Akka.Actor.ExtendedActorSystem System { get; }
         protected bool UseUntrustedMode { get; set; }
-        public bool logRemoteLifeCycleEvents { get; set; }
+        public bool logRemoteLifeCycleEvents { get; protected set; }
         public abstract Akka.Actor.Address LocalAddressForRemote(Akka.Actor.Address remote);
         public abstract System.Threading.Tasks.Task<bool> ManagementCommand(object cmd);
         public abstract System.Threading.Tasks.Task<bool> ManagementCommand(object cmd, System.Threading.CancellationToken cancellationToken);
-        public abstract void Quarantine(Akka.Actor.Address address, System.Nullable<int> uid);
+        public abstract void Quarantine(Akka.Actor.Address address, int? uid);
         public abstract void Send(object message, Akka.Actor.IActorRef sender, Akka.Remote.RemoteActorRef recipient);
         public abstract System.Threading.Tasks.Task Shutdown();
         public abstract void Start();
     }
     public class RemoteTransportException : Akka.Actor.AkkaException
     {
-        public RemoteTransportException(string message, System.Exception cause = null) { }
         protected RemoteTransportException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public RemoteTransportException(string message, System.Exception cause = null) { }
     }
     public class RemoteWatcher : Akka.Actor.UntypedActor, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedMessageQueueSemantics>
     {
@@ -304,13 +304,13 @@ namespace Akka.Remote
         protected void AddWatching(Akka.Actor.IInternalActorRef watchee, Akka.Actor.IInternalActorRef watcher) { }
         protected override void OnReceive(object message) { }
         protected override void PostStop() { }
-        public static Akka.Actor.Props Props(Akka.Remote.IFailureDetectorRegistry<Akka.Actor.Address> failureDetector, System.TimeSpan heartbeatInterval, System.TimeSpan unreachableReaperInterval, System.TimeSpan heartbeatExpectedResponseAfter) { }
         protected virtual void PublishAddressTerminated(Akka.Actor.Address address) { }
-        protected virtual void Quarantine(Akka.Actor.Address address, System.Nullable<int> addressUid) { }
+        protected virtual void Quarantine(Akka.Actor.Address address, int? addressUid) { }
         protected void RemoveWatch(Akka.Actor.IInternalActorRef watchee, Akka.Actor.IInternalActorRef watcher) { }
         protected void RemoveWatchee(Akka.Actor.IInternalActorRef watchee) { }
         protected void UnwatchNode(Akka.Actor.Address watcheeAddress) { }
         protected virtual void WatchNode(Akka.Actor.IInternalActorRef watchee) { }
+        public static Akka.Actor.Props Props(Akka.Remote.IFailureDetectorRegistry<Akka.Actor.Address> failureDetector, System.TimeSpan heartbeatInterval, System.TimeSpan unreachableReaperInterval, System.TimeSpan heartbeatExpectedResponseAfter) { }
         public sealed class ExpectedFirstHeartbeat
         {
             public ExpectedFirstHeartbeat(Akka.Actor.Address from) { }
@@ -343,10 +343,10 @@ namespace Akka.Remote
             public int WatchingNodes { get; }
             public System.Collections.Immutable.ImmutableHashSet<System.ValueTuple<Akka.Actor.IActorRef, Akka.Actor.IActorRef>> WatchingRefs { get; }
             public Akka.Remote.RemoteWatcher.Stats Copy(int watching, int watchingNodes, System.Collections.Immutable.ImmutableHashSet<System.ValueTuple<Akka.Actor.IActorRef, Akka.Actor.IActorRef>> watchingRefs = null, System.Collections.Immutable.ImmutableHashSet<Akka.Actor.Address> watchingAddresses = null) { }
-            public static Akka.Remote.RemoteWatcher.Stats Counts(int watching, int watchingNodes) { }
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
+            public static Akka.Remote.RemoteWatcher.Stats Counts(int watching, int watchingNodes) { }
         }
         public sealed class UnwatchRemote : Akka.Remote.RemoteWatcher.WatchCommand
         {
@@ -511,8 +511,8 @@ namespace Akka.Remote.Transport
     }
     public abstract class ActorTransportAdapter : Akka.Remote.Transport.AbstractTransportAdapter
     {
+        protected volatile Akka.Actor.IActorRef manager;
         public static readonly System.TimeSpan AskTimeout;
-        protected Akka.Actor.IActorRef modreq(System.Runtime.CompilerServices.IsVolatile) manager;
         protected ActorTransportAdapter(Akka.Remote.Transport.Transport wrappedTransport, Akka.Actor.ActorSystem system) { }
         protected abstract string ManagerName { get; }
         protected abstract Akka.Actor.Props ManagerProps { get; }
@@ -533,8 +533,8 @@ namespace Akka.Remote.Transport
     }
     public class AkkaProtocolException : Akka.Actor.AkkaException
     {
-        public AkkaProtocolException(string message, System.Exception cause = null) { }
         protected AkkaProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public AkkaProtocolException(string message, System.Exception cause = null) { }
     }
     public sealed class AssociateAttempt : Akka.Remote.Transport.Activity
     {
@@ -551,26 +551,24 @@ namespace Akka.Remote.Transport
     public abstract class AssociationHandle
     {
         protected AssociationHandle(Akka.Actor.Address localAddress, Akka.Actor.Address remoteAddress) { }
-        public Akka.Actor.Address LocalAddress { get; set; }
-        public System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IHandleEventListener> ReadHandlerSource { get; set; }
-        public Akka.Actor.Address RemoteAddress { get; set; }
-        [System.ObsoleteAttribute("Use the method that states reasons to make sure disassociation reasons are logged" +
+        public Akka.Actor.Address LocalAddress { get; protected set; }
+        public System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IHandleEventListener> ReadHandlerSource { get; protected set; }
+        public Akka.Actor.Address RemoteAddress { get; protected set; }
+        [System.Obsolete("Use the method that states reasons to make sure disassociation reasons are logged" +
             ".")]
         public abstract void Disassociate();
         public void Disassociate(string reason, Akka.Event.ILoggingAdapter log) { }
-        public override bool Equals(object obj) { }
         protected bool Equals(Akka.Remote.Transport.AssociationHandle other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public abstract bool Write(Google.Protobuf.ByteString payload);
     }
     public class AssociationRegistry
     {
         public AssociationRegistry() { }
-        public static void Clear() { }
         public void ClearLog() { }
         public Akka.Util.Option<System.ValueTuple<Akka.Remote.Transport.IHandleEventListener, Akka.Remote.Transport.IHandleEventListener>> DeregisterAssociation(System.ValueTuple<Akka.Actor.Address, Akka.Actor.Address> key) { }
         public bool ExistsAssociation(Akka.Actor.Address initiatorAddress, Akka.Actor.Address remoteAddress) { }
-        public static Akka.Remote.Transport.AssociationRegistry Get(string key) { }
         public Akka.Remote.Transport.IHandleEventListener GetRemoteReadHandlerFor(Akka.Remote.Transport.TestAssociationHandle localHandle) { }
         public void LogActivity(Akka.Remote.Transport.Activity activity) { }
         public System.Collections.Generic.IList<Akka.Remote.Transport.Activity> LogSnapshot() { }
@@ -580,6 +578,8 @@ namespace Akka.Remote.Transport
         public void Reset() { }
         public Akka.Util.Option<System.ValueTuple<Akka.Remote.Transport.TestTransport, System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener>>> TransportFor(Akka.Actor.Address address) { }
         public bool TransportsReady(params Akka.Actor.Address[] addresses) { }
+        public static void Clear() { }
+        public static Akka.Remote.Transport.AssociationRegistry Get(string key) { }
     }
     public class Blackhole : Akka.Remote.Transport.ThrottleMode
     {
@@ -697,8 +697,8 @@ namespace Akka.Remote.Transport
     }
     public class InvalidAssociationException : Akka.Actor.AkkaException
     {
-        public InvalidAssociationException(string message, System.Exception cause = null) { }
         protected InvalidAssociationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public InvalidAssociationException(string message, System.Exception cause = null) { }
     }
     public sealed class ListenAttempt : Akka.Remote.Transport.Activity
     {
@@ -720,10 +720,10 @@ namespace Akka.Remote.Transport
     {
         public readonly string AddedSchemeIdentifier;
         public SchemeAugmenter(string addedSchemeIdentifier) { }
-        public string AugmentScheme(string originalScheme) { }
         public Akka.Actor.Address AugmentScheme(Akka.Actor.Address address) { }
-        public string RemoveScheme(string scheme) { }
+        public string AugmentScheme(string originalScheme) { }
         public Akka.Actor.Address RemoveScheme(Akka.Actor.Address address) { }
+        public string RemoveScheme(string scheme) { }
     }
     public sealed class SetThrottle
     {
@@ -733,8 +733,8 @@ namespace Akka.Remote.Transport
         public Akka.Remote.Transport.ThrottleMode Mode { get; }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public static bool ==(Akka.Remote.Transport.SetThrottle left, Akka.Remote.Transport.SetThrottle right) { }
-        public static bool !=(Akka.Remote.Transport.SetThrottle left, Akka.Remote.Transport.SetThrottle right) { }
+        public static bool operator !=(Akka.Remote.Transport.SetThrottle left, Akka.Remote.Transport.SetThrottle right) { }
+        public static bool operator ==(Akka.Remote.Transport.SetThrottle left, Akka.Remote.Transport.SetThrottle right) { }
     }
     public sealed class SetThrottleAck
     {
@@ -819,16 +819,16 @@ namespace Akka.Remote.Transport
         public override int GetHashCode() { }
         public override System.TimeSpan TimeToAvailable(long currentNanoTime, int tokens) { }
         public override System.ValueTuple<Akka.Remote.Transport.ThrottleMode, bool> TryConsumeTokens(long nanoTimeOfSend, int tokens) { }
-        public static bool ==(Akka.Remote.Transport.TokenBucket left, Akka.Remote.Transport.TokenBucket right) { }
-        public static bool !=(Akka.Remote.Transport.TokenBucket left, Akka.Remote.Transport.TokenBucket right) { }
+        public static bool operator !=(Akka.Remote.Transport.TokenBucket left, Akka.Remote.Transport.TokenBucket right) { }
+        public static bool operator ==(Akka.Remote.Transport.TokenBucket left, Akka.Remote.Transport.TokenBucket right) { }
     }
     public abstract class Transport
     {
         protected Transport() { }
-        public Akka.Configuration.Config Config { get; set; }
-        public virtual long MaximumPayloadBytes { get; set; }
-        public virtual string SchemeIdentifier { get; set; }
-        public Akka.Actor.ActorSystem System { get; set; }
+        public Akka.Configuration.Config Config { get; protected set; }
+        public virtual long MaximumPayloadBytes { get; protected set; }
+        public virtual string SchemeIdentifier { get; protected set; }
+        public Akka.Actor.ActorSystem System { get; protected set; }
         public abstract System.Threading.Tasks.Task<Akka.Remote.Transport.AssociationHandle> Associate(Akka.Actor.Address remoteAddress);
         public abstract bool IsResponsibleFor(Akka.Actor.Address remote);
         public abstract System.Threading.Tasks.Task<System.ValueTuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> Listen();
@@ -860,34 +860,26 @@ namespace Akka.Remote.Transport
 }
 namespace Akka.Remote.Transport.DotNetty
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static CertificateValidation
+    public static class CertificateValidation
     {
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ChainPlusThen([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                1,
-                2,
-                2,
-                1})] System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, string, bool> customCheck, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ChainPlusThen(System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2?, System.Security.Cryptography.X509Certificates.X509Chain?, string, bool> customCheck, Akka.Event.ILoggingAdapter? log = null) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback Combine(params Akka.Remote.Transport.DotNetty.CertificateValidationCallback[] validators) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback PinnedCertificate(params string[] allowedThumbprints) { }
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateChain([System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateHostname(string expectedHostname = null, Akka.Event.ILoggingAdapter log = null) { }
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateIssuer(string expectedIssuerPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateSubject(string expectedSubjectPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateChain(Akka.Event.ILoggingAdapter? log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateHostname(string? expectedHostname = null, Akka.Event.ILoggingAdapter? log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateIssuer(string expectedIssuerPattern, Akka.Event.ILoggingAdapter? log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateSubject(string expectedSubjectPattern, Akka.Event.ILoggingAdapter? log = null) { }
     }
-    public delegate bool CertificateValidationCallback([System.Runtime.CompilerServices.NullableAttribute(2)] System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, [System.Runtime.CompilerServices.NullableAttribute(2)] System.Security.Cryptography.X509Certificates.X509Chain chain, string remotePeer, System.Net.Security.SslPolicyErrors errors, Akka.Event.ILoggingAdapter log);
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    public delegate bool CertificateValidationCallback(System.Security.Cryptography.X509Certificates.X509Certificate2? certificate, System.Security.Cryptography.X509Certificates.X509Chain? chain, string remotePeer, System.Net.Security.SslPolicyErrors errors, Akka.Event.ILoggingAdapter log);
     public sealed class DotNettySslSetup : Akka.Actor.Setup.Setup
     {
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation) { }
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication) { }
+        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, Akka.Remote.Transport.DotNetty.CertificateValidationCallback? customValidator) { }
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname) { }
-        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Remote.Transport.DotNetty.CertificateValidationCallback customValidator) { }
-        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Remote.Transport.DotNetty.CertificateValidationCallback customValidator) { }
+        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname, Akka.Remote.Transport.DotNetty.CertificateValidationCallback? customValidator) { }
         public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Remote.Transport.DotNetty.CertificateValidationCallback CustomValidator { get; }
+        public Akka.Remote.Transport.DotNetty.CertificateValidationCallback? CustomValidator { get; }
         public bool RequireMutualAuthentication { get; }
         public bool SuppressValidation { get; }
         public bool ValidateCertificateHostname { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveRemote.Net.verified.txt
@@ -1,21 +1,21 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Metrics")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Sharding")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Cluster.Tools")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.TestKit.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests.MultiNode")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Remote.Tests.Performance")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("78986bdb-73f7-4532-8e03-1c9ccbe8148e")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Metrics")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Sharding")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Cluster.Tools")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.TestKit.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.Tests.MultiNode")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Remote.Tests.Performance")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("78986bdb-73f7-4532-8e03-1c9ccbe8148e")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Remote
 {
     public class AddressUid : Akka.Actor.IExtension
@@ -40,18 +40,18 @@ namespace Akka.Remote
     public sealed class AssociatedEvent : Akka.Remote.AssociationEvent
     {
         public AssociatedEvent(Akka.Actor.Address localAddress, Akka.Actor.Address remoteAddress, bool inbound) { }
-        public override bool IsInbound { get; set; }
-        public override Akka.Actor.Address LocalAddress { get; set; }
-        public override Akka.Actor.Address RemoteAddress { get; set; }
+        public override bool IsInbound { get; protected set; }
+        public override Akka.Actor.Address LocalAddress { get; protected set; }
+        public override Akka.Actor.Address RemoteAddress { get; protected set; }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public sealed class AssociationErrorEvent : Akka.Remote.AssociationEvent
     {
         public AssociationErrorEvent(System.Exception cause, Akka.Actor.Address localAddress, Akka.Actor.Address remoteAddress, bool inbound, Akka.Event.LogLevel level) { }
         public System.Exception Cause { get; }
-        public override bool IsInbound { get; set; }
-        public override Akka.Actor.Address LocalAddress { get; set; }
-        public override Akka.Actor.Address RemoteAddress { get; set; }
+        public override bool IsInbound { get; protected set; }
+        public override Akka.Actor.Address LocalAddress { get; protected set; }
+        public override Akka.Actor.Address RemoteAddress { get; protected set; }
         public override Akka.Event.LogLevel LogLevel() { }
         public override string ToString() { }
     }
@@ -59,9 +59,9 @@ namespace Akka.Remote
     {
         protected string EventName;
         protected AssociationEvent() { }
-        public abstract bool IsInbound { get; set; }
-        public abstract Akka.Actor.Address LocalAddress { get; set; }
-        public abstract Akka.Actor.Address RemoteAddress { get; set; }
+        public abstract bool IsInbound { get; protected set; }
+        public abstract Akka.Actor.Address LocalAddress { get; protected set; }
+        public abstract Akka.Actor.Address RemoteAddress { get; protected set; }
         public override string ToString() { }
     }
     public delegate long Clock();
@@ -70,21 +70,21 @@ namespace Akka.Remote
         public Deadline(System.DateTime when) { }
         public bool HasTimeLeft { get; }
         public bool IsOverdue { get; }
-        public static Akka.Remote.Deadline Now { get; }
         public System.TimeSpan TimeLeft { get; }
         public System.DateTime When { get; }
+        public static Akka.Remote.Deadline Now { get; }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public static Akka.Remote.Deadline +(Akka.Remote.Deadline deadline, System.TimeSpan duration) { }
-        public static Akka.Remote.Deadline +(Akka.Remote.Deadline deadline, System.Nullable<System.TimeSpan> duration) { }
+        public static Akka.Remote.Deadline operator +(Akka.Remote.Deadline deadline, System.TimeSpan duration) { }
+        public static Akka.Remote.Deadline operator +(Akka.Remote.Deadline deadline, System.TimeSpan? duration) { }
     }
     public class DeadlineFailureDetector : Akka.Remote.FailureDetector
     {
-        [System.ObsoleteAttribute("Use DeadlineFailureDetector(acceptableHeartbeatPause, heartbeatInterval, clock) i" +
+        public DeadlineFailureDetector(Akka.Configuration.Config config, Akka.Event.EventStream eventStream) { }
+        [System.Obsolete("Use DeadlineFailureDetector(acceptableHeartbeatPause, heartbeatInterval, clock) i" +
             "nstead. [1.1.2]")]
         public DeadlineFailureDetector(System.TimeSpan acceptableHeartbeatPause, Akka.Remote.Clock clock = null) { }
         public DeadlineFailureDetector(System.TimeSpan acceptableHeartbeatPause, System.TimeSpan heartbeatInterval, Akka.Remote.Clock clock = null) { }
-        public DeadlineFailureDetector(Akka.Configuration.Config config, Akka.Event.EventStream eventStream) { }
         public override bool IsAvailable { get; }
         public override bool IsMonitoring { get; }
         public override void HeartBeat() { }
@@ -101,9 +101,9 @@ namespace Akka.Remote
     public sealed class DisassociatedEvent : Akka.Remote.AssociationEvent
     {
         public DisassociatedEvent(Akka.Actor.Address localAddress, Akka.Actor.Address remoteAddress, bool inbound) { }
-        public override bool IsInbound { get; set; }
-        public override Akka.Actor.Address LocalAddress { get; set; }
-        public override Akka.Actor.Address RemoteAddress { get; set; }
+        public override bool IsInbound { get; protected set; }
+        public override Akka.Actor.Address LocalAddress { get; protected set; }
+        public override Akka.Actor.Address RemoteAddress { get; protected set; }
         public override Akka.Event.LogLevel LogLevel() { }
     }
     public abstract class FailureDetector
@@ -114,8 +114,8 @@ namespace Akka.Remote
         public abstract bool IsMonitoring { get; }
         public abstract void HeartBeat();
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static FailureDetectorLoader
+    [Akka.Annotations.InternalApi]
+    public static class FailureDetectorLoader
     {
         public static Akka.Remote.FailureDetector Load(string fqcn, Akka.Configuration.Config config, Akka.Actor.ActorSystem system) { }
         public static Akka.Remote.FailureDetector LoadFailureDetector(this Akka.Actor.IActorContext context, string fqcn, Akka.Configuration.Config config) { }
@@ -128,9 +128,9 @@ namespace Akka.Remote
         void Remove(T resource);
         void Reset();
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IInternalRemotingMessage { }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IRemoteActorRefProvider : Akka.Actor.IActorRefProvider
     {
         Akka.Actor.IInternalActorRef RemoteDaemon { get; }
@@ -140,17 +140,17 @@ namespace Akka.Remote
         bool HasAddress(Akka.Actor.Address address);
         Akka.Actor.IActorRef InternalResolveActorRef(string path);
         Akka.Actor.Deploy LookUpRemotes(System.Collections.Generic.IEnumerable<string> p);
-        void Quarantine(Akka.Actor.Address address, System.Nullable<int> uid);
+        void Quarantine(Akka.Actor.Address address, int? uid);
         Akka.Actor.IInternalActorRef ResolveActorRefWithLocalAddress(string path, Akka.Actor.Address localAddress);
         void UseActorOnNode(Akka.Remote.RemoteActorRef actor, Akka.Actor.Props props, Akka.Actor.Deploy deploy, Akka.Actor.IInternalActorRef supervisor);
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public interface IRemoteRef : Akka.Actor.IActorRefScope { }
     public class PhiAccrualFailureDetector : Akka.Remote.FailureDetector
     {
-        public PhiAccrualFailureDetector(double threshold, int maxSampleSize, System.TimeSpan minStdDeviation, System.TimeSpan acceptableHeartbeatPause, System.TimeSpan firstHeartbeatEstimate, Akka.Remote.Clock clock = null) { }
-        public PhiAccrualFailureDetector(Akka.Configuration.Config config, Akka.Event.EventStream ev) { }
         protected PhiAccrualFailureDetector(Akka.Remote.Clock clock) { }
+        public PhiAccrualFailureDetector(Akka.Configuration.Config config, Akka.Event.EventStream ev) { }
+        public PhiAccrualFailureDetector(double threshold, int maxSampleSize, System.TimeSpan minStdDeviation, System.TimeSpan acceptableHeartbeatPause, System.TimeSpan firstHeartbeatEstimate, Akka.Remote.Clock clock = null) { }
         public string Address { get; set; }
         public override bool IsAvailable { get; }
         public override bool IsMonitoring { get; }
@@ -168,7 +168,7 @@ namespace Akka.Remote
     {
         public RemoteActorRef(Akka.Remote.RemoteTransport remote, Akka.Actor.Address localAddressToUse, Akka.Actor.ActorPath path, Akka.Actor.IInternalActorRef parent, Akka.Actor.Props props, Akka.Actor.Deploy deploy) { }
         public override bool IsLocal { get; }
-        [System.ObsoleteAttribute("Use Context.Watch and Receive<Terminated> [1.1.0]")]
+        [System.Obsolete("Use Context.Watch and Receive<Terminated> [1.1.0]")]
         public override bool IsTerminated { get; }
         public Akka.Actor.Address LocalAddressToUse { get; }
         public override Akka.Actor.IInternalActorRef Parent { get; }
@@ -184,13 +184,13 @@ namespace Akka.Remote
         public override void Suspend() { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class RemoteActorRefProvider : Akka.Actor.IActorRefProvider, Akka.Remote.IRemoteActorRefProvider
     {
         public RemoteActorRefProvider(string systemName, Akka.Actor.Settings settings, Akka.Event.EventStream eventStream) { }
         public Akka.Actor.IActorRef DeadLetters { get; }
         public Akka.Actor.Address DefaultAddress { get; }
-        public Akka.Actor.Deployer Deployer { get; set; }
+        public Akka.Actor.Deployer Deployer { get; protected set; }
         public Akka.Actor.LocalActorRef Guardian { get; }
         public Akka.Actor.IActorRef IgnoreRef { get; }
         public Akka.Actor.IInternalActorRef RemoteDaemon { get; }
@@ -216,10 +216,10 @@ namespace Akka.Remote
         public virtual void Init(Akka.Actor.Internal.ActorSystemImpl system) { }
         public Akka.Actor.IActorRef InternalResolveActorRef(string path) { }
         public Akka.Actor.Deploy LookUpRemotes(System.Collections.Generic.IEnumerable<string> p) { }
-        public void Quarantine(Akka.Actor.Address address, System.Nullable<int> uid) { }
+        public void Quarantine(Akka.Actor.Address address, int? uid) { }
         public void RegisterTempActor(Akka.Actor.IInternalActorRef actorRef, Akka.Actor.ActorPath path) { }
-        public Akka.Actor.IActorRef ResolveActorRef(string path) { }
         public Akka.Actor.IActorRef ResolveActorRef(Akka.Actor.ActorPath actorPath) { }
+        public Akka.Actor.IActorRef ResolveActorRef(string path) { }
         public Akka.Actor.IInternalActorRef ResolveActorRefWithLocalAddress(string path, Akka.Actor.Address localAddress) { }
         public Akka.Actor.IActorRef RootGuardianAt(Akka.Actor.Address address) { }
         public Akka.Actor.ActorPath TempPath() { }
@@ -240,7 +240,7 @@ namespace Akka.Remote
         public int LogBufferSizeExceeding { get; set; }
         public bool LogReceive { get; set; }
         public bool LogSend { get; set; }
-        public System.Nullable<System.TimeSpan> QuarantineDuration { get; set; }
+        public System.TimeSpan? QuarantineDuration { get; set; }
         public System.TimeSpan QuarantineSilentSystemTimeout { get; set; }
         public string RemoteLifecycleEventsLogLevel { get; set; }
         public System.TimeSpan RetryGateClosedFor { get; set; }
@@ -251,7 +251,7 @@ namespace Akka.Remote
         public int SysResendLimit { get; set; }
         public System.TimeSpan SysResendTimeout { get; set; }
         public System.Collections.Generic.IList<string> TransportNames { get; set; }
-        public TransportSettings[] Transports { get; set; }
+        public Akka.Remote.RemoteSettings.TransportSettings[] Transports { get; set; }
         public System.Collections.Generic.HashSet<string> TrustedSelectionPaths { get; set; }
         public bool UntrustedMode { get; set; }
         public bool UsePassiveConnections { get; set; }
@@ -269,29 +269,29 @@ namespace Akka.Remote
             public string TransportClass { get; set; }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class RemoteTransport
     {
         protected RemoteTransport(Akka.Actor.ExtendedActorSystem system, Akka.Remote.RemoteActorRefProvider provider) { }
         public abstract System.Collections.Generic.ISet<Akka.Actor.Address> Addresses { get; }
         public abstract Akka.Actor.Address DefaultAddress { get; }
-        public Akka.Event.ILoggingAdapter Log { get; set; }
+        public Akka.Event.ILoggingAdapter Log { get; protected set; }
         public Akka.Remote.RemoteActorRefProvider Provider { get; }
         public Akka.Actor.ExtendedActorSystem System { get; }
         protected bool UseUntrustedMode { get; set; }
-        public bool logRemoteLifeCycleEvents { get; set; }
+        public bool logRemoteLifeCycleEvents { get; protected set; }
         public abstract Akka.Actor.Address LocalAddressForRemote(Akka.Actor.Address remote);
         public abstract System.Threading.Tasks.Task<bool> ManagementCommand(object cmd);
         public abstract System.Threading.Tasks.Task<bool> ManagementCommand(object cmd, System.Threading.CancellationToken cancellationToken);
-        public abstract void Quarantine(Akka.Actor.Address address, System.Nullable<int> uid);
+        public abstract void Quarantine(Akka.Actor.Address address, int? uid);
         public abstract void Send(object message, Akka.Actor.IActorRef sender, Akka.Remote.RemoteActorRef recipient);
         public abstract System.Threading.Tasks.Task Shutdown();
         public abstract void Start();
     }
     public class RemoteTransportException : Akka.Actor.AkkaException
     {
-        public RemoteTransportException(string message, System.Exception cause = null) { }
         protected RemoteTransportException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public RemoteTransportException(string message, System.Exception cause = null) { }
     }
     public class RemoteWatcher : Akka.Actor.UntypedActor, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedMessageQueueSemantics>
     {
@@ -304,13 +304,13 @@ namespace Akka.Remote
         protected void AddWatching(Akka.Actor.IInternalActorRef watchee, Akka.Actor.IInternalActorRef watcher) { }
         protected override void OnReceive(object message) { }
         protected override void PostStop() { }
-        public static Akka.Actor.Props Props(Akka.Remote.IFailureDetectorRegistry<Akka.Actor.Address> failureDetector, System.TimeSpan heartbeatInterval, System.TimeSpan unreachableReaperInterval, System.TimeSpan heartbeatExpectedResponseAfter) { }
         protected virtual void PublishAddressTerminated(Akka.Actor.Address address) { }
-        protected virtual void Quarantine(Akka.Actor.Address address, System.Nullable<int> addressUid) { }
+        protected virtual void Quarantine(Akka.Actor.Address address, int? addressUid) { }
         protected void RemoveWatch(Akka.Actor.IInternalActorRef watchee, Akka.Actor.IInternalActorRef watcher) { }
         protected void RemoveWatchee(Akka.Actor.IInternalActorRef watchee) { }
         protected void UnwatchNode(Akka.Actor.Address watcheeAddress) { }
         protected virtual void WatchNode(Akka.Actor.IInternalActorRef watchee) { }
+        public static Akka.Actor.Props Props(Akka.Remote.IFailureDetectorRegistry<Akka.Actor.Address> failureDetector, System.TimeSpan heartbeatInterval, System.TimeSpan unreachableReaperInterval, System.TimeSpan heartbeatExpectedResponseAfter) { }
         public sealed class ExpectedFirstHeartbeat
         {
             public ExpectedFirstHeartbeat(Akka.Actor.Address from) { }
@@ -343,10 +343,10 @@ namespace Akka.Remote
             public int WatchingNodes { get; }
             public System.Collections.Immutable.ImmutableHashSet<System.ValueTuple<Akka.Actor.IActorRef, Akka.Actor.IActorRef>> WatchingRefs { get; }
             public Akka.Remote.RemoteWatcher.Stats Copy(int watching, int watchingNodes, System.Collections.Immutable.ImmutableHashSet<System.ValueTuple<Akka.Actor.IActorRef, Akka.Actor.IActorRef>> watchingRefs = null, System.Collections.Immutable.ImmutableHashSet<Akka.Actor.Address> watchingAddresses = null) { }
-            public static Akka.Remote.RemoteWatcher.Stats Counts(int watching, int watchingNodes) { }
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
+            public static Akka.Remote.RemoteWatcher.Stats Counts(int watching, int watchingNodes) { }
         }
         public sealed class UnwatchRemote : Akka.Remote.RemoteWatcher.WatchCommand
         {
@@ -511,8 +511,8 @@ namespace Akka.Remote.Transport
     }
     public abstract class ActorTransportAdapter : Akka.Remote.Transport.AbstractTransportAdapter
     {
+        protected volatile Akka.Actor.IActorRef manager;
         public static readonly System.TimeSpan AskTimeout;
-        protected Akka.Actor.IActorRef modreq(System.Runtime.CompilerServices.IsVolatile) manager;
         protected ActorTransportAdapter(Akka.Remote.Transport.Transport wrappedTransport, Akka.Actor.ActorSystem system) { }
         protected abstract string ManagerName { get; }
         protected abstract Akka.Actor.Props ManagerProps { get; }
@@ -533,8 +533,8 @@ namespace Akka.Remote.Transport
     }
     public class AkkaProtocolException : Akka.Actor.AkkaException
     {
-        public AkkaProtocolException(string message, System.Exception cause = null) { }
         protected AkkaProtocolException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public AkkaProtocolException(string message, System.Exception cause = null) { }
     }
     public sealed class AssociateAttempt : Akka.Remote.Transport.Activity
     {
@@ -551,26 +551,24 @@ namespace Akka.Remote.Transport
     public abstract class AssociationHandle
     {
         protected AssociationHandle(Akka.Actor.Address localAddress, Akka.Actor.Address remoteAddress) { }
-        public Akka.Actor.Address LocalAddress { get; set; }
-        public System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IHandleEventListener> ReadHandlerSource { get; set; }
-        public Akka.Actor.Address RemoteAddress { get; set; }
-        [System.ObsoleteAttribute("Use the method that states reasons to make sure disassociation reasons are logged" +
+        public Akka.Actor.Address LocalAddress { get; protected set; }
+        public System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IHandleEventListener> ReadHandlerSource { get; protected set; }
+        public Akka.Actor.Address RemoteAddress { get; protected set; }
+        [System.Obsolete("Use the method that states reasons to make sure disassociation reasons are logged" +
             ".")]
         public abstract void Disassociate();
         public void Disassociate(string reason, Akka.Event.ILoggingAdapter log) { }
-        public override bool Equals(object obj) { }
         protected bool Equals(Akka.Remote.Transport.AssociationHandle other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public abstract bool Write(Google.Protobuf.ByteString payload);
     }
     public class AssociationRegistry
     {
         public AssociationRegistry() { }
-        public static void Clear() { }
         public void ClearLog() { }
         public Akka.Util.Option<System.ValueTuple<Akka.Remote.Transport.IHandleEventListener, Akka.Remote.Transport.IHandleEventListener>> DeregisterAssociation(System.ValueTuple<Akka.Actor.Address, Akka.Actor.Address> key) { }
         public bool ExistsAssociation(Akka.Actor.Address initiatorAddress, Akka.Actor.Address remoteAddress) { }
-        public static Akka.Remote.Transport.AssociationRegistry Get(string key) { }
         public Akka.Remote.Transport.IHandleEventListener GetRemoteReadHandlerFor(Akka.Remote.Transport.TestAssociationHandle localHandle) { }
         public void LogActivity(Akka.Remote.Transport.Activity activity) { }
         public System.Collections.Generic.IList<Akka.Remote.Transport.Activity> LogSnapshot() { }
@@ -580,6 +578,8 @@ namespace Akka.Remote.Transport
         public void Reset() { }
         public Akka.Util.Option<System.ValueTuple<Akka.Remote.Transport.TestTransport, System.Threading.Tasks.Task<Akka.Remote.Transport.IAssociationEventListener>>> TransportFor(Akka.Actor.Address address) { }
         public bool TransportsReady(params Akka.Actor.Address[] addresses) { }
+        public static void Clear() { }
+        public static Akka.Remote.Transport.AssociationRegistry Get(string key) { }
     }
     public class Blackhole : Akka.Remote.Transport.ThrottleMode
     {
@@ -697,8 +697,8 @@ namespace Akka.Remote.Transport
     }
     public class InvalidAssociationException : Akka.Actor.AkkaException
     {
-        public InvalidAssociationException(string message, System.Exception cause = null) { }
         protected InvalidAssociationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public InvalidAssociationException(string message, System.Exception cause = null) { }
     }
     public sealed class ListenAttempt : Akka.Remote.Transport.Activity
     {
@@ -720,10 +720,10 @@ namespace Akka.Remote.Transport
     {
         public readonly string AddedSchemeIdentifier;
         public SchemeAugmenter(string addedSchemeIdentifier) { }
-        public string AugmentScheme(string originalScheme) { }
         public Akka.Actor.Address AugmentScheme(Akka.Actor.Address address) { }
-        public string RemoveScheme(string scheme) { }
+        public string AugmentScheme(string originalScheme) { }
         public Akka.Actor.Address RemoveScheme(Akka.Actor.Address address) { }
+        public string RemoveScheme(string scheme) { }
     }
     public sealed class SetThrottle
     {
@@ -733,8 +733,8 @@ namespace Akka.Remote.Transport
         public Akka.Remote.Transport.ThrottleMode Mode { get; }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public static bool ==(Akka.Remote.Transport.SetThrottle left, Akka.Remote.Transport.SetThrottle right) { }
-        public static bool !=(Akka.Remote.Transport.SetThrottle left, Akka.Remote.Transport.SetThrottle right) { }
+        public static bool operator !=(Akka.Remote.Transport.SetThrottle left, Akka.Remote.Transport.SetThrottle right) { }
+        public static bool operator ==(Akka.Remote.Transport.SetThrottle left, Akka.Remote.Transport.SetThrottle right) { }
     }
     public sealed class SetThrottleAck
     {
@@ -819,16 +819,16 @@ namespace Akka.Remote.Transport
         public override int GetHashCode() { }
         public override System.TimeSpan TimeToAvailable(long currentNanoTime, int tokens) { }
         public override System.ValueTuple<Akka.Remote.Transport.ThrottleMode, bool> TryConsumeTokens(long nanoTimeOfSend, int tokens) { }
-        public static bool ==(Akka.Remote.Transport.TokenBucket left, Akka.Remote.Transport.TokenBucket right) { }
-        public static bool !=(Akka.Remote.Transport.TokenBucket left, Akka.Remote.Transport.TokenBucket right) { }
+        public static bool operator !=(Akka.Remote.Transport.TokenBucket left, Akka.Remote.Transport.TokenBucket right) { }
+        public static bool operator ==(Akka.Remote.Transport.TokenBucket left, Akka.Remote.Transport.TokenBucket right) { }
     }
     public abstract class Transport
     {
         protected Transport() { }
-        public Akka.Configuration.Config Config { get; set; }
-        public virtual long MaximumPayloadBytes { get; set; }
-        public virtual string SchemeIdentifier { get; set; }
-        public Akka.Actor.ActorSystem System { get; set; }
+        public Akka.Configuration.Config Config { get; protected set; }
+        public virtual long MaximumPayloadBytes { get; protected set; }
+        public virtual string SchemeIdentifier { get; protected set; }
+        public Akka.Actor.ActorSystem System { get; protected set; }
         public abstract System.Threading.Tasks.Task<Akka.Remote.Transport.AssociationHandle> Associate(Akka.Actor.Address remoteAddress);
         public abstract bool IsResponsibleFor(Akka.Actor.Address remote);
         public abstract System.Threading.Tasks.Task<System.ValueTuple<Akka.Actor.Address, System.Threading.Tasks.TaskCompletionSource<Akka.Remote.Transport.IAssociationEventListener>>> Listen();
@@ -860,34 +860,26 @@ namespace Akka.Remote.Transport
 }
 namespace Akka.Remote.Transport.DotNetty
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static CertificateValidation
+    public static class CertificateValidation
     {
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ChainPlusThen([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                1,
-                2,
-                2,
-                1})] System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, string, bool> customCheck, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ChainPlusThen(System.Func<System.Security.Cryptography.X509Certificates.X509Certificate2?, System.Security.Cryptography.X509Certificates.X509Chain?, string, bool> customCheck, Akka.Event.ILoggingAdapter? log = null) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback Combine(params Akka.Remote.Transport.DotNetty.CertificateValidationCallback[] validators) { }
         public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback PinnedCertificate(params string[] allowedThumbprints) { }
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateChain([System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateHostname(string expectedHostname = null, Akka.Event.ILoggingAdapter log = null) { }
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateIssuer(string expectedIssuerPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
-        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateSubject(string expectedSubjectPattern, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Event.ILoggingAdapter log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateChain(Akka.Event.ILoggingAdapter? log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateHostname(string? expectedHostname = null, Akka.Event.ILoggingAdapter? log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateIssuer(string expectedIssuerPattern, Akka.Event.ILoggingAdapter? log = null) { }
+        public static Akka.Remote.Transport.DotNetty.CertificateValidationCallback ValidateSubject(string expectedSubjectPattern, Akka.Event.ILoggingAdapter? log = null) { }
     }
-    public delegate bool CertificateValidationCallback([System.Runtime.CompilerServices.NullableAttribute(2)] System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, [System.Runtime.CompilerServices.NullableAttribute(2)] System.Security.Cryptography.X509Certificates.X509Chain chain, string remotePeer, System.Net.Security.SslPolicyErrors errors, Akka.Event.ILoggingAdapter log);
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    public delegate bool CertificateValidationCallback(System.Security.Cryptography.X509Certificates.X509Certificate2? certificate, System.Security.Cryptography.X509Certificates.X509Chain? chain, string remotePeer, System.Net.Security.SslPolicyErrors errors, Akka.Event.ILoggingAdapter log);
     public sealed class DotNettySslSetup : Akka.Actor.Setup.Setup
     {
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation) { }
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication) { }
+        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, Akka.Remote.Transport.DotNetty.CertificateValidationCallback? customValidator) { }
         public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname) { }
-        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Remote.Transport.DotNetty.CertificateValidationCallback customValidator) { }
-        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Remote.Transport.DotNetty.CertificateValidationCallback customValidator) { }
+        public DotNettySslSetup(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, bool suppressValidation, bool requireMutualAuthentication, bool validateCertificateHostname, Akka.Remote.Transport.DotNetty.CertificateValidationCallback? customValidator) { }
         public System.Security.Cryptography.X509Certificates.X509Certificate2 Certificate { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public Akka.Remote.Transport.DotNetty.CertificateValidationCallback CustomValidator { get; }
+        public Akka.Remote.Transport.DotNetty.CertificateValidationCallback? CustomValidator { get; }
         public bool RequireMutualAuthentication { get; }
         public bool SuppressValidation { get; }
         public bool ValidateCertificateHostname { get; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
@@ -1,12 +1,12 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.Query.Sql")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.TCK")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams.Tests")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("123b83e9-21f8-49a8-888a-3b1212ff21dc")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.Query.Sql")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.TCK")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Streams.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Streams.Tests")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("123b83e9-21f8-49a8-888a-3b1212ff21dc")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Streams
 {
     public sealed class AbruptStageTerminationException : System.Exception
@@ -14,13 +14,14 @@ namespace Akka.Streams
         public AbruptStageTerminationException(Akka.Streams.Stage.GraphStageLogic logic) { }
         public AbruptStageTerminationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.Serializable]
     public class AbruptTerminationException : System.Exception
     {
         public readonly Akka.Actor.IActorRef Actor;
         public AbruptTerminationException(Akka.Actor.IActorRef actor) { }
         protected AbruptTerminationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static ActorAttributes
+    public static class ActorAttributes
     {
         public static Akka.Streams.ActorAttributes.Dispatcher IODispatcher { get; }
         public static Akka.Streams.Attributes CreateDebugLogging(bool enabled) { }
@@ -112,8 +113,6 @@ namespace Akka.Streams
         public abstract Akka.Actor.IActorRef Supervisor { get; }
         public abstract Akka.Actor.ActorSystem System { get; }
         public abstract Akka.Actor.IActorRef ActorOf(Akka.Streams.MaterializationContext context, Akka.Actor.Props props);
-        public static Akka.Streams.ActorMaterializer Create(Akka.Actor.IActorRefFactory context, Akka.Streams.ActorMaterializerSettings settings = null, string namePrefix = null) { }
-        public static Akka.Configuration.Config DefaultConfig() { }
         public void Dispose() { }
         public abstract Akka.Streams.ActorMaterializerSettings EffectiveSettings(Akka.Streams.Attributes attributes);
         public abstract Akka.Event.ILoggingAdapter MakeLogger(object logSource);
@@ -123,8 +122,10 @@ namespace Akka.Streams
         public abstract Akka.Actor.ICancelable ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action);
         public abstract void Shutdown();
         public abstract Akka.Streams.IMaterializer WithNamePrefix(string namePrefix);
+        public static Akka.Streams.ActorMaterializer Create(Akka.Actor.IActorRefFactory context, Akka.Streams.ActorMaterializerSettings settings = null, string namePrefix = null) { }
+        public static Akka.Configuration.Config DefaultConfig() { }
     }
-    public class static ActorMaterializerExtensions
+    public static class ActorMaterializerExtensions
     {
         public static Akka.Streams.ActorMaterializer Materializer(this Akka.Actor.IActorRefFactory context, Akka.Streams.ActorMaterializerSettings settings = null, string namePrefix = null) { }
     }
@@ -143,7 +144,6 @@ namespace Akka.Streams
         public readonly Akka.Streams.Supervision.Decider SupervisionDecider;
         public readonly int SyncProcessingLimit;
         public ActorMaterializerSettings(int initialInputBufferSize, int maxInputBufferSize, string dispatcher, Akka.Streams.Supervision.Decider supervisionDecider, Akka.Streams.StreamSubscriptionTimeoutSettings subscriptionTimeoutSettings, Akka.Streams.Dsl.StreamRefSettings streamRefSettings, bool isDebugLogging, int outputBurstLimit, bool isFuzzingMode, bool isAutoFusing, int maxFixedBufferSize, int syncProcessingLimit = 1000) { }
-        public static Akka.Streams.ActorMaterializerSettings Create(Akka.Actor.ActorSystem system) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public Akka.Streams.ActorMaterializerSettings WithAutoFusing(bool isAutoFusing) { }
@@ -157,6 +157,7 @@ namespace Akka.Streams
         public Akka.Streams.ActorMaterializerSettings WithSubscriptionTimeoutSettings(Akka.Streams.StreamSubscriptionTimeoutSettings settings) { }
         public Akka.Streams.ActorMaterializerSettings WithSupervisionStrategy(Akka.Streams.Supervision.Decider decider) { }
         public Akka.Streams.ActorMaterializerSettings WithSyncProcessingLimit(int limit) { }
+        public static Akka.Streams.ActorMaterializerSettings Create(Akka.Actor.ActorSystem system) { }
     }
     public class AmorphousShape : Akka.Streams.Shape
     {
@@ -169,39 +170,38 @@ namespace Akka.Streams
     public sealed class Attributes
     {
         public static readonly Akka.Streams.Attributes None;
-        public Attributes(params IAttribute[] attributes) { }
+        public Attributes(params Akka.Streams.Attributes.IAttribute[] attributes) { }
         public System.Collections.Generic.IEnumerable<Akka.Streams.Attributes.IAttribute> AttributeList { get; }
         public Akka.Streams.Attributes And(Akka.Streams.Attributes other) { }
         public Akka.Streams.Attributes And(Akka.Streams.Attributes.IAttribute other) { }
-        [System.ObsoleteAttribute("Use Contains<TAttr>() instead")]
-        public bool Contains<TAttr>(TAttr attribute)
-            where TAttr : Akka.Streams.Attributes.IAttribute { }
         public bool Contains<TAttr>()
             where TAttr : Akka.Streams.Attributes.IAttribute { }
-        public static Akka.Streams.Attributes CreateAsyncBoundary() { }
-        public static Akka.Streams.Attributes CreateInputBuffer(int initial, int max) { }
-        public static Akka.Streams.Attributes CreateLogLevels(Akka.Event.LogLevel onElement = 0, Akka.Event.LogLevel onFinish = 0, Akka.Event.LogLevel onError = 3) { }
-        public static Akka.Streams.Attributes CreateName(string name) { }
-        public static string ExtractName(Akka.Streams.Implementation.IModule module, string defaultIfNotFound) { }
-        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultIfNotFound")]
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public TAttr GetAttribute<TAttr>([System.Runtime.CompilerServices.NullableAttribute(2)] TAttr defaultIfNotFound)
-            where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
+        [System.Obsolete("Use Contains<TAttr>() instead")]
+        public bool Contains<TAttr>(TAttr attribute)
+            where TAttr : Akka.Streams.Attributes.IAttribute { }
         public TAttr GetAttribute<TAttr>()
+            where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultIfNotFound")]
+        public TAttr? GetAttribute<TAttr>(TAttr? defaultIfNotFound)
             where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
         public System.Collections.Generic.IEnumerable<TAttr> GetAttributeList<TAttr>()
             where TAttr : Akka.Streams.Attributes.IAttribute { }
-        [System.ObsoleteAttribute("Attributes should always be most specific, use GetAttribute<TAttr>()")]
-        public TAttr GetFirstAttribute<TAttr>(TAttr defaultIfNotFound)
-            where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
-        [System.ObsoleteAttribute("Attributes should always be most specific, use GetAttribute<TAttr>()")]
+        [System.Obsolete("Attributes should always be most specific, use GetAttribute<TAttr>()")]
         public TAttr GetFirstAttribute<TAttr>()
+            where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
+        [System.Obsolete("Attributes should always be most specific, use GetAttribute<TAttr>()")]
+        public TAttr GetFirstAttribute<TAttr>(TAttr defaultIfNotFound)
             where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
         public TAttr GetMandatoryAttribute<TAttr>()
             where TAttr :  class, Akka.Streams.Attributes.IMandatoryAttribute { }
         public string GetNameLifted() { }
         public string GetNameOrDefault(string defaultIfNotFound = "unknown-operation") { }
         public override string ToString() { }
+        public static Akka.Streams.Attributes CreateAsyncBoundary() { }
+        public static Akka.Streams.Attributes CreateInputBuffer(int initial, int max) { }
+        public static Akka.Streams.Attributes CreateLogLevels(Akka.Event.LogLevel onElement = 0, Akka.Event.LogLevel onFinish = 0, Akka.Event.LogLevel onError = 3) { }
+        public static Akka.Streams.Attributes CreateName(string name) { }
+        public static string ExtractName(Akka.Streams.Implementation.IModule module, string defaultIfNotFound) { }
         public sealed class AsyncBoundary : Akka.Streams.Attributes.IAttribute, System.IEquatable<Akka.Streams.Attributes.AsyncBoundary>
         {
             public static readonly Akka.Streams.Attributes.AsyncBoundary Instance;
@@ -248,10 +248,10 @@ namespace Akka.Streams
         }
         public sealed class LogLevels : Akka.Streams.Attributes.IAttribute, System.IEquatable<Akka.Streams.Attributes.LogLevels>
         {
-            public static readonly Akka.Event.LogLevel Off;
             public readonly Akka.Event.LogLevel OnElement;
             public readonly Akka.Event.LogLevel OnFailure;
             public readonly Akka.Event.LogLevel OnFinish;
+            public static readonly Akka.Event.LogLevel Off;
             public LogLevels(Akka.Event.LogLevel onElement, Akka.Event.LogLevel onFinish, Akka.Event.LogLevel onFailure) { }
             public bool Equals(Akka.Streams.Attributes.LogLevels other) { }
             public override bool Equals(object obj) { }
@@ -268,7 +268,7 @@ namespace Akka.Streams
             public override string ToString() { }
         }
     }
-    public class static BidiShape
+    public static class BidiShape
     {
         public static Akka.Streams.BidiShape<TIn1, TOut1, TIn2, TOut2> FromFlows<TIn1, TOut1, TIn2, TOut2>(Akka.Streams.FlowShape<TIn1, TOut1> top, Akka.Streams.FlowShape<TIn2, TOut2> bottom) { }
     }
@@ -278,8 +278,8 @@ namespace Akka.Streams
         public readonly Akka.Streams.Inlet<TIn2> Inlet2;
         public readonly Akka.Streams.Outlet<TOut1> Outlet1;
         public readonly Akka.Streams.Outlet<TOut2> Outlet2;
-        public BidiShape(Akka.Streams.Inlet<TIn1> in1, Akka.Streams.Outlet<TOut1> out1, Akka.Streams.Inlet<TIn2> in2, Akka.Streams.Outlet<TOut2> out2) { }
         public BidiShape(Akka.Streams.FlowShape<TIn1, TOut1> top, Akka.Streams.FlowShape<TIn2, TOut2> bottom) { }
+        public BidiShape(Akka.Streams.Inlet<TIn1> in1, Akka.Streams.Outlet<TOut1> out1, Akka.Streams.Inlet<TIn2> in2, Akka.Streams.Outlet<TOut2> out2) { }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> Inlets { get; }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> Outlets { get; }
         public override Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
@@ -291,11 +291,12 @@ namespace Akka.Streams
         public static readonly Akka.Streams.BindFailedException Instance;
         protected BindFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.Serializable]
     public class BufferOverflowException : System.Exception
     {
         public BufferOverflowException(string message) { }
-        public BufferOverflowException(string message, System.Exception innerException) { }
         protected BufferOverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public BufferOverflowException(string message, System.Exception innerException) { }
     }
     public class ClosedShape : Akka.Streams.Shape
     {
@@ -308,10 +309,10 @@ namespace Akka.Streams
     public class ConnectionException : Akka.Streams.StreamTcpException
     {
         public ConnectionException(string message) { }
-        public ConnectionException(string message, System.Exception innerException) { }
         protected ConnectionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public ConnectionException(string message, System.Exception innerException) { }
     }
-    public class static Construct
+    public static class Construct
     {
         public static object Instantiate(this System.Type genericType, System.Type genericParam, params object[] constructorArgs) { }
         public static object Instantiate(this System.Type genericType, System.Type[] genericParams, params object[] constructorArgs) { }
@@ -331,38 +332,40 @@ namespace Akka.Streams
         public readonly Akka.Streams.Inlet<T0> In0;
         public readonly System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet<T1>> In1s;
         public readonly int N;
-        public FanInShapeN(int n, Akka.Streams.FanInShape<TOut>.IInit init) { }
         public FanInShapeN(int n) { }
+        public FanInShapeN(int n, Akka.Streams.FanInShape<TOut>.IInit init) { }
         public FanInShapeN(int n, string name) { }
-        public FanInShapeN(Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Inlet<T0> in0, params Akka.Streams.Inlet<>[] inlets) { }
+        public FanInShapeN(Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Inlet<T0> in0, params Akka.Streams.Inlet<T1>[] inlets) { }
         protected override Akka.Streams.FanInShape<TOut> Construct(Akka.Streams.FanInShape<TOut>.IInit init) { }
         public Akka.Streams.Inlet<T1> In(int n) { }
     }
     public abstract class FanInShape<TOut> : Akka.Streams.Shape
     {
-        protected FanInShape(Akka.Streams.Outlet<TOut> outlet, System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> registered, string name) { }
         protected FanInShape(Akka.Streams.FanInShape<TOut>.IInit init) { }
+        protected FanInShape(Akka.Streams.Outlet<TOut> outlet, System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> registered, string name) { }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> Inlets { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> Outlets { get; }
         protected abstract Akka.Streams.FanInShape<TOut> Construct(Akka.Streams.FanInShape<TOut>.IInit init);
-        public virtual Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
+        public override sealed Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
         public override Akka.Streams.Shape DeepCopy() { }
         protected Akka.Streams.Inlet<T> NewInlet<T>(string name) { }
-        public interface IInit<TOut>
+        public interface IInit
         {
             System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> Inlets { get; }
             string Name { get; }
             Akka.Streams.Outlet<TOut> Outlet { get; }
         }
-        public sealed class InitName<TOut> : Akka.Streams.FanInShape<TOut>.IInit
+        [System.Serializable]
+        public sealed class InitName : Akka.Streams.FanInShape<TOut>.IInit
         {
             public InitName(string name) { }
             public System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> Inlets { get; }
             public string Name { get; }
             public Akka.Streams.Outlet<TOut> Outlet { get; }
         }
-        public sealed class InitPorts<TOut> : Akka.Streams.FanInShape<TOut>.IInit
+        [System.Serializable]
+        public sealed class InitPorts : Akka.Streams.FanInShape<TOut>.IInit
         {
             public InitPorts(Akka.Streams.Outlet<TOut> outlet, System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> inlets) { }
             public System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> Inlets { get; }
@@ -472,29 +475,31 @@ namespace Akka.Streams
     }
     public abstract class FanOutShape<TIn> : Akka.Streams.Shape
     {
-        protected FanOutShape(Akka.Streams.Inlet<TIn> inlet, System.Collections.Generic.IEnumerable<Akka.Streams.Outlet> registered, string name) { }
         protected FanOutShape(Akka.Streams.FanOutShape<TIn>.IInit init) { }
+        protected FanOutShape(Akka.Streams.Inlet<TIn> inlet, System.Collections.Generic.IEnumerable<Akka.Streams.Outlet> registered, string name) { }
         public Akka.Streams.Inlet<TIn> In { get; }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> Inlets { get; }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> Outlets { get; }
         protected abstract Akka.Streams.FanOutShape<TIn> Construct(Akka.Streams.FanOutShape<TIn>.IInit init);
-        public virtual Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
+        public override sealed Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
         public override Akka.Streams.Shape DeepCopy() { }
         protected Akka.Streams.Outlet<T> NewOutlet<T>(string name) { }
-        public interface IInit<TIn>
+        public interface IInit
         {
             Akka.Streams.Inlet<TIn> Inlet { get; }
             string Name { get; }
             System.Collections.Generic.IEnumerable<Akka.Streams.Outlet> Outlets { get; }
         }
-        public sealed class InitName<TIn> : Akka.Streams.FanOutShape<TIn>.IInit
+        [System.Serializable]
+        public sealed class InitName : Akka.Streams.FanOutShape<TIn>.IInit
         {
             public InitName(string name) { }
             public Akka.Streams.Inlet<TIn> Inlet { get; }
             public string Name { get; }
             public System.Collections.Generic.IEnumerable<Akka.Streams.Outlet> Outlets { get; }
         }
-        public sealed class InitPorts<TIn> : Akka.Streams.FanOutShape<TIn>.IInit
+        [System.Serializable]
+        public sealed class InitPorts : Akka.Streams.FanOutShape<TIn>.IInit
         {
             public InitPorts(Akka.Streams.Inlet<TIn> inlet, System.Collections.Generic.IEnumerable<Akka.Streams.Outlet> outlets) { }
             public Akka.Streams.Inlet<TIn> Inlet { get; }
@@ -602,7 +607,7 @@ namespace Akka.Streams
         public FanOutShape(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<T0> out0, Akka.Streams.Outlet<T1> out1, Akka.Streams.Outlet<T2> out2, Akka.Streams.Outlet<T3> out3, Akka.Streams.Outlet<T4> out4, Akka.Streams.Outlet<T5> out5, Akka.Streams.Outlet<T6> out6, Akka.Streams.Outlet<T7> out7) { }
         protected override Akka.Streams.FanOutShape<TIn> Construct(Akka.Streams.FanOutShape<TIn>.IInit init) { }
     }
-    public class static FlowMonitor
+    public static class FlowMonitor
     {
         public sealed class Failed : Akka.Streams.FlowMonitor.IStreamState
         {
@@ -634,7 +639,7 @@ namespace Akka.Streams
         public override Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
         public override Akka.Streams.Shape DeepCopy() { }
     }
-    public class static Fusing
+    public static class Fusing
     {
         public static Akka.Streams.Fusing.FusedGraph<TShape, TMat> Aggressive<TShape, TMat>(Akka.Streams.IGraph<TShape, TMat> graph)
             where TShape : Akka.Streams.Shape { }
@@ -676,7 +681,7 @@ namespace Akka.Streams
     public interface IGraph<out TShape>
         where out TShape : Akka.Streams.Shape
     {
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         Akka.Streams.Implementation.IModule Module { get; }
         TShape Shape { get; }
     }
@@ -762,8 +767,8 @@ namespace Akka.Streams
         public readonly string Name;
         protected Inlet(string name) { }
         public abstract Akka.Streams.Inlet CarbonCopy();
+        public override sealed string ToString() { }
         public static Akka.Streams.Inlet<T> Create<T>(Akka.Streams.Inlet inlet) { }
-        public virtual string ToString() { }
     }
     public sealed class Inlet<T> : Akka.Streams.Inlet
     {
@@ -772,27 +777,26 @@ namespace Akka.Streams
     }
     public sealed class InvalidPartnerActorException : Akka.Pattern.IllegalStateException
     {
-        public InvalidPartnerActorException(Akka.Actor.IActorRef expectedRef, Akka.Actor.IActorRef gotRef, string message) { }
         protected InvalidPartnerActorException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public InvalidPartnerActorException(Akka.Actor.IActorRef expectedRef, Akka.Actor.IActorRef gotRef, string message) { }
         public Akka.Actor.IActorRef ExpectedRef { get; }
         public Akka.Actor.IActorRef GotRef { get; }
     }
     public sealed class InvalidSequenceNumberException : Akka.Pattern.IllegalStateException
     {
-        public InvalidSequenceNumberException(long expectedSeqNr, long gotSeqNr, string message) { }
         protected InvalidSequenceNumberException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public InvalidSequenceNumberException(long expectedSeqNr, long gotSeqNr, string message) { }
         public long ExpectedSeqNr { get; }
         public long GotSeqNr { get; }
     }
-    public class static KillSwitches
+    public static class KillSwitches
     {
-        public static Akka.Streams.IGraph<Akka.Streams.FlowShape<T, T>, Akka.NotUsed> AsFlow<T>(this System.Threading.CancellationToken cancellationToken, bool cancelGracefully = False) { }
+        public static Akka.Streams.IGraph<Akka.Streams.FlowShape<T, T>, Akka.NotUsed> AsFlow<T>(this System.Threading.CancellationToken cancellationToken, bool cancelGracefully = false) { }
         public static Akka.Streams.SharedKillSwitch Shared(string name) { }
         public static Akka.Streams.IGraph<Akka.Streams.FlowShape<T, T>, Akka.Streams.UniqueKillSwitch> Single<T>() { }
         public static Akka.Streams.IGraph<Akka.Streams.BidiShape<T1, T1, T2, T2>, Akka.Streams.UniqueKillSwitch> SingleBidi<T1, T2>() { }
     }
-    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-    public struct MaterializationContext
+    public readonly struct MaterializationContext
     {
         public readonly Akka.Streams.Attributes EffectiveAttributes;
         public readonly Akka.Streams.IMaterializer Materializer;
@@ -801,8 +805,8 @@ namespace Akka.Streams
     }
     public class MaterializationException : System.Exception
     {
-        public MaterializationException(string message, System.Exception innerException) { }
         protected MaterializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public MaterializationException(string message, System.Exception innerException) { }
     }
     public sealed class NoMaterializer : Akka.Streams.IMaterializer
     {
@@ -828,8 +832,8 @@ namespace Akka.Streams
         public readonly string Name;
         protected Outlet(string name) { }
         public abstract Akka.Streams.Outlet CarbonCopy();
+        public override sealed string ToString() { }
         public static Akka.Streams.Outlet<T> Create<T>(Akka.Streams.Outlet outlet) { }
-        public virtual string ToString() { }
     }
     public sealed class Outlet<T> : Akka.Streams.Outlet
     {
@@ -878,12 +882,12 @@ namespace Akka.Streams
         public System.TimeSpan MaxRestartsWithin { get; }
         public System.TimeSpan MinBackoff { get; }
         public double RandomFactor { get; }
-        public static Akka.Streams.RestartSettings Create(System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public override string ToString() { }
         public Akka.Streams.RestartSettings WithMaxBackoff(System.TimeSpan value) { }
         public Akka.Streams.RestartSettings WithMaxRestarts(int count, System.TimeSpan within) { }
         public Akka.Streams.RestartSettings WithMinBackoff(System.TimeSpan value) { }
         public Akka.Streams.RestartSettings WithRandomFactor(double value) { }
+        public static Akka.Streams.RestartSettings Create(System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
     }
     public abstract class Shape : System.ICloneable
     {
@@ -895,7 +899,7 @@ namespace Akka.Streams
         public abstract Akka.Streams.Shape DeepCopy();
         public bool HasSamePortsAndShapeAs(Akka.Streams.Shape shape) { }
         public bool HasSamePortsAs(Akka.Streams.Shape shape) { }
-        public virtual string ToString() { }
+        public override sealed string ToString() { }
     }
     public sealed class SharedKillSwitch : Akka.Streams.IKillSwitch
     {
@@ -938,7 +942,7 @@ namespace Akka.Streams
         public StreamLimitReachedException(long max) { }
         protected StreamLimitReachedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static StreamRefAttributes
+    public static class StreamRefAttributes
     {
         public static Akka.Streams.Attributes CreateBufferCapacity(int capacity) { }
         public static Akka.Streams.Attributes CreateDemandRedeliveryInterval(System.TimeSpan timeout) { }
@@ -992,11 +996,11 @@ namespace Akka.Streams
         public readonly Akka.Streams.StreamSubscriptionTimeoutTerminationMode Mode;
         public readonly System.TimeSpan Timeout;
         public StreamSubscriptionTimeoutSettings(Akka.Streams.StreamSubscriptionTimeoutTerminationMode mode, System.TimeSpan timeout) { }
-        public static Akka.Streams.StreamSubscriptionTimeoutSettings Create(Akka.Configuration.Config config) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Streams.StreamSubscriptionTimeoutSettings other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
+        public static Akka.Streams.StreamSubscriptionTimeoutSettings Create(Akka.Configuration.Config config) { }
     }
     public enum StreamSubscriptionTimeoutTerminationMode
     {
@@ -1007,20 +1011,20 @@ namespace Akka.Streams
     public class StreamTcpException : System.Exception
     {
         public StreamTcpException(string message) { }
-        public StreamTcpException(string message, System.Exception innerException) { }
         protected StreamTcpException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public StreamTcpException(string message, System.Exception innerException) { }
     }
-    public class static SubscriptionWithCancelException
+    public static class SubscriptionWithCancelException
     {
         public sealed class NoMoreElementsNeeded : Akka.Streams.SubscriptionWithCancelException.NonFailureCancellation
         {
             public static readonly Akka.Streams.SubscriptionWithCancelException.NoMoreElementsNeeded Instance;
         }
-        [Akka.Annotations.DoNotInheritAttribute()]
+        [Akka.Annotations.DoNotInherit]
         public abstract class NonFailureCancellation : System.Exception
         {
             protected NonFailureCancellation() { }
-            public virtual string StackTrace { get; }
+            public override sealed string StackTrace { get; }
         }
         public sealed class StageWasCompleted : Akka.Streams.SubscriptionWithCancelException.NonFailureCancellation
         {
@@ -1058,20 +1062,20 @@ namespace Akka.Streams
     public class UniformFanInShape<TIn, TOut> : Akka.Streams.FanInShape<TOut>
     {
         public readonly int N;
-        public UniformFanInShape(int n, Akka.Streams.FanInShape<TOut>.IInit init) { }
         public UniformFanInShape(int n) { }
+        public UniformFanInShape(Akka.Streams.Outlet<TOut> outlet, params Akka.Streams.Inlet<TIn>[] inlets) { }
+        public UniformFanInShape(int n, Akka.Streams.FanInShape<TOut>.IInit init) { }
         public UniformFanInShape(int n, string name) { }
-        public UniformFanInShape(Akka.Streams.Outlet<TOut> outlet, params Akka.Streams.Inlet<>[] inlets) { }
         public System.Collections.Immutable.IImmutableList<Akka.Streams.Inlet<TIn>> Ins { get; }
         protected override Akka.Streams.FanInShape<TOut> Construct(Akka.Streams.FanInShape<TOut>.IInit init) { }
         public Akka.Streams.Inlet<TIn> In(int n) { }
     }
     public class UniformFanOutShape<TIn, TOut> : Akka.Streams.FanOutShape<TIn>
     {
-        public UniformFanOutShape(int n, Akka.Streams.FanOutShape<TIn>.IInit init) { }
         public UniformFanOutShape(int n) { }
+        public UniformFanOutShape(Akka.Streams.Inlet<TIn> inlet, params Akka.Streams.Outlet<TOut>[] outlets) { }
+        public UniformFanOutShape(int n, Akka.Streams.FanOutShape<TIn>.IInit init) { }
         public UniformFanOutShape(int n, string name) { }
-        public UniformFanOutShape(Akka.Streams.Inlet<TIn> inlet, params Akka.Streams.Outlet<>[] outlets) { }
         public System.Collections.Immutable.IImmutableList<Akka.Streams.Outlet<TOut>> Outs { get; }
         protected override Akka.Streams.FanOutShape<TIn> Construct(Akka.Streams.FanOutShape<TIn>.IInit init) { }
         public Akka.Streams.Outlet<TOut> Out(int n) { }
@@ -1084,13 +1088,13 @@ namespace Akka.Streams
     }
     public class WatchedActorTerminatedException : Akka.Actor.AkkaException
     {
-        public WatchedActorTerminatedException(string stageName, Akka.Actor.IActorRef actorRef) { }
         protected WatchedActorTerminatedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public WatchedActorTerminatedException(string stageName, Akka.Actor.IActorRef actorRef) { }
     }
 }
 namespace Akka.Streams.Actors
 {
-    public class static ActorPublisher
+    public static class ActorPublisher
     {
         public static Reactive.Streams.IPublisher<T> Create<T>(Akka.Actor.IActorRef @ref) { }
     }
@@ -1112,7 +1116,7 @@ namespace Akka.Streams.Actors
         public bool IsCanceled { get; }
         public bool IsCompleted { get; }
         public bool IsErrorEmitted { get; }
-        public System.TimeSpan SubscriptionTimeout { get; set; }
+        public System.TimeSpan SubscriptionTimeout { get; protected set; }
         public long TotalDemand { get; }
         public override void AroundPostRestart(System.Exception cause, object message) { }
         public override void AroundPostStop() { }
@@ -1137,8 +1141,8 @@ namespace Akka.Streams.Actors
         public override void AroundPreStart() { }
         protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         protected void Cancel() { }
-        public static Reactive.Streams.ISubscriber<T> Create<T>(Akka.Actor.IActorRef @ref) { }
         protected void Request(long n) { }
+        public static Reactive.Streams.ISubscriber<T> Create<T>(Akka.Actor.IActorRef @ref) { }
     }
     public sealed class ActorSubscriberImpl<T> : Reactive.Streams.ISubscriber<T>
     {
@@ -1156,6 +1160,7 @@ namespace Akka.Streams.Actors
         public Akka.Streams.Actors.ActorSubscriberState.State Get(Akka.Actor.IActorRef actorRef) { }
         public Akka.Streams.Actors.ActorSubscriberState.State Remove(Akka.Actor.IActorRef actorRef) { }
         public void Set(Akka.Actor.IActorRef actorRef, Akka.Streams.Actors.ActorSubscriberState.State s) { }
+        [System.Serializable]
         public sealed class State
         {
             public readonly bool IsCanceled;
@@ -1164,6 +1169,7 @@ namespace Akka.Streams.Actors
             public State(Reactive.Streams.ISubscription subscription, long requested, bool isCanceled) { }
         }
     }
+    [System.Serializable]
     public sealed class Cancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorPublisherMessage
     {
         public static readonly Akka.Streams.Actors.Cancel Instance;
@@ -1174,6 +1180,7 @@ namespace Akka.Streams.Actors
     {
         int RequestDemand(int remainingRequested);
     }
+    [System.Serializable]
     public enum LifecycleState
     {
         PreSubscriber = 0,
@@ -1191,10 +1198,12 @@ namespace Akka.Streams.Actors
         public abstract int InFlight { get; }
         public int RequestDemand(int remainingRequested) { }
     }
+    [System.Serializable]
     public sealed class OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorSubscriberMessage
     {
         public static readonly Akka.Streams.Actors.OnComplete Instance;
     }
+    [System.Serializable]
     public sealed class OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorSubscriberMessage
     {
         public readonly System.Exception Cause;
@@ -1206,11 +1215,13 @@ namespace Akka.Streams.Actors
         public readonly bool Stop;
         public OnErrorBlock(System.Exception cause, bool stop) { }
     }
+    [System.Serializable]
     public sealed class OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorSubscriberMessage
     {
         public readonly object Element;
         public OnNext(object element) { }
     }
+    [System.Serializable]
     public sealed class OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
     {
         public readonly Reactive.Streams.ISubscription Subscription;
@@ -1221,6 +1232,7 @@ namespace Akka.Streams.Actors
         public static readonly Akka.Streams.Actors.OneByOneRequestStrategy Instance;
         public int RequestDemand(int remainingRequested) { }
     }
+    [System.Serializable]
     public sealed class Request : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorPublisherMessage
     {
         public readonly long Count;
@@ -1231,6 +1243,7 @@ namespace Akka.Streams.Actors
         public readonly Reactive.Streams.ISubscriber<T> Subscriber;
         public Subscribe(Reactive.Streams.ISubscriber<T> subscriber) { }
     }
+    [System.Serializable]
     public sealed class SubscriptionTimeoutExceeded : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorPublisherMessage
     {
         public static readonly Akka.Streams.Actors.SubscriptionTimeoutExceeded Instance;
@@ -1261,7 +1274,7 @@ namespace Akka.Streams.Dsl
     }
     public sealed class Balance<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanOutShape<T, T>>
     {
-        public Balance(int outputPorts, bool waitForAllDownstreams = False) { }
+        public Balance(int outputPorts, bool waitForAllDownstreams = false) { }
         public Akka.Streams.Inlet<T> In { get; }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public override Akka.Streams.UniformFanOutShape<T, T> Shape { get; }
@@ -1269,7 +1282,7 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Outlet<T> Out(int id) { }
         public override string ToString() { }
     }
-    public class static BidiFlow
+    public static class BidiFlow
     {
         public static Akka.Streams.Dsl.BidiFlow<TIn, TIn, TOut, TOut, Akka.NotUsed> BidirectionalIdleTimeout<TIn, TOut>(System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.BidiFlow<TIn1, TOut1, TIn2, TOut2, Akka.NotUsed> FromFlows<TIn1, TOut1, TIn2, TOut2, TMat1, TMat2>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn1, TOut1>, TMat1> flow1, Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn2, TOut2>, TMat2> flow2) { }
@@ -1295,30 +1308,30 @@ namespace Akka.Streams.Dsl
     public class BroadcastHub
     {
         public BroadcastHub() { }
-        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int bufferSize) { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>() { }
+        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int bufferSize) { }
     }
     public sealed class Broadcast<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanOutShape<T, T>>
     {
         public readonly Akka.Streams.Inlet<T> In;
-        public Broadcast(int outputPorts, bool eagerCancel = False) { }
+        public Broadcast(int outputPorts, bool eagerCancel = false) { }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public override Akka.Streams.UniformFanOutShape<T, T> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public Akka.Streams.Outlet<T> Out(int id) { }
         public override string ToString() { }
     }
-    public class static ChannelSink
+    public static class ChannelSink
     {
-        public static Akka.Streams.Dsl.Sink<T, System.Threading.Channels.ChannelReader<T>> AsReader<T>(int bufferSize, bool singleReader = False, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
+        public static Akka.Streams.Dsl.Sink<T, System.Threading.Channels.ChannelReader<T>> AsReader<T>(int bufferSize, bool singleReader = false, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
         public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> FromWriter<T>(System.Threading.Channels.ChannelWriter<T> writer, bool isOwner) { }
     }
-    public class static ChannelSource
+    public static class ChannelSource
     {
-        public static Akka.Streams.Dsl.Source<T, System.Threading.Channels.ChannelWriter<T>> Create<T>(int bufferSize, bool singleWriter = False, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
+        public static Akka.Streams.Dsl.Source<T, System.Threading.Channels.ChannelWriter<T>> Create<T>(int bufferSize, bool singleWriter = false, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromReader<T>(System.Threading.Channels.ChannelReader<T> reader) { }
     }
-    public class static Concat
+    public static class Concat
     {
         public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, T>, Akka.NotUsed> Create<T>(int inputPorts = 2) { }
     }
@@ -1338,17 +1351,17 @@ namespace Akka.Streams.Dsl
         public DelayFlow(System.TimeSpan fixedDelay) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    public class static FileIO
+    public static class FileIO
     {
         public static Akka.Streams.Dsl.Source<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> FromFile(System.IO.FileInfo f, int chunkSize = 8192, long startPosition = 0) { }
-        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> ToFile(System.IO.FileInfo f, System.Nullable<System.IO.FileMode> fileMode = null, long startPosition = 0, bool autoFlush = False, Akka.Streams.Implementation.IO.FlushSignaler flushSignaler = null) { }
+        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> ToFile(System.IO.FileInfo f, System.IO.FileMode? fileMode = default, long startPosition = 0, bool autoFlush = false, Akka.Streams.Implementation.IO.FlushSignaler flushSignaler = null) { }
     }
     public class FixedDelay<T> : Akka.Streams.Dsl.IDelayStrategy<T>
     {
         public FixedDelay(System.TimeSpan delay) { }
         public System.TimeSpan NextDelay(T element) { }
     }
-    public class static Flow
+    public static class Flow
     {
         public static Akka.Streams.Dsl.Flow<T, T, Akka.NotUsed> Create<T>() { }
         public static Akka.Streams.Dsl.Flow<T, T, TMat> Create<T, TMat>() { }
@@ -1363,7 +1376,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut, System.Threading.Tasks.Task<Akka.Util.Option<TMat>>> LazyInitAsync<TIn, TOut, TMat>(System.Func<System.Threading.Tasks.Task<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>>> flowFactory) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, System.Threading.Tasks.Task<TMat>> Setup<TIn, TOut, TMat>(System.Func<Akka.Streams.ActorMaterializer, Akka.Streams.Attributes, Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> factory) { }
     }
-    public class static FlowOperations
+    public static class FlowOperations
     {
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Aggregate<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, TOut2 zero, System.Func<TOut2, TOut1, TOut2> fold) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> AggregateAsync<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, TOut2 zero, System.Func<TOut2, TOut1, System.Threading.Tasks.Task<TOut2>> fold) { }
@@ -1376,7 +1389,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Batch<TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> BatchWeighted<TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Buffer<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int size, Akka.Streams.OverflowStrategy strategy) { }
-        [System.ObsoleteAttribute("Deprecated. Please use Collect(isDefined, collector) instead")]
+        [System.Obsolete("Deprecated. Please use Collect(isDefined, collector) instead")]
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Collect<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Collect<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<TOut1, bool> isDefined, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> CompletionTimeout<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan timeout) { }
@@ -1384,15 +1397,15 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> ConcatMany<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Conflate<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TOut, TOut> aggregate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TSeed, TMat> ConflateWithSeed<TIn, TOut, TMat, TSeed>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TSeed> seed, System.Func<TSeed, TOut, TSeed> aggregate) { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Delay<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan of, System.Nullable<Akka.Streams.DelayOverflowStrategy> strategy = null) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Delay<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan of, Akka.Streams.DelayOverflowStrategy? strategy = default) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Detach<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> DivertTo<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that, System.Func<TOut, bool> when) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat3> DivertToMaterialized<TIn, TOut, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TOut, bool> when, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Expand<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<TOut1, System.Collections.Generic.IEnumerator<TOut2>> extrapolate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc, bool allowClosedSubstreamRecreation) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TKey> groupingFunc, bool allowClosedSubstreamRecreation) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TKey> groupingFunc) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc, bool allowClosedSubstreamRecreation) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> Grouped<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n, System.TimeSpan timeout) { }
@@ -1403,22 +1416,22 @@ namespace Akka.Streams.Dsl
             where T1 : T2 { }
         public static Akka.Streams.Dsl.Flow<TIn, T2, TMat3> InterleaveMaterialized<TIn, T1, T2, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Flow<TIn, T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat2> graph, int segmentSize, System.Func<TMat, TMat2, TMat3> combine)
             where T1 : T2 { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Intersperse<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Intersperse<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, TOut inject) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Intersperse<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.Flow<TIn, TInjected, TMat> KeepAlive<TIn, TOut, TInjected, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan timeout, System.Func<TInjected> injectElement)
             where TOut : TInjected { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Limit<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> LimitWeighted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, long> costFunc) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Log<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null, Akka.Event.LogLevel logLevel = 0) { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Merge<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = False)
+        public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Merge<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = false)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> MergeMany<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, int breadth, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat3> MergeMaterialized<TIn, TOut1, TOut2, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat2> that, System.Func<TMat, TMat2, TMat3> combine)
             where TOut1 : TOut2 { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> MergeSorted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> MergeSorted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other)
             where TOut : System.IComparable<TOut> { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> MergeSorted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Collections.Generic.IComparer<TOut> comparer) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> MergeSorted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat2> Monitor<TIn, TOut, TMat, TMat2>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TMat, Akka.Streams.IFlowMonitor, TMat2> combine) { }
         public static Akka.Streams.Dsl.Flow<T, T, TMat> OrElse<T, TMat>(this Akka.Streams.Dsl.Flow<T, T, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat> secondary) { }
         public static Akka.Streams.Dsl.Flow<T, T, TMat3> OrElseMaterialized<T, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Flow<T, T, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat2> secondary, System.Func<TMat, TMat2, TMat3> materializedFunction) { }
@@ -1426,7 +1439,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Prepend<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> that)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Recover<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<System.Exception, Akka.Util.Option<TOut>> partialFunc) { }
-        [System.ObsoleteAttribute("Use RecoverWithRetries instead. [1.1.2]")]
+        [System.Obsolete("Use RecoverWithRetries instead. [1.1.2]")]
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> RecoverWith<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> RecoverWithRetries<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc, int attempts) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> RepeatPrevious<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow) { }
@@ -1442,58 +1455,54 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> SkipWhile<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Predicate<TOut> predicate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> SkipWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan duration) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> Sliding<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n, int step = 1) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitAfter<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitAfter<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, bool> predicate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitWhen<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitAfter<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitWhen<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitWhen<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.Flow<T, TOut, TMat> StatefulSelectMany<T, TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<T, TIn, TMat> flow, System.Func<System.Func<TIn, System.Collections.Generic.IEnumerable<TOut>>> mapConcaterFactory) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Sum<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TOut, TOut> reduce) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Take<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long n) { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> TakeWhile<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Predicate<TOut> predicate, bool inclusive = False) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> TakeWhile<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Predicate<TOut> predicate, bool inclusive = false) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> TakeWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan duration) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Throttle<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int elements, System.TimeSpan per, int maximumBurst, Akka.Streams.ThrottleMode mode) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Throttle<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int cost, System.TimeSpan per, int maximumBurst, System.Func<TOut, int> calculateCost, Akka.Streams.ThrottleMode mode) { }
-        [System.ObsoleteAttribute("Use Via(GraphStage) instead. [1.1.2]")]
+        [System.Obsolete("Use Via(GraphStage) instead. [1.1.2]")]
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Transform<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<Akka.Streams.Stage.IStage<TOut1, TOut2>> stageFactory) { }
         public static Akka.Streams.Dsl.Flow<T, T, TMat> Watch<T, TMat>(this Akka.Streams.Dsl.Flow<T, T, TMat> flow, Akka.Actor.IActorRef actorRef) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat2> WatchTermination<TIn, TOut, TMat, TMat2>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TMat, System.Threading.Tasks.Task<Akka.Done>, TMat2> materializerFunction) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Where<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Predicate<TOut> predicate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> WhereNot<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Predicate<TOut> predicate) { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> WireTap<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> WireTap<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> WireTap<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat3> WireTapMaterialized<TIn, TOut, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.ValueTuple<T1, T2>, TMat> Zip<TIn, T1, T2, TMat>(this Akka.Streams.Dsl.Flow<TIn, T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other) { }
         public static Akka.Streams.Dsl.Flow<TIn, T3, TMat> ZipWith<TIn, T1, T2, T3, TMat>(this Akka.Streams.Dsl.Flow<TIn, T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other, System.Func<T1, T2, T3> combine) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.ValueTuple<TOut, long>, TMat> ZipWithIndex<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow) { }
     }
-    public class static FlowWithContext
+    public static class FlowWithContext
     {
         public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TIn, TCtx, Akka.NotUsed> Create<TIn, TCtx>() { }
         public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat> From<TIn, TCtxIn, TOut, TCtxOut, TMat>(Akka.Streams.Dsl.Flow<System.ValueTuple<TIn, TCtxIn>, System.ValueTuple<TOut, TCtxOut>, TMat> flow) { }
     }
-    public class static FlowWithContextOperations
+    public static class FlowWithContextOperations
     {
-        [System.ObsoleteAttribute("Deprecated. Please use Collect(FlowWithContext, Func, Func) instead. Since v1.5.4" +
+        [System.Obsolete("Deprecated. Please use Collect(FlowWithContext, Func, Func) instead. Since v1.5.4" +
             "4, will be removed in v1.6")]
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, TOut2> fn)
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                0,
-                0,
-                0})] System.Func<System.ValueTuple<TOut, TCtx>, bool> isDefined, System.Func<TOut, TOut2> fn)
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<System.ValueTuple<TOut, TCtx>, bool>? isDefined, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, int n) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Select<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, TOut2> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectAsync<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, int parallelism, System.Func<TOut, System.Threading.Tasks.Task<TOut2>> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectConcat<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx2, TMat> SelectContext<TIn, TCtx, TOut, TCtx2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TCtx, TCtx2> mapContext) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Sliding<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, int n, int step = 1) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> StatefulSelectConcat<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>>> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> Where<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, bool> predicate) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> WhereNot<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, int n) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Select<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectAsync<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, int parallelism, System.Func<TOut, System.Threading.Tasks.Task<TOut2>> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectConcat<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx2, TMat> SelectContext<TIn, TCtx, TOut, TCtx2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TCtx, TCtx2> mapContext) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Sliding<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, int n, int step = 1) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> StatefulSelectConcat<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>>> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> Where<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> WhereNot<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TOut, bool> predicate) { }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
+    [Akka.Annotations.ApiMayChange]
     public sealed class FlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat> : Akka.Streams.GraphDelegate<Akka.Streams.FlowShape<System.ValueTuple<TIn, TCtxIn>, System.ValueTuple<TOut, TCtxOut>>, TMat>
     {
         public Akka.Streams.Dsl.Flow<System.ValueTuple<TIn, TCtxIn>, System.ValueTuple<TOut, TCtxOut>, TMat> AsFlow() { }
@@ -1511,8 +1520,8 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.Flow<TIn, TOut, TMat3> ConcatMaterialized<TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat2> that, System.Func<TMat, TMat2, TMat3> materializedFunction) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> Join<TMat2>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TOut, TIn>, TMat2> flow) { }
         public Akka.Streams.Dsl.Flow<TIn2, TOut2, TMat> Join<TIn2, TOut2, TMat2>(Akka.Streams.IGraph<Akka.Streams.BidiShape<TOut, TOut2, TIn2, TIn>, TMat2> bidi) { }
-        public Akka.Streams.Dsl.Flow<TIn2, TOut2, TMatRes> JoinMaterialized<TIn2, TOut2, TMat2, TMatRes>(Akka.Streams.IGraph<Akka.Streams.BidiShape<TOut, TOut2, TIn2, TIn>, TMat2> bidi, System.Func<TMat, TMat2, TMatRes> combine) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat3> JoinMaterialized<TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TOut, TIn>, TMat2> flow, System.Func<TMat, TMat2, TMat3> combine) { }
+        public Akka.Streams.Dsl.Flow<TIn2, TOut2, TMatRes> JoinMaterialized<TIn2, TOut2, TMat2, TMatRes>(Akka.Streams.IGraph<Akka.Streams.BidiShape<TOut, TOut2, TIn2, TIn>, TMat2> bidi, System.Func<TMat, TMat2, TMatRes> combine) { }
         public Akka.Streams.Dsl.Flow<TIn, TOut, TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> mapFunc) { }
         public Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Named(string name) { }
         public System.ValueTuple<TMat1, TMat2> RunWith<TMat1, TMat2>(Akka.Streams.IGraph<Akka.Streams.SourceShape<TIn>, TMat1> source, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Streams.IMaterializer materializer) { }
@@ -1524,13 +1533,13 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.Flow<TIn, TOut2, TMat3> ViaMaterialized<TOut2, TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TOut, TOut2>, TMat2> flow, System.Func<TMat, TMat2, TMat3> combine) { }
         public Akka.Streams.Dsl.Flow<TIn, TOut, TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    public class static ForwardOps
+    public static class ForwardOps
     {
+        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> To<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, TMat> ops, Akka.Streams.FlowShape<TIn, TOut> flow)
+            where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> To<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, TMat> ops, Akka.Streams.Inlet<TIn> inlet)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> To<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, TMat> ops, Akka.Streams.SinkShape<TIn> sink)
-            where TIn : TOut { }
-        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> To<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, TMat> ops, Akka.Streams.FlowShape<TIn, TOut> flow)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> To<TIn, TOut, TMat, TMat2>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, TMat> ops, Akka.Streams.IGraph<Akka.Streams.SinkShape<TIn>, TMat2> sink)
             where TIn : TOut { }
@@ -1547,9 +1556,9 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut2, TMat> Via<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut1, TMat> ops, Akka.Streams.UniformFanOutShape<TIn, TOut2> junction)
             where TIn : TOut1 { }
     }
-    public class static Framing
+    public static class Framing
     {
-        public static Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> Delimiter(Akka.IO.ByteString delimiter, int maximumFrameLength, bool allowTruncation = False) { }
+        public static Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> Delimiter(Akka.IO.ByteString delimiter, int maximumFrameLength, bool allowTruncation = false) { }
         public static Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> LengthField(int fieldLength, int maximumFramelength, int fieldOffset = 0, Akka.IO.ByteOrder byteOrder = 1) { }
         public static Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> LengthField(int fieldLength, int fieldOffset, int maximumFrameLength, Akka.IO.ByteOrder byteOrder, System.Func<System.Collections.Generic.IReadOnlyList<byte>, int, int> computeFrameSize) { }
         public static Akka.Streams.Dsl.BidiFlow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> SimpleFramingProtocol(int maximumMessageLength) { }
@@ -1561,7 +1570,7 @@ namespace Akka.Streams.Dsl
             protected FramingException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }
-    public class static GraphDsl
+    public static class GraphDsl
     {
         public static Akka.Streams.IGraph<TShape, Akka.NotUsed> Create<TShape>(System.Func<Akka.Streams.Dsl.GraphDsl.Builder<Akka.NotUsed>, TShape> buildBlock)
             where TShape : Akka.Streams.Shape { }
@@ -1598,20 +1607,20 @@ namespace Akka.Streams.Dsl
             public Akka.Streams.Implementation.IModule Module { get; }
             public TShape Add<TShape, TMat>(Akka.Streams.IGraph<TShape, TMat> graph)
                 where TShape : Akka.Streams.Shape { }
+            public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TOut>(Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, T> source) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TOut>(Akka.Streams.Outlet<TOut> outlet) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TOut>(Akka.Streams.SourceShape<TOut> source) { }
-            public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TOut>(Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, T> source) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TIn, TOut>(Akka.Streams.FlowShape<TIn, TOut> flow) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TIn, TOut>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn, TOut>, T> flow) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TIn, TOut>(Akka.Streams.UniformFanInShape<TIn, TOut> fanIn) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TIn, TOut>(Akka.Streams.UniformFanOutShape<TIn, TOut> fanOut) { }
             public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn>(Akka.Streams.Inlet<TIn> inlet) { }
             public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn>(Akka.Streams.SinkShape<TIn> sink) { }
-            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TMat>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TIn>, TMat> sink) { }
-            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut, TMat>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn, TOut>, TMat> flow) { }
             public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut>(Akka.Streams.FlowShape<TIn, TOut> flow) { }
-            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut>(Akka.Streams.UniformFanOutShape<TIn, TOut> fanOut) { }
+            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TMat>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TIn>, TMat> sink) { }
             public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut>(Akka.Streams.UniformFanInShape<TIn, TOut> fanOut) { }
+            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut>(Akka.Streams.UniformFanOutShape<TIn, TOut> fanOut) { }
+            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut, TMat>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn, TOut>, TMat> flow) { }
         }
         public sealed class ForwardOps<TOut, TMat>
         {
@@ -1639,8 +1648,8 @@ namespace Akka.Streams.Dsl
         Akka.Streams.Dsl.IRunnableGraph<TMat> AddAttributes(Akka.Streams.Attributes attributes);
         Akka.Streams.Dsl.IRunnableGraph<TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> func);
         Akka.Streams.Dsl.IRunnableGraph<TMat> Named(string name);
-        TMat Run(Akka.Streams.IMaterializer materializer);
         TMat Run(Akka.Actor.ActorSystem actorSystem);
+        TMat Run(Akka.Streams.IMaterializer materializer);
         Akka.Streams.Dsl.IRunnableGraph<TMat> WithAttributes(Akka.Streams.Attributes attributes);
     }
     public interface IUnzipWithCreator<out TIn, in TOut, out T>
@@ -1652,9 +1661,9 @@ namespace Akka.Streams.Dsl
         System.Threading.Tasks.Task<bool> Flip(Akka.Streams.Dsl.SwitchMode mode);
         System.Threading.Tasks.Task<Akka.Streams.Dsl.SwitchMode> GetMode();
     }
-    public class static Interleave
+    public static class Interleave
     {
-        public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, T>, Akka.NotUsed> Create<T>(int inputPorts, int segmentSize, bool eagerClose = False) { }
+        public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, T>, Akka.NotUsed> Create<T>(int inputPorts, int segmentSize, bool eagerClose = false) { }
     }
     public sealed class Interleave<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanInShape<TIn, TOut>>
         where TIn : TOut
@@ -1665,16 +1674,16 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn> In(int id) { }
         public override string ToString() { }
     }
-    public class static IntervalBasedRateLimiter
+    public static class IntervalBasedRateLimiter
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.IGraph<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>, Akka.NotUsed> Create<T>(System.TimeSpan minInterval, int maxBatchSize) { }
     }
-    public class static JsonFraming
+    public static class JsonFraming
     {
         public static Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> ObjectScanner(int maximumObjectLength) { }
     }
-    public class static Keep
+    public static class Keep
     {
         public static System.ValueTuple<TLeft, TRight> Both<TLeft, TRight>(TLeft left, TRight right) { }
         public static bool IsLeft<T1, T2, T3>(System.Func<T1, T2, T3> fn) { }
@@ -1701,14 +1710,14 @@ namespace Akka.Streams.Dsl
     }
     public class LinearIncreasingDelay<T> : Akka.Streams.Dsl.IDelayStrategy<T>
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public LinearIncreasingDelay(System.TimeSpan increaseStep, System.Func<T, bool> needsIncrease, System.TimeSpan initialDelay, System.TimeSpan maxDelay) { }
         public System.TimeSpan NextDelay(T element) { }
     }
-    public class static MergeHub
+    public static class MergeHub
     {
-        public static Akka.Streams.Dsl.Source<T, Akka.Streams.Dsl.Sink<T, Akka.NotUsed>> Source<T>(int perProducerBufferSize) { }
         public static Akka.Streams.Dsl.Source<T, Akka.Streams.Dsl.Sink<T, Akka.NotUsed>> Source<T>() { }
+        public static Akka.Streams.Dsl.Source<T, Akka.Streams.Dsl.Sink<T, Akka.NotUsed>> Source<T>(int perProducerBufferSize) { }
         public sealed class ProducerFailed : System.Exception
         {
             public ProducerFailed(string message, System.Exception cause) { }
@@ -1716,14 +1725,14 @@ namespace Akka.Streams.Dsl
     }
     public sealed class MergePreferred<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.Dsl.MergePreferred<T>.MergePreferredShape>
     {
-        public MergePreferred(int secondaryPorts, bool eagerClose = False) { }
+        public MergePreferred(int secondaryPorts, bool eagerClose = false) { }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T> Out { get; }
         public Akka.Streams.Inlet<T> Preferred { get; }
         public override Akka.Streams.Dsl.MergePreferred<T>.MergePreferredShape Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public Akka.Streams.Inlet<T> In(int id) { }
-        public sealed class MergePreferredShape<T> : Akka.Streams.UniformFanInShape<T, T>
+        public sealed class MergePreferredShape : Akka.Streams.UniformFanInShape<T, T>
         {
             public MergePreferredShape(int secondaryPorts, Akka.Streams.FanInShape<T>.IInit init) { }
             public MergePreferredShape(int secondaryPorts, string name) { }
@@ -1733,7 +1742,7 @@ namespace Akka.Streams.Dsl
     }
     public sealed class MergePrioritized<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanInShape<T, T>>
     {
-        public MergePrioritized(System.Collections.Generic.IEnumerable<int> priorities, bool eagerComplete = False) { }
+        public MergePrioritized(System.Collections.Generic.IEnumerable<int> priorities, bool eagerComplete = false) { }
         public System.Collections.Generic.IReadOnlyList<Akka.Streams.Inlet<T>> In { get; }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T> Out { get; }
@@ -1751,12 +1760,12 @@ namespace Akka.Streams.Dsl
     }
     public sealed class Merge<T> : Akka.Streams.Dsl.Merge<T, T>
     {
-        public Merge(int inputPorts, bool eagerComplete = False) { }
+        public Merge(int inputPorts, bool eagerComplete = false) { }
     }
     public class Merge<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanInShape<TIn, TOut>>
         where TIn : TOut
     {
-        public Merge(int inputPorts, bool eagerComplete = False) { }
+        public Merge(int inputPorts, bool eagerComplete = false) { }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
         public override Akka.Streams.UniformFanInShape<TIn, TOut> Shape { get; }
@@ -1764,7 +1773,7 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn> In(int id) { }
         public override string ToString() { }
     }
-    public class static One2OneBidiFlow
+    public static class One2OneBidiFlow
     {
         public static Akka.Streams.Dsl.BidiFlow<TIn, TIn, TOut, TOut, Akka.NotUsed> Apply<TIn, TOut>(int maxPending) { }
     }
@@ -1776,7 +1785,7 @@ namespace Akka.Streams.Dsl
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    public class static OrElse
+    public static class OrElse
     {
         public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, T>, Akka.NotUsed> Create<T>() { }
     }
@@ -1796,9 +1805,9 @@ namespace Akka.Streams.Dsl
         public OutputTruncationException() { }
         protected OutputTruncationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static PagedSource
+    public static class PagedSource
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> Create<T, TKey>(TKey firstKey, System.Func<TKey, System.Threading.Tasks.Task<Akka.Streams.Dsl.PagedSource.Page<T, TKey>>> pageFactory) { }
         public class Page<T, TKey>
         {
@@ -1807,13 +1816,13 @@ namespace Akka.Streams.Dsl
             public Akka.Util.Option<TKey> NextKey { get; }
         }
     }
-    public class static PartitionHub
+    public static class PartitionHub
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(System.Func<int, T, int> partitioner, int startAfterNrOfConsumers, int bufferSize = 256) { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> StatefulSink<T>(System.Func<System.Func<Akka.Streams.Dsl.PartitionHub.IConsumerInfo, T, long>> partitioner, int startAfterNrOfConsumers, int bufferSize = 256) { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public interface IConsumerInfo
         {
             System.Collections.Immutable.ImmutableArray<long> ConsumerIds { get; }
@@ -1844,42 +1853,42 @@ namespace Akka.Streams.Dsl
     }
     public class Pulse<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
-        public Pulse(System.TimeSpan interval, bool initiallyOpen = False) { }
+        public Pulse(System.TimeSpan interval, bool initiallyOpen = false) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    public class static RestartFlow
+    public static class RestartFlow
     {
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, Akka.Streams.RestartSettings settings) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, Akka.Streams.RestartSettings settings) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
     }
-    public class static RestartSink
+    public static class RestartSink
     {
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, Akka.Streams.RestartSettings settings) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
     }
-    public class static RestartSource
+    public static class RestartSource
     {
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, Akka.Streams.RestartSettings settings) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, Akka.Streams.RestartSettings settings) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
     }
     public class RestartWithBackoffFlow
     {
@@ -1894,11 +1903,11 @@ namespace Akka.Streams.Dsl
             public override string ToString() { }
         }
     }
-    public class static Retry
+    public static class Retry
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TIn, TState>, System.ValueTuple<Akka.Util.Result<TOut>, TState>>, TMat> Concat<TIn, TState, TOut, TMat>(long limit, Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TIn, TState>, System.ValueTuple<Akka.Util.Result<TOut>, TState>>, TMat> flow, System.Func<TState, System.Collections.Generic.IEnumerable<System.ValueTuple<TIn, TState>>> retryWith) { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TIn, TState>, System.ValueTuple<Akka.Util.Result<TOut>, TState>>, TMat> Create<TIn, TState, TOut, TMat>(Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TIn, TState>, System.ValueTuple<Akka.Util.Result<TOut>, TState>>, TMat> flow, System.Func<TState, Akka.Util.Option<System.ValueTuple<TIn, TState>>> retryWith) { }
     }
     public sealed class ReuseLatest<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, T>>
@@ -1909,30 +1918,30 @@ namespace Akka.Streams.Dsl
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    public class static ReverseOps
+    public static class ReverseOps
     {
-        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.Outlet<TOut> outlet)
-            where TIn : TOut { }
-        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.SourceShape<TOut> source)
+        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.FlowShape<TIn, TOut> flow)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> source)
             where TIn : TOut { }
-        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.FlowShape<TIn, TOut> flow)
+        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.Outlet<TOut> outlet)
+            where TIn : TOut { }
+        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.SourceShape<TOut> source)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.UniformFanInShape<TIn, TOut> junction)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.UniformFanOutShape<TOut1, TOut2> junction)
             where TIn : TOut2 { }
-        public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TOut1, TMat> Via<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.FlowShape<TOut1, TOut2> flow)
-            where TIn : TOut2 { }
-        public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TOut1, TMat> Via<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.IGraph<Akka.Streams.FlowShape<TOut1, TOut2>, TMat> flow)
-            where TIn : TOut2 { }
         public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> Via<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.UniformFanInShape<TIn, TOut> junction)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> Via<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.UniformFanOutShape<TIn, TOut> junction)
             where TIn : TOut { }
+        public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TOut1, TMat> Via<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.FlowShape<TOut1, TOut2> flow)
+            where TIn : TOut2 { }
+        public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TOut1, TMat> Via<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.IGraph<Akka.Streams.FlowShape<TOut1, TOut2>, TMat> flow)
+            where TIn : TOut2 { }
     }
-    public class static RunnableGraph
+    public static class RunnableGraph
     {
         public static Akka.Streams.Dsl.RunnableGraph<TMat> FromGraph<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> g) { }
     }
@@ -1945,25 +1954,25 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.IRunnableGraph<TMat> Async() { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> func) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> Named(string name) { }
-        public TMat Run(Akka.Streams.IMaterializer materializer) { }
         public TMat Run(Akka.Actor.ActorSystem actorSystem) { }
+        public TMat Run(Akka.Streams.IMaterializer materializer) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
     public class Sample<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, T>>
     {
-        public Sample(int nth) { }
         public Sample(System.Func<int> next) { }
+        public Sample(int nth) { }
         public Akka.Streams.Inlet<T> In { get; }
         public Akka.Streams.Outlet<T> Out { get; }
         public override Akka.Streams.FlowShape<T, T> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public static Akka.Streams.Dsl.Sample<T> Random(int maxStep = 1000) { }
     }
-    public class static Sink
+    public static class Sink
     {
-        public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> ActorRef<TIn>(Akka.Actor.IActorRef actorRef, object onCompleteMessage, System.Func<System.Exception, object> onFailureMessage) { }
-        [System.ObsoleteAttribute("Use overload accepting both on complete and on failure message")]
+        [System.Obsolete("Use overload accepting both on complete and on failure message")]
         public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> ActorRef<TIn>(Akka.Actor.IActorRef actorRef, object onCompleteMessage) { }
+        public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> ActorRef<TIn>(Akka.Actor.IActorRef actorRef, object onCompleteMessage, System.Func<System.Exception, object> onFailureMessage) { }
         public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> ActorRefWithAck<TIn>(Akka.Actor.IActorRef actorRef, object onInitMessage, object ackMessage, object onCompleteMessage, System.Func<System.Exception, object> onFailureMessage = null) { }
         public static Akka.Streams.Dsl.Sink<TIn, Akka.Actor.IActorRef> ActorSubscriber<TIn>(Akka.Actor.Props props) { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TOut>> Aggregate<TIn, TOut>(TOut zero, System.Func<TOut, TIn, TOut> aggregate) { }
@@ -1972,16 +1981,16 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Sink<TIn, Reactive.Streams.IPublisher<TIn>> AsPublisher<TIn>(bool fanout) { }
         public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> Cancelled<TIn>() { }
         public static Akka.Streams.Dsl.Sink<T, System.Threading.Channels.ChannelReader<T>> ChannelReader<T>(int bufferSize, bool singleReader, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
-        public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> Combine<TIn, TOut, TMat>(System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanOutShape<TIn, TOut>, TMat>> strategy, Akka.Streams.Dsl.Sink<TOut, Akka.NotUsed> first, Akka.Streams.Dsl.Sink<TOut, Akka.NotUsed> second, params Akka.Streams.Dsl.Sink<, >[] rest) { }
+        public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> Combine<TIn, TOut, TMat>(System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanOutShape<TIn, TOut>, TMat>> strategy, Akka.Streams.Dsl.Sink<TOut, Akka.NotUsed> first, Akka.Streams.Dsl.Sink<TOut, Akka.NotUsed> second, params Akka.Streams.Dsl.Sink<TOut, Akka.NotUsed>[] rest) { }
         public static Akka.Streams.Dsl.Sink<TIn, object> Create<TIn>(Reactive.Streams.ISubscriber<TIn> subscriber) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public static Akka.Streams.Dsl.Sink<TIn, Reactive.Streams.IPublisher<TIn>> DistinctRetainingFanOutPublisher<TIn>(System.Action onTerminated = null) { }
         public static Akka.Streams.Dsl.Sink<TIn, Reactive.Streams.IPublisher<TIn>> FanoutPublisher<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TIn>> First<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TIn>> FirstOrDefault<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<Akka.Done>> ForEach<TIn>(System.Action<TIn> action) { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<Akka.Done>> ForEachAsync<TIn>(int parallelism, System.Func<TIn, System.Threading.Tasks.Task> action) { }
-        [System.ObsoleteAttribute("Use `ForEachAsync` instead, it allows you to choose how to run the procedure, by " +
+        [System.Obsolete("Use `ForEachAsync` instead, it allows you to choose how to run the procedure, by " +
             "calling some other API returning a Task or using Task.Run. Obsolete since 1.5.2")]
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<Akka.Done>> ForEachParallel<TIn>(int parallelism, System.Action<TIn> action) { }
         public static Akka.Streams.Dsl.Sink<TIn, TMat> FromGraph<TIn, TMat>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TIn>, TMat> graph) { }
@@ -1991,7 +2000,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TIn>> Last<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TIn>> LastOrDefault<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<Akka.Util.Option<TMat>>> LazyInitAsync<TIn, TMat>(System.Func<System.Threading.Tasks.Task<Akka.Streams.Dsl.Sink<TIn, TMat>>> sinkFactory) { }
-        [System.ObsoleteAttribute("Use LazyInitAsync instead. LazyInitAsync no more needs a fallback function and th" +
+        [System.Obsolete("Use LazyInitAsync instead. LazyInitAsync no more needs a fallback function and th" +
             "e materialized value more clearly indicates if the internal sink was materialize" +
             "d or not.")]
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TMat>> LazySink<TIn, TMat>(System.Func<TIn, System.Threading.Tasks.Task<Akka.Streams.Dsl.Sink<TIn, TMat>>> sinkFactory, System.Func<TMat> fallback) { }
@@ -2005,7 +2014,7 @@ namespace Akka.Streams.Dsl
     }
     public sealed class SinkQueueAsyncEnumerator<T> : System.Collections.Generic.IAsyncEnumerator<T>, System.IAsyncDisposable
     {
-        public SinkQueueAsyncEnumerator([System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+        public SinkQueueAsyncEnumerator([System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "killSwitch",
                 "sinkQueue"})] System.ValueTuple<Akka.Streams.UniqueKillSwitch, Akka.Streams.ISinkQueue<T>> queueAndSwitch, System.Threading.CancellationToken token) { }
         public T Current { get; }
@@ -2027,14 +2036,14 @@ namespace Akka.Streams.Dsl
         public override string ToString() { }
         public Akka.Streams.Dsl.Sink<TIn, TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    public class static Source
+    public static class Source
     {
         public static Akka.Streams.Dsl.Source<T, Akka.Actor.IActorRef> ActorPublisher<T>(Akka.Actor.Props props) { }
         public static Akka.Streams.Dsl.Source<T, Akka.Actor.IActorRef> ActorRef<T>(int bufferSize, Akka.Streams.OverflowStrategy overflowStrategy) { }
         public static Akka.Streams.Dsl.Source<T, Reactive.Streams.ISubscriber<T>> AsSubscriber<T>() { }
-        public static Akka.Streams.Dsl.Source<T, System.Threading.Channels.ChannelWriter<T>> Channel<T>(int bufferSize, bool singleWriter = False, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
+        public static Akka.Streams.Dsl.Source<T, System.Threading.Channels.ChannelWriter<T>> Channel<T>(int bufferSize, bool singleWriter = false, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> ChannelReader<T>(System.Threading.Channels.ChannelReader<T> channelReader) { }
-        public static Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> Combine<T, TOut2>(Akka.Streams.Dsl.Source<T, Akka.NotUsed> first, Akka.Streams.Dsl.Source<T, Akka.NotUsed> second, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, params Akka.Streams.Dsl.Source<, >[] rest) { }
+        public static Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> Combine<T, TOut2>(Akka.Streams.Dsl.Source<T, Akka.NotUsed> first, Akka.Streams.Dsl.Source<T, Akka.NotUsed> second, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, params Akka.Streams.Dsl.Source<T, Akka.NotUsed>[] rest) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMatOut> CombineMaterialized<T, TOut2, TMat1, TMat2, TMatOut>(Akka.Streams.Dsl.Source<T, TMat1> first, Akka.Streams.Dsl.Source<T, TMat2> second, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, System.Func<TMat1, TMat2, TMatOut> combineMaterializers) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> Cycle<T>(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> Empty<T>() { }
@@ -2042,8 +2051,8 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> From<T>(System.Collections.Generic.IEnumerable<T> enumerable) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> From<T>(System.Func<System.Collections.Generic.IAsyncEnumerable<T>> asyncEnumerable) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEnumerator<T>(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
-        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEvent<TDelegate, T>(System.Func<System.Action<T>, TDelegate> conversion, System.Action<TDelegate> addHandler, System.Action<TDelegate> removeHandler, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEvent<T>(System.Action<System.EventHandler<T>> addHandler, System.Action<System.EventHandler<T>> removeHandler, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEvent<TDelegate, T>(System.Func<System.Action<T>, TDelegate> conversion, System.Action<TDelegate> addHandler, System.Action<TDelegate> removeHandler, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
         public static Akka.Streams.Dsl.Source<T, TMat> FromGraph<T, TMat>(Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat> source) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromObservable<T>(System.IObservable<T> observable, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromPublisher<T>(Reactive.Streams.IPublisher<T> publisher) { }
@@ -2066,14 +2075,14 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<System.Collections.Immutable.IImmutableList<T>, Akka.NotUsed> ZipN<T>(System.Collections.Generic.IEnumerable<Akka.Streams.Dsl.Source<T, Akka.NotUsed>> sources) { }
         public static Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> ZipWithN<T, TOut2>(System.Func<System.Collections.Immutable.IImmutableList<T>, TOut2> zipper, System.Collections.Generic.IEnumerable<Akka.Streams.Dsl.Source<T, Akka.NotUsed>> sources) { }
     }
-    public class static SourceGen
+    public static class SourceGen
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Source<TOut, TMat> UnfoldFlow<TState, TOut, TMat>(TState seed, Akka.Streams.IGraph<Akka.Streams.FlowShape<TState, System.ValueTuple<TState, TOut>>, TMat> flow, System.TimeSpan timeout) { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Source<TOut, TMat> UnfoldFlowWith<TOut, TState, TFlowOut, TMat>(TState seed, Akka.Streams.IGraph<Akka.Streams.FlowShape<TState, TFlowOut>, TMat> flow, System.Func<TFlowOut, Akka.Util.Option<System.ValueTuple<TState, TOut>>> unfoldWith, System.TimeSpan timeout) { }
     }
-    public class static SourceOperations
+    public static class SourceOperations
     {
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Aggregate<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, TOut2 zero, System.Func<TOut2, TOut1, TOut2> fold) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> AggregateAsync<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, TOut2 zero, System.Func<TOut2, TOut1, System.Threading.Tasks.Task<TOut2>> fold) { }
@@ -2086,7 +2095,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Batch<TOut, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> BatchWeighted<TOut, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Buffer<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int size, Akka.Streams.OverflowStrategy strategy) { }
-        [System.ObsoleteAttribute("Deprecated. Please use Collect(isDefined, collector) instead")]
+        [System.Obsolete("Deprecated. Please use Collect(isDefined, collector) instead")]
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Collect<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Collect<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, bool> isDefined, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMatOut> CombineMaterialized<T, TOut2, TMat1, TMat2, TMatOut>(this Akka.Streams.Dsl.Source<T, TMat1> flow, Akka.Streams.Dsl.Source<T, TMat2> other, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, System.Func<TMat1, TMat2, TMatOut> combineMaterializers) { }
@@ -2095,13 +2104,13 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut2, TMat> ConcatMany<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Conflate<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, TOut, TOut> aggregate) { }
         public static Akka.Streams.Dsl.Source<TSeed, TMat> ConflateWithSeed<TOut, TMat, TSeed>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, TSeed> seed, System.Func<TSeed, TOut, TSeed> aggregate) { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> Delay<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan of, System.Nullable<Akka.Streams.DelayOverflowStrategy> strategy = null) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> Delay<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan of, Akka.Streams.DelayOverflowStrategy? strategy = default) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Detach<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> DivertTo<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that, System.Func<TOut, bool> when) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat3> DivertToMaterialized<TOut, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TOut, bool> when, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Expand<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, System.Collections.Generic.IEnumerator<TOut2>> extrapolate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> GroupBy<TOut, TMat, TKey>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> GroupBy<TOut, TMat, TKey>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, TKey> groupingFunc) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> GroupBy<TOut, TMat, TKey>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> Grouped<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int n) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long maxWeight, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
@@ -2113,22 +2122,22 @@ namespace Akka.Streams.Dsl
             where T1 : T2 { }
         public static Akka.Streams.Dsl.Source<T2, TMat3> InterleaveMaterialized<T1, T2, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Source<T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat2> graph, int segmentSize, System.Func<TMat, TMat2, TMat3> combine)
             where T1 : T2 { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> Intersperse<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Intersperse<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, TOut inject) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> Intersperse<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.Source<TInjected, TMat> KeepAlive<TOut, TInjected, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan timeout, System.Func<TInjected> injectElement)
             where TOut : TInjected { }
         public static Akka.Streams.Dsl.Source<T, TMat> Limit<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, long max) { }
         public static Akka.Streams.Dsl.Source<T, TMat> LimitWeighted<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, long max, System.Func<T, long> costFunc) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Log<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null, Akka.Event.LogLevel logLevel = 0) { }
-        public static Akka.Streams.Dsl.Source<TOut2, TMat> Merge<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = False)
+        public static Akka.Streams.Dsl.Source<TOut2, TMat> Merge<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = false)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> MergeMany<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, int breadth, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat3> MergeMaterialized<TOut1, TOut2, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat2> that, System.Func<TMat, TMat2, TMat3> combine)
             where TOut1 : TOut2 { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> MergeSorted<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> MergeSorted<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other)
             where TOut : System.IComparable<TOut> { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> MergeSorted<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Collections.Generic.IComparer<TOut> comparer) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> MergeSorted<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat2> Monitor<TOut, TMat, TMat2>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TMat, Akka.Streams.IFlowMonitor, TMat2> combine) { }
         public static Akka.Streams.Dsl.Source<T, TMat> OrElse<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat> secondary) { }
         public static Akka.Streams.Dsl.Source<T, TMat3> OrElseMaterialized<T, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Source<T, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat2> secondary, System.Func<TMat, TMat2, TMat3> materializedFunction) { }
@@ -2136,7 +2145,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Prepend<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> that)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Recover<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<System.Exception, Akka.Util.Option<TOut>> partialFunc) { }
-        [System.ObsoleteAttribute("Use RecoverWithRetries instead. [1.1.2]")]
+        [System.Obsolete("Use RecoverWithRetries instead. [1.1.2]")]
         public static Akka.Streams.Dsl.Source<TOut, TMat> RecoverWith<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> RecoverWithRetries<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc, int attempts) { }
         public static Akka.Streams.Dsl.Source<T, TMat> RepeatPrevious<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> source) { }
@@ -2152,45 +2161,41 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut, TMat> SkipWhile<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Predicate<TOut> predicate) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> SkipWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan duration) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> Sliding<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int n, int step = 1) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitAfter<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitAfter<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, bool> predicate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitWhen<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitAfter<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitWhen<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitWhen<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> StatefulSelectMany<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<System.Func<TOut1, System.Collections.Generic.IEnumerable<TOut2>>> mapConcaterFactory) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Sum<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, TOut, TOut> reduce) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Take<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long n) { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> TakeWhile<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Predicate<TOut> predicate, bool inclusive = False) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> TakeWhile<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Predicate<TOut> predicate, bool inclusive = false) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> TakeWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan duration) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Throttle<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int elements, System.TimeSpan per, int maximumBurst, Akka.Streams.ThrottleMode mode) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Throttle<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int cost, System.TimeSpan per, int maximumBurst, System.Func<TOut, int> calculateCost, Akka.Streams.ThrottleMode mode) { }
-        [System.ObsoleteAttribute("Use Via(GraphStage) instead. [1.1.2]")]
+        [System.Obsolete("Use Via(GraphStage) instead. [1.1.2]")]
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Transform<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<Akka.Streams.Stage.IStage<TOut1, TOut2>> stageFactory) { }
         public static Akka.Streams.Dsl.Source<T, TMat> Watch<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, Akka.Actor.IActorRef actorRef) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat2> WatchTermination<TOut, TMat, TMat2>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TMat, System.Threading.Tasks.Task<Akka.Done>, TMat2> materializerFunction) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Where<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Predicate<TOut> predicate) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> WhereNot<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Predicate<TOut> predicate) { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> WireTap<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> WireTap<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> WireTap<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat3> WireTapMaterialized<TOut, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
         public static Akka.Streams.Dsl.Source<System.ValueTuple<T1, T2>, TMat> Zip<T1, T2, TMat>(this Akka.Streams.Dsl.Source<T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other) { }
         public static Akka.Streams.Dsl.Source<T3, TMat> ZipWith<T1, T2, T3, TMat>(this Akka.Streams.Dsl.Source<T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other, System.Func<T1, T2, T3> combine) { }
         public static Akka.Streams.Dsl.Source<System.ValueTuple<TOut1, long>, TMat> ZipWithIndex<TOut1, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow) { }
     }
-    public class static SourceWithContext
+    public static class SourceWithContext
     {
         public static Akka.Streams.Dsl.SourceWithContext<TOut, TCtxOut, TMat> FromTuples<TOut, TCtxOut, TMat>(Akka.Streams.Dsl.Source<System.ValueTuple<TOut, TCtxOut>, TMat> source) { }
     }
-    public class static SourceWithContextOperations
+    public static class SourceWithContextOperations
     {
-        [System.ObsoleteAttribute("Deprecated. Please use Collect(SourceWithContext, Func, Func) instead. Since v1.5" +
+        [System.Obsolete("Deprecated. Please use Collect(SourceWithContext, Func, Func) instead. Since v1.5" +
             ".44, will be removed in v1.6")]
         public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
-        public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                0,
-                0,
-                0})] System.Func<System.ValueTuple<TOut, TCtx>, bool> isDefined, System.Func<TOut, TOut2> fn)
+        public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<System.ValueTuple<TOut, TCtx>, bool>? isDefined, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
         public static Akka.Streams.Dsl.SourceWithContext<System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, int n) { }
         public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Select<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn) { }
@@ -2202,7 +2207,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> Where<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> WhereNot<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, bool> predicate) { }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
+    [Akka.Annotations.ApiMayChange]
     public sealed class SourceWithContext<TOut, TCtx, TMat> : Akka.Streams.GraphDelegate<Akka.Streams.SourceShape<System.ValueTuple<TOut, TCtx>>, TMat>
     {
         public SourceWithContext(Akka.Streams.Dsl.Source<System.ValueTuple<TOut, TCtx>, TMat> source) { }
@@ -2222,26 +2227,26 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.Source<TOut, TMat> AddAttributes(Akka.Streams.Attributes attributes) { }
         public Akka.Streams.Dsl.Source<TOut2, TMat> Ask<TOut2>(Akka.Actor.IActorRef actorRef, System.TimeSpan timeout, int parallelism = 2) { }
         public Akka.Streams.Dsl.Source<TOut, TMat> Async() { }
-        public Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> Combine<T, TOut2>(Akka.Streams.Dsl.Source<T, Akka.NotUsed> first, Akka.Streams.Dsl.Source<T, Akka.NotUsed> second, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, params Akka.Streams.Dsl.Source<, >[] rest) { }
+        public Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> Combine<T, TOut2>(Akka.Streams.Dsl.Source<T, Akka.NotUsed> first, Akka.Streams.Dsl.Source<T, Akka.NotUsed> second, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, params Akka.Streams.Dsl.Source<T, Akka.NotUsed>[] rest) { }
         public Akka.Streams.Dsl.Source<TOut, TMat3> ConcatMaterialized<TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat2> that, System.Func<TMat, TMat2, TMat3> materializedFunction) { }
         public Akka.Streams.Dsl.Source<TOut, TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> mapFunc) { }
         public Akka.Streams.Dsl.Source<TOut, TMat> Named(string name) { }
-        public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Streams.IMaterializer materializer) { }
         public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Actor.ActorSystem actorSystem) { }
-        public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Streams.IMaterializer materializer) { }
+        public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Streams.IMaterializer materializer) { }
         public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Actor.ActorSystem materializer) { }
-        public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Streams.IMaterializer materializer) { }
         public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Actor.ActorSystem materializer) { }
-        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Streams.IMaterializer materializer) { }
         public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Actor.ActorSystem materializer) { }
-        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Streams.IMaterializer materializer, int minBuffer = 4, int maxBuffer = 16) { }
+        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Streams.IMaterializer materializer) { }
         public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Actor.ActorSystem materializer, int minBuffer = 4, int maxBuffer = 16) { }
-        public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Streams.IMaterializer materializer) { }
+        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Streams.IMaterializer materializer, int minBuffer = 4, int maxBuffer = 16) { }
         public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Actor.ActorSystem materializer) { }
-        public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Streams.IMaterializer materializer) { }
         public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Actor.ActorSystem materializer) { }
-        public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Streams.IMaterializer materializer) { }
         public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Actor.ActorSystem materializer) { }
+        public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Streams.IMaterializer materializer) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> To<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat3> ToMaterialized<TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, System.Func<TMat, TMat2, TMat3> combine) { }
         public override string ToString() { }
@@ -2251,14 +2256,14 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.Source<System.Collections.Immutable.IImmutableList<T>, Akka.NotUsed> ZipN<T>(System.Collections.Generic.IEnumerable<Akka.Streams.Dsl.Source<T, Akka.NotUsed>> sources) { }
         public Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> ZipWithN<T, TOut2>(System.Func<System.Collections.Immutable.IImmutableList<T>, TOut2> zipper, System.Collections.Generic.IEnumerable<Akka.Streams.Dsl.Source<T, Akka.NotUsed>> sources) { }
     }
-    public class static StreamConverters
+    public static class StreamConverters
     {
-        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.IO.Stream> AsInputStream(System.Nullable<System.TimeSpan> readTimeout = null) { }
-        public static Akka.Streams.Dsl.Source<Akka.IO.ByteString, System.IO.Stream> AsOutputStream(System.Nullable<System.TimeSpan> writeTimeout = null) { }
+        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.IO.Stream> AsInputStream(System.TimeSpan? readTimeout = default) { }
+        public static Akka.Streams.Dsl.Source<Akka.IO.ByteString, System.IO.Stream> AsOutputStream(System.TimeSpan? writeTimeout = default) { }
         public static Akka.Streams.Dsl.Source<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> FromInputStream(System.Func<System.IO.Stream> createInputStream, int chunkSize = 8192) { }
-        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> FromOutputStream(System.Func<System.IO.Stream> createOutputStream, bool autoFlush = False) { }
+        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> FromOutputStream(System.Func<System.IO.Stream> createOutputStream, bool autoFlush = false) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class StreamRefSettings
     {
         public StreamRefSettings(int bufferCapacity, System.TimeSpan demandRedeliveryInterval, System.TimeSpan subscriptionTimeout, System.TimeSpan finalTerminationSignalDeadline) { }
@@ -2267,18 +2272,18 @@ namespace Akka.Streams.Dsl
         public System.TimeSpan FinalTerminationSignalDeadline { get; }
         public string ProductPrefix { get; }
         public System.TimeSpan SubscriptionTimeout { get; }
-        public Akka.Streams.Dsl.StreamRefSettings Copy(System.Nullable<int> bufferCapacity = null, System.Nullable<System.TimeSpan> demandRedeliveryInterval = null, System.Nullable<System.TimeSpan> subscriptionTimeout = null, System.Nullable<System.TimeSpan> finalTerminationSignalDeadline = null) { }
-        public static Akka.Streams.Dsl.StreamRefSettings Create(Akka.Configuration.Config config) { }
+        public Akka.Streams.Dsl.StreamRefSettings Copy(int? bufferCapacity = default, System.TimeSpan? demandRedeliveryInterval = default, System.TimeSpan? subscriptionTimeout = default, System.TimeSpan? finalTerminationSignalDeadline = default) { }
         public Akka.Streams.Dsl.StreamRefSettings WithBufferCapacity(int value) { }
         public Akka.Streams.Dsl.StreamRefSettings WithDemandRedeliveryInterval(System.TimeSpan value) { }
         public Akka.Streams.Dsl.StreamRefSettings WithSubscriptionTimeout(System.TimeSpan value) { }
+        public static Akka.Streams.Dsl.StreamRefSettings Create(Akka.Configuration.Config config) { }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
-    public class static StreamRefs
+    [Akka.Annotations.ApiMayChange]
+    public static class StreamRefs
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Source<T, System.Threading.Tasks.Task<Akka.Streams.ISinkRef<T>>> SinkRef<T>() { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Sink<T, System.Threading.Tasks.Task<Akka.Streams.ISourceRef<T>>> SourceRef<T>() { }
     }
     public sealed class StreamsAsyncEnumerableRerunnable<T, TMat> : System.Collections.Generic.IAsyncEnumerable<T>
@@ -2287,7 +2292,7 @@ namespace Akka.Streams.Dsl
         public StreamsAsyncEnumerableRerunnable(Akka.Streams.Dsl.Source<T, TMat> source, Akka.Streams.IMaterializer materializer, int minBuf, int maxBuf) { }
         public System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken) { }
     }
-    public class static SubFlowOperations
+    public static class SubFlowOperations
     {
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Aggregate<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, TOut2 zero, System.Func<TOut2, TOut1, TOut2> fold) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> AggregateAsync<TIn, TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TIn, TMat, TClosed> flow, TOut zero, System.Func<TOut, TIn, System.Threading.Tasks.Task<TOut>> fold) { }
@@ -2299,18 +2304,16 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Batch<TOut, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> BatchWeighted<TOut, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Buffer<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int size, Akka.Streams.OverflowStrategy strategy) { }
-        [System.ObsoleteAttribute("Deprecated. Please use Collect(SubFlow, Func, Func) instead. Since v1.5.44, will " +
+        [System.Obsolete("Deprecated. Please use Collect(SubFlow, Func, Func) instead. Since v1.5.44, will " +
             "be removed in v1.6")]
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, TOut2> collector) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                0})] System.Func<TOut1, bool> isDefined, System.Func<TOut1, TOut2> collector) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, bool>? isDefined, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> CompletionTimeout<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Concat<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> ConcatMany<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Conflate<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<TOut, TOut, TOut> aggregate) { }
         public static Akka.Streams.Dsl.SubFlow<TSeed, TMat, TClosed> ConflateWithSeed<TOut, TMat, TSeed, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<TOut, TSeed> seed, System.Func<TSeed, TOut, TSeed> aggregate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Delay<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan of, System.Nullable<Akka.Streams.DelayOverflowStrategy> strategy = null) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Delay<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan of, Akka.Streams.DelayOverflowStrategy? strategy = default) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Detach<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> DivertTo<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that, System.Func<TOut, bool> when) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat3, TClosed> DivertToMaterialized<TOut, TMat, TMat2, TMat3, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TOut, bool> when, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
@@ -2325,28 +2328,28 @@ namespace Akka.Streams.Dsl
             where T1 : T2 { }
         public static Akka.Streams.Dsl.SubFlow<T2, TMat3, TClosed> InterleaveMaterialized<T1, T2, TMat, TMat2, TMat3, TClosed>(this Akka.Streams.Dsl.SubFlow<T1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat2> graph, int segmentSize, System.Func<TMat, TMat2, TMat3> combine)
             where T1 : T2 { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Intersperse<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Intersperse<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, TOut inject) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Intersperse<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.SubFlow<TInjected, TMat, TClosed> KeepAlive<TOut, TInjected, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan timeout, System.Func<TInjected> injectElement)
             where TOut : TInjected { }
         public static Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> Limit<T, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> flow, long max) { }
         public static Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> LimitWeighted<T, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> flow, long max, System.Func<T, long> costFunc) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Log<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Merge<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = False)
+        public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Merge<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = false)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> MergeMany<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, int breadth, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat3, TClosed> MergeMaterialized<TOut1, TOut2, TMat, TMat2, TMat3, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat2> that, System.Func<TMat, TMat2, TMat3> combine)
             where TOut1 : TOut2 { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> MergeSorted<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> MergeSorted<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other)
             where TOut : System.IComparable<TOut> { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> MergeSorted<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Collections.Generic.IComparer<TOut> comparer) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> MergeSorted<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> OrElse<T, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat> secondary) { }
         public static Akka.Streams.Dsl.SubFlow<System.ValueTuple<System.Collections.Immutable.IImmutableList<TOut>, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>>, TMat, TClosed> PrefixAndTail<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int n) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Prepend<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> that)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.SubFlow<Akka.Util.Option<TOut>, TMat, TClosed> Recover<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<System.Exception, Akka.Util.Option<TOut>> partialFunc) { }
-        [System.ObsoleteAttribute("Use RecoverWithRetries instead. [1.1.2]")]
+        [System.Obsolete("Use RecoverWithRetries instead. [1.1.2]")]
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> RecoverWith<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> RecoverWithRetries<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc, int attempts) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Scan<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, TOut2 zero, System.Func<TOut2, TOut1, TOut2> scan) { }
@@ -2363,17 +2366,17 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> StatefulSelectMany<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<System.Func<TOut1, System.Collections.Generic.IEnumerable<TOut2>>> mapConcaterFactory) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Sum<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<TOut, TOut, TOut> reduce) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Take<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long n) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> TakeWhile<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Predicate<TOut> predicate, bool inclusive = False) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> TakeWhile<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Predicate<TOut> predicate, bool inclusive = false) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> TakeWithin<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan duration) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Throttle<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int elements, System.TimeSpan per, int maximumBurst, Akka.Streams.ThrottleMode mode) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Throttle<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int cost, System.TimeSpan per, int maximumBurst, System.Func<TOut, int> calculateCost, Akka.Streams.ThrottleMode mode) { }
-        [System.ObsoleteAttribute("Use Via(GraphStage) instead. [1.1.2]")]
+        [System.Obsolete("Use Via(GraphStage) instead. [1.1.2]")]
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Transform<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<Akka.Streams.Stage.IStage<TOut1, TOut2>> stageFactory) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat2, TClosed> WatchTermination<TOut, TMat, TMat2, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<TMat, System.Threading.Tasks.Task<Akka.Done>, TMat2> materializerFunction) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Where<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Predicate<TOut> predicate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> WhereNot<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Predicate<TOut> predicate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> WireTap<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> WireTap<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> WireTap<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.SubFlow<System.ValueTuple<T1, T2>, TMat, TClosed> Zip<T1, T2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<T1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other) { }
         public static Akka.Streams.Dsl.SubFlow<T3, TMat, TClosed> ZipWith<T1, T2, T3, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<T1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other, System.Func<T1, T2, T3> combine) { }
         public static Akka.Streams.Dsl.SubFlow<System.ValueTuple<TOut1, long>, TMat, TClosed> ZipWithIndex<TOut1, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow) { }
@@ -2399,8 +2402,7 @@ namespace Akka.Streams.Dsl
     {
         public Tcp() { }
         public override Akka.Streams.Dsl.TcpExt CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct IncomingConnection
+        public readonly struct IncomingConnection
         {
             public readonly Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> Flow;
             public readonly System.Net.EndPoint LocalAddress;
@@ -2408,15 +2410,13 @@ namespace Akka.Streams.Dsl
             public IncomingConnection(System.Net.EndPoint localAddress, System.Net.EndPoint remoteAddress, Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> flow) { }
             public TMat HandleWith<TMat>(Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, TMat> handler, Akka.Streams.IMaterializer materializer) { }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct OutgoingConnection
+        public readonly struct OutgoingConnection
         {
             public readonly System.Net.EndPoint LocalAddress;
             public readonly System.Net.EndPoint RemoteAddress;
             public OutgoingConnection(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress) { }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct ServerBinding
+        public readonly struct ServerBinding
         {
             public readonly System.Net.EndPoint LocalAddress;
             public ServerBinding(System.Net.EndPoint localAddress, System.Func<System.Threading.Tasks.Task> unbindAction) { }
@@ -2426,20 +2426,20 @@ namespace Akka.Streams.Dsl
     public class TcpExt : Akka.Actor.IExtension
     {
         protected readonly System.TimeSpan BindShutdownTimeout;
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public TcpExt(Akka.Actor.ExtendedActorSystem system) { }
-        public Akka.Streams.Dsl.Source<Akka.Streams.Dsl.Tcp.IncomingConnection, System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.ServerBinding>> Bind(string host, int port, int backlog = 100, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = False, System.Nullable<System.TimeSpan> idleTimeout = null) { }
-        public System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.ServerBinding> BindAndHandle(Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> handler, Akka.Streams.IMaterializer materializer, string host, int port, int backlog = 100, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = False, System.Nullable<System.TimeSpan> idleTimeout = null) { }
-        public Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.OutgoingConnection>> OutgoingConnection(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress = null, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = True, System.Nullable<System.TimeSpan> connectionTimeout = null, System.Nullable<System.TimeSpan> idleTimeout = null) { }
+        public Akka.Streams.Dsl.Source<Akka.Streams.Dsl.Tcp.IncomingConnection, System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.ServerBinding>> Bind(string host, int port, int backlog = 100, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = false, System.TimeSpan? idleTimeout = default) { }
+        public System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.ServerBinding> BindAndHandle(Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> handler, Akka.Streams.IMaterializer materializer, string host, int port, int backlog = 100, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = false, System.TimeSpan? idleTimeout = default) { }
         public Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.OutgoingConnection>> OutgoingConnection(string host, int port) { }
+        public Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.OutgoingConnection>> OutgoingConnection(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress = null, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = true, System.TimeSpan? connectionTimeout = default, System.TimeSpan? idleTimeout = default) { }
     }
     public sealed class TcpIdleTimeoutException : System.TimeoutException
     {
-        public TcpIdleTimeoutException(string message, System.TimeSpan duration) { }
         public TcpIdleTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TcpIdleTimeoutException(string message, System.TimeSpan duration) { }
         public System.TimeSpan Duration { get; }
     }
-    public class static TcpStreamExtensions
+    public static class TcpStreamExtensions
     {
         public static Akka.Streams.Dsl.TcpExt TcpStream(this Akka.Actor.ActorSystem system) { }
     }
@@ -2497,67 +2497,67 @@ namespace Akka.Streams.Dsl
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class UnzipWith<TIn, T0, T1, T2> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<TIn, T0, T1, T2>>
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1, T2>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
         public Akka.Streams.Outlet<T2> Out2 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1, T2> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1, T2> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class UnzipWith<TIn, T0, T1, T2, T3> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3>>
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1, T2, T3>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
         public Akka.Streams.Outlet<T2> Out2 { get; }
         public Akka.Streams.Outlet<T3> Out3 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class UnzipWith<TIn, T0, T1, T2, T3, T4> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4>>
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1, T2, T3, T4>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
         public Akka.Streams.Outlet<T2> Out2 { get; }
         public Akka.Streams.Outlet<T3> Out3 { get; }
         public Akka.Streams.Outlet<T4> Out4 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class UnzipWith<TIn, T0, T1, T2, T3, T4, T5> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5>>
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1, T2, T3, T4, T5>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
         public Akka.Streams.Outlet<T2> Out2 { get; }
         public Akka.Streams.Outlet<T3> Out3 { get; }
         public Akka.Streams.Outlet<T4> Out4 { get; }
         public Akka.Streams.Outlet<T5> Out5 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class UnzipWith<TIn, T0, T1, T2, T3, T4, T5, T6> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5, T6>>
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1, T2, T3, T4, T5, T6>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
         public Akka.Streams.Outlet<T2> Out2 { get; }
@@ -2565,8 +2565,8 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Outlet<T4> Out4 { get; }
         public Akka.Streams.Outlet<T5> Out5 { get; }
         public Akka.Streams.Outlet<T6> Out6 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5, T6> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5, T6> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class Valve<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.FlowShape<T, T>, System.Threading.Tasks.Task<Akka.Streams.Dsl.IValveSwitch>>
     {
@@ -2577,11 +2577,11 @@ namespace Akka.Streams.Dsl
         public override Akka.Streams.FlowShape<T, T> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<Akka.Streams.Dsl.IValveSwitch>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    public class static WireTap
+    public static class WireTap
     {
         public static Akka.Streams.Dsl.WireTap<T> Create<T>() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class WireTap<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<T, T, T>>
     {
         public WireTap() { }
@@ -2593,7 +2593,7 @@ namespace Akka.Streams.Dsl
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    public class static ZipN
+    public static class ZipN
     {
         public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, System.Collections.Immutable.IImmutableList<T>>> Create<T>(int n) { }
     }
@@ -2615,7 +2615,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> Apply<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut>(System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> zipper) { }
         public static Akka.Streams.Dsl.ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut> Apply<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut>(System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut> zipper) { }
     }
-    public class static ZipWithN
+    public static class ZipWithN
     {
         public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<TIn, TOut>> Create<TIn, TOut>(System.Func<System.Collections.Immutable.IImmutableList<TIn>, TOut> zipper, int n) { }
     }
@@ -2642,22 +2642,22 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn6> In6 { get; }
         public Akka.Streams.Inlet<TIn7> In7 { get; }
         public Akka.Streams.Inlet<TIn8> In8 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TOut>>
     {
         public ZipWith(System.Func<TIn0, TIn1, TOut> zipper) { }
         public Akka.Streams.Inlet<TIn0> In0 { get; }
         public Akka.Streams.Inlet<TIn1> In1 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TOut>>
     {
@@ -2665,11 +2665,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn0> In0 { get; }
         public Akka.Streams.Inlet<TIn1> In1 { get; }
         public Akka.Streams.Inlet<TIn2> In2 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TIn3, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TOut>>
     {
@@ -2678,11 +2678,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn1> In1 { get; }
         public Akka.Streams.Inlet<TIn2> In2 { get; }
         public Akka.Streams.Inlet<TIn3> In3 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TOut>>
     {
@@ -2692,11 +2692,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn2> In2 { get; }
         public Akka.Streams.Inlet<TIn3> In3 { get; }
         public Akka.Streams.Inlet<TIn4> In4 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TOut>>
     {
@@ -2707,11 +2707,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn3> In3 { get; }
         public Akka.Streams.Inlet<TIn4> In4 { get; }
         public Akka.Streams.Inlet<TIn5> In5 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TOut>>
     {
@@ -2723,11 +2723,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn4> In4 { get; }
         public Akka.Streams.Inlet<TIn5> In5 { get; }
         public Akka.Streams.Inlet<TIn6> In6 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut>>
     {
@@ -2740,11 +2740,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn5> In5 { get; }
         public Akka.Streams.Inlet<TIn6> In6 { get; }
         public Akka.Streams.Inlet<TIn7> In7 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public sealed class Zip<T1, T2> : Akka.Streams.Dsl.ZipWith<T1, T2, System.ValueTuple<T1, T2>>
     {
@@ -2754,7 +2754,7 @@ namespace Akka.Streams.Dsl
 }
 namespace Akka.Streams.Dsl.Internal
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class GraphImpl<TShape, TMat> : Akka.Streams.IGraph<TShape>, Akka.Streams.IGraph<TShape, TMat>
         where TShape : Akka.Streams.Shape
     {
@@ -2767,8 +2767,8 @@ namespace Akka.Streams.Dsl.Internal
         public override string ToString() { }
         public Akka.Streams.IGraph<TShape, TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static ModuleExtractor
+    [Akka.Annotations.InternalApi]
+    public static class ModuleExtractor
     {
         public static Akka.Util.Option<Akka.Streams.Implementation.IModule> Unapply<TShape, TMat>(Akka.Streams.IGraph<TShape, TMat> graph)
             where TShape : Akka.Streams.Shape { }
@@ -2776,12 +2776,12 @@ namespace Akka.Streams.Dsl.Internal
 }
 namespace Akka.Streams.Extra
 {
-    public class static TimedFlowDsl
+    public static class TimedFlowDsl
     {
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat2> Timed<TIn, TOut, TOut2, TMat, TMat2>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>, Akka.Streams.Dsl.Flow<TIn, TOut2, TMat2>> measuredOps, System.Action<System.TimeSpan> onComplete) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> TimedIntervalBetween<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, bool> matching, System.Action<System.TimeSpan> onInterval) { }
     }
-    public class static TimedSourceDsl
+    public static class TimedSourceDsl
     {
         public static Akka.Streams.Dsl.Source<TOut, TMat2> Timed<TIn, TOut, TMat, TMat2>(this Akka.Streams.Dsl.Source<TIn, TMat> source, System.Func<Akka.Streams.Dsl.Source<TIn, TMat>, Akka.Streams.Dsl.Source<TOut, TMat2>> measuredOps, System.Action<System.TimeSpan> onComplete) { }
         public static Akka.Streams.Dsl.Source<TIn, TMat> TimedIntervalBetween<TIn, TMat>(this Akka.Streams.Dsl.Source<TIn, TMat> source, System.Func<TIn, bool> matching, System.Action<System.TimeSpan> onInterval) { }
@@ -2794,8 +2794,7 @@ namespace Akka.Streams.IO
         public AbruptIOTerminationException(Akka.Streams.IO.IOResult ioResult, System.Exception cause) { }
         public Akka.Streams.IO.IOResult IoResult { get; }
     }
-    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-    public struct IOResult
+    public readonly struct IOResult
     {
         public readonly long Count;
         public IOResult(long count, Akka.Util.Result<Akka.NotUsed> status) { }
@@ -2812,29 +2811,29 @@ namespace Akka.Streams.Implementation
         public ActorMaterializerImpl(Akka.Actor.ActorSystem system, Akka.Streams.ActorMaterializerSettings settings, Akka.Dispatch.Dispatchers dispatchers, Akka.Actor.IActorRef supervisor, Akka.Util.AtomicBoolean haveShutDown, Akka.Streams.Implementation.EnumerableActorName flowNames) { }
         public override Akka.Dispatch.MessageDispatcher ExecutionContext { get; }
         public override bool IsShutdown { get; }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public override Akka.Event.ILoggingAdapter Logger { get; }
         public override Akka.Streams.ActorMaterializerSettings Settings { get; }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public override Akka.Actor.IActorRef Supervisor { get; }
         public override Akka.Actor.ActorSystem System { get; }
         public override Akka.Streams.ActorMaterializerSettings EffectiveSettings(Akka.Streams.Attributes attributes) { }
         public override Akka.Event.ILoggingAdapter MakeLogger(object logSource) { }
         public override TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable) { }
-        public override TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser) { }
         public override TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, Akka.Streams.Attributes initialAttributes) { }
+        public override TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser) { }
         public override TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser, Akka.Streams.Attributes initialAttributes) { }
         public override Akka.Actor.ICancelable ScheduleOnce(System.TimeSpan delay, System.Action action) { }
         public override Akka.Actor.ICancelable ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action) { }
         public override void Shutdown() { }
         public override Akka.Streams.IMaterializer WithNamePrefix(string name) { }
     }
-    public class static ActorPublisher
+    public static class ActorPublisher
     {
-        public static readonly Akka.Streams.Implementation.NormalShutdownException NormalShutdownReason;
         public const string NormalShutdownReasonMessage = "Cannot subscribe to shut-down Publisher";
+        public static readonly Akka.Streams.Implementation.NormalShutdownException NormalShutdownReason;
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ActorPublisherSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef>
     {
         public ActorPublisherSource(Akka.Actor.Props props, Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -2843,7 +2842,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef> NewInstance(Akka.Streams.SourceShape<TOut> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ActorPublisher<TOut> : Akka.Streams.IUntypedPublisher, Akka.Streams.Implementation.IActorPublisher, Reactive.Streams.IPublisher<TOut>
     {
         protected readonly Akka.Actor.IActorRef Impl;
@@ -2853,7 +2852,7 @@ namespace Akka.Streams.Implementation
         public void Subscribe(Reactive.Streams.ISubscriber<TOut> subscriber) { }
         public System.Collections.Generic.IEnumerable<Reactive.Streams.ISubscriber<TOut>> TakePendingSubscribers() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ActorRefSinkStage<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.SinkShape<T>>
     {
         public ActorRefSinkStage(Akka.Actor.IActorRef actorRef, object onCompleteMessage, System.Func<System.Exception, object> onFailureMessage) { }
@@ -2862,7 +2861,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SinkShape<T> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ActorRefSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef>
     {
         public ActorRefSource(int bufferSize, Akka.Streams.OverflowStrategy overflowStrategy, Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -2872,7 +2871,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef> NewInstance(Akka.Streams.SourceShape<TOut> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ActorSubscriberSink<TIn> : Akka.Streams.Implementation.SinkModule<TIn, Akka.Actor.IActorRef>
     {
         public ActorSubscriberSink(Akka.Actor.Props props, Akka.Streams.Attributes attributes, Akka.Streams.SinkShape<TIn> shape) { }
@@ -2881,7 +2880,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SinkModule<TIn, Akka.Actor.IActorRef> NewInstance(Akka.Streams.SinkShape<TIn> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    public class static ActorSubscription
+    public static class ActorSubscription
     {
         public static Akka.Streams.Implementation.IActorSubscription Create<T>(Akka.Actor.IActorRef implementor, Reactive.Streams.ISubscriber<T> subscriber) { }
     }
@@ -2891,8 +2890,8 @@ namespace Akka.Streams.Implementation
         public long Cursor { get; }
         public bool IsActive { get; }
         public long TotalDemand { get; }
-        public void Dispatch(object element) { }
         public void Dispatch(TIn element) { }
+        public void Dispatch(object element) { }
     }
     public class ActorSubscription<T> : Akka.Streams.Implementation.IActorSubscription, Reactive.Streams.ISubscription
     {
@@ -2905,11 +2904,11 @@ namespace Akka.Streams.Implementation
     public abstract class AtomicModule : Akka.Streams.Implementation.Module
     {
         protected AtomicModule() { }
-        public virtual System.Collections.Immutable.IImmutableDictionary<Akka.Streams.OutPort, Akka.Streams.InPort> Downstreams { get; }
-        public virtual System.Collections.Immutable.ImmutableArray<Akka.Streams.Implementation.IModule> SubModules { get; }
-        public virtual System.Collections.Immutable.IImmutableDictionary<Akka.Streams.InPort, Akka.Streams.OutPort> Upstreams { get; }
+        public override sealed System.Collections.Immutable.IImmutableDictionary<Akka.Streams.OutPort, Akka.Streams.InPort> Downstreams { get; }
+        public override sealed System.Collections.Immutable.ImmutableArray<Akka.Streams.Implementation.IModule> SubModules { get; }
+        public override sealed System.Collections.Immutable.IImmutableDictionary<Akka.Streams.InPort, Akka.Streams.OutPort> Upstreams { get; }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class BackpressureTimeout<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -2942,7 +2941,7 @@ namespace Akka.Streams.Implementation
         protected virtual bool UpstreamRunning(object message) { }
         protected virtual bool WaitingForUpstream(object message) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class CancelSink<T> : Akka.Streams.Implementation.SinkModule<T, Akka.NotUsed>
     {
         public CancelSink(Akka.Streams.Attributes attributes, Akka.Streams.SinkShape<T> shape) { }
@@ -2959,7 +2958,7 @@ namespace Akka.Streams.Implementation
         public void OnNext(T element) { }
         public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Completion<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -2978,10 +2977,10 @@ namespace Akka.Streams.Implementation
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Implementation.IModule> SubModules { get; }
         public override System.Collections.Immutable.IImmutableDictionary<Akka.Streams.InPort, Akka.Streams.OutPort> Upstreams { get; }
         public override Akka.Streams.Implementation.IModule CarbonCopy() { }
-        public static Akka.Streams.Implementation.CompositeModule Create(Akka.Streams.Implementation.Module module, Akka.Streams.Shape shape) { }
         public override Akka.Streams.Implementation.IModule ReplaceShape(Akka.Streams.Shape shape) { }
         public override string ToString() { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
+        public static Akka.Streams.Implementation.CompositeModule Create(Akka.Streams.Implementation.Module module, Akka.Streams.Shape shape) { }
     }
     public sealed class CopiedModule : Akka.Streams.Implementation.Module
     {
@@ -2997,7 +2996,7 @@ namespace Akka.Streams.Implementation
         public override string ToString() { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class DelayInitial<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Delay;
@@ -3047,8 +3046,8 @@ namespace Akka.Streams.Implementation
     {
         protected EnumerableActorName() { }
         public abstract Akka.Streams.Implementation.EnumerableActorName Copy(string newPrefix);
-        public static Akka.Streams.Implementation.EnumerableActorName Create(string prefix) { }
         public abstract string Next();
+        public static Akka.Streams.Implementation.EnumerableActorName Create(string prefix) { }
     }
     public abstract class ExposedPublisherReceive
     {
@@ -3060,44 +3059,44 @@ namespace Akka.Streams.Implementation
     public abstract class ExtendedActorMaterializer : Akka.Streams.ActorMaterializer
     {
         protected ExtendedActorMaterializer() { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public override Akka.Actor.IActorRef ActorOf(Akka.Streams.MaterializationContext context, Akka.Actor.Props props) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string name, string dispatcher) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public abstract TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser);
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public abstract TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser, Akka.Streams.Attributes initialAttributes);
     }
-    public class static FanIn
+    public static class FanIn
     {
         public const byte Cancelled = 16;
         public const byte Completed = 8;
         public const byte Depleted = 4;
         public const byte Marked = 1;
         public const byte Pending = 2;
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
             public OnComplete(int id) { }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Exception Cause;
             public readonly int Id;
             public OnError(int id, System.Exception cause) { }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly object Element;
             public readonly int Id;
             public OnNext(int id, object element) { }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
             public readonly Reactive.Streams.ISubscription Subscription;
@@ -3126,8 +3125,7 @@ namespace Akka.Streams.Implementation
         public void PumpFinished() { }
         protected override bool Receive(object message) { }
         public void WaitForUpstream(int waitForUpstream) { }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct SubInput<T> : Reactive.Streams.ISubscriber<T>
+        public readonly struct SubInput : Reactive.Streams.ISubscriber<T>
         {
             public SubInput(Akka.Actor.IActorRef impl, int id) { }
             public void OnComplete() { }
@@ -3136,30 +3134,30 @@ namespace Akka.Streams.Implementation
             public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static FanOut
+    [Akka.Annotations.InternalApi]
+    public static class FanOut
     {
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct ExposedPublishers<T> : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct ExposedPublishers<T> : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Collections.Immutable.ImmutableList<Akka.Streams.Implementation.ActorPublisher<T>> Publishers;
             public ExposedPublishers(System.Collections.Immutable.ImmutableList<Akka.Streams.Implementation.ActorPublisher<T>> publishers) { }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct SubstreamCancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct SubstreamCancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
             public SubstreamCancel(int id) { }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct SubstreamRequestMore : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct SubstreamRequestMore : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly long Demand;
             public readonly int Id;
             public SubstreamRequestMore(int id, long demand) { }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct SubstreamSubscribePending : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct SubstreamSubscribePending : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
             public SubstreamSubscribePending(int id) { }
@@ -3172,7 +3170,7 @@ namespace Akka.Streams.Implementation
             public override string ToString() { }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class FanOut<T> : Akka.Actor.ActorBase, Akka.Streams.Implementation.IPump
     {
         protected readonly Akka.Streams.Implementation.OutputBunch<T> OutputBunch;
@@ -3194,7 +3192,7 @@ namespace Akka.Streams.Implementation
         protected override bool Receive(object message) { }
         public void WaitForUpstream(int waitForUpstream) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class FirstOrDefaultStage<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task<T>>
     {
         public readonly Akka.Streams.Inlet<T> In;
@@ -3287,7 +3285,7 @@ namespace Akka.Streams.Implementation
         void WaitForUpstream(int waitForUpstream);
     }
     public interface ISpecViolation { }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class IdleInject<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
         where TIn : TOut
     {
@@ -3297,7 +3295,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class IdleTimeoutBidi<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.BidiShape<TIn, TIn, TOut, TOut>>
     {
         public readonly Akka.Streams.Inlet<TIn> In1;
@@ -3311,7 +3309,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Idle<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -3320,12 +3318,12 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    public class static IgnorableMaterializedValueComposites
+    public static class IgnorableMaterializedValueComposites
     {
-        public static bool Apply(Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode composition) { }
         public static bool Apply(Akka.Streams.Implementation.IModule module) { }
+        public static bool Apply(Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode composition) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Initial<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -3363,7 +3361,7 @@ namespace Akka.Streams.Implementation
         public void UnmarkAllInputs() { }
         public void UnmarkInput(int input) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class JsonObjectParser
     {
         public JsonObjectParser(int maximumObjectLength = 2147483647) { }
@@ -3371,7 +3369,7 @@ namespace Akka.Streams.Implementation
         public void Offer(Akka.IO.ByteString input) { }
         public Akka.Util.Option<Akka.IO.ByteString> Poll() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class LastOrDefaultStage<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task<T>>
     {
         public readonly Akka.Streams.Inlet<T> In;
@@ -3379,11 +3377,11 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SinkShape<T> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<T>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    public class static LazySource
+    public static class LazySource
     {
         public static Akka.Streams.Implementation.LazySource<TOut, TMat> Create<TOut, TMat>(System.Func<Akka.Streams.Dsl.Source<TOut, TMat>> create) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class LazySource<TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SourceShape<TOut>, System.Threading.Tasks.Task<TMat>>
     {
         public LazySource(System.Func<Akka.Streams.Dsl.Source<TOut, TMat>> sourceFactory) { }
@@ -3393,12 +3391,12 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<TMat>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class MaterializerSession
     {
         protected readonly Akka.Streams.Attributes InitialAttributes;
-        public static readonly bool IsDebug;
         protected readonly Akka.Streams.Implementation.IModule TopLevel;
+        public static readonly bool IsDebug;
         protected MaterializerSession(Akka.Streams.Implementation.IModule topLevel, Akka.Streams.Attributes initialAttributes) { }
         protected void AssignPort(Akka.Streams.InPort inPort, object subscriberOrVirtual) { }
         protected void AssignPort(Akka.Streams.OutPort outPort, Akka.Streams.IUntypedPublisher publisher) { }
@@ -3416,7 +3414,7 @@ namespace Akka.Streams.Implementation
             protected MaterializationPanicException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class MaybeSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, System.Threading.Tasks.TaskCompletionSource<TOut>>
     {
         public MaybeSource(Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -3458,7 +3456,7 @@ namespace Akka.Streams.Implementation
         public virtual Akka.Streams.Implementation.IModule Wire(Akka.Streams.OutPort from, Akka.Streams.InPort to) { }
         public abstract Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes);
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class NoopSubscriptionTimeout : Akka.Actor.ICancelable
     {
         public static readonly Akka.Streams.Implementation.NoopSubscriptionTimeout Instance;
@@ -3469,11 +3467,13 @@ namespace Akka.Streams.Implementation
         public void CancelAfter(System.TimeSpan delay) { }
         public void CancelAfter(int millisecondsDelay) { }
     }
+    [System.Serializable]
     public class NormalShutdownException : Akka.Pattern.IllegalStateException
     {
         public NormalShutdownException(string message) { }
         protected NormalShutdownException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.Serializable]
     public class NothingToReadException : System.Exception
     {
         public static readonly Akka.Streams.Implementation.NothingToReadException Instance;
@@ -3508,7 +3508,7 @@ namespace Akka.Streams.Implementation
         public void UnmarkCancelledOutputs(bool enabled) { }
         public void UnmarkOutput(int output) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ProcessorModule<TIn, TOut, TMat> : Akka.Streams.Implementation.AtomicModule
     {
         public ProcessorModule(System.Func<System.ValueTuple<Reactive.Streams.IProcessor<TIn, TOut>, TMat>> createProcessor, Akka.Streams.Attributes attributes = null) { }
@@ -3521,7 +3521,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Implementation.IModule ReplaceShape(Akka.Streams.Shape shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class PublisherSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Akka.NotUsed>
     {
         public PublisherSource(Reactive.Streams.IPublisher<TOut> publisher, Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -3531,14 +3531,8 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SourceModule<TOut, Akka.NotUsed> NewInstance(Akka.Streams.SourceShape<TOut> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1,
-            1,
-            1,
-            1})]
-    public sealed class QueueSink<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, Akka.Streams.ISinkQueue<T>>
+    [Akka.Annotations.InternalApi]
+    public sealed class QueueSink<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, Akka.Streams.ISinkQueue<T>>
     {
         public readonly Akka.Streams.Inlet<T> In;
         public QueueSink() { }
@@ -3547,49 +3541,39 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.Streams.ISinkQueue<T>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1,
-            1,
-            1,
-            1})]
-    public sealed class QueueSource<[System.Runtime.CompilerServices.NullableAttribute(2)]  TOut> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SourceShape<TOut>, Akka.Streams.ISourceQueueWithComplete<TOut>>
+    [Akka.Annotations.InternalApi]
+    public sealed class QueueSource<TOut> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SourceShape<TOut>, Akka.Streams.ISourceQueueWithComplete<TOut>>
     {
         public QueueSource(int maxBuffer, Akka.Streams.OverflowStrategy overflowStrategy) { }
         public Akka.Streams.Outlet<TOut> Out { get; }
         public override Akka.Streams.SourceShape<TOut> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.Streams.ISourceQueueWithComplete<TOut>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
-        public interface IInput<[System.Runtime.CompilerServices.NullableAttribute(2)]  TOut> { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class Materialized<[System.Runtime.CompilerServices.NullableAttribute(2)]  TOut> : Akka.Streams.ISourceQueueWithComplete<TOut>, Akka.Streams.ISourceQueue<TOut>
+        public interface IInput { }
+        public sealed class Materialized : Akka.Streams.ISourceQueueWithComplete<TOut>, Akka.Streams.ISourceQueue<TOut>
         {
-            public Materialized([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    1,
-                    1,
-                    0})] System.Action<Akka.Streams.Implementation.QueueSource<TOut>.IInput> invokeLogic, System.Threading.Tasks.TaskCompletionSource<object> completion) { }
+            public Materialized(System.Action<Akka.Streams.Implementation.QueueSource<TOut>.IInput> invokeLogic, System.Threading.Tasks.TaskCompletionSource<object> completion) { }
             public void Complete() { }
             public void Fail(System.Exception ex) { }
             public System.Threading.Tasks.Task<Akka.Streams.IQueueOfferResult> OfferAsync(TOut element) { }
             public System.Threading.Tasks.Task WatchCompletionAsync() { }
         }
     }
-    public class static ReactiveStreamsCompliance
+    public static class ReactiveStreamsCompliance
     {
         public const string CanNotSubscribeTheSameSubscriberMultipleTimes = "can not subscribe the same subscriber multiple times (see reactive-streams specif" +
             "ication, rules 1.10 and 2.12)";
-        public static readonly System.Exception CanNotSubscribeTheSameSubscriberMultipleTimesException;
-        public static readonly System.Exception ElementMustNotBeNullException;
         public const string ElementMustNotBeNullMsg = "Element must not be null, rule 2.13";
         public const string ExceptionMustNotBeNullMsg = "Exception must not be null, rule 2.13";
-        public static readonly System.Exception NumberOfElementsInRequestMustBePositiveException;
         public const string NumberOfElementsInRequestMustBePositiveMsg = "The number of requested elements must be > 0 (see reactive-streams specification," +
             " rule 3.9)";
         public const string SubscriberMustNotBeNullMsg = "Subscriber must not be null, rule 1.9";
-        public static readonly System.Exception SubscriptionMustNotBeNullException;
         public const string SubscriptionMustNotBeNullMsg = "Subscription must not be null, rule 2.13";
         public const string SupportsOnlyASingleSubscriber = "only supports one subscriber (which is allowed, see reactive-streams specificatio" +
             "n, rule 1.12)";
+        public static readonly System.Exception CanNotSubscribeTheSameSubscriberMultipleTimesException;
+        public static readonly System.Exception ElementMustNotBeNullException;
+        public static readonly System.Exception NumberOfElementsInRequestMustBePositiveException;
+        public static readonly System.Exception SubscriptionMustNotBeNullException;
         public static System.Exception ExceptionMustNotBeNullException { get; }
         public static System.Exception SubscriberMustNotBeNullException { get; }
         public static void RejectAdditionalSubscriber<T>(Reactive.Streams.ISubscriber<T> subscriber, string rejector) { }
@@ -3606,7 +3590,7 @@ namespace Akka.Streams.Implementation
         public static void TryOnSubscribe<T>(Reactive.Streams.ISubscriber<T> subscriber, Reactive.Streams.ISubscription subscription) { }
         public static void TryRequest(Reactive.Streams.ISubscription subscription, long demand) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ResizableMultiReaderRingBuffer<T>
     {
         protected readonly Akka.Streams.Implementation.ICursors Cursors;
@@ -3641,7 +3625,7 @@ namespace Akka.Streams.Implementation
         public override string ToString() { }
         public virtual bool Write(T value) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SeqStage<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<T>>>
     {
         public readonly Akka.Streams.Inlet<T> In;
@@ -3651,7 +3635,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<T>>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SetupFlowStage<TIn, TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.FlowShape<TIn, TOut>, System.Threading.Tasks.Task<TMat>>
     {
         public SetupFlowStage(System.Func<Akka.Streams.ActorMaterializer, Akka.Streams.Attributes, Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> factory) { }
@@ -3661,7 +3645,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<TMat>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SetupSourceStage<TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SourceShape<TOut>, System.Threading.Tasks.Task<TMat>>
     {
         public SetupSourceStage(System.Func<Akka.Streams.ActorMaterializer, Akka.Streams.Attributes, Akka.Streams.Dsl.Source<TOut, TMat>> factory) { }
@@ -3670,10 +3654,11 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SourceShape<TOut> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<TMat>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [System.Serializable]
     public class SignalThrewException : Akka.Pattern.IllegalStateException, Akka.Streams.Implementation.ISpecViolation
     {
-        public SignalThrewException(string message, System.Exception cause) { }
         protected SignalThrewException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public SignalThrewException(string message, System.Exception cause) { }
     }
     public class SimpleOutputs
     {
@@ -3700,7 +3685,7 @@ namespace Akka.Streams.Implementation
         public virtual void Error(System.Exception e) { }
         protected bool WaitingExposedPublisher(object message) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class SinkModule<TIn, TMat> : Akka.Streams.Implementation.AtomicModule
     {
         protected SinkModule(Akka.Streams.SinkShape<TIn> shape) { }
@@ -3711,9 +3696,9 @@ namespace Akka.Streams.Implementation
         public abstract object Create(Akka.Streams.MaterializationContext context, out TMat materializer);
         protected abstract Akka.Streams.Implementation.SinkModule<TIn, TMat> NewInstance(Akka.Streams.SinkShape<TIn> shape);
         public override Akka.Streams.Implementation.IModule ReplaceShape(Akka.Streams.Shape shape) { }
-        public virtual string ToString() { }
+        public override sealed string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SinkholeSubscriber<TIn> : Reactive.Streams.ISubscriber<TIn>
     {
         public SinkholeSubscriber(System.Threading.Tasks.TaskCompletionSource<Akka.NotUsed> whenCompleted) { }
@@ -3722,7 +3707,7 @@ namespace Akka.Streams.Implementation
         public void OnNext(TIn element) { }
         public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class SourceModule<TOut, TMat> : Akka.Streams.Implementation.AtomicModule
     {
         protected SourceModule(Akka.Streams.SourceShape<TOut> shape) { }
@@ -3733,12 +3718,12 @@ namespace Akka.Streams.Implementation
         public abstract Reactive.Streams.IPublisher<TOut> Create(Akka.Streams.MaterializationContext context, out TMat materializer);
         protected abstract Akka.Streams.Implementation.SourceModule<TOut, TMat> NewInstance(Akka.Streams.SourceShape<TOut> shape);
         public override Akka.Streams.Implementation.IModule ReplaceShape(Akka.Streams.Shape shape) { }
-        public virtual string ToString() { }
+        public override sealed string ToString() { }
     }
-    public class static StreamLayout
+    public static class StreamLayout
     {
         public const bool IsDebug = false;
-        public static void Validate(Akka.Streams.Implementation.IModule module, int level = 0, bool shouldPrint = False, System.Collections.Generic.IDictionary<object, int> idMap = null) { }
+        public static void Validate(Akka.Streams.Implementation.IModule module, int level = 0, bool shouldPrint = false, System.Collections.Generic.IDictionary<object, int> idMap = null) { }
         public sealed class Atomic : Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode
         {
             public readonly Akka.Streams.Implementation.IModule Module;
@@ -3772,11 +3757,11 @@ namespace Akka.Streams.Implementation
         public readonly Akka.Util.AtomicBoolean HaveShutdown;
         public readonly Akka.Streams.ActorMaterializerSettings Settings;
         public StreamSupervisor(Akka.Streams.ActorMaterializerSettings settings, Akka.Util.AtomicBoolean haveShutdown) { }
-        public static string NextName() { }
         protected override void PostStop() { }
-        public static Akka.Actor.Props Props(Akka.Streams.ActorMaterializerSettings settings, Akka.Util.AtomicBoolean haveShutdown) { }
         protected override bool Receive(object message) { }
         protected override Akka.Actor.SupervisorStrategy SupervisorStrategy() { }
+        public static string NextName() { }
+        public static Akka.Actor.Props Props(Akka.Streams.ActorMaterializerSettings settings, Akka.Util.AtomicBoolean haveShutdown) { }
         public sealed class Children
         {
             public readonly System.Collections.Immutable.IImmutableSet<Akka.Actor.IActorRef> Refs;
@@ -3850,7 +3835,7 @@ namespace Akka.Streams.Implementation
         public Akka.Actor.Receive CurrentReceive { get; }
         public void Become(Akka.Actor.Receive receive) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SubscriberSink<TIn> : Akka.Streams.Implementation.SinkModule<TIn, Akka.NotUsed>
     {
         public SubscriberSink(Reactive.Streams.ISubscriber<TIn> subscriber, Akka.Streams.Attributes attributes, Akka.Streams.SinkShape<TIn> shape) { }
@@ -3859,7 +3844,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SinkModule<TIn, Akka.NotUsed> NewInstance(Akka.Streams.SinkShape<TIn> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SubscriberSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Reactive.Streams.ISubscriber<TOut>>
     {
         public SubscriberSource(Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -3871,24 +3856,23 @@ namespace Akka.Streams.Implementation
     public class SubscriptionTimeoutException : System.Exception
     {
         public SubscriptionTimeoutException(string message) { }
-        public SubscriptionTimeoutException(string message, System.Exception innerException) { }
         protected SubscriptionTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public SubscriptionTimeoutException(string message, System.Exception innerException) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class Throttle<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Throttle(int cost, System.TimeSpan per, int maximumBurst, System.Func<T, int> costCalculation, Akka.Streams.ThrottleMode mode) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static Timers
+    [Akka.Annotations.InternalApi]
+    public static class Timers
     {
         public const string GraphStageLogicTimer = "GraphStageLogicTimer";
         public static System.TimeSpan IdleTimeoutCheckInterval(System.TimeSpan timeout) { }
     }
-    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-    public struct TransferPhase
+    public readonly struct TransferPhase
     {
         public readonly System.Action Action;
         public readonly Akka.Streams.Implementation.TransferState Precondition;
@@ -3903,7 +3887,7 @@ namespace Akka.Streams.Implementation
         public Akka.Streams.Implementation.TransferState And(Akka.Streams.Implementation.TransferState other) { }
         public Akka.Streams.Implementation.TransferState Or(Akka.Streams.Implementation.TransferState other) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class UnfoldAsync<TState, TElement> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TElement>>
     {
         public readonly Akka.Streams.Outlet<TElement> Out;
@@ -3913,7 +3897,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SourceShape<TElement> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class UnfoldInfinite<TState, TElement> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TElement>>
     {
         public readonly Akka.Streams.Outlet<TElement> Out;
@@ -3923,7 +3907,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SourceShape<TElement> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class UnfoldResourceSourceAsync<TOut, TSource> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TOut>>
     {
         public UnfoldResourceSourceAsync(System.Func<System.Threading.Tasks.Task<TSource>> create, System.Func<TSource, System.Threading.Tasks.Task<Akka.Util.Option<TOut>>> readData, System.Func<TSource, System.Threading.Tasks.Task> close) { }
@@ -3933,7 +3917,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class UnfoldResourceSource<TOut, TSource> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TOut>>
     {
         public UnfoldResourceSource(System.Func<TSource> create, System.Func<TSource, Akka.Util.Option<TOut>> readData, System.Action<TSource> close) { }
@@ -3943,7 +3927,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class Unfold<TState, TElement> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TElement>>
     {
         public readonly Akka.Streams.Outlet<TElement> Out;
@@ -3953,7 +3937,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SourceShape<TElement> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class VirtualProcessor<T> : Akka.Util.AtomicReference<object>, Reactive.Streams.IProcessor<T, T>, Reactive.Streams.IPublisher<T>, Reactive.Streams.ISubscriber<T>
     {
         public const bool IsDebug = true;
@@ -3968,24 +3952,22 @@ namespace Akka.Streams.Implementation
 }
 namespace Akka.Streams.Implementation.Fusing
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ActorGraphInterpreter : Akka.Actor.ActorBase
     {
         public ActorGraphInterpreter(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
         public Akka.Event.ILoggingAdapter Log { get; }
         protected override void PostStop() { }
         protected override void PreStart() { }
-        public static Akka.Actor.Props Props(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
         protected override bool Receive(object message) { }
         public Akka.Actor.IActorRef RegisterShell(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct Abort : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public static Akka.Actor.Props Props(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
+        public readonly struct Abort : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public Abort(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct AsyncInput : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct AsyncInput : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly object Event;
             public readonly System.Action<object> Handler;
@@ -4027,16 +4009,14 @@ namespace Akka.Streams.Implementation.Fusing
             public void Request(long elements) { }
             public override string ToString() { }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct Cancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct Cancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public Cancel(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, System.Exception cause) { }
             public System.Exception Cause { get; }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct ExposedPublisher : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct ExposedPublisher : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public readonly Akka.Streams.Implementation.IActorPublisher Publisher;
@@ -4047,60 +4027,53 @@ namespace Akka.Streams.Implementation.Fusing
         {
             Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public OnComplete(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly System.Exception Cause;
             public readonly int Id;
             public OnError(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, System.Exception cause) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly object Event;
             public readonly int Id;
             public OnNext(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, object @event) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public readonly Reactive.Streams.ISubscription Subscription;
             public OnSubscribe(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, Reactive.Streams.ISubscription subscription) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct RequestMore : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct RequestMore : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly long Demand;
             public readonly int Id;
             public RequestMore(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, long demand) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct Resume : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct Resume : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public Resume(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-        public struct SubscribePending : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct SubscribePending : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public SubscribePending(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class AggregateAsync<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public AggregateAsync(TOut zero, System.Func<TOut, TIn, System.Threading.Tasks.Task<TOut>> aggregate) { }
@@ -4111,7 +4084,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Aggregate<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Aggregate(TOut zero, System.Func<TOut, TIn, TOut> aggregate) { }
@@ -4122,7 +4095,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class AsyncEnumerable<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<T>>
     {
         public AsyncEnumerable(System.Func<System.Collections.Generic.IAsyncEnumerable<T>> factory) { }
@@ -4131,26 +4104,23 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Batch<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Batch(long max, System.Func<TIn, long> costFunc, System.Func<TIn, TOut> seed, System.Func<TOut, TIn, TOut> aggregate) { }
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1})]
-    public sealed class Buffer<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
+    [Akka.Annotations.InternalApi]
+    public sealed class Buffer<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Buffer(int count, Akka.Streams.OverflowStrategy overflowStrategy) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Collect<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
-        [System.ObsoleteAttribute("Deprecated. Please use the .ctor(Func, Func) constructor")]
+        [System.Obsolete("Deprecated. Please use the .ctor(Func, Func) constructor")]
         public Collect(System.Func<TIn, TOut> func) { }
         public Collect(System.Func<TIn, bool> isDefined, System.Func<TIn, TOut> collector) { }
         public Akka.Streams.Inlet<TIn> In { get; }
@@ -4160,18 +4130,15 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1})]
-    public sealed class Delay<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
+    [Akka.Annotations.InternalApi]
+    public sealed class Delay<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Delay(System.TimeSpan delay, Akka.Streams.DelayOverflowStrategy strategy) { }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Detacher<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Detacher() { }
@@ -4183,7 +4150,7 @@ namespace Akka.Streams.Implementation.Fusing
     {
         public DownstreamCompletedWithNoCauseException() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Expand<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Expand(System.Func<TIn, System.Collections.Generic.IEnumerator<TOut>> extrapolate) { }
@@ -4194,7 +4161,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class GraphAssembly
     {
         public readonly int[] InletOwners;
@@ -4202,19 +4169,19 @@ namespace Akka.Streams.Implementation.Fusing
         public readonly Akka.Streams.Attributes[] OriginalAttributes;
         public readonly int[] OutletOwners;
         public readonly Akka.Streams.Outlet[] Outlets;
-        public readonly Akka.Streams.Stage.IGraphStageWithMaterializedValue<, >[] Stages;
-        public GraphAssembly(Akka.Streams.Stage.IGraphStageWithMaterializedValue<, >[] stages, Akka.Streams.Attributes[] originalAttributes, Akka.Streams.Inlet[] inlets, int[] inletOwners, Akka.Streams.Outlet[] outlets, int[] outletOwners) { }
+        public readonly Akka.Streams.Stage.IGraphStageWithMaterializedValue<Akka.Streams.Shape, object>[] Stages;
+        public GraphAssembly(Akka.Streams.Stage.IGraphStageWithMaterializedValue<Akka.Streams.Shape, object>[] stages, Akka.Streams.Attributes[] originalAttributes, Akka.Streams.Inlet[] inlets, int[] inletOwners, Akka.Streams.Outlet[] outlets, int[] outletOwners) { }
         public int ConnectionCount { get; }
-        public static Akka.Streams.Implementation.Fusing.GraphAssembly Create(System.Collections.Generic.IList<Akka.Streams.Inlet> inlets, System.Collections.Generic.IList<Akka.Streams.Outlet> outlets, System.Collections.Generic.IList<Akka.Streams.Stage.IGraphStageWithMaterializedValue<Akka.Streams.Shape, object>> stages) { }
-        public System.ValueTuple<Connection[], Akka.Streams.Stage.GraphStageLogic[]> Materialize(Akka.Streams.Attributes inheritedAttributes, Akka.Streams.Implementation.IModule[] copiedModules, System.Collections.Generic.IDictionary<Akka.Streams.Implementation.IModule, object> materializedValues, System.Action<Akka.Streams.Implementation.Fusing.IMaterializedValueSource> register) { }
+        public System.ValueTuple<Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection[], Akka.Streams.Stage.GraphStageLogic[]> Materialize(Akka.Streams.Attributes inheritedAttributes, Akka.Streams.Implementation.IModule[] copiedModules, System.Collections.Generic.IDictionary<Akka.Streams.Implementation.IModule, object> materializedValues, System.Action<Akka.Streams.Implementation.Fusing.IMaterializedValueSource> register) { }
         public override string ToString() { }
+        public static Akka.Streams.Implementation.Fusing.GraphAssembly Create(System.Collections.Generic.IList<Akka.Streams.Inlet> inlets, System.Collections.Generic.IList<Akka.Streams.Outlet> outlets, System.Collections.Generic.IList<Akka.Streams.Stage.IGraphStageWithMaterializedValue<Akka.Streams.Shape, object>> stages) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class GraphInterpreter
     {
         public readonly Akka.Streams.Implementation.Fusing.GraphAssembly Assembly;
         public const int Boundary = -1;
-        public readonly Connection[] Connections;
+        public readonly Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection[] Connections;
         public readonly bool FuzzingMode;
         public const int InClosed = 16;
         public const int InFailed = 64;
@@ -4237,12 +4204,12 @@ namespace Akka.Streams.Implementation.Fusing
         public const int Pushing = 4;
         public int RunningStagesCount;
         public static readonly Akka.Streams.Attributes[] SingleNoAttribute;
-        public GraphInterpreter(Akka.Streams.Implementation.Fusing.GraphAssembly assembly, Akka.Streams.IMaterializer materializer, Akka.Event.ILoggingAdapter log, Akka.Streams.Stage.GraphStageLogic[] logics, Connection[] connections, System.Action<Akka.Streams.Stage.GraphStageLogic, object, System.Threading.Tasks.TaskCompletionSource<Akka.Done>, System.Action<object>> onAsyncInput, bool fuzzingMode, Akka.Actor.IActorRef context) { }
+        public GraphInterpreter(Akka.Streams.Implementation.Fusing.GraphAssembly assembly, Akka.Streams.IMaterializer materializer, Akka.Event.ILoggingAdapter log, Akka.Streams.Stage.GraphStageLogic[] logics, Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection[] connections, System.Action<Akka.Streams.Stage.GraphStageLogic, object, System.Threading.Tasks.TaskCompletionSource<Akka.Done>, System.Action<object>> onAsyncInput, bool fuzzingMode, Akka.Actor.IActorRef context) { }
         public Akka.Actor.IActorRef Context { get; }
-        public static Akka.Streams.Implementation.Fusing.GraphInterpreter Current { get; }
-        public static Akka.Streams.Implementation.Fusing.GraphInterpreter CurrentInterpreterOrNull { get; }
         public bool IsCompleted { get; }
         public bool IsSuspended { get; }
+        public static Akka.Streams.Implementation.Fusing.GraphInterpreter Current { get; }
+        public static Akka.Streams.Implementation.Fusing.GraphInterpreter CurrentInterpreterOrNull { get; }
         public void AttachDownstreamBoundary(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Implementation.Fusing.GraphInterpreter.DownstreamBoundaryStageLogic logic) { }
         public void AttachDownstreamBoundary(int connection, Akka.Streams.Implementation.Fusing.GraphInterpreter.DownstreamBoundaryStageLogic logic) { }
         public void AttachUpstreamBoundary(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Implementation.Fusing.GraphInterpreter.UpstreamBoundaryStageLogic logic) { }
@@ -4261,7 +4228,7 @@ namespace Akka.Streams.Implementation.Fusing
             public readonly System.Exception Cause;
             public Cancelled(System.Exception cause) { }
         }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public sealed class Connection
         {
             public Connection(int id, int inOwnerId, Akka.Streams.Stage.GraphStageLogic inOwner, int outOwnerId, Akka.Streams.Stage.GraphStageLogic outOwner, Akka.Streams.Stage.IInHandler inHandler, Akka.Streams.Stage.IOutHandler outHandler) { }
@@ -4298,10 +4265,10 @@ namespace Akka.Streams.Implementation.Fusing
             public abstract Akka.Streams.Outlet Out { get; }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class GraphInterpreterShell
     {
-        public GraphInterpreterShell(Akka.Streams.Implementation.Fusing.GraphAssembly assembly, Connection[] connections, Akka.Streams.Stage.GraphStageLogic[] logics, Akka.Streams.Shape shape, Akka.Streams.ActorMaterializerSettings settings, Akka.Streams.Implementation.ExtendedActorMaterializer materializer) { }
+        public GraphInterpreterShell(Akka.Streams.Implementation.Fusing.GraphAssembly assembly, Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection[] connections, Akka.Streams.Stage.GraphStageLogic[] logics, Akka.Streams.Shape shape, Akka.Streams.ActorMaterializerSettings settings, Akka.Streams.Implementation.ExtendedActorMaterializer materializer) { }
         public bool CanShutdown { get; }
         public Akka.Streams.Implementation.Fusing.GraphInterpreter Interpreter { get; }
         public bool IsInitialized { get; }
@@ -4313,7 +4280,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override string ToString() { }
         public void TryAbort(System.Exception reason) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class GraphModule : Akka.Streams.Implementation.AtomicModule
     {
         public readonly Akka.Streams.Implementation.Fusing.GraphAssembly Assembly;
@@ -4326,7 +4293,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override string ToString() { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class GraphStageModule : Akka.Streams.Implementation.AtomicModule
     {
         public readonly Akka.Streams.Stage.IGraphStageWithMaterializedValue<Akka.Streams.Shape, object> Stage;
@@ -4338,11 +4305,11 @@ namespace Akka.Streams.Implementation.Fusing
         public override string ToString() { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    public class static GraphStages
+    public static class GraphStages
     {
         public static Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T> Identity<T>() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class GroupedWeightedWithin<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
         public GroupedWeightedWithin(long maxWeight, int maxNumber, System.Func<T, long> costFn, System.TimeSpan interval) { }
@@ -4350,7 +4317,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Grouped<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
         public Grouped(int count) { }
@@ -4375,7 +4342,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class IgnoreSink<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task<Akka.Done>>
     {
         public IgnoreSink() { }
@@ -4385,7 +4352,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<Akka.Done>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Intersperse<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Intersperse(T inject) { }
@@ -4393,7 +4360,7 @@ namespace Akka.Streams.Implementation.Fusing
         public bool InjectStartEnd { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class LazyFlow<TIn, TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.FlowShape<TIn, TOut>, System.Threading.Tasks.Task<Akka.Util.Option<TMat>>>
     {
         public LazyFlow(System.Func<TIn, System.Threading.Tasks.Task<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>>> flowFactory) { }
@@ -4404,7 +4371,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<Akka.Util.Option<TMat>>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class LimitWeighted<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public LimitWeighted(long max, System.Func<T, long> costFunc) { }
@@ -4412,19 +4379,19 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Log<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Log(string name, System.Func<T, object> extract, Akka.Event.ILoggingAdapter adapter, Akka.Event.LogLevel defaultLogLevel) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class MaterializedValueSource<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<T>>, Akka.Streams.Implementation.Fusing.IMaterializedValueSource
     {
         public readonly Akka.Streams.Outlet<T> Outlet;
-        public MaterializedValueSource(Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode computation, Akka.Streams.Outlet<T> outlet) { }
         public MaterializedValueSource(Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode computation) { }
+        public MaterializedValueSource(Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode computation, Akka.Streams.Outlet<T> outlet) { }
         public Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode Computation { get; }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public override Akka.Streams.SourceShape<T> Shape { get; }
@@ -4433,7 +4400,7 @@ namespace Akka.Streams.Implementation.Fusing
         public void SetValue(T value) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class OnCompleted<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, Akka.NotUsed>>
     {
         public OnCompleted(System.Action success, System.Action<System.Exception> failure) { }
@@ -4442,7 +4409,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.FlowShape<T, Akka.NotUsed> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class RecoverWith<TOut, TMat> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<TOut>
     {
         public RecoverWith(System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunction, int maximumRetries) { }
@@ -4450,7 +4417,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Recover<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Recover(System.Func<System.Exception, Akka.Util.Option<T>> recovery) { }
@@ -4458,7 +4425,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ScanAsync<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public ScanAsync(TOut zero, System.Func<TOut, TIn, System.Threading.Tasks.Task<TOut>> aggregate) { }
@@ -4469,7 +4436,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Scan<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Scan(TOut zero, System.Func<TOut, TIn, TOut> aggregate) { }
@@ -4480,13 +4447,8 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1,
-            1,
-            1})]
-    public sealed class SelectAsyncUnordered<[System.Runtime.CompilerServices.NullableAttribute(2)]  TIn, [System.Runtime.CompilerServices.NullableAttribute(2)]  TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
+    [Akka.Annotations.InternalApi]
+    public sealed class SelectAsyncUnordered<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public readonly Akka.Streams.Inlet<TIn> In;
         public readonly Akka.Streams.Outlet<TOut> Out;
@@ -4495,13 +4457,8 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1,
-            1,
-            1})]
-    public sealed class SelectAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  TIn, [System.Runtime.CompilerServices.NullableAttribute(2)]  TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
+    [Akka.Annotations.InternalApi]
+    public sealed class SelectAsync<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public readonly Akka.Streams.Inlet<TIn> In;
         public readonly Akka.Streams.Outlet<TOut> Out;
@@ -4510,13 +4467,13 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SelectError<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public SelectError(System.Func<System.Exception, System.Exception> selector) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Select<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Select(System.Func<TIn, TOut> func) { }
@@ -4527,7 +4484,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class SimpleLinearGraphStage<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, T>>
     {
         public readonly Akka.Streams.Inlet<T> Inlet;
@@ -4542,7 +4499,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.SourceShape<T> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SkipWhile<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public SkipWhile(System.Predicate<T> predicate) { }
@@ -4550,13 +4507,13 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SkipWithin<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public SkipWithin(System.TimeSpan timeout) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Skip<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Skip(long count) { }
@@ -4564,7 +4521,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Sliding<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
         public Sliding(int count, int step) { }
@@ -4575,7 +4532,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class StatefulSelectMany<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public StatefulSelectMany(System.Func<System.Func<TIn, System.Collections.Generic.IEnumerable<TOut>>> concatFactory) { }
@@ -4584,7 +4541,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Sum<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Sum(System.Func<T, T, T> reduce) { }
@@ -4592,7 +4549,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class SupervisedGraphStageLogic : Akka.Streams.Stage.GraphStageLogic
     {
         protected SupervisedGraphStageLogic(Akka.Streams.Attributes inheritedAttributes, Akka.Streams.Shape shape) { }
@@ -4601,7 +4558,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected virtual void OnStop(System.Exception ex) { }
         protected Akka.Util.Option<T> WithSupervision<T>(System.Func<T> function) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class TakeWhile<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public TakeWhile(System.Predicate<T> predicate, bool inclusive) { }
@@ -4609,13 +4566,13 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class TakeWithin<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public TakeWithin(System.TimeSpan timeout) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Take<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Take(long count) { }
@@ -4649,7 +4606,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.Actor.ICancelable> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Where<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Where(System.Predicate<T> predicate) { }
@@ -4664,7 +4621,7 @@ namespace Akka.Streams.Implementation.IO
         public FlushSignaler() { }
         public void Flush() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class IncomingConnectionStage : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<Akka.IO.ByteString, Akka.IO.ByteString>>
     {
         public IncomingConnectionStage(Akka.Actor.IActorRef connection, System.Net.EndPoint remoteAddress, bool halfClose) { }
@@ -4676,7 +4633,7 @@ namespace Akka.Streams.Implementation.IO
 }
 namespace Akka.Streams.Implementation.Stages
 {
-    public class static DefaultAttributes
+    public static class DefaultAttributes
     {
         public static readonly Akka.Streams.Attributes ActorPublisherSource;
         public static readonly Akka.Streams.Attributes ActorRefSink;
@@ -4790,7 +4747,7 @@ namespace Akka.Streams.Implementation.Stages
     }
     public sealed class FirstOrDefault<TIn> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<TIn>, System.Threading.Tasks.Task<TIn>>
     {
-        public FirstOrDefault(bool throwOnDefault = False) { }
+        public FirstOrDefault(bool throwOnDefault = false) { }
         public override Akka.Streams.SinkShape<TIn> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<TIn>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
@@ -4802,7 +4759,7 @@ namespace Akka.Streams.Implementation.Stages
     }
     public sealed class LastOrDefault<TIn> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<TIn>, System.Threading.Tasks.Task<TIn>>
     {
-        public LastOrDefault(bool throwOnDefault = False) { }
+        public LastOrDefault(bool throwOnDefault = false) { }
         public override Akka.Streams.SinkShape<TIn> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<TIn>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
@@ -4821,7 +4778,6 @@ namespace Akka.Streams.Implementation.Stages
 }
 namespace Akka.Streams.Serialization
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class StreamRefSerializer : Akka.Serialization.SerializerWithStringManifest
     {
         public StreamRefSerializer(Akka.Actor.ExtendedActorSystem system) { }
@@ -4832,7 +4788,7 @@ namespace Akka.Streams.Serialization
 }
 namespace Akka.Streams.Stage
 {
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.2]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.2]")]
     public abstract class AbstractStage<TIn, TOut> : Akka.Streams.Stage.IStage<TIn, TOut>
     {
         protected AbstractStage() { }
@@ -4847,7 +4803,7 @@ namespace Akka.Streams.Stage
         public virtual void PreStart(Akka.Streams.Stage.ILifecycleContext context) { }
         public virtual Akka.Streams.Stage.IStage<TIn, TOut> Restart() { }
     }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.2]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.2]")]
     public abstract class AbstractStage<TIn, TOut, TPushDirective, TPullDirective, TContext> : Akka.Streams.Stage.AbstractStage<TIn, TOut>
         where TPushDirective : Akka.Streams.Stage.IDirective
         where TPullDirective : Akka.Streams.Stage.IDirective
@@ -4855,15 +4811,15 @@ namespace Akka.Streams.Stage
     {
         protected TContext Context;
         protected AbstractStage() { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context, System.Exception cause) { }
+        public override sealed Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context, System.Exception cause) { }
         public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(TContext context, System.Exception cause) { }
-        public abstract TPullDirective OnPull(TContext context);
         public override Akka.Streams.Stage.IDirective OnPull(Akka.Streams.Stage.IContext context) { }
+        public abstract TPullDirective OnPull(TContext context);
+        public override sealed Akka.Streams.Stage.IDirective OnPush(TIn element, Akka.Streams.Stage.IContext context) { }
         public abstract TPushDirective OnPush(TIn element, TContext context);
-        public virtual Akka.Streams.Stage.IDirective OnPush(TIn element, Akka.Streams.Stage.IContext context) { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnUpstreamFailure(System.Exception cause, Akka.Streams.Stage.IContext context) { }
+        public override sealed Akka.Streams.Stage.ITerminationDirective OnUpstreamFailure(System.Exception cause, Akka.Streams.Stage.IContext context) { }
         public virtual Akka.Streams.Stage.ITerminationDirective OnUpstreamFailure(System.Exception cause, TContext context) { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnUpstreamFinish(Akka.Streams.Stage.IContext context) { }
+        public override sealed Akka.Streams.Stage.ITerminationDirective OnUpstreamFinish(Akka.Streams.Stage.IContext context) { }
         public virtual Akka.Streams.Stage.ITerminationDirective OnUpstreamFinish(TContext context) { }
     }
     public delegate void AsyncCallback(object element);
@@ -4880,7 +4836,7 @@ namespace Akka.Streams.Stage
         public override void OnDownstreamFinish(System.Exception cause) { }
         public override void OnPull() { }
     }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.0]")]
     public abstract class DetachedStage<TIn, TOut> : Akka.Streams.Stage.AbstractStage<TIn, TOut, Akka.Streams.Stage.IUpstreamDirective, Akka.Streams.Stage.IDownstreamDirective, Akka.Streams.Stage.IDetachedContext<TOut>>
     {
         protected DetachedStage() { }
@@ -4902,61 +4858,59 @@ namespace Akka.Streams.Stage
     }
     public abstract class GraphStageLogic : Akka.Streams.Stage.IStageLogging
     {
+        public readonly int InCount;
+        public readonly int OutCount;
         public static readonly System.Action DoNothing;
         public static readonly Akka.Streams.Stage.InHandler EagerTerminateInput;
         public static readonly Akka.Streams.Stage.OutHandler EagerTerminateOutput;
         public static readonly Akka.Streams.Stage.InHandler IgnoreTerminateInput;
         public static readonly Akka.Streams.Stage.OutHandler IgnoreTerminateOutput;
-        public readonly int InCount;
         public static readonly System.Threading.Tasks.TaskCompletionSource<Akka.Done> NoPromise;
-        public readonly int OutCount;
         public static readonly Akka.Streams.Stage.InHandler TotallyIgnorantInput;
-        protected GraphStageLogic(int inCount, int outCount) { }
         protected GraphStageLogic(Akka.Streams.Shape shape) { }
+        protected GraphStageLogic(int inCount, int outCount) { }
         public virtual bool KeepGoingAfterAllPortsClosed { get; }
         public Akka.Event.ILoggingAdapter Log { get; }
         protected virtual object LogSource { get; }
         protected Akka.Streams.IMaterializer Materializer { get; }
         public Akka.Streams.Stage.StageActor StageActor { get; }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         protected virtual string StageActorName { get; }
         protected Akka.Streams.IMaterializer SubFusingMaterializer { get; }
         protected void AbortEmitting<T>(Akka.Streams.Outlet<T> outlet) { }
         protected void AbortReading<T>(Akka.Streams.Inlet<T> inlet) { }
         protected virtual void AfterPostStop() { }
         protected virtual void BeforePreStart() { }
-        protected void Cancel<T>(Akka.Streams.Inlet<T> inlet, System.Exception cause) { }
         protected void Cancel<T>(Akka.Streams.Inlet<T> inlet) { }
+        protected void Cancel<T>(Akka.Streams.Inlet<T> inlet, System.Exception cause) { }
         public void CancelStage(System.Exception cause) { }
         protected void Complete<T>(Akka.Streams.Outlet<T> outlet) { }
         public void CompleteStage() { }
-        public static Akka.Streams.Stage.InHandler ConditionalTerminateInput(System.Func<bool> predicate) { }
-        public static Akka.Streams.Stage.OutHandler ConditionalTerminateOutput(System.Func<bool> predicate) { }
         protected Akka.Streams.Stage.GraphStageLogic.SubSinkInlet<T> CreateSubSinkInlet<T>(string name) { }
-        protected void Emit<T>(Akka.Streams.Outlet<T> outlet, T element, System.Action andThen) { }
         protected void Emit<T>(Akka.Streams.Outlet<T> outlet, T element) { }
-        protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerable<T> elements, System.Action andThen) { }
+        protected void Emit<T>(Akka.Streams.Outlet<T> outlet, T element, System.Action andThen) { }
         protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerable<T> elements) { }
-        protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerator<T> enumerator, System.Action andThen) { }
         protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerator<T> enumerator) { }
+        protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerable<T> elements, System.Action andThen) { }
+        protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerator<T> enumerator, System.Action andThen) { }
         protected void Fail<T>(Akka.Streams.Outlet<T> outlet, System.Exception reason) { }
         public void FailStage(System.Exception reason) { }
-        protected System.Action<T> GetAsyncCallback<T>(System.Action<T> handler) { }
         protected System.Action GetAsyncCallback(System.Action handler) { }
+        protected System.Action<T> GetAsyncCallback<T>(System.Action<T> handler) { }
         protected Akka.Streams.Stage.IInHandler GetHandler<T>(Akka.Streams.Inlet<T> inlet) { }
         protected Akka.Streams.Stage.IOutHandler GetHandler<T>(Akka.Streams.Outlet<T> outlet) { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         protected Akka.Streams.Stage.StageActor GetStageActor(Akka.Streams.Stage.StageActorRef.Receive receive) { }
         protected Akka.Streams.Stage.IAsyncCallback<T> GetTypedAsyncCallback<T>(System.Action<T> handler) { }
         protected T Grab<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool HasBeenPulled<T>(Akka.Streams.Inlet<T> inlet) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public void InternalOnDownstreamFinish(System.Exception cause) { }
         protected bool IsAvailable<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool IsAvailable<T>(Akka.Streams.Outlet<T> outlet) { }
         protected bool IsClosed<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool IsClosed<T>(Akka.Streams.Outlet<T> outlet) { }
-        protected void PassAlong<TOut, TIn>(Akka.Streams.Inlet<TIn> from, Akka.Streams.Outlet<TOut> to, bool doFinish = True, bool doFail = True, bool doPull = False)
+        protected void PassAlong<TOut, TIn>(Akka.Streams.Inlet<TIn> from, Akka.Streams.Outlet<TOut> to, bool doFinish = true, bool doFail = true, bool doPull = false)
             where TIn : TOut { }
         public virtual void PostStop() { }
         public virtual void PreStart() { }
@@ -4965,14 +4919,16 @@ namespace Akka.Streams.Stage
         protected void Read<T>(Akka.Streams.Inlet<T> inlet, System.Action<T> andThen, System.Action onClose) { }
         protected void ReadMany<T>(Akka.Streams.Inlet<T> inlet, int n, System.Action<System.Collections.Generic.IEnumerable<T>> andThen, System.Action<System.Collections.Generic.IEnumerable<T>> onComplete) { }
         protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, Akka.Streams.Stage.IInHandler handler) { }
-        protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, System.Action onPush, System.Action onUpstreamFinish = null, System.Action<System.Exception> onUpstreamFailure = null) { }
         protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, Akka.Streams.Stage.IOutHandler handler) { }
         protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, System.Action onPull, System.Action<System.Exception> onDownstreamFinish = null) { }
-        [System.ObsoleteAttribute("Use method `SetHandlers` instead. Will be removed in v1.5")]
+        protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, System.Action onPush, System.Action onUpstreamFinish = null, System.Action<System.Exception> onUpstreamFailure = null) { }
+        [System.Obsolete("Use method `SetHandlers` instead. Will be removed in v1.5")]
         protected void SetHandler<TIn, TOut>(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Stage.InAndOutGraphStageLogic handler) { }
         protected void SetHandlers<TIn, TOut>(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Stage.InAndOutGraphStageLogic handler) { }
         protected void SetKeepGoing(bool enabled) { }
         protected void TryPull<T>(Akka.Streams.Inlet<T> inlet) { }
+        public static Akka.Streams.Stage.InHandler ConditionalTerminateInput(System.Func<bool> predicate) { }
+        public static Akka.Streams.Stage.OutHandler ConditionalTerminateOutput(System.Func<bool> predicate) { }
         protected sealed class LambdaInHandler : Akka.Streams.Stage.InHandler
         {
             public LambdaInHandler(System.Action onPush, System.Action onUpstreamFinish = null, System.Action<System.Exception> onUpstreamFailure = null) { }
@@ -4986,7 +4942,7 @@ namespace Akka.Streams.Stage
             public override void OnDownstreamFinish(System.Exception cause) { }
             public override void OnPull() { }
         }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected class SubSinkInlet<T>
         {
             public SubSinkInlet(Akka.Streams.Stage.GraphStageLogic logic, string name) { }
@@ -5001,7 +4957,7 @@ namespace Akka.Streams.Stage
             public void SetHandler(Akka.Streams.Stage.IInHandler handler) { }
             public override string ToString() { }
         }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected class SubSourceOutlet<T>
         {
             public SubSourceOutlet(Akka.Streams.Stage.GraphStageLogic logic, string name) { }
@@ -5034,7 +4990,7 @@ namespace Akka.Streams.Stage
     {
         protected GraphStage() { }
         protected abstract Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes);
-        public virtual Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.NotUsed> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.NotUsed> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public interface IAsyncCallback<in T>
     {
@@ -5119,7 +5075,7 @@ namespace Akka.Streams.Stage
     {
         Akka.Event.ILoggingAdapter Log { get; }
     }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.0]")]
     public interface IStage<in TIn, out TOut> { }
     public interface ISyncDirective : Akka.Streams.Stage.IDirective { }
     public interface ITerminationDirective : Akka.Streams.Stage.IDirective, Akka.Streams.Stage.ISyncDirective { }
@@ -5138,8 +5094,8 @@ namespace Akka.Streams.Stage
     }
     public abstract class InAndOutGraphStageLogic : Akka.Streams.Stage.GraphStageLogic, Akka.Streams.Stage.IInHandler, Akka.Streams.Stage.IOutHandler
     {
-        protected InAndOutGraphStageLogic(int inCount, int outCount) { }
         protected InAndOutGraphStageLogic(Akka.Streams.Shape shape) { }
+        protected InAndOutGraphStageLogic(int inCount, int outCount) { }
         public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
         public abstract void OnPush();
@@ -5157,8 +5113,8 @@ namespace Akka.Streams.Stage
     }
     public abstract class InGraphStageLogic : Akka.Streams.Stage.GraphStageLogic, Akka.Streams.Stage.IInHandler
     {
-        protected InGraphStageLogic(int inCount, int outCount) { }
         protected InGraphStageLogic(Akka.Streams.Shape shape) { }
+        protected InGraphStageLogic(int inCount, int outCount) { }
         public abstract void OnPush();
         public virtual void OnUpstreamFailure(System.Exception e) { }
         public virtual void OnUpstreamFinish() { }
@@ -5170,8 +5126,7 @@ namespace Akka.Streams.Stage
         public virtual void OnUpstreamFailure(System.Exception e) { }
         public virtual void OnUpstreamFinish() { }
     }
-    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
-    public struct LogicAndMaterializedValue<TMaterialized> : Akka.Streams.Stage.ILogicAndMaterializedValue<TMaterialized>
+    public readonly struct LogicAndMaterializedValue<TMaterialized> : Akka.Streams.Stage.ILogicAndMaterializedValue<TMaterialized>
     {
         public LogicAndMaterializedValue(Akka.Streams.Stage.GraphStageLogic logic, TMaterialized materializedValue) { }
         public Akka.Streams.Stage.GraphStageLogic Logic { get; }
@@ -5179,8 +5134,8 @@ namespace Akka.Streams.Stage
     }
     public abstract class OutGraphStageLogic : Akka.Streams.Stage.GraphStageLogic, Akka.Streams.Stage.IOutHandler
     {
-        protected OutGraphStageLogic(int inCount, int outCount) { }
         protected OutGraphStageLogic(Akka.Streams.Shape shape) { }
+        protected OutGraphStageLogic(int inCount, int outCount) { }
         public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
     }
@@ -5197,22 +5152,22 @@ namespace Akka.Streams.Stage
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<TMat> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
-        public virtual string ToString() { }
+        public override sealed string ToString() { }
     }
     public class PushPullGraphStage<TIn, TOut> : Akka.Streams.Stage.PushPullGraphStageWithMaterializedValue<TIn, TOut, Akka.NotUsed>
     {
         public PushPullGraphStage(System.Func<Akka.Streams.Attributes, Akka.Streams.Stage.IStage<TIn, TOut>> factory, Akka.Streams.Attributes stageAttributes) { }
     }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.0]")]
     public abstract class PushPullStage<TIn, TOut> : Akka.Streams.Stage.AbstractStage<TIn, TOut, Akka.Streams.Stage.ISyncDirective, Akka.Streams.Stage.ISyncDirective, Akka.Streams.Stage.IContext<TOut>>
     {
         protected PushPullStage() { }
     }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.0]")]
     public abstract class PushStage<TIn, TOut> : Akka.Streams.Stage.PushPullStage<TIn, TOut>
     {
         protected PushStage() { }
-        public virtual Akka.Streams.Stage.ISyncDirective OnPull(Akka.Streams.Stage.IContext<TOut> context) { }
+        public override sealed Akka.Streams.Stage.ISyncDirective OnPull(Akka.Streams.Stage.IContext<TOut> context) { }
     }
     public sealed class StageActor
     {
@@ -5223,10 +5178,11 @@ namespace Akka.Streams.Stage
         public void Unwatch(Akka.Actor.IActorRef actorRef) { }
         public void Watch(Akka.Actor.IActorRef actorRef) { }
     }
-    public class static StageActorRef
+    public static class StageActorRef
     {
         public delegate void Receive(System.ValueTuple<Akka.Actor.IActorRef, object> args);
     }
+    [System.Serializable]
     public class StageActorRefNotInitializedException : System.Exception
     {
         public static readonly Akka.Streams.Stage.StageActorRefNotInitializedException Instance;
@@ -5238,8 +5194,8 @@ namespace Akka.Streams.Stage
         public virtual Akka.Streams.Stage.ISyncDirective OnPull(Akka.Streams.Stage.IContext<TOut> context) { }
         public abstract Akka.Streams.Stage.ISyncDirective OnPush(TIn element, Akka.Streams.Stage.IContext<TOut> context);
     }
-    public class static StatefulStage { }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
+    public static class StatefulStage { }
+    [System.Obsolete("Please use GraphStage instead. [1.1.0]")]
     public abstract class StatefulStage<TIn, TOut> : Akka.Streams.Stage.PushPullStage<TIn, TOut>
     {
         protected StatefulStage(Akka.Streams.Stage.StageState<TIn, TOut> current) { }
@@ -5249,8 +5205,8 @@ namespace Akka.Streams.Stage
         public Akka.Streams.Stage.ISyncDirective Emit(System.Collections.Generic.IEnumerator<TOut> enumerator, Akka.Streams.Stage.IContext<TOut> context) { }
         public Akka.Streams.Stage.ISyncDirective Emit(System.Collections.Generic.IEnumerator<TOut> enumerator, Akka.Streams.Stage.IContext<TOut> context, Akka.Streams.Stage.StageState<TIn, TOut> nextState) { }
         public Akka.Streams.Stage.ISyncDirective EmitAndFinish(System.Collections.Generic.IEnumerator<TOut> enumerator, Akka.Streams.Stage.IContext<TOut> context) { }
-        public virtual Akka.Streams.Stage.ISyncDirective OnPull(Akka.Streams.Stage.IContext<TOut> context) { }
-        public virtual Akka.Streams.Stage.ISyncDirective OnPush(TIn element, Akka.Streams.Stage.IContext<TOut> context) { }
+        public override sealed Akka.Streams.Stage.ISyncDirective OnPull(Akka.Streams.Stage.IContext<TOut> context) { }
+        public override sealed Akka.Streams.Stage.ISyncDirective OnPush(TIn element, Akka.Streams.Stage.IContext<TOut> context) { }
         public override Akka.Streams.Stage.ITerminationDirective OnUpstreamFinish(Akka.Streams.Stage.IContext<TOut> context) { }
         public Akka.Streams.Stage.ISyncDirective TerminationEmit(System.Collections.Generic.IEnumerator<TOut> enumerator, Akka.Streams.Stage.IContext<TOut> context) { }
     }
@@ -5262,8 +5218,8 @@ namespace Akka.Streams.Stage
         protected bool IsTimerActive(object timerKey) { }
         protected abstract void OnTimer(object timerKey);
         protected void ScheduleOnce(object timerKey, System.TimeSpan delay) { }
-        protected void ScheduleRepeatedly(object timerKey, System.TimeSpan initialDelay, System.TimeSpan interval) { }
         protected void ScheduleRepeatedly(object timerKey, System.TimeSpan interval) { }
+        protected void ScheduleRepeatedly(object timerKey, System.TimeSpan initialDelay, System.TimeSpan interval) { }
     }
     public sealed class TotallyIgnorantInput : Akka.Streams.Stage.InHandler
     {
@@ -5276,7 +5232,7 @@ namespace Akka.Streams.Stage
 namespace Akka.Streams.Supervision
 {
     public delegate Akka.Streams.Supervision.Directive Decider(System.Exception cause);
-    public class static Deciders
+    public static class Deciders
     {
         public static readonly Akka.Streams.Supervision.Decider RestartingDecider;
         public static readonly Akka.Streams.Supervision.Decider ResumingDecider;
@@ -5295,7 +5251,7 @@ namespace Akka.Streams.Util
     {
         public ContinuallyEnumerable(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
         public System.Collections.Generic.IEnumerator<T> GetEnumerator() { }
-        public sealed class ContinuallyEnumerator<T> : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+        public sealed class ContinuallyEnumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
         {
             public ContinuallyEnumerator(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
             public T Current { get; }
@@ -5309,12 +5265,12 @@ namespace Akka.Streams.Util
         public EnumeratorEnumerable(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
         public System.Collections.Generic.IEnumerator<T> GetEnumerator() { }
     }
-    public class static Int32Extensions { }
-    public class static ObjectExtensions
+    public static class Int32Extensions { }
+    public static class ObjectExtensions
     {
         public static bool IsDefaultForType<T>(this T obj) { }
     }
-    public class static TypeExtensions
+    public static class TypeExtensions
     {
         public static System.Type GetPublishedType(this System.Type type) { }
         public static System.Type GetSubscribedType(this System.Type type) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
@@ -1,12 +1,12 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Benchmarks")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.Query.Sql")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Persistence.TCK")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams.TestKit")]
-[assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams.Tests")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("123b83e9-21f8-49a8-888a-3b1212ff21dc")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Benchmarks")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.Query.Sql")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Persistence.TCK")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Streams.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Streams.Tests")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("123b83e9-21f8-49a8-888a-3b1212ff21dc")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.Streams
 {
     public sealed class AbruptStageTerminationException : System.Exception
@@ -14,13 +14,14 @@ namespace Akka.Streams
         public AbruptStageTerminationException(Akka.Streams.Stage.GraphStageLogic logic) { }
         public AbruptStageTerminationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.Serializable]
     public class AbruptTerminationException : System.Exception
     {
         public readonly Akka.Actor.IActorRef Actor;
         public AbruptTerminationException(Akka.Actor.IActorRef actor) { }
         protected AbruptTerminationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static ActorAttributes
+    public static class ActorAttributes
     {
         public static Akka.Streams.ActorAttributes.Dispatcher IODispatcher { get; }
         public static Akka.Streams.Attributes CreateDebugLogging(bool enabled) { }
@@ -112,8 +113,6 @@ namespace Akka.Streams
         public abstract Akka.Actor.IActorRef Supervisor { get; }
         public abstract Akka.Actor.ActorSystem System { get; }
         public abstract Akka.Actor.IActorRef ActorOf(Akka.Streams.MaterializationContext context, Akka.Actor.Props props);
-        public static Akka.Streams.ActorMaterializer Create(Akka.Actor.IActorRefFactory context, Akka.Streams.ActorMaterializerSettings settings = null, string namePrefix = null) { }
-        public static Akka.Configuration.Config DefaultConfig() { }
         public void Dispose() { }
         public abstract Akka.Streams.ActorMaterializerSettings EffectiveSettings(Akka.Streams.Attributes attributes);
         public abstract Akka.Event.ILoggingAdapter MakeLogger(object logSource);
@@ -123,8 +122,10 @@ namespace Akka.Streams
         public abstract Akka.Actor.ICancelable ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action);
         public abstract void Shutdown();
         public abstract Akka.Streams.IMaterializer WithNamePrefix(string namePrefix);
+        public static Akka.Streams.ActorMaterializer Create(Akka.Actor.IActorRefFactory context, Akka.Streams.ActorMaterializerSettings settings = null, string namePrefix = null) { }
+        public static Akka.Configuration.Config DefaultConfig() { }
     }
-    public class static ActorMaterializerExtensions
+    public static class ActorMaterializerExtensions
     {
         public static Akka.Streams.ActorMaterializer Materializer(this Akka.Actor.IActorRefFactory context, Akka.Streams.ActorMaterializerSettings settings = null, string namePrefix = null) { }
     }
@@ -143,7 +144,6 @@ namespace Akka.Streams
         public readonly Akka.Streams.Supervision.Decider SupervisionDecider;
         public readonly int SyncProcessingLimit;
         public ActorMaterializerSettings(int initialInputBufferSize, int maxInputBufferSize, string dispatcher, Akka.Streams.Supervision.Decider supervisionDecider, Akka.Streams.StreamSubscriptionTimeoutSettings subscriptionTimeoutSettings, Akka.Streams.Dsl.StreamRefSettings streamRefSettings, bool isDebugLogging, int outputBurstLimit, bool isFuzzingMode, bool isAutoFusing, int maxFixedBufferSize, int syncProcessingLimit = 1000) { }
-        public static Akka.Streams.ActorMaterializerSettings Create(Akka.Actor.ActorSystem system) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public Akka.Streams.ActorMaterializerSettings WithAutoFusing(bool isAutoFusing) { }
@@ -157,6 +157,7 @@ namespace Akka.Streams
         public Akka.Streams.ActorMaterializerSettings WithSubscriptionTimeoutSettings(Akka.Streams.StreamSubscriptionTimeoutSettings settings) { }
         public Akka.Streams.ActorMaterializerSettings WithSupervisionStrategy(Akka.Streams.Supervision.Decider decider) { }
         public Akka.Streams.ActorMaterializerSettings WithSyncProcessingLimit(int limit) { }
+        public static Akka.Streams.ActorMaterializerSettings Create(Akka.Actor.ActorSystem system) { }
     }
     public class AmorphousShape : Akka.Streams.Shape
     {
@@ -169,38 +170,38 @@ namespace Akka.Streams
     public sealed class Attributes
     {
         public static readonly Akka.Streams.Attributes None;
-        public Attributes(params IAttribute[] attributes) { }
+        public Attributes(params Akka.Streams.Attributes.IAttribute[] attributes) { }
         public System.Collections.Generic.IEnumerable<Akka.Streams.Attributes.IAttribute> AttributeList { get; }
         public Akka.Streams.Attributes And(Akka.Streams.Attributes other) { }
         public Akka.Streams.Attributes And(Akka.Streams.Attributes.IAttribute other) { }
-        [System.ObsoleteAttribute("Use Contains<TAttr>() instead")]
-        public bool Contains<TAttr>(TAttr attribute)
-            where TAttr : Akka.Streams.Attributes.IAttribute { }
         public bool Contains<TAttr>()
             where TAttr : Akka.Streams.Attributes.IAttribute { }
-        public static Akka.Streams.Attributes CreateAsyncBoundary() { }
-        public static Akka.Streams.Attributes CreateInputBuffer(int initial, int max) { }
-        public static Akka.Streams.Attributes CreateLogLevels(Akka.Event.LogLevel onElement = 0, Akka.Event.LogLevel onFinish = 0, Akka.Event.LogLevel onError = 3) { }
-        public static Akka.Streams.Attributes CreateName(string name) { }
-        public static string ExtractName(Akka.Streams.Implementation.IModule module, string defaultIfNotFound) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(2)]
-        public TAttr GetAttribute<TAttr>([System.Runtime.CompilerServices.NullableAttribute(2)] TAttr defaultIfNotFound)
-            where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
+        [System.Obsolete("Use Contains<TAttr>() instead")]
+        public bool Contains<TAttr>(TAttr attribute)
+            where TAttr : Akka.Streams.Attributes.IAttribute { }
         public TAttr GetAttribute<TAttr>()
+            where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull("defaultIfNotFound")]
+        public TAttr? GetAttribute<TAttr>(TAttr? defaultIfNotFound)
             where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
         public System.Collections.Generic.IEnumerable<TAttr> GetAttributeList<TAttr>()
             where TAttr : Akka.Streams.Attributes.IAttribute { }
-        [System.ObsoleteAttribute("Attributes should always be most specific, use GetAttribute<TAttr>()")]
-        public TAttr GetFirstAttribute<TAttr>(TAttr defaultIfNotFound)
-            where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
-        [System.ObsoleteAttribute("Attributes should always be most specific, use GetAttribute<TAttr>()")]
+        [System.Obsolete("Attributes should always be most specific, use GetAttribute<TAttr>()")]
         public TAttr GetFirstAttribute<TAttr>()
+            where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
+        [System.Obsolete("Attributes should always be most specific, use GetAttribute<TAttr>()")]
+        public TAttr GetFirstAttribute<TAttr>(TAttr defaultIfNotFound)
             where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
         public TAttr GetMandatoryAttribute<TAttr>()
             where TAttr :  class, Akka.Streams.Attributes.IMandatoryAttribute { }
         public string GetNameLifted() { }
         public string GetNameOrDefault(string defaultIfNotFound = "unknown-operation") { }
         public override string ToString() { }
+        public static Akka.Streams.Attributes CreateAsyncBoundary() { }
+        public static Akka.Streams.Attributes CreateInputBuffer(int initial, int max) { }
+        public static Akka.Streams.Attributes CreateLogLevels(Akka.Event.LogLevel onElement = 0, Akka.Event.LogLevel onFinish = 0, Akka.Event.LogLevel onError = 3) { }
+        public static Akka.Streams.Attributes CreateName(string name) { }
+        public static string ExtractName(Akka.Streams.Implementation.IModule module, string defaultIfNotFound) { }
         public sealed class AsyncBoundary : Akka.Streams.Attributes.IAttribute, System.IEquatable<Akka.Streams.Attributes.AsyncBoundary>
         {
             public static readonly Akka.Streams.Attributes.AsyncBoundary Instance;
@@ -247,10 +248,10 @@ namespace Akka.Streams
         }
         public sealed class LogLevels : Akka.Streams.Attributes.IAttribute, System.IEquatable<Akka.Streams.Attributes.LogLevels>
         {
-            public static readonly Akka.Event.LogLevel Off;
             public readonly Akka.Event.LogLevel OnElement;
             public readonly Akka.Event.LogLevel OnFailure;
             public readonly Akka.Event.LogLevel OnFinish;
+            public static readonly Akka.Event.LogLevel Off;
             public LogLevels(Akka.Event.LogLevel onElement, Akka.Event.LogLevel onFinish, Akka.Event.LogLevel onFailure) { }
             public bool Equals(Akka.Streams.Attributes.LogLevels other) { }
             public override bool Equals(object obj) { }
@@ -267,7 +268,7 @@ namespace Akka.Streams
             public override string ToString() { }
         }
     }
-    public class static BidiShape
+    public static class BidiShape
     {
         public static Akka.Streams.BidiShape<TIn1, TOut1, TIn2, TOut2> FromFlows<TIn1, TOut1, TIn2, TOut2>(Akka.Streams.FlowShape<TIn1, TOut1> top, Akka.Streams.FlowShape<TIn2, TOut2> bottom) { }
     }
@@ -277,8 +278,8 @@ namespace Akka.Streams
         public readonly Akka.Streams.Inlet<TIn2> Inlet2;
         public readonly Akka.Streams.Outlet<TOut1> Outlet1;
         public readonly Akka.Streams.Outlet<TOut2> Outlet2;
-        public BidiShape(Akka.Streams.Inlet<TIn1> in1, Akka.Streams.Outlet<TOut1> out1, Akka.Streams.Inlet<TIn2> in2, Akka.Streams.Outlet<TOut2> out2) { }
         public BidiShape(Akka.Streams.FlowShape<TIn1, TOut1> top, Akka.Streams.FlowShape<TIn2, TOut2> bottom) { }
+        public BidiShape(Akka.Streams.Inlet<TIn1> in1, Akka.Streams.Outlet<TOut1> out1, Akka.Streams.Inlet<TIn2> in2, Akka.Streams.Outlet<TOut2> out2) { }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> Inlets { get; }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> Outlets { get; }
         public override Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
@@ -290,11 +291,12 @@ namespace Akka.Streams
         public static readonly Akka.Streams.BindFailedException Instance;
         protected BindFailedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.Serializable]
     public class BufferOverflowException : System.Exception
     {
         public BufferOverflowException(string message) { }
-        public BufferOverflowException(string message, System.Exception innerException) { }
         protected BufferOverflowException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public BufferOverflowException(string message, System.Exception innerException) { }
     }
     public class ClosedShape : Akka.Streams.Shape
     {
@@ -307,10 +309,10 @@ namespace Akka.Streams
     public class ConnectionException : Akka.Streams.StreamTcpException
     {
         public ConnectionException(string message) { }
-        public ConnectionException(string message, System.Exception innerException) { }
         protected ConnectionException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public ConnectionException(string message, System.Exception innerException) { }
     }
-    public class static Construct
+    public static class Construct
     {
         public static object Instantiate(this System.Type genericType, System.Type genericParam, params object[] constructorArgs) { }
         public static object Instantiate(this System.Type genericType, System.Type[] genericParams, params object[] constructorArgs) { }
@@ -330,38 +332,40 @@ namespace Akka.Streams
         public readonly Akka.Streams.Inlet<T0> In0;
         public readonly System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet<T1>> In1s;
         public readonly int N;
-        public FanInShapeN(int n, Akka.Streams.FanInShape<TOut>.IInit init) { }
         public FanInShapeN(int n) { }
+        public FanInShapeN(int n, Akka.Streams.FanInShape<TOut>.IInit init) { }
         public FanInShapeN(int n, string name) { }
-        public FanInShapeN(Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Inlet<T0> in0, params Akka.Streams.Inlet<>[] inlets) { }
+        public FanInShapeN(Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Inlet<T0> in0, params Akka.Streams.Inlet<T1>[] inlets) { }
         protected override Akka.Streams.FanInShape<TOut> Construct(Akka.Streams.FanInShape<TOut>.IInit init) { }
         public Akka.Streams.Inlet<T1> In(int n) { }
     }
     public abstract class FanInShape<TOut> : Akka.Streams.Shape
     {
-        protected FanInShape(Akka.Streams.Outlet<TOut> outlet, System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> registered, string name) { }
         protected FanInShape(Akka.Streams.FanInShape<TOut>.IInit init) { }
+        protected FanInShape(Akka.Streams.Outlet<TOut> outlet, System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> registered, string name) { }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> Inlets { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> Outlets { get; }
         protected abstract Akka.Streams.FanInShape<TOut> Construct(Akka.Streams.FanInShape<TOut>.IInit init);
-        public virtual Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
+        public override sealed Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
         public override Akka.Streams.Shape DeepCopy() { }
         protected Akka.Streams.Inlet<T> NewInlet<T>(string name) { }
-        public interface IInit<TOut>
+        public interface IInit
         {
             System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> Inlets { get; }
             string Name { get; }
             Akka.Streams.Outlet<TOut> Outlet { get; }
         }
-        public sealed class InitName<TOut> : Akka.Streams.FanInShape<TOut>.IInit
+        [System.Serializable]
+        public sealed class InitName : Akka.Streams.FanInShape<TOut>.IInit
         {
             public InitName(string name) { }
             public System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> Inlets { get; }
             public string Name { get; }
             public Akka.Streams.Outlet<TOut> Outlet { get; }
         }
-        public sealed class InitPorts<TOut> : Akka.Streams.FanInShape<TOut>.IInit
+        [System.Serializable]
+        public sealed class InitPorts : Akka.Streams.FanInShape<TOut>.IInit
         {
             public InitPorts(Akka.Streams.Outlet<TOut> outlet, System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> inlets) { }
             public System.Collections.Generic.IEnumerable<Akka.Streams.Inlet> Inlets { get; }
@@ -471,29 +475,31 @@ namespace Akka.Streams
     }
     public abstract class FanOutShape<TIn> : Akka.Streams.Shape
     {
-        protected FanOutShape(Akka.Streams.Inlet<TIn> inlet, System.Collections.Generic.IEnumerable<Akka.Streams.Outlet> registered, string name) { }
         protected FanOutShape(Akka.Streams.FanOutShape<TIn>.IInit init) { }
+        protected FanOutShape(Akka.Streams.Inlet<TIn> inlet, System.Collections.Generic.IEnumerable<Akka.Streams.Outlet> registered, string name) { }
         public Akka.Streams.Inlet<TIn> In { get; }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> Inlets { get; }
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> Outlets { get; }
         protected abstract Akka.Streams.FanOutShape<TIn> Construct(Akka.Streams.FanOutShape<TIn>.IInit init);
-        public virtual Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
+        public override sealed Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
         public override Akka.Streams.Shape DeepCopy() { }
         protected Akka.Streams.Outlet<T> NewOutlet<T>(string name) { }
-        public interface IInit<TIn>
+        public interface IInit
         {
             Akka.Streams.Inlet<TIn> Inlet { get; }
             string Name { get; }
             System.Collections.Generic.IEnumerable<Akka.Streams.Outlet> Outlets { get; }
         }
-        public sealed class InitName<TIn> : Akka.Streams.FanOutShape<TIn>.IInit
+        [System.Serializable]
+        public sealed class InitName : Akka.Streams.FanOutShape<TIn>.IInit
         {
             public InitName(string name) { }
             public Akka.Streams.Inlet<TIn> Inlet { get; }
             public string Name { get; }
             public System.Collections.Generic.IEnumerable<Akka.Streams.Outlet> Outlets { get; }
         }
-        public sealed class InitPorts<TIn> : Akka.Streams.FanOutShape<TIn>.IInit
+        [System.Serializable]
+        public sealed class InitPorts : Akka.Streams.FanOutShape<TIn>.IInit
         {
             public InitPorts(Akka.Streams.Inlet<TIn> inlet, System.Collections.Generic.IEnumerable<Akka.Streams.Outlet> outlets) { }
             public Akka.Streams.Inlet<TIn> Inlet { get; }
@@ -601,7 +607,7 @@ namespace Akka.Streams
         public FanOutShape(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<T0> out0, Akka.Streams.Outlet<T1> out1, Akka.Streams.Outlet<T2> out2, Akka.Streams.Outlet<T3> out3, Akka.Streams.Outlet<T4> out4, Akka.Streams.Outlet<T5> out5, Akka.Streams.Outlet<T6> out6, Akka.Streams.Outlet<T7> out7) { }
         protected override Akka.Streams.FanOutShape<TIn> Construct(Akka.Streams.FanOutShape<TIn>.IInit init) { }
     }
-    public class static FlowMonitor
+    public static class FlowMonitor
     {
         public sealed class Failed : Akka.Streams.FlowMonitor.IStreamState
         {
@@ -633,7 +639,7 @@ namespace Akka.Streams
         public override Akka.Streams.Shape CopyFromPorts(System.Collections.Immutable.ImmutableArray<Akka.Streams.Inlet> inlets, System.Collections.Immutable.ImmutableArray<Akka.Streams.Outlet> outlets) { }
         public override Akka.Streams.Shape DeepCopy() { }
     }
-    public class static Fusing
+    public static class Fusing
     {
         public static Akka.Streams.Fusing.FusedGraph<TShape, TMat> Aggressive<TShape, TMat>(Akka.Streams.IGraph<TShape, TMat> graph)
             where TShape : Akka.Streams.Shape { }
@@ -675,7 +681,7 @@ namespace Akka.Streams
     public interface IGraph<out TShape>
         where out TShape : Akka.Streams.Shape
     {
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         Akka.Streams.Implementation.IModule Module { get; }
         TShape Shape { get; }
     }
@@ -761,8 +767,8 @@ namespace Akka.Streams
         public readonly string Name;
         protected Inlet(string name) { }
         public abstract Akka.Streams.Inlet CarbonCopy();
+        public override sealed string ToString() { }
         public static Akka.Streams.Inlet<T> Create<T>(Akka.Streams.Inlet inlet) { }
-        public virtual string ToString() { }
     }
     public sealed class Inlet<T> : Akka.Streams.Inlet
     {
@@ -771,26 +777,26 @@ namespace Akka.Streams
     }
     public sealed class InvalidPartnerActorException : Akka.Pattern.IllegalStateException
     {
-        public InvalidPartnerActorException(Akka.Actor.IActorRef expectedRef, Akka.Actor.IActorRef gotRef, string message) { }
         protected InvalidPartnerActorException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public InvalidPartnerActorException(Akka.Actor.IActorRef expectedRef, Akka.Actor.IActorRef gotRef, string message) { }
         public Akka.Actor.IActorRef ExpectedRef { get; }
         public Akka.Actor.IActorRef GotRef { get; }
     }
     public sealed class InvalidSequenceNumberException : Akka.Pattern.IllegalStateException
     {
-        public InvalidSequenceNumberException(long expectedSeqNr, long gotSeqNr, string message) { }
         protected InvalidSequenceNumberException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public InvalidSequenceNumberException(long expectedSeqNr, long gotSeqNr, string message) { }
         public long ExpectedSeqNr { get; }
         public long GotSeqNr { get; }
     }
-    public class static KillSwitches
+    public static class KillSwitches
     {
-        public static Akka.Streams.IGraph<Akka.Streams.FlowShape<T, T>, Akka.NotUsed> AsFlow<T>(this System.Threading.CancellationToken cancellationToken, bool cancelGracefully = False) { }
+        public static Akka.Streams.IGraph<Akka.Streams.FlowShape<T, T>, Akka.NotUsed> AsFlow<T>(this System.Threading.CancellationToken cancellationToken, bool cancelGracefully = false) { }
         public static Akka.Streams.SharedKillSwitch Shared(string name) { }
         public static Akka.Streams.IGraph<Akka.Streams.FlowShape<T, T>, Akka.Streams.UniqueKillSwitch> Single<T>() { }
         public static Akka.Streams.IGraph<Akka.Streams.BidiShape<T1, T1, T2, T2>, Akka.Streams.UniqueKillSwitch> SingleBidi<T1, T2>() { }
     }
-    public struct MaterializationContext
+    public readonly struct MaterializationContext
     {
         public readonly Akka.Streams.Attributes EffectiveAttributes;
         public readonly Akka.Streams.IMaterializer Materializer;
@@ -799,8 +805,8 @@ namespace Akka.Streams
     }
     public class MaterializationException : System.Exception
     {
-        public MaterializationException(string message, System.Exception innerException) { }
         protected MaterializationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public MaterializationException(string message, System.Exception innerException) { }
     }
     public sealed class NoMaterializer : Akka.Streams.IMaterializer
     {
@@ -826,8 +832,8 @@ namespace Akka.Streams
         public readonly string Name;
         protected Outlet(string name) { }
         public abstract Akka.Streams.Outlet CarbonCopy();
+        public override sealed string ToString() { }
         public static Akka.Streams.Outlet<T> Create<T>(Akka.Streams.Outlet outlet) { }
-        public virtual string ToString() { }
     }
     public sealed class Outlet<T> : Akka.Streams.Outlet
     {
@@ -876,12 +882,12 @@ namespace Akka.Streams
         public System.TimeSpan MaxRestartsWithin { get; }
         public System.TimeSpan MinBackoff { get; }
         public double RandomFactor { get; }
-        public static Akka.Streams.RestartSettings Create(System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
         public override string ToString() { }
         public Akka.Streams.RestartSettings WithMaxBackoff(System.TimeSpan value) { }
         public Akka.Streams.RestartSettings WithMaxRestarts(int count, System.TimeSpan within) { }
         public Akka.Streams.RestartSettings WithMinBackoff(System.TimeSpan value) { }
         public Akka.Streams.RestartSettings WithRandomFactor(double value) { }
+        public static Akka.Streams.RestartSettings Create(System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
     }
     public abstract class Shape : System.ICloneable
     {
@@ -893,7 +899,7 @@ namespace Akka.Streams
         public abstract Akka.Streams.Shape DeepCopy();
         public bool HasSamePortsAndShapeAs(Akka.Streams.Shape shape) { }
         public bool HasSamePortsAs(Akka.Streams.Shape shape) { }
-        public virtual string ToString() { }
+        public override sealed string ToString() { }
     }
     public sealed class SharedKillSwitch : Akka.Streams.IKillSwitch
     {
@@ -936,7 +942,7 @@ namespace Akka.Streams
         public StreamLimitReachedException(long max) { }
         protected StreamLimitReachedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static StreamRefAttributes
+    public static class StreamRefAttributes
     {
         public static Akka.Streams.Attributes CreateBufferCapacity(int capacity) { }
         public static Akka.Streams.Attributes CreateDemandRedeliveryInterval(System.TimeSpan timeout) { }
@@ -990,11 +996,11 @@ namespace Akka.Streams
         public readonly Akka.Streams.StreamSubscriptionTimeoutTerminationMode Mode;
         public readonly System.TimeSpan Timeout;
         public StreamSubscriptionTimeoutSettings(Akka.Streams.StreamSubscriptionTimeoutTerminationMode mode, System.TimeSpan timeout) { }
-        public static Akka.Streams.StreamSubscriptionTimeoutSettings Create(Akka.Configuration.Config config) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Streams.StreamSubscriptionTimeoutSettings other) { }
+        public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
+        public static Akka.Streams.StreamSubscriptionTimeoutSettings Create(Akka.Configuration.Config config) { }
     }
     public enum StreamSubscriptionTimeoutTerminationMode
     {
@@ -1005,20 +1011,20 @@ namespace Akka.Streams
     public class StreamTcpException : System.Exception
     {
         public StreamTcpException(string message) { }
-        public StreamTcpException(string message, System.Exception innerException) { }
         protected StreamTcpException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public StreamTcpException(string message, System.Exception innerException) { }
     }
-    public class static SubscriptionWithCancelException
+    public static class SubscriptionWithCancelException
     {
         public sealed class NoMoreElementsNeeded : Akka.Streams.SubscriptionWithCancelException.NonFailureCancellation
         {
             public static readonly Akka.Streams.SubscriptionWithCancelException.NoMoreElementsNeeded Instance;
         }
-        [Akka.Annotations.DoNotInheritAttribute()]
+        [Akka.Annotations.DoNotInherit]
         public abstract class NonFailureCancellation : System.Exception
         {
             protected NonFailureCancellation() { }
-            public virtual string StackTrace { get; }
+            public override sealed string StackTrace { get; }
         }
         public sealed class StageWasCompleted : Akka.Streams.SubscriptionWithCancelException.NonFailureCancellation
         {
@@ -1056,20 +1062,20 @@ namespace Akka.Streams
     public class UniformFanInShape<TIn, TOut> : Akka.Streams.FanInShape<TOut>
     {
         public readonly int N;
-        public UniformFanInShape(int n, Akka.Streams.FanInShape<TOut>.IInit init) { }
         public UniformFanInShape(int n) { }
+        public UniformFanInShape(Akka.Streams.Outlet<TOut> outlet, params Akka.Streams.Inlet<TIn>[] inlets) { }
+        public UniformFanInShape(int n, Akka.Streams.FanInShape<TOut>.IInit init) { }
         public UniformFanInShape(int n, string name) { }
-        public UniformFanInShape(Akka.Streams.Outlet<TOut> outlet, params Akka.Streams.Inlet<>[] inlets) { }
         public System.Collections.Immutable.IImmutableList<Akka.Streams.Inlet<TIn>> Ins { get; }
         protected override Akka.Streams.FanInShape<TOut> Construct(Akka.Streams.FanInShape<TOut>.IInit init) { }
         public Akka.Streams.Inlet<TIn> In(int n) { }
     }
     public class UniformFanOutShape<TIn, TOut> : Akka.Streams.FanOutShape<TIn>
     {
-        public UniformFanOutShape(int n, Akka.Streams.FanOutShape<TIn>.IInit init) { }
         public UniformFanOutShape(int n) { }
+        public UniformFanOutShape(Akka.Streams.Inlet<TIn> inlet, params Akka.Streams.Outlet<TOut>[] outlets) { }
+        public UniformFanOutShape(int n, Akka.Streams.FanOutShape<TIn>.IInit init) { }
         public UniformFanOutShape(int n, string name) { }
-        public UniformFanOutShape(Akka.Streams.Inlet<TIn> inlet, params Akka.Streams.Outlet<>[] outlets) { }
         public System.Collections.Immutable.IImmutableList<Akka.Streams.Outlet<TOut>> Outs { get; }
         protected override Akka.Streams.FanOutShape<TIn> Construct(Akka.Streams.FanOutShape<TIn>.IInit init) { }
         public Akka.Streams.Outlet<TOut> Out(int n) { }
@@ -1082,13 +1088,13 @@ namespace Akka.Streams
     }
     public class WatchedActorTerminatedException : Akka.Actor.AkkaException
     {
-        public WatchedActorTerminatedException(string stageName, Akka.Actor.IActorRef actorRef) { }
         protected WatchedActorTerminatedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public WatchedActorTerminatedException(string stageName, Akka.Actor.IActorRef actorRef) { }
     }
 }
 namespace Akka.Streams.Actors
 {
-    public class static ActorPublisher
+    public static class ActorPublisher
     {
         public static Reactive.Streams.IPublisher<T> Create<T>(Akka.Actor.IActorRef @ref) { }
     }
@@ -1110,7 +1116,7 @@ namespace Akka.Streams.Actors
         public bool IsCanceled { get; }
         public bool IsCompleted { get; }
         public bool IsErrorEmitted { get; }
-        public System.TimeSpan SubscriptionTimeout { get; set; }
+        public System.TimeSpan SubscriptionTimeout { get; protected set; }
         public long TotalDemand { get; }
         public override void AroundPostRestart(System.Exception cause, object message) { }
         public override void AroundPostStop() { }
@@ -1135,8 +1141,8 @@ namespace Akka.Streams.Actors
         public override void AroundPreStart() { }
         protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         protected void Cancel() { }
-        public static Reactive.Streams.ISubscriber<T> Create<T>(Akka.Actor.IActorRef @ref) { }
         protected void Request(long n) { }
+        public static Reactive.Streams.ISubscriber<T> Create<T>(Akka.Actor.IActorRef @ref) { }
     }
     public sealed class ActorSubscriberImpl<T> : Reactive.Streams.ISubscriber<T>
     {
@@ -1154,6 +1160,7 @@ namespace Akka.Streams.Actors
         public Akka.Streams.Actors.ActorSubscriberState.State Get(Akka.Actor.IActorRef actorRef) { }
         public Akka.Streams.Actors.ActorSubscriberState.State Remove(Akka.Actor.IActorRef actorRef) { }
         public void Set(Akka.Actor.IActorRef actorRef, Akka.Streams.Actors.ActorSubscriberState.State s) { }
+        [System.Serializable]
         public sealed class State
         {
             public readonly bool IsCanceled;
@@ -1162,6 +1169,7 @@ namespace Akka.Streams.Actors
             public State(Reactive.Streams.ISubscription subscription, long requested, bool isCanceled) { }
         }
     }
+    [System.Serializable]
     public sealed class Cancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorPublisherMessage
     {
         public static readonly Akka.Streams.Actors.Cancel Instance;
@@ -1172,6 +1180,7 @@ namespace Akka.Streams.Actors
     {
         int RequestDemand(int remainingRequested);
     }
+    [System.Serializable]
     public enum LifecycleState
     {
         PreSubscriber = 0,
@@ -1189,10 +1198,12 @@ namespace Akka.Streams.Actors
         public abstract int InFlight { get; }
         public int RequestDemand(int remainingRequested) { }
     }
+    [System.Serializable]
     public sealed class OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorSubscriberMessage
     {
         public static readonly Akka.Streams.Actors.OnComplete Instance;
     }
+    [System.Serializable]
     public sealed class OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorSubscriberMessage
     {
         public readonly System.Exception Cause;
@@ -1204,11 +1215,13 @@ namespace Akka.Streams.Actors
         public readonly bool Stop;
         public OnErrorBlock(System.Exception cause, bool stop) { }
     }
+    [System.Serializable]
     public sealed class OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorSubscriberMessage
     {
         public readonly object Element;
         public OnNext(object element) { }
     }
+    [System.Serializable]
     public sealed class OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
     {
         public readonly Reactive.Streams.ISubscription Subscription;
@@ -1219,6 +1232,7 @@ namespace Akka.Streams.Actors
         public static readonly Akka.Streams.Actors.OneByOneRequestStrategy Instance;
         public int RequestDemand(int remainingRequested) { }
     }
+    [System.Serializable]
     public sealed class Request : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorPublisherMessage
     {
         public readonly long Count;
@@ -1229,6 +1243,7 @@ namespace Akka.Streams.Actors
         public readonly Reactive.Streams.ISubscriber<T> Subscriber;
         public Subscribe(Reactive.Streams.ISubscriber<T> subscriber) { }
     }
+    [System.Serializable]
     public sealed class SubscriptionTimeoutExceeded : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Actors.IActorPublisherMessage
     {
         public static readonly Akka.Streams.Actors.SubscriptionTimeoutExceeded Instance;
@@ -1259,7 +1274,7 @@ namespace Akka.Streams.Dsl
     }
     public sealed class Balance<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanOutShape<T, T>>
     {
-        public Balance(int outputPorts, bool waitForAllDownstreams = False) { }
+        public Balance(int outputPorts, bool waitForAllDownstreams = false) { }
         public Akka.Streams.Inlet<T> In { get; }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public override Akka.Streams.UniformFanOutShape<T, T> Shape { get; }
@@ -1267,7 +1282,7 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Outlet<T> Out(int id) { }
         public override string ToString() { }
     }
-    public class static BidiFlow
+    public static class BidiFlow
     {
         public static Akka.Streams.Dsl.BidiFlow<TIn, TIn, TOut, TOut, Akka.NotUsed> BidirectionalIdleTimeout<TIn, TOut>(System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.BidiFlow<TIn1, TOut1, TIn2, TOut2, Akka.NotUsed> FromFlows<TIn1, TOut1, TIn2, TOut2, TMat1, TMat2>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn1, TOut1>, TMat1> flow1, Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn2, TOut2>, TMat2> flow2) { }
@@ -1293,30 +1308,30 @@ namespace Akka.Streams.Dsl
     public class BroadcastHub
     {
         public BroadcastHub() { }
-        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int bufferSize) { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>() { }
+        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int bufferSize) { }
     }
     public sealed class Broadcast<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanOutShape<T, T>>
     {
         public readonly Akka.Streams.Inlet<T> In;
-        public Broadcast(int outputPorts, bool eagerCancel = False) { }
+        public Broadcast(int outputPorts, bool eagerCancel = false) { }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public override Akka.Streams.UniformFanOutShape<T, T> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public Akka.Streams.Outlet<T> Out(int id) { }
         public override string ToString() { }
     }
-    public class static ChannelSink
+    public static class ChannelSink
     {
-        public static Akka.Streams.Dsl.Sink<T, System.Threading.Channels.ChannelReader<T>> AsReader<T>(int bufferSize, bool singleReader = False, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
+        public static Akka.Streams.Dsl.Sink<T, System.Threading.Channels.ChannelReader<T>> AsReader<T>(int bufferSize, bool singleReader = false, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
         public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> FromWriter<T>(System.Threading.Channels.ChannelWriter<T> writer, bool isOwner) { }
     }
-    public class static ChannelSource
+    public static class ChannelSource
     {
-        public static Akka.Streams.Dsl.Source<T, System.Threading.Channels.ChannelWriter<T>> Create<T>(int bufferSize, bool singleWriter = False, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
+        public static Akka.Streams.Dsl.Source<T, System.Threading.Channels.ChannelWriter<T>> Create<T>(int bufferSize, bool singleWriter = false, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromReader<T>(System.Threading.Channels.ChannelReader<T> reader) { }
     }
-    public class static Concat
+    public static class Concat
     {
         public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, T>, Akka.NotUsed> Create<T>(int inputPorts = 2) { }
     }
@@ -1336,17 +1351,17 @@ namespace Akka.Streams.Dsl
         public DelayFlow(System.TimeSpan fixedDelay) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    public class static FileIO
+    public static class FileIO
     {
         public static Akka.Streams.Dsl.Source<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> FromFile(System.IO.FileInfo f, int chunkSize = 8192, long startPosition = 0) { }
-        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> ToFile(System.IO.FileInfo f, System.Nullable<System.IO.FileMode> fileMode = null, long startPosition = 0, bool autoFlush = False, Akka.Streams.Implementation.IO.FlushSignaler flushSignaler = null) { }
+        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> ToFile(System.IO.FileInfo f, System.IO.FileMode? fileMode = default, long startPosition = 0, bool autoFlush = false, Akka.Streams.Implementation.IO.FlushSignaler flushSignaler = null) { }
     }
     public class FixedDelay<T> : Akka.Streams.Dsl.IDelayStrategy<T>
     {
         public FixedDelay(System.TimeSpan delay) { }
         public System.TimeSpan NextDelay(T element) { }
     }
-    public class static Flow
+    public static class Flow
     {
         public static Akka.Streams.Dsl.Flow<T, T, Akka.NotUsed> Create<T>() { }
         public static Akka.Streams.Dsl.Flow<T, T, TMat> Create<T, TMat>() { }
@@ -1361,7 +1376,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut, System.Threading.Tasks.Task<Akka.Util.Option<TMat>>> LazyInitAsync<TIn, TOut, TMat>(System.Func<System.Threading.Tasks.Task<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>>> flowFactory) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, System.Threading.Tasks.Task<TMat>> Setup<TIn, TOut, TMat>(System.Func<Akka.Streams.ActorMaterializer, Akka.Streams.Attributes, Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> factory) { }
     }
-    public class static FlowOperations
+    public static class FlowOperations
     {
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Aggregate<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, TOut2 zero, System.Func<TOut2, TOut1, TOut2> fold) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> AggregateAsync<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, TOut2 zero, System.Func<TOut2, TOut1, System.Threading.Tasks.Task<TOut2>> fold) { }
@@ -1374,7 +1389,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Batch<TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> BatchWeighted<TIn, TOut, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Buffer<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int size, Akka.Streams.OverflowStrategy strategy) { }
-        [System.ObsoleteAttribute("Deprecated. Please use Collect(isDefined, collector) instead")]
+        [System.Obsolete("Deprecated. Please use Collect(isDefined, collector) instead")]
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Collect<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Collect<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<TOut1, bool> isDefined, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> CompletionTimeout<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan timeout) { }
@@ -1382,15 +1397,15 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> ConcatMany<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Conflate<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TOut, TOut> aggregate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TSeed, TMat> ConflateWithSeed<TIn, TOut, TMat, TSeed>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TSeed> seed, System.Func<TSeed, TOut, TSeed> aggregate) { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Delay<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan of, System.Nullable<Akka.Streams.DelayOverflowStrategy> strategy = null) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Delay<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan of, Akka.Streams.DelayOverflowStrategy? strategy = default) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Detach<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> DivertTo<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that, System.Func<TOut, bool> when) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat3> DivertToMaterialized<TIn, TOut, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TOut, bool> when, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Expand<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<TOut1, System.Collections.Generic.IEnumerator<TOut2>> extrapolate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc, bool allowClosedSubstreamRecreation) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TKey> groupingFunc, bool allowClosedSubstreamRecreation) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TKey> groupingFunc) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> GroupBy<TIn, TOut, TMat, TKey>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc, bool allowClosedSubstreamRecreation) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> Grouped<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n, System.TimeSpan timeout) { }
@@ -1401,22 +1416,22 @@ namespace Akka.Streams.Dsl
             where T1 : T2 { }
         public static Akka.Streams.Dsl.Flow<TIn, T2, TMat3> InterleaveMaterialized<TIn, T1, T2, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Flow<TIn, T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat2> graph, int segmentSize, System.Func<TMat, TMat2, TMat3> combine)
             where T1 : T2 { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Intersperse<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Intersperse<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, TOut inject) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Intersperse<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.Flow<TIn, TInjected, TMat> KeepAlive<TIn, TOut, TInjected, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan timeout, System.Func<TInjected> injectElement)
             where TOut : TInjected { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Limit<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> LimitWeighted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long max, System.Func<TOut, long> costFunc) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Log<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null, Akka.Event.LogLevel logLevel = 0) { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Merge<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = False)
+        public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Merge<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = false)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> MergeMany<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, int breadth, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat3> MergeMaterialized<TIn, TOut1, TOut2, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat2> that, System.Func<TMat, TMat2, TMat3> combine)
             where TOut1 : TOut2 { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> MergeSorted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> MergeSorted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other)
             where TOut : System.IComparable<TOut> { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> MergeSorted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Collections.Generic.IComparer<TOut> comparer) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> MergeSorted<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat2> Monitor<TIn, TOut, TMat, TMat2>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TMat, Akka.Streams.IFlowMonitor, TMat2> combine) { }
         public static Akka.Streams.Dsl.Flow<T, T, TMat> OrElse<T, TMat>(this Akka.Streams.Dsl.Flow<T, T, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat> secondary) { }
         public static Akka.Streams.Dsl.Flow<T, T, TMat3> OrElseMaterialized<T, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Flow<T, T, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat2> secondary, System.Func<TMat, TMat2, TMat3> materializedFunction) { }
@@ -1424,7 +1439,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Prepend<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> that)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Recover<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<System.Exception, Akka.Util.Option<TOut>> partialFunc) { }
-        [System.ObsoleteAttribute("Use RecoverWithRetries instead. [1.1.2]")]
+        [System.Obsolete("Use RecoverWithRetries instead. [1.1.2]")]
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> RecoverWith<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> RecoverWithRetries<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc, int attempts) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> RepeatPrevious<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow) { }
@@ -1440,58 +1455,54 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> SkipWhile<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Predicate<TOut> predicate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> SkipWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan duration) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.Collections.Generic.IEnumerable<TOut>, TMat> Sliding<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int n, int step = 1) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitAfter<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitAfter<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, bool> predicate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitWhen<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitAfter<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitWhen<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.Sink<TIn, TMat>> SplitWhen<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.Flow<T, TOut, TMat> StatefulSelectMany<T, TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<T, TIn, TMat> flow, System.Func<System.Func<TIn, System.Collections.Generic.IEnumerable<TOut>>> mapConcaterFactory) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Sum<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, TOut, TOut> reduce) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Take<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, long n) { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> TakeWhile<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Predicate<TOut> predicate, bool inclusive = False) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> TakeWhile<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Predicate<TOut> predicate, bool inclusive = false) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> TakeWithin<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.TimeSpan duration) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Throttle<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int elements, System.TimeSpan per, int maximumBurst, Akka.Streams.ThrottleMode mode) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Throttle<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, int cost, System.TimeSpan per, int maximumBurst, System.Func<TOut, int> calculateCost, Akka.Streams.ThrottleMode mode) { }
-        [System.ObsoleteAttribute("Use Via(GraphStage) instead. [1.1.2]")]
+        [System.Obsolete("Use Via(GraphStage) instead. [1.1.2]")]
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat> Transform<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut1, TMat> flow, System.Func<Akka.Streams.Stage.IStage<TOut1, TOut2>> stageFactory) { }
         public static Akka.Streams.Dsl.Flow<T, T, TMat> Watch<T, TMat>(this Akka.Streams.Dsl.Flow<T, T, TMat> flow, Akka.Actor.IActorRef actorRef) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat2> WatchTermination<TIn, TOut, TMat, TMat2>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TMat, System.Threading.Tasks.Task<Akka.Done>, TMat2> materializerFunction) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Where<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Predicate<TOut> predicate) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> WhereNot<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Predicate<TOut> predicate) { }
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> WireTap<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> WireTap<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that) { }
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> WireTap<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat3> WireTapMaterialized<TIn, TOut, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.ValueTuple<T1, T2>, TMat> Zip<TIn, T1, T2, TMat>(this Akka.Streams.Dsl.Flow<TIn, T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other) { }
         public static Akka.Streams.Dsl.Flow<TIn, T3, TMat> ZipWith<TIn, T1, T2, T3, TMat>(this Akka.Streams.Dsl.Flow<TIn, T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other, System.Func<T1, T2, T3> combine) { }
         public static Akka.Streams.Dsl.Flow<TIn, System.ValueTuple<TOut, long>, TMat> ZipWithIndex<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow) { }
     }
-    public class static FlowWithContext
+    public static class FlowWithContext
     {
         public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TIn, TCtx, Akka.NotUsed> Create<TIn, TCtx>() { }
         public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat> From<TIn, TCtxIn, TOut, TCtxOut, TMat>(Akka.Streams.Dsl.Flow<System.ValueTuple<TIn, TCtxIn>, System.ValueTuple<TOut, TCtxOut>, TMat> flow) { }
     }
-    public class static FlowWithContextOperations
+    public static class FlowWithContextOperations
     {
-        [System.ObsoleteAttribute("Deprecated. Please use Collect(FlowWithContext, Func, Func) instead. Since v1.5.4" +
+        [System.Obsolete("Deprecated. Please use Collect(FlowWithContext, Func, Func) instead. Since v1.5.4" +
             "4, will be removed in v1.6")]
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, TOut2> fn)
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                0,
-                0,
-                0})] System.Func<System.ValueTuple<TOut, TCtx>, bool> isDefined, System.Func<TOut, TOut2> fn)
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Collect<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<System.ValueTuple<TOut, TCtx>, bool>? isDefined, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, int n) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Select<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, TOut2> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectAsync<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, int parallelism, System.Func<TOut, System.Threading.Tasks.Task<TOut2>> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectConcat<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx2, TMat> SelectContext<TIn, TCtx, TOut, TCtx2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TCtx, TCtx2> mapContext) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Sliding<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, int n, int step = 1) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> StatefulSelectConcat<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>>> fn) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> Where<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, bool> predicate) { }
-        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> WhereNot<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, int n) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> Select<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectAsync<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, int parallelism, System.Func<TOut, System.Threading.Tasks.Task<TOut2>> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> SelectConcat<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx2, TMat> SelectContext<TIn, TCtx, TOut, TCtx2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TCtx, TCtx2> mapContext) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Sliding<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, int n, int step = 1) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut2, TCtx, TMat> StatefulSelectConcat<TIn, TCtx, TOut, TOut2, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<System.Func<TOut, System.Collections.Generic.IEnumerable<TOut2>>> fn) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> Where<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> WhereNot<TIn, TCtx, TOut, TMat>(this Akka.Streams.Dsl.FlowWithContext<TIn, TCtx, TOut, TCtx, TMat> flow, System.Func<TOut, bool> predicate) { }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
+    [Akka.Annotations.ApiMayChange]
     public sealed class FlowWithContext<TIn, TCtxIn, TOut, TCtxOut, TMat> : Akka.Streams.GraphDelegate<Akka.Streams.FlowShape<System.ValueTuple<TIn, TCtxIn>, System.ValueTuple<TOut, TCtxOut>>, TMat>
     {
         public Akka.Streams.Dsl.Flow<System.ValueTuple<TIn, TCtxIn>, System.ValueTuple<TOut, TCtxOut>, TMat> AsFlow() { }
@@ -1509,8 +1520,8 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.Flow<TIn, TOut, TMat3> ConcatMaterialized<TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat2> that, System.Func<TMat, TMat2, TMat3> materializedFunction) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> Join<TMat2>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TOut, TIn>, TMat2> flow) { }
         public Akka.Streams.Dsl.Flow<TIn2, TOut2, TMat> Join<TIn2, TOut2, TMat2>(Akka.Streams.IGraph<Akka.Streams.BidiShape<TOut, TOut2, TIn2, TIn>, TMat2> bidi) { }
-        public Akka.Streams.Dsl.Flow<TIn2, TOut2, TMatRes> JoinMaterialized<TIn2, TOut2, TMat2, TMatRes>(Akka.Streams.IGraph<Akka.Streams.BidiShape<TOut, TOut2, TIn2, TIn>, TMat2> bidi, System.Func<TMat, TMat2, TMatRes> combine) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat3> JoinMaterialized<TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TOut, TIn>, TMat2> flow, System.Func<TMat, TMat2, TMat3> combine) { }
+        public Akka.Streams.Dsl.Flow<TIn2, TOut2, TMatRes> JoinMaterialized<TIn2, TOut2, TMat2, TMatRes>(Akka.Streams.IGraph<Akka.Streams.BidiShape<TOut, TOut2, TIn2, TIn>, TMat2> bidi, System.Func<TMat, TMat2, TMatRes> combine) { }
         public Akka.Streams.Dsl.Flow<TIn, TOut, TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> mapFunc) { }
         public Akka.Streams.Dsl.Flow<TIn, TOut, TMat> Named(string name) { }
         public System.ValueTuple<TMat1, TMat2> RunWith<TMat1, TMat2>(Akka.Streams.IGraph<Akka.Streams.SourceShape<TIn>, TMat1> source, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Streams.IMaterializer materializer) { }
@@ -1522,13 +1533,13 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.Flow<TIn, TOut2, TMat3> ViaMaterialized<TOut2, TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TOut, TOut2>, TMat2> flow, System.Func<TMat, TMat2, TMat3> combine) { }
         public Akka.Streams.Dsl.Flow<TIn, TOut, TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    public class static ForwardOps
+    public static class ForwardOps
     {
+        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> To<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, TMat> ops, Akka.Streams.FlowShape<TIn, TOut> flow)
+            where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> To<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, TMat> ops, Akka.Streams.Inlet<TIn> inlet)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> To<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, TMat> ops, Akka.Streams.SinkShape<TIn> sink)
-            where TIn : TOut { }
-        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> To<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, TMat> ops, Akka.Streams.FlowShape<TIn, TOut> flow)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> To<TIn, TOut, TMat, TMat2>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, TMat> ops, Akka.Streams.IGraph<Akka.Streams.SinkShape<TIn>, TMat2> sink)
             where TIn : TOut { }
@@ -1545,9 +1556,9 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut2, TMat> Via<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut1, TMat> ops, Akka.Streams.UniformFanOutShape<TIn, TOut2> junction)
             where TIn : TOut1 { }
     }
-    public class static Framing
+    public static class Framing
     {
-        public static Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> Delimiter(Akka.IO.ByteString delimiter, int maximumFrameLength, bool allowTruncation = False) { }
+        public static Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> Delimiter(Akka.IO.ByteString delimiter, int maximumFrameLength, bool allowTruncation = false) { }
         public static Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> LengthField(int fieldLength, int maximumFramelength, int fieldOffset = 0, Akka.IO.ByteOrder byteOrder = 1) { }
         public static Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> LengthField(int fieldLength, int fieldOffset, int maximumFrameLength, Akka.IO.ByteOrder byteOrder, System.Func<System.Collections.Generic.IReadOnlyList<byte>, int, int> computeFrameSize) { }
         public static Akka.Streams.Dsl.BidiFlow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> SimpleFramingProtocol(int maximumMessageLength) { }
@@ -1559,7 +1570,7 @@ namespace Akka.Streams.Dsl
             protected FramingException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }
-    public class static GraphDsl
+    public static class GraphDsl
     {
         public static Akka.Streams.IGraph<TShape, Akka.NotUsed> Create<TShape>(System.Func<Akka.Streams.Dsl.GraphDsl.Builder<Akka.NotUsed>, TShape> buildBlock)
             where TShape : Akka.Streams.Shape { }
@@ -1596,20 +1607,20 @@ namespace Akka.Streams.Dsl
             public Akka.Streams.Implementation.IModule Module { get; }
             public TShape Add<TShape, TMat>(Akka.Streams.IGraph<TShape, TMat> graph)
                 where TShape : Akka.Streams.Shape { }
+            public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TOut>(Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, T> source) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TOut>(Akka.Streams.Outlet<TOut> outlet) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TOut>(Akka.Streams.SourceShape<TOut> source) { }
-            public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TOut>(Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, T> source) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TIn, TOut>(Akka.Streams.FlowShape<TIn, TOut> flow) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TIn, TOut>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn, TOut>, T> flow) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TIn, TOut>(Akka.Streams.UniformFanInShape<TIn, TOut> fanIn) { }
             public Akka.Streams.Dsl.GraphDsl.ForwardOps<TOut, T> From<TIn, TOut>(Akka.Streams.UniformFanOutShape<TIn, TOut> fanOut) { }
             public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn>(Akka.Streams.Inlet<TIn> inlet) { }
             public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn>(Akka.Streams.SinkShape<TIn> sink) { }
-            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TMat>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TIn>, TMat> sink) { }
-            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut, TMat>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn, TOut>, TMat> flow) { }
             public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut>(Akka.Streams.FlowShape<TIn, TOut> flow) { }
-            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut>(Akka.Streams.UniformFanOutShape<TIn, TOut> fanOut) { }
+            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TMat>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TIn>, TMat> sink) { }
             public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut>(Akka.Streams.UniformFanInShape<TIn, TOut> fanOut) { }
+            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut>(Akka.Streams.UniformFanOutShape<TIn, TOut> fanOut) { }
+            public Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, T> To<TIn, TOut, TMat>(Akka.Streams.IGraph<Akka.Streams.FlowShape<TIn, TOut>, TMat> flow) { }
         }
         public sealed class ForwardOps<TOut, TMat>
         {
@@ -1637,8 +1648,8 @@ namespace Akka.Streams.Dsl
         Akka.Streams.Dsl.IRunnableGraph<TMat> AddAttributes(Akka.Streams.Attributes attributes);
         Akka.Streams.Dsl.IRunnableGraph<TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> func);
         Akka.Streams.Dsl.IRunnableGraph<TMat> Named(string name);
-        TMat Run(Akka.Streams.IMaterializer materializer);
         TMat Run(Akka.Actor.ActorSystem actorSystem);
+        TMat Run(Akka.Streams.IMaterializer materializer);
         Akka.Streams.Dsl.IRunnableGraph<TMat> WithAttributes(Akka.Streams.Attributes attributes);
     }
     public interface IUnzipWithCreator<out TIn, in TOut, out T>
@@ -1650,9 +1661,9 @@ namespace Akka.Streams.Dsl
         System.Threading.Tasks.Task<bool> Flip(Akka.Streams.Dsl.SwitchMode mode);
         System.Threading.Tasks.Task<Akka.Streams.Dsl.SwitchMode> GetMode();
     }
-    public class static Interleave
+    public static class Interleave
     {
-        public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, T>, Akka.NotUsed> Create<T>(int inputPorts, int segmentSize, bool eagerClose = False) { }
+        public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, T>, Akka.NotUsed> Create<T>(int inputPorts, int segmentSize, bool eagerClose = false) { }
     }
     public sealed class Interleave<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanInShape<TIn, TOut>>
         where TIn : TOut
@@ -1663,16 +1674,16 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn> In(int id) { }
         public override string ToString() { }
     }
-    public class static IntervalBasedRateLimiter
+    public static class IntervalBasedRateLimiter
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.IGraph<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>, Akka.NotUsed> Create<T>(System.TimeSpan minInterval, int maxBatchSize) { }
     }
-    public class static JsonFraming
+    public static class JsonFraming
     {
         public static Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> ObjectScanner(int maximumObjectLength) { }
     }
-    public class static Keep
+    public static class Keep
     {
         public static System.ValueTuple<TLeft, TRight> Both<TLeft, TRight>(TLeft left, TRight right) { }
         public static bool IsLeft<T1, T2, T3>(System.Func<T1, T2, T3> fn) { }
@@ -1699,14 +1710,14 @@ namespace Akka.Streams.Dsl
     }
     public class LinearIncreasingDelay<T> : Akka.Streams.Dsl.IDelayStrategy<T>
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public LinearIncreasingDelay(System.TimeSpan increaseStep, System.Func<T, bool> needsIncrease, System.TimeSpan initialDelay, System.TimeSpan maxDelay) { }
         public System.TimeSpan NextDelay(T element) { }
     }
-    public class static MergeHub
+    public static class MergeHub
     {
-        public static Akka.Streams.Dsl.Source<T, Akka.Streams.Dsl.Sink<T, Akka.NotUsed>> Source<T>(int perProducerBufferSize) { }
         public static Akka.Streams.Dsl.Source<T, Akka.Streams.Dsl.Sink<T, Akka.NotUsed>> Source<T>() { }
+        public static Akka.Streams.Dsl.Source<T, Akka.Streams.Dsl.Sink<T, Akka.NotUsed>> Source<T>(int perProducerBufferSize) { }
         public sealed class ProducerFailed : System.Exception
         {
             public ProducerFailed(string message, System.Exception cause) { }
@@ -1714,14 +1725,14 @@ namespace Akka.Streams.Dsl
     }
     public sealed class MergePreferred<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.Dsl.MergePreferred<T>.MergePreferredShape>
     {
-        public MergePreferred(int secondaryPorts, bool eagerClose = False) { }
+        public MergePreferred(int secondaryPorts, bool eagerClose = false) { }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T> Out { get; }
         public Akka.Streams.Inlet<T> Preferred { get; }
         public override Akka.Streams.Dsl.MergePreferred<T>.MergePreferredShape Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public Akka.Streams.Inlet<T> In(int id) { }
-        public sealed class MergePreferredShape<T> : Akka.Streams.UniformFanInShape<T, T>
+        public sealed class MergePreferredShape : Akka.Streams.UniformFanInShape<T, T>
         {
             public MergePreferredShape(int secondaryPorts, Akka.Streams.FanInShape<T>.IInit init) { }
             public MergePreferredShape(int secondaryPorts, string name) { }
@@ -1731,7 +1742,7 @@ namespace Akka.Streams.Dsl
     }
     public sealed class MergePrioritized<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanInShape<T, T>>
     {
-        public MergePrioritized(System.Collections.Generic.IEnumerable<int> priorities, bool eagerComplete = False) { }
+        public MergePrioritized(System.Collections.Generic.IEnumerable<int> priorities, bool eagerComplete = false) { }
         public System.Collections.Generic.IReadOnlyList<Akka.Streams.Inlet<T>> In { get; }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T> Out { get; }
@@ -1749,12 +1760,12 @@ namespace Akka.Streams.Dsl
     }
     public sealed class Merge<T> : Akka.Streams.Dsl.Merge<T, T>
     {
-        public Merge(int inputPorts, bool eagerComplete = False) { }
+        public Merge(int inputPorts, bool eagerComplete = false) { }
     }
     public class Merge<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanInShape<TIn, TOut>>
         where TIn : TOut
     {
-        public Merge(int inputPorts, bool eagerComplete = False) { }
+        public Merge(int inputPorts, bool eagerComplete = false) { }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
         public override Akka.Streams.UniformFanInShape<TIn, TOut> Shape { get; }
@@ -1762,7 +1773,7 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn> In(int id) { }
         public override string ToString() { }
     }
-    public class static One2OneBidiFlow
+    public static class One2OneBidiFlow
     {
         public static Akka.Streams.Dsl.BidiFlow<TIn, TIn, TOut, TOut, Akka.NotUsed> Apply<TIn, TOut>(int maxPending) { }
     }
@@ -1774,7 +1785,7 @@ namespace Akka.Streams.Dsl
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    public class static OrElse
+    public static class OrElse
     {
         public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, T>, Akka.NotUsed> Create<T>() { }
     }
@@ -1794,9 +1805,9 @@ namespace Akka.Streams.Dsl
         public OutputTruncationException() { }
         protected OutputTruncationException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    public class static PagedSource
+    public static class PagedSource
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> Create<T, TKey>(TKey firstKey, System.Func<TKey, System.Threading.Tasks.Task<Akka.Streams.Dsl.PagedSource.Page<T, TKey>>> pageFactory) { }
         public class Page<T, TKey>
         {
@@ -1805,13 +1816,13 @@ namespace Akka.Streams.Dsl
             public Akka.Util.Option<TKey> NextKey { get; }
         }
     }
-    public class static PartitionHub
+    public static class PartitionHub
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(System.Func<int, T, int> partitioner, int startAfterNrOfConsumers, int bufferSize = 256) { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> StatefulSink<T>(System.Func<System.Func<Akka.Streams.Dsl.PartitionHub.IConsumerInfo, T, long>> partitioner, int startAfterNrOfConsumers, int bufferSize = 256) { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public interface IConsumerInfo
         {
             System.Collections.Immutable.ImmutableArray<long> ConsumerIds { get; }
@@ -1842,42 +1853,42 @@ namespace Akka.Streams.Dsl
     }
     public class Pulse<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
-        public Pulse(System.TimeSpan interval, bool initiallyOpen = False) { }
+        public Pulse(System.TimeSpan interval, bool initiallyOpen = false) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    public class static RestartFlow
+    public static class RestartFlow
     {
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, Akka.Streams.RestartSettings settings) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> OnFailuresWithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, Akka.Streams.RestartSettings settings) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Flow<TIn, TOut, Akka.NotUsed> WithBackoff<TIn, TOut, TMat>(System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> flowFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
     }
-    public class static RestartSink
+    public static class RestartSink
     {
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, Akka.Streams.RestartSettings settings) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Sink<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Sink<T, TMat>> sinkFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
     }
-    public class static RestartSource
+    public static class RestartSource
     {
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, Akka.Streams.RestartSettings settings) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
-        [System.ObsoleteAttribute("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
-        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> OnFailuresWithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, Akka.Streams.RestartSettings settings) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor) { }
+        [System.Obsolete("Use the overloaded method which accepts Akka.Stream.RestartSettings instead.")]
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> WithBackoff<T, TMat>(System.Func<Akka.Streams.Dsl.Source<T, TMat>> sourceFactory, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, int maxRestarts) { }
     }
     public class RestartWithBackoffFlow
     {
@@ -1892,11 +1903,11 @@ namespace Akka.Streams.Dsl
             public override string ToString() { }
         }
     }
-    public class static Retry
+    public static class Retry
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TIn, TState>, System.ValueTuple<Akka.Util.Result<TOut>, TState>>, TMat> Concat<TIn, TState, TOut, TMat>(long limit, Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TIn, TState>, System.ValueTuple<Akka.Util.Result<TOut>, TState>>, TMat> flow, System.Func<TState, System.Collections.Generic.IEnumerable<System.ValueTuple<TIn, TState>>> retryWith) { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TIn, TState>, System.ValueTuple<Akka.Util.Result<TOut>, TState>>, TMat> Create<TIn, TState, TOut, TMat>(Akka.Streams.IGraph<Akka.Streams.FlowShape<System.ValueTuple<TIn, TState>, System.ValueTuple<Akka.Util.Result<TOut>, TState>>, TMat> flow, System.Func<TState, Akka.Util.Option<System.ValueTuple<TIn, TState>>> retryWith) { }
     }
     public sealed class ReuseLatest<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, T>>
@@ -1907,30 +1918,30 @@ namespace Akka.Streams.Dsl
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    public class static ReverseOps
+    public static class ReverseOps
     {
-        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.Outlet<TOut> outlet)
-            where TIn : TOut { }
-        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.SourceShape<TOut> source)
+        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.FlowShape<TIn, TOut> flow)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> source)
             where TIn : TOut { }
-        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.FlowShape<TIn, TOut> flow)
+        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.Outlet<TOut> outlet)
+            where TIn : TOut { }
+        public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.SourceShape<TOut> source)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.UniformFanInShape<TIn, TOut> junction)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.Builder<TMat> From<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.UniformFanOutShape<TOut1, TOut2> junction)
             where TIn : TOut2 { }
-        public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TOut1, TMat> Via<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.FlowShape<TOut1, TOut2> flow)
-            where TIn : TOut2 { }
-        public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TOut1, TMat> Via<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.IGraph<Akka.Streams.FlowShape<TOut1, TOut2>, TMat> flow)
-            where TIn : TOut2 { }
         public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> Via<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.UniformFanInShape<TIn, TOut> junction)
             where TIn : TOut { }
         public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> Via<TIn, TOut, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.UniformFanOutShape<TIn, TOut> junction)
             where TIn : TOut { }
+        public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TOut1, TMat> Via<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.FlowShape<TOut1, TOut2> flow)
+            where TIn : TOut2 { }
+        public static Akka.Streams.Dsl.GraphDsl.ReverseOps<TOut1, TMat> Via<TIn, TOut1, TOut2, TMat>(this Akka.Streams.Dsl.GraphDsl.ReverseOps<TIn, TMat> ops, Akka.Streams.IGraph<Akka.Streams.FlowShape<TOut1, TOut2>, TMat> flow)
+            where TIn : TOut2 { }
     }
-    public class static RunnableGraph
+    public static class RunnableGraph
     {
         public static Akka.Streams.Dsl.RunnableGraph<TMat> FromGraph<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> g) { }
     }
@@ -1943,25 +1954,25 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.IRunnableGraph<TMat> Async() { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> func) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> Named(string name) { }
-        public TMat Run(Akka.Streams.IMaterializer materializer) { }
         public TMat Run(Akka.Actor.ActorSystem actorSystem) { }
+        public TMat Run(Akka.Streams.IMaterializer materializer) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
     public class Sample<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, T>>
     {
-        public Sample(int nth) { }
         public Sample(System.Func<int> next) { }
+        public Sample(int nth) { }
         public Akka.Streams.Inlet<T> In { get; }
         public Akka.Streams.Outlet<T> Out { get; }
         public override Akka.Streams.FlowShape<T, T> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public static Akka.Streams.Dsl.Sample<T> Random(int maxStep = 1000) { }
     }
-    public class static Sink
+    public static class Sink
     {
-        public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> ActorRef<TIn>(Akka.Actor.IActorRef actorRef, object onCompleteMessage, System.Func<System.Exception, object> onFailureMessage) { }
-        [System.ObsoleteAttribute("Use overload accepting both on complete and on failure message")]
+        [System.Obsolete("Use overload accepting both on complete and on failure message")]
         public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> ActorRef<TIn>(Akka.Actor.IActorRef actorRef, object onCompleteMessage) { }
+        public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> ActorRef<TIn>(Akka.Actor.IActorRef actorRef, object onCompleteMessage, System.Func<System.Exception, object> onFailureMessage) { }
         public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> ActorRefWithAck<TIn>(Akka.Actor.IActorRef actorRef, object onInitMessage, object ackMessage, object onCompleteMessage, System.Func<System.Exception, object> onFailureMessage = null) { }
         public static Akka.Streams.Dsl.Sink<TIn, Akka.Actor.IActorRef> ActorSubscriber<TIn>(Akka.Actor.Props props) { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TOut>> Aggregate<TIn, TOut>(TOut zero, System.Func<TOut, TIn, TOut> aggregate) { }
@@ -1970,16 +1981,16 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Sink<TIn, Reactive.Streams.IPublisher<TIn>> AsPublisher<TIn>(bool fanout) { }
         public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> Cancelled<TIn>() { }
         public static Akka.Streams.Dsl.Sink<T, System.Threading.Channels.ChannelReader<T>> ChannelReader<T>(int bufferSize, bool singleReader, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
-        public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> Combine<TIn, TOut, TMat>(System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanOutShape<TIn, TOut>, TMat>> strategy, Akka.Streams.Dsl.Sink<TOut, Akka.NotUsed> first, Akka.Streams.Dsl.Sink<TOut, Akka.NotUsed> second, params Akka.Streams.Dsl.Sink<, >[] rest) { }
+        public static Akka.Streams.Dsl.Sink<TIn, Akka.NotUsed> Combine<TIn, TOut, TMat>(System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanOutShape<TIn, TOut>, TMat>> strategy, Akka.Streams.Dsl.Sink<TOut, Akka.NotUsed> first, Akka.Streams.Dsl.Sink<TOut, Akka.NotUsed> second, params Akka.Streams.Dsl.Sink<TOut, Akka.NotUsed>[] rest) { }
         public static Akka.Streams.Dsl.Sink<TIn, object> Create<TIn>(Reactive.Streams.ISubscriber<TIn> subscriber) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public static Akka.Streams.Dsl.Sink<TIn, Reactive.Streams.IPublisher<TIn>> DistinctRetainingFanOutPublisher<TIn>(System.Action onTerminated = null) { }
         public static Akka.Streams.Dsl.Sink<TIn, Reactive.Streams.IPublisher<TIn>> FanoutPublisher<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TIn>> First<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TIn>> FirstOrDefault<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<Akka.Done>> ForEach<TIn>(System.Action<TIn> action) { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<Akka.Done>> ForEachAsync<TIn>(int parallelism, System.Func<TIn, System.Threading.Tasks.Task> action) { }
-        [System.ObsoleteAttribute("Use `ForEachAsync` instead, it allows you to choose how to run the procedure, by " +
+        [System.Obsolete("Use `ForEachAsync` instead, it allows you to choose how to run the procedure, by " +
             "calling some other API returning a Task or using Task.Run. Obsolete since 1.5.2")]
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<Akka.Done>> ForEachParallel<TIn>(int parallelism, System.Action<TIn> action) { }
         public static Akka.Streams.Dsl.Sink<TIn, TMat> FromGraph<TIn, TMat>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TIn>, TMat> graph) { }
@@ -1989,7 +2000,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TIn>> Last<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TIn>> LastOrDefault<TIn>() { }
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<Akka.Util.Option<TMat>>> LazyInitAsync<TIn, TMat>(System.Func<System.Threading.Tasks.Task<Akka.Streams.Dsl.Sink<TIn, TMat>>> sinkFactory) { }
-        [System.ObsoleteAttribute("Use LazyInitAsync instead. LazyInitAsync no more needs a fallback function and th" +
+        [System.Obsolete("Use LazyInitAsync instead. LazyInitAsync no more needs a fallback function and th" +
             "e materialized value more clearly indicates if the internal sink was materialize" +
             "d or not.")]
         public static Akka.Streams.Dsl.Sink<TIn, System.Threading.Tasks.Task<TMat>> LazySink<TIn, TMat>(System.Func<TIn, System.Threading.Tasks.Task<Akka.Streams.Dsl.Sink<TIn, TMat>>> sinkFactory, System.Func<TMat> fallback) { }
@@ -2003,7 +2014,7 @@ namespace Akka.Streams.Dsl
     }
     public sealed class SinkQueueAsyncEnumerator<T> : System.Collections.Generic.IAsyncEnumerator<T>, System.IAsyncDisposable
     {
-        public SinkQueueAsyncEnumerator([System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+        public SinkQueueAsyncEnumerator([System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "killSwitch",
                 "sinkQueue"})] System.ValueTuple<Akka.Streams.UniqueKillSwitch, Akka.Streams.ISinkQueue<T>> queueAndSwitch, System.Threading.CancellationToken token) { }
         public T Current { get; }
@@ -2025,14 +2036,14 @@ namespace Akka.Streams.Dsl
         public override string ToString() { }
         public Akka.Streams.Dsl.Sink<TIn, TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    public class static Source
+    public static class Source
     {
         public static Akka.Streams.Dsl.Source<T, Akka.Actor.IActorRef> ActorPublisher<T>(Akka.Actor.Props props) { }
         public static Akka.Streams.Dsl.Source<T, Akka.Actor.IActorRef> ActorRef<T>(int bufferSize, Akka.Streams.OverflowStrategy overflowStrategy) { }
         public static Akka.Streams.Dsl.Source<T, Reactive.Streams.ISubscriber<T>> AsSubscriber<T>() { }
-        public static Akka.Streams.Dsl.Source<T, System.Threading.Channels.ChannelWriter<T>> Channel<T>(int bufferSize, bool singleWriter = False, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
+        public static Akka.Streams.Dsl.Source<T, System.Threading.Channels.ChannelWriter<T>> Channel<T>(int bufferSize, bool singleWriter = false, System.Threading.Channels.BoundedChannelFullMode fullMode = 0) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> ChannelReader<T>(System.Threading.Channels.ChannelReader<T> channelReader) { }
-        public static Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> Combine<T, TOut2>(Akka.Streams.Dsl.Source<T, Akka.NotUsed> first, Akka.Streams.Dsl.Source<T, Akka.NotUsed> second, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, params Akka.Streams.Dsl.Source<, >[] rest) { }
+        public static Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> Combine<T, TOut2>(Akka.Streams.Dsl.Source<T, Akka.NotUsed> first, Akka.Streams.Dsl.Source<T, Akka.NotUsed> second, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, params Akka.Streams.Dsl.Source<T, Akka.NotUsed>[] rest) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMatOut> CombineMaterialized<T, TOut2, TMat1, TMat2, TMatOut>(Akka.Streams.Dsl.Source<T, TMat1> first, Akka.Streams.Dsl.Source<T, TMat2> second, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, System.Func<TMat1, TMat2, TMatOut> combineMaterializers) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> Cycle<T>(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> Empty<T>() { }
@@ -2040,8 +2051,8 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> From<T>(System.Collections.Generic.IEnumerable<T> enumerable) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> From<T>(System.Func<System.Collections.Generic.IAsyncEnumerable<T>> asyncEnumerable) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEnumerator<T>(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
-        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEvent<TDelegate, T>(System.Func<System.Action<T>, TDelegate> conversion, System.Action<TDelegate> addHandler, System.Action<TDelegate> removeHandler, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEvent<T>(System.Action<System.EventHandler<T>> addHandler, System.Action<System.EventHandler<T>> removeHandler, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
+        public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromEvent<TDelegate, T>(System.Func<System.Action<T>, TDelegate> conversion, System.Action<TDelegate> addHandler, System.Action<TDelegate> removeHandler, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
         public static Akka.Streams.Dsl.Source<T, TMat> FromGraph<T, TMat>(Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat> source) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromObservable<T>(System.IObservable<T> observable, int maxBufferCapacity = 128, Akka.Streams.OverflowStrategy overflowStrategy = 2) { }
         public static Akka.Streams.Dsl.Source<T, Akka.NotUsed> FromPublisher<T>(Reactive.Streams.IPublisher<T> publisher) { }
@@ -2064,14 +2075,14 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<System.Collections.Immutable.IImmutableList<T>, Akka.NotUsed> ZipN<T>(System.Collections.Generic.IEnumerable<Akka.Streams.Dsl.Source<T, Akka.NotUsed>> sources) { }
         public static Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> ZipWithN<T, TOut2>(System.Func<System.Collections.Immutable.IImmutableList<T>, TOut2> zipper, System.Collections.Generic.IEnumerable<Akka.Streams.Dsl.Source<T, Akka.NotUsed>> sources) { }
     }
-    public class static SourceGen
+    public static class SourceGen
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Source<TOut, TMat> UnfoldFlow<TState, TOut, TMat>(TState seed, Akka.Streams.IGraph<Akka.Streams.FlowShape<TState, System.ValueTuple<TState, TOut>>, TMat> flow, System.TimeSpan timeout) { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Source<TOut, TMat> UnfoldFlowWith<TOut, TState, TFlowOut, TMat>(TState seed, Akka.Streams.IGraph<Akka.Streams.FlowShape<TState, TFlowOut>, TMat> flow, System.Func<TFlowOut, Akka.Util.Option<System.ValueTuple<TState, TOut>>> unfoldWith, System.TimeSpan timeout) { }
     }
-    public class static SourceOperations
+    public static class SourceOperations
     {
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Aggregate<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, TOut2 zero, System.Func<TOut2, TOut1, TOut2> fold) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> AggregateAsync<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, TOut2 zero, System.Func<TOut2, TOut1, System.Threading.Tasks.Task<TOut2>> fold) { }
@@ -2084,7 +2095,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Batch<TOut, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> BatchWeighted<TOut, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Buffer<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int size, Akka.Streams.OverflowStrategy strategy) { }
-        [System.ObsoleteAttribute("Deprecated. Please use Collect(isDefined, collector) instead")]
+        [System.Obsolete("Deprecated. Please use Collect(isDefined, collector) instead")]
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Collect<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Collect<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, bool> isDefined, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMatOut> CombineMaterialized<T, TOut2, TMat1, TMat2, TMatOut>(this Akka.Streams.Dsl.Source<T, TMat1> flow, Akka.Streams.Dsl.Source<T, TMat2> other, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, System.Func<TMat1, TMat2, TMatOut> combineMaterializers) { }
@@ -2093,13 +2104,13 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut2, TMat> ConcatMany<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Conflate<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, TOut, TOut> aggregate) { }
         public static Akka.Streams.Dsl.Source<TSeed, TMat> ConflateWithSeed<TOut, TMat, TSeed>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, TSeed> seed, System.Func<TSeed, TOut, TSeed> aggregate) { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> Delay<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan of, System.Nullable<Akka.Streams.DelayOverflowStrategy> strategy = null) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> Delay<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan of, Akka.Streams.DelayOverflowStrategy? strategy = default) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Detach<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> DivertTo<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that, System.Func<TOut, bool> when) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat3> DivertToMaterialized<TOut, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TOut, bool> when, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Expand<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<TOut1, System.Collections.Generic.IEnumerator<TOut2>> extrapolate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> GroupBy<TOut, TMat, TKey>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> GroupBy<TOut, TMat, TKey>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, TKey> groupingFunc) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> GroupBy<TOut, TMat, TKey>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int maxSubstreams, System.Func<TOut, TKey> groupingFunc) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> Grouped<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int n) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long maxWeight, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> GroupedWeightedWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long maxWeight, int maxNumber, System.TimeSpan interval, System.Func<TOut, long> costFn) { }
@@ -2111,22 +2122,22 @@ namespace Akka.Streams.Dsl
             where T1 : T2 { }
         public static Akka.Streams.Dsl.Source<T2, TMat3> InterleaveMaterialized<T1, T2, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Source<T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat2> graph, int segmentSize, System.Func<TMat, TMat2, TMat3> combine)
             where T1 : T2 { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> Intersperse<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Intersperse<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, TOut inject) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> Intersperse<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.Source<TInjected, TMat> KeepAlive<TOut, TInjected, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan timeout, System.Func<TInjected> injectElement)
             where TOut : TInjected { }
         public static Akka.Streams.Dsl.Source<T, TMat> Limit<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, long max) { }
         public static Akka.Streams.Dsl.Source<T, TMat> LimitWeighted<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, long max, System.Func<T, long> costFunc) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Log<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null, Akka.Event.LogLevel logLevel = 0) { }
-        public static Akka.Streams.Dsl.Source<TOut2, TMat> Merge<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = False)
+        public static Akka.Streams.Dsl.Source<TOut2, TMat> Merge<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = false)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> MergeMany<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, int breadth, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat3> MergeMaterialized<TOut1, TOut2, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat2> that, System.Func<TMat, TMat2, TMat3> combine)
             where TOut1 : TOut2 { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> MergeSorted<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> MergeSorted<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other)
             where TOut : System.IComparable<TOut> { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> MergeSorted<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Collections.Generic.IComparer<TOut> comparer) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> MergeSorted<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat2> Monitor<TOut, TMat, TMat2>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TMat, Akka.Streams.IFlowMonitor, TMat2> combine) { }
         public static Akka.Streams.Dsl.Source<T, TMat> OrElse<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat> secondary) { }
         public static Akka.Streams.Dsl.Source<T, TMat3> OrElseMaterialized<T, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Source<T, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat2> secondary, System.Func<TMat, TMat2, TMat3> materializedFunction) { }
@@ -2134,7 +2145,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Prepend<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> that)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Recover<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<System.Exception, Akka.Util.Option<TOut>> partialFunc) { }
-        [System.ObsoleteAttribute("Use RecoverWithRetries instead. [1.1.2]")]
+        [System.Obsolete("Use RecoverWithRetries instead. [1.1.2]")]
         public static Akka.Streams.Dsl.Source<TOut, TMat> RecoverWith<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> RecoverWithRetries<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc, int attempts) { }
         public static Akka.Streams.Dsl.Source<T, TMat> RepeatPrevious<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> source) { }
@@ -2150,45 +2161,41 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.Source<TOut, TMat> SkipWhile<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Predicate<TOut> predicate) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> SkipWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan duration) { }
         public static Akka.Streams.Dsl.Source<System.Collections.Generic.IEnumerable<TOut>, TMat> Sliding<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int n, int step = 1) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitAfter<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitAfter<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, bool> predicate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitWhen<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitAfter<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitWhen<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, bool> predicate) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, Akka.Streams.Dsl.IRunnableGraph<TMat>> SplitWhen<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.SubstreamCancelStrategy substreamCancelStrategy, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.Source<TOut2, TMat> StatefulSelectMany<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<System.Func<TOut1, System.Collections.Generic.IEnumerable<TOut2>>> mapConcaterFactory) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Sum<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TOut, TOut, TOut> reduce) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Take<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, long n) { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> TakeWhile<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Predicate<TOut> predicate, bool inclusive = False) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> TakeWhile<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Predicate<TOut> predicate, bool inclusive = false) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> TakeWithin<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.TimeSpan duration) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Throttle<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int elements, System.TimeSpan per, int maximumBurst, Akka.Streams.ThrottleMode mode) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Throttle<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, int cost, System.TimeSpan per, int maximumBurst, System.Func<TOut, int> calculateCost, Akka.Streams.ThrottleMode mode) { }
-        [System.ObsoleteAttribute("Use Via(GraphStage) instead. [1.1.2]")]
+        [System.Obsolete("Use Via(GraphStage) instead. [1.1.2]")]
         public static Akka.Streams.Dsl.Source<TOut2, TMat> Transform<TOut1, TOut2, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow, System.Func<Akka.Streams.Stage.IStage<TOut1, TOut2>> stageFactory) { }
         public static Akka.Streams.Dsl.Source<T, TMat> Watch<T, TMat>(this Akka.Streams.Dsl.Source<T, TMat> flow, Akka.Actor.IActorRef actorRef) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat2> WatchTermination<TOut, TMat, TMat2>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Func<TMat, System.Threading.Tasks.Task<Akka.Done>, TMat2> materializerFunction) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> Where<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Predicate<TOut> predicate) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> WhereNot<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Predicate<TOut> predicate) { }
-        public static Akka.Streams.Dsl.Source<TOut, TMat> WireTap<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat> WireTap<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that) { }
+        public static Akka.Streams.Dsl.Source<TOut, TMat> WireTap<TOut, TMat>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.Source<TOut, TMat3> WireTapMaterialized<TOut, TMat, TMat2, TMat3>(this Akka.Streams.Dsl.Source<TOut, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
         public static Akka.Streams.Dsl.Source<System.ValueTuple<T1, T2>, TMat> Zip<T1, T2, TMat>(this Akka.Streams.Dsl.Source<T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other) { }
         public static Akka.Streams.Dsl.Source<T3, TMat> ZipWith<T1, T2, T3, TMat>(this Akka.Streams.Dsl.Source<T1, TMat> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other, System.Func<T1, T2, T3> combine) { }
         public static Akka.Streams.Dsl.Source<System.ValueTuple<TOut1, long>, TMat> ZipWithIndex<TOut1, TMat>(this Akka.Streams.Dsl.Source<TOut1, TMat> flow) { }
     }
-    public class static SourceWithContext
+    public static class SourceWithContext
     {
         public static Akka.Streams.Dsl.SourceWithContext<TOut, TCtxOut, TMat> FromTuples<TOut, TCtxOut, TMat>(Akka.Streams.Dsl.Source<System.ValueTuple<TOut, TCtxOut>, TMat> source) { }
     }
-    public class static SourceWithContextOperations
+    public static class SourceWithContextOperations
     {
-        [System.ObsoleteAttribute("Deprecated. Please use Collect(SourceWithContext, Func, Func) instead. Since v1.5" +
+        [System.Obsolete("Deprecated. Please use Collect(SourceWithContext, Func, Func) instead. Since v1.5" +
             ".44, will be removed in v1.6")]
         public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
-        public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                0,
-                0,
-                0})] System.Func<System.ValueTuple<TOut, TCtx>, bool> isDefined, System.Func<TOut, TOut2> fn)
+        public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Collect<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<System.ValueTuple<TOut, TCtx>, bool>? isDefined, System.Func<TOut, TOut2> fn)
             where TOut2 :  class { }
         public static Akka.Streams.Dsl.SourceWithContext<System.Collections.Generic.IReadOnlyList<TOut>, System.Collections.Generic.IReadOnlyList<TCtx>, TMat> Grouped<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, int n) { }
         public static Akka.Streams.Dsl.SourceWithContext<TOut2, TCtx, TMat> Select<TOut, TCtx, TOut2, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, TOut2> fn) { }
@@ -2200,7 +2207,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> Where<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, bool> predicate) { }
         public static Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> WhereNot<TOut, TCtx, TMat>(this Akka.Streams.Dsl.SourceWithContext<TOut, TCtx, TMat> flow, System.Func<TOut, bool> predicate) { }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
+    [Akka.Annotations.ApiMayChange]
     public sealed class SourceWithContext<TOut, TCtx, TMat> : Akka.Streams.GraphDelegate<Akka.Streams.SourceShape<System.ValueTuple<TOut, TCtx>>, TMat>
     {
         public SourceWithContext(Akka.Streams.Dsl.Source<System.ValueTuple<TOut, TCtx>, TMat> source) { }
@@ -2220,26 +2227,26 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.Source<TOut, TMat> AddAttributes(Akka.Streams.Attributes attributes) { }
         public Akka.Streams.Dsl.Source<TOut2, TMat> Ask<TOut2>(Akka.Actor.IActorRef actorRef, System.TimeSpan timeout, int parallelism = 2) { }
         public Akka.Streams.Dsl.Source<TOut, TMat> Async() { }
-        public Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> Combine<T, TOut2>(Akka.Streams.Dsl.Source<T, Akka.NotUsed> first, Akka.Streams.Dsl.Source<T, Akka.NotUsed> second, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, params Akka.Streams.Dsl.Source<, >[] rest) { }
+        public Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> Combine<T, TOut2>(Akka.Streams.Dsl.Source<T, Akka.NotUsed> first, Akka.Streams.Dsl.Source<T, Akka.NotUsed> second, System.Func<int, Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, TOut2>, Akka.NotUsed>> strategy, params Akka.Streams.Dsl.Source<T, Akka.NotUsed>[] rest) { }
         public Akka.Streams.Dsl.Source<TOut, TMat3> ConcatMaterialized<TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat2> that, System.Func<TMat, TMat2, TMat3> materializedFunction) { }
         public Akka.Streams.Dsl.Source<TOut, TMat2> MapMaterializedValue<TMat2>(System.Func<TMat, TMat2> mapFunc) { }
         public Akka.Streams.Dsl.Source<TOut, TMat> Named(string name) { }
-        public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Streams.IMaterializer materializer) { }
         public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Actor.ActorSystem actorSystem) { }
-        public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Streams.IMaterializer materializer) { }
+        public System.ValueTuple<TMat, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>> PreMaterialize(Akka.Streams.IMaterializer materializer) { }
         public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Actor.ActorSystem materializer) { }
-        public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut2> RunAggregate<TOut2>(TOut2 zero, System.Func<TOut2, TOut, TOut2> aggregate, Akka.Streams.IMaterializer materializer) { }
         public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Actor.ActorSystem materializer) { }
-        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut2> RunAggregateAsync<TOut2>(TOut2 zero, System.Func<TOut2, TOut, System.Threading.Tasks.Task<TOut2>> aggregate, Akka.Streams.IMaterializer materializer) { }
         public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Actor.ActorSystem materializer) { }
-        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Streams.IMaterializer materializer, int minBuffer = 4, int maxBuffer = 16) { }
+        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerable(Akka.Streams.IMaterializer materializer) { }
         public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Actor.ActorSystem materializer, int minBuffer = 4, int maxBuffer = 16) { }
-        public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Streams.IMaterializer materializer) { }
+        public System.Collections.Generic.IAsyncEnumerable<TOut> RunAsAsyncEnumerableBuffer(Akka.Streams.IMaterializer materializer, int minBuffer = 4, int maxBuffer = 16) { }
         public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Actor.ActorSystem materializer) { }
-        public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task RunForeach(System.Action<TOut> action, Akka.Streams.IMaterializer materializer) { }
         public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Actor.ActorSystem materializer) { }
-        public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Streams.IMaterializer materializer) { }
+        public System.Threading.Tasks.Task<TOut> RunSum(System.Func<TOut, TOut, TOut> reduce, Akka.Streams.IMaterializer materializer) { }
         public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Actor.ActorSystem materializer) { }
+        public TMat2 RunWith<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, Akka.Streams.IMaterializer materializer) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat> To<TMat2>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink) { }
         public Akka.Streams.Dsl.IRunnableGraph<TMat3> ToMaterialized<TMat2, TMat3>(Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> sink, System.Func<TMat, TMat2, TMat3> combine) { }
         public override string ToString() { }
@@ -2249,14 +2256,14 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Dsl.Source<System.Collections.Immutable.IImmutableList<T>, Akka.NotUsed> ZipN<T>(System.Collections.Generic.IEnumerable<Akka.Streams.Dsl.Source<T, Akka.NotUsed>> sources) { }
         public Akka.Streams.Dsl.Source<TOut2, Akka.NotUsed> ZipWithN<T, TOut2>(System.Func<System.Collections.Immutable.IImmutableList<T>, TOut2> zipper, System.Collections.Generic.IEnumerable<Akka.Streams.Dsl.Source<T, Akka.NotUsed>> sources) { }
     }
-    public class static StreamConverters
+    public static class StreamConverters
     {
-        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.IO.Stream> AsInputStream(System.Nullable<System.TimeSpan> readTimeout = null) { }
-        public static Akka.Streams.Dsl.Source<Akka.IO.ByteString, System.IO.Stream> AsOutputStream(System.Nullable<System.TimeSpan> writeTimeout = null) { }
+        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.IO.Stream> AsInputStream(System.TimeSpan? readTimeout = default) { }
+        public static Akka.Streams.Dsl.Source<Akka.IO.ByteString, System.IO.Stream> AsOutputStream(System.TimeSpan? writeTimeout = default) { }
         public static Akka.Streams.Dsl.Source<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> FromInputStream(System.Func<System.IO.Stream> createInputStream, int chunkSize = 8192) { }
-        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> FromOutputStream(System.Func<System.IO.Stream> createOutputStream, bool autoFlush = False) { }
+        public static Akka.Streams.Dsl.Sink<Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.IO.IOResult>> FromOutputStream(System.Func<System.IO.Stream> createOutputStream, bool autoFlush = false) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class StreamRefSettings
     {
         public StreamRefSettings(int bufferCapacity, System.TimeSpan demandRedeliveryInterval, System.TimeSpan subscriptionTimeout, System.TimeSpan finalTerminationSignalDeadline) { }
@@ -2265,18 +2272,18 @@ namespace Akka.Streams.Dsl
         public System.TimeSpan FinalTerminationSignalDeadline { get; }
         public string ProductPrefix { get; }
         public System.TimeSpan SubscriptionTimeout { get; }
-        public Akka.Streams.Dsl.StreamRefSettings Copy(System.Nullable<int> bufferCapacity = null, System.Nullable<System.TimeSpan> demandRedeliveryInterval = null, System.Nullable<System.TimeSpan> subscriptionTimeout = null, System.Nullable<System.TimeSpan> finalTerminationSignalDeadline = null) { }
-        public static Akka.Streams.Dsl.StreamRefSettings Create(Akka.Configuration.Config config) { }
+        public Akka.Streams.Dsl.StreamRefSettings Copy(int? bufferCapacity = default, System.TimeSpan? demandRedeliveryInterval = default, System.TimeSpan? subscriptionTimeout = default, System.TimeSpan? finalTerminationSignalDeadline = default) { }
         public Akka.Streams.Dsl.StreamRefSettings WithBufferCapacity(int value) { }
         public Akka.Streams.Dsl.StreamRefSettings WithDemandRedeliveryInterval(System.TimeSpan value) { }
         public Akka.Streams.Dsl.StreamRefSettings WithSubscriptionTimeout(System.TimeSpan value) { }
+        public static Akka.Streams.Dsl.StreamRefSettings Create(Akka.Configuration.Config config) { }
     }
-    [Akka.Annotations.ApiMayChangeAttribute()]
-    public class static StreamRefs
+    [Akka.Annotations.ApiMayChange]
+    public static class StreamRefs
     {
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Source<T, System.Threading.Tasks.Task<Akka.Streams.ISinkRef<T>>> SinkRef<T>() { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         public static Akka.Streams.Dsl.Sink<T, System.Threading.Tasks.Task<Akka.Streams.ISourceRef<T>>> SourceRef<T>() { }
     }
     public sealed class StreamsAsyncEnumerableRerunnable<T, TMat> : System.Collections.Generic.IAsyncEnumerable<T>
@@ -2285,7 +2292,7 @@ namespace Akka.Streams.Dsl
         public StreamsAsyncEnumerableRerunnable(Akka.Streams.Dsl.Source<T, TMat> source, Akka.Streams.IMaterializer materializer, int minBuf, int maxBuf) { }
         public System.Collections.Generic.IAsyncEnumerator<T> GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken) { }
     }
-    public class static SubFlowOperations
+    public static class SubFlowOperations
     {
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Aggregate<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, TOut2 zero, System.Func<TOut2, TOut1, TOut2> fold) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> AggregateAsync<TIn, TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TIn, TMat, TClosed> flow, TOut zero, System.Func<TOut, TIn, System.Threading.Tasks.Task<TOut>> fold) { }
@@ -2297,18 +2304,16 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Batch<TOut, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long max, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> BatchWeighted<TOut, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long max, System.Func<TOut, long> costFunction, System.Func<TOut, TOut2> seed, System.Func<TOut2, TOut, TOut2> aggregate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Buffer<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int size, Akka.Streams.OverflowStrategy strategy) { }
-        [System.ObsoleteAttribute("Deprecated. Please use Collect(SubFlow, Func, Func) instead. Since v1.5.44, will " +
+        [System.Obsolete("Deprecated. Please use Collect(SubFlow, Func, Func) instead. Since v1.5.44, will " +
             "be removed in v1.6")]
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, TOut2> collector) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                0})] System.Func<TOut1, bool> isDefined, System.Func<TOut1, TOut2> collector) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Collect<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, bool>? isDefined, System.Func<TOut1, TOut2> collector) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> CompletionTimeout<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan timeout) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Concat<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> ConcatMany<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Conflate<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<TOut, TOut, TOut> aggregate) { }
         public static Akka.Streams.Dsl.SubFlow<TSeed, TMat, TClosed> ConflateWithSeed<TOut, TMat, TSeed, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<TOut, TSeed> seed, System.Func<TSeed, TOut, TSeed> aggregate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Delay<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan of, System.Nullable<Akka.Streams.DelayOverflowStrategy> strategy = null) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Delay<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan of, Akka.Streams.DelayOverflowStrategy? strategy = default) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Detach<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> DivertTo<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that, System.Func<TOut, bool> when) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat3, TClosed> DivertToMaterialized<TOut, TMat, TMat2, TMat3, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat2> that, System.Func<TOut, bool> when, System.Func<TMat, TMat2, TMat3> materializerFunction) { }
@@ -2323,28 +2328,28 @@ namespace Akka.Streams.Dsl
             where T1 : T2 { }
         public static Akka.Streams.Dsl.SubFlow<T2, TMat3, TClosed> InterleaveMaterialized<T1, T2, TMat, TMat2, TMat3, TClosed>(this Akka.Streams.Dsl.SubFlow<T1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat2> graph, int segmentSize, System.Func<TMat, TMat2, TMat3> combine)
             where T1 : T2 { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Intersperse<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Intersperse<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, TOut inject) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Intersperse<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, TOut start, TOut inject, TOut end) { }
         public static Akka.Streams.Dsl.SubFlow<TInjected, TMat, TClosed> KeepAlive<TOut, TInjected, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan timeout, System.Func<TInjected> injectElement)
             where TOut : TInjected { }
         public static Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> Limit<T, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> flow, long max) { }
         public static Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> LimitWeighted<T, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> flow, long max, System.Func<T, long> costFunc) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Log<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, string name, System.Func<TOut, object> extract = null, Akka.Event.ILoggingAdapter log = null) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Merge<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = False)
+        public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Merge<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> other, bool eagerComplete = false)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> MergeMany<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, int breadth, System.Func<TOut1, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat>> flatten) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat3, TClosed> MergeMaterialized<TOut1, TOut2, TMat, TMat2, TMat3, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat2> that, System.Func<TMat, TMat2, TMat3> combine)
             where TOut1 : TOut2 { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> MergeSorted<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> MergeSorted<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other)
             where TOut : System.IComparable<TOut> { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> MergeSorted<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Collections.Generic.IComparer<TOut> comparer) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> MergeSorted<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat> other, System.Func<TOut, TOut, int> orderFunc) { }
         public static Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> OrElse<T, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<T, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T>, TMat> secondary) { }
         public static Akka.Streams.Dsl.SubFlow<System.ValueTuple<System.Collections.Immutable.IImmutableList<TOut>, Akka.Streams.Dsl.Source<TOut, Akka.NotUsed>>, TMat, TClosed> PrefixAndTail<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int n) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Prepend<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut2>, TMat> that)
             where TOut1 : TOut2 { }
         public static Akka.Streams.Dsl.SubFlow<Akka.Util.Option<TOut>, TMat, TClosed> Recover<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<System.Exception, Akka.Util.Option<TOut>> partialFunc) { }
-        [System.ObsoleteAttribute("Use RecoverWithRetries instead. [1.1.2]")]
+        [System.Obsolete("Use RecoverWithRetries instead. [1.1.2]")]
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> RecoverWith<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> RecoverWithRetries<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunc, int attempts) { }
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Scan<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, TOut2 zero, System.Func<TOut2, TOut1, TOut2> scan) { }
@@ -2361,17 +2366,17 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> StatefulSelectMany<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<System.Func<TOut1, System.Collections.Generic.IEnumerable<TOut2>>> mapConcaterFactory) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Sum<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<TOut, TOut, TOut> reduce) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Take<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, long n) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> TakeWhile<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Predicate<TOut> predicate, bool inclusive = False) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> TakeWhile<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Predicate<TOut> predicate, bool inclusive = false) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> TakeWithin<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.TimeSpan duration) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Throttle<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int elements, System.TimeSpan per, int maximumBurst, Akka.Streams.ThrottleMode mode) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Throttle<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, int cost, System.TimeSpan per, int maximumBurst, System.Func<TOut, int> calculateCost, Akka.Streams.ThrottleMode mode) { }
-        [System.ObsoleteAttribute("Use Via(GraphStage) instead. [1.1.2]")]
+        [System.Obsolete("Use Via(GraphStage) instead. [1.1.2]")]
         public static Akka.Streams.Dsl.SubFlow<TOut2, TMat, TClosed> Transform<TOut1, TOut2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow, System.Func<Akka.Streams.Stage.IStage<TOut1, TOut2>> stageFactory) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat2, TClosed> WatchTermination<TOut, TMat, TMat2, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Func<TMat, System.Threading.Tasks.Task<Akka.Done>, TMat2> materializerFunction) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> Where<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Predicate<TOut> predicate) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> WhereNot<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Predicate<TOut> predicate) { }
-        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> WireTap<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> WireTap<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SinkShape<TOut>, TMat> that) { }
+        public static Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> WireTap<TOut, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut, TMat, TClosed> flow, System.Action<TOut> action) { }
         public static Akka.Streams.Dsl.SubFlow<System.ValueTuple<T1, T2>, TMat, TClosed> Zip<T1, T2, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<T1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other) { }
         public static Akka.Streams.Dsl.SubFlow<T3, TMat, TClosed> ZipWith<T1, T2, T3, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<T1, TMat, TClosed> flow, Akka.Streams.IGraph<Akka.Streams.SourceShape<T2>, TMat> other, System.Func<T1, T2, T3> combine) { }
         public static Akka.Streams.Dsl.SubFlow<System.ValueTuple<TOut1, long>, TMat, TClosed> ZipWithIndex<TOut1, TMat, TClosed>(this Akka.Streams.Dsl.SubFlow<TOut1, TMat, TClosed> flow) { }
@@ -2397,7 +2402,7 @@ namespace Akka.Streams.Dsl
     {
         public Tcp() { }
         public override Akka.Streams.Dsl.TcpExt CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
-        public struct IncomingConnection
+        public readonly struct IncomingConnection
         {
             public readonly Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> Flow;
             public readonly System.Net.EndPoint LocalAddress;
@@ -2405,13 +2410,13 @@ namespace Akka.Streams.Dsl
             public IncomingConnection(System.Net.EndPoint localAddress, System.Net.EndPoint remoteAddress, Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> flow) { }
             public TMat HandleWith<TMat>(Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, TMat> handler, Akka.Streams.IMaterializer materializer) { }
         }
-        public struct OutgoingConnection
+        public readonly struct OutgoingConnection
         {
             public readonly System.Net.EndPoint LocalAddress;
             public readonly System.Net.EndPoint RemoteAddress;
             public OutgoingConnection(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress) { }
         }
-        public struct ServerBinding
+        public readonly struct ServerBinding
         {
             public readonly System.Net.EndPoint LocalAddress;
             public ServerBinding(System.Net.EndPoint localAddress, System.Func<System.Threading.Tasks.Task> unbindAction) { }
@@ -2421,20 +2426,20 @@ namespace Akka.Streams.Dsl
     public class TcpExt : Akka.Actor.IExtension
     {
         protected readonly System.TimeSpan BindShutdownTimeout;
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public TcpExt(Akka.Actor.ExtendedActorSystem system) { }
-        public Akka.Streams.Dsl.Source<Akka.Streams.Dsl.Tcp.IncomingConnection, System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.ServerBinding>> Bind(string host, int port, int backlog = 100, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = False, System.Nullable<System.TimeSpan> idleTimeout = null) { }
-        public System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.ServerBinding> BindAndHandle(Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> handler, Akka.Streams.IMaterializer materializer, string host, int port, int backlog = 100, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = False, System.Nullable<System.TimeSpan> idleTimeout = null) { }
-        public Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.OutgoingConnection>> OutgoingConnection(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress = null, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = True, System.Nullable<System.TimeSpan> connectionTimeout = null, System.Nullable<System.TimeSpan> idleTimeout = null) { }
+        public Akka.Streams.Dsl.Source<Akka.Streams.Dsl.Tcp.IncomingConnection, System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.ServerBinding>> Bind(string host, int port, int backlog = 100, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = false, System.TimeSpan? idleTimeout = default) { }
+        public System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.ServerBinding> BindAndHandle(Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> handler, Akka.Streams.IMaterializer materializer, string host, int port, int backlog = 100, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = false, System.TimeSpan? idleTimeout = default) { }
         public Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.OutgoingConnection>> OutgoingConnection(string host, int port) { }
+        public Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, System.Threading.Tasks.Task<Akka.Streams.Dsl.Tcp.OutgoingConnection>> OutgoingConnection(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress = null, System.Collections.Immutable.IImmutableList<Akka.IO.Inet.SocketOption> options = null, bool halfClose = true, System.TimeSpan? connectionTimeout = default, System.TimeSpan? idleTimeout = default) { }
     }
     public sealed class TcpIdleTimeoutException : System.TimeoutException
     {
-        public TcpIdleTimeoutException(string message, System.TimeSpan duration) { }
         public TcpIdleTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public TcpIdleTimeoutException(string message, System.TimeSpan duration) { }
         public System.TimeSpan Duration { get; }
     }
-    public class static TcpStreamExtensions
+    public static class TcpStreamExtensions
     {
         public static Akka.Streams.Dsl.TcpExt TcpStream(this Akka.Actor.ActorSystem system) { }
     }
@@ -2492,67 +2497,67 @@ namespace Akka.Streams.Dsl
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class UnzipWith<TIn, T0, T1, T2> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<TIn, T0, T1, T2>>
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1, T2>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
         public Akka.Streams.Outlet<T2> Out2 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1, T2> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1, T2> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class UnzipWith<TIn, T0, T1, T2, T3> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3>>
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1, T2, T3>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
         public Akka.Streams.Outlet<T2> Out2 { get; }
         public Akka.Streams.Outlet<T3> Out3 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class UnzipWith<TIn, T0, T1, T2, T3, T4> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4>>
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1, T2, T3, T4>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
         public Akka.Streams.Outlet<T2> Out2 { get; }
         public Akka.Streams.Outlet<T3> Out3 { get; }
         public Akka.Streams.Outlet<T4> Out4 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class UnzipWith<TIn, T0, T1, T2, T3, T4, T5> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5>>
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1, T2, T3, T4, T5>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
         public Akka.Streams.Outlet<T2> Out2 { get; }
         public Akka.Streams.Outlet<T3> Out3 { get; }
         public Akka.Streams.Outlet<T4> Out4 { get; }
         public Akka.Streams.Outlet<T5> Out5 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class UnzipWith<TIn, T0, T1, T2, T3, T4, T5, T6> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5, T6>>
     {
         public UnzipWith(System.Func<TIn, System.ValueTuple<T0, T1, T2, T3, T4, T5, T6>> unzipper) { }
         public Akka.Streams.Inlet<TIn> In { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<T0> Out0 { get; }
         public Akka.Streams.Outlet<T1> Out1 { get; }
         public Akka.Streams.Outlet<T2> Out2 { get; }
@@ -2560,8 +2565,8 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Outlet<T4> Out4 { get; }
         public Akka.Streams.Outlet<T5> Out5 { get; }
         public Akka.Streams.Outlet<T6> Out6 { get; }
-        public virtual Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5, T6> Shape { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.FanOutShape<TIn, T0, T1, T2, T3, T4, T5, T6> Shape { get; }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class Valve<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.FlowShape<T, T>, System.Threading.Tasks.Task<Akka.Streams.Dsl.IValveSwitch>>
     {
@@ -2572,11 +2577,11 @@ namespace Akka.Streams.Dsl
         public override Akka.Streams.FlowShape<T, T> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<Akka.Streams.Dsl.IValveSwitch>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    public class static WireTap
+    public static class WireTap
     {
         public static Akka.Streams.Dsl.WireTap<T> Create<T>() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class WireTap<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanOutShape<T, T, T>>
     {
         public WireTap() { }
@@ -2588,7 +2593,7 @@ namespace Akka.Streams.Dsl
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    public class static ZipN
+    public static class ZipN
     {
         public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<T, System.Collections.Immutable.IImmutableList<T>>> Create<T>(int n) { }
     }
@@ -2610,7 +2615,7 @@ namespace Akka.Streams.Dsl
         public static Akka.Streams.Dsl.ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> Apply<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut>(System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> zipper) { }
         public static Akka.Streams.Dsl.ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut> Apply<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut>(System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut> zipper) { }
     }
-    public class static ZipWithN
+    public static class ZipWithN
     {
         public static Akka.Streams.IGraph<Akka.Streams.UniformFanInShape<TIn, TOut>> Create<TIn, TOut>(System.Func<System.Collections.Immutable.IImmutableList<TIn>, TOut> zipper, int n) { }
     }
@@ -2637,22 +2642,22 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn6> In6 { get; }
         public Akka.Streams.Inlet<TIn7> In7 { get; }
         public Akka.Streams.Inlet<TIn8> In8 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TIn8, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TOut>>
     {
         public ZipWith(System.Func<TIn0, TIn1, TOut> zipper) { }
         public Akka.Streams.Inlet<TIn0> In0 { get; }
         public Akka.Streams.Inlet<TIn1> In1 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TOut>>
     {
@@ -2660,11 +2665,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn0> In0 { get; }
         public Akka.Streams.Inlet<TIn1> In1 { get; }
         public Akka.Streams.Inlet<TIn2> In2 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TIn3, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TOut>>
     {
@@ -2673,11 +2678,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn1> In1 { get; }
         public Akka.Streams.Inlet<TIn2> In2 { get; }
         public Akka.Streams.Inlet<TIn3> In3 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TOut>>
     {
@@ -2687,11 +2692,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn2> In2 { get; }
         public Akka.Streams.Inlet<TIn3> In3 { get; }
         public Akka.Streams.Inlet<TIn4> In4 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TOut>>
     {
@@ -2702,11 +2707,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn3> In3 { get; }
         public Akka.Streams.Inlet<TIn4> In4 { get; }
         public Akka.Streams.Inlet<TIn5> In5 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TOut>>
     {
@@ -2718,11 +2723,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn4> In4 { get; }
         public Akka.Streams.Inlet<TIn5> In5 { get; }
         public Akka.Streams.Inlet<TIn6> In6 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public class ZipWith<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut>>
     {
@@ -2735,11 +2740,11 @@ namespace Akka.Streams.Dsl
         public Akka.Streams.Inlet<TIn5> In5 { get; }
         public Akka.Streams.Inlet<TIn6> In6 { get; }
         public Akka.Streams.Inlet<TIn7> In7 { get; }
-        protected virtual Akka.Streams.Attributes InitialAttributes { get; }
+        protected override sealed Akka.Streams.Attributes InitialAttributes { get; }
         public Akka.Streams.Outlet<TOut> Out { get; }
-        public virtual Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> Shape { get; }
+        public override sealed Akka.Streams.FanInShape<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> Shape { get; }
         public System.Func<TIn0, TIn1, TIn2, TIn3, TIn4, TIn5, TIn6, TIn7, TOut> Zipper { get; }
-        protected virtual Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
+        protected override sealed Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public sealed class Zip<T1, T2> : Akka.Streams.Dsl.ZipWith<T1, T2, System.ValueTuple<T1, T2>>
     {
@@ -2749,7 +2754,7 @@ namespace Akka.Streams.Dsl
 }
 namespace Akka.Streams.Dsl.Internal
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class GraphImpl<TShape, TMat> : Akka.Streams.IGraph<TShape>, Akka.Streams.IGraph<TShape, TMat>
         where TShape : Akka.Streams.Shape
     {
@@ -2762,8 +2767,8 @@ namespace Akka.Streams.Dsl.Internal
         public override string ToString() { }
         public Akka.Streams.IGraph<TShape, TMat> WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static ModuleExtractor
+    [Akka.Annotations.InternalApi]
+    public static class ModuleExtractor
     {
         public static Akka.Util.Option<Akka.Streams.Implementation.IModule> Unapply<TShape, TMat>(Akka.Streams.IGraph<TShape, TMat> graph)
             where TShape : Akka.Streams.Shape { }
@@ -2771,12 +2776,12 @@ namespace Akka.Streams.Dsl.Internal
 }
 namespace Akka.Streams.Extra
 {
-    public class static TimedFlowDsl
+    public static class TimedFlowDsl
     {
         public static Akka.Streams.Dsl.Flow<TIn, TOut2, TMat2> Timed<TIn, TOut, TOut2, TMat, TMat2>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>, Akka.Streams.Dsl.Flow<TIn, TOut2, TMat2>> measuredOps, System.Action<System.TimeSpan> onComplete) { }
         public static Akka.Streams.Dsl.Flow<TIn, TOut, TMat> TimedIntervalBetween<TIn, TOut, TMat>(this Akka.Streams.Dsl.Flow<TIn, TOut, TMat> flow, System.Func<TOut, bool> matching, System.Action<System.TimeSpan> onInterval) { }
     }
-    public class static TimedSourceDsl
+    public static class TimedSourceDsl
     {
         public static Akka.Streams.Dsl.Source<TOut, TMat2> Timed<TIn, TOut, TMat, TMat2>(this Akka.Streams.Dsl.Source<TIn, TMat> source, System.Func<Akka.Streams.Dsl.Source<TIn, TMat>, Akka.Streams.Dsl.Source<TOut, TMat2>> measuredOps, System.Action<System.TimeSpan> onComplete) { }
         public static Akka.Streams.Dsl.Source<TIn, TMat> TimedIntervalBetween<TIn, TMat>(this Akka.Streams.Dsl.Source<TIn, TMat> source, System.Func<TIn, bool> matching, System.Action<System.TimeSpan> onInterval) { }
@@ -2789,7 +2794,7 @@ namespace Akka.Streams.IO
         public AbruptIOTerminationException(Akka.Streams.IO.IOResult ioResult, System.Exception cause) { }
         public Akka.Streams.IO.IOResult IoResult { get; }
     }
-    public struct IOResult
+    public readonly struct IOResult
     {
         public readonly long Count;
         public IOResult(long count, Akka.Util.Result<Akka.NotUsed> status) { }
@@ -2806,29 +2811,29 @@ namespace Akka.Streams.Implementation
         public ActorMaterializerImpl(Akka.Actor.ActorSystem system, Akka.Streams.ActorMaterializerSettings settings, Akka.Dispatch.Dispatchers dispatchers, Akka.Actor.IActorRef supervisor, Akka.Util.AtomicBoolean haveShutDown, Akka.Streams.Implementation.EnumerableActorName flowNames) { }
         public override Akka.Dispatch.MessageDispatcher ExecutionContext { get; }
         public override bool IsShutdown { get; }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public override Akka.Event.ILoggingAdapter Logger { get; }
         public override Akka.Streams.ActorMaterializerSettings Settings { get; }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public override Akka.Actor.IActorRef Supervisor { get; }
         public override Akka.Actor.ActorSystem System { get; }
         public override Akka.Streams.ActorMaterializerSettings EffectiveSettings(Akka.Streams.Attributes attributes) { }
         public override Akka.Event.ILoggingAdapter MakeLogger(object logSource) { }
         public override TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable) { }
-        public override TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser) { }
         public override TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, Akka.Streams.Attributes initialAttributes) { }
+        public override TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser) { }
         public override TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser, Akka.Streams.Attributes initialAttributes) { }
         public override Akka.Actor.ICancelable ScheduleOnce(System.TimeSpan delay, System.Action action) { }
         public override Akka.Actor.ICancelable ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action) { }
         public override void Shutdown() { }
         public override Akka.Streams.IMaterializer WithNamePrefix(string name) { }
     }
-    public class static ActorPublisher
+    public static class ActorPublisher
     {
-        public static readonly Akka.Streams.Implementation.NormalShutdownException NormalShutdownReason;
         public const string NormalShutdownReasonMessage = "Cannot subscribe to shut-down Publisher";
+        public static readonly Akka.Streams.Implementation.NormalShutdownException NormalShutdownReason;
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ActorPublisherSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef>
     {
         public ActorPublisherSource(Akka.Actor.Props props, Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -2837,7 +2842,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef> NewInstance(Akka.Streams.SourceShape<TOut> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ActorPublisher<TOut> : Akka.Streams.IUntypedPublisher, Akka.Streams.Implementation.IActorPublisher, Reactive.Streams.IPublisher<TOut>
     {
         protected readonly Akka.Actor.IActorRef Impl;
@@ -2847,7 +2852,7 @@ namespace Akka.Streams.Implementation
         public void Subscribe(Reactive.Streams.ISubscriber<TOut> subscriber) { }
         public System.Collections.Generic.IEnumerable<Reactive.Streams.ISubscriber<TOut>> TakePendingSubscribers() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ActorRefSinkStage<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.SinkShape<T>>
     {
         public ActorRefSinkStage(Akka.Actor.IActorRef actorRef, object onCompleteMessage, System.Func<System.Exception, object> onFailureMessage) { }
@@ -2856,7 +2861,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SinkShape<T> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ActorRefSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef>
     {
         public ActorRefSource(int bufferSize, Akka.Streams.OverflowStrategy overflowStrategy, Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -2866,7 +2871,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SourceModule<TOut, Akka.Actor.IActorRef> NewInstance(Akka.Streams.SourceShape<TOut> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ActorSubscriberSink<TIn> : Akka.Streams.Implementation.SinkModule<TIn, Akka.Actor.IActorRef>
     {
         public ActorSubscriberSink(Akka.Actor.Props props, Akka.Streams.Attributes attributes, Akka.Streams.SinkShape<TIn> shape) { }
@@ -2875,7 +2880,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SinkModule<TIn, Akka.Actor.IActorRef> NewInstance(Akka.Streams.SinkShape<TIn> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    public class static ActorSubscription
+    public static class ActorSubscription
     {
         public static Akka.Streams.Implementation.IActorSubscription Create<T>(Akka.Actor.IActorRef implementor, Reactive.Streams.ISubscriber<T> subscriber) { }
     }
@@ -2885,8 +2890,8 @@ namespace Akka.Streams.Implementation
         public long Cursor { get; }
         public bool IsActive { get; }
         public long TotalDemand { get; }
-        public void Dispatch(object element) { }
         public void Dispatch(TIn element) { }
+        public void Dispatch(object element) { }
     }
     public class ActorSubscription<T> : Akka.Streams.Implementation.IActorSubscription, Reactive.Streams.ISubscription
     {
@@ -2899,11 +2904,11 @@ namespace Akka.Streams.Implementation
     public abstract class AtomicModule : Akka.Streams.Implementation.Module
     {
         protected AtomicModule() { }
-        public virtual System.Collections.Immutable.IImmutableDictionary<Akka.Streams.OutPort, Akka.Streams.InPort> Downstreams { get; }
-        public virtual System.Collections.Immutable.ImmutableArray<Akka.Streams.Implementation.IModule> SubModules { get; }
-        public virtual System.Collections.Immutable.IImmutableDictionary<Akka.Streams.InPort, Akka.Streams.OutPort> Upstreams { get; }
+        public override sealed System.Collections.Immutable.IImmutableDictionary<Akka.Streams.OutPort, Akka.Streams.InPort> Downstreams { get; }
+        public override sealed System.Collections.Immutable.ImmutableArray<Akka.Streams.Implementation.IModule> SubModules { get; }
+        public override sealed System.Collections.Immutable.IImmutableDictionary<Akka.Streams.InPort, Akka.Streams.OutPort> Upstreams { get; }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class BackpressureTimeout<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -2936,7 +2941,7 @@ namespace Akka.Streams.Implementation
         protected virtual bool UpstreamRunning(object message) { }
         protected virtual bool WaitingForUpstream(object message) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class CancelSink<T> : Akka.Streams.Implementation.SinkModule<T, Akka.NotUsed>
     {
         public CancelSink(Akka.Streams.Attributes attributes, Akka.Streams.SinkShape<T> shape) { }
@@ -2953,7 +2958,7 @@ namespace Akka.Streams.Implementation
         public void OnNext(T element) { }
         public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Completion<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -2972,10 +2977,10 @@ namespace Akka.Streams.Implementation
         public override System.Collections.Immutable.ImmutableArray<Akka.Streams.Implementation.IModule> SubModules { get; }
         public override System.Collections.Immutable.IImmutableDictionary<Akka.Streams.InPort, Akka.Streams.OutPort> Upstreams { get; }
         public override Akka.Streams.Implementation.IModule CarbonCopy() { }
-        public static Akka.Streams.Implementation.CompositeModule Create(Akka.Streams.Implementation.Module module, Akka.Streams.Shape shape) { }
         public override Akka.Streams.Implementation.IModule ReplaceShape(Akka.Streams.Shape shape) { }
         public override string ToString() { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
+        public static Akka.Streams.Implementation.CompositeModule Create(Akka.Streams.Implementation.Module module, Akka.Streams.Shape shape) { }
     }
     public sealed class CopiedModule : Akka.Streams.Implementation.Module
     {
@@ -2991,7 +2996,7 @@ namespace Akka.Streams.Implementation
         public override string ToString() { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class DelayInitial<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Delay;
@@ -3041,8 +3046,8 @@ namespace Akka.Streams.Implementation
     {
         protected EnumerableActorName() { }
         public abstract Akka.Streams.Implementation.EnumerableActorName Copy(string newPrefix);
-        public static Akka.Streams.Implementation.EnumerableActorName Create(string prefix) { }
         public abstract string Next();
+        public static Akka.Streams.Implementation.EnumerableActorName Create(string prefix) { }
     }
     public abstract class ExposedPublisherReceive
     {
@@ -3054,40 +3059,44 @@ namespace Akka.Streams.Implementation
     public abstract class ExtendedActorMaterializer : Akka.Streams.ActorMaterializer
     {
         protected ExtendedActorMaterializer() { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public override Akka.Actor.IActorRef ActorOf(Akka.Streams.MaterializationContext context, Akka.Actor.Props props) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string name, string dispatcher) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public abstract TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser);
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public abstract TMat Materialize<TMat>(Akka.Streams.IGraph<Akka.Streams.ClosedShape, TMat> runnable, System.Func<Akka.Streams.Implementation.Fusing.GraphInterpreterShell, Akka.Actor.IActorRef> subFlowFuser, Akka.Streams.Attributes initialAttributes);
     }
-    public class static FanIn
+    public static class FanIn
     {
         public const byte Cancelled = 16;
         public const byte Completed = 8;
         public const byte Depleted = 4;
         public const byte Marked = 1;
         public const byte Pending = 2;
-        public struct OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
             public OnComplete(int id) { }
         }
-        public struct OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Exception Cause;
             public readonly int Id;
             public OnError(int id, System.Exception cause) { }
         }
-        public struct OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly object Element;
             public readonly int Id;
             public OnNext(int id, object element) { }
         }
-        public struct OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
             public readonly Reactive.Streams.ISubscription Subscription;
@@ -3116,7 +3125,7 @@ namespace Akka.Streams.Implementation
         public void PumpFinished() { }
         protected override bool Receive(object message) { }
         public void WaitForUpstream(int waitForUpstream) { }
-        public struct SubInput<T> : Reactive.Streams.ISubscriber<T>
+        public readonly struct SubInput : Reactive.Streams.ISubscriber<T>
         {
             public SubInput(Akka.Actor.IActorRef impl, int id) { }
             public void OnComplete() { }
@@ -3125,26 +3134,30 @@ namespace Akka.Streams.Implementation
             public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static FanOut
+    [Akka.Annotations.InternalApi]
+    public static class FanOut
     {
-        public struct ExposedPublishers<T> : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct ExposedPublishers<T> : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Collections.Immutable.ImmutableList<Akka.Streams.Implementation.ActorPublisher<T>> Publishers;
             public ExposedPublishers(System.Collections.Immutable.ImmutableList<Akka.Streams.Implementation.ActorPublisher<T>> publishers) { }
         }
-        public struct SubstreamCancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct SubstreamCancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
             public SubstreamCancel(int id) { }
         }
-        public struct SubstreamRequestMore : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct SubstreamRequestMore : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly long Demand;
             public readonly int Id;
             public SubstreamRequestMore(int id, long demand) { }
         }
-        public struct SubstreamSubscribePending : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        [System.Serializable]
+        public readonly struct SubstreamSubscribePending : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
             public SubstreamSubscribePending(int id) { }
@@ -3157,7 +3170,7 @@ namespace Akka.Streams.Implementation
             public override string ToString() { }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class FanOut<T> : Akka.Actor.ActorBase, Akka.Streams.Implementation.IPump
     {
         protected readonly Akka.Streams.Implementation.OutputBunch<T> OutputBunch;
@@ -3179,7 +3192,7 @@ namespace Akka.Streams.Implementation
         protected override bool Receive(object message) { }
         public void WaitForUpstream(int waitForUpstream) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class FirstOrDefaultStage<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task<T>>
     {
         public readonly Akka.Streams.Inlet<T> In;
@@ -3272,7 +3285,7 @@ namespace Akka.Streams.Implementation
         void WaitForUpstream(int waitForUpstream);
     }
     public interface ISpecViolation { }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class IdleInject<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
         where TIn : TOut
     {
@@ -3282,7 +3295,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class IdleTimeoutBidi<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.BidiShape<TIn, TIn, TOut, TOut>>
     {
         public readonly Akka.Streams.Inlet<TIn> In1;
@@ -3296,7 +3309,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Idle<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -3305,12 +3318,12 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    public class static IgnorableMaterializedValueComposites
+    public static class IgnorableMaterializedValueComposites
     {
-        public static bool Apply(Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode composition) { }
         public static bool Apply(Akka.Streams.Implementation.IModule module) { }
+        public static bool Apply(Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode composition) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Initial<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public readonly System.TimeSpan Timeout;
@@ -3348,7 +3361,7 @@ namespace Akka.Streams.Implementation
         public void UnmarkAllInputs() { }
         public void UnmarkInput(int input) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class JsonObjectParser
     {
         public JsonObjectParser(int maximumObjectLength = 2147483647) { }
@@ -3356,7 +3369,7 @@ namespace Akka.Streams.Implementation
         public void Offer(Akka.IO.ByteString input) { }
         public Akka.Util.Option<Akka.IO.ByteString> Poll() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class LastOrDefaultStage<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task<T>>
     {
         public readonly Akka.Streams.Inlet<T> In;
@@ -3364,11 +3377,11 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SinkShape<T> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<T>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    public class static LazySource
+    public static class LazySource
     {
         public static Akka.Streams.Implementation.LazySource<TOut, TMat> Create<TOut, TMat>(System.Func<Akka.Streams.Dsl.Source<TOut, TMat>> create) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class LazySource<TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SourceShape<TOut>, System.Threading.Tasks.Task<TMat>>
     {
         public LazySource(System.Func<Akka.Streams.Dsl.Source<TOut, TMat>> sourceFactory) { }
@@ -3378,12 +3391,12 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<TMat>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class MaterializerSession
     {
         protected readonly Akka.Streams.Attributes InitialAttributes;
-        public static readonly bool IsDebug;
         protected readonly Akka.Streams.Implementation.IModule TopLevel;
+        public static readonly bool IsDebug;
         protected MaterializerSession(Akka.Streams.Implementation.IModule topLevel, Akka.Streams.Attributes initialAttributes) { }
         protected void AssignPort(Akka.Streams.InPort inPort, object subscriberOrVirtual) { }
         protected void AssignPort(Akka.Streams.OutPort outPort, Akka.Streams.IUntypedPublisher publisher) { }
@@ -3401,7 +3414,7 @@ namespace Akka.Streams.Implementation
             protected MaterializationPanicException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class MaybeSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, System.Threading.Tasks.TaskCompletionSource<TOut>>
     {
         public MaybeSource(Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -3443,7 +3456,7 @@ namespace Akka.Streams.Implementation
         public virtual Akka.Streams.Implementation.IModule Wire(Akka.Streams.OutPort from, Akka.Streams.InPort to) { }
         public abstract Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes);
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class NoopSubscriptionTimeout : Akka.Actor.ICancelable
     {
         public static readonly Akka.Streams.Implementation.NoopSubscriptionTimeout Instance;
@@ -3454,11 +3467,13 @@ namespace Akka.Streams.Implementation
         public void CancelAfter(System.TimeSpan delay) { }
         public void CancelAfter(int millisecondsDelay) { }
     }
+    [System.Serializable]
     public class NormalShutdownException : Akka.Pattern.IllegalStateException
     {
         public NormalShutdownException(string message) { }
         protected NormalShutdownException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
+    [System.Serializable]
     public class NothingToReadException : System.Exception
     {
         public static readonly Akka.Streams.Implementation.NothingToReadException Instance;
@@ -3493,7 +3508,7 @@ namespace Akka.Streams.Implementation
         public void UnmarkCancelledOutputs(bool enabled) { }
         public void UnmarkOutput(int output) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ProcessorModule<TIn, TOut, TMat> : Akka.Streams.Implementation.AtomicModule
     {
         public ProcessorModule(System.Func<System.ValueTuple<Reactive.Streams.IProcessor<TIn, TOut>, TMat>> createProcessor, Akka.Streams.Attributes attributes = null) { }
@@ -3506,7 +3521,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Implementation.IModule ReplaceShape(Akka.Streams.Shape shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class PublisherSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Akka.NotUsed>
     {
         public PublisherSource(Reactive.Streams.IPublisher<TOut> publisher, Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -3516,14 +3531,8 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SourceModule<TOut, Akka.NotUsed> NewInstance(Akka.Streams.SourceShape<TOut> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1,
-            1,
-            1,
-            1})]
-    public sealed class QueueSink<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, Akka.Streams.ISinkQueue<T>>
+    [Akka.Annotations.InternalApi]
+    public sealed class QueueSink<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, Akka.Streams.ISinkQueue<T>>
     {
         public readonly Akka.Streams.Inlet<T> In;
         public QueueSink() { }
@@ -3532,49 +3541,39 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.Streams.ISinkQueue<T>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1,
-            1,
-            1,
-            1})]
-    public sealed class QueueSource<[System.Runtime.CompilerServices.NullableAttribute(2)]  TOut> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SourceShape<TOut>, Akka.Streams.ISourceQueueWithComplete<TOut>>
+    [Akka.Annotations.InternalApi]
+    public sealed class QueueSource<TOut> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SourceShape<TOut>, Akka.Streams.ISourceQueueWithComplete<TOut>>
     {
         public QueueSource(int maxBuffer, Akka.Streams.OverflowStrategy overflowStrategy) { }
         public Akka.Streams.Outlet<TOut> Out { get; }
         public override Akka.Streams.SourceShape<TOut> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.Streams.ISourceQueueWithComplete<TOut>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
-        public interface IInput<[System.Runtime.CompilerServices.NullableAttribute(2)]  TOut> { }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
-        public sealed class Materialized<[System.Runtime.CompilerServices.NullableAttribute(2)]  TOut> : Akka.Streams.ISourceQueueWithComplete<TOut>, Akka.Streams.ISourceQueue<TOut>
+        public interface IInput { }
+        public sealed class Materialized : Akka.Streams.ISourceQueueWithComplete<TOut>, Akka.Streams.ISourceQueue<TOut>
         {
-            public Materialized([System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                    1,
-                    1,
-                    0})] System.Action<Akka.Streams.Implementation.QueueSource<TOut>.IInput> invokeLogic, System.Threading.Tasks.TaskCompletionSource<object> completion) { }
+            public Materialized(System.Action<Akka.Streams.Implementation.QueueSource<TOut>.IInput> invokeLogic, System.Threading.Tasks.TaskCompletionSource<object> completion) { }
             public void Complete() { }
             public void Fail(System.Exception ex) { }
             public System.Threading.Tasks.Task<Akka.Streams.IQueueOfferResult> OfferAsync(TOut element) { }
             public System.Threading.Tasks.Task WatchCompletionAsync() { }
         }
     }
-    public class static ReactiveStreamsCompliance
+    public static class ReactiveStreamsCompliance
     {
         public const string CanNotSubscribeTheSameSubscriberMultipleTimes = "can not subscribe the same subscriber multiple times (see reactive-streams specif" +
             "ication, rules 1.10 and 2.12)";
-        public static readonly System.Exception CanNotSubscribeTheSameSubscriberMultipleTimesException;
-        public static readonly System.Exception ElementMustNotBeNullException;
         public const string ElementMustNotBeNullMsg = "Element must not be null, rule 2.13";
         public const string ExceptionMustNotBeNullMsg = "Exception must not be null, rule 2.13";
-        public static readonly System.Exception NumberOfElementsInRequestMustBePositiveException;
         public const string NumberOfElementsInRequestMustBePositiveMsg = "The number of requested elements must be > 0 (see reactive-streams specification," +
             " rule 3.9)";
         public const string SubscriberMustNotBeNullMsg = "Subscriber must not be null, rule 1.9";
-        public static readonly System.Exception SubscriptionMustNotBeNullException;
         public const string SubscriptionMustNotBeNullMsg = "Subscription must not be null, rule 2.13";
         public const string SupportsOnlyASingleSubscriber = "only supports one subscriber (which is allowed, see reactive-streams specificatio" +
             "n, rule 1.12)";
+        public static readonly System.Exception CanNotSubscribeTheSameSubscriberMultipleTimesException;
+        public static readonly System.Exception ElementMustNotBeNullException;
+        public static readonly System.Exception NumberOfElementsInRequestMustBePositiveException;
+        public static readonly System.Exception SubscriptionMustNotBeNullException;
         public static System.Exception ExceptionMustNotBeNullException { get; }
         public static System.Exception SubscriberMustNotBeNullException { get; }
         public static void RejectAdditionalSubscriber<T>(Reactive.Streams.ISubscriber<T> subscriber, string rejector) { }
@@ -3591,7 +3590,7 @@ namespace Akka.Streams.Implementation
         public static void TryOnSubscribe<T>(Reactive.Streams.ISubscriber<T> subscriber, Reactive.Streams.ISubscription subscription) { }
         public static void TryRequest(Reactive.Streams.ISubscription subscription, long demand) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ResizableMultiReaderRingBuffer<T>
     {
         protected readonly Akka.Streams.Implementation.ICursors Cursors;
@@ -3626,7 +3625,7 @@ namespace Akka.Streams.Implementation
         public override string ToString() { }
         public virtual bool Write(T value) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SeqStage<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<T>>>
     {
         public readonly Akka.Streams.Inlet<T> In;
@@ -3636,7 +3635,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableList<T>>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SetupFlowStage<TIn, TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.FlowShape<TIn, TOut>, System.Threading.Tasks.Task<TMat>>
     {
         public SetupFlowStage(System.Func<Akka.Streams.ActorMaterializer, Akka.Streams.Attributes, Akka.Streams.Dsl.Flow<TIn, TOut, TMat>> factory) { }
@@ -3646,7 +3645,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<TMat>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SetupSourceStage<TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SourceShape<TOut>, System.Threading.Tasks.Task<TMat>>
     {
         public SetupSourceStage(System.Func<Akka.Streams.ActorMaterializer, Akka.Streams.Attributes, Akka.Streams.Dsl.Source<TOut, TMat>> factory) { }
@@ -3655,10 +3654,11 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SourceShape<TOut> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<TMat>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
     }
+    [System.Serializable]
     public class SignalThrewException : Akka.Pattern.IllegalStateException, Akka.Streams.Implementation.ISpecViolation
     {
-        public SignalThrewException(string message, System.Exception cause) { }
         protected SignalThrewException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public SignalThrewException(string message, System.Exception cause) { }
     }
     public class SimpleOutputs
     {
@@ -3685,7 +3685,7 @@ namespace Akka.Streams.Implementation
         public virtual void Error(System.Exception e) { }
         protected bool WaitingExposedPublisher(object message) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class SinkModule<TIn, TMat> : Akka.Streams.Implementation.AtomicModule
     {
         protected SinkModule(Akka.Streams.SinkShape<TIn> shape) { }
@@ -3696,9 +3696,9 @@ namespace Akka.Streams.Implementation
         public abstract object Create(Akka.Streams.MaterializationContext context, out TMat materializer);
         protected abstract Akka.Streams.Implementation.SinkModule<TIn, TMat> NewInstance(Akka.Streams.SinkShape<TIn> shape);
         public override Akka.Streams.Implementation.IModule ReplaceShape(Akka.Streams.Shape shape) { }
-        public virtual string ToString() { }
+        public override sealed string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SinkholeSubscriber<TIn> : Reactive.Streams.ISubscriber<TIn>
     {
         public SinkholeSubscriber(System.Threading.Tasks.TaskCompletionSource<Akka.NotUsed> whenCompleted) { }
@@ -3707,7 +3707,7 @@ namespace Akka.Streams.Implementation
         public void OnNext(TIn element) { }
         public void OnSubscribe(Reactive.Streams.ISubscription subscription) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class SourceModule<TOut, TMat> : Akka.Streams.Implementation.AtomicModule
     {
         protected SourceModule(Akka.Streams.SourceShape<TOut> shape) { }
@@ -3718,12 +3718,12 @@ namespace Akka.Streams.Implementation
         public abstract Reactive.Streams.IPublisher<TOut> Create(Akka.Streams.MaterializationContext context, out TMat materializer);
         protected abstract Akka.Streams.Implementation.SourceModule<TOut, TMat> NewInstance(Akka.Streams.SourceShape<TOut> shape);
         public override Akka.Streams.Implementation.IModule ReplaceShape(Akka.Streams.Shape shape) { }
-        public virtual string ToString() { }
+        public override sealed string ToString() { }
     }
-    public class static StreamLayout
+    public static class StreamLayout
     {
         public const bool IsDebug = false;
-        public static void Validate(Akka.Streams.Implementation.IModule module, int level = 0, bool shouldPrint = False, System.Collections.Generic.IDictionary<object, int> idMap = null) { }
+        public static void Validate(Akka.Streams.Implementation.IModule module, int level = 0, bool shouldPrint = false, System.Collections.Generic.IDictionary<object, int> idMap = null) { }
         public sealed class Atomic : Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode
         {
             public readonly Akka.Streams.Implementation.IModule Module;
@@ -3757,11 +3757,11 @@ namespace Akka.Streams.Implementation
         public readonly Akka.Util.AtomicBoolean HaveShutdown;
         public readonly Akka.Streams.ActorMaterializerSettings Settings;
         public StreamSupervisor(Akka.Streams.ActorMaterializerSettings settings, Akka.Util.AtomicBoolean haveShutdown) { }
-        public static string NextName() { }
         protected override void PostStop() { }
-        public static Akka.Actor.Props Props(Akka.Streams.ActorMaterializerSettings settings, Akka.Util.AtomicBoolean haveShutdown) { }
         protected override bool Receive(object message) { }
         protected override Akka.Actor.SupervisorStrategy SupervisorStrategy() { }
+        public static string NextName() { }
+        public static Akka.Actor.Props Props(Akka.Streams.ActorMaterializerSettings settings, Akka.Util.AtomicBoolean haveShutdown) { }
         public sealed class Children
         {
             public readonly System.Collections.Immutable.IImmutableSet<Akka.Actor.IActorRef> Refs;
@@ -3835,7 +3835,7 @@ namespace Akka.Streams.Implementation
         public Akka.Actor.Receive CurrentReceive { get; }
         public void Become(Akka.Actor.Receive receive) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SubscriberSink<TIn> : Akka.Streams.Implementation.SinkModule<TIn, Akka.NotUsed>
     {
         public SubscriberSink(Reactive.Streams.ISubscriber<TIn> subscriber, Akka.Streams.Attributes attributes, Akka.Streams.SinkShape<TIn> shape) { }
@@ -3844,7 +3844,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Implementation.SinkModule<TIn, Akka.NotUsed> NewInstance(Akka.Streams.SinkShape<TIn> shape) { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SubscriberSource<TOut> : Akka.Streams.Implementation.SourceModule<TOut, Reactive.Streams.ISubscriber<TOut>>
     {
         public SubscriberSource(Akka.Streams.Attributes attributes, Akka.Streams.SourceShape<TOut> shape) { }
@@ -3856,23 +3856,23 @@ namespace Akka.Streams.Implementation
     public class SubscriptionTimeoutException : System.Exception
     {
         public SubscriptionTimeoutException(string message) { }
-        public SubscriptionTimeoutException(string message, System.Exception innerException) { }
         protected SubscriptionTimeoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public SubscriptionTimeoutException(string message, System.Exception innerException) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class Throttle<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Throttle(int cost, System.TimeSpan per, int maximumBurst, System.Func<T, int> costCalculation, Akka.Streams.ThrottleMode mode) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    public class static Timers
+    [Akka.Annotations.InternalApi]
+    public static class Timers
     {
         public const string GraphStageLogicTimer = "GraphStageLogicTimer";
         public static System.TimeSpan IdleTimeoutCheckInterval(System.TimeSpan timeout) { }
     }
-    public struct TransferPhase
+    public readonly struct TransferPhase
     {
         public readonly System.Action Action;
         public readonly Akka.Streams.Implementation.TransferState Precondition;
@@ -3887,7 +3887,7 @@ namespace Akka.Streams.Implementation
         public Akka.Streams.Implementation.TransferState And(Akka.Streams.Implementation.TransferState other) { }
         public Akka.Streams.Implementation.TransferState Or(Akka.Streams.Implementation.TransferState other) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class UnfoldAsync<TState, TElement> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TElement>>
     {
         public readonly Akka.Streams.Outlet<TElement> Out;
@@ -3897,7 +3897,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SourceShape<TElement> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class UnfoldInfinite<TState, TElement> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TElement>>
     {
         public readonly Akka.Streams.Outlet<TElement> Out;
@@ -3907,7 +3907,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SourceShape<TElement> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class UnfoldResourceSourceAsync<TOut, TSource> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TOut>>
     {
         public UnfoldResourceSourceAsync(System.Func<System.Threading.Tasks.Task<TSource>> create, System.Func<TSource, System.Threading.Tasks.Task<Akka.Util.Option<TOut>>> readData, System.Func<TSource, System.Threading.Tasks.Task> close) { }
@@ -3917,7 +3917,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class UnfoldResourceSource<TOut, TSource> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TOut>>
     {
         public UnfoldResourceSource(System.Func<TSource> create, System.Func<TSource, Akka.Util.Option<TOut>> readData, System.Action<TSource> close) { }
@@ -3927,7 +3927,7 @@ namespace Akka.Streams.Implementation
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class Unfold<TState, TElement> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<TElement>>
     {
         public readonly Akka.Streams.Outlet<TElement> Out;
@@ -3937,7 +3937,7 @@ namespace Akka.Streams.Implementation
         public override Akka.Streams.SourceShape<TElement> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class VirtualProcessor<T> : Akka.Util.AtomicReference<object>, Reactive.Streams.IProcessor<T, T>, Reactive.Streams.IPublisher<T>, Reactive.Streams.ISubscriber<T>
     {
         public const bool IsDebug = true;
@@ -3952,22 +3952,22 @@ namespace Akka.Streams.Implementation
 }
 namespace Akka.Streams.Implementation.Fusing
 {
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class ActorGraphInterpreter : Akka.Actor.ActorBase
     {
         public ActorGraphInterpreter(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
         public Akka.Event.ILoggingAdapter Log { get; }
         protected override void PostStop() { }
         protected override void PreStart() { }
-        public static Akka.Actor.Props Props(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
         protected override bool Receive(object message) { }
         public Akka.Actor.IActorRef RegisterShell(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
-        public struct Abort : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public static Akka.Actor.Props Props(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
+        public readonly struct Abort : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public Abort(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        public struct AsyncInput : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct AsyncInput : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly object Event;
             public readonly System.Action<object> Handler;
@@ -4009,14 +4009,14 @@ namespace Akka.Streams.Implementation.Fusing
             public void Request(long elements) { }
             public override string ToString() { }
         }
-        public struct Cancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct Cancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public Cancel(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, System.Exception cause) { }
             public System.Exception Cause { get; }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        public struct ExposedPublisher : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct ExposedPublisher : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public readonly Akka.Streams.Implementation.IActorPublisher Publisher;
@@ -4027,53 +4027,53 @@ namespace Akka.Streams.Implementation.Fusing
         {
             Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        public struct OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public OnComplete(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        public struct OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly System.Exception Cause;
             public readonly int Id;
             public OnError(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, System.Exception cause) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        public struct OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly object Event;
             public readonly int Id;
             public OnNext(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, object @event) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        public struct OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public readonly Reactive.Streams.ISubscription Subscription;
             public OnSubscribe(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, Reactive.Streams.ISubscription subscription) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        public struct RequestMore : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct RequestMore : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly long Demand;
             public readonly int Id;
             public RequestMore(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, long demand) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        public struct Resume : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct Resume : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public Resume(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
-        public struct SubscribePending : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
+        public readonly struct SubscribePending : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public SubscribePending(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class AggregateAsync<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public AggregateAsync(TOut zero, System.Func<TOut, TIn, System.Threading.Tasks.Task<TOut>> aggregate) { }
@@ -4084,7 +4084,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Aggregate<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Aggregate(TOut zero, System.Func<TOut, TIn, TOut> aggregate) { }
@@ -4095,7 +4095,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class AsyncEnumerable<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<T>>
     {
         public AsyncEnumerable(System.Func<System.Collections.Generic.IAsyncEnumerable<T>> factory) { }
@@ -4104,26 +4104,23 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Batch<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Batch(long max, System.Func<TIn, long> costFunc, System.Func<TIn, TOut> seed, System.Func<TOut, TIn, TOut> aggregate) { }
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1})]
-    public sealed class Buffer<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
+    [Akka.Annotations.InternalApi]
+    public sealed class Buffer<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Buffer(int count, Akka.Streams.OverflowStrategy overflowStrategy) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Collect<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
-        [System.ObsoleteAttribute("Deprecated. Please use the .ctor(Func, Func) constructor")]
+        [System.Obsolete("Deprecated. Please use the .ctor(Func, Func) constructor")]
         public Collect(System.Func<TIn, TOut> func) { }
         public Collect(System.Func<TIn, bool> isDefined, System.Func<TIn, TOut> collector) { }
         public Akka.Streams.Inlet<TIn> In { get; }
@@ -4133,18 +4130,15 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1})]
-    public sealed class Delay<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
+    [Akka.Annotations.InternalApi]
+    public sealed class Delay<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Delay(System.TimeSpan delay, Akka.Streams.DelayOverflowStrategy strategy) { }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Detacher<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Detacher() { }
@@ -4156,7 +4150,7 @@ namespace Akka.Streams.Implementation.Fusing
     {
         public DownstreamCompletedWithNoCauseException() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Expand<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Expand(System.Func<TIn, System.Collections.Generic.IEnumerator<TOut>> extrapolate) { }
@@ -4167,7 +4161,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class GraphAssembly
     {
         public readonly int[] InletOwners;
@@ -4175,19 +4169,19 @@ namespace Akka.Streams.Implementation.Fusing
         public readonly Akka.Streams.Attributes[] OriginalAttributes;
         public readonly int[] OutletOwners;
         public readonly Akka.Streams.Outlet[] Outlets;
-        public readonly Akka.Streams.Stage.IGraphStageWithMaterializedValue<, >[] Stages;
-        public GraphAssembly(Akka.Streams.Stage.IGraphStageWithMaterializedValue<, >[] stages, Akka.Streams.Attributes[] originalAttributes, Akka.Streams.Inlet[] inlets, int[] inletOwners, Akka.Streams.Outlet[] outlets, int[] outletOwners) { }
+        public readonly Akka.Streams.Stage.IGraphStageWithMaterializedValue<Akka.Streams.Shape, object>[] Stages;
+        public GraphAssembly(Akka.Streams.Stage.IGraphStageWithMaterializedValue<Akka.Streams.Shape, object>[] stages, Akka.Streams.Attributes[] originalAttributes, Akka.Streams.Inlet[] inlets, int[] inletOwners, Akka.Streams.Outlet[] outlets, int[] outletOwners) { }
         public int ConnectionCount { get; }
-        public static Akka.Streams.Implementation.Fusing.GraphAssembly Create(System.Collections.Generic.IList<Akka.Streams.Inlet> inlets, System.Collections.Generic.IList<Akka.Streams.Outlet> outlets, System.Collections.Generic.IList<Akka.Streams.Stage.IGraphStageWithMaterializedValue<Akka.Streams.Shape, object>> stages) { }
-        public System.ValueTuple<Connection[], Akka.Streams.Stage.GraphStageLogic[]> Materialize(Akka.Streams.Attributes inheritedAttributes, Akka.Streams.Implementation.IModule[] copiedModules, System.Collections.Generic.IDictionary<Akka.Streams.Implementation.IModule, object> materializedValues, System.Action<Akka.Streams.Implementation.Fusing.IMaterializedValueSource> register) { }
+        public System.ValueTuple<Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection[], Akka.Streams.Stage.GraphStageLogic[]> Materialize(Akka.Streams.Attributes inheritedAttributes, Akka.Streams.Implementation.IModule[] copiedModules, System.Collections.Generic.IDictionary<Akka.Streams.Implementation.IModule, object> materializedValues, System.Action<Akka.Streams.Implementation.Fusing.IMaterializedValueSource> register) { }
         public override string ToString() { }
+        public static Akka.Streams.Implementation.Fusing.GraphAssembly Create(System.Collections.Generic.IList<Akka.Streams.Inlet> inlets, System.Collections.Generic.IList<Akka.Streams.Outlet> outlets, System.Collections.Generic.IList<Akka.Streams.Stage.IGraphStageWithMaterializedValue<Akka.Streams.Shape, object>> stages) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class GraphInterpreter
     {
         public readonly Akka.Streams.Implementation.Fusing.GraphAssembly Assembly;
         public const int Boundary = -1;
-        public readonly Connection[] Connections;
+        public readonly Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection[] Connections;
         public readonly bool FuzzingMode;
         public const int InClosed = 16;
         public const int InFailed = 64;
@@ -4210,12 +4204,12 @@ namespace Akka.Streams.Implementation.Fusing
         public const int Pushing = 4;
         public int RunningStagesCount;
         public static readonly Akka.Streams.Attributes[] SingleNoAttribute;
-        public GraphInterpreter(Akka.Streams.Implementation.Fusing.GraphAssembly assembly, Akka.Streams.IMaterializer materializer, Akka.Event.ILoggingAdapter log, Akka.Streams.Stage.GraphStageLogic[] logics, Connection[] connections, System.Action<Akka.Streams.Stage.GraphStageLogic, object, System.Threading.Tasks.TaskCompletionSource<Akka.Done>, System.Action<object>> onAsyncInput, bool fuzzingMode, Akka.Actor.IActorRef context) { }
+        public GraphInterpreter(Akka.Streams.Implementation.Fusing.GraphAssembly assembly, Akka.Streams.IMaterializer materializer, Akka.Event.ILoggingAdapter log, Akka.Streams.Stage.GraphStageLogic[] logics, Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection[] connections, System.Action<Akka.Streams.Stage.GraphStageLogic, object, System.Threading.Tasks.TaskCompletionSource<Akka.Done>, System.Action<object>> onAsyncInput, bool fuzzingMode, Akka.Actor.IActorRef context) { }
         public Akka.Actor.IActorRef Context { get; }
-        public static Akka.Streams.Implementation.Fusing.GraphInterpreter Current { get; }
-        public static Akka.Streams.Implementation.Fusing.GraphInterpreter CurrentInterpreterOrNull { get; }
         public bool IsCompleted { get; }
         public bool IsSuspended { get; }
+        public static Akka.Streams.Implementation.Fusing.GraphInterpreter Current { get; }
+        public static Akka.Streams.Implementation.Fusing.GraphInterpreter CurrentInterpreterOrNull { get; }
         public void AttachDownstreamBoundary(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Implementation.Fusing.GraphInterpreter.DownstreamBoundaryStageLogic logic) { }
         public void AttachDownstreamBoundary(int connection, Akka.Streams.Implementation.Fusing.GraphInterpreter.DownstreamBoundaryStageLogic logic) { }
         public void AttachUpstreamBoundary(Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection connection, Akka.Streams.Implementation.Fusing.GraphInterpreter.UpstreamBoundaryStageLogic logic) { }
@@ -4234,7 +4228,7 @@ namespace Akka.Streams.Implementation.Fusing
             public readonly System.Exception Cause;
             public Cancelled(System.Exception cause) { }
         }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public sealed class Connection
         {
             public Connection(int id, int inOwnerId, Akka.Streams.Stage.GraphStageLogic inOwner, int outOwnerId, Akka.Streams.Stage.GraphStageLogic outOwner, Akka.Streams.Stage.IInHandler inHandler, Akka.Streams.Stage.IOutHandler outHandler) { }
@@ -4271,10 +4265,10 @@ namespace Akka.Streams.Implementation.Fusing
             public abstract Akka.Streams.Outlet Out { get; }
         }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class GraphInterpreterShell
     {
-        public GraphInterpreterShell(Akka.Streams.Implementation.Fusing.GraphAssembly assembly, Connection[] connections, Akka.Streams.Stage.GraphStageLogic[] logics, Akka.Streams.Shape shape, Akka.Streams.ActorMaterializerSettings settings, Akka.Streams.Implementation.ExtendedActorMaterializer materializer) { }
+        public GraphInterpreterShell(Akka.Streams.Implementation.Fusing.GraphAssembly assembly, Akka.Streams.Implementation.Fusing.GraphInterpreter.Connection[] connections, Akka.Streams.Stage.GraphStageLogic[] logics, Akka.Streams.Shape shape, Akka.Streams.ActorMaterializerSettings settings, Akka.Streams.Implementation.ExtendedActorMaterializer materializer) { }
         public bool CanShutdown { get; }
         public Akka.Streams.Implementation.Fusing.GraphInterpreter Interpreter { get; }
         public bool IsInitialized { get; }
@@ -4286,7 +4280,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override string ToString() { }
         public void TryAbort(System.Exception reason) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class GraphModule : Akka.Streams.Implementation.AtomicModule
     {
         public readonly Akka.Streams.Implementation.Fusing.GraphAssembly Assembly;
@@ -4299,7 +4293,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override string ToString() { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class GraphStageModule : Akka.Streams.Implementation.AtomicModule
     {
         public readonly Akka.Streams.Stage.IGraphStageWithMaterializedValue<Akka.Streams.Shape, object> Stage;
@@ -4311,11 +4305,11 @@ namespace Akka.Streams.Implementation.Fusing
         public override string ToString() { }
         public override Akka.Streams.Implementation.IModule WithAttributes(Akka.Streams.Attributes attributes) { }
     }
-    public class static GraphStages
+    public static class GraphStages
     {
         public static Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T> Identity<T>() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class GroupedWeightedWithin<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
         public GroupedWeightedWithin(long maxWeight, int maxNumber, System.Func<T, long> costFn, System.TimeSpan interval) { }
@@ -4323,7 +4317,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Grouped<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
         public Grouped(int count) { }
@@ -4348,7 +4342,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class IgnoreSink<T> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<T>, System.Threading.Tasks.Task<Akka.Done>>
     {
         public IgnoreSink() { }
@@ -4358,7 +4352,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<Akka.Done>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Intersperse<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Intersperse(T inject) { }
@@ -4366,7 +4360,7 @@ namespace Akka.Streams.Implementation.Fusing
         public bool InjectStartEnd { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class LazyFlow<TIn, TOut, TMat> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.FlowShape<TIn, TOut>, System.Threading.Tasks.Task<Akka.Util.Option<TMat>>>
     {
         public LazyFlow(System.Func<TIn, System.Threading.Tasks.Task<Akka.Streams.Dsl.Flow<TIn, TOut, TMat>>> flowFactory) { }
@@ -4377,7 +4371,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<Akka.Util.Option<TMat>>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class LimitWeighted<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public LimitWeighted(long max, System.Func<T, long> costFunc) { }
@@ -4385,19 +4379,19 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Log<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Log(string name, System.Func<T, object> extract, Akka.Event.ILoggingAdapter adapter, Akka.Event.LogLevel defaultLogLevel) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class MaterializedValueSource<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.SourceShape<T>>, Akka.Streams.Implementation.Fusing.IMaterializedValueSource
     {
         public readonly Akka.Streams.Outlet<T> Outlet;
-        public MaterializedValueSource(Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode computation, Akka.Streams.Outlet<T> outlet) { }
         public MaterializedValueSource(Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode computation) { }
+        public MaterializedValueSource(Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode computation, Akka.Streams.Outlet<T> outlet) { }
         public Akka.Streams.Implementation.StreamLayout.IMaterializedValueNode Computation { get; }
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public override Akka.Streams.SourceShape<T> Shape { get; }
@@ -4406,7 +4400,7 @@ namespace Akka.Streams.Implementation.Fusing
         public void SetValue(T value) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class OnCompleted<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, Akka.NotUsed>>
     {
         public OnCompleted(System.Action success, System.Action<System.Exception> failure) { }
@@ -4415,7 +4409,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.FlowShape<T, Akka.NotUsed> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class RecoverWith<TOut, TMat> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<TOut>
     {
         public RecoverWith(System.Func<System.Exception, Akka.Streams.IGraph<Akka.Streams.SourceShape<TOut>, TMat>> partialFunction, int maximumRetries) { }
@@ -4423,7 +4417,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Recover<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Recover(System.Func<System.Exception, Akka.Util.Option<T>> recovery) { }
@@ -4431,7 +4425,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class ScanAsync<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public ScanAsync(TOut zero, System.Func<TOut, TIn, System.Threading.Tasks.Task<TOut>> aggregate) { }
@@ -4442,7 +4436,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Scan<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Scan(TOut zero, System.Func<TOut, TIn, TOut> aggregate) { }
@@ -4453,13 +4447,8 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1,
-            1,
-            1})]
-    public sealed class SelectAsyncUnordered<[System.Runtime.CompilerServices.NullableAttribute(2)]  TIn, [System.Runtime.CompilerServices.NullableAttribute(2)]  TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
+    [Akka.Annotations.InternalApi]
+    public sealed class SelectAsyncUnordered<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public readonly Akka.Streams.Inlet<TIn> In;
         public readonly Akka.Streams.Outlet<TOut> Out;
@@ -4468,13 +4457,8 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
-    [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-            0,
-            1,
-            1,
-            1})]
-    public sealed class SelectAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  TIn, [System.Runtime.CompilerServices.NullableAttribute(2)]  TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
+    [Akka.Annotations.InternalApi]
+    public sealed class SelectAsync<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public readonly Akka.Streams.Inlet<TIn> In;
         public readonly Akka.Streams.Outlet<TOut> Out;
@@ -4483,13 +4467,13 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SelectError<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public SelectError(System.Func<System.Exception, System.Exception> selector) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Select<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public Select(System.Func<TIn, TOut> func) { }
@@ -4500,7 +4484,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class SimpleLinearGraphStage<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, T>>
     {
         public readonly Akka.Streams.Inlet<T> Inlet;
@@ -4515,7 +4499,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.SourceShape<T> Shape { get; }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SkipWhile<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public SkipWhile(System.Predicate<T> predicate) { }
@@ -4523,13 +4507,13 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class SkipWithin<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public SkipWithin(System.TimeSpan timeout) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Skip<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Skip(long count) { }
@@ -4537,7 +4521,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Sliding<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<T, System.Collections.Generic.IEnumerable<T>>>
     {
         public Sliding(int count, int step) { }
@@ -4548,7 +4532,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class StatefulSelectMany<TIn, TOut> : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<TIn, TOut>>
     {
         public StatefulSelectMany(System.Func<System.Func<TIn, System.Collections.Generic.IEnumerable<TOut>>> concatFactory) { }
@@ -4557,7 +4541,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Sum<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Sum(System.Func<T, T, T> reduce) { }
@@ -4565,7 +4549,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public abstract class SupervisedGraphStageLogic : Akka.Streams.Stage.GraphStageLogic
     {
         protected SupervisedGraphStageLogic(Akka.Streams.Attributes inheritedAttributes, Akka.Streams.Shape shape) { }
@@ -4574,7 +4558,7 @@ namespace Akka.Streams.Implementation.Fusing
         protected virtual void OnStop(System.Exception ex) { }
         protected Akka.Util.Option<T> WithSupervision<T>(System.Func<T> function) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class TakeWhile<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public TakeWhile(System.Predicate<T> predicate, bool inclusive) { }
@@ -4582,13 +4566,13 @@ namespace Akka.Streams.Implementation.Fusing
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class TakeWithin<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public TakeWithin(System.TimeSpan timeout) { }
         protected override Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes) { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Take<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Take(long count) { }
@@ -4622,7 +4606,7 @@ namespace Akka.Streams.Implementation.Fusing
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.Actor.ICancelable> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public sealed class Where<T> : Akka.Streams.Implementation.Fusing.SimpleLinearGraphStage<T>
     {
         public Where(System.Predicate<T> predicate) { }
@@ -4637,7 +4621,7 @@ namespace Akka.Streams.Implementation.IO
         public FlushSignaler() { }
         public void Flush() { }
     }
-    [Akka.Annotations.InternalApiAttribute()]
+    [Akka.Annotations.InternalApi]
     public class IncomingConnectionStage : Akka.Streams.Stage.GraphStage<Akka.Streams.FlowShape<Akka.IO.ByteString, Akka.IO.ByteString>>
     {
         public IncomingConnectionStage(Akka.Actor.IActorRef connection, System.Net.EndPoint remoteAddress, bool halfClose) { }
@@ -4649,7 +4633,7 @@ namespace Akka.Streams.Implementation.IO
 }
 namespace Akka.Streams.Implementation.Stages
 {
-    public class static DefaultAttributes
+    public static class DefaultAttributes
     {
         public static readonly Akka.Streams.Attributes ActorPublisherSource;
         public static readonly Akka.Streams.Attributes ActorRefSink;
@@ -4763,7 +4747,7 @@ namespace Akka.Streams.Implementation.Stages
     }
     public sealed class FirstOrDefault<TIn> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<TIn>, System.Threading.Tasks.Task<TIn>>
     {
-        public FirstOrDefault(bool throwOnDefault = False) { }
+        public FirstOrDefault(bool throwOnDefault = false) { }
         public override Akka.Streams.SinkShape<TIn> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<TIn>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
@@ -4775,7 +4759,7 @@ namespace Akka.Streams.Implementation.Stages
     }
     public sealed class LastOrDefault<TIn> : Akka.Streams.Stage.GraphStageWithMaterializedValue<Akka.Streams.SinkShape<TIn>, System.Threading.Tasks.Task<TIn>>
     {
-        public LastOrDefault(bool throwOnDefault = False) { }
+        public LastOrDefault(bool throwOnDefault = false) { }
         public override Akka.Streams.SinkShape<TIn> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<System.Threading.Tasks.Task<TIn>> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
         public override string ToString() { }
@@ -4794,7 +4778,6 @@ namespace Akka.Streams.Implementation.Stages
 }
 namespace Akka.Streams.Serialization
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class StreamRefSerializer : Akka.Serialization.SerializerWithStringManifest
     {
         public StreamRefSerializer(Akka.Actor.ExtendedActorSystem system) { }
@@ -4805,7 +4788,7 @@ namespace Akka.Streams.Serialization
 }
 namespace Akka.Streams.Stage
 {
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.2]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.2]")]
     public abstract class AbstractStage<TIn, TOut> : Akka.Streams.Stage.IStage<TIn, TOut>
     {
         protected AbstractStage() { }
@@ -4820,7 +4803,7 @@ namespace Akka.Streams.Stage
         public virtual void PreStart(Akka.Streams.Stage.ILifecycleContext context) { }
         public virtual Akka.Streams.Stage.IStage<TIn, TOut> Restart() { }
     }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.2]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.2]")]
     public abstract class AbstractStage<TIn, TOut, TPushDirective, TPullDirective, TContext> : Akka.Streams.Stage.AbstractStage<TIn, TOut>
         where TPushDirective : Akka.Streams.Stage.IDirective
         where TPullDirective : Akka.Streams.Stage.IDirective
@@ -4828,15 +4811,15 @@ namespace Akka.Streams.Stage
     {
         protected TContext Context;
         protected AbstractStage() { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context, System.Exception cause) { }
+        public override sealed Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(Akka.Streams.Stage.IContext context, System.Exception cause) { }
         public virtual Akka.Streams.Stage.ITerminationDirective OnDownstreamFinish(TContext context, System.Exception cause) { }
-        public abstract TPullDirective OnPull(TContext context);
         public override Akka.Streams.Stage.IDirective OnPull(Akka.Streams.Stage.IContext context) { }
+        public abstract TPullDirective OnPull(TContext context);
+        public override sealed Akka.Streams.Stage.IDirective OnPush(TIn element, Akka.Streams.Stage.IContext context) { }
         public abstract TPushDirective OnPush(TIn element, TContext context);
-        public virtual Akka.Streams.Stage.IDirective OnPush(TIn element, Akka.Streams.Stage.IContext context) { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnUpstreamFailure(System.Exception cause, Akka.Streams.Stage.IContext context) { }
+        public override sealed Akka.Streams.Stage.ITerminationDirective OnUpstreamFailure(System.Exception cause, Akka.Streams.Stage.IContext context) { }
         public virtual Akka.Streams.Stage.ITerminationDirective OnUpstreamFailure(System.Exception cause, TContext context) { }
-        public virtual Akka.Streams.Stage.ITerminationDirective OnUpstreamFinish(Akka.Streams.Stage.IContext context) { }
+        public override sealed Akka.Streams.Stage.ITerminationDirective OnUpstreamFinish(Akka.Streams.Stage.IContext context) { }
         public virtual Akka.Streams.Stage.ITerminationDirective OnUpstreamFinish(TContext context) { }
     }
     public delegate void AsyncCallback(object element);
@@ -4853,7 +4836,7 @@ namespace Akka.Streams.Stage
         public override void OnDownstreamFinish(System.Exception cause) { }
         public override void OnPull() { }
     }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.0]")]
     public abstract class DetachedStage<TIn, TOut> : Akka.Streams.Stage.AbstractStage<TIn, TOut, Akka.Streams.Stage.IUpstreamDirective, Akka.Streams.Stage.IDownstreamDirective, Akka.Streams.Stage.IDetachedContext<TOut>>
     {
         protected DetachedStage() { }
@@ -4875,61 +4858,59 @@ namespace Akka.Streams.Stage
     }
     public abstract class GraphStageLogic : Akka.Streams.Stage.IStageLogging
     {
+        public readonly int InCount;
+        public readonly int OutCount;
         public static readonly System.Action DoNothing;
         public static readonly Akka.Streams.Stage.InHandler EagerTerminateInput;
         public static readonly Akka.Streams.Stage.OutHandler EagerTerminateOutput;
         public static readonly Akka.Streams.Stage.InHandler IgnoreTerminateInput;
         public static readonly Akka.Streams.Stage.OutHandler IgnoreTerminateOutput;
-        public readonly int InCount;
         public static readonly System.Threading.Tasks.TaskCompletionSource<Akka.Done> NoPromise;
-        public readonly int OutCount;
         public static readonly Akka.Streams.Stage.InHandler TotallyIgnorantInput;
-        protected GraphStageLogic(int inCount, int outCount) { }
         protected GraphStageLogic(Akka.Streams.Shape shape) { }
+        protected GraphStageLogic(int inCount, int outCount) { }
         public virtual bool KeepGoingAfterAllPortsClosed { get; }
         public Akka.Event.ILoggingAdapter Log { get; }
         protected virtual object LogSource { get; }
         protected Akka.Streams.IMaterializer Materializer { get; }
         public Akka.Streams.Stage.StageActor StageActor { get; }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         protected virtual string StageActorName { get; }
         protected Akka.Streams.IMaterializer SubFusingMaterializer { get; }
         protected void AbortEmitting<T>(Akka.Streams.Outlet<T> outlet) { }
         protected void AbortReading<T>(Akka.Streams.Inlet<T> inlet) { }
         protected virtual void AfterPostStop() { }
         protected virtual void BeforePreStart() { }
-        protected void Cancel<T>(Akka.Streams.Inlet<T> inlet, System.Exception cause) { }
         protected void Cancel<T>(Akka.Streams.Inlet<T> inlet) { }
+        protected void Cancel<T>(Akka.Streams.Inlet<T> inlet, System.Exception cause) { }
         public void CancelStage(System.Exception cause) { }
         protected void Complete<T>(Akka.Streams.Outlet<T> outlet) { }
         public void CompleteStage() { }
-        public static Akka.Streams.Stage.InHandler ConditionalTerminateInput(System.Func<bool> predicate) { }
-        public static Akka.Streams.Stage.OutHandler ConditionalTerminateOutput(System.Func<bool> predicate) { }
         protected Akka.Streams.Stage.GraphStageLogic.SubSinkInlet<T> CreateSubSinkInlet<T>(string name) { }
-        protected void Emit<T>(Akka.Streams.Outlet<T> outlet, T element, System.Action andThen) { }
         protected void Emit<T>(Akka.Streams.Outlet<T> outlet, T element) { }
-        protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerable<T> elements, System.Action andThen) { }
+        protected void Emit<T>(Akka.Streams.Outlet<T> outlet, T element, System.Action andThen) { }
         protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerable<T> elements) { }
-        protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerator<T> enumerator, System.Action andThen) { }
         protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerator<T> enumerator) { }
+        protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerable<T> elements, System.Action andThen) { }
+        protected void EmitMultiple<T>(Akka.Streams.Outlet<T> outlet, System.Collections.Generic.IEnumerator<T> enumerator, System.Action andThen) { }
         protected void Fail<T>(Akka.Streams.Outlet<T> outlet, System.Exception reason) { }
         public void FailStage(System.Exception reason) { }
-        protected System.Action<T> GetAsyncCallback<T>(System.Action<T> handler) { }
         protected System.Action GetAsyncCallback(System.Action handler) { }
+        protected System.Action<T> GetAsyncCallback<T>(System.Action<T> handler) { }
         protected Akka.Streams.Stage.IInHandler GetHandler<T>(Akka.Streams.Inlet<T> inlet) { }
         protected Akka.Streams.Stage.IOutHandler GetHandler<T>(Akka.Streams.Outlet<T> outlet) { }
-        [Akka.Annotations.ApiMayChangeAttribute()]
+        [Akka.Annotations.ApiMayChange]
         protected Akka.Streams.Stage.StageActor GetStageActor(Akka.Streams.Stage.StageActorRef.Receive receive) { }
         protected Akka.Streams.Stage.IAsyncCallback<T> GetTypedAsyncCallback<T>(System.Action<T> handler) { }
         protected T Grab<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool HasBeenPulled<T>(Akka.Streams.Inlet<T> inlet) { }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         public void InternalOnDownstreamFinish(System.Exception cause) { }
         protected bool IsAvailable<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool IsAvailable<T>(Akka.Streams.Outlet<T> outlet) { }
         protected bool IsClosed<T>(Akka.Streams.Inlet<T> inlet) { }
         protected bool IsClosed<T>(Akka.Streams.Outlet<T> outlet) { }
-        protected void PassAlong<TOut, TIn>(Akka.Streams.Inlet<TIn> from, Akka.Streams.Outlet<TOut> to, bool doFinish = True, bool doFail = True, bool doPull = False)
+        protected void PassAlong<TOut, TIn>(Akka.Streams.Inlet<TIn> from, Akka.Streams.Outlet<TOut> to, bool doFinish = true, bool doFail = true, bool doPull = false)
             where TIn : TOut { }
         public virtual void PostStop() { }
         public virtual void PreStart() { }
@@ -4938,14 +4919,16 @@ namespace Akka.Streams.Stage
         protected void Read<T>(Akka.Streams.Inlet<T> inlet, System.Action<T> andThen, System.Action onClose) { }
         protected void ReadMany<T>(Akka.Streams.Inlet<T> inlet, int n, System.Action<System.Collections.Generic.IEnumerable<T>> andThen, System.Action<System.Collections.Generic.IEnumerable<T>> onComplete) { }
         protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, Akka.Streams.Stage.IInHandler handler) { }
-        protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, System.Action onPush, System.Action onUpstreamFinish = null, System.Action<System.Exception> onUpstreamFailure = null) { }
         protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, Akka.Streams.Stage.IOutHandler handler) { }
         protected void SetHandler<T>(Akka.Streams.Outlet<T> outlet, System.Action onPull, System.Action<System.Exception> onDownstreamFinish = null) { }
-        [System.ObsoleteAttribute("Use method `SetHandlers` instead. Will be removed in v1.5")]
+        protected void SetHandler<T>(Akka.Streams.Inlet<T> inlet, System.Action onPush, System.Action onUpstreamFinish = null, System.Action<System.Exception> onUpstreamFailure = null) { }
+        [System.Obsolete("Use method `SetHandlers` instead. Will be removed in v1.5")]
         protected void SetHandler<TIn, TOut>(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Stage.InAndOutGraphStageLogic handler) { }
         protected void SetHandlers<TIn, TOut>(Akka.Streams.Inlet<TIn> inlet, Akka.Streams.Outlet<TOut> outlet, Akka.Streams.Stage.InAndOutGraphStageLogic handler) { }
         protected void SetKeepGoing(bool enabled) { }
         protected void TryPull<T>(Akka.Streams.Inlet<T> inlet) { }
+        public static Akka.Streams.Stage.InHandler ConditionalTerminateInput(System.Func<bool> predicate) { }
+        public static Akka.Streams.Stage.OutHandler ConditionalTerminateOutput(System.Func<bool> predicate) { }
         protected sealed class LambdaInHandler : Akka.Streams.Stage.InHandler
         {
             public LambdaInHandler(System.Action onPush, System.Action onUpstreamFinish = null, System.Action<System.Exception> onUpstreamFailure = null) { }
@@ -4959,7 +4942,7 @@ namespace Akka.Streams.Stage
             public override void OnDownstreamFinish(System.Exception cause) { }
             public override void OnPull() { }
         }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected class SubSinkInlet<T>
         {
             public SubSinkInlet(Akka.Streams.Stage.GraphStageLogic logic, string name) { }
@@ -4974,7 +4957,7 @@ namespace Akka.Streams.Stage
             public void SetHandler(Akka.Streams.Stage.IInHandler handler) { }
             public override string ToString() { }
         }
-        [Akka.Annotations.InternalApiAttribute()]
+        [Akka.Annotations.InternalApi]
         protected class SubSourceOutlet<T>
         {
             public SubSourceOutlet(Akka.Streams.Stage.GraphStageLogic logic, string name) { }
@@ -5007,7 +4990,7 @@ namespace Akka.Streams.Stage
     {
         protected GraphStage() { }
         protected abstract Akka.Streams.Stage.GraphStageLogic CreateLogic(Akka.Streams.Attributes inheritedAttributes);
-        public virtual Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.NotUsed> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
+        public override sealed Akka.Streams.Stage.ILogicAndMaterializedValue<Akka.NotUsed> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
     }
     public interface IAsyncCallback<in T>
     {
@@ -5092,7 +5075,7 @@ namespace Akka.Streams.Stage
     {
         Akka.Event.ILoggingAdapter Log { get; }
     }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.0]")]
     public interface IStage<in TIn, out TOut> { }
     public interface ISyncDirective : Akka.Streams.Stage.IDirective { }
     public interface ITerminationDirective : Akka.Streams.Stage.IDirective, Akka.Streams.Stage.ISyncDirective { }
@@ -5111,8 +5094,8 @@ namespace Akka.Streams.Stage
     }
     public abstract class InAndOutGraphStageLogic : Akka.Streams.Stage.GraphStageLogic, Akka.Streams.Stage.IInHandler, Akka.Streams.Stage.IOutHandler
     {
-        protected InAndOutGraphStageLogic(int inCount, int outCount) { }
         protected InAndOutGraphStageLogic(Akka.Streams.Shape shape) { }
+        protected InAndOutGraphStageLogic(int inCount, int outCount) { }
         public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
         public abstract void OnPush();
@@ -5130,8 +5113,8 @@ namespace Akka.Streams.Stage
     }
     public abstract class InGraphStageLogic : Akka.Streams.Stage.GraphStageLogic, Akka.Streams.Stage.IInHandler
     {
-        protected InGraphStageLogic(int inCount, int outCount) { }
         protected InGraphStageLogic(Akka.Streams.Shape shape) { }
+        protected InGraphStageLogic(int inCount, int outCount) { }
         public abstract void OnPush();
         public virtual void OnUpstreamFailure(System.Exception e) { }
         public virtual void OnUpstreamFinish() { }
@@ -5143,7 +5126,7 @@ namespace Akka.Streams.Stage
         public virtual void OnUpstreamFailure(System.Exception e) { }
         public virtual void OnUpstreamFinish() { }
     }
-    public struct LogicAndMaterializedValue<TMaterialized> : Akka.Streams.Stage.ILogicAndMaterializedValue<TMaterialized>
+    public readonly struct LogicAndMaterializedValue<TMaterialized> : Akka.Streams.Stage.ILogicAndMaterializedValue<TMaterialized>
     {
         public LogicAndMaterializedValue(Akka.Streams.Stage.GraphStageLogic logic, TMaterialized materializedValue) { }
         public Akka.Streams.Stage.GraphStageLogic Logic { get; }
@@ -5151,8 +5134,8 @@ namespace Akka.Streams.Stage
     }
     public abstract class OutGraphStageLogic : Akka.Streams.Stage.GraphStageLogic, Akka.Streams.Stage.IOutHandler
     {
-        protected OutGraphStageLogic(int inCount, int outCount) { }
         protected OutGraphStageLogic(Akka.Streams.Shape shape) { }
+        protected OutGraphStageLogic(int inCount, int outCount) { }
         public virtual void OnDownstreamFinish(System.Exception cause) { }
         public abstract void OnPull();
     }
@@ -5169,22 +5152,22 @@ namespace Akka.Streams.Stage
         protected override Akka.Streams.Attributes InitialAttributes { get; }
         public override Akka.Streams.FlowShape<TIn, TOut> Shape { get; }
         public override Akka.Streams.Stage.ILogicAndMaterializedValue<TMat> CreateLogicAndMaterializedValue(Akka.Streams.Attributes inheritedAttributes) { }
-        public virtual string ToString() { }
+        public override sealed string ToString() { }
     }
     public class PushPullGraphStage<TIn, TOut> : Akka.Streams.Stage.PushPullGraphStageWithMaterializedValue<TIn, TOut, Akka.NotUsed>
     {
         public PushPullGraphStage(System.Func<Akka.Streams.Attributes, Akka.Streams.Stage.IStage<TIn, TOut>> factory, Akka.Streams.Attributes stageAttributes) { }
     }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.0]")]
     public abstract class PushPullStage<TIn, TOut> : Akka.Streams.Stage.AbstractStage<TIn, TOut, Akka.Streams.Stage.ISyncDirective, Akka.Streams.Stage.ISyncDirective, Akka.Streams.Stage.IContext<TOut>>
     {
         protected PushPullStage() { }
     }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
+    [System.Obsolete("Please use GraphStage instead. [1.1.0]")]
     public abstract class PushStage<TIn, TOut> : Akka.Streams.Stage.PushPullStage<TIn, TOut>
     {
         protected PushStage() { }
-        public virtual Akka.Streams.Stage.ISyncDirective OnPull(Akka.Streams.Stage.IContext<TOut> context) { }
+        public override sealed Akka.Streams.Stage.ISyncDirective OnPull(Akka.Streams.Stage.IContext<TOut> context) { }
     }
     public sealed class StageActor
     {
@@ -5195,10 +5178,11 @@ namespace Akka.Streams.Stage
         public void Unwatch(Akka.Actor.IActorRef actorRef) { }
         public void Watch(Akka.Actor.IActorRef actorRef) { }
     }
-    public class static StageActorRef
+    public static class StageActorRef
     {
         public delegate void Receive(System.ValueTuple<Akka.Actor.IActorRef, object> args);
     }
+    [System.Serializable]
     public class StageActorRefNotInitializedException : System.Exception
     {
         public static readonly Akka.Streams.Stage.StageActorRefNotInitializedException Instance;
@@ -5210,8 +5194,8 @@ namespace Akka.Streams.Stage
         public virtual Akka.Streams.Stage.ISyncDirective OnPull(Akka.Streams.Stage.IContext<TOut> context) { }
         public abstract Akka.Streams.Stage.ISyncDirective OnPush(TIn element, Akka.Streams.Stage.IContext<TOut> context);
     }
-    public class static StatefulStage { }
-    [System.ObsoleteAttribute("Please use GraphStage instead. [1.1.0]")]
+    public static class StatefulStage { }
+    [System.Obsolete("Please use GraphStage instead. [1.1.0]")]
     public abstract class StatefulStage<TIn, TOut> : Akka.Streams.Stage.PushPullStage<TIn, TOut>
     {
         protected StatefulStage(Akka.Streams.Stage.StageState<TIn, TOut> current) { }
@@ -5221,8 +5205,8 @@ namespace Akka.Streams.Stage
         public Akka.Streams.Stage.ISyncDirective Emit(System.Collections.Generic.IEnumerator<TOut> enumerator, Akka.Streams.Stage.IContext<TOut> context) { }
         public Akka.Streams.Stage.ISyncDirective Emit(System.Collections.Generic.IEnumerator<TOut> enumerator, Akka.Streams.Stage.IContext<TOut> context, Akka.Streams.Stage.StageState<TIn, TOut> nextState) { }
         public Akka.Streams.Stage.ISyncDirective EmitAndFinish(System.Collections.Generic.IEnumerator<TOut> enumerator, Akka.Streams.Stage.IContext<TOut> context) { }
-        public virtual Akka.Streams.Stage.ISyncDirective OnPull(Akka.Streams.Stage.IContext<TOut> context) { }
-        public virtual Akka.Streams.Stage.ISyncDirective OnPush(TIn element, Akka.Streams.Stage.IContext<TOut> context) { }
+        public override sealed Akka.Streams.Stage.ISyncDirective OnPull(Akka.Streams.Stage.IContext<TOut> context) { }
+        public override sealed Akka.Streams.Stage.ISyncDirective OnPush(TIn element, Akka.Streams.Stage.IContext<TOut> context) { }
         public override Akka.Streams.Stage.ITerminationDirective OnUpstreamFinish(Akka.Streams.Stage.IContext<TOut> context) { }
         public Akka.Streams.Stage.ISyncDirective TerminationEmit(System.Collections.Generic.IEnumerator<TOut> enumerator, Akka.Streams.Stage.IContext<TOut> context) { }
     }
@@ -5234,8 +5218,8 @@ namespace Akka.Streams.Stage
         protected bool IsTimerActive(object timerKey) { }
         protected abstract void OnTimer(object timerKey);
         protected void ScheduleOnce(object timerKey, System.TimeSpan delay) { }
-        protected void ScheduleRepeatedly(object timerKey, System.TimeSpan initialDelay, System.TimeSpan interval) { }
         protected void ScheduleRepeatedly(object timerKey, System.TimeSpan interval) { }
+        protected void ScheduleRepeatedly(object timerKey, System.TimeSpan initialDelay, System.TimeSpan interval) { }
     }
     public sealed class TotallyIgnorantInput : Akka.Streams.Stage.InHandler
     {
@@ -5248,7 +5232,7 @@ namespace Akka.Streams.Stage
 namespace Akka.Streams.Supervision
 {
     public delegate Akka.Streams.Supervision.Directive Decider(System.Exception cause);
-    public class static Deciders
+    public static class Deciders
     {
         public static readonly Akka.Streams.Supervision.Decider RestartingDecider;
         public static readonly Akka.Streams.Supervision.Decider ResumingDecider;
@@ -5267,7 +5251,7 @@ namespace Akka.Streams.Util
     {
         public ContinuallyEnumerable(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
         public System.Collections.Generic.IEnumerator<T> GetEnumerator() { }
-        public sealed class ContinuallyEnumerator<T> : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
+        public sealed class ContinuallyEnumerator : System.Collections.Generic.IEnumerator<T>, System.Collections.IEnumerator, System.IDisposable
         {
             public ContinuallyEnumerator(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
             public T Current { get; }
@@ -5281,12 +5265,12 @@ namespace Akka.Streams.Util
         public EnumeratorEnumerable(System.Func<System.Collections.Generic.IEnumerator<T>> enumeratorFactory) { }
         public System.Collections.Generic.IEnumerator<T> GetEnumerator() { }
     }
-    public class static Int32Extensions { }
-    public class static ObjectExtensions
+    public static class Int32Extensions { }
+    public static class ObjectExtensions
     {
         public static bool IsDefaultForType<T>(this T obj) { }
     }
-    public class static TypeExtensions
+    public static class TypeExtensions
     {
         public static System.Type GetPublishedType(this System.Type type) { }
         public static System.Type GetSubscribedType(this System.Type type) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
@@ -1,7 +1,7 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("ae01b790-1478-4917-9299-b4855ba997cb")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("ae01b790-1478-4917-9299-b4855ba997cb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.TestKit
 {
     public abstract class AutoPilot
@@ -24,12 +24,9 @@ namespace Akka.TestKit
         public CallingThreadDispatcherConfigurator(Akka.Configuration.Config config, Akka.Dispatch.IDispatcherPrerequisites prerequisites) { }
         public override Akka.Dispatch.MessageDispatcher Dispatcher() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class DeadLettersFilter : Akka.TestKit.Internal.EventFilterBase
     {
-        public DeadLettersFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<Akka.Event.DeadLetter> isMatch = null) { }
+        public DeadLettersFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher, System.Predicate<Akka.Event.DeadLetter>? isMatch = null) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
@@ -48,49 +45,39 @@ namespace Akka.TestKit
         public override Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
         public void Update(Akka.Actor.IActorRef child, Akka.Actor.SupervisorStrategy supervisorStrategy) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class EventFilterFactory
     {
         public EventFilterFactory(Akka.TestKit.TestKitBase testkit) { }
         public EventFilterFactory(Akka.TestKit.TestKitBase testkit, Akka.Actor.ActorSystem system) { }
         public EventFilterFactory(Akka.TestKit.TestKitBase testkit, Akka.Actor.ActorSystem actorSystem, System.Collections.Generic.IReadOnlyList<Akka.TestKit.Internal.EventFilterBase> filters) { }
         protected Akka.TestKit.IEventFilterApplier CreateApplier(Akka.TestKit.Internal.EventFilterBase filter, Akka.Actor.ActorSystem system) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        protected static Akka.TestKit.Internal.StringMatcher.IStringMatcher CreateMessageMatcher(string message, string start, string contains) { }
         public Akka.TestKit.IEventFilterApplier Custom(System.Predicate<Akka.Event.LogEvent> predicate) { }
-        public Akka.TestKit.IEventFilterApplier Custom<[System.Runtime.CompilerServices.NullableAttribute(0)]  TLogEvent>(System.Predicate<TLogEvent> predicate)
+        public Akka.TestKit.IEventFilterApplier Custom<TLogEvent>(System.Predicate<TLogEvent> predicate)
             where TLogEvent : Akka.Event.LogEvent { }
         public Akka.TestKit.IEventFilterApplier DeadLetter() { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier DeadLetter<TMessage>(string source = null) { }
-        public Akka.TestKit.IEventFilterApplier DeadLetter<[System.Runtime.CompilerServices.NullableAttribute(2)]  TMessage>(System.Func<TMessage, bool> isMatch, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        public Akka.TestKit.IEventFilterApplier DeadLetter(System.Type type, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        public Akka.TestKit.IEventFilterApplier DeadLetter(System.Type type, System.Func<object, bool> isMatch, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Debug(string message = null, string start = null, string contains = null, string source = null) { }
-        public Akka.TestKit.IEventFilterApplier Debug(System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Error(string message = null, string start = null, string contains = null, string source = null) { }
-        public Akka.TestKit.IEventFilterApplier Error(System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        public Akka.TestKit.IEventFilterApplier Exception<[System.Runtime.CompilerServices.NullableAttribute(0)]  TException>(System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null)
+        public Akka.TestKit.IEventFilterApplier DeadLetter(System.Type type, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier DeadLetter(System.Type type, System.Func<object, bool> isMatch, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier DeadLetter<TMessage>(string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier DeadLetter<TMessage>(System.Func<TMessage, bool> isMatch, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Debug(System.Text.RegularExpressions.Regex pattern, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Debug(string? message = null, string? start = null, string? contains = null, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Error(System.Text.RegularExpressions.Regex pattern, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Error(string? message = null, string? start = null, string? contains = null, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Exception(System.Type exceptionType, System.Text.RegularExpressions.Regex pattern, string? source = null, bool checkInnerExceptions = false) { }
+        public Akka.TestKit.IEventFilterApplier Exception(System.Type exceptionType, string? message = null, string? start = null, string? contains = null, string? source = null, bool checkInnerExceptions = false) { }
+        public Akka.TestKit.IEventFilterApplier Exception<TException>(System.Text.RegularExpressions.Regex pattern, string? source = null)
             where TException : System.Exception { }
-        public Akka.TestKit.IEventFilterApplier Exception(System.Type exceptionType, System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null, bool checkInnerExceptions = False) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Exception<[System.Runtime.CompilerServices.NullableAttribute(0)]  TException>(string message = null, string start = null, string contains = null, string source = null)
+        public Akka.TestKit.IEventFilterApplier Exception<TException>(string? message = null, string? start = null, string? contains = null, string? source = null)
             where TException : System.Exception { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Exception([System.Runtime.CompilerServices.NullableAttribute(1)] System.Type exceptionType, string message = null, string start = null, string contains = null, string source = null, bool checkInnerExceptions = False) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier ForLogLevel(Akka.Event.LogLevel logLevel, string message = null, string start = null, string contains = null, string source = null) { }
-        public Akka.TestKit.IEventFilterApplier ForLogLevel(Akka.Event.LogLevel logLevel, System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Info(string message = null, string start = null, string contains = null, string source = null) { }
-        public Akka.TestKit.IEventFilterApplier Info(System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Warning(string message = null, string start = null, string contains = null, string source = null) { }
-        public Akka.TestKit.IEventFilterApplier Warning(System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
+        public Akka.TestKit.IEventFilterApplier ForLogLevel(Akka.Event.LogLevel logLevel, System.Text.RegularExpressions.Regex pattern, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier ForLogLevel(Akka.Event.LogLevel logLevel, string? message = null, string? start = null, string? contains = null, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Info(System.Text.RegularExpressions.Regex pattern, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Info(string? message = null, string? start = null, string? contains = null, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Warning(System.Text.RegularExpressions.Regex pattern, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Warning(string? message = null, string? start = null, string? contains = null, string? source = null) { }
+        protected static Akka.TestKit.Internal.StringMatcher.IStringMatcher CreateMessageMatcher(string? message, string? start, string? contains) { }
     }
-    public class static FSMSpecHelpers
+    public static class FSMSpecHelpers
     {
         public static System.Func<object, object, bool> CurrentStateExpector<TS>() { }
         public static System.Func<object, object, bool> TransitionStateExpector<TS>() { }
@@ -102,37 +89,37 @@ namespace Akka.TestKit
     public interface IEventFilterApplier
     {
         Akka.TestKit.EventFilterFactory And { get; }
-        void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        T Expect<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        T Expect<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
-        [System.ObsoleteAttribute("Use ExpectAsync<T>(expectedCount, TimeSpan, Func<Task<T>>) instead. This method o" +
+        void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        T Expect<T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default);
+        T Expect<T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.TimeSpan? timeout, System.Threading.CancellationToken cancellationToken = default);
+        [System.Obsolete("Use ExpectAsync<T>(expectedCount, TimeSpan, Func<Task<T>>) instead. This method o" +
             "nly exists to support backwards compatibility as of Akka.NET v1.5.")]
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        T ExpectOne<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        T ExpectOne<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
-        [System.ObsoleteAttribute("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default);
+        void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        T ExpectOne<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = default);
+        T ExpectOne<T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default);
+        [System.Obsolete("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
             "ead beginning in Akka.NET v1.5")]
-        System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectOneAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectOneAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        T Mute<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        void Mute(System.Action action, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default);
         Akka.TestKit.IUnmutableFilter Mute();
-        System.Threading.Tasks.Task<T> MuteAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task MuteAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
-        [System.ObsoleteAttribute("Use MuteAsync(Func<Task>) instead. This method only exists for backwards compatib" +
+        void Mute(System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        T Mute<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = default);
+        [System.Obsolete("Use MuteAsync(Func<Task>) instead. This method only exists for backwards compatib" +
             "ility as of Akka.NET v1.5.0.")]
-        System.Threading.Tasks.Task MuteAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task MuteAsync(System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task MuteAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<T> MuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default);
     }
     public interface INoImplicitSender { }
     public interface ITestKitAssertions
@@ -180,13 +167,13 @@ namespace Akka.TestKit
     {
         public System.Delegate PredicateT { get; }
         public System.Type Type { get; }
-        public static Akka.TestKit.PredicateInfo Create<T>(System.Predicate<T> predicateT) { }
         public override string ToString() { }
+        public static Akka.TestKit.PredicateInfo Create<T>(System.Predicate<T> predicateT) { }
     }
-    public class static PredicateInfoFactory
+    public static class PredicateInfoFactory
     {
-        public static Akka.TestKit.PredicateInfo CreatePredicateInfo<T>(this System.Predicate<T> predicateT) { }
         public static Akka.TestKit.PredicateInfo CreatePredicateInfo<T>(this System.Delegate predicateT) { }
+        public static Akka.TestKit.PredicateInfo CreatePredicateInfo<T>(this System.Predicate<T> predicateT) { }
     }
     public class RealMessageEnvelope : Akka.TestKit.MessageEnvelope
     {
@@ -195,12 +182,11 @@ namespace Akka.TestKit
         public override Akka.Actor.IActorRef Sender { get; }
         public override string ToString() { }
     }
-    public class static TestActor
+    public static class TestActor
     {
         public static Akka.TestKit.AutoPilot KeepRunning { get; }
         public static Akka.TestKit.AutoPilot NoAutoPilot { get; }
         public static Akka.TestKit.NullMessageEnvelope NullMessage { get; }
-        public delegate bool Ignore(object message);
         public class SetAutoPilot : Akka.Actor.INoSerializationVerificationNeeded
         {
             public SetAutoPilot(Akka.TestKit.AutoPilot autoPilot) { }
@@ -229,6 +215,7 @@ namespace Akka.TestKit
             public Watch(Akka.Actor.IActorRef actorToWatch) { }
             public Akka.Actor.IActorRef Actor { get; }
         }
+        public delegate bool Ignore(object message);
     }
     public abstract class TestActorRefBase<TActor> : Akka.Actor.IActorRef, Akka.Actor.IActorRefScope, Akka.Actor.ICanTell, Akka.Actor.IInternalActorRef, Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.IActorRef>, System.IEquatable<Akka.Actor.IActorRef>
         where TActor : Akka.Actor.ActorBase
@@ -239,39 +226,39 @@ namespace Akka.TestKit
         public Akka.Actor.IActorRef Ref { get; }
         public TActor UnderlyingActor { get; }
         public int CompareTo(object obj) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Actor.IActorRef other) { }
+        public override bool Equals(object obj) { }
         public void Forward(object message) { }
         public override int GetHashCode() { }
         public void Receive(object message, Akka.Actor.IActorRef sender = null) { }
         public System.Threading.Tasks.Task ReceiveAsync(object message, Akka.Actor.IActorRef sender = null) { }
-        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
+        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public void Tell(object message) { }
         public void Tell(object message, Akka.Actor.IActorRef sender) { }
-        public static Akka.Actor.IActorRef ToActorRef(Akka.TestKit.TestActorRefBase<TActor> actorRef) { }
         public override string ToString() { }
         public void Unwatch(Akka.Actor.IActorRef subject) { }
         public void Watch(Akka.Actor.IActorRef subject) { }
-        public static bool ==(Akka.TestKit.TestActorRefBase<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
-        public static bool ==(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRefBase<TActor> testActorRef) { }
-        public static bool !=(Akka.TestKit.TestActorRefBase<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
-        public static bool !=(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRefBase<TActor> testActorRef) { }
+        public static Akka.Actor.IActorRef ToActorRef(Akka.TestKit.TestActorRefBase<TActor> actorRef) { }
+        public static bool operator !=(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRefBase<TActor> testActorRef) { }
+        public static bool operator !=(Akka.TestKit.TestActorRefBase<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
+        public static bool operator ==(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRefBase<TActor> testActorRef) { }
+        public static bool operator ==(Akka.TestKit.TestActorRefBase<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
     }
     public class TestActorRef<TActor> : Akka.TestKit.TestActorRefBase<TActor>
         where TActor : Akka.Actor.ActorBase
     {
         public TestActorRef(Akka.Actor.ActorSystem system, Akka.Actor.Props actorProps, Akka.Actor.IActorRef supervisor = null, string name = null) { }
-        public static bool ==(Akka.TestKit.TestActorRef<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
-        public static bool ==(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRef<TActor> testActorRef) { }
-        public static bool !=(Akka.TestKit.TestActorRef<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
-        public static bool !=(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRef<TActor> testActorRef) { }
+        public static bool operator !=(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRef<TActor> testActorRef) { }
+        public static bool operator !=(Akka.TestKit.TestActorRef<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
+        public static bool operator ==(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRef<TActor> testActorRef) { }
+        public static bool operator ==(Akka.TestKit.TestActorRef<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
     }
     public class TestBarrier
     {
-        [System.ObsoleteAttribute("This field will be removed in future versions.")]
+        [System.Obsolete("This field will be removed in future versions.")]
         public static readonly System.TimeSpan DefaultTimeout;
-        public TestBarrier(Akka.TestKit.TestKitBase testKit, int count, System.Nullable<System.TimeSpan> defaultTimeout = null) { }
+        public TestBarrier(Akka.TestKit.TestKitBase testKit, int count, System.TimeSpan? defaultTimeout = default) { }
         public void Await() { }
         public void Await(System.TimeSpan timeout) { }
         public void Reset() { }
@@ -284,7 +271,6 @@ namespace Akka.TestKit
         public Akka.Pattern.CircuitBreaker Instance { get; }
         public System.Threading.CountdownEvent OpenLatch { get; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class TestEventListener : Akka.Event.DefaultLogger
     {
         public TestEventListener() { }
@@ -293,17 +279,17 @@ namespace Akka.TestKit
     public class TestFSMRef<TActor, TState, TData> : Akka.TestKit.TestActorRefBase<TActor>
         where TActor : Akka.Actor.FSM<TState, TData>
     {
-        public TestFSMRef(Akka.Actor.ActorSystem system, Akka.Actor.Props props, Akka.Actor.IActorRef supervisor = null, string name = null, bool activateLogging = False) { }
+        public TestFSMRef(Akka.Actor.ActorSystem system, Akka.Actor.Props props, Akka.Actor.IActorRef supervisor = null, string name = null, bool activateLogging = false) { }
         public TData StateData { get; }
         public TState StateName { get; }
         public void CancelTimer(string name) { }
         public bool IsStateTimerActive() { }
         public bool IsTimerActive(string name) { }
-        public void SetState(TState stateName, System.Nullable<System.TimeSpan> timeout = null) { }
-        public void SetState(TState stateName, TData stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null) { }
-        public void SetStateData(TData stateData, System.Nullable<System.TimeSpan> timeout = null) { }
+        public void SetState(TState stateName, System.TimeSpan? timeout = default) { }
+        public void SetState(TState stateName, TData stateData, System.TimeSpan? timeout = default, Akka.Actor.FSMBase.Reason stopReason = null) { }
+        public void SetStateData(TData stateData, System.TimeSpan? timeout = default) { }
         public void SetStateTimeout(System.TimeSpan timeout) { }
-        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = False) { }
+        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = false) { }
     }
     public class TestKitAssertionsExtension : Akka.Actor.ExtensionIdProvider<Akka.TestKit.TestKitAssertionsProvider>
     {
@@ -322,84 +308,84 @@ namespace Akka.TestKit
         protected TestKitBase(Akka.TestKit.ITestKitAssertions assertions, Akka.Actor.Setup.ActorSystemSetup setup, string actorSystemName = null, string testActorName = null) { }
         protected TestKitBase(Akka.TestKit.ITestKitAssertions assertions, Akka.Configuration.Config config, string actorSystemName = null, string testActorName = null) { }
         protected TestKitBase(Akka.TestKit.ITestKitAssertions assertions, Akka.Actor.ActorSystem system, Akka.Actor.Setup.ActorSystemSetup config, string actorSystemName, string testActorName) { }
-        public static Akka.Configuration.Config DefaultConfig { get; }
         public Akka.TestKit.EventFilterFactory EventFilter { get; }
-        public static Akka.Configuration.Config FullDebugConfig { get; }
         public bool HasMessages { get; }
         public object LastMessage { get; }
         public Akka.Actor.IActorRef LastSender { get; }
         public Akka.Event.ILoggingAdapter Log { get; }
         public System.TimeSpan NoMessageRemainingOrDefault { get; }
-        public static System.TimeSpan Now { get; }
         public System.TimeSpan Remaining { get; }
         public System.TimeSpan RemainingOrDefault { get; }
         public Akka.Actor.ActorSystem Sys { get; }
         public Akka.Actor.IActorRef TestActor { get; }
         public Akka.TestKit.TestKitSettings TestKitSettings { get; }
+        public static Akka.Configuration.Config DefaultConfig { get; }
+        public static Akka.Configuration.Config FullDebugConfig { get; }
+        public static System.TimeSpan Now { get; }
         public Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props) { }
         public Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string name) { }
+        public Akka.Actor.IActorRef ActorOf(System.Action<Akka.Actor.Dsl.IActorDsl> configure, string name = null) { }
+        public Akka.Actor.IActorRef ActorOf(System.Action<Akka.Actor.Dsl.IActorDsl, Akka.Actor.IActorContext> configure, string name = null) { }
         public Akka.Actor.IActorRef ActorOf<TActor>()
-            where TActor : Akka.Actor.ActorBase, new () { }
-        public Akka.Actor.IActorRef ActorOf<TActor>(string name)
             where TActor : Akka.Actor.ActorBase, new () { }
         public Akka.Actor.IActorRef ActorOf<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory)
             where TActor : Akka.Actor.ActorBase { }
+        public Akka.Actor.IActorRef ActorOf<TActor>(string name)
+            where TActor : Akka.Actor.ActorBase, new () { }
         public Akka.Actor.IActorRef ActorOf<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, string name)
             where TActor : Akka.Actor.ActorBase { }
-        public Akka.Actor.IActorRef ActorOf(System.Action<Akka.Actor.Dsl.IActorDsl, Akka.Actor.IActorContext> configure, string name = null) { }
-        public Akka.Actor.IActorRef ActorOf(System.Action<Akka.Actor.Dsl.IActorDsl> configure, string name = null) { }
-        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Akka.Actor.Props props, Akka.Actor.IActorRef supervisor, string name = null)
-            where TActor : Akka.Actor.ActorBase { }
+        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(string name = null)
+            where TActor : Akka.Actor.ActorBase, new () { }
+        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Akka.Actor.IActorRef supervisor, string name = null)
+            where TActor : Akka.Actor.ActorBase, new () { }
         public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Akka.Actor.Props props, string name = null)
-            where TActor : Akka.Actor.ActorBase { }
-        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, Akka.Actor.IActorRef supervisor, string name = null)
             where TActor : Akka.Actor.ActorBase { }
         public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, string name = null)
             where TActor : Akka.Actor.ActorBase { }
-        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Akka.Actor.IActorRef supervisor, string name = null)
-            where TActor : Akka.Actor.ActorBase, new () { }
-        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(string name = null)
-            where TActor : Akka.Actor.ActorBase, new () { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.Props props, Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = False)
-            where TFsmActor : Akka.Actor.FSM<TState, TData> { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.Props props, string name = null, bool withLogging = False)
-            where TFsmActor : Akka.Actor.FSM<TState, TData> { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = False)
+        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Akka.Actor.Props props, Akka.Actor.IActorRef supervisor, string name = null)
+            where TActor : Akka.Actor.ActorBase { }
+        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, Akka.Actor.IActorRef supervisor, string name = null)
+            where TActor : Akka.Actor.ActorBase { }
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(string name = null, bool withLogging = false)
             where TFsmActor : Akka.Actor.FSM<TState, TData>, new () { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(string name = null, bool withLogging = False)
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = false)
             where TFsmActor : Akka.Actor.FSM<TState, TData>, new () { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(System.Linq.Expressions.Expression<System.Func<TFsmActor>> factory, Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = False)
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.Props props, string name = null, bool withLogging = false)
             where TFsmActor : Akka.Actor.FSM<TState, TData> { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(System.Linq.Expressions.Expression<System.Func<TFsmActor>> factory, string name = null, bool withLogging = False)
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(System.Linq.Expressions.Expression<System.Func<TFsmActor>> factory, string name = null, bool withLogging = false)
+            where TFsmActor : Akka.Actor.FSM<TState, TData> { }
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.Props props, Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = false)
+            where TFsmActor : Akka.Actor.FSM<TState, TData> { }
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(System.Linq.Expressions.Expression<System.Func<TFsmActor>> factory, Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = false)
             where TFsmActor : Akka.Actor.FSM<TState, TData> { }
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath actorPath) { }
         public Akka.Actor.ActorSelection ActorSelection(string actorPath) { }
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.IActorRef anchorRef, string actorPath) { }
-        public void AwaitAssert(System.Action assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitAssertAsync(System.Action assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitAssertAsync(System.Func<System.Threading.Tasks.Task> assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public bool AwaitConditionNoThrow(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, string name, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, string name, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, System.Threading.CancellationToken cancellationToken = null) { }
+        public void AwaitAssert(System.Action assertion, System.TimeSpan? duration = default, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitAssertAsync(System.Action assertion, System.TimeSpan? duration = default, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitAssertAsync(System.Func<System.Threading.Tasks.Task> assertion, System.TimeSpan? duration = default, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = default) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan? max, System.Threading.CancellationToken cancellationToken = default) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan? max, string message, System.Threading.CancellationToken cancellationToken = default) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan? max, System.TimeSpan? interval, string message = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan? max, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan? max, string message, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.TimeSpan? max, string message, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan? max, System.TimeSpan? interval, string message = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.TimeSpan? max, System.TimeSpan? interval, string message = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public bool AwaitConditionNoThrow(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, System.Threading.CancellationToken cancellationToken = default) { }
+        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default) { }
+        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, string name, System.Threading.CancellationToken cancellationToken = default) { }
+        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, string name, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default) { }
         public Akka.TestKit.EventFilterFactory CreateEventFilter(Akka.Actor.ActorSystem system) { }
         public Akka.Actor.IActorRef CreateTestActor(string name) { }
         public Akka.TestKit.TestBarrier CreateTestBarrier(int count) { }
@@ -407,128 +393,118 @@ namespace Akka.TestKit
         public virtual Akka.TestKit.TestProbe CreateTestProbe(string name = null) { }
         public virtual Akka.TestKit.TestProbe CreateTestProbe(Akka.Actor.ActorSystem system, string name = null) { }
         public System.TimeSpan Dilated(System.TimeSpan duration) { }
-        public T ExpectMsg<T>(System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Action<T> assert, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(T expected, System.Func<T, T, bool> comparer, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(System.TimeSpan? duration = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(System.Action<T> assert, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(T message, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(T expected, System.Func<T, T, bool> comparer, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(params T[] messages) { }
-        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, params T[] messages) { }
-        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__157<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__160<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(params Akka.TestKit.PredicateInfo[] predicates) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, params Akka.TestKit.PredicateInfo[] predicates) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__167))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__170))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgAnyOf<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAnyOfAsync<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T> assert, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T expected, System.Func<T, T, bool> comparer, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectNoMsg(System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectNoMsg(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectNoMsg(int milliseconds, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(int milliseconds, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.Terminated ExpectTerminated(Akka.Actor.IActorRef target, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<Akka.Actor.Terminated> ExpectTerminatedAsync(Akka.Actor.IActorRef target, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public object FishForMessage(System.Predicate<object> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<object> FishForMessageAsync(System.Predicate<object> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task FishUntilMessageAsync<T>(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.TimeSpan GetTimeoutOrDefault(System.Nullable<System.TimeSpan> timeout) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgAnyOf<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAnyOfAsync<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.TimeSpan? duration = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T> assert, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T message, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T expected, System.Func<T, T, bool> comparer, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.TimeSpan? duration = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, T message, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.TimeSpan? duration = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, T message, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public void ExpectNoMsg(System.Threading.CancellationToken cancellationToken = default) { }
+        public void ExpectNoMsg(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = default) { }
+        public void ExpectNoMsg(int milliseconds, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(int milliseconds, System.Threading.CancellationToken cancellationToken = default) { }
+        public Akka.Actor.Terminated ExpectTerminated(Akka.Actor.IActorRef target, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<Akka.Actor.Terminated> ExpectTerminatedAsync(Akka.Actor.IActorRef target, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public object FishForMessage(System.Predicate<object> isMessage, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public T FishForMessage<T>(System.Predicate<T> isMessage, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<object> FishForMessageAsync(System.Predicate<object> isMessage, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task FishUntilMessageAsync<T>(System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.TimeSpan GetTimeoutOrDefault(System.TimeSpan? timeout) { }
         public void IgnoreMessages(System.Func<object, bool> shouldIgnoreMessage) { }
-        public void IgnoreMessages<TMsg>(System.Func<TMsg, bool> shouldIgnoreMessage) { }
         public void IgnoreMessages<TMsg>() { }
+        public void IgnoreMessages<TMsg>(System.Func<TMsg, bool> shouldIgnoreMessage) { }
         public void IgnoreNoMessages() { }
         protected virtual void InitializeTest(Akka.Actor.ActorSystem system, Akka.Actor.Setup.ActorSystemSetup config, string actorSystemName, string testActorName) { }
         protected void InitializeTest(Akka.Actor.ActorSystem system, Akka.Configuration.Config config, string actorSystemName, string testActorName) { }
-        protected static bool InternalAwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval, System.Action<string, object[]> fail, System.Threading.CancellationToken cancellationToken = null) { }
-        protected static bool InternalAwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval, System.Action<string, object[]> fail, Akka.Event.ILoggingAdapter logger, System.Threading.CancellationToken cancellationToken = null) { }
-        protected static System.Threading.Tasks.Task<bool> InternalAwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval, System.Action<string, object[]> fail, System.Threading.CancellationToken cancellationToken = null) { }
-        protected static System.Threading.Tasks.Task<bool> InternalAwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval, System.Action<string, object[]> fail, Akka.Event.ILoggingAdapter logger, System.Threading.CancellationToken cancellationToken = null) { }
-        public object PeekOne(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
         public object PeekOne(System.Threading.CancellationToken cancellationToken) { }
-        public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public object PeekOne(System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.Threading.CancellationToken cancellationToken) { }
-        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.TimeSpan max, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__216))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__218))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, System.TimeSpan max, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        public object ReceiveOne(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<object> ReceiveOneAsync(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__207<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__209<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__211<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__213<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.TimeSpan max, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, System.TimeSpan max, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public object ReceiveOne(System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<object> ReceiveOneAsync(System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.TimeSpan? max, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Func<object, T> filter, System.TimeSpan? max = default, System.TimeSpan? idle = default, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.TimeSpan? max, System.TimeSpan? idle, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Predicate<T> shouldContinue, System.TimeSpan? max = default, System.TimeSpan? idle = default, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = true, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.TimeSpan? max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, System.TimeSpan? max = default, System.TimeSpan? idle = default, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.TimeSpan? max, System.TimeSpan? idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Predicate<T> shouldContinue, System.TimeSpan? max = default, System.TimeSpan? idle = default, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = true, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
         protected System.TimeSpan RemainingOr(System.TimeSpan duration) { }
-        public System.TimeSpan RemainingOrDilated(System.Nullable<System.TimeSpan> duration) { }
+        public System.TimeSpan RemainingOrDilated(System.TimeSpan? duration) { }
         public void SetAutoPilot(Akka.TestKit.AutoPilot pilot) { }
-        public virtual void Shutdown(System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
-        protected virtual void Shutdown(Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
-        public bool TryPeekOne(out Akka.TestKit.MessageEnvelope envelope, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken) { }
-        [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+        public virtual void Shutdown(System.TimeSpan? duration = default, bool verifySystemShutdown = false) { }
+        protected virtual void Shutdown(Akka.Actor.ActorSystem system, System.TimeSpan? duration = default, bool verifySystemShutdown = false) { }
+        public bool TryPeekOne(out Akka.TestKit.MessageEnvelope envelope, System.TimeSpan? max, System.Threading.CancellationToken cancellationToken) { }
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "success",
                 "envelope"})]
-        public System.Threading.Tasks.ValueTask<System.ValueTuple<bool, Akka.TestKit.MessageEnvelope>> TryPeekOneAsync(System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken) { }
-        public bool TryReceiveOne(out Akka.TestKit.MessageEnvelope envelope, System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
-        [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+        public System.Threading.Tasks.ValueTask<System.ValueTuple<bool, Akka.TestKit.MessageEnvelope>> TryPeekOneAsync(System.TimeSpan? max, System.Threading.CancellationToken cancellationToken) { }
+        public bool TryReceiveOne(out Akka.TestKit.MessageEnvelope envelope, System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "success",
                 "envelope"})]
-        public System.Threading.Tasks.ValueTask<System.ValueTuple<bool, Akka.TestKit.MessageEnvelope>> TryReceiveOneAsync(System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<System.ValueTuple<bool, Akka.TestKit.MessageEnvelope>> TryReceiveOneAsync(System.TimeSpan? max, System.Threading.CancellationToken cancellationToken = default) { }
         public Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef actorToUnwatch) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> UnwatchAsync(Akka.Actor.IActorRef actorToUnwatch) { }
-        public System.Threading.Tasks.Task<System.Collections.ArrayList> WaitForRadioSilenceAsync(System.Nullable<System.TimeSpan> max = null, System.Nullable<uint> maxMessages = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<System.Collections.ArrayList> WaitForRadioSilenceAsync(System.TimeSpan? max = default, uint? maxMessages = default, System.Threading.CancellationToken cancellationToken = default) { }
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef actorToWatch) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> WatchAsync(Akka.Actor.IActorRef actorToWatch) { }
-        public void Within(System.TimeSpan max, System.Action action, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Within(System.TimeSpan min, System.TimeSpan max, System.Action action, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Within<T>(System.TimeSpan max, System.Func<T> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Within<T>(System.TimeSpan min, System.TimeSpan max, System.Func<T> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public void Within(System.TimeSpan max, System.Action action, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public void Within(System.TimeSpan min, System.TimeSpan max, System.Action action, string hint = null, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public T Within<T>(System.TimeSpan max, System.Func<T> function, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public T Within<T>(System.TimeSpan min, System.TimeSpan max, System.Func<T> function, string hint = null, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, string hint = null, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, string hint = null, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        protected static bool InternalAwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval, System.Action<string, object[]> fail, System.Threading.CancellationToken cancellationToken = default) { }
+        protected static bool InternalAwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval, System.Action<string, object[]> fail, Akka.Event.ILoggingAdapter logger, System.Threading.CancellationToken cancellationToken = default) { }
+        protected static System.Threading.Tasks.Task<bool> InternalAwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval, System.Action<string, object[]> fail, System.Threading.CancellationToken cancellationToken = default) { }
+        protected static System.Threading.Tasks.Task<bool> InternalAwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval, System.Action<string, object[]> fail, Akka.Event.ILoggingAdapter logger, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class TestKitExtension : Akka.Actor.ExtensionIdProvider<Akka.TestKit.TestKitSettings>
     {
@@ -549,7 +525,7 @@ namespace Akka.TestKit
     }
     public class TestLatch
     {
-        [System.ObsoleteAttribute("This field will be removed. TestKitSettings.DefaultTimeout is an alternative.")]
+        [System.Obsolete("This field will be removed. TestKitSettings.DefaultTimeout is an alternative.")]
         public static readonly System.TimeSpan DefaultTimeout;
         public TestLatch() { }
         public TestLatch(int count) { }
@@ -558,8 +534,8 @@ namespace Akka.TestKit
         public bool IsOpen { get; }
         public void CountDown() { }
         public void Open() { }
-        public void Ready(System.TimeSpan timeout) { }
         public void Ready() { }
+        public void Ready(System.TimeSpan timeout) { }
         public void Reset() { }
     }
     public class TestProbe : Akka.TestKit.TestKitBase, Akka.Actor.IActorRef, Akka.Actor.IActorRefScope, Akka.Actor.ICanTell, Akka.Actor.IInternalActorRef, Akka.TestKit.INoImplicitSender, Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.IActorRef>, System.IEquatable<Akka.Actor.IActorRef>
@@ -567,33 +543,33 @@ namespace Akka.TestKit
         public TestProbe(Akka.Actor.ActorSystem system, Akka.TestKit.ITestKitAssertions assertions, string testProbeName = null) { }
         public Akka.Actor.IActorRef Ref { get; }
         public Akka.Actor.IActorRef Sender { get; }
-        public Akka.Actor.IActorRef ChildActorOf<T>(string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null)
+        public Akka.Actor.IActorRef ChildActorOf<T>(System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public Akka.Actor.IActorRef ChildActorOf<T>(Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null)
+        public Akka.Actor.IActorRef ChildActorOf<T>(Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public Akka.Actor.IActorRef ChildActorOf<T>(string name, System.Threading.CancellationToken cancellationToken = null)
+        public Akka.Actor.IActorRef ChildActorOf<T>(string name, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public Akka.Actor.IActorRef ChildActorOf<T>(System.Threading.CancellationToken cancellationToken = null)
+        public Akka.Actor.IActorRef ChildActorOf<T>(string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null)
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null)
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(string name, System.Threading.CancellationToken cancellationToken = null)
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(string name, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(System.Threading.CancellationToken cancellationToken = null)
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
         public int CompareTo(object obj) { }
-        [System.ObsoleteAttribute("Cannot create a TestProbe from a TestProbe", true)]
+        [System.Obsolete("Cannot create a TestProbe from a TestProbe", true)]
         public override Akka.TestKit.TestProbe CreateTestProbe(string name = null) { }
         public override bool Equals(object obj) { }
-        public void Forward(Akka.Actor.IActorRef actor, object message) { }
         public void Forward(Akka.Actor.IActorRef actor) { }
+        public void Forward(Akka.Actor.IActorRef actor, object message) { }
         public override int GetHashCode() { }
         public void Reply(object message) { }
         public void Send(Akka.Actor.IActorRef actor, object message) { }
-        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
+        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public override string ToString() { }
     }
     public class TestScheduler : Akka.Actor.IActionScheduler, Akka.Actor.IAdvancedScheduler, Akka.Actor.IRunnableScheduler, Akka.Actor.IScheduler, Akka.Actor.ITellScheduler, Akka.Actor.ITimeProvider
@@ -606,14 +582,14 @@ namespace Akka.TestKit
         protected System.DateTimeOffset TimeNow { get; }
         public void Advance(System.TimeSpan offset) { }
         public void AdvanceTo(System.DateTimeOffset when) { }
-        public void ScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable) { }
+        public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action) { }
         public void ScheduleOnce(System.TimeSpan delay, System.Action action) { }
         public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
-        public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action) { }
-        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable) { }
+        public void ScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable) { }
+        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action) { }
         public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action) { }
         public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
-        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action) { }
+        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable) { }
         public void ScheduleTellOnce(System.TimeSpan delay, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender) { }
         public void ScheduleTellOnce(System.TimeSpan delay, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable) { }
         public void ScheduleTellRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender) { }
@@ -622,8 +598,7 @@ namespace Akka.TestKit
 }
 namespace Akka.TestKit.Configs
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static TestConfigs
+    public static class TestConfigs
     {
         public static Akka.Configuration.Config DefaultConfig { get; }
         public static Akka.Configuration.Config TestSchedulerConfig { get; }
@@ -631,96 +606,87 @@ namespace Akka.TestKit.Configs
 }
 namespace Akka.TestKit.Extensions
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static TaskExtensions
+    public static class TaskExtensions
     {
-        public static System.Threading.Tasks.Task<bool> AwaitWithTimeout(this System.Threading.Tasks.Task parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = null) { }
-        public static System.Threading.Tasks.Task<T> WithTimeout<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(this System.Threading.Tasks.Task<T> parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = null) { }
+        public static System.Threading.Tasks.Task<bool> AwaitWithTimeout(this System.Threading.Tasks.Task parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<T> WithTimeout<T>(this System.Threading.Tasks.Task<T> parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = default) { }
     }
 }
 namespace Akka.TestKit.Internal
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class CustomEventFilter : Akka.TestKit.Internal.EventFilterBase
     {
         public CustomEventFilter(System.Predicate<Akka.Event.LogEvent> predicate) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class DebugFilter : Akka.TestKit.Internal.EventFilterBase
     {
-        public DebugFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher = null) { }
+        public DebugFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher = null) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ErrorFilter : Akka.TestKit.Internal.EventFilterBase
     {
-        public ErrorFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher = null) { }
-        public ErrorFilter(System.Type exceptionType, Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher = null, bool recurseInnerExceptions = False) { }
-        [System.Runtime.CompilerServices.NullableAttribute(1)]
+        public ErrorFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher = null) { }
+        public ErrorFilter(System.Type? exceptionType, Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher = null, bool recurseInnerExceptions = false) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class EventFilterBase : Akka.TestKit.IEventFilter
     {
-        protected EventFilterBase(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher) { }
+        protected EventFilterBase(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher) { }
         protected abstract string FilterDescriptiveName { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public event Akka.TestKit.Internal.EventMatched EventMatched;
+        public event Akka.TestKit.Internal.EventMatched? EventMatched;
         public bool Apply(Akka.Event.LogEvent logEvent) { }
-        protected bool InternalDoMatch(string src, [System.Runtime.CompilerServices.NullableAttribute(2)] object msg) { }
+        protected bool InternalDoMatch(string src, object? msg) { }
         protected abstract bool IsMatch(Akka.Event.LogEvent evt);
         protected virtual void OnEventMatched(Akka.Event.LogEvent logEvent) { }
         public override string ToString() { }
     }
     public delegate void EventMatched(Akka.TestKit.Internal.EventFilterBase eventFilter, Akka.Event.LogEvent logEvent);
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class InfoFilter : Akka.TestKit.Internal.EventFilterBase
     {
-        public InfoFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher = null) { }
+        public InfoFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher = null) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class InternalEventFilterApplier : Akka.TestKit.IEventFilterApplier
     {
         public InternalEventFilterApplier(Akka.TestKit.TestKitBase testkit, Akka.Actor.ActorSystem system, System.Collections.Generic.IReadOnlyList<Akka.TestKit.Internal.EventFilterBase> filters) { }
         public Akka.TestKit.EventFilterFactory And { get; }
-        protected bool AwaitDone(System.TimeSpan timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = null) { }
-        protected System.Threading.Tasks.Task<bool> AwaitDoneAsync(System.TimeSpan timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Expect<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Expect<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectOne<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectOne<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.ObsoleteAttribute("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
+        protected bool AwaitDone(System.TimeSpan timeout, int? expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = default) { }
+        protected System.Threading.Tasks.Task<bool> AwaitDoneAsync(System.TimeSpan timeout, int? expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = default) { }
+        public void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public T Expect<T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public T Expect<T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.TimeSpan? timeout, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectOne<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectOne<T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default) { }
+        [System.Obsolete("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
             "ead beginning in Akka.NET v1.5")]
-        public System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectOneAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectOneAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        protected static string GetMessageString(int number) { }
-        protected T Intercept<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func, Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> timeout, System.Nullable<int> expectedOccurrences, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = null) { }
-        protected System.Threading.Tasks.Task<T> InterceptAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<System.Threading.Tasks.Task<T>> func, Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> timeout, System.Nullable<int> expectedOccurrences, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Mute<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Mute(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default) { }
+        protected T Intercept<T>(System.Func<T> func, Akka.Actor.ActorSystem system, System.TimeSpan? timeout, int? expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler? matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = default) { }
+        protected System.Threading.Tasks.Task<T> InterceptAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, Akka.Actor.ActorSystem system, System.TimeSpan? timeout, int? expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler? matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = default) { }
         public Akka.TestKit.IUnmutableFilter Mute() { }
-        public System.Threading.Tasks.Task<T> MuteAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task MuteAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task MuteAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
+        public void Mute(System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public T Mute<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task MuteAsync(System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task MuteAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> MuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default) { }
+        protected static string GetMessageString(int number) { }
         protected class InternalUnmutableFilter : Akka.TestKit.IUnmutableFilter, System.IDisposable
         {
             public InternalUnmutableFilter(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.Internal.EventFilterBase> filters, Akka.Actor.ActorSystem system) { }
@@ -735,78 +701,70 @@ namespace Akka.TestKit.Internal
             public virtual void HandleEvent(Akka.TestKit.Internal.EventFilterBase eventFilter, Akka.Event.LogEvent logEvent) { }
         }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class InternalTestActorRef : Akka.Actor.LocalActorRef
     {
         public object UnderlyingActor { get; }
-        public static Akka.TestKit.Internal.InternalTestActorRef Create(Akka.Actor.ActorSystem system, Akka.Actor.Props props, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Actor.IActorRef supervisor = null, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null) { }
-        public static string CreateUniqueName() { }
         protected Akka.TestKit.Internal.InternalTestActorRef.TestActorCell GetTestActorCell() { }
         protected override Akka.Actor.ActorCell NewActorCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.IInternalActorRef self, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Actor.IInternalActorRef supervisor) { }
-        public void Receive(object message, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Actor.IActorRef sender = null) { }
-        public System.Threading.Tasks.Task ReceiveAsync(object message, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Actor.IActorRef sender = null) { }
+        public void Receive(object message, Akka.Actor.IActorRef? sender = null) { }
+        public System.Threading.Tasks.Task ReceiveAsync(object message, Akka.Actor.IActorRef? sender = null) { }
         public override string ToString() { }
         public void Unwatch(Akka.Actor.IActorRef subject) { }
         public void Watch(Akka.Actor.IActorRef subject) { }
+        public static Akka.TestKit.Internal.InternalTestActorRef Create(Akka.Actor.ActorSystem system, Akka.Actor.Props props, Akka.Actor.IActorRef? supervisor = null, string? name = null) { }
+        public static string CreateUniqueName() { }
         public class InternalGetActor : Akka.Actor.IAutoReceivedMessage, Akka.Actor.IPossiblyHarmful
         {
-            [System.Runtime.CompilerServices.NullableAttribute(1)]
             public static readonly Akka.TestKit.Internal.InternalTestActorRef.InternalGetActor Instance;
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         protected class TestActorCell : Akka.Actor.ActorCell
         {
             public TestActorCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.IInternalActorRef self, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Actor.IInternalActorRef parent) { }
-            [System.Runtime.CompilerServices.NullableAttribute(2)]
-            public object Actor { get; }
+            public new object? Actor { get; }
             public override Akka.Dispatch.ActorTaskScheduler TaskScheduler { get; }
             protected override void AutoReceiveMessage(Akka.Actor.Envelope envelope) { }
             public System.Threading.Tasks.Task ReceiveMessageForTestAsync(Akka.Actor.Envelope envelope) { }
             public System.Threading.Tasks.Task UseThreadContextAsync(System.Func<System.Threading.Tasks.Task> actionAsync) { }
         }
     }
-    public class static TimeSpanExtensions
+    public static class TimeSpanExtensions
     {
         public static void EnsureIsPositiveFinite(this System.TimeSpan timeSpan, string parameterName) { }
         public static bool IsInfinite(this System.TimeSpan timeSpan) { }
-        public static bool IsInfinite(this System.Nullable<System.TimeSpan> timeSpan) { }
+        public static bool IsInfinite(this System.TimeSpan? timeSpan) { }
         public static bool IsInfiniteTimeout(this System.TimeSpan timeSpan) { }
-        public static bool IsInfiniteTimeout(this System.Nullable<System.TimeSpan> timeSpan) { }
+        public static bool IsInfiniteTimeout(this System.TimeSpan? timeSpan) { }
         public static bool IsPositiveFinite(this System.TimeSpan timeSpan) { }
-        public static bool IsPositiveFinite(this System.Nullable<System.TimeSpan> timeSpan) { }
-        public static bool IsUndefined(this System.Nullable<System.TimeSpan> timeSpan) { }
+        public static bool IsPositiveFinite(this System.TimeSpan? timeSpan) { }
+        public static bool IsUndefined(this System.TimeSpan? timeSpan) { }
         public static bool IsZero(this System.TimeSpan timeSpan) { }
-        public static bool IsZero(this System.Nullable<System.TimeSpan> timeSpan) { }
-        public static System.TimeSpan Min(this System.TimeSpan a, System.Nullable<System.TimeSpan> b) { }
+        public static bool IsZero(this System.TimeSpan? timeSpan) { }
+        public static System.TimeSpan Min(this System.TimeSpan a, System.TimeSpan? b) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class WarningFilter : Akka.TestKit.Internal.EventFilterBase
     {
-        public WarningFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher = null) { }
+        public WarningFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher = null) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
 }
 namespace Akka.TestKit.Internal.StringMatcher
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ContainsString : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public ContainsString(string part) { }
         public bool IsMatch(string s) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class EqualsString : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public EqualsString(string s) { }
         public bool IsMatch(string s) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class EqualsStringAndPathMatcher : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
-        public EqualsStringAndPathMatcher(string path, bool canBeRelative = True) { }
+        public EqualsStringAndPathMatcher(string path, bool canBeRelative = true) { }
         public bool IsMatch(string path) { }
         public override string ToString() { }
     }
@@ -814,28 +772,24 @@ namespace Akka.TestKit.Internal.StringMatcher
     {
         bool IsMatch(string s);
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class MatchesAll : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public static Akka.TestKit.Internal.StringMatcher.IStringMatcher Instance { get; }
         public bool IsMatch(string s) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class PredicateMatcher : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public PredicateMatcher(System.Predicate<string> predicate, string hint = "") { }
         public bool IsMatch(string s) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class RegexMatcher : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public RegexMatcher(System.Text.RegularExpressions.Regex regex) { }
         public bool IsMatch(string s) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class StartsWithString : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public StartsWithString(string start) { }
@@ -845,20 +799,17 @@ namespace Akka.TestKit.Internal.StringMatcher
 }
 namespace Akka.TestKit.TestActors
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class BlackHoleActor : Akka.Actor.ActorBase
     {
         public BlackHoleActor() { }
         public static Akka.Actor.Props Props { get; }
         protected override bool Receive(object message) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class EchoActor : Akka.Actor.ReceiveActor
     {
-        public EchoActor(Akka.TestKit.TestKitBase testkit, bool echoBackToSenderAsWell = True) { }
-        public static Akka.Actor.Props Props(Akka.TestKit.TestKitBase testkit, bool echoBackToSenderAsWell = True) { }
+        public EchoActor(Akka.TestKit.TestKitBase testkit, bool echoBackToSenderAsWell = true) { }
+        public static Akka.Actor.Props Props(Akka.TestKit.TestKitBase testkit, bool echoBackToSenderAsWell = true) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ForwardActor : Akka.Actor.ReceiveActor
     {
         public ForwardActor(Akka.Actor.IActorRef target) { }
@@ -876,14 +827,12 @@ namespace Akka.TestKit.TestActors
 }
 namespace Akka.TestKit.TestEvent
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class Mute : Akka.Actor.INoSerializationVerificationNeeded
     {
         public Mute(params Akka.TestKit.Internal.EventFilterBase[] filters) { }
         public Mute(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.Internal.EventFilterBase> filters) { }
         public System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.Internal.EventFilterBase> Filters { get; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class Unmute : Akka.Actor.INoSerializationVerificationNeeded
     {
         public Unmute(params Akka.TestKit.Internal.EventFilterBase[] filters) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.Net.verified.txt
@@ -1,7 +1,7 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("ae01b790-1478-4917-9299-b4855ba997cb")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("ae01b790-1478-4917-9299-b4855ba997cb")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.TestKit
 {
     public abstract class AutoPilot
@@ -24,12 +24,9 @@ namespace Akka.TestKit
         public CallingThreadDispatcherConfigurator(Akka.Configuration.Config config, Akka.Dispatch.IDispatcherPrerequisites prerequisites) { }
         public override Akka.Dispatch.MessageDispatcher Dispatcher() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class DeadLettersFilter : Akka.TestKit.Internal.EventFilterBase
     {
-        public DeadLettersFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher, [System.Runtime.CompilerServices.NullableAttribute(new byte[] {
-                2,
-                1})] System.Predicate<Akka.Event.DeadLetter> isMatch = null) { }
+        public DeadLettersFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher, System.Predicate<Akka.Event.DeadLetter>? isMatch = null) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
@@ -48,49 +45,39 @@ namespace Akka.TestKit
         public override Akka.Util.ISurrogate ToSurrogate(Akka.Actor.ActorSystem system) { }
         public void Update(Akka.Actor.IActorRef child, Akka.Actor.SupervisorStrategy supervisorStrategy) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class EventFilterFactory
     {
         public EventFilterFactory(Akka.TestKit.TestKitBase testkit) { }
         public EventFilterFactory(Akka.TestKit.TestKitBase testkit, Akka.Actor.ActorSystem system) { }
         public EventFilterFactory(Akka.TestKit.TestKitBase testkit, Akka.Actor.ActorSystem actorSystem, System.Collections.Generic.IReadOnlyList<Akka.TestKit.Internal.EventFilterBase> filters) { }
         protected Akka.TestKit.IEventFilterApplier CreateApplier(Akka.TestKit.Internal.EventFilterBase filter, Akka.Actor.ActorSystem system) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        protected static Akka.TestKit.Internal.StringMatcher.IStringMatcher CreateMessageMatcher(string message, string start, string contains) { }
         public Akka.TestKit.IEventFilterApplier Custom(System.Predicate<Akka.Event.LogEvent> predicate) { }
-        public Akka.TestKit.IEventFilterApplier Custom<[System.Runtime.CompilerServices.NullableAttribute(0)]  TLogEvent>(System.Predicate<TLogEvent> predicate)
+        public Akka.TestKit.IEventFilterApplier Custom<TLogEvent>(System.Predicate<TLogEvent> predicate)
             where TLogEvent : Akka.Event.LogEvent { }
         public Akka.TestKit.IEventFilterApplier DeadLetter() { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier DeadLetter<TMessage>(string source = null) { }
-        public Akka.TestKit.IEventFilterApplier DeadLetter<[System.Runtime.CompilerServices.NullableAttribute(2)]  TMessage>(System.Func<TMessage, bool> isMatch, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        public Akka.TestKit.IEventFilterApplier DeadLetter(System.Type type, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        public Akka.TestKit.IEventFilterApplier DeadLetter(System.Type type, System.Func<object, bool> isMatch, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Debug(string message = null, string start = null, string contains = null, string source = null) { }
-        public Akka.TestKit.IEventFilterApplier Debug(System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Error(string message = null, string start = null, string contains = null, string source = null) { }
-        public Akka.TestKit.IEventFilterApplier Error(System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        public Akka.TestKit.IEventFilterApplier Exception<[System.Runtime.CompilerServices.NullableAttribute(0)]  TException>(System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null)
+        public Akka.TestKit.IEventFilterApplier DeadLetter(System.Type type, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier DeadLetter(System.Type type, System.Func<object, bool> isMatch, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier DeadLetter<TMessage>(string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier DeadLetter<TMessage>(System.Func<TMessage, bool> isMatch, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Debug(System.Text.RegularExpressions.Regex pattern, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Debug(string? message = null, string? start = null, string? contains = null, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Error(System.Text.RegularExpressions.Regex pattern, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Error(string? message = null, string? start = null, string? contains = null, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Exception(System.Type exceptionType, System.Text.RegularExpressions.Regex pattern, string? source = null, bool checkInnerExceptions = false) { }
+        public Akka.TestKit.IEventFilterApplier Exception(System.Type exceptionType, string? message = null, string? start = null, string? contains = null, string? source = null, bool checkInnerExceptions = false) { }
+        public Akka.TestKit.IEventFilterApplier Exception<TException>(System.Text.RegularExpressions.Regex pattern, string? source = null)
             where TException : System.Exception { }
-        public Akka.TestKit.IEventFilterApplier Exception(System.Type exceptionType, System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null, bool checkInnerExceptions = False) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Exception<[System.Runtime.CompilerServices.NullableAttribute(0)]  TException>(string message = null, string start = null, string contains = null, string source = null)
+        public Akka.TestKit.IEventFilterApplier Exception<TException>(string? message = null, string? start = null, string? contains = null, string? source = null)
             where TException : System.Exception { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Exception([System.Runtime.CompilerServices.NullableAttribute(1)] System.Type exceptionType, string message = null, string start = null, string contains = null, string source = null, bool checkInnerExceptions = False) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier ForLogLevel(Akka.Event.LogLevel logLevel, string message = null, string start = null, string contains = null, string source = null) { }
-        public Akka.TestKit.IEventFilterApplier ForLogLevel(Akka.Event.LogLevel logLevel, System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Info(string message = null, string start = null, string contains = null, string source = null) { }
-        public Akka.TestKit.IEventFilterApplier Info(System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public Akka.TestKit.IEventFilterApplier Warning(string message = null, string start = null, string contains = null, string source = null) { }
-        public Akka.TestKit.IEventFilterApplier Warning(System.Text.RegularExpressions.Regex pattern, [System.Runtime.CompilerServices.NullableAttribute(2)] string source = null) { }
+        public Akka.TestKit.IEventFilterApplier ForLogLevel(Akka.Event.LogLevel logLevel, System.Text.RegularExpressions.Regex pattern, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier ForLogLevel(Akka.Event.LogLevel logLevel, string? message = null, string? start = null, string? contains = null, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Info(System.Text.RegularExpressions.Regex pattern, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Info(string? message = null, string? start = null, string? contains = null, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Warning(System.Text.RegularExpressions.Regex pattern, string? source = null) { }
+        public Akka.TestKit.IEventFilterApplier Warning(string? message = null, string? start = null, string? contains = null, string? source = null) { }
+        protected static Akka.TestKit.Internal.StringMatcher.IStringMatcher CreateMessageMatcher(string? message, string? start, string? contains) { }
     }
-    public class static FSMSpecHelpers
+    public static class FSMSpecHelpers
     {
         public static System.Func<object, object, bool> CurrentStateExpector<TS>() { }
         public static System.Func<object, object, bool> TransitionStateExpector<TS>() { }
@@ -102,37 +89,37 @@ namespace Akka.TestKit
     public interface IEventFilterApplier
     {
         Akka.TestKit.EventFilterFactory And { get; }
-        void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        T Expect<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        T Expect<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
-        [System.ObsoleteAttribute("Use ExpectAsync<T>(expectedCount, TimeSpan, Func<Task<T>>) instead. This method o" +
+        void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        T Expect<T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default);
+        T Expect<T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.TimeSpan? timeout, System.Threading.CancellationToken cancellationToken = default);
+        [System.Obsolete("Use ExpectAsync<T>(expectedCount, TimeSpan, Func<Task<T>>) instead. This method o" +
             "nly exists to support backwards compatibility as of Akka.NET v1.5.")]
-        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        T ExpectOne<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        T ExpectOne<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
-        [System.ObsoleteAttribute("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default);
+        void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        T ExpectOne<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = default);
+        T ExpectOne<T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default);
+        [System.Obsolete("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
             "ead beginning in Akka.NET v1.5")]
-        System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectOneAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task<T> ExpectOneAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        T Mute<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null);
-        void Mute(System.Action action, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default);
         Akka.TestKit.IUnmutableFilter Mute();
-        System.Threading.Tasks.Task<T> MuteAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null);
-        System.Threading.Tasks.Task MuteAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null);
-        [System.ObsoleteAttribute("Use MuteAsync(Func<Task>) instead. This method only exists for backwards compatib" +
+        void Mute(System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        T Mute<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = default);
+        [System.Obsolete("Use MuteAsync(Func<Task>) instead. This method only exists for backwards compatib" +
             "ility as of Akka.NET v1.5.0.")]
-        System.Threading.Tasks.Task MuteAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task MuteAsync(System.Action action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task MuteAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<T> MuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default);
     }
     public interface INoImplicitSender { }
     public interface ITestKitAssertions
@@ -180,13 +167,13 @@ namespace Akka.TestKit
     {
         public System.Delegate PredicateT { get; }
         public System.Type Type { get; }
-        public static Akka.TestKit.PredicateInfo Create<T>(System.Predicate<T> predicateT) { }
         public override string ToString() { }
+        public static Akka.TestKit.PredicateInfo Create<T>(System.Predicate<T> predicateT) { }
     }
-    public class static PredicateInfoFactory
+    public static class PredicateInfoFactory
     {
-        public static Akka.TestKit.PredicateInfo CreatePredicateInfo<T>(this System.Predicate<T> predicateT) { }
         public static Akka.TestKit.PredicateInfo CreatePredicateInfo<T>(this System.Delegate predicateT) { }
+        public static Akka.TestKit.PredicateInfo CreatePredicateInfo<T>(this System.Predicate<T> predicateT) { }
     }
     public class RealMessageEnvelope : Akka.TestKit.MessageEnvelope
     {
@@ -195,12 +182,11 @@ namespace Akka.TestKit
         public override Akka.Actor.IActorRef Sender { get; }
         public override string ToString() { }
     }
-    public class static TestActor
+    public static class TestActor
     {
         public static Akka.TestKit.AutoPilot KeepRunning { get; }
         public static Akka.TestKit.AutoPilot NoAutoPilot { get; }
         public static Akka.TestKit.NullMessageEnvelope NullMessage { get; }
-        public delegate bool Ignore(object message);
         public class SetAutoPilot : Akka.Actor.INoSerializationVerificationNeeded
         {
             public SetAutoPilot(Akka.TestKit.AutoPilot autoPilot) { }
@@ -229,6 +215,7 @@ namespace Akka.TestKit
             public Watch(Akka.Actor.IActorRef actorToWatch) { }
             public Akka.Actor.IActorRef Actor { get; }
         }
+        public delegate bool Ignore(object message);
     }
     public abstract class TestActorRefBase<TActor> : Akka.Actor.IActorRef, Akka.Actor.IActorRefScope, Akka.Actor.ICanTell, Akka.Actor.IInternalActorRef, Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.IActorRef>, System.IEquatable<Akka.Actor.IActorRef>
         where TActor : Akka.Actor.ActorBase
@@ -239,39 +226,39 @@ namespace Akka.TestKit
         public Akka.Actor.IActorRef Ref { get; }
         public TActor UnderlyingActor { get; }
         public int CompareTo(object obj) { }
-        public override bool Equals(object obj) { }
         public bool Equals(Akka.Actor.IActorRef other) { }
+        public override bool Equals(object obj) { }
         public void Forward(object message) { }
         public override int GetHashCode() { }
         public void Receive(object message, Akka.Actor.IActorRef sender = null) { }
         public System.Threading.Tasks.Task ReceiveAsync(object message, Akka.Actor.IActorRef sender = null) { }
-        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
+        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public void Tell(object message) { }
         public void Tell(object message, Akka.Actor.IActorRef sender) { }
-        public static Akka.Actor.IActorRef ToActorRef(Akka.TestKit.TestActorRefBase<TActor> actorRef) { }
         public override string ToString() { }
         public void Unwatch(Akka.Actor.IActorRef subject) { }
         public void Watch(Akka.Actor.IActorRef subject) { }
-        public static bool ==(Akka.TestKit.TestActorRefBase<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
-        public static bool ==(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRefBase<TActor> testActorRef) { }
-        public static bool !=(Akka.TestKit.TestActorRefBase<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
-        public static bool !=(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRefBase<TActor> testActorRef) { }
+        public static Akka.Actor.IActorRef ToActorRef(Akka.TestKit.TestActorRefBase<TActor> actorRef) { }
+        public static bool operator !=(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRefBase<TActor> testActorRef) { }
+        public static bool operator !=(Akka.TestKit.TestActorRefBase<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
+        public static bool operator ==(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRefBase<TActor> testActorRef) { }
+        public static bool operator ==(Akka.TestKit.TestActorRefBase<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
     }
     public class TestActorRef<TActor> : Akka.TestKit.TestActorRefBase<TActor>
         where TActor : Akka.Actor.ActorBase
     {
         public TestActorRef(Akka.Actor.ActorSystem system, Akka.Actor.Props actorProps, Akka.Actor.IActorRef supervisor = null, string name = null) { }
-        public static bool ==(Akka.TestKit.TestActorRef<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
-        public static bool ==(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRef<TActor> testActorRef) { }
-        public static bool !=(Akka.TestKit.TestActorRef<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
-        public static bool !=(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRef<TActor> testActorRef) { }
+        public static bool operator !=(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRef<TActor> testActorRef) { }
+        public static bool operator !=(Akka.TestKit.TestActorRef<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
+        public static bool operator ==(Akka.Actor.IActorRef actorRef, Akka.TestKit.TestActorRef<TActor> testActorRef) { }
+        public static bool operator ==(Akka.TestKit.TestActorRef<TActor> testActorRef, Akka.Actor.IActorRef actorRef) { }
     }
     public class TestBarrier
     {
-        [System.ObsoleteAttribute("This field will be removed in future versions.")]
+        [System.Obsolete("This field will be removed in future versions.")]
         public static readonly System.TimeSpan DefaultTimeout;
-        public TestBarrier(Akka.TestKit.TestKitBase testKit, int count, System.Nullable<System.TimeSpan> defaultTimeout = null) { }
+        public TestBarrier(Akka.TestKit.TestKitBase testKit, int count, System.TimeSpan? defaultTimeout = default) { }
         public void Await() { }
         public void Await(System.TimeSpan timeout) { }
         public void Reset() { }
@@ -284,7 +271,6 @@ namespace Akka.TestKit
         public Akka.Pattern.CircuitBreaker Instance { get; }
         public System.Threading.CountdownEvent OpenLatch { get; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class TestEventListener : Akka.Event.DefaultLogger
     {
         public TestEventListener() { }
@@ -293,17 +279,17 @@ namespace Akka.TestKit
     public class TestFSMRef<TActor, TState, TData> : Akka.TestKit.TestActorRefBase<TActor>
         where TActor : Akka.Actor.FSM<TState, TData>
     {
-        public TestFSMRef(Akka.Actor.ActorSystem system, Akka.Actor.Props props, Akka.Actor.IActorRef supervisor = null, string name = null, bool activateLogging = False) { }
+        public TestFSMRef(Akka.Actor.ActorSystem system, Akka.Actor.Props props, Akka.Actor.IActorRef supervisor = null, string name = null, bool activateLogging = false) { }
         public TData StateData { get; }
         public TState StateName { get; }
         public void CancelTimer(string name) { }
         public bool IsStateTimerActive() { }
         public bool IsTimerActive(string name) { }
-        public void SetState(TState stateName, System.Nullable<System.TimeSpan> timeout = null) { }
-        public void SetState(TState stateName, TData stateData, System.Nullable<System.TimeSpan> timeout = null, Akka.Actor.FSMBase.Reason stopReason = null) { }
-        public void SetStateData(TData stateData, System.Nullable<System.TimeSpan> timeout = null) { }
+        public void SetState(TState stateName, System.TimeSpan? timeout = default) { }
+        public void SetState(TState stateName, TData stateData, System.TimeSpan? timeout = default, Akka.Actor.FSMBase.Reason stopReason = null) { }
+        public void SetStateData(TData stateData, System.TimeSpan? timeout = default) { }
         public void SetStateTimeout(System.TimeSpan timeout) { }
-        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = False) { }
+        public void SetTimer(string name, object msg, System.TimeSpan timeout, bool repeat = false) { }
     }
     public class TestKitAssertionsExtension : Akka.Actor.ExtensionIdProvider<Akka.TestKit.TestKitAssertionsProvider>
     {
@@ -322,84 +308,84 @@ namespace Akka.TestKit
         protected TestKitBase(Akka.TestKit.ITestKitAssertions assertions, Akka.Actor.Setup.ActorSystemSetup setup, string actorSystemName = null, string testActorName = null) { }
         protected TestKitBase(Akka.TestKit.ITestKitAssertions assertions, Akka.Configuration.Config config, string actorSystemName = null, string testActorName = null) { }
         protected TestKitBase(Akka.TestKit.ITestKitAssertions assertions, Akka.Actor.ActorSystem system, Akka.Actor.Setup.ActorSystemSetup config, string actorSystemName, string testActorName) { }
-        public static Akka.Configuration.Config DefaultConfig { get; }
         public Akka.TestKit.EventFilterFactory EventFilter { get; }
-        public static Akka.Configuration.Config FullDebugConfig { get; }
         public bool HasMessages { get; }
         public object LastMessage { get; }
         public Akka.Actor.IActorRef LastSender { get; }
         public Akka.Event.ILoggingAdapter Log { get; }
         public System.TimeSpan NoMessageRemainingOrDefault { get; }
-        public static System.TimeSpan Now { get; }
         public System.TimeSpan Remaining { get; }
         public System.TimeSpan RemainingOrDefault { get; }
         public Akka.Actor.ActorSystem Sys { get; }
         public Akka.Actor.IActorRef TestActor { get; }
         public Akka.TestKit.TestKitSettings TestKitSettings { get; }
+        public static Akka.Configuration.Config DefaultConfig { get; }
+        public static Akka.Configuration.Config FullDebugConfig { get; }
+        public static System.TimeSpan Now { get; }
         public Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props) { }
         public Akka.Actor.IActorRef ActorOf(Akka.Actor.Props props, string name) { }
+        public Akka.Actor.IActorRef ActorOf(System.Action<Akka.Actor.Dsl.IActorDsl> configure, string name = null) { }
+        public Akka.Actor.IActorRef ActorOf(System.Action<Akka.Actor.Dsl.IActorDsl, Akka.Actor.IActorContext> configure, string name = null) { }
         public Akka.Actor.IActorRef ActorOf<TActor>()
-            where TActor : Akka.Actor.ActorBase, new () { }
-        public Akka.Actor.IActorRef ActorOf<TActor>(string name)
             where TActor : Akka.Actor.ActorBase, new () { }
         public Akka.Actor.IActorRef ActorOf<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory)
             where TActor : Akka.Actor.ActorBase { }
+        public Akka.Actor.IActorRef ActorOf<TActor>(string name)
+            where TActor : Akka.Actor.ActorBase, new () { }
         public Akka.Actor.IActorRef ActorOf<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, string name)
             where TActor : Akka.Actor.ActorBase { }
-        public Akka.Actor.IActorRef ActorOf(System.Action<Akka.Actor.Dsl.IActorDsl, Akka.Actor.IActorContext> configure, string name = null) { }
-        public Akka.Actor.IActorRef ActorOf(System.Action<Akka.Actor.Dsl.IActorDsl> configure, string name = null) { }
-        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Akka.Actor.Props props, Akka.Actor.IActorRef supervisor, string name = null)
-            where TActor : Akka.Actor.ActorBase { }
+        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(string name = null)
+            where TActor : Akka.Actor.ActorBase, new () { }
+        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Akka.Actor.IActorRef supervisor, string name = null)
+            where TActor : Akka.Actor.ActorBase, new () { }
         public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Akka.Actor.Props props, string name = null)
-            where TActor : Akka.Actor.ActorBase { }
-        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, Akka.Actor.IActorRef supervisor, string name = null)
             where TActor : Akka.Actor.ActorBase { }
         public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, string name = null)
             where TActor : Akka.Actor.ActorBase { }
-        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Akka.Actor.IActorRef supervisor, string name = null)
-            where TActor : Akka.Actor.ActorBase, new () { }
-        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(string name = null)
-            where TActor : Akka.Actor.ActorBase, new () { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.Props props, Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = False)
-            where TFsmActor : Akka.Actor.FSM<TState, TData> { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.Props props, string name = null, bool withLogging = False)
-            where TFsmActor : Akka.Actor.FSM<TState, TData> { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = False)
+        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(Akka.Actor.Props props, Akka.Actor.IActorRef supervisor, string name = null)
+            where TActor : Akka.Actor.ActorBase { }
+        public Akka.TestKit.TestActorRef<TActor> ActorOfAsTestActorRef<TActor>(System.Linq.Expressions.Expression<System.Func<TActor>> factory, Akka.Actor.IActorRef supervisor, string name = null)
+            where TActor : Akka.Actor.ActorBase { }
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(string name = null, bool withLogging = false)
             where TFsmActor : Akka.Actor.FSM<TState, TData>, new () { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(string name = null, bool withLogging = False)
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = false)
             where TFsmActor : Akka.Actor.FSM<TState, TData>, new () { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(System.Linq.Expressions.Expression<System.Func<TFsmActor>> factory, Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = False)
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.Props props, string name = null, bool withLogging = false)
             where TFsmActor : Akka.Actor.FSM<TState, TData> { }
-        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(System.Linq.Expressions.Expression<System.Func<TFsmActor>> factory, string name = null, bool withLogging = False)
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(System.Linq.Expressions.Expression<System.Func<TFsmActor>> factory, string name = null, bool withLogging = false)
+            where TFsmActor : Akka.Actor.FSM<TState, TData> { }
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(Akka.Actor.Props props, Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = false)
+            where TFsmActor : Akka.Actor.FSM<TState, TData> { }
+        public Akka.TestKit.TestFSMRef<TFsmActor, TState, TData> ActorOfAsTestFSMRef<TFsmActor, TState, TData>(System.Linq.Expressions.Expression<System.Func<TFsmActor>> factory, Akka.Actor.IActorRef supervisor, string name = null, bool withLogging = false)
             where TFsmActor : Akka.Actor.FSM<TState, TData> { }
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.ActorPath actorPath) { }
         public Akka.Actor.ActorSelection ActorSelection(string actorPath) { }
         public Akka.Actor.ActorSelection ActorSelection(Akka.Actor.IActorRef anchorRef, string actorPath) { }
-        public void AwaitAssert(System.Action assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitAssertAsync(System.Action assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitAssertAsync(System.Func<System.Threading.Tasks.Task> assertion, System.Nullable<System.TimeSpan> duration = null, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, string message, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> interval, string message = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public bool AwaitConditionNoThrow(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, string name, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, string name, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, System.Threading.CancellationToken cancellationToken = null) { }
+        public void AwaitAssert(System.Action assertion, System.TimeSpan? duration = default, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitAssertAsync(System.Action assertion, System.TimeSpan? duration = default, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitAssertAsync(System.Func<System.Threading.Tasks.Task> assertion, System.TimeSpan? duration = default, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = default) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan? max, System.Threading.CancellationToken cancellationToken = default) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan? max, string message, System.Threading.CancellationToken cancellationToken = default) { }
+        public void AwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan? max, System.TimeSpan? interval, string message = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan? max, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan? max, string message, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.TimeSpan? max, string message, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan? max, System.TimeSpan? interval, string message = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task AwaitConditionAsync(System.Func<bool> conditionIsFulfilled, System.TimeSpan? max, System.TimeSpan? interval, string message = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public bool AwaitConditionNoThrow(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<bool> AwaitConditionNoThrowAsync(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, System.Threading.CancellationToken cancellationToken = default) { }
+        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default) { }
+        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, string name, System.Threading.CancellationToken cancellationToken = default) { }
+        public Akka.Actor.IActorRef ChildActorOf(Akka.Actor.Props props, string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, string name, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync(Akka.Actor.Props props, string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default) { }
         public Akka.TestKit.EventFilterFactory CreateEventFilter(Akka.Actor.ActorSystem system) { }
         public Akka.Actor.IActorRef CreateTestActor(string name) { }
         public Akka.TestKit.TestBarrier CreateTestBarrier(int count) { }
@@ -407,128 +393,118 @@ namespace Akka.TestKit
         public virtual Akka.TestKit.TestProbe CreateTestProbe(string name = null) { }
         public virtual Akka.TestKit.TestProbe CreateTestProbe(Akka.Actor.ActorSystem system, string name = null) { }
         public System.TimeSpan Dilated(System.TimeSpan duration) { }
-        public T ExpectMsg<T>(System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Action<T> assert, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsg<T>(T expected, System.Func<T, T, bool> comparer, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public T ExpectMsg<T>(System.TimeSpan? duration = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(System.Action<T> assert, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(T message, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsg<T>(T expected, System.Func<T, T, bool> comparer, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(params T[] messages) { }
-        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, params T[] messages) { }
-        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__157<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__160<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(params Akka.TestKit.PredicateInfo[] predicates) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, params Akka.TestKit.PredicateInfo[] predicates) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__167))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__170))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgAnyOf<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAnyOfAsync<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T> assert, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T expected, System.Func<T, T, bool> comparer, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectMsgFrom<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Nullable<System.TimeSpan> duration = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, T message, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectNoMsg(System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectNoMsg(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectNoMsg(int milliseconds, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(int milliseconds, System.Threading.CancellationToken cancellationToken = null) { }
-        public Akka.Actor.Terminated ExpectTerminated(Akka.Actor.IActorRef target, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<Akka.Actor.Terminated> ExpectTerminatedAsync(Akka.Actor.IActorRef target, System.Nullable<System.TimeSpan> timeout = null, string hint = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public object FishForMessage(System.Predicate<object> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<object> FishForMessageAsync(System.Predicate<object> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.Nullable<System.TimeSpan> max = null, string hint = "", System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task FishUntilMessageAsync<T>(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.TimeSpan GetTimeoutOrDefault(System.Nullable<System.TimeSpan> timeout) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgAnyOf<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAnyOfAsync<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.TimeSpan? duration = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T> assert, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Action<T, Akka.Actor.IActorRef> assertMessageAndSender, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Func<T, Akka.Actor.IActorRef, bool> isMessageAndSender, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T message, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgAsync<T>(T expected, System.Func<T, T, bool> comparer, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.TimeSpan? duration = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(Akka.Actor.IActorRef sender, T message, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectMsgFrom<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.TimeSpan? duration = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Action<T> assertMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(Akka.Actor.IActorRef sender, T message, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Action<Akka.Actor.IActorRef> assertSender, System.Action<T> assertMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> ExpectMsgFromAsync<T>(System.Predicate<Akka.Actor.IActorRef> isSender, System.Predicate<T> isMessage, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public void ExpectNoMsg(System.Threading.CancellationToken cancellationToken = default) { }
+        public void ExpectNoMsg(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = default) { }
+        public void ExpectNoMsg(int milliseconds, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(System.TimeSpan duration, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask ExpectNoMsgAsync(int milliseconds, System.Threading.CancellationToken cancellationToken = default) { }
+        public Akka.Actor.Terminated ExpectTerminated(Akka.Actor.IActorRef target, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<Akka.Actor.Terminated> ExpectTerminatedAsync(Akka.Actor.IActorRef target, System.TimeSpan? timeout = default, string hint = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public object FishForMessage(System.Predicate<object> isMessage, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public T FishForMessage<T>(System.Predicate<T> isMessage, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public T FishForMessage<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<object> FishForMessageAsync(System.Predicate<object> isMessage, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<T> FishForMessageAsync<T>(System.Predicate<T> isMessage, System.Collections.ArrayList allMessages, System.TimeSpan? max = default, string hint = "", System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task FishUntilMessageAsync<T>(System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.TimeSpan GetTimeoutOrDefault(System.TimeSpan? timeout) { }
         public void IgnoreMessages(System.Func<object, bool> shouldIgnoreMessage) { }
-        public void IgnoreMessages<TMsg>(System.Func<TMsg, bool> shouldIgnoreMessage) { }
         public void IgnoreMessages<TMsg>() { }
+        public void IgnoreMessages<TMsg>(System.Func<TMsg, bool> shouldIgnoreMessage) { }
         public void IgnoreNoMessages() { }
         protected virtual void InitializeTest(Akka.Actor.ActorSystem system, Akka.Actor.Setup.ActorSystemSetup config, string actorSystemName, string testActorName) { }
         protected void InitializeTest(Akka.Actor.ActorSystem system, Akka.Configuration.Config config, string actorSystemName, string testActorName) { }
-        protected static bool InternalAwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval, System.Action<string, object[]> fail, System.Threading.CancellationToken cancellationToken = null) { }
-        protected static bool InternalAwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval, System.Action<string, object[]> fail, Akka.Event.ILoggingAdapter logger, System.Threading.CancellationToken cancellationToken = null) { }
-        protected static System.Threading.Tasks.Task<bool> InternalAwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval, System.Action<string, object[]> fail, System.Threading.CancellationToken cancellationToken = null) { }
-        protected static System.Threading.Tasks.Task<bool> InternalAwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.Nullable<System.TimeSpan> interval, System.Action<string, object[]> fail, Akka.Event.ILoggingAdapter logger, System.Threading.CancellationToken cancellationToken = null) { }
-        public object PeekOne(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
         public object PeekOne(System.Threading.CancellationToken cancellationToken) { }
-        public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public object PeekOne(System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.Threading.CancellationToken cancellationToken) { }
-        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.TimeSpan max, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__216))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__218))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, System.TimeSpan max, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        public object ReceiveOne(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.ValueTask<object> ReceiveOneAsync(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__207<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__209<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__211<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__213<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.TimeSpan max, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, System.TimeSpan max, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public object ReceiveOne(System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.ValueTask<object> ReceiveOneAsync(System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.TimeSpan? max, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Func<object, T> filter, System.TimeSpan? max = default, System.TimeSpan? idle = default, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.TimeSpan? max, System.TimeSpan? idle, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Predicate<T> shouldContinue, System.TimeSpan? max = default, System.TimeSpan? idle = default, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = true, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.TimeSpan? max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, System.TimeSpan? max = default, System.TimeSpan? idle = default, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.TimeSpan? max, System.TimeSpan? idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Predicate<T> shouldContinue, System.TimeSpan? max = default, System.TimeSpan? idle = default, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = true, [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default) { }
         protected System.TimeSpan RemainingOr(System.TimeSpan duration) { }
-        public System.TimeSpan RemainingOrDilated(System.Nullable<System.TimeSpan> duration) { }
+        public System.TimeSpan RemainingOrDilated(System.TimeSpan? duration) { }
         public void SetAutoPilot(Akka.TestKit.AutoPilot pilot) { }
-        public virtual void Shutdown(System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
-        protected virtual void Shutdown(Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
-        public bool TryPeekOne(out Akka.TestKit.MessageEnvelope envelope, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken) { }
-        [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+        public virtual void Shutdown(System.TimeSpan? duration = default, bool verifySystemShutdown = false) { }
+        protected virtual void Shutdown(Akka.Actor.ActorSystem system, System.TimeSpan? duration = default, bool verifySystemShutdown = false) { }
+        public bool TryPeekOne(out Akka.TestKit.MessageEnvelope envelope, System.TimeSpan? max, System.Threading.CancellationToken cancellationToken) { }
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "success",
                 "envelope"})]
-        public System.Threading.Tasks.ValueTask<System.ValueTuple<bool, Akka.TestKit.MessageEnvelope>> TryPeekOneAsync(System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken) { }
-        public bool TryReceiveOne(out Akka.TestKit.MessageEnvelope envelope, System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
-        [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+        public System.Threading.Tasks.ValueTask<System.ValueTuple<bool, Akka.TestKit.MessageEnvelope>> TryPeekOneAsync(System.TimeSpan? max, System.Threading.CancellationToken cancellationToken) { }
+        public bool TryReceiveOne(out Akka.TestKit.MessageEnvelope envelope, System.TimeSpan? max = default, System.Threading.CancellationToken cancellationToken = default) { }
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "success",
                 "envelope"})]
-        public System.Threading.Tasks.ValueTask<System.ValueTuple<bool, Akka.TestKit.MessageEnvelope>> TryReceiveOneAsync(System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.ValueTask<System.ValueTuple<bool, Akka.TestKit.MessageEnvelope>> TryReceiveOneAsync(System.TimeSpan? max, System.Threading.CancellationToken cancellationToken = default) { }
         public Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef actorToUnwatch) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> UnwatchAsync(Akka.Actor.IActorRef actorToUnwatch) { }
-        public System.Threading.Tasks.Task<System.Collections.ArrayList> WaitForRadioSilenceAsync(System.Nullable<System.TimeSpan> max = null, System.Nullable<uint> maxMessages = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task<System.Collections.ArrayList> WaitForRadioSilenceAsync(System.TimeSpan? max = default, uint? maxMessages = default, System.Threading.CancellationToken cancellationToken = default) { }
         public Akka.Actor.IActorRef Watch(Akka.Actor.IActorRef actorToWatch) { }
         public System.Threading.Tasks.Task<Akka.Actor.IActorRef> WatchAsync(Akka.Actor.IActorRef actorToWatch) { }
-        public void Within(System.TimeSpan max, System.Action action, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Within(System.TimeSpan min, System.TimeSpan max, System.Action action, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Within<T>(System.TimeSpan max, System.Func<T> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Within<T>(System.TimeSpan min, System.TimeSpan max, System.Func<T> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, string hint = null, System.Nullable<System.TimeSpan> epsilonValue = null, System.Threading.CancellationToken cancellationToken = null) { }
+        public void Within(System.TimeSpan max, System.Action action, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public void Within(System.TimeSpan min, System.TimeSpan max, System.Action action, string hint = null, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public T Within<T>(System.TimeSpan max, System.Func<T> function, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public T Within<T>(System.TimeSpan min, System.TimeSpan max, System.Func<T> function, string hint = null, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task WithinAsync(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task> actionAsync, string hint = null, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> WithinAsync<T>(System.TimeSpan min, System.TimeSpan max, System.Func<System.Threading.Tasks.Task<T>> function, string hint = null, System.TimeSpan? epsilonValue = default, System.Threading.CancellationToken cancellationToken = default) { }
+        protected static bool InternalAwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval, System.Action<string, object[]> fail, System.Threading.CancellationToken cancellationToken = default) { }
+        protected static bool InternalAwaitCondition(System.Func<bool> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval, System.Action<string, object[]> fail, Akka.Event.ILoggingAdapter logger, System.Threading.CancellationToken cancellationToken = default) { }
+        protected static System.Threading.Tasks.Task<bool> InternalAwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval, System.Action<string, object[]> fail, System.Threading.CancellationToken cancellationToken = default) { }
+        protected static System.Threading.Tasks.Task<bool> InternalAwaitConditionAsync(System.Func<System.Threading.Tasks.Task<bool>> conditionIsFulfilled, System.TimeSpan max, System.TimeSpan? interval, System.Action<string, object[]> fail, Akka.Event.ILoggingAdapter logger, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class TestKitExtension : Akka.Actor.ExtensionIdProvider<Akka.TestKit.TestKitSettings>
     {
@@ -549,7 +525,7 @@ namespace Akka.TestKit
     }
     public class TestLatch
     {
-        [System.ObsoleteAttribute("This field will be removed. TestKitSettings.DefaultTimeout is an alternative.")]
+        [System.Obsolete("This field will be removed. TestKitSettings.DefaultTimeout is an alternative.")]
         public static readonly System.TimeSpan DefaultTimeout;
         public TestLatch() { }
         public TestLatch(int count) { }
@@ -558,8 +534,8 @@ namespace Akka.TestKit
         public bool IsOpen { get; }
         public void CountDown() { }
         public void Open() { }
-        public void Ready(System.TimeSpan timeout) { }
         public void Ready() { }
+        public void Ready(System.TimeSpan timeout) { }
         public void Reset() { }
     }
     public class TestProbe : Akka.TestKit.TestKitBase, Akka.Actor.IActorRef, Akka.Actor.IActorRefScope, Akka.Actor.ICanTell, Akka.Actor.IInternalActorRef, Akka.TestKit.INoImplicitSender, Akka.Util.ISurrogated, System.IComparable, System.IComparable<Akka.Actor.IActorRef>, System.IEquatable<Akka.Actor.IActorRef>
@@ -567,33 +543,33 @@ namespace Akka.TestKit
         public TestProbe(Akka.Actor.ActorSystem system, Akka.TestKit.ITestKitAssertions assertions, string testProbeName = null) { }
         public Akka.Actor.IActorRef Ref { get; }
         public Akka.Actor.IActorRef Sender { get; }
-        public Akka.Actor.IActorRef ChildActorOf<T>(string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null)
+        public Akka.Actor.IActorRef ChildActorOf<T>(System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public Akka.Actor.IActorRef ChildActorOf<T>(Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null)
+        public Akka.Actor.IActorRef ChildActorOf<T>(Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public Akka.Actor.IActorRef ChildActorOf<T>(string name, System.Threading.CancellationToken cancellationToken = null)
+        public Akka.Actor.IActorRef ChildActorOf<T>(string name, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public Akka.Actor.IActorRef ChildActorOf<T>(System.Threading.CancellationToken cancellationToken = null)
+        public Akka.Actor.IActorRef ChildActorOf<T>(string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null)
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = null)
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(string name, System.Threading.CancellationToken cancellationToken = null)
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(string name, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
-        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(System.Threading.CancellationToken cancellationToken = null)
+        public System.Threading.Tasks.Task<Akka.Actor.IActorRef> ChildActorOfAsync<T>(string name, Akka.Actor.SupervisorStrategy supervisorStrategy, System.Threading.CancellationToken cancellationToken = default)
             where T : Akka.Actor.ActorBase { }
         public int CompareTo(object obj) { }
-        [System.ObsoleteAttribute("Cannot create a TestProbe from a TestProbe", true)]
+        [System.Obsolete("Cannot create a TestProbe from a TestProbe", true)]
         public override Akka.TestKit.TestProbe CreateTestProbe(string name = null) { }
         public override bool Equals(object obj) { }
-        public void Forward(Akka.Actor.IActorRef actor, object message) { }
         public void Forward(Akka.Actor.IActorRef actor) { }
+        public void Forward(Akka.Actor.IActorRef actor, object message) { }
         public override int GetHashCode() { }
         public void Reply(object message) { }
         public void Send(Akka.Actor.IActorRef actor, object message) { }
-        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message) { }
+        public void SendSystemMessage(Akka.Dispatch.SysMsg.ISystemMessage message, Akka.Actor.IActorRef sender) { }
         public override string ToString() { }
     }
     public class TestScheduler : Akka.Actor.IActionScheduler, Akka.Actor.IAdvancedScheduler, Akka.Actor.IRunnableScheduler, Akka.Actor.IScheduler, Akka.Actor.ITellScheduler, Akka.Actor.ITimeProvider
@@ -606,14 +582,14 @@ namespace Akka.TestKit
         protected System.DateTimeOffset TimeNow { get; }
         public void Advance(System.TimeSpan offset) { }
         public void AdvanceTo(System.DateTimeOffset when) { }
-        public void ScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable) { }
+        public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action) { }
         public void ScheduleOnce(System.TimeSpan delay, System.Action action) { }
         public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
-        public void ScheduleOnce(System.TimeSpan delay, Akka.Dispatch.IRunnable action) { }
-        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable) { }
+        public void ScheduleOnce(System.TimeSpan delay, System.Action action, Akka.Actor.ICancelable cancelable) { }
+        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action) { }
         public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action) { }
         public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action, Akka.Actor.ICancelable cancelable) { }
-        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Dispatch.IRunnable action) { }
+        public void ScheduleRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, System.Action action, Akka.Actor.ICancelable cancelable) { }
         public void ScheduleTellOnce(System.TimeSpan delay, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender) { }
         public void ScheduleTellOnce(System.TimeSpan delay, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender, Akka.Actor.ICancelable cancelable) { }
         public void ScheduleTellRepeatedly(System.TimeSpan initialDelay, System.TimeSpan interval, Akka.Actor.ICanTell receiver, object message, Akka.Actor.IActorRef sender) { }
@@ -622,8 +598,7 @@ namespace Akka.TestKit
 }
 namespace Akka.TestKit.Configs
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static TestConfigs
+    public static class TestConfigs
     {
         public static Akka.Configuration.Config DefaultConfig { get; }
         public static Akka.Configuration.Config TestSchedulerConfig { get; }
@@ -631,96 +606,87 @@ namespace Akka.TestKit.Configs
 }
 namespace Akka.TestKit.Extensions
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    public class static TaskExtensions
+    public static class TaskExtensions
     {
-        public static System.Threading.Tasks.Task<bool> AwaitWithTimeout(this System.Threading.Tasks.Task parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = null) { }
-        public static System.Threading.Tasks.Task<T> WithTimeout<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(this System.Threading.Tasks.Task<T> parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = null) { }
+        public static System.Threading.Tasks.Task<bool> AwaitWithTimeout(this System.Threading.Tasks.Task parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task<T> WithTimeout<T>(this System.Threading.Tasks.Task<T> parentTask, System.TimeSpan timeout, System.Threading.CancellationToken cancellationToken = default) { }
     }
 }
 namespace Akka.TestKit.Internal
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class CustomEventFilter : Akka.TestKit.Internal.EventFilterBase
     {
         public CustomEventFilter(System.Predicate<Akka.Event.LogEvent> predicate) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class DebugFilter : Akka.TestKit.Internal.EventFilterBase
     {
-        public DebugFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher = null) { }
+        public DebugFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher = null) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ErrorFilter : Akka.TestKit.Internal.EventFilterBase
     {
-        public ErrorFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher = null) { }
-        public ErrorFilter(System.Type exceptionType, Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher = null, bool recurseInnerExceptions = False) { }
-        [System.Runtime.CompilerServices.NullableAttribute(1)]
+        public ErrorFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher = null) { }
+        public ErrorFilter(System.Type? exceptionType, Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher = null, bool recurseInnerExceptions = false) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public abstract class EventFilterBase : Akka.TestKit.IEventFilter
     {
-        protected EventFilterBase(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher) { }
+        protected EventFilterBase(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher) { }
         protected abstract string FilterDescriptiveName { get; }
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        public event Akka.TestKit.Internal.EventMatched EventMatched;
+        public event Akka.TestKit.Internal.EventMatched? EventMatched;
         public bool Apply(Akka.Event.LogEvent logEvent) { }
-        protected bool InternalDoMatch(string src, [System.Runtime.CompilerServices.NullableAttribute(2)] object msg) { }
+        protected bool InternalDoMatch(string src, object? msg) { }
         protected abstract bool IsMatch(Akka.Event.LogEvent evt);
         protected virtual void OnEventMatched(Akka.Event.LogEvent logEvent) { }
         public override string ToString() { }
     }
     public delegate void EventMatched(Akka.TestKit.Internal.EventFilterBase eventFilter, Akka.Event.LogEvent logEvent);
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class InfoFilter : Akka.TestKit.Internal.EventFilterBase
     {
-        public InfoFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher = null) { }
+        public InfoFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher = null) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class InternalEventFilterApplier : Akka.TestKit.IEventFilterApplier
     {
         public InternalEventFilterApplier(Akka.TestKit.TestKitBase testkit, Akka.Actor.ActorSystem system, System.Collections.Generic.IReadOnlyList<Akka.TestKit.Internal.EventFilterBase> filters) { }
         public Akka.TestKit.EventFilterFactory And { get; }
-        protected bool AwaitDone(System.TimeSpan timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = null) { }
-        protected System.Threading.Tasks.Task<bool> AwaitDoneAsync(System.TimeSpan timeout, System.Nullable<int> expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Expect<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Expect<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Nullable<System.TimeSpan> timeout, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectOne<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public T ExpectOne<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.ObsoleteAttribute("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
+        protected bool AwaitDone(System.TimeSpan timeout, int? expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = default) { }
+        protected System.Threading.Tasks.Task<bool> AwaitDoneAsync(System.TimeSpan timeout, int? expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler, System.Threading.CancellationToken cancellationToken = default) { }
+        public void Expect(int expectedCount, System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public void Expect(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public T Expect<T>(int expectedCount, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public T Expect<T>(int expectedCount, System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.Func<System.Threading.Tasks.Task> actionAsync, System.TimeSpan? timeout, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectAsync(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> ExpectAsync<T>(int expectedCount, System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public void ExpectOne(System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public void ExpectOne(System.TimeSpan timeout, System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectOne<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public T ExpectOne<T>(System.TimeSpan timeout, System.Func<T> func, System.Threading.CancellationToken cancellationToken = default) { }
+        [System.Obsolete("Only for backwards compat. Use ExpectOneAsync(Func<Task>, CancellationToken) inst" +
             "ead beginning in Akka.NET v1.5")]
-        public System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectOneAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task<T> ExpectOneAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        protected static string GetMessageString(int number) { }
-        protected T Intercept<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func, Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> timeout, System.Nullable<int> expectedOccurrences, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = null) { }
-        protected System.Threading.Tasks.Task<T> InterceptAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<System.Threading.Tasks.Task<T>> func, Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> timeout, System.Nullable<int> expectedOccurrences, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = null) { }
-        public T Mute<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public void Mute(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Threading.Tasks.Task ExpectOneAsync(System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectOneAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ExpectOneAsync(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> ExpectOneAsync<T>(System.TimeSpan timeout, System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default) { }
+        protected T Intercept<T>(System.Func<T> func, Akka.Actor.ActorSystem system, System.TimeSpan? timeout, int? expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler? matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = default) { }
+        protected System.Threading.Tasks.Task<T> InterceptAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, Akka.Actor.ActorSystem system, System.TimeSpan? timeout, int? expectedOccurrences, Akka.TestKit.Internal.InternalEventFilterApplier.MatchedEventHandler? matchedEventHandler = null, System.Threading.CancellationToken cancellationToken = default) { }
         public Akka.TestKit.IUnmutableFilter Mute() { }
-        public System.Threading.Tasks.Task<T> MuteAsync<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task MuteAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = null) { }
-        public System.Threading.Tasks.Task MuteAsync(System.Action action, System.Threading.CancellationToken cancellationToken = null) { }
+        public void Mute(System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public T Mute<T>(System.Func<T> func, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task MuteAsync(System.Action action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task MuteAsync(System.Func<System.Threading.Tasks.Task> action, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<T> MuteAsync<T>(System.Func<System.Threading.Tasks.Task<T>> func, System.Threading.CancellationToken cancellationToken = default) { }
+        protected static string GetMessageString(int number) { }
         protected class InternalUnmutableFilter : Akka.TestKit.IUnmutableFilter, System.IDisposable
         {
             public InternalUnmutableFilter(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.Internal.EventFilterBase> filters, Akka.Actor.ActorSystem system) { }
@@ -735,78 +701,70 @@ namespace Akka.TestKit.Internal
             public virtual void HandleEvent(Akka.TestKit.Internal.EventFilterBase eventFilter, Akka.Event.LogEvent logEvent) { }
         }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class InternalTestActorRef : Akka.Actor.LocalActorRef
     {
         public object UnderlyingActor { get; }
-        public static Akka.TestKit.Internal.InternalTestActorRef Create(Akka.Actor.ActorSystem system, Akka.Actor.Props props, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Actor.IActorRef supervisor = null, [System.Runtime.CompilerServices.NullableAttribute(2)] string name = null) { }
-        public static string CreateUniqueName() { }
         protected Akka.TestKit.Internal.InternalTestActorRef.TestActorCell GetTestActorCell() { }
         protected override Akka.Actor.ActorCell NewActorCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.IInternalActorRef self, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Actor.IInternalActorRef supervisor) { }
-        public void Receive(object message, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Actor.IActorRef sender = null) { }
-        public System.Threading.Tasks.Task ReceiveAsync(object message, [System.Runtime.CompilerServices.NullableAttribute(2)] Akka.Actor.IActorRef sender = null) { }
+        public void Receive(object message, Akka.Actor.IActorRef? sender = null) { }
+        public System.Threading.Tasks.Task ReceiveAsync(object message, Akka.Actor.IActorRef? sender = null) { }
         public override string ToString() { }
         public void Unwatch(Akka.Actor.IActorRef subject) { }
         public void Watch(Akka.Actor.IActorRef subject) { }
+        public static Akka.TestKit.Internal.InternalTestActorRef Create(Akka.Actor.ActorSystem system, Akka.Actor.Props props, Akka.Actor.IActorRef? supervisor = null, string? name = null) { }
+        public static string CreateUniqueName() { }
         public class InternalGetActor : Akka.Actor.IAutoReceivedMessage, Akka.Actor.IPossiblyHarmful
         {
-            [System.Runtime.CompilerServices.NullableAttribute(1)]
             public static readonly Akka.TestKit.Internal.InternalTestActorRef.InternalGetActor Instance;
         }
-        [System.Runtime.CompilerServices.NullableAttribute(0)]
         protected class TestActorCell : Akka.Actor.ActorCell
         {
             public TestActorCell(Akka.Actor.Internal.ActorSystemImpl system, Akka.Actor.IInternalActorRef self, Akka.Actor.Props props, Akka.Dispatch.MessageDispatcher dispatcher, Akka.Actor.IInternalActorRef parent) { }
-            [System.Runtime.CompilerServices.NullableAttribute(2)]
-            public object Actor { get; }
+            public new object? Actor { get; }
             public override Akka.Dispatch.ActorTaskScheduler TaskScheduler { get; }
             protected override void AutoReceiveMessage(Akka.Actor.Envelope envelope) { }
             public System.Threading.Tasks.Task ReceiveMessageForTestAsync(Akka.Actor.Envelope envelope) { }
             public System.Threading.Tasks.Task UseThreadContextAsync(System.Func<System.Threading.Tasks.Task> actionAsync) { }
         }
     }
-    public class static TimeSpanExtensions
+    public static class TimeSpanExtensions
     {
         public static void EnsureIsPositiveFinite(this System.TimeSpan timeSpan, string parameterName) { }
         public static bool IsInfinite(this System.TimeSpan timeSpan) { }
-        public static bool IsInfinite(this System.Nullable<System.TimeSpan> timeSpan) { }
+        public static bool IsInfinite(this System.TimeSpan? timeSpan) { }
         public static bool IsInfiniteTimeout(this System.TimeSpan timeSpan) { }
-        public static bool IsInfiniteTimeout(this System.Nullable<System.TimeSpan> timeSpan) { }
+        public static bool IsInfiniteTimeout(this System.TimeSpan? timeSpan) { }
         public static bool IsPositiveFinite(this System.TimeSpan timeSpan) { }
-        public static bool IsPositiveFinite(this System.Nullable<System.TimeSpan> timeSpan) { }
-        public static bool IsUndefined(this System.Nullable<System.TimeSpan> timeSpan) { }
+        public static bool IsPositiveFinite(this System.TimeSpan? timeSpan) { }
+        public static bool IsUndefined(this System.TimeSpan? timeSpan) { }
         public static bool IsZero(this System.TimeSpan timeSpan) { }
-        public static bool IsZero(this System.Nullable<System.TimeSpan> timeSpan) { }
-        public static System.TimeSpan Min(this System.TimeSpan a, System.Nullable<System.TimeSpan> b) { }
+        public static bool IsZero(this System.TimeSpan? timeSpan) { }
+        public static System.TimeSpan Min(this System.TimeSpan a, System.TimeSpan? b) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class WarningFilter : Akka.TestKit.Internal.EventFilterBase
     {
-        public WarningFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher sourceMatcher = null) { }
+        public WarningFilter(Akka.TestKit.Internal.StringMatcher.IStringMatcher? messageMatcher = null, Akka.TestKit.Internal.StringMatcher.IStringMatcher? sourceMatcher = null) { }
         protected override string FilterDescriptiveName { get; }
         protected override bool IsMatch(Akka.Event.LogEvent evt) { }
     }
 }
 namespace Akka.TestKit.Internal.StringMatcher
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ContainsString : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public ContainsString(string part) { }
         public bool IsMatch(string s) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class EqualsString : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public EqualsString(string s) { }
         public bool IsMatch(string s) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class EqualsStringAndPathMatcher : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
-        public EqualsStringAndPathMatcher(string path, bool canBeRelative = True) { }
+        public EqualsStringAndPathMatcher(string path, bool canBeRelative = true) { }
         public bool IsMatch(string path) { }
         public override string ToString() { }
     }
@@ -814,28 +772,24 @@ namespace Akka.TestKit.Internal.StringMatcher
     {
         bool IsMatch(string s);
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class MatchesAll : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public static Akka.TestKit.Internal.StringMatcher.IStringMatcher Instance { get; }
         public bool IsMatch(string s) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class PredicateMatcher : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public PredicateMatcher(System.Predicate<string> predicate, string hint = "") { }
         public bool IsMatch(string s) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class RegexMatcher : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public RegexMatcher(System.Text.RegularExpressions.Regex regex) { }
         public bool IsMatch(string s) { }
         public override string ToString() { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class StartsWithString : Akka.TestKit.Internal.StringMatcher.IStringMatcher
     {
         public StartsWithString(string start) { }
@@ -845,20 +799,17 @@ namespace Akka.TestKit.Internal.StringMatcher
 }
 namespace Akka.TestKit.TestActors
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class BlackHoleActor : Akka.Actor.ActorBase
     {
         public BlackHoleActor() { }
         public static Akka.Actor.Props Props { get; }
         protected override bool Receive(object message) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class EchoActor : Akka.Actor.ReceiveActor
     {
-        public EchoActor(Akka.TestKit.TestKitBase testkit, bool echoBackToSenderAsWell = True) { }
-        public static Akka.Actor.Props Props(Akka.TestKit.TestKitBase testkit, bool echoBackToSenderAsWell = True) { }
+        public EchoActor(Akka.TestKit.TestKitBase testkit, bool echoBackToSenderAsWell = true) { }
+        public static Akka.Actor.Props Props(Akka.TestKit.TestKitBase testkit, bool echoBackToSenderAsWell = true) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class ForwardActor : Akka.Actor.ReceiveActor
     {
         public ForwardActor(Akka.Actor.IActorRef target) { }
@@ -876,14 +827,12 @@ namespace Akka.TestKit.TestActors
 }
 namespace Akka.TestKit.TestEvent
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class Mute : Akka.Actor.INoSerializationVerificationNeeded
     {
         public Mute(params Akka.TestKit.Internal.EventFilterBase[] filters) { }
         public Mute(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.Internal.EventFilterBase> filters) { }
         public System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.Internal.EventFilterBase> Filters { get; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public sealed class Unmute : Akka.Actor.INoSerializationVerificationNeeded
     {
         public Unmute(params Akka.TestKit.Internal.EventFilterBase[] filters) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKitXunit2.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKitXunit2.DotNet.verified.txt
@@ -1,51 +1,45 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("a48eb1da-be56-4078-a5f7-29d8e2bcd590")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("a48eb1da-be56-4078-a5f7-29d8e2bcd590")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.TestKit.Xunit2.Attributes
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class LocalFactAttribute : Xunit.FactAttribute
     {
         public LocalFactAttribute() { }
-        public override string Skip { get; set; }
-        public string SkipLocal { get; set; }
+        public override string? Skip { get; set; }
+        public string? SkipLocal { get; set; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    [Xunit.Sdk.XunitTestCaseDiscovererAttribute("Xunit.Sdk.TheoryDiscoverer", "xunit.execution.{Platform}")]
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [Xunit.Sdk.XunitTestCaseDiscoverer("Xunit.Sdk.TheoryDiscoverer", "xunit.execution.{Platform}")]
     public class LocalTheoryAttribute : Xunit.TheoryAttribute
     {
         public LocalTheoryAttribute() { }
-        public override string Skip { get; set; }
-        public string SkipLocal { get; set; }
+        public override string? Skip { get; set; }
+        public string? SkipLocal { get; set; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class WindowsFactAttribute : Xunit.FactAttribute
     {
         public WindowsFactAttribute() { }
-        public override string Skip { get; set; }
-        public string SkipUnix { get; set; }
+        public override string? Skip { get; set; }
+        public string? SkipUnix { get; set; }
     }
 }
 namespace Akka.TestKit.Xunit2.Internals
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class AkkaAssertEqualityComparer<T> : System.Collections.Generic.IEqualityComparer<T>
     {
-        public AkkaAssertEqualityComparer(bool skipTypeCheck = False, System.Collections.IEqualityComparer innerComparer = null) { }
-        public bool Equals(T x, T y) { }
+        public AkkaAssertEqualityComparer(bool skipTypeCheck = false, System.Collections.IEqualityComparer? innerComparer = null) { }
+        public bool Equals(T? x, T? y) { }
         public int GetHashCode(T obj) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [System.Serializable]
     public class AkkaEqualException : Xunit.Sdk.XunitException
     {
-        public AkkaEqualException(string format = "", params object[] args) { }
         protected AkkaEqualException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public static Akka.TestKit.Xunit2.Internals.AkkaEqualException ForMismatchedValues(object expected, object actual, string format = null, [System.Runtime.CompilerServices.NullableAttribute(1)] params object[] args) { }
+        public AkkaEqualException(string format = "", params object[] args) { }
+        public static Akka.TestKit.Xunit2.Internals.AkkaEqualException ForMismatchedValues(object? expected, object? actual, string? format = null, params object[] args) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class TestOutputLogger : Akka.Actor.ReceiveActor
     {
         public TestOutputLogger(Xunit.Abstractions.ITestOutputHelper output) { }
@@ -53,36 +47,33 @@ namespace Akka.TestKit.Xunit2.Internals
 }
 namespace Akka.TestKit.Xunit2
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class TestKit : Akka.TestKit.TestKitBase, System.IDisposable
     {
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        protected readonly Xunit.Abstractions.ITestOutputHelper Output;
-        public TestKit(Akka.Actor.ActorSystem system = null, Xunit.Abstractions.ITestOutputHelper output = null) { }
-        public TestKit([System.Runtime.CompilerServices.NullableAttribute(1)] Akka.Actor.Setup.ActorSystemSetup config, string actorSystemName = null, Xunit.Abstractions.ITestOutputHelper output = null) { }
-        public TestKit([System.Runtime.CompilerServices.NullableAttribute(1)] Akka.Configuration.Config config, string actorSystemName = null, Xunit.Abstractions.ITestOutputHelper output = null) { }
-        public TestKit(string config, [System.Runtime.CompilerServices.NullableAttribute(2)] Xunit.Abstractions.ITestOutputHelper output = null) { }
+        protected readonly Xunit.Abstractions.ITestOutputHelper? Output;
+        public TestKit(Akka.Actor.ActorSystem? system = null, Xunit.Abstractions.ITestOutputHelper? output = null) { }
+        public TestKit(string config, Xunit.Abstractions.ITestOutputHelper? output = null) { }
+        public TestKit(Akka.Actor.Setup.ActorSystemSetup config, string? actorSystemName = null, Xunit.Abstractions.ITestOutputHelper? output = null) { }
+        public TestKit(Akka.Configuration.Config config, string? actorSystemName = null, Xunit.Abstractions.ITestOutputHelper? output = null) { }
         protected static Akka.TestKit.Xunit2.XunitAssertions Assertions { get; }
         public new static Akka.Configuration.Config DefaultConfig { get; }
         public new static Akka.Configuration.Config FullDebugConfig { get; }
         protected virtual void AfterAll() { }
-        protected virtual void Dispose(bool disposing) { }
         public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
         protected void InitializeLogger(Akka.Actor.ActorSystem system) { }
         protected void InitializeLogger(Akka.Actor.ActorSystem system, string prefix) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class XunitAssertions : Akka.TestKit.ITestKitAssertions
     {
         public XunitAssertions() { }
-        public void AssertEqual<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(T expected, T actual, string format = "", params object[] args) { }
-        public void AssertEqual<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(T expected, T actual, System.Func<T, T, bool> comparer, string format = "", params object[] args) { }
+        public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args) { }
+        public void AssertEqual<T>(T expected, T actual, System.Func<T, T, bool> comparer, string format = "", params object[] args) { }
         public void AssertFalse(bool condition, string format = "", params object[] args) { }
         public System.Exception AssertThrows(System.Action action) { }
-        public TException AssertThrows<[System.Runtime.CompilerServices.NullableAttribute(0)]  TException>(System.Action action)
+        public TException AssertThrows<TException>(System.Action action)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<System.Exception> AssertThrowsAsync(System.Func<System.Threading.Tasks.Task> action) { }
-        public System.Threading.Tasks.Task<TException> AssertThrowsAsync<[System.Runtime.CompilerServices.NullableAttribute(0)]  TException>(System.Func<System.Threading.Tasks.Task> action)
+        public System.Threading.Tasks.Task<TException> AssertThrowsAsync<TException>(System.Func<System.Threading.Tasks.Task> action)
             where TException : System.Exception { }
         public void AssertTrue(bool condition, string format = "", params object[] args) { }
         public void Fail(string format = "", params object[] args) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKitXunit2.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKitXunit2.Net.verified.txt
@@ -1,51 +1,45 @@
-﻿[assembly: System.Reflection.AssemblyMetadataAttribute("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
-[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
-[assembly: System.Runtime.InteropServices.GuidAttribute("a48eb1da-be56-4078-a5f7-29d8e2bcd590")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.InteropServices.ComVisible(false)]
+[assembly: System.Runtime.InteropServices.Guid("a48eb1da-be56-4078-a5f7-29d8e2bcd590")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace Akka.TestKit.Xunit2.Attributes
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class LocalFactAttribute : Xunit.FactAttribute
     {
         public LocalFactAttribute() { }
-        public override string Skip { get; set; }
-        public string SkipLocal { get; set; }
+        public override string? Skip { get; set; }
+        public string? SkipLocal { get; set; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Method | System.AttributeTargets.All, AllowMultiple=false)]
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
-    [Xunit.Sdk.XunitTestCaseDiscovererAttribute("Xunit.Sdk.TheoryDiscoverer", "xunit.execution.{Platform}")]
+    [System.AttributeUsage(System.AttributeTargets.Method, AllowMultiple=false)]
+    [Xunit.Sdk.XunitTestCaseDiscoverer("Xunit.Sdk.TheoryDiscoverer", "xunit.execution.{Platform}")]
     public class LocalTheoryAttribute : Xunit.TheoryAttribute
     {
         public LocalTheoryAttribute() { }
-        public override string Skip { get; set; }
-        public string SkipLocal { get; set; }
+        public override string? Skip { get; set; }
+        public string? SkipLocal { get; set; }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class WindowsFactAttribute : Xunit.FactAttribute
     {
         public WindowsFactAttribute() { }
-        public override string Skip { get; set; }
-        public string SkipUnix { get; set; }
+        public override string? Skip { get; set; }
+        public string? SkipUnix { get; set; }
     }
 }
 namespace Akka.TestKit.Xunit2.Internals
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class AkkaAssertEqualityComparer<T> : System.Collections.Generic.IEqualityComparer<T>
     {
-        public AkkaAssertEqualityComparer(bool skipTypeCheck = False, System.Collections.IEqualityComparer innerComparer = null) { }
-        public bool Equals(T x, T y) { }
+        public AkkaAssertEqualityComparer(bool skipTypeCheck = false, System.Collections.IEqualityComparer? innerComparer = null) { }
+        public bool Equals(T? x, T? y) { }
         public int GetHashCode(T obj) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
+    [System.Serializable]
     public class AkkaEqualException : Xunit.Sdk.XunitException
     {
-        public AkkaEqualException(string format = "", params object[] args) { }
         protected AkkaEqualException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        [return: System.Runtime.CompilerServices.NullableAttribute(1)]
-        public static Akka.TestKit.Xunit2.Internals.AkkaEqualException ForMismatchedValues(object expected, object actual, string format = null, [System.Runtime.CompilerServices.NullableAttribute(1)] params object[] args) { }
+        public AkkaEqualException(string format = "", params object[] args) { }
+        public static Akka.TestKit.Xunit2.Internals.AkkaEqualException ForMismatchedValues(object? expected, object? actual, string? format = null, params object[] args) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class TestOutputLogger : Akka.Actor.ReceiveActor
     {
         public TestOutputLogger(Xunit.Abstractions.ITestOutputHelper output) { }
@@ -53,36 +47,33 @@ namespace Akka.TestKit.Xunit2.Internals
 }
 namespace Akka.TestKit.Xunit2
 {
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class TestKit : Akka.TestKit.TestKitBase, System.IDisposable
     {
-        [System.Runtime.CompilerServices.NullableAttribute(2)]
-        protected readonly Xunit.Abstractions.ITestOutputHelper Output;
-        public TestKit(Akka.Actor.ActorSystem system = null, Xunit.Abstractions.ITestOutputHelper output = null) { }
-        public TestKit([System.Runtime.CompilerServices.NullableAttribute(1)] Akka.Actor.Setup.ActorSystemSetup config, string actorSystemName = null, Xunit.Abstractions.ITestOutputHelper output = null) { }
-        public TestKit([System.Runtime.CompilerServices.NullableAttribute(1)] Akka.Configuration.Config config, string actorSystemName = null, Xunit.Abstractions.ITestOutputHelper output = null) { }
-        public TestKit(string config, [System.Runtime.CompilerServices.NullableAttribute(2)] Xunit.Abstractions.ITestOutputHelper output = null) { }
+        protected readonly Xunit.Abstractions.ITestOutputHelper? Output;
+        public TestKit(Akka.Actor.ActorSystem? system = null, Xunit.Abstractions.ITestOutputHelper? output = null) { }
+        public TestKit(string config, Xunit.Abstractions.ITestOutputHelper? output = null) { }
+        public TestKit(Akka.Actor.Setup.ActorSystemSetup config, string? actorSystemName = null, Xunit.Abstractions.ITestOutputHelper? output = null) { }
+        public TestKit(Akka.Configuration.Config config, string? actorSystemName = null, Xunit.Abstractions.ITestOutputHelper? output = null) { }
         protected static Akka.TestKit.Xunit2.XunitAssertions Assertions { get; }
         public new static Akka.Configuration.Config DefaultConfig { get; }
         public new static Akka.Configuration.Config FullDebugConfig { get; }
         protected virtual void AfterAll() { }
-        protected virtual void Dispose(bool disposing) { }
         public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
         protected void InitializeLogger(Akka.Actor.ActorSystem system) { }
         protected void InitializeLogger(Akka.Actor.ActorSystem system, string prefix) { }
     }
-    [System.Runtime.CompilerServices.NullableAttribute(0)]
     public class XunitAssertions : Akka.TestKit.ITestKitAssertions
     {
         public XunitAssertions() { }
-        public void AssertEqual<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(T expected, T actual, string format = "", params object[] args) { }
-        public void AssertEqual<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(T expected, T actual, System.Func<T, T, bool> comparer, string format = "", params object[] args) { }
+        public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args) { }
+        public void AssertEqual<T>(T expected, T actual, System.Func<T, T, bool> comparer, string format = "", params object[] args) { }
         public void AssertFalse(bool condition, string format = "", params object[] args) { }
         public System.Exception AssertThrows(System.Action action) { }
-        public TException AssertThrows<[System.Runtime.CompilerServices.NullableAttribute(0)]  TException>(System.Action action)
+        public TException AssertThrows<TException>(System.Action action)
             where TException : System.Exception { }
         public System.Threading.Tasks.Task<System.Exception> AssertThrowsAsync(System.Func<System.Threading.Tasks.Task> action) { }
-        public System.Threading.Tasks.Task<TException> AssertThrowsAsync<[System.Runtime.CompilerServices.NullableAttribute(0)]  TException>(System.Func<System.Threading.Tasks.Task> action)
+        public System.Threading.Tasks.Task<TException> AssertThrowsAsync<TException>(System.Func<System.Threading.Tasks.Task> action)
             where TException : System.Exception { }
         public void AssertTrue(bool condition, string format = "", params object[] args) { }
         public void Fail(string format = "", params object[] args) { }


### PR DESCRIPTION
## Summary

- Upgrade PublicApiGenerator from 9.3.0 to 11.5.0
- Configure `ApiGeneratorOptions` to exclude compiler-generated state machine attributes:
  - `AsyncIteratorStateMachineAttribute`
  - `AsyncStateMachineAttribute`  
  - `IteratorStateMachineAttribute`

## Problem

These attributes contain auto-generated type names (e.g., `<MethodName>d__123`) that change whenever code structure changes - even adding a private field or modifying internal method logic causes the C# compiler to renumber these state machines. This caused unnecessary API approval test failures even when no actual public API changes occurred.

## Solution

By excluding these attributes from the API surface, we focus the approval tests on meaningful API changes (method signatures, types, etc.) rather than internal compiler implementation details.

## Test plan

- [x] All 17 API approval tests pass on .NET 8.0
- [x] All 17 API approval tests pass on .NET Framework 4.8
- [x] Regenerated all verified files to reflect cleaner API surface