### PR TITLE
Fix AwaitAssertAsync logic causing premature timeout

### DIFF
--- a/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
@@ -37,7 +37,7 @@ namespace Akka.TestKit
         public void AwaitAssert(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
         {
             AwaitAssertAsync(assertion, duration, interval, cancellationToken)
-                .WaitAndUnwrapException();
+                .WaitAndUnwrapException(cancellationToken);
         }
         
         /// <inheritdoc cref="AwaitAssert(Action, TimeSpan?, TimeSpan?, CancellationToken)"/>
@@ -46,14 +46,14 @@ namespace Akka.TestKit
             var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
             if(intervalValue == Timeout.InfiniteTimeSpan) intervalValue = TimeSpan.MaxValue;
             intervalValue.EnsureIsPositiveFinite(nameof(interval));
-            var start = Now;
             var max = RemainingOrDilated(duration);
             var stop = Now + max;
-            var t = max.Min(intervalValue);
             var attempts = 0;
+            var start = Now;
             while(true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                attempts++;
                 try
                 {
                     // TODO: assertion can run forever, need a way to stop this if this happens.
@@ -62,7 +62,7 @@ namespace Akka.TestKit
                 }
                 catch(Exception)
                 {
-                    var stopped = Now + t;
+                    var stopped = Now;
                     if (stopped >= stop)
                     {
                         Sys.Log.Warning("AwaitAssert failed, timeout [{0}] is over after [{1}] attempts and [{2}] elapsed time", max, attempts, stopped - start);
@@ -70,9 +70,9 @@ namespace Akka.TestKit
                     }
                         
                 }
-                attempts++;
+                
+                var t = (stop - Now).Min(intervalValue);
                 await Task.Delay(t, cancellationToken);
-                t = (stop - Now).Min(intervalValue);
             }
         }
 
@@ -98,10 +98,12 @@ namespace Akka.TestKit
             intervalValue.EnsureIsPositiveFinite("interval");
             var max = RemainingOrDilated(duration);
             var stop = Now + max;
-            var t = max.Min(intervalValue);
+            var attempts = 0;
+            var start = Now;
             while(true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                attempts++;
                 try
                 {
                     await assertion();
@@ -109,11 +111,16 @@ namespace Akka.TestKit
                 }
                 catch(Exception)
                 {
-                    if(Now + t >= stop)
+                    var stopped = Now;
+                    if (stopped >= stop)
+                    {
+                        Sys.Log.Warning("AwaitAssert failed, timeout [{0}] is over after [{1}] attempts and [{2}] elapsed time", max, attempts, stopped - start);
                         throw;
+                    }
                 }
+                
+                var t = (stop - Now).Min(intervalValue);
                 await Task.Delay(t, cancellationToken);
-                t = (stop - Now).Min(intervalValue);
             }
         }
     }


### PR DESCRIPTION
Closes #7976

## Changes

* Attempt counter incremented after assertion, creating an off by one count bug
* Stop time is compared against (now + delay-interval), causing at least one missing assertion attempt