### PR TITLE
Fix race condition in DistributedPubSubRestartSpec

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
@@ -165,11 +165,6 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
                     var newMediator = DistributedPubSub.Get(newSystem).Mediator;
                     var probe = CreateTestProbe(newSystem);
 
-                    // Create shutdown actor FIRST so First node can find it while we verify gossip isolation
-                    // This fixes the race condition where First node times out waiting for this actor
-                    newSystem.Log.Info("Creating shutdown actor on {0}", node3Address);
-                    newSystem.ActorOf<DistributedPubSubRestartSpecConfig.Shutdown>("shutdown");
-
                     newMediator.Tell(new Subscribe("topic2", probe.Ref), probe.Ref);
                     await probe.ExpectMsgAsync<SubscribeAck>();
 
@@ -177,6 +172,13 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
                     await probe.ExpectNoMsgAsync(5.Seconds());
                     newMediator.Tell(DeltaCount.Instance, probe.Ref);
                     await probe.ExpectMsgAsync(0L);
+
+                    // Create shutdown actor AFTER verifying gossip isolation.
+                    // First node will find this actor and send "shutdown" to terminate newSystem.
+                    // We must complete the DeltaCount check above before this, otherwise there's
+                    // a race where First triggers shutdown while we're still verifying.
+                    newSystem.Log.Info("Creating shutdown actor on {0}", node3Address);
+                    newSystem.ActorOf<DistributedPubSubRestartSpecConfig.Shutdown>("shutdown");
 
                     await newSystem.WhenTerminated.WaitAsync(30.Seconds());
                 }


### PR DESCRIPTION
## Summary
- Fixes race condition where First node could trigger system shutdown while Third node was still verifying gossip isolation

## Root Cause
The test was creating the Shutdown actor early (before DeltaCount verification). This allowed First node to:
1. Find the Shutdown actor via `Identify`
2. Send "shutdown" message
3. Trigger `newSystem.Terminate()`

Meanwhile, Third node was:
1. Waiting 5 seconds for no gossip messages
2. Sending DeltaCount to mediator
3. **But the mediator was stopping** because it received `MemberRemoved` for itself during system termination

The DeltaCount response never arrived because the mediator had already stopped.

## Fix
Move Shutdown actor creation to AFTER the DeltaCount verification. The Shutdown actor's existence now serves as the synchronization signal - First cannot trigger shutdown until Third has completed its verification and created the actor.

## Test plan
- [x] Ran test 10 times locally - all passed
- [ ] CI validation