### PR TITLE
Add AwaitClusterUpAsync overload without CancellationToken

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRolePartitioningSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRolePartitioningSpec.cs
@@ -198,7 +198,7 @@ namespace Akka.Cluster.Sharding.Tests
                 settings: Settings.Value.WithRole("R2"),
                 messageExtractor: new E2.MessageExtractor());
 
-            await AwaitClusterUpAsync(default, Config.First, Config.Second, Config.Third, Config.Fourth, Config.Fifth);
+            await AwaitClusterUpAsync(Config.First, Config.Second, Config.Third, Config.Fourth, Config.Fifth);
 
             await RunOnAsync(async () =>
             {

--- a/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
+++ b/src/core/Akka.Cluster.TestKit/MultiNodeClusterSpec.cs
@@ -307,7 +307,7 @@ namespace Akka.Cluster.TestKit
             await RunOnAsync(async () => await StartClusterNodeAsync(cancellationToken), roles.First());
 
             await EnterBarrierAsync(cancellationToken, roles.First().Name + "-started");
-            if (roles.Skip(1).Contains(Myself)) 
+            if (roles.Skip(1).Contains(Myself))
                 await Cluster.JoinAsync(GetAddress(roles.First()), cancellationToken);
 
             if (roles.Contains(Myself))
@@ -316,6 +316,18 @@ namespace Akka.Cluster.TestKit
             }
             await EnterBarrierAsync(cancellationToken, roles.Select(r => r.Name).Aggregate((a, b) => a + "-" + b) + "-joined");
         }
+
+        /// <summary>
+        /// Initialize the cluster of the specified member nodes (<paramref name="roles"/>)
+        /// and wait until all joined and <see cref="MemberStatus.Up"/>.
+        ///
+        /// First node will be started first and others will join the first.
+        /// </summary>
+        /// <remarks>
+        /// Convenience overload that passes <see cref="CancellationToken.None"/>.
+        /// </remarks>
+        public Task AwaitClusterUpAsync(params RoleName[] roles)
+            => AwaitClusterUpAsync(CancellationToken.None, roles);
 
         public void JoinWithin(RoleName joinNode, TimeSpan? max = null, TimeSpan? interval = null)
         {


### PR DESCRIPTION
## Summary

Add convenience overload of `AwaitClusterUpAsync` that doesn't require passing `CancellationToken.None`.

## Changes

Added new overload to `MultiNodeClusterSpec`:

```csharp
public Task AwaitClusterUpAsync(params RoleName[] roles)
    => AwaitClusterUpAsync(CancellationToken.None, roles);
```

## Before/After

```csharp
// Before
await AwaitClusterUpAsync(CancellationToken.None, _config.First, _config.Second, _config.Third);

// After
await AwaitClusterUpAsync(_config.First, _config.Second, _config.Third);
```

## Test Plan

- [ ] Existing MNTR tests continue to pass (they use the original overload)
- [ ] New overload can be used in future tests

Closes #8026