### PR TITLE
Fix MetricsCollectorSpec timeout by avoiding blocking GC

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Base/AkkaSpecWithCollector.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Base/AkkaSpecWithCollector.cs
@@ -71,21 +71,26 @@ namespace Akka.Cluster.Metrics.Tests.Base
         {
             using var cts = new CancellationTokenSource(timeout);
             NodeMetrics metrics = null;
-            
+
             // Give the collector extra time to initialize on first sample
             // The DefaultCollector needs time for CPU timing initialization
             var attemptCount = 0;
             var exceptionCount = 0;
             const int maxExceptionAttempts = 3;
-            
+            string lastDiagnostics = "no samples taken";
+
             do
             {
                 cts.Token.ThrowIfCancellationRequested();
-                
+
                 try
                 {
                     metrics = Collector.Sample();
-                    
+
+                    // Collect diagnostics for debugging CI failures
+                    var metricNames = string.Join(", ", metrics.Metrics.Select(m => $"{m.Name}={m.Value}"));
+                    lastDiagnostics = $"Attempt {attemptCount}: [{metricNames}]";
+
                     if (HasRequiredMetrics(metrics.Metrics, requiredMetrics))
                     {
                         return metrics;
@@ -96,38 +101,41 @@ namespace Akka.Cluster.Metrics.Tests.Base
                     // Log but continue - collector might need more time to initialize
                     // This handles platform-specific issues like process access on Linux
                     exceptionCount++;
+                    lastDiagnostics = $"Attempt {attemptCount}: Exception - {ex.Message}";
+
                     if (exceptionCount >= maxExceptionAttempts)
                     {
                         throw new InvalidOperationException($"Metrics collector failed after {maxExceptionAttempts} consecutive exceptions. Last error: {ex.Message}", ex);
                     }
-                    
+
                     // Longer delay after exceptions to allow system to recover
                     await Task.Delay(1000, cts.Token);
                     attemptCount++;
                     continue;
                 }
-                
+
                 // Reset exception count on successful sample
                 exceptionCount = 0;
-                
+
                 // Progressive backoff: longer delays for later attempts
                 var delayMs = attemptCount switch
                 {
                     < 5 => 200,   // First few attempts: 200ms
-                    < 15 => 500,  // Middle attempts: 500ms  
+                    < 15 => 500,  // Middle attempts: 500ms
                     _ => 1000     // Later attempts: 1000ms
                 };
-                
+
                 attemptCount++;
                 await Task.Delay(delayMs, cts.Token);
-                
+
             } while (!cts.Token.IsCancellationRequested);
-            
+
             // Provide detailed diagnostics for timeout failures
             var availableMetrics = string.Join(", ", metrics?.Metrics?.Select(m => m.Name) ?? new[] { "none" });
             throw new OperationCanceledException(
                 $"Could not collect required metrics [{string.Join(", ", requiredMetrics)}] within {timeout}. " +
-                $"Available metrics: [{availableMetrics}]. Attempts made: {attemptCount}");
+                $"Available metrics: [{availableMetrics}]. Attempts made: {attemptCount}. " +
+                $"Last sample: {lastDiagnostics}");
         }
 
         private static bool HasRequiredMetrics(ImmutableHashSet<NodeMetrics.Types.Metric> metrics, string[] requiredMetrics)

--- a/src/contrib/cluster/Akka.Cluster.Metrics/Collectors/DefaultCollector.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/Collectors/DefaultCollector.cs
@@ -61,11 +61,8 @@ namespace Akka.Cluster.Metrics.Collectors
                 process.Refresh();
                 var metrics = new List<NodeMetrics.Types.Metric>();
 
-                // Use GC.GetTotalMemory(false) to avoid forcing a blocking GC.
-                // GC.GetTotalMemory(true) can be extremely slow (seconds to minutes) in containerized
-                // or memory-pressured environments like CI/CD, potentially causing test timeouts.
-                // The non-forcing version returns a reasonably accurate approximation.
-                var memoryUsedValue = GC.GetTotalMemory(false);
+                // Get memory used - managed heap size with fallbacks for known .NET runtime bugs
+                var memoryUsedValue = GetMemoryUsedBytes(process);
                 var totalMemory = NodeMetrics.Types.Metric.Create(StandardMetrics.MemoryUsed, memoryUsedValue);
                 if (totalMemory.HasValue)
                     metrics.Add(totalMemory.Value);
