### PR TITLE
CoordinatedShutdown: clearly log the reason why we're exiting

### DIFF
--- a/src/core/Akka/Actor/CoordinatedShutdown.cs
+++ b/src/core/Akka/Actor/CoordinatedShutdown.cs
@@ -429,7 +429,7 @@ namespace Akka.Actor
         {
             if (_runStarted.CompareAndSet(null, reason))
             {
-                Log.Info("CoordinatedShutdown invoked due to [Reason:{Reason}]. Exiting with planned [ExitCode:{ExitCode}].]", reason.GetType(), reason.ExitCode);
+                Log.Info("CoordinatedShutdown invoked due to [Reason:{Reason}]. Exiting with [ExitCode:{ExitCode}].", reason.GetType(), reason.ExitCode);
                 
                 var debugEnabled = Log.IsDebugEnabled;
 

--- a/src/core/Akka/Actor/CoordinatedShutdown.cs
+++ b/src/core/Akka/Actor/CoordinatedShutdown.cs
@@ -429,6 +429,8 @@ namespace Akka.Actor
         {
             if (_runStarted.CompareAndSet(null, reason))
             {
+                Log.Info("CoordinatedShutdown invoked due to [Reason:{Reason}]. Exiting with planned [ExitCode:{ExitCode}].]", reason.GetType(), reason.ExitCode);
+                
                 var debugEnabled = Log.IsDebugEnabled;
 
                 Task<Done> Loop(List<string> remainingPhases)


### PR DESCRIPTION
## Changes

Added a tiny bit of logging to CoordinatedShutdown to try to make it easier to debug the reason why we're leaving.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
