### PR TITLE
Backport 1.5.59 fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.57-beta2</VersionPrefix>
+    <VersionPrefix>1.5.59</VersionPrefix>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>https://getakka.net/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -50,62 +50,33 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Akka.NET v1.5.57-beta2 is a beta release containing significant new APIs for Akka.Persistence that add completion callbacks and async handler support.
+    <PackageReleaseNotes>Akka.NET v1.5.59 is a maintenance release with critical bug fixes and new features for observability.
 
-**New Features:**
+**Critical Bug Fixes**
 
-* [Persistence completion callbacks via Defer - simplified alternative](https://github.com/akkadotnet/akka.net/pull/7957) - This release adds completion callback and async handler support to `Persist`, `PersistAsync`, `PersistAll`, and `PersistAllAsync` methods in Akka.Persistence. Key improvements include:
-  - **Async Handler Support**: All persist methods now support `Func&lt;TEvent, Task&gt;` handlers for async event processing
-  - **Completion Callbacks**: `PersistAll` and `PersistAllAsync` now accept optional completion callbacks (both sync `Action` and async `Func&lt;Task&gt;`) that execute after all events are persisted and handled
-  - **Ordering Guarantees**: Completion callbacks use `Defer`/`DeferAsync` internally to maintain strict ordering guarantees
-  - **Zero Breaking Changes**: All new APIs are additive overloads
+* [Fix MergeSeen to filter Seen against current Members](https://github.com/akkadotnet/akka.net/pull/8011) - Fixes [issue #8009](https://github.com/akkadotnet/akka.net/issues/8009). Resolves a cluster gossip serialization failure that could occur with the error "Unknown address in cluster message" when the `Seen` table contained addresses of members that had already left the cluster.
 
-**Code Examples:**
+**Bug Fixes**
 
-```csharp
-// Async handler support - process events asynchronously
-Persist(new OrderPlaced(orderId), async evt =&gt;
-{
-    await _orderService.ProcessOrderAsync(evt);
-});
+* [Fix logger initialization continuation race in LoggingBus](https://github.com/akkadotnet/akka.net/pull/8006) - Fixes a race condition during logger initialization that could cause logging failures during actor system startup.
+* [Fix Inbox.AwaitResult throwing AggregateException instead of TimeoutException](https://github.com/akkadotnet/akka.net/pull/8005) - `Inbox.AwaitResult` now correctly throws `TimeoutException` when a timeout occurs, rather than wrapping it in an `AggregateException`.
+* [Fix DeferAsync async handler nesting bug in CommandAsync](https://github.com/akkadotnet/akka.net/pull/7999) - Fixes [issue #7998](https://github.com/akkadotnet/akka.net/issues/7998). Resolves an issue where `DeferAsync` with an async handler would throw "RunTask calls cannot be nested" when called from `CommandAsync`.
+* [Fix AwaitAssertAsync logic causing premature timeout](https://github.com/akkadotnet/akka.net/pull/7986) - Fixes `AwaitAssertAsync` in Akka.TestKit to correctly wait for the full timeout duration before failing assertions.
 
-// PersistAll with completion callback - know when all events are done
-PersistAll(orderEvents, evt =&gt;
-{
-    _state.Apply(evt);
-}, onComplete: () =&gt;
-{
-    // All events persisted and handlers executed
-    _logger.Info("Order batch completed");
-    Sender.Tell(new BatchComplete());
-});
+**New Features**
 
-// PersistAll with async handler AND async completion callback
-PersistAll(events,
-    handler: async evt =&gt; await ProcessEventAsync(evt),
-    onCompleteAsync: async () =&gt;
-    {
-        await NotifyCompletionAsync();
-        Sender.Tell(Done.Instance);
-    });
+* [Add ActivityContext capture to LogEvent for trace correlation](https://github.com/akkadotnet/akka.net/pull/7995) - Log events now automatically capture the current `System.Diagnostics.ActivityContext` when created, enabling correlation between Akka.NET logs and distributed traces in observability platforms like OpenTelemetry, Application Insights, and Jaeger.
+* [Add BroadcastHub startAfterNrOfConsumers parameter](https://github.com/akkadotnet/akka.net/pull/8018) - Fixes [issue #8017](https://github.com/akkadotnet/akka.net/issues/8017). Port from Apache Pekko - adds a `startAfterNrOfConsumers` parameter to `BroadcastHub.Sink&lt;T&gt;()` that delays broadcasting until the specified number of consumers have subscribed:
+  ```csharp
+  // Wait for 3 consumers before starting to broadcast
+  var sink = BroadcastHub.Sink&lt;int&gt;(startAfterNrOfConsumers: 3, bufferSize: 256);
+  ```
 
-// PersistAllAsync with completion - allows commands between handlers
-PersistAllAsync(largeEventBatch,
-    handler: evt =&gt; _state.Apply(evt),
-    onComplete: () =&gt; Sender.Tell(new BatchProcessed()));
-```
+**Improvements**
 
-**Technical Details:**
+* [CoordinatedShutdown: clearly log the reason why we're exiting](https://github.com/akkadotnet/akka.net/pull/7988) - `CoordinatedShutdown` now logs the specific reason for shutdown at INFO level, making it easier to diagnose why an actor system terminated.
 
-The implementation maintains Akka.Persistence's strict ordering guarantees by using `Defer`/`DeferAsync` for completion callbacks, ensuring they execute in order even when called with empty event collections. The new async handler invocations (`IAsyncHandlerInvocation`) are processed via `RunTask` to preserve the actor's single-threaded execution model.
-
-1 contributor since release 1.5.57-beta1
-
-| COMMITS | LOC+ | LOC- | AUTHOR |
-| --- | --- | --- | --- |
-| 1 | 1386 | 67 | Aaron Stannard |
-
-To [see the full set of changes in Akka.NET v1.5.57-beta2, click here](https://github.com/akkadotnet/akka.net/milestone/141?closed=1)</PackageReleaseNotes>
+To see the full set of changes in Akka.NET v1.5.59, [click here](https://github.com/akkadotnet/akka.net/milestone/142?closed=1).</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup Label="Analyzers" Condition="'$(MSBuildProjectName)' != 'Akka'">
     <PackageReference Include="Akka.Analyzers" Version="$(AkkaAnalyzerVersion)" PrivateAssets="all" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,33 @@
+#### 1.5.59 January 27th, 2026 ####
+
+Akka.NET v1.5.59 is a maintenance release with critical bug fixes and new features for observability.
+
+**Critical Bug Fixes**
+
+* [Fix MergeSeen to filter Seen against current Members](https://github.com/akkadotnet/akka.net/pull/8011) - Fixes [issue #8009](https://github.com/akkadotnet/akka.net/issues/8009). Resolves a cluster gossip serialization failure that could occur with the error "Unknown address in cluster message" when the `Seen` table contained addresses of members that had already left the cluster.
+
+**Bug Fixes**
+
+* [Fix logger initialization continuation race in LoggingBus](https://github.com/akkadotnet/akka.net/pull/8006) - Fixes a race condition during logger initialization that could cause logging failures during actor system startup.
+* [Fix Inbox.AwaitResult throwing AggregateException instead of TimeoutException](https://github.com/akkadotnet/akka.net/pull/8005) - `Inbox.AwaitResult` now correctly throws `TimeoutException` when a timeout occurs, rather than wrapping it in an `AggregateException`.
+* [Fix DeferAsync async handler nesting bug in CommandAsync](https://github.com/akkadotnet/akka.net/pull/7999) - Fixes [issue #7998](https://github.com/akkadotnet/akka.net/issues/7998). Resolves an issue where `DeferAsync` with an async handler would throw "RunTask calls cannot be nested" when called from `CommandAsync`.
+* [Fix AwaitAssertAsync logic causing premature timeout](https://github.com/akkadotnet/akka.net/pull/7986) - Fixes `AwaitAssertAsync` in Akka.TestKit to correctly wait for the full timeout duration before failing assertions.
+
+**New Features**
+
+* [Add ActivityContext capture to LogEvent for trace correlation](https://github.com/akkadotnet/akka.net/pull/7995) - Log events now automatically capture the current `System.Diagnostics.ActivityContext` when created, enabling correlation between Akka.NET logs and distributed traces in observability platforms like OpenTelemetry, Application Insights, and Jaeger.
+* [Add BroadcastHub startAfterNrOfConsumers parameter](https://github.com/akkadotnet/akka.net/pull/8018) - Fixes [issue #8017](https://github.com/akkadotnet/akka.net/issues/8017). Port from Apache Pekko - adds a `startAfterNrOfConsumers` parameter to `BroadcastHub.Sink<T>()` that delays broadcasting until the specified number of consumers have subscribed:
+  ```csharp
+  // Wait for 3 consumers before starting to broadcast
+  var sink = BroadcastHub.Sink<int>(startAfterNrOfConsumers: 3, bufferSize: 256);
+  ```
+
+**Improvements**
+
+* [CoordinatedShutdown: clearly log the reason why we're exiting](https://github.com/akkadotnet/akka.net/pull/7988) - `CoordinatedShutdown` now logs the specific reason for shutdown at INFO level, making it easier to diagnose why an actor system terminated.
+
+To see the full set of changes in Akka.NET v1.5.59, [click here](https://github.com/akkadotnet/akka.net/milestone/142?closed=1).
+
 #### 1.5.58 January 8th, 2026 ####
 
 Akka.NET v1.5.58 is a maintenance release with important bug fixes and performance improvements.

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3474,10 +3474,11 @@ namespace Akka.Event
     public abstract class LogEvent : Akka.Actor.INoSerializationVerificationNeeded
     {
         protected LogEvent() { }
-        public System.Exception Cause { get; set; }
-        public System.Type LogClass { get; set; }
-        public string LogSource { get; set; }
-        public object Message { get; set; }
+        public System.Diagnostics.ActivityContext? ActivityContext { get; }
+        public System.Exception Cause { get; protected set; }
+        public System.Type LogClass { get; protected set; }
+        public string LogSource { get; protected set; }
+        public object Message { get; protected set; }
         public System.Threading.Thread Thread { get; }
         public System.DateTime Timestamp { get; }
         public abstract Akka.Event.LogLevel LogLevel();

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -3474,11 +3474,11 @@ namespace Akka.Event
     public abstract class LogEvent : Akka.Actor.INoSerializationVerificationNeeded
     {
         protected LogEvent() { }
-        public System.Diagnostics.ActivityContext? ActivityContext { get; }
-        public System.Exception Cause { get; protected set; }
-        public System.Type LogClass { get; protected set; }
-        public string LogSource { get; protected set; }
-        public object Message { get; protected set; }
+        public System.Nullable<System.Diagnostics.ActivityContext> ActivityContext { get; }
+        public System.Exception Cause { get; set; }
+        public System.Type LogClass { get; set; }
+        public string LogSource { get; set; }
+        public object Message { get; set; }
         public System.Threading.Thread Thread { get; }
         public System.DateTime Timestamp { get; }
         public abstract Akka.Event.LogLevel LogLevel();

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -3465,10 +3465,11 @@ namespace Akka.Event
     public abstract class LogEvent : Akka.Actor.INoSerializationVerificationNeeded
     {
         protected LogEvent() { }
-        public System.Exception Cause { get; set; }
-        public System.Type LogClass { get; set; }
-        public string LogSource { get; set; }
-        public object Message { get; set; }
+        public System.Diagnostics.ActivityContext? ActivityContext { get; }
+        public System.Exception Cause { get; protected set; }
+        public System.Type LogClass { get; protected set; }
+        public string LogSource { get; protected set; }
+        public object Message { get; protected set; }
         public System.Threading.Thread Thread { get; }
         public System.DateTime Timestamp { get; }
         public abstract Akka.Event.LogLevel LogLevel();

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -33,7 +33,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Tests.Performance")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("1a5cab08-b032-49ca-8db3-9428c5a9db14")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Actor
 {
     public abstract class ActorBase : Akka.Actor.IInternalActor
@@ -144,7 +144,7 @@ namespace Akka.Actor
                 0,
                 1})] Akka.Util.Option<object> customMessage) { }
         public bool TryGetChildStatsByName(string name, out Akka.Actor.Internal.IChildStats child) { }
-        protected bool TryGetChildStatsByRef(Akka.Actor.IActorRef actor, [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats child) { }
+        protected bool TryGetChildStatsByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats child) { }
         public void UnbecomeStacked() { }
         protected void UnreserveChild(string name) { }
         public Akka.Actor.IActorRef Unwatch(Akka.Actor.IActorRef subject) { }
@@ -744,6 +744,7 @@ namespace Akka.Actor
         protected virtual bool SpecialHandle(object message, Akka.Actor.IActorRef sender) { }
         protected override void TellInternal(object message, Akka.Actor.IActorRef sender) { }
     }
+    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
     public struct Envelope
     {
         public Envelope(object message, Akka.Actor.IActorRef sender, Akka.Actor.ActorSystem system) { }
@@ -794,6 +795,7 @@ namespace Akka.Actor
             public override int GetHashCode() { }
             public override string ToString() { }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct Event<TD> : Akka.Actor.INoSerializationVerificationNeeded
         {
             public Event(object fsmEvent, TD stateData) { }
@@ -2090,7 +2092,7 @@ namespace Akka.Actor.Internal
         public abstract Akka.Actor.Internal.IChildrenContainer Reserve(string name);
         public abstract Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor);
         public bool TryGetByName(string name, out Akka.Actor.Internal.IChildStats stats) { }
-        public bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats childRestartStats) { }
+        public bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats childRestartStats) { }
         public abstract Akka.Actor.Internal.IChildrenContainer Unreserve(string name);
     }
     public class EmptyChildrenContainer : Akka.Actor.Internal.IChildrenContainer
@@ -2124,7 +2126,7 @@ namespace Akka.Actor.Internal
         Akka.Actor.Internal.IChildrenContainer Reserve(string name);
         Akka.Actor.Internal.IChildrenContainer ShallDie(Akka.Actor.IActorRef actor);
         bool TryGetByName(string name, out Akka.Actor.Internal.IChildStats stats);
-        bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats stats);
+        bool TryGetByRef(Akka.Actor.IActorRef actor, [System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] [System.Runtime.CompilerServices.NullableAttribute(2)] out Akka.Actor.Internal.ChildRestartStats stats);
         Akka.Actor.Internal.IChildrenContainer Unreserve(string name);
     }
     public interface IInitializableActor
@@ -2276,6 +2278,7 @@ namespace Akka.Configuration
         public virtual System.Collections.Generic.IList<bool> GetBooleanList(string path) { }
         public virtual System.Collections.Generic.IList<byte> GetByteList(string path) { }
         public virtual System.Nullable<long> GetByteSize(string path) { }
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("def")]
         public virtual System.Nullable<long> GetByteSize(string path, System.Nullable<long> def = null) { }
         public virtual Akka.Configuration.Config GetConfig(string path) { }
         public virtual decimal GetDecimal(string path, [System.Runtime.CompilerServices.DecimalConstantAttribute(0, 0, 0u, 0u, 0u)] decimal @default) { }
@@ -2659,6 +2662,7 @@ namespace Akka.Delivery
             public Akka.Delivery.DurableProducerQueue.MessageSent<T> WithQualifier(string qualifier) { }
             public Akka.Delivery.DurableProducerQueue.MessageSent<T> WithTimestamp(long timestamp) { }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         [System.Runtime.CompilerServices.NullableAttribute(0)]
         public struct State<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : Akka.Delivery.Internal.IDeliverySerializable, System.IEquatable<Akka.Delivery.DurableProducerQueue.State<T>>
         {
@@ -2784,6 +2788,7 @@ namespace Akka.Delivery
 namespace Akka.Delivery.Internal
 {
     [Akka.Annotations.InternalApiAttribute()]
+    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
     [System.Runtime.CompilerServices.NullableAttribute(0)]
     public struct ChunkedMessage
     {
@@ -2798,6 +2803,7 @@ namespace Akka.Delivery.Internal
     [Akka.Annotations.InternalApiAttribute()]
     public interface IDeliverySerializable { }
     [Akka.Annotations.InternalApiAttribute()]
+    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
     [System.Runtime.CompilerServices.NullableAttribute(0)]
     public struct MessageOrChunk<T> : System.IEquatable<Akka.Delivery.Internal.MessageOrChunk<T>>
     {
@@ -2830,14 +2836,16 @@ namespace Akka.Delivery.Internal
 }
 namespace Akka.Dispatch
 {
-    public sealed class ActionRunnable : Akka.Dispatch.IRunnable
+    public sealed class ActionRunnable : Akka.Dispatch.IRunnable, System.Threading.IThreadPoolWorkItem
     {
         public ActionRunnable(System.Action action) { }
+        public void Execute() { }
         public void Run() { }
     }
-    public sealed class ActionWithStateRunnable : Akka.Dispatch.IRunnable
+    public sealed class ActionWithStateRunnable : Akka.Dispatch.IRunnable, System.Threading.IThreadPoolWorkItem
     {
         public ActionWithStateRunnable(System.Action<object> actionWithState, object state) { }
+        public void Execute() { }
         public void Run() { }
     }
     public class ActorTaskScheduler : System.Threading.Tasks.TaskScheduler
@@ -2976,14 +2984,14 @@ namespace Akka.Dispatch
     }
     public interface IRequiresMessageQueue<T>
         where T : Akka.Dispatch.ISemantics { }
-    public interface IRunnable
+    public interface IRunnable : System.Threading.IThreadPoolWorkItem
     {
         void Run();
     }
     public interface ISemantics { }
     public interface IUnboundedDequeBasedMessageQueueSemantics : Akka.Dispatch.IDequeBasedMessageQueueSemantics, Akka.Dispatch.ISemantics, Akka.Dispatch.IUnboundedMessageQueueSemantics { }
     public interface IUnboundedMessageQueueSemantics : Akka.Dispatch.ISemantics { }
-    public class Mailbox : Akka.Dispatch.IRunnable
+    public class Mailbox : Akka.Dispatch.IRunnable, System.Threading.IThreadPoolWorkItem
     {
         public Mailbox(Akka.Dispatch.MessageQueues.IMessageQueue messageQueue) { }
         public Akka.Dispatch.MessageDispatcher Dispatcher { get; }
@@ -2991,6 +2999,7 @@ namespace Akka.Dispatch
         public virtual void CleanUp() { }
         [System.Diagnostics.ConditionalAttribute("MAILBOXDEBUG")]
         public static void DebugPrint(string message, params object[] args) { }
+        public void Execute() { }
         public void Run() { }
         public virtual void SetActor(Akka.Actor.ActorCell actorCell) { }
     }
@@ -3465,11 +3474,11 @@ namespace Akka.Event
     public abstract class LogEvent : Akka.Actor.INoSerializationVerificationNeeded
     {
         protected LogEvent() { }
-        public System.Diagnostics.ActivityContext? ActivityContext { get; }
-        public System.Exception Cause { get; protected set; }
-        public System.Type LogClass { get; protected set; }
-        public string LogSource { get; protected set; }
-        public object Message { get; protected set; }
+        public System.Nullable<System.Diagnostics.ActivityContext> ActivityContext { get; }
+        public System.Exception Cause { get; set; }
+        public System.Type LogClass { get; set; }
+        public string LogSource { get; set; }
+        public object Message { get; set; }
         public System.Threading.Thread Thread { get; }
         public System.DateTime Timestamp { get; }
         public abstract Akka.Event.LogLevel LogLevel();
@@ -3555,7 +3564,9 @@ namespace Akka.Event
     public class static LogMessageExtensions { }
     public struct LogSource
     {
+        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public string Source { get; }
+        [get: System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public System.Type Type { get; }
         public static Akka.Event.LogSource Create(object o) { }
         public static Akka.Event.LogSource Create(object o, Akka.Actor.ActorSystem system) { }
@@ -5551,6 +5562,7 @@ namespace Akka.Util
         public static int SymmetricHash<T>(System.Collections.Generic.IEnumerable<T> xs, uint seed) { }
     }
     [Akka.Annotations.InternalStableApiAttribute()]
+    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
     public struct Option<T>
     {
         public static readonly Akka.Util.Option<T> None;
@@ -5592,6 +5604,7 @@ namespace Akka.Util
                 1})]
         public static Akka.Util.Result<T> Success<[System.Runtime.CompilerServices.NullableAttribute(2)]  T>(T value) { }
     }
+    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
     public struct Result<[System.Runtime.CompilerServices.NullableAttribute(2)]  T> : System.IEquatable<Akka.Util.Result<T>>
     {
         [System.Runtime.CompilerServices.NullableAttribute(2)]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Core.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Core.verified.txt
@@ -1288,6 +1288,7 @@ namespace Akka.Streams.Dsl
     {
         public BroadcastHub() { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int bufferSize) { }
+        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int startAfterNrOfConsumers, int bufferSize) { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>() { }
     }
     public sealed class Broadcast<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanOutShape<T, T>>

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
@@ -1296,8 +1296,8 @@ namespace Akka.Streams.Dsl
     {
         public BroadcastHub() { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int bufferSize) { }
-        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>() { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int startAfterNrOfConsumers, int bufferSize) { }
+        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>() { }
     }
     public sealed class Broadcast<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanOutShape<T, T>>
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
@@ -1297,6 +1297,7 @@ namespace Akka.Streams.Dsl
         public BroadcastHub() { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int bufferSize) { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>() { }
+        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int startAfterNrOfConsumers, int bufferSize) { }
     }
     public sealed class Broadcast<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanOutShape<T, T>>
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
@@ -1295,6 +1295,7 @@ namespace Akka.Streams.Dsl
         public BroadcastHub() { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int bufferSize) { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>() { }
+        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int startAfterNrOfConsumers, int bufferSize) { }
     }
     public sealed class Broadcast<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanOutShape<T, T>>
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
@@ -6,7 +6,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Akka.Streams.Tests")]
 [assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
 [assembly: System.Runtime.InteropServices.GuidAttribute("123b83e9-21f8-49a8-888a-3b1212ff21dc")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
 namespace Akka.Streams
 {
     public sealed class AbruptStageTerminationException : System.Exception
@@ -183,6 +183,7 @@ namespace Akka.Streams
         public static Akka.Streams.Attributes CreateLogLevels(Akka.Event.LogLevel onElement = 0, Akka.Event.LogLevel onFinish = 0, Akka.Event.LogLevel onError = 3) { }
         public static Akka.Streams.Attributes CreateName(string name) { }
         public static string ExtractName(Akka.Streams.Implementation.IModule module, string defaultIfNotFound) { }
+        [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("defaultIfNotFound")]
         [return: System.Runtime.CompilerServices.NullableAttribute(2)]
         public TAttr GetAttribute<TAttr>([System.Runtime.CompilerServices.NullableAttribute(2)] TAttr defaultIfNotFound)
             where TAttr :  class, Akka.Streams.Attributes.IAttribute { }
@@ -790,6 +791,7 @@ namespace Akka.Streams
         public static Akka.Streams.IGraph<Akka.Streams.FlowShape<T, T>, Akka.Streams.UniqueKillSwitch> Single<T>() { }
         public static Akka.Streams.IGraph<Akka.Streams.BidiShape<T1, T1, T2, T2>, Akka.Streams.UniqueKillSwitch> SingleBidi<T1, T2>() { }
     }
+    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
     public struct MaterializationContext
     {
         public readonly Akka.Streams.Attributes EffectiveAttributes;
@@ -1294,8 +1296,8 @@ namespace Akka.Streams.Dsl
     {
         public BroadcastHub() { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int bufferSize) { }
-        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>() { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int startAfterNrOfConsumers, int bufferSize) { }
+        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>() { }
     }
     public sealed class Broadcast<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanOutShape<T, T>>
     {
@@ -2398,6 +2400,7 @@ namespace Akka.Streams.Dsl
     {
         public Tcp() { }
         public override Akka.Streams.Dsl.TcpExt CreateExtension(Akka.Actor.ExtendedActorSystem system) { }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct IncomingConnection
         {
             public readonly Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> Flow;
@@ -2406,12 +2409,14 @@ namespace Akka.Streams.Dsl
             public IncomingConnection(System.Net.EndPoint localAddress, System.Net.EndPoint remoteAddress, Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, Akka.NotUsed> flow) { }
             public TMat HandleWith<TMat>(Akka.Streams.Dsl.Flow<Akka.IO.ByteString, Akka.IO.ByteString, TMat> handler, Akka.Streams.IMaterializer materializer) { }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct OutgoingConnection
         {
             public readonly System.Net.EndPoint LocalAddress;
             public readonly System.Net.EndPoint RemoteAddress;
             public OutgoingConnection(System.Net.EndPoint remoteAddress, System.Net.EndPoint localAddress) { }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct ServerBinding
         {
             public readonly System.Net.EndPoint LocalAddress;
@@ -2790,6 +2795,7 @@ namespace Akka.Streams.IO
         public AbruptIOTerminationException(Akka.Streams.IO.IOResult ioResult, System.Exception cause) { }
         public Akka.Streams.IO.IOResult IoResult { get; }
     }
+    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
     public struct IOResult
     {
         public readonly long Count;
@@ -3071,23 +3077,27 @@ namespace Akka.Streams.Implementation
         public const byte Depleted = 4;
         public const byte Marked = 1;
         public const byte Pending = 2;
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
             public OnComplete(int id) { }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Exception Cause;
             public readonly int Id;
             public OnError(int id, System.Exception cause) { }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly object Element;
             public readonly int Id;
             public OnNext(int id, object element) { }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
@@ -3117,6 +3127,7 @@ namespace Akka.Streams.Implementation
         public void PumpFinished() { }
         protected override bool Receive(object message) { }
         public void WaitForUpstream(int waitForUpstream) { }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct SubInput<T> : Reactive.Streams.ISubscriber<T>
         {
             public SubInput(Akka.Actor.IActorRef impl, int id) { }
@@ -3129,22 +3140,26 @@ namespace Akka.Streams.Implementation
     [Akka.Annotations.InternalApiAttribute()]
     public class static FanOut
     {
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct ExposedPublishers<T> : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly System.Collections.Immutable.ImmutableList<Akka.Streams.Implementation.ActorPublisher<T>> Publishers;
             public ExposedPublishers(System.Collections.Immutable.ImmutableList<Akka.Streams.Implementation.ActorPublisher<T>> publishers) { }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct SubstreamCancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
             public SubstreamCancel(int id) { }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct SubstreamRequestMore : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly long Demand;
             public readonly int Id;
             public SubstreamRequestMore(int id, long demand) { }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct SubstreamSubscribePending : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
         {
             public readonly int Id;
@@ -3873,6 +3888,7 @@ namespace Akka.Streams.Implementation
         public const string GraphStageLogicTimer = "GraphStageLogicTimer";
         public static System.TimeSpan IdleTimeoutCheckInterval(System.TimeSpan timeout) { }
     }
+    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
     public struct TransferPhase
     {
         public readonly System.Action Action;
@@ -3963,11 +3979,13 @@ namespace Akka.Streams.Implementation.Fusing
         public static Akka.Actor.Props Props(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
         protected override bool Receive(object message) { }
         public Akka.Actor.IActorRef RegisterShell(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct Abort : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public Abort(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct AsyncInput : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly object Event;
@@ -4010,6 +4028,7 @@ namespace Akka.Streams.Implementation.Fusing
             public void Request(long elements) { }
             public override string ToString() { }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct Cancel : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
@@ -4017,6 +4036,7 @@ namespace Akka.Streams.Implementation.Fusing
             public System.Exception Cause { get; }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct ExposedPublisher : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
@@ -4028,12 +4048,14 @@ namespace Akka.Streams.Implementation.Fusing
         {
             Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct OnComplete : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
             public OnComplete(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct OnError : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly System.Exception Cause;
@@ -4041,6 +4063,7 @@ namespace Akka.Streams.Implementation.Fusing
             public OnError(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, System.Exception cause) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct OnNext : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly object Event;
@@ -4048,6 +4071,7 @@ namespace Akka.Streams.Implementation.Fusing
             public OnNext(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, object @event) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct OnSubscribe : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
@@ -4055,6 +4079,7 @@ namespace Akka.Streams.Implementation.Fusing
             public OnSubscribe(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, Reactive.Streams.ISubscription subscription) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct RequestMore : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly long Demand;
@@ -4062,11 +4087,13 @@ namespace Akka.Streams.Implementation.Fusing
             public RequestMore(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell, int id, long demand) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct Resume : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public Resume(Akka.Streams.Implementation.Fusing.GraphInterpreterShell shell) { }
             public Akka.Streams.Implementation.Fusing.GraphInterpreterShell Shell { get; }
         }
+        [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
         public struct SubscribePending : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression, Akka.Streams.Implementation.Fusing.ActorGraphInterpreter.IBoundaryEvent
         {
             public readonly int Id;
@@ -5144,6 +5171,7 @@ namespace Akka.Streams.Stage
         public virtual void OnUpstreamFailure(System.Exception e) { }
         public virtual void OnUpstreamFinish() { }
     }
+    [System.Runtime.CompilerServices.IsReadOnlyAttribute()]
     public struct LogicAndMaterializedValue<TMaterialized> : Akka.Streams.Stage.ILogicAndMaterializedValue<TMaterialized>
     {
         public LogicAndMaterializedValue(Akka.Streams.Stage.GraphStageLogic logic, TMaterialized materializedValue) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.verified.txt
@@ -1266,6 +1266,7 @@ namespace Akka.Streams.Dsl
     {
         public BroadcastHub() { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int bufferSize) { }
+        public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>(int startAfterNrOfConsumers, int bufferSize) { }
         public static Akka.Streams.Dsl.Sink<T, Akka.Streams.Dsl.Source<T, Akka.NotUsed>> Sink<T>() { }
     }
     public sealed class Broadcast<T> : Akka.Streams.Stage.GraphStage<Akka.Streams.UniformFanOutShape<T, T>>

--- a/src/core/Akka.Cluster/Gossip.cs
+++ b/src/core/Akka.Cluster/Gossip.cs
@@ -240,13 +240,17 @@ namespace Akka.Cluster
         }
 
         /// <summary>
-        /// TBD
+        /// Merges the seen table from two <see cref="Gossip"/> instances.
+        /// The resulting seen set is filtered to only include addresses that are current members,
+        /// ensuring the invariant that Seen ⊆ Members is always maintained.
         /// </summary>
-        /// <param name="that">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="that">The other gossip instance to merge seen state from.</param>
+        /// <returns>A new gossip instance with merged and filtered seen state.</returns>
         public Gossip MergeSeen(Gossip that)
         {
-            return Copy(overview: _overview.Copy(seen: _overview.Seen.Union(that._overview.Seen)));
+            var memberAddresses = _members.Select(m => m.UniqueAddress).ToImmutableHashSet();
+            var mergedSeen = _overview.Seen.Union(that._overview.Seen).Intersect(memberAddresses);
+            return Copy(overview: _overview.Copy(seen: mergedSeen));
         }
 
         /// <summary>

--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
@@ -363,6 +363,102 @@ namespace Akka.Persistence.Tests
         }
     }
 
+    /// <summary>
+    /// Test actor that uses DeferAsync with an async handler inside CommandAsync.
+    /// This reproduces the bug where DeferAsync throws "RunTask calls cannot be nested"
+    /// when called from within a CommandAsync handler after an await, with no pending persist operations.
+    /// See: https://github.com/akkadotnet/akka.net/issues/7998
+    /// </summary>
+    public sealed class DeferAsyncFromCommandAsyncActor : ReceivePersistentActor
+    {
+        public override string PersistenceId { get; }
+
+        public DeferAsyncFromCommandAsyncActor(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(_ => { });
+
+            // This pattern triggers the bug: CommandAsync -> await -> DeferAsync(async handler)
+            // with no prior Persist/PersistAsync calls
+            CommandAsync<string>(async msg =>
+            {
+                // Any await causes us to be in a RunTask context
+                await Task.Delay(10);
+
+                // DeferAsync with async handler, no pending persist operations
+                // BUG: This throws "RunTask calls cannot be nested" because
+                // _pendingInvocations.Count == 0 triggers immediate RunTask execution
+                DeferAsync(msg, async evt =>
+                {
+                    await Task.CompletedTask;
+                    Sender.Tell("deferred-" + evt);
+                });
+            });
+        }
+    }
+
+    /// <summary>
+    /// Test actor that uses DeferAsync with a sync handler inside CommandAsync.
+    /// This should work correctly (sync handler doesn't use RunTask).
+    /// </summary>
+    public sealed class DeferAsyncSyncHandlerFromCommandAsyncActor : ReceivePersistentActor
+    {
+        public override string PersistenceId { get; }
+
+        public DeferAsyncSyncHandlerFromCommandAsyncActor(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(_ => { });
+
+            CommandAsync<string>(async msg =>
+            {
+                await Task.Delay(10);
+
+                // DeferAsync with sync handler - this should work
+                DeferAsync(msg, evt =>
+                {
+                    Sender.Tell("deferred-" + evt);
+                });
+            });
+        }
+    }
+
+    /// <summary>
+    /// Test actor that uses DeferAsync with an async handler after PersistAsync.
+    /// This should work because _pendingInvocations.Count > 0.
+    /// </summary>
+    public sealed class DeferAsyncAfterPersistAsyncActor : ReceivePersistentActor
+    {
+        public override string PersistenceId { get; }
+
+        public DeferAsyncAfterPersistAsyncActor(string persistenceId)
+        {
+            PersistenceId = persistenceId;
+
+            RecoverAny(_ => { });
+
+            CommandAsync<string>(async msg =>
+            {
+                await Task.Delay(10);
+
+                // PersistAsync first - this populates _pendingInvocations
+                PersistAsync(msg, evt =>
+                {
+                    Sender.Tell("persisted-" + evt);
+                });
+
+                // DeferAsync with async handler - should queue and work
+                DeferAsync(msg, async evt =>
+                {
+                    await Task.CompletedTask;
+                    Sender.Tell("deferred-" + evt);
+                });
+            });
+        }
+    }
+
     public class ReceivePersistentActorAsyncAwaitSpec : AkkaSpec
     {
         public ReceivePersistentActorAsyncAwaitSpec(ITestOutputHelper output = null)
@@ -650,6 +746,52 @@ namespace Akka.Persistence.Tests
             actor.Tell(1.0);
             ExpectMsg<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000));
             return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/akkadotnet/akka.net/issues/7998
+        /// DeferAsync with async handler should work when called from CommandAsync,
+        /// even without prior Persist/PersistAsync calls.
+        /// </summary>
+        [Fact(DisplayName = "DeferAsync with async handler should work from CommandAsync without prior persist calls")]
+        public async Task DeferAsync_with_async_handler_should_work_from_CommandAsync_without_prior_persist_calls()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new DeferAsyncFromCommandAsyncActor("defer-async-pid")));
+
+            actor.Tell("hello");
+            var response = await ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+            response.ShouldBe("deferred-hello");
+        }
+
+        /// <summary>
+        /// Verify that DeferAsync with sync handler still works from CommandAsync.
+        /// </summary>
+        [Fact(DisplayName = "DeferAsync with sync handler should work from CommandAsync")]
+        public async Task DeferAsync_with_sync_handler_should_work_from_CommandAsync()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new DeferAsyncSyncHandlerFromCommandAsyncActor("defer-sync-pid")));
+
+            actor.Tell("world");
+            var response = await ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+            response.ShouldBe("deferred-world");
+        }
+
+        /// <summary>
+        /// Verify that DeferAsync with async handler works after PersistAsync
+        /// (this path was already working since _pendingInvocations.Count > 0).
+        /// </summary>
+        [Fact(DisplayName = "DeferAsync with async handler should work after PersistAsync")]
+        public async Task DeferAsync_with_async_handler_should_work_after_PersistAsync()
+        {
+            var actor = Sys.ActorOf(Props.Create(() => new DeferAsyncAfterPersistAsyncActor("defer-after-persist-pid")));
+
+            actor.Tell("test");
+            // Should receive both persist and defer responses in order
+            var first = await ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+            first.ShouldBe("persisted-test");
+
+            var second = await ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+            second.ShouldBe("deferred-test");
         }
     }
 }

--- a/src/core/Akka.Persistence/Eventsourced.cs
+++ b/src/core/Akka.Persistence/Eventsourced.cs
@@ -800,8 +800,8 @@ namespace Akka.Persistence
         ///
         /// This call will NOT result in <paramref name="evt"/> being persisted.
         ///
-        /// If there are no pending persist handler calls, the <paramref name="handler"/> will be called immediately
-        /// via <see cref="RunTask"/>.
+        /// The handler is always queued and will be executed after the current command handler completes.
+        /// This avoids "RunTask calls cannot be nested" errors when called from within CommandAsync handlers.
         ///
         /// If persistence of an earlier event fails, the persistent actor will stop, and the
         /// <paramref name="handler"/> will not be run.
@@ -816,15 +816,14 @@ namespace Akka.Persistence
                 throw new InvalidOperationException("Cannot persist during replay. Events can be persisted when receiving RecoveryCompleted or later.");
             }
 
-            if (_pendingInvocations.Count == 0)
-            {
-                RunTask(() => handler(evt));
-            }
-            else
-            {
-                _pendingInvocations.AddLast(new AsyncAsyncHandlerInvocation(evt, o => handler((TEvent)o)));
-                _eventBatch.AddLast(new NonPersistentMessage(evt, Sender));
-            }
+            // Always queue the async handler - do not use RunTask directly here.
+            // This avoids "RunTask calls cannot be nested" errors when DeferAsync
+            // is called from within a CommandAsync handler (which is already in a RunTask context).
+            // The handler will be executed via PeekApplyHandler when the batch is processed
+            // after the command handler completes.
+            // See: https://github.com/akkadotnet/akka.net/issues/7998
+            _pendingInvocations.AddLast(new AsyncAsyncHandlerInvocation(evt, o => handler((TEvent)o)));
+            _eventBatch.AddLast(new NonPersistentMessage(evt, Sender));
         }
 
         /// <summary>

--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -319,48 +319,46 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [LocalFact(SkipLocal = "Racy in AzDo CI/CD")]
+        [Fact]
         public async Task BroadcastHub_must_send_the_same_elements_to_consumers_attaching_around_the_same_time()
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
                 var other = Source.From(Enumerable.Range(2, 9))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
+                // Use startAfterNrOfConsumers: 2 to ensure both consumers are registered before pulling upstream
                 var (firstElement, source) = Source.Maybe<int>()
                     .Concat(other)
-                    .ToMaterialized(BroadcastHub.Sink<int>(8), Keep.Both)
+                    .ToMaterialized(BroadcastHub.Sink<int>(startAfterNrOfConsumers: 2, bufferSize: 8), Keep.Both)
                     .Run(Materializer);
 
                 var f1 = source.RunWith(Sink.Seq<int>(), Materializer);
                 var f2 = source.RunWith(Sink.Seq<int>(), Materializer);
 
-                // Ensure subscription of Sinks. This is racy but there is no event we can hook into here.
-                await Task.Delay(500);
-                
+                // No Task.Delay needed - hub waits for 2 consumers before pulling upstream
                 firstElement.SetResult(1);
                 (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
                 (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
 
-        [LocalFact(SkipLocal = "Racy in AzDo CI/CD")]
+        [Fact]
         public async Task BroadcastHub_must_send_the_same_prefix_to_consumers_attaching_around_the_same_time_if_one_cancels_earlier()
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
                 var other = Source.From(Enumerable.Range(2, 19))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
+                // Use startAfterNrOfConsumers: 2 to ensure both consumers are registered before pulling upstream
                 var (firstElement, source) = Source.Maybe<int>()
                     .Concat(other)
-                    .ToMaterialized(BroadcastHub.Sink<int>(8), Keep.Both)
+                    .ToMaterialized(BroadcastHub.Sink<int>(startAfterNrOfConsumers: 2, bufferSize: 8), Keep.Both)
                     .Run(Materializer);
 
                 var f1 = source.RunWith(Sink.Seq<int>(), Materializer);
                 var f2 = source.Take(10).RunWith(Sink.Seq<int>(), Materializer);
 
-                // Ensure subscription of Sinks. This is racy but there is no event we can hook into here.
-                await Task.Delay(500);
-                
+                // No Task.Delay needed - hub waits for 2 consumers before pulling upstream
                 firstElement.SetResult(1);
                 (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 20));
                 (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
@@ -380,66 +378,65 @@ namespace Akka.Streams.Tests.Dsl
             }, Materializer);
         }
 
-        [LocalFact(SkipLocal = "Racy in AzDo CI/CD")]
+        [Fact]
         public async Task BroadcastHub_must_send_the_same_elements_to_consumers_of_different_speed_attaching_around_the_same_time()
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
                 var other = Source.From(Enumerable.Range(2, 9))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
+                // Use startAfterNrOfConsumers: 2 to ensure both consumers are registered before pulling upstream
                 var (firstElement, source) = Source.Maybe<int>()
                     .Concat(other)
-                    .ToMaterialized(BroadcastHub.Sink<int>(8), Keep.Both)
+                    .ToMaterialized(BroadcastHub.Sink<int>(startAfterNrOfConsumers: 2, bufferSize: 8), Keep.Both)
                     .Run(Materializer);
 
                 var f1 = source.Throttle(1, TimeSpan.FromMilliseconds(10), 3, ThrottleMode.Shaping)
                     .RunWith(Sink.Seq<int>(), Materializer);
                 var f2 = source.RunWith(Sink.Seq<int>(), Materializer);
 
-                // Ensure subscription of Sinks. This is racy but there is no event we can hook into here.
-                await Task.Delay(500);
-                
+                // No Task.Delay needed - hub waits for 2 consumers before pulling upstream
                 firstElement.SetResult(1);
                 (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
                 (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
 
-        [LocalFact(SkipLocal = "Racy in AzDo CI/CD")]
+        [Fact]
         public async Task BroadcastHub_must_send_the_same_elements_to_consumers_of_attaching_around_the_same_time_if_the_producer_is_slow()
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
                 var other = Source.From(Enumerable.Range(2, 9))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
+                // Use startAfterNrOfConsumers: 2 to ensure both consumers are registered before pulling upstream
                 var (firstElement, source) = Source.Maybe<int>()
                     .Concat(other)
                     .Throttle(1, TimeSpan.FromMilliseconds(10), 3, ThrottleMode.Shaping)
-                    .ToMaterialized(BroadcastHub.Sink<int>(8), Keep.Both)
+                    .ToMaterialized(BroadcastHub.Sink<int>(startAfterNrOfConsumers: 2, bufferSize: 8), Keep.Both)
                     .Run(Materializer);
 
                 var f1 = source.RunWith(Sink.Seq<int>(), Materializer);
                 var f2 = source.RunWith(Sink.Seq<int>(), Materializer);
 
-                // Ensure subscription of Sinks. This is racy but there is no event we can hook into here.
-                await Task.Delay(500);
-                
+                // No Task.Delay needed - hub waits for 2 consumers before pulling upstream
                 firstElement.SetResult(1);
                 (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
                 (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
             }, Materializer);
         }
 
-        [LocalFact(SkipLocal = "Racy in AzDo CI/CD")]
+        [Fact]
         public async Task BroadcastHub_must_ensure_that_from_two_different_speed_consumers_the_slower_controls_the_rate()
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
                 var other = Source.From(Enumerable.Range(2, 19))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
+                // Use startAfterNrOfConsumers: 2 to ensure both consumers are registered before pulling upstream
                 var (firstElement, source) = Source.Maybe<int>()
                     .Concat(other)
-                    .ToMaterialized(BroadcastHub.Sink<int>(1), Keep.Both)
+                    .ToMaterialized(BroadcastHub.Sink<int>(startAfterNrOfConsumers: 2, bufferSize: 1), Keep.Both)
                     .Run(Materializer);
 
                 var f1 = source
@@ -450,33 +447,30 @@ namespace Akka.Streams.Tests.Dsl
                     .Throttle(10, TimeSpan.FromMilliseconds(10), 8, ThrottleMode.Shaping)
                     .RunWith(Sink.Seq<int>(), Materializer);
 
-                // Ensure subscription of Sinks. This is racy but there is no event we can hook into here.
-                await Task.Delay(500);
-                
+                // No Task.Delay needed - hub waits for 2 consumers before pulling upstream
                 firstElement.SetResult(1);
                 (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 20));
                 (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 20));
             }, Materializer);
         }
 
-        [LocalFact(SkipLocal = "Racy in AzDo CI/CD")]
+        [Fact]
         public async Task BroadcastHub_must_send_the_same_elements_to_consumers_attaching_around_the_same_time_with_a_buffer_size_of_one()
         {
             await this.AssertAllStagesStoppedAsync(async () =>
             {
                 var other = Source.From(Enumerable.Range(2, 9))
                     .MapMaterializedValue<TaskCompletionSource<int>>(_ => null);
+                // Use startAfterNrOfConsumers: 2 to ensure both consumers are registered before pulling upstream
                 var (firstElement, source) = Source.Maybe<int>()
                     .Concat(other)
-                    .ToMaterialized(BroadcastHub.Sink<int>(1), Keep.Both)
+                    .ToMaterialized(BroadcastHub.Sink<int>(startAfterNrOfConsumers: 2, bufferSize: 1), Keep.Both)
                     .Run(Materializer);
 
                 var f1 = source.RunWith(Sink.Seq<int>(), Materializer);
                 var f2 = source.RunWith(Sink.Seq<int>(), Materializer);
 
-                // Ensure subscription of Sinks. This is racy but there is no event we can hook into here.
-                await Task.Delay(500);
-                
+                // No Task.Delay needed - hub waits for 2 consumers before pulling upstream
                 firstElement.SetResult(1);
                 (await f1.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));
                 (await f2.ShouldCompleteWithin(3.Seconds())).Should().BeEquivalentTo(Enumerable.Range(1, 10));

--- a/src/core/Akka.Streams/Dsl/Hub.cs
+++ b/src/core/Akka.Streams/Dsl/Hub.cs
@@ -506,6 +506,35 @@ namespace Akka.Streams.Dsl
         public static Sink<T, Source<T, NotUsed>> Sink<T>(int bufferSize)
             => Dsl.Sink.FromGraph(new BroadcastHub<T>(bufferSize));
 
+        /// <summary>
+        /// Creates a <see cref="Sink{TIn,TMat}"/> that receives elements from its upstream producer and broadcasts them to a dynamic set
+        /// of consumers. After the <see cref="Sink{TIn,TMat}"/> returned by this method is materialized, it returns a <see cref="Source{TOut,TMat}"/> as materialized
+        /// value. This <see cref="Source{TOut,TMat}"/> can be materialized arbitrary many times and each materialization will receive the
+        /// broadcast elements from the original <see cref="Sink{TIn,TMat}"/>.
+        ///
+        /// Every new materialization of the <see cref="Sink{TIn,TMat}"/> results in a new, independent hub, which materializes to its own
+        /// <see cref="Source{TOut,TMat}"/> for consuming the <see cref="Sink{TIn,TMat}"/> of that materialization.
+        ///
+        /// If the original <see cref="Sink{TIn,TMat}"/> is failed, then the failure is immediately propagated to all of its materialized
+        /// <see cref="Source{TOut,TMat}"/>s (possibly jumping over already buffered elements). If the original <see cref="Sink{TIn,TMat}"/> is completed, then
+        /// all corresponding <see cref="Source{TOut,TMat}"/>s are completed. Both failure and normal completion is "remembered" and later
+        /// materializations of the <see cref="Source{TOut,TMat}"/> will see the same (failure or completion) state. <see cref="Source{TOut,TMat}"/>s that are
+        /// cancelled are simply removed from the dynamic set of consumers.
+        /// </summary>
+        /// <typeparam name="T">The type of elements that flow through the hub</typeparam>
+        /// <param name="startAfterNrOfConsumers">
+        /// Elements are buffered until this number of consumers have been connected.
+        /// This is only used initially when the operator is starting up, i.e. it is not honored when consumers have
+        /// been removed (canceled).
+        /// </param>
+        /// <param name="bufferSize">
+        /// Buffer size used by the producer. Gives an upper bound on how "far" from each other two
+        /// concurrent consumers can be in terms of element. If this buffer is full, the producer
+        /// is backpressured. Must be a power of two and less than 4096.
+        /// </param>
+        /// <returns>A sink that can be used to broadcast elements to multiple consumers</returns>
+        public static Sink<T, Source<T, NotUsed>> Sink<T>(int startAfterNrOfConsumers, int bufferSize)
+            => Dsl.Sink.FromGraph(new BroadcastHub<T>(startAfterNrOfConsumers, bufferSize));
 
         /// <summary>
         /// Creates a <see cref="Sink{TIn,TMat}"/> that receives elements from its upstream producer and broadcasts them to a dynamic set
@@ -622,6 +651,7 @@ namespace Akka.Streams.Dsl
             private readonly ImmutableList<Consumer>[] _consumerWheel;
 
             private int _activeConsumer;
+            private bool _initialized;
 
             public HubLogic(BroadcastHub<T> stage) : base(stage.Shape)
             {
@@ -640,7 +670,19 @@ namespace Akka.Streams.Dsl
             {
                 SetKeepGoing(true);
                 _callbackCompletion.SetResult(GetAsyncCallback<IHubEvent>(OnEvent));
-                Pull(_stage.In);
+
+                // Only start pulling immediately if we don't need to wait for consumers
+                if (_stage._startAfterNrOfConsumers == 0)
+                {
+                    _initialized = true;
+                    Pull(_stage.In);
+                }
+            }
+
+            private void TryPull()
+            {
+                if (_initialized && !IsClosed(_stage.In) && !HasBeenPulled(_stage.In) && !IsFull)
+                    Pull(_stage.In);
             }
 
             public override void OnUpstreamFinish()
@@ -653,8 +695,7 @@ namespace Akka.Streams.Dsl
             public override void OnPush()
             {
                 Publish(Grab(_stage.In));
-                if (!IsFull)
-                    Pull(_stage.In);
+                TryPull();
             }
 
             private void OnEvent(IHubEvent hubEvent)
@@ -696,6 +737,11 @@ namespace Akka.Streams.Dsl
                             }
                         }
 
+                        // Check if we've reached the consumer threshold to start pulling
+                        if (_activeConsumer >= _stage._startAfterNrOfConsumers)
+                            _initialized = true;
+
+                        TryPull();
                         return;
                     }
                     case UnRegister unregister:
@@ -719,8 +765,7 @@ namespace Akka.Streams.Dsl
                                 }
 
                                 _head = unregister.FinalOffset;
-                                if (!HasBeenPulled(_stage.In))
-                                    Pull(_stage.In);
+                                TryPull();
                             }
                         }
                         else
@@ -807,8 +852,8 @@ namespace Akka.Streams.Dsl
                 {
                     if (IsClosed(_stage.In))
                         Complete();
-                    else if (!HasBeenPulled(_stage.In))
-                        Pull(_stage.In);
+                    else
+                        TryPull();
                 }
             }
 
@@ -1013,7 +1058,15 @@ namespace Akka.Streams.Dsl
                 }
 
                 public override void PostStop()
-                    => _hubCallback?.Invoke(new UnRegister(_id, _previousPublishedOffset, _offset));
+                {
+                    // If `PostStop` is called before the consumer has processed the `RegistrationPending`'s `Initialize` event,
+                    // then the `Initialize` message will fail with a `StreamDetachedException`,
+                    // upon which the `RegistrationPending` logic itself unregisters this consumer.
+                    // In particular, this client must not send the `UnRegister` event itself because the values in
+                    // `_previousPublishedOffset` and `_offset` are wrong.
+                    if (_hubCallback != null && _offsetInitialized)
+                        _hubCallback.Invoke(new UnRegister(_id, _previousPublishedOffset, _offset));
+                }
 
                 private void OnCommand(IConsumerEvent e)
                 {
@@ -1059,21 +1112,40 @@ namespace Akka.Streams.Dsl
 
         #endregion
 
+        private readonly int _startAfterNrOfConsumers;
         private readonly int _bufferSize;
         private readonly int _mask;
         private readonly int _wheelMask;
         private readonly int _demandThreshold;
 
         /// <summary>
-        /// TBD
+        /// Creates a new BroadcastHub with the specified buffer size and no consumer threshold.
         /// </summary>
-        /// <param name="bufferSize">TBD</param>
+        /// <param name="bufferSize">Buffer size used by the producer. Must be a power of two and less than 4096.</param>
         /// <exception cref="ArgumentException">
         /// This exception is thrown when either the specified <paramref name="bufferSize"/>
         /// is less than or equal to zero, is greater than 4095, or is not a power of two.
         /// </exception>
-        public BroadcastHub(int bufferSize)
+        public BroadcastHub(int bufferSize) : this(0, bufferSize)
         {
+        }
+
+        /// <summary>
+        /// Creates a new BroadcastHub with the specified consumer threshold and buffer size.
+        /// </summary>
+        /// <param name="startAfterNrOfConsumers">
+        /// Elements are buffered until this number of consumers have been connected.
+        /// This is only used initially when the operator is starting up, i.e. it is not honored when consumers have
+        /// been removed (canceled).
+        /// </param>
+        /// <param name="bufferSize">Buffer size used by the producer. Must be a power of two and less than 4096.</param>
+        /// <exception cref="ArgumentException">
+        /// This exception is thrown when the specified parameters are invalid.
+        /// </exception>
+        public BroadcastHub(int startAfterNrOfConsumers, int bufferSize)
+        {
+            if (startAfterNrOfConsumers < 0)
+                throw new ArgumentException("startAfterNrOfConsumers must be >= 0", nameof(startAfterNrOfConsumers));
             if (bufferSize <= 0)
                 throw new ArgumentException("Buffer must be positive", nameof(bufferSize));
             if (bufferSize > 4095)
@@ -1081,6 +1153,7 @@ namespace Akka.Streams.Dsl
             if ((bufferSize & bufferSize - 1) != 0)
                 throw new ArgumentException("Buffer size must be a power of two", nameof(bufferSize));
 
+            _startAfterNrOfConsumers = startAfterNrOfConsumers;
             _bufferSize = bufferSize;
             _mask = _bufferSize - 1;
             _wheelMask = bufferSize * 2 - 1;

--- a/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
+++ b/src/core/Akka.TestKit/TestKitBase_AwaitAssert.cs
@@ -37,7 +37,7 @@ namespace Akka.TestKit
         public void AwaitAssert(Action assertion, TimeSpan? duration=null, TimeSpan? interval=null, CancellationToken cancellationToken = default)
         {
             AwaitAssertAsync(assertion, duration, interval, cancellationToken)
-                .WaitAndUnwrapException();
+                .WaitAndUnwrapException(cancellationToken);
         }
         
         /// <inheritdoc cref="AwaitAssert(Action, TimeSpan?, TimeSpan?, CancellationToken)"/>
@@ -46,14 +46,14 @@ namespace Akka.TestKit
             var intervalValue = interval.GetValueOrDefault(TimeSpan.FromMilliseconds(100));
             if(intervalValue == Timeout.InfiniteTimeSpan) intervalValue = TimeSpan.MaxValue;
             intervalValue.EnsureIsPositiveFinite(nameof(interval));
-            var start = Now;
             var max = RemainingOrDilated(duration);
             var stop = Now + max;
-            var t = max.Min(intervalValue);
             var attempts = 0;
+            var start = Now;
             while(true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                attempts++;
                 try
                 {
                     // TODO: assertion can run forever, need a way to stop this if this happens.
@@ -62,7 +62,7 @@ namespace Akka.TestKit
                 }
                 catch(Exception)
                 {
-                    var stopped = Now + t;
+                    var stopped = Now;
                     if (stopped >= stop)
                     {
                         Sys.Log.Warning("AwaitAssert failed, timeout [{0}] is over after [{1}] attempts and [{2}] elapsed time", max, attempts, stopped - start);
@@ -70,9 +70,9 @@ namespace Akka.TestKit
                     }
                         
                 }
-                attempts++;
+                
+                var t = (stop - Now).Min(intervalValue);
                 await Task.Delay(t, cancellationToken);
-                t = (stop - Now).Min(intervalValue);
             }
         }
 
@@ -98,10 +98,12 @@ namespace Akka.TestKit
             intervalValue.EnsureIsPositiveFinite("interval");
             var max = RemainingOrDilated(duration);
             var stop = Now + max;
-            var t = max.Min(intervalValue);
+            var attempts = 0;
+            var start = Now;
             while(true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+                attempts++;
                 try
                 {
                     await assertion();
@@ -109,11 +111,16 @@ namespace Akka.TestKit
                 }
                 catch(Exception)
                 {
-                    if(Now + t >= stop)
+                    var stopped = Now;
+                    if (stopped >= stop)
+                    {
+                        Sys.Log.Warning("AwaitAssert failed, timeout [{0}] is over after [{1}] attempts and [{2}] elapsed time", max, attempts, stopped - start);
                         throw;
+                    }
                 }
+                
+                var t = (stop - Now).Min(intervalValue);
                 await Task.Delay(t, cancellationToken);
-                t = (stop - Now).Min(intervalValue);
             }
         }
     }

--- a/src/core/Akka.Tests/Event/LogEventActivityContextSpec.cs
+++ b/src/core/Akka.Tests/Event/LogEventActivityContextSpec.cs
@@ -1,0 +1,93 @@
+//-----------------------------------------------------------------------
+// <copyright file="LogEventActivityContextSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Diagnostics;
+using Akka.Event;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Tests.Event
+{
+    public class LogEventActivityContextSpec
+    {
+        private static readonly ActivitySource TestSource = new("Akka.Tests.LogEventActivityContextSpec");
+
+        static LogEventActivityContextSpec()
+        {
+            // Enable activity creation for tests
+            ActivitySource.AddActivityListener(new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == TestSource.Name,
+                Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData
+            });
+        }
+
+        [Fact(DisplayName = "LogEvent should capture ActivityContext when Activity.Current exists")]
+        public void LogEvent_should_capture_ActivityContext_when_Activity_exists()
+        {
+            using var activity = TestSource.StartActivity("TestOperation");
+            activity.Should().NotBeNull("ActivityListener should be registered");
+
+            var logEvent = new Info("test", typeof(LogEventActivityContextSpec), "test message");
+
+            logEvent.ActivityContext.Should().NotBeNull();
+            logEvent.ActivityContext.Value.TraceId.Should().Be(activity!.TraceId);
+            logEvent.ActivityContext.Value.SpanId.Should().Be(activity.SpanId);
+        }
+
+        [Fact(DisplayName = "LogEvent should have null ActivityContext when no Activity.Current")]
+        public void LogEvent_should_have_null_ActivityContext_when_no_Activity()
+        {
+            // Ensure no activity is current
+            Activity.Current = null;
+
+            var logEvent = new Info("test", typeof(LogEventActivityContextSpec), "test message");
+
+            logEvent.ActivityContext.Should().BeNull();
+        }
+
+        [Fact(DisplayName = "LogEvent should capture context at creation time, not access time")]
+        public void LogEvent_should_capture_context_at_creation_time()
+        {
+            using var activity = TestSource.StartActivity("TestOperation");
+            activity.Should().NotBeNull();
+
+            var logEvent = new Info("test", typeof(LogEventActivityContextSpec), "test message");
+            var capturedTraceId = logEvent.ActivityContext!.Value.TraceId;
+
+            // Stop the activity
+            activity!.Stop();
+            Activity.Current = null;
+
+            // LogEvent should still have the original context
+            logEvent.ActivityContext.Should().NotBeNull();
+            logEvent.ActivityContext.Value.TraceId.Should().Be(capturedTraceId);
+        }
+
+        [Fact(DisplayName = "All LogEvent types should capture ActivityContext")]
+        public void All_LogEvent_types_should_capture_ActivityContext()
+        {
+            using var activity = TestSource.StartActivity("TestOperation");
+            activity.Should().NotBeNull();
+
+            var debug = new Akka.Event.Debug("test", typeof(LogEventActivityContextSpec), "debug");
+            var info = new Akka.Event.Info("test", typeof(LogEventActivityContextSpec), "info");
+            var warning = new Akka.Event.Warning("test", typeof(LogEventActivityContextSpec), "warning");
+            var error = new Akka.Event.Error(null, "test", typeof(LogEventActivityContextSpec), "error");
+
+            debug.ActivityContext.Should().NotBeNull();
+            info.ActivityContext.Should().NotBeNull();
+            warning.ActivityContext.Should().NotBeNull();
+            error.ActivityContext.Should().NotBeNull();
+
+            debug.ActivityContext.Value.TraceId.Should().Be(activity!.TraceId);
+            info.ActivityContext.Value.TraceId.Should().Be(activity.TraceId);
+            warning.ActivityContext.Value.TraceId.Should().Be(activity.TraceId);
+            error.ActivityContext.Value.TraceId.Should().Be(activity.TraceId);
+        }
+    }
+}

--- a/src/core/Akka/Actor/CoordinatedShutdown.cs
+++ b/src/core/Akka/Actor/CoordinatedShutdown.cs
@@ -429,6 +429,8 @@ namespace Akka.Actor
         {
             if (_runStarted.CompareAndSet(null, reason))
             {
+                Log.Info("CoordinatedShutdown invoked due to [Reason:{Reason}]. Exiting with [ExitCode:{ExitCode}].", reason.GetType(), reason.ExitCode);
+                
                 var debugEnabled = Log.IsDebugEnabled;
 
                 Task<Done> Loop(List<string> remainingPhases)

--- a/src/core/Akka/Actor/Inbox.cs
+++ b/src/core/Akka/Actor/Inbox.cs
@@ -578,6 +578,16 @@ namespace Akka.Actor
                 throw new TimeoutException(
                     $"Inbox {Receiver.Path} didn't receive a response message in specified timeout {timeout}");
 
+            // Handle faulted tasks to avoid AggregateException when accessing task.Result
+            if (task.IsFaulted)
+            {
+                var exception = task.Exception?.InnerException ?? task.Exception;
+                if (exception is TimeoutException timeoutEx)
+                    throw new TimeoutException(
+                        $"Inbox {Receiver.Path} received a timeout: {timeoutEx.Message}", timeoutEx);
+                throw exception!;
+            }
+
             if (task.Result is Status.Failure received && received.Cause is TimeoutException)
             {
                 throw new TimeoutException(

--- a/src/core/Akka/Akka.csproj
+++ b/src/core/Akka/Akka.csproj
@@ -22,6 +22,7 @@
   <!-- Packages only for NetStandard -->
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetStandardLibVersion)'">
     <PackageReference Include="Polyfill" Version="1.28.0" PrivateAssets="all" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(MicrosoftLibVersion)" />
     <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
     <PackageReference Include="System.Threading.Channels" Version="$(MicrosoftLibVersion)" />
   </ItemGroup>

--- a/src/core/Akka/Event/LogEvent.cs
+++ b/src/core/Akka/Event/LogEvent.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using Akka.Actor;
 
@@ -45,10 +46,18 @@ namespace Akka.Event
         /// <summary>
         /// Initializes a new instance of the <see cref="LogEvent" /> class.
         /// </summary>
+        /// <remarks>
+        /// Captures <see cref="Activity.Current"/> trace context at creation time.
+        /// This enables log correlation with distributed traces even after the log event
+        /// crosses actor mailbox boundaries (where <see cref="Activity.Current"/> would be lost).
+        /// </remarks>
         protected LogEvent()
         {
             Timestamp = DateTime.UtcNow;
             Thread = Thread.CurrentThread;
+
+            // Capture Activity.Current context NOW (before mailbox crossing)
+            ActivityContext = Activity.Current?.Context;
         }
 
         /// <summary>
@@ -65,6 +74,16 @@ namespace Akka.Event
         /// The thread where this event occurred.
         /// </summary>
         public Thread Thread { get; private set; }
+
+        /// <summary>
+        /// The trace context from <see cref="Activity.Current"/> captured at log event creation time.
+        /// </summary>
+        /// <remarks>
+        /// This value is captured before the log event crosses actor mailbox boundaries,
+        /// enabling trace correlation with OpenTelemetry and other distributed tracing systems.
+        /// Will be <c>null</c> if no <see cref="Activity"/> was active when the log event was created.
+        /// </remarks>
+        public ActivityContext? ActivityContext { get; private set; }
 
         /// <summary>
         /// The source that generated this event.

--- a/src/core/Akka/Event/LoggingBus.cs
+++ b/src/core/Akka/Event/LoggingBus.cs
@@ -204,8 +204,10 @@ namespace Akka.Event
             var fullLoggerName = $"{loggerName} [{loggerType.FullName}]";
             var logger = system.SystemActorOf(Props.Create(loggerType).WithDispatcher(system.Settings.LoggersDispatcher), loggerName);
             var askTask = logger.Ask(new InitializeLogger(this), Timeout.InfiniteTimeSpan, _shutdownCts.Token);
-            
-            askTask.ContinueWith(t =>
+
+            // Return the continuation task, not the ask task, so callers wait for
+            // the full initialization sequence including the "Logger started" message
+            var continuationTask = askTask.ContinueWith(t =>
                 {
                     // _shutdownCts was cancelled while this logger is still loading
                     if (t.IsCanceled)
@@ -215,7 +217,16 @@ namespace Akka.Event
                         RemoveLogger(logger);
                         return;
                     }
-                    
+
+                    // Ask operation failed with an exception
+                    if (t.IsFaulted)
+                    {
+                        Publish(new Error(t.Exception, loggingBusName, GetType(),
+                            $"Logger {fullLoggerName} failed to respond to initialization request. Stopping logger."));
+                        RemoveLogger(logger);
+                        return;
+                    }
+
                     // Task ran to completion successfully
                     var response = t.Result;
                     if (response is not LoggerInitialized)
@@ -231,8 +242,8 @@ namespace Akka.Event
                     _loggers.Add(logger);
                     SubscribeLogLevelAndAbove(LogLevel, logger);
                     Publish(new Debug(loggingBusName, GetType(), $"Logger {fullLoggerName} started"));
-                });
-            return (askTask, fullLoggerName);
+                }, TaskContinuationOptions.ExecuteSynchronously);
+            return (continuationTask, fullLoggerName);
         }
 
         private string CreateLoggerName(Type actorClass)


### PR DESCRIPTION
Cherry-picked fixes for 1.5.59 release from `dev` branch.

## Included PRs

| PR | Title |
|----|-------|
| #7986 | Fix AwaitAssertAsync logic |
| #7988 | CoordinatedShutdown: clearly log the reason why we're exiting |
| #7999 | Fix DeferAsync async handler nesting bug in CommandAsync |
| #8005 | Fix Inbox.AwaitResult throwing AggregateException instead of TimeoutException |
| #8006 | Fix logger initialization continuation race in LoggingBus |
| #8011 | Fix MergeSeen to filter Seen against current Members |
| #8018 | Add BroadcastHub startAfterNrOfConsumers parameter |
| #7995 | Add ActivityContext capture to LogEvent for trace correlation |

## Conflict Resolutions

- API verification files for BroadcastHub: Added new `Sink<T>(int startAfterNrOfConsumers, int bufferSize)` overload
- API verification files for LogEvent: Added `ActivityContext` property and changed setter visibility to `protected set`