### PR TITLE
Fix Inbox.AwaitResult throwing AggregateException instead of TimeoutException

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
@@ -176,7 +176,7 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
                     // let them gossip, but Delta should not be exchanged
                     await probe.ExpectNoMsgAsync(5.Seconds());
                     newMediator.Tell(DeltaCount.Instance, probe.Ref);
-                    await probe.ExpectMsgAsync(0L);
+                    await probe.ExpectMsgAsync(0L, 10.Seconds());
 
                     await newSystem.WhenTerminated.WaitAsync(30.Seconds());
                 }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
@@ -176,7 +176,7 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
                     // let them gossip, but Delta should not be exchanged
                     await probe.ExpectNoMsgAsync(5.Seconds());
                     newMediator.Tell(DeltaCount.Instance, probe.Ref);
-                    await probe.ExpectMsgAsync(0L, 10.Seconds());
+                    await probe.ExpectMsgAsync(0L);
 
                     await newSystem.WhenTerminated.WaitAsync(30.Seconds());
                 }

--- a/src/core/Akka/Actor/Inbox.cs
+++ b/src/core/Akka/Actor/Inbox.cs
@@ -578,6 +578,16 @@ namespace Akka.Actor
                 throw new TimeoutException(
                     $"Inbox {Receiver.Path} didn't receive a response message in specified timeout {timeout}");
 
+            // Handle faulted tasks to avoid AggregateException when accessing task.Result
+            if (task.IsFaulted)
+            {
+                var exception = task.Exception?.InnerException ?? task.Exception;
+                if (exception is TimeoutException timeoutEx)
+                    throw new TimeoutException(
+                        $"Inbox {Receiver.Path} received a timeout: {timeoutEx.Message}", timeoutEx);
+                throw exception!;
+            }
+
             if (task.Result is Status.Failure received && received.Cause is TimeoutException)
             {
                 throw new TimeoutException(


### PR DESCRIPTION
## Summary
Fixes flaky InboxSpec test failure where `AggregateException` was thrown instead of the expected `TimeoutException`.

## Problem
When `FutureActorRef` faults the task with a `TimeoutException` (via `Status.Failure`), accessing `task.Result` would throw `AggregateException` instead of the expected `TimeoutException`. This caused test assertions expecting `TimeoutException` to fail intermittently when the internal `Kick` message timeout won the race against `task.Wait(timeout)`.

## Solution
The fix checks `task.IsFaulted` after `Wait()` returns and properly unwraps the exception before throwing, ensuring `TimeoutException` is thrown directly.

## Changes
- `src/core/Akka/Actor/Inbox.cs`: Added faulted task handling in `AwaitResult()` method

## Test plan
- [x] Verified `InboxSpec.Inbox_have_a_default_and_custom_timeouts` passes 10/10 runs
- [x] Verified all 7 InboxSpec tests pass