@@ -75,29 +72,6 @@ namespace Akka.Cluster.Metrics.Collectors
                 var availableMemory = NodeMetrics.Types.Metric.Create(StandardMetrics.MemoryAvailable, availableMemoryValue);
                 if (availableMemory.HasValue)
                     metrics.Add(availableMemory.Value);
-
-                // Diagnostic: If either critical metric is missing, throw with details
-                // This helps diagnose CI failures where metrics silently fail to be created
-                if (!totalMemory.HasValue || !availableMemory.HasValue)
-                {
-                    var workingSet = process.WorkingSet64;
-#if NET6_0_OR_GREATER
-                    var gcInfo = GC.GetGCMemoryInfo();
-                    throw new InvalidOperationException(
-                        $"Failed to create memory metrics. " +
-                        $"MemoryUsed: value={memoryUsedValue}, created={totalMemory.HasValue}. " +
-                        $"MemoryAvailable: value={availableMemoryValue}, created={availableMemory.HasValue}. " +
-                        $"Diagnostics: WorkingSet64={workingSet}, GCMemoryInfo.Index={gcInfo.Index}, " +
-                        $"TotalAvailableMemoryBytes={gcInfo.TotalAvailableMemoryBytes}, " +
-                        $"HighMemoryLoadThresholdBytes={gcInfo.HighMemoryLoadThresholdBytes}");
-#else
-                    throw new InvalidOperationException(
-                        $"Failed to create memory metrics. " +
-                        $"MemoryUsed: value={memoryUsedValue}, created={totalMemory.HasValue}. " +
-                        $"MemoryAvailable: value={availableMemoryValue}, created={availableMemory.HasValue}. " +
-                        $"Diagnostics: WorkingSet64={workingSet}");
-#endif
-                }
 
                 var processorCount = NodeMetrics.Types.Metric.Create(StandardMetrics.Processors, Environment.ProcessorCount);
                 if(processorCount.HasValue)
@@ -202,6 +176,61 @@ namespace Akka.Cluster.Metrics.Collectors
                 .Select(proc => Try<(int Id, TimeSpan Time)>.From(() => (proc.Id, proc.TotalProcessorTime)))
                 .Where(result => result.IsSuccess)
                 .ToImmutableDictionary(result => result.Get().Id, p => p.Get().Time);
+        }
+
+        /// <summary>
+        /// Gets the memory used (managed heap size) for the current process.
+        /// Handles a known .NET runtime bug where GC.GetTotalMemory() can occasionally
+        /// return negative values due to gen0 fragmentation calculations.
+        /// Falls back to GCMemoryInfo.HeapSizeBytes or process private memory if needed.
+        /// </summary>
+        /// <remarks>
+        /// See: https://github.com/dotnet/runtime/issues/106712
+        /// The bug was introduced in .NET 7 with the regions GC feature and causes
+        /// gen0 fragmentation to sometimes be calculated as larger than gen0 size,
+        /// resulting in a negative total memory value. As of .NET 9, this is unfixed.
+        /// </remarks>
+        private static long GetMemoryUsedBytes(Process process)
+        {
+#if NET6_0_OR_GREATER
+            // Use GC.GetTotalMemory(false) to avoid forcing a blocking GC.
+            // GC.GetTotalMemory(true) can be extremely slow in containerized environments.
+            var memoryUsed = GC.GetTotalMemory(false);
+
+            // Known .NET runtime bug: GC.GetTotalMemory() can return negative values
+            // when gen0 fragmentation exceeds gen0 size. Calling GC.GetTotalMemory(true)
+            // fixes it, but we avoid that for performance. Instead, we fall back to
+            // GCMemoryInfo.HeapSizeBytes when the value is invalid.
+            // See: https://github.com/dotnet/runtime/issues/106712
+            if (memoryUsed <= 0)
+            {
+                // Fall back to GCMemoryInfo.HeapSizeBytes which is the total heap size
+                var gcMemoryInfo = GC.GetGCMemoryInfo();
+                if (gcMemoryInfo.Index > 0 && gcMemoryInfo.HeapSizeBytes > 0)
+                {
+                    memoryUsed = gcMemoryInfo.HeapSizeBytes;
+                }
+                else
+                {
+                    // Final fallback: use private memory size (includes managed + some unmanaged)
+                    memoryUsed = process.PrivateMemorySize64;
+                }
+            }
+
+            return memoryUsed;
+#else
+            // For .NET Framework / netstandard2.0, GC.GetTotalMemory should work reliably.
+            // The bug is specific to .NET 7+ regions GC feature.
+            var memoryUsed = GC.GetTotalMemory(false);
+
+            // Still add a fallback for safety
+            if (memoryUsed <= 0)
+            {
+                memoryUsed = process.PrivateMemorySize64;
+            }
+
+            return memoryUsed;
+#endif
         }
 
         /// <summary>

--- a/src/contrib/cluster/Akka.Cluster.Metrics/Collectors/DefaultCollector.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics/Collectors/DefaultCollector.cs
@@ -37,13 +37,9 @@ namespace Akka.Cluster.Metrics.Collectors
         {
             _address = address;
             _cpuWatch = new Stopwatch();
-
-#if NET6_0_OR_GREATER
-            // Initialize GC memory info by forcing a quick generation 0 collection.
-            // This ensures GetGCMemoryInfo() returns valid data on first Sample() call.
-            // Without this, TotalAvailableMemoryBytes may return 0 or negative on first access.
-            GC.Collect(0, GCCollectionMode.Optimized, blocking: false);
-#endif
+            // Note: We no longer force a GC here because GC.Collect() can be slow in
+            // containerized environments. Instead, GetAvailableMemoryBytes() checks
+            // GCMemoryInfo.Index and falls back to process.WorkingSet64 if no GC has occurred.
         }
         
         public DefaultCollector(ActorSystem system) 
@@ -65,9 +61,12 @@ namespace Akka.Cluster.Metrics.Collectors
                 process.Refresh();
                 var metrics = new List<NodeMetrics.Types.Metric>();
 
-                // GC.GetTotalMemory(true) forces a blocking GC, which also ensures
-                // GetGCMemoryInfo() returns valid data for subsequent calls
-                var totalMemory = NodeMetrics.Types.Metric.Create(StandardMetrics.MemoryUsed, GC.GetTotalMemory(true));
+                // Use GC.GetTotalMemory(false) to avoid forcing a blocking GC.
+                // GC.GetTotalMemory(true) can be extremely slow (seconds to minutes) in containerized
+                // or memory-pressured environments like CI/CD, potentially causing test timeouts.
+                // The non-forcing version returns a reasonably accurate approximation.
+                var memoryUsedValue = GC.GetTotalMemory(false);
+                var totalMemory = NodeMetrics.Types.Metric.Create(StandardMetrics.MemoryUsed, memoryUsedValue);
                 if (totalMemory.HasValue)
                     metrics.Add(totalMemory.Value);
 
@@ -76,6 +75,29 @@ namespace Akka.Cluster.Metrics.Collectors
                 var availableMemory = NodeMetrics.Types.Metric.Create(StandardMetrics.MemoryAvailable, availableMemoryValue);
                 if (availableMemory.HasValue)
                     metrics.Add(availableMemory.Value);
+
+                // Diagnostic: If either critical metric is missing, throw with details
+                // This helps diagnose CI failures where metrics silently fail to be created
+                if (!totalMemory.HasValue || !availableMemory.HasValue)
+                {
+                    var workingSet = process.WorkingSet64;
+#if NET6_0_OR_GREATER
+                    var gcInfo = GC.GetGCMemoryInfo();
+                    throw new InvalidOperationException(
+                        $"Failed to create memory metrics. " +
+                        $"MemoryUsed: value={memoryUsedValue}, created={totalMemory.HasValue}. " +
+                        $"MemoryAvailable: value={availableMemoryValue}, created={availableMemory.HasValue}. " +
+                        $"Diagnostics: WorkingSet64={workingSet}, GCMemoryInfo.Index={gcInfo.Index}, " +
+                        $"TotalAvailableMemoryBytes={gcInfo.TotalAvailableMemoryBytes}, " +
+                        $"HighMemoryLoadThresholdBytes={gcInfo.HighMemoryLoadThresholdBytes}");
+#else
+                    throw new InvalidOperationException(
+                        $"Failed to create memory metrics. " +
+                        $"MemoryUsed: value={memoryUsedValue}, created={totalMemory.HasValue}. " +
+                        $"MemoryAvailable: value={availableMemoryValue}, created={availableMemory.HasValue}. " +
+                        $"Diagnostics: WorkingSet64={workingSet}");
+#endif
+                }
 
                 var processorCount = NodeMetrics.Types.Metric.Create(StandardMetrics.Processors, Environment.ProcessorCount);
                 if(processorCount.HasValue)
@@ -190,29 +212,46 @@ namespace Akka.Cluster.Metrics.Collectors
         private static long GetAvailableMemoryBytes(Process process)
         {
 #if NET6_0_OR_GREATER
-            // Use GCMemoryInfo for accurate, container-aware memory information.
-            // TotalAvailableMemoryBytes represents the total memory available to the GC,
-            // respecting container cgroup limits. This is the correct semantic for
-            // "available memory" in the context of cluster load balancing.
-            var gcMemoryInfo = GC.GetGCMemoryInfo();
-            var availableBytes = gcMemoryInfo.TotalAvailableMemoryBytes;
-
-            // TotalAvailableMemoryBytes can return 0 or negative before GC properly initializes,
-            // even after our constructor warm-up. Fall back to HighMemoryLoadThresholdBytes
-            // which represents the threshold before the GC considers memory pressure.
-            // This is still a valid proxy for "available memory capacity".
-            if (availableBytes <= 0)
+            try
             {
-                availableBytes = gcMemoryInfo.HighMemoryLoadThresholdBytes;
-            }
+                // Use GCMemoryInfo for accurate, container-aware memory information.
+                // TotalAvailableMemoryBytes represents the total memory available to the GC,
+                // respecting container cgroup limits. This is the correct semantic for
+                // "available memory" in the context of cluster load balancing.
+                var gcMemoryInfo = GC.GetGCMemoryInfo();
 
-            // If still invalid (very rare edge case), fall back to process working set
-            if (availableBytes <= 0)
+                // If Index is 0, no GC has occurred yet and all values will be 0.
+                // Fall back to process working set in this case.
+                // See: https://learn.microsoft.com/en-us/dotnet/api/system.gc.getgcmemoryinfo
+                if (gcMemoryInfo.Index == 0)
+                {
+                    return process.WorkingSet64;
+                }
+
+                var availableBytes = gcMemoryInfo.TotalAvailableMemoryBytes;
+
+                // TotalAvailableMemoryBytes can return 0 or negative on some platforms
+                // (e.g., ARM32, certain container configurations).
+                // Fall back to HighMemoryLoadThresholdBytes which represents the threshold
+                // before the GC considers memory pressure.
+                if (availableBytes <= 0)
+                {
+                    availableBytes = gcMemoryInfo.HighMemoryLoadThresholdBytes;
+                }
+
+                // If still invalid, fall back to process working set
+                if (availableBytes <= 0)
+                {
+                    availableBytes = process.WorkingSet64;
+                }
+
+                return availableBytes;
+            }
+            catch
             {
-                availableBytes = process.WorkingSet64;
+                // If GC memory info throws for any reason, fall back to working set
+                return process.WorkingSet64;
             }
-
-            return availableBytes;
 #else
             // For .NET Framework / netstandard2.0, GCMemoryInfo is not available.
             // Use process working set as the best available approximation.


### PR DESCRIPTION
## Summary
Fixes the intermittent MetricsCollectorSpec timeout on Windows CI by avoiding blocking GC operations.

## Root Cause
`GC.GetTotalMemory(true)` forces a blocking garbage collection. In containerized or memory-pressured CI environments (like Azure DevOps Windows agents), blocking GC can take **seconds to minutes**, causing the 60-second test timeout to be exceeded.

Research sources:
- [dotnet/runtime#55126](https://github.com/dotnet/runtime/issues/55126) - Unexpected values from GetGCMemoryInfo
- [aspnet/dnx#2886](https://github.com/aspnet/dnx/issues/2886) - GetTotalMemory(true) 50x slower under DNX
- [Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/api/system.gc.getgcmemoryinfo) - GCMemoryInfo returns 0 before any GC

## Changes

### DefaultCollector.cs
- Use `GC.GetTotalMemory(false)` instead of `true` to avoid forcing a blocking GC
- Check `GCMemoryInfo.Index == 0` to detect if no GC has occurred yet (all values will be 0)
- Fall back to `process.WorkingSet64` when GC memory info is unavailable or invalid
- Remove unnecessary `GC.Collect` warmup from constructor (now handled by fallback logic)

### AkkaSpecWithCollector.cs
- Add better diagnostics showing metric values on each attempt for debugging CI failures

## Test Plan
- [x] MetricsCollectorSpec passes 5/5 runs locally
- [ ] CI passes on Windows (the platform where this was failing)