### PR TITLE
Fix race condition in cluster sharding when entity constructor fails

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -1856,21 +1856,31 @@ namespace Akka.Cluster.Sharding
             // We only have to do this if we have R-E enabled
             if (!_rememberEntities)
                 return;
-            
+
             var id = _entities.EntityId(msg.Child);
             // Just return if the child actor is not a recorded shard entity
-            if (id is null) 
+            if (id is null)
                 return;
-            
-            // Remove the child actor from the entity list
-            _entities.RemoveEntity(id);
-                
+
+            // Only transition to Passivating if entity is Active.
+            // If already Passivating (entity requested passivation then threw), the normal flow handles it.
+            //
+            // Using Passivating state (instead of RemoveEntity which sets NoState):
+            // 1. Buffers messages arriving during termination (fixes race condition crash)
+            // 2. Persists removal from store when EntityTerminated arrives
+            // 3. Restarts entity if messages arrive (transient failure, try again)
+            // 4. Stays forgotten if no messages arrive
+            if (_entities.EntityState(id) is Active)
+            {
+                _entities.EntityPassivating(id);
+            }
+
             // Force stop the child actor, it might have been restarted
             Context.Stop(msg.Child);
-            
+
             Log.Error(
-                msg.LastCause, 
-                "{0}: Remembered entity {1} was stopped: {2}", 
+                msg.LastCause,
+                "{0}: Remembered entity {1} was stopped: {2}",
                 _typeName, id, msg.Reason);
         }
 


### PR DESCRIPTION
## Summary

- Fixes a race condition where a shard can crash with `InvalidActorNameException: Actor name "X" is not unique!` when a remembered entity's constructor throws an exception

## Problem

When `HandleSupervisorStop` was called, it called `RemoveEntity(id)` which set the entity state to `NoState` immediately. But the actor was still in the ActorCell's `TerminatingChildrenContainer` (termination is asynchronous).

If a new message arrived before `EntityTerminated` was processed:
1. Shard sees `NoState`, thinks entity doesn't exist
2. Tries to create entity with `Context.ActorOf`
3. `TerminatingChildrenContainer.Reserve` throws because name is still reserved

## Fix

Use `EntityPassivating` instead of `RemoveEntity`:
- Buffers messages arriving during termination (prevents race condition crash)
- Persists removal from store when termination completes
- Restarts entity if messages arrived (transient failure, try again)
- Stays forgotten if no messages arrive

## Test plan

- [x] Existing test `Persistent_Shard_must_recover_from_failing_entity` passes (both constructor and PreStart failure cases)
- [x] No "Actor name is not unique!" crashes in test output

Closes #7979