### PR TITLE
Fix logger initialization continuation race in LoggingBus

### DIFF
--- a/src/core/Akka/Event/LoggingBus.cs
+++ b/src/core/Akka/Event/LoggingBus.cs
@@ -218,6 +218,15 @@ namespace Akka.Event
                         return;
                     }
 
+                    // Ask operation failed with an exception
+                    if (t.IsFaulted)
+                    {
+                        Publish(new Error(t.Exception, loggingBusName, GetType(),
+                            $"Logger {fullLoggerName} failed to respond to initialization request. Stopping logger."));
+                        RemoveLogger(logger);
+                        return;
+                    }
+
                     // Task ran to completion successfully
                     var response = t.Result;
                     if (response is not LoggerInitialized)

--- a/src/core/Akka/Event/LoggingBus.cs
+++ b/src/core/Akka/Event/LoggingBus.cs
@@ -204,8 +204,10 @@ namespace Akka.Event
             var fullLoggerName = $"{loggerName} [{loggerType.FullName}]";
             var logger = system.SystemActorOf(Props.Create(loggerType).WithDispatcher(system.Settings.LoggersDispatcher), loggerName);
             var askTask = logger.Ask(new InitializeLogger(this), Timeout.InfiniteTimeSpan, _shutdownCts.Token);
-            
-            askTask.ContinueWith(t =>
+
+            // Return the continuation task, not the ask task, so callers wait for
+            // the full initialization sequence including the "Logger started" message
+            var continuationTask = askTask.ContinueWith(t =>
                 {
                     // _shutdownCts was cancelled while this logger is still loading
                     if (t.IsCanceled)
@@ -215,7 +217,7 @@ namespace Akka.Event
                         RemoveLogger(logger);
                         return;
                     }
-                    
+
                     // Task ran to completion successfully
                     var response = t.Result;
                     if (response is not LoggerInitialized)
@@ -231,8 +233,8 @@ namespace Akka.Event
                     _loggers.Add(logger);
                     SubscribeLogLevelAndAbove(LogLevel, logger);
                     Publish(new Debug(loggingBusName, GetType(), $"Logger {fullLoggerName} started"));
-                });
-            return (askTask, fullLoggerName);
+                }, TaskContinuationOptions.ExecuteSynchronously);
+            return (continuationTask, fullLoggerName);
         }
 
         private string CreateLoggerName(Type actorClass)


### PR DESCRIPTION
## Summary
Fixes flaky EventFilterDebugTests where "Logger started" message was published during test teardown.

## Problem
`StartDefaultLoggers` was only waiting for the Ask task (logger ACK), not the continuation that publishes "Logger started" message. This caused the continuation to run during test teardown, triggering EventFilter assertions.

## Solution
The fix makes two changes to `AddLogger`:
1. Returns the continuation task instead of the Ask task, so `Task.WaitAll` waits for the full initialization sequence
2. Uses `TaskContinuationOptions.ExecuteSynchronously` to ensure the continuation runs immediately when the Ask completes

## Changes
- `src/core/Akka/Event/LoggingBus.cs`: Return continuation task from `AddLogger()` and add `ExecuteSynchronously` option

## Test plan
- [x] Verified `EventFilterDebugTests.Messages_can_be_muted_from_now_on_with_using` passes 10/10 runs
- [x] Both EventFilterDebugTests and CustomEventFilterDebugTests variants pass