### PR TITLE
Add ActivityContext capture to LogEvent for trace correlation

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3345,6 +3345,7 @@ namespace Akka.Event
     public abstract class LogEvent : Akka.Actor.INoSerializationVerificationNeeded
     {
         protected LogEvent() { }
+        public System.Diagnostics.ActivityContext? ActivityContext { get; }
         public System.Exception Cause { get; protected set; }
         public System.Type LogClass { get; protected set; }
         public string LogSource { get; protected set; }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3362,6 +3362,7 @@ namespace Akka.Event
     public abstract class LogEvent : Akka.Actor.INoSerializationVerificationNeeded
     {
         protected LogEvent() { }
+        public System.Diagnostics.ActivityContext? ActivityContext { get; }
         public System.Exception Cause { get; protected set; }
         public System.Type LogClass { get; protected set; }
         public string LogSource { get; protected set; }

--- a/src/core/Akka.Tests/Event/LogEventActivityContextSpec.cs
+++ b/src/core/Akka.Tests/Event/LogEventActivityContextSpec.cs
@@ -1,0 +1,93 @@
+//-----------------------------------------------------------------------
+// <copyright file="LogEventActivityContextSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Diagnostics;
+using Akka.Event;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Tests.Event
+{
+    public class LogEventActivityContextSpec
+    {
+        private static readonly ActivitySource TestSource = new("Akka.Tests.LogEventActivityContextSpec");
+
+        static LogEventActivityContextSpec()
+        {
+            // Enable activity creation for tests
+            ActivitySource.AddActivityListener(new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == TestSource.Name,
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData
+            });
+        }
+
+        [Fact(DisplayName = "LogEvent should capture ActivityContext when Activity.Current exists")]
+        public void LogEvent_should_capture_ActivityContext_when_Activity_exists()
+        {
+            using var activity = TestSource.StartActivity("TestOperation");
+            activity.Should().NotBeNull("ActivityListener should be registered");
+
+            var logEvent = new Info("test", typeof(LogEventActivityContextSpec), "test message");
+
+            logEvent.ActivityContext.Should().NotBeNull();
+            logEvent.ActivityContext.Value.TraceId.Should().Be(activity!.TraceId);
+            logEvent.ActivityContext.Value.SpanId.Should().Be(activity.SpanId);
+        }
+
+        [Fact(DisplayName = "LogEvent should have null ActivityContext when no Activity.Current")]
+        public void LogEvent_should_have_null_ActivityContext_when_no_Activity()
+        {
+            // Ensure no activity is current
+            Activity.Current = null;
+
+            var logEvent = new Info("test", typeof(LogEventActivityContextSpec), "test message");
+
+            logEvent.ActivityContext.Should().BeNull();
+        }
+
+        [Fact(DisplayName = "LogEvent should capture context at creation time, not access time")]
+        public void LogEvent_should_capture_context_at_creation_time()
+        {
+            using var activity = TestSource.StartActivity("TestOperation");
+            activity.Should().NotBeNull();
+
+            var logEvent = new Info("test", typeof(LogEventActivityContextSpec), "test message");
+            var capturedTraceId = logEvent.ActivityContext!.Value.TraceId;
+
+            // Stop the activity
+            activity!.Stop();
+            Activity.Current = null;
+
+            // LogEvent should still have the original context
+            logEvent.ActivityContext.Should().NotBeNull();
+            logEvent.ActivityContext.Value.TraceId.Should().Be(capturedTraceId);
+        }
+
+        [Fact(DisplayName = "All LogEvent types should capture ActivityContext")]
+        public void All_LogEvent_types_should_capture_ActivityContext()
+        {
+            using var activity = TestSource.StartActivity("TestOperation");
+            activity.Should().NotBeNull();
+
+            var debug = new Akka.Event.Debug("test", typeof(LogEventActivityContextSpec), "debug");
+            var info = new Akka.Event.Info("test", typeof(LogEventActivityContextSpec), "info");
+            var warning = new Akka.Event.Warning("test", typeof(LogEventActivityContextSpec), "warning");
+            var error = new Akka.Event.Error(null, "test", typeof(LogEventActivityContextSpec), "error");
+
+            debug.ActivityContext.Should().NotBeNull();
+            info.ActivityContext.Should().NotBeNull();
+            warning.ActivityContext.Should().NotBeNull();
+            error.ActivityContext.Should().NotBeNull();
+
+            debug.ActivityContext.Value.TraceId.Should().Be(activity!.TraceId);
+            info.ActivityContext.Value.TraceId.Should().Be(activity.TraceId);
+            warning.ActivityContext.Value.TraceId.Should().Be(activity.TraceId);
+            error.ActivityContext.Value.TraceId.Should().Be(activity.TraceId);
+        }
+    }
+}

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -22,6 +22,7 @@
   <!-- Packages only for NetStandard -->
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardLibVersion)'">
     <PackageReference Include="Polyfill" Version="1.28.0" PrivateAssets="all" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftLibVersion)" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Threading.Channels" Version="$(MicrosoftLibVersion)" />
   </ItemGroup>

