### PR TITLE
Fix racy InMemory specs

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
@@ -18,6 +18,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
 
         public InMemoryAllEventsSpec(ITestOutputHelper output) : base(Config(), nameof(InMemoryAllEventsSpec), output)
         {
+            Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
@@ -23,4 +23,3 @@ namespace Akka.Persistence.Query.InMemory.Tests
         }
     }
 }
-

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
@@ -23,3 +23,4 @@ namespace Akka.Persistence.Query.InMemory.Tests
         }
     }
 }
+

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentAllEventsSpec.cs
@@ -18,6 +18,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
 
         public InMemoryCurrentAllEventsSpec(ITestOutputHelper output) : base(Config(), nameof(InMemoryCurrentAllEventsSpec), output)
         {
+            Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByPersistenceIdSpec.cs
@@ -19,6 +19,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
         public InMemoryCurrentEventsByPersistenceIdSpec(ITestOutputHelper output) : 
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
         {
+            Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByTagSpec.cs
@@ -28,6 +28,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
         public InMemoryCurrentEventsByTagSpec(ITestOutputHelper output) : 
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
         {
+            Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
 

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentPersistenceIdsSpec.cs
@@ -19,6 +19,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
         public InMemoryCurrentPersistenceIdsSpec(ITestOutputHelper output) : 
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
         {
+            Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByPersistenceIdSpec.cs
@@ -19,6 +19,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
         public InMemoryEventsByPersistenceIdSpec(ITestOutputHelper output) :
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
         {
+            Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
@@ -28,6 +28,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
         public InMemoryEventsByTagSpec(ITestOutputHelper output) : 
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
         {
+            Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
 

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceIdsSpec.cs
@@ -21,6 +21,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
 
         public InMemoryPersistenceIdsSpec(ITestOutputHelper output) : base(Config(), nameof(InMemoryPersistenceIdsSpec), output)
         {
+            Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }
     }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceSpecConfig.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceSpecConfig.cs
@@ -14,11 +14,11 @@ public static class InMemoryPersistenceSpecConfig
     /// <summary>
     /// Sets the refresh interval to 1s and uses the in-memory journal and snapshot store.
     /// </summary>
-    public static readonly Config Config = ConfigurationFactory.ParseString("""
-                                                                            
-                                                                                        akka.persistence.query.journal.inmem.refresh-interval = 1s
-                                                                                        akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
-                                                                                        akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.inmem"
-                                                                            """)
+    public static readonly Config Config = ConfigurationFactory.ParseString(
+            """
+            akka.persistence.query.journal.inmem.refresh-interval = 1s
+            akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+            akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.inmem"
+            """)
         .WithFallback(InMemoryReadJournal.DefaultConfiguration());
 }


### PR DESCRIPTION
Apparently, the race condition happened when more than 2 persistence actors tried to initialize the persistence plugin at the same time. The race condition causes a recovery permitter deadlock between these actors.

Pre-initializing the persistence plugin at the start of the test fixes this.

Example deadlock:
```
[DEBUG][01/15/2026 19:33:59.983Z][Thread 0007][akka://InMemoryAllEventsSpec/user/c] Waiting for recovery permit
[DEBUG][01/15/2026 19:33:59.986Z][Thread 0007][akka://InMemoryAllEventsSpec/system/recoveryPermitter-akka.persistence.snapshot-store.inmem] RecoveryPermitter started with max-concurrent-recoveries = 50
[DEBUG][01/15/2026 19:33:59.991Z][Thread 0007][akka://InMemoryAllEventsSpec/system/recoveryPermitter-akka.persistence.journal.inmem] RecoveryPermitter started with max-concurrent-recoveries = 50
[DEBUG][01/15/2026 19:33:59.992Z][Thread 0007][akka://InMemoryAllEventsSpec/system/recoveryPermitter-akka.persistence.journal.inmem] Recovery permit granted for [akka://InMemoryAllEventsSpec/user/c#1047392886]
[DEBUG][01/15/2026 19:34:01.858Z][Thread 0015][akka://InMemoryAllEventsSpec/user/a] Waiting for recovery permit
[DEBUG][01/15/2026 19:34:01.859Z][Thread 0015][akka://InMemoryAllEventsSpec/system/recoveryPermitter-akka.persistence.journal.inmem] Recovery permit granted for [akka://InMemoryAllEventsSpec/user/a#2008260183]
[DEBUG][01/15/2026 19:34:02.839Z][Thread 0016][akka://InMemoryAllEventsSpec/user/b] Waiting for recovery permit
[DEBUG][01/15/2026 19:34:02.839Z][Thread 0016][akka://InMemoryAllEventsSpec/system/recoveryPermitter-akka.persistence.journal.inmem] Recovery permit granted for [akka://InMemoryAllEventsSpec/user/b#206551667]
[INFO][01/15/2026 19:34:03.856Z][Thread 0017][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] CoordinatedShutdown invoked due to [Reason:Akka.Actor.CoordinatedShutdown+ActorSystemTerminateReason]. Exiting with [ExitCode:0].
[DEBUG][01/15/2026 19:34:03.857Z][Thread 0017][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [before-service-unbind] with [0] tasks.
[DEBUG][01/15/2026 19:34:04.840Z][Thread 0018][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [service-unbind] with [0] tasks.
[DEBUG][01/15/2026 19:34:04.841Z][Thread 0018][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [service-requests-done] with [0] tasks.
[DEBUG][01/15/2026 19:34:04.841Z][Thread 0018][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [service-stop] with [0] tasks.
[DEBUG][01/15/2026 19:34:04.841Z][Thread 0018][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [before-cluster-shutdown] with [0] tasks.
[DEBUG][01/15/2026 19:34:04.841Z][Thread 0018][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [cluster-sharding-shutdown-region] with [0] tasks.
[DEBUG][01/15/2026 19:34:04.841Z][Thread 0018][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [cluster-leave] with [0] tasks.
[DEBUG][01/15/2026 19:34:04.841Z][Thread 0018][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [cluster-exiting] with [0] tasks.
[DEBUG][01/15/2026 19:34:04.841Z][Thread 0018][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [cluster-exiting-done] with [0] tasks.
[DEBUG][01/15/2026 19:34:04.841Z][Thread 0018][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [cluster-shutdown] with [0] tasks.
[DEBUG][01/15/2026 19:34:04.841Z][Thread 0018][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [before-actor-system-terminate] with [0] tasks.
[DEBUG][01/15/2026 19:34:04.846Z][Thread 0018][CoordinatedShutdown (akka://InMemoryAllEventsSpec)] Performing phase [actor-system-terminate] with [1] tasks: [terminate-system]
[DEBUG][01/15/2026 19:34:04.846Z][Thread 0018][ActorSystem(InMemoryAllEventsSpec)] System shutdown initiated
[DEBUG][01/15/2026 19:34:05.859Z][Thread 0016][akka://InMemoryAllEventsSpec/user/b] Recovery started <-- Recovery deadlocked and only started after the actor system starting to shut down
[DEBUG][01/15/2026 19:34:05.859Z][Thread 0007][akka://InMemoryAllEventsSpec/user/c] Recovery started
[DEBUG][01/15/2026 19:34:05.859Z][Thread 0015][akka://InMemoryAllEventsSpec/user/a] Recovery started
[DEBUG][01/15/2026 19:34:05.867Z][Thread 0016][EventStream] Shutting down: StandardOutLogger started
[DEBUG][01/15/2026 19:34:05.868Z][Thread 0016][EventStream] All default loggers stopped
```
