### PR TITLE
Fix ClusterClientSpec flaky shutdown test with ask-pattern confirmation

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
@@ -85,6 +85,8 @@ public class ClusterClientSpecConfig : MultiNodeConfig
         {
             Receive<string>(cmd => cmd.Equals("shutdown"), _ =>
             {
+                // Send confirmation before terminating so the sender knows the message was received
+                Sender.Tell("shutting-down");
                 Context.System.Terminate();
             });
 
@@ -677,8 +679,13 @@ public class ClusterClientSpec : MultiNodeClusterSpec
                     reply2.Msg.Should().Be("bonjour5-ack");
                 }, 15.Seconds());
 
-                c.Tell(new ClusterClient.Send("/user/service2", "shutdown", localAffinity: true));
-                await Task.Delay(2000); // to ensure that it is sent out before shutting down system
+                // Use AwaitAssertAsync to retry until we get confirmation the shutdown was received
+                await AwaitAssertAsync(async () =>
+                {
+                    var probe = CreateTestProbe();
+                    c.Tell(new ClusterClient.Send("/user/service2", "shutdown", localAffinity: true), probe.Ref);
+                    await probe.ExpectMsgAsync<string>(s => s == "shutting-down", 3.Seconds());
+                }, 15.Seconds());
             }, _config.Client);
 
             await RunOnAsync(async () =>


### PR DESCRIPTION
## Summary

This PR fixes a flaky test in `ClusterClientSpec.ClusterClient_must_reestablish_connection_to_receptionist_after_server_restart`.

This is a follow-up to https://github.com/akkadotnet/akka.net/pull/8004, which added verification that the reconnected service is responsive before sending the shutdown command. However, that fix was incomplete because the shutdown message itself is still fire-and-forget - there's no guarantee the message is delivered before the test proceeds to wait for `sys2.WhenTerminated`.

## Root Cause

The test was sending the shutdown command without any delivery confirmation:
```csharp
c.Tell(new ClusterClient.Send("/user/service2", "shutdown", localAffinity: true));
await Task.Delay(2.Seconds());
```

The `Task.Delay` was a heuristic that could fail under load. Even with PR #8004's fix ensuring the service is responsive, the subsequent shutdown message could still be lost or delayed.

## Solution

1. **Modified `TestService`** to send a confirmation message before terminating:
   ```csharp
   Receive<string>(cmd => cmd.Equals("shutdown"), _ =>
   {
       Sender.Tell("shutting-down");
       Context.System.Terminate();
   });
   ```

2. **Replaced fire-and-forget with ask-pattern** using `AwaitAssertAsync` to retry until confirmation is received:
   ```csharp
   await AwaitAssertAsync(async () =>
   {
       var probe = CreateTestProbe();
       c.Tell(new ClusterClient.Send("/user/service2", "shutdown", localAffinity: true), probe.Ref);
       await probe.ExpectMsgAsync<string>(s => s == "shutting-down", 3.Seconds());
   }, 15.Seconds());
   ```

This ensures the shutdown command is actually received before the test proceeds to wait for system termination.

## Test plan

- [x] Verified locally with 10 consecutive runs on net8.0
- [ ] CI passes