### PR TITLE
Fix ReceivePersistentActorAsyncAwaitSpec timeout

### DIFF
--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
@@ -93,6 +93,16 @@ namespace Akka.Persistence.Tests
 
     public class AsyncAwaitActor : ReceivePersistentActor
     {
+        /// <summary>
+        /// Marker class for testing - sending this will get a synchronous "pong" reply.
+        /// Use this to verify the actor has completed recovery before testing async handlers.
+        /// </summary>
+        public sealed class Ping
+        {
+            public static readonly Ping Instance = new();
+            private Ping() { }
+        }
+
         public override string PersistenceId { get; }
 
         public AsyncAwaitActor(string persistenceId)
@@ -100,6 +110,9 @@ namespace Akka.Persistence.Tests
             PersistenceId = persistenceId;
 
             RecoverAny(_ => { });
+
+            // Synchronous handler for verifying actor is ready
+            Command<Ping>(_ => Sender.Tell("pong"));
 
             CommandAsync<string>(async _ =>
             {
@@ -643,6 +656,13 @@ namespace Akka.Persistence.Tests
             // previous test runs or parallel tests sharing static journal state
             var persistenceId = $"async-overloads-{Guid.NewGuid():N}";
             var actor = Sys.ActorOf(Props.Create(() => new AsyncAwaitActor(persistenceId)));
+
+            // Wait for recovery to complete before testing async handlers.
+            // Under CI load, recovery can take time and messages sent before recovery
+            // completes are stashed, adding variable delay to the first response.
+            actor.Tell(AsyncAwaitActor.Ping.Instance);
+            ExpectMsg<string>(m => "pong".Equals(m), TimeSpan.FromSeconds(10),
+                "Actor should respond to Ping after recovery completes");
 
             actor.Tell(11);
             ExpectMsg<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000),

--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
@@ -639,16 +639,22 @@ namespace Akka.Persistence.Tests
         [Fact]
         public Task Actor_receiveasync_overloads_should_work()
         {
-            var actor = Sys.ActorOf(Props.Create(() => new AsyncAwaitActor("pid")));
+            // Use unique persistence ID to avoid any potential interference from
+            // previous test runs or parallel tests sharing static journal state
+            var persistenceId = $"async-overloads-{Guid.NewGuid():N}";
+            var actor = Sys.ActorOf(Props.Create(() => new AsyncAwaitActor(persistenceId)));
 
             actor.Tell(11);
-            ExpectMsg<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000));
+            ExpectMsg<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000),
+                "Expected 'handled' for int > 10 via CommandAsync<int>");
 
             actor.Tell(9);
-            ExpectMsg<string>(m => "receiveany".Equals(m), TimeSpan.FromMilliseconds(1000));
+            ExpectMsg<string>(m => "receiveany".Equals(m), TimeSpan.FromMilliseconds(1000),
+                "Expected 'receiveany' for int <= 10 via CommandAnyAsync");
 
             actor.Tell(1.0);
-            ExpectMsg<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000));
+            ExpectMsg<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000),
+                "Expected 'handled' for double via CommandAsync(typeof(double))");
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary
- Fixed timeout in `ReceivePersistentActorAsyncAwaitSpec.Actor_receiveasync_overloads_should_work`
- Added unique persistence ID using `Guid.NewGuid()` to avoid potential interference from shared static journal state
- Added descriptive hints to `ExpectMsg` calls for better diagnostics

## Problem
The test uses hardcoded persistence ID "intasync" which could collide with static `MemoryJournal` state from other tests or previous runs in the same process, potentially causing recovery to interfere with the test timing.

## Test plan
- [ ] CI passes for `ReceivePersistentActorAsyncAwaitSpec.Actor_receiveasync_overloads_should_work`