--- a/src/core/Akka/Event/LogEvent.cs
+++ b/src/core/Akka/Event/LogEvent.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using Akka.Actor;
 
@@ -45,10 +46,18 @@ namespace Akka.Event
         /// <summary>
         /// Initializes a new instance of the <see cref="LogEvent" /> class.
         /// </summary>
+        /// <remarks>
+        /// Captures <see cref="Activity.Current"/> trace context at creation time.
+        /// This enables log correlation with distributed traces even after the log event
+        /// crosses actor mailbox boundaries (where <see cref="Activity.Current"/> would be lost).
+        /// </remarks>
         protected LogEvent()
         {
             Timestamp = DateTime.UtcNow;
             Thread = Thread.CurrentThread;
+
+            // Capture Activity.Current context NOW (before mailbox crossing)
+            ActivityContext = Activity.Current?.Context;
         }
 
         /// <summary>
@@ -65,6 +74,16 @@ namespace Akka.Event
         /// The thread where this event occurred.
         /// </summary>
         public Thread Thread { get; private set; }
+
+        /// <summary>
+        /// The trace context from <see cref="Activity.Current"/> captured at log event creation time.
+        /// </summary>
+        /// <remarks>
+        /// This value is captured before the log event crosses actor mailbox boundaries,
+        /// enabling trace correlation with OpenTelemetry and other distributed tracing systems.
+        /// Will be <c>null</c> if no <see cref="Activity"/> was active when the log event was created.
+        /// </remarks>
+        public ActivityContext? ActivityContext { get; private set; }
 
         /// <summary>
         /// The source that generated this event.


### PR DESCRIPTION
## Summary

- Adds `ActivityContext?` property to `LogEvent` base class
- Captures `Activity.Current?.Context` at log event creation time (before mailbox crossing)
- Enables downstream logging backends (like OpenTelemetry) to correlate logs with their parent trace/span

## Motivation

Related to #6855 - `Activity.Current` uses `AsyncLocal<T>` which doesn't flow across actor mailbox boundaries. By capturing the `ActivityContext` at log event creation time, we preserve the trace context for use by logging backends like `LoggerFactoryLogger` in Akka.Hosting.

## Changes

- `LogEvent.cs` - Added `ActivityContext?` property with capture in constructor
- `Akka.csproj` - Added `System.Diagnostics.DiagnosticSource` package for netstandard2.0
- Added unit tests validating trace context capture behavior
- Updated API approval baselines

## Test plan

- [x] Unit tests for `ActivityContext` capture when `Activity.Current` exists
- [x] Unit tests for null `ActivityContext` when no activity
- [x] Unit tests verifying capture happens at creation time
- [x] All existing tests pass
- [x] API approval tests updated