### PR TITLE
Fix racy ClusterClientSpec server restart test

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
@@ -642,7 +642,7 @@ public class ClusterClientSpec : MultiNodeClusterSpec
 
     public async Task ClusterClient_must_reestablish_connection_to_receptionist_after_server_restart()
     {
-        await WithinAsync(30.Seconds(), async () =>
+        await WithinAsync(60.Seconds(), async () =>
         {
             await RunOnAsync(async () =>
             {
@@ -666,6 +666,17 @@ public class ClusterClientSpec : MultiNodeClusterSpec
                     });
                 });
 
+                // After reconnection, verify we can communicate with the restarted server
+                // by sending a test message and expecting a reply. This ensures service2
+                // is fully registered on sys2 before we send the shutdown command.
+                await AwaitAssertAsync(async () =>
+                {
+                    var probe = CreateTestProbe();
+                    c.Tell(new ClusterClient.Send("/user/service2", "bonjour5", localAffinity: true), probe.Ref);
+                    var reply2 = await probe.ExpectMsgAsync<ClusterClientSpecConfig.Reply>(3.Seconds());
+                    reply2.Msg.Should().Be("bonjour5-ack");
+                }, 15.Seconds());
+
                 c.Tell(new ClusterClient.Send("/user/service2", "shutdown", localAffinity: true));
                 await Task.Delay(2000); // to ensure that it is sent out before shutting down system
             }, _config.Client);
@@ -681,7 +692,7 @@ public class ClusterClientSpec : MultiNodeClusterSpec
                 Cluster.Get(sys2).Join(Cluster.Get(sys2).SelfAddress);
                 var service2 = sys2.ActorOf(Props.Create(() => new ClusterClientSpecConfig.TestService(TestActor)), "service2");
                 ClusterClientReceptionist.Get(sys2).RegisterService(service2);
-                await sys2.WhenTerminated.WaitAsync(20.Seconds());
+                await sys2.WhenTerminated.WaitAsync(40.Seconds());
             }, _remainingServerRoleNames.ToArray());
         });
     }


### PR DESCRIPTION
## Summary

Fixes a race condition in `ClusterClient_must_reestablish_connection_to_receptionist_after_server_restart` that caused intermittent multi-node test failures unrelated to actual code changes (e.g., in PR #7995).

## Root Cause

The test sent the "shutdown" message immediately after receiving a "Connected to" log event, without verifying that:
1. The new `sys2` ActorSystem was fully operational
2. The `service2` actor was registered with the receptionist

This caused the shutdown message to be lost when:
- Sent to the old system that was already shutting down, OR
- Sent before `service2` was registered on `sys2`

## Changes

- Add `AwaitAssertAsync` verification step that sends a test message and expects a reply before sending the shutdown command - this ensures `service2` is fully registered and reachable on `sys2`
- Increase outer timeout from 30s to 60s for retry headroom
- Increase `sys2` termination timeout from 20s to 40s

## Test Plan

- [x] Ran the test 10 consecutive times locally - all passed
- [x] Build succeeds