### PR TITLE
Fix racy InMemoryJournal tests

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
@@ -18,6 +18,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
 
         public InMemoryAllEventsSpec(ITestOutputHelper output) : base(Config(), nameof(InMemoryAllEventsSpec), output)
         {
+            InMemoryPersistenceSpecConfig.EnsureThreadPoolWarmed();
             Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentAllEventsSpec.cs
@@ -18,6 +18,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
 
         public InMemoryCurrentAllEventsSpec(ITestOutputHelper output) : base(Config(), nameof(InMemoryCurrentAllEventsSpec), output)
         {
+            InMemoryPersistenceSpecConfig.EnsureThreadPoolWarmed();
             Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByPersistenceIdSpec.cs
@@ -17,8 +17,9 @@ namespace Akka.Persistence.Query.InMemory.Tests
             .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryCurrentEventsByPersistenceIdSpec(ITestOutputHelper output) : 
-            base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
+            base(Config(), nameof(InMemoryCurrentEventsByPersistenceIdSpec), output)
         {
+            InMemoryPersistenceSpecConfig.EnsureThreadPoolWarmed();
             Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByTagSpec.cs
@@ -26,8 +26,9 @@ namespace Akka.Persistence.Query.InMemory.Tests
             .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryCurrentEventsByTagSpec(ITestOutputHelper output) : 
-            base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
+            base(Config(), nameof(InMemoryCurrentEventsByTagSpec), output)
         {
+            InMemoryPersistenceSpecConfig.EnsureThreadPoolWarmed();
             Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentPersistenceIdsSpec.cs
@@ -19,6 +19,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
         public InMemoryCurrentPersistenceIdsSpec(ITestOutputHelper output) : 
             base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
         {
+            InMemoryPersistenceSpecConfig.EnsureThreadPoolWarmed();
             Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByPersistenceIdSpec.cs
@@ -17,8 +17,9 @@ namespace Akka.Persistence.Query.InMemory.Tests
             .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryEventsByPersistenceIdSpec(ITestOutputHelper output) :
-            base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
+            base(Config(), nameof(InMemoryEventsByPersistenceIdSpec), output)
         {
+            InMemoryPersistenceSpecConfig.EnsureThreadPoolWarmed();
             Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
@@ -26,8 +26,9 @@ namespace Akka.Persistence.Query.InMemory.Tests
             .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryEventsByTagSpec(ITestOutputHelper output) : 
-            base(Config(), nameof(InMemoryCurrentPersistenceIdsSpec), output)
+            base(Config(), nameof(InMemoryEventsByTagSpec), output)
         {
+            InMemoryPersistenceSpecConfig.EnsureThreadPoolWarmed();
             Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceIdsSpec.cs
@@ -21,6 +21,7 @@ namespace Akka.Persistence.Query.InMemory.Tests
 
         public InMemoryPersistenceIdsSpec(ITestOutputHelper output) : base(Config(), nameof(InMemoryPersistenceIdsSpec), output)
         {
+            InMemoryPersistenceSpecConfig.EnsureThreadPoolWarmed();
             Persistence.Instance.Get(Sys); // Initialize persistence immediately
             ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
         }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceSpecConfig.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceSpecConfig.cs
@@ -5,12 +5,35 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
+using System;
+using System.Threading;
 using Akka.Configuration;
 
 namespace Akka.Persistence.Query.InMemory.Tests;
 
 public static class InMemoryPersistenceSpecConfig
 {
+    /// <summary>
+    /// Pre-warms the thread pool to avoid cold-start delays in CI environments.
+    /// Thread pool growth is throttled (~500ms per new thread), which can cause
+    /// actor recovery to timeout when many actors are created simultaneously.
+    /// This is especially important for persistence tests that create multiple
+    /// persistent actors that all need RecoveryPermitter grants.
+    /// </summary>
+    /// <remarks>
+    /// This method is safe to call multiple times - it uses <see cref="Math.Max(int, int)"/> to ensure
+    /// the thread pool minimum is never decreased from a previously set value.
+    /// </remarks>
+    public static void EnsureThreadPoolWarmed(int minimumThreadCount = -1)
+    {
+        if(minimumThreadCount < 0)
+            minimumThreadCount = Environment.ProcessorCount * 2;
+
+        ThreadPool.GetMinThreads(out var minWorker, out var minIo);
+        var targetMin = Math.Max(minWorker, minimumThreadCount);
+        ThreadPool.SetMinThreads(targetMin, minIo);
+    }
+    
     /// <summary>
     /// Sets the refresh interval to 1s and uses the in-memory journal and snapshot store.
     /// </summary>


### PR DESCRIPTION
## Problem

The test `InMemoryEventsByTagSpec.ReadJournal_live_query_EventsByTag_should_find_events_from_offset_exclusive` was timing out intermittently in CI environments.

### Root Cause

**.NET ThreadPool cold start throttling.** When the thread pool is below its minimum thread count, new threads are created immediately. Once at or above the minimum, the thread pool throttles injection to ~1 thread per 500ms (controlled by the hill-climbing algorithm's `GateActivitiesPeriodMs`).

In CI environments with fresh processes and minimal initial threads, creating multiple persistent actors simultaneously causes:
1. Each actor's mailbox needs a thread to process `AroundPreStart`
2. Thread pool is quickly saturated
3. Subsequent actors wait ~500ms-1000ms per thread injection cycle
4. Test timeouts after 3 seconds while waiting for thread pool growth

### Evidence

CI logs showed a distinctive pattern of ~1 second delays between actor operations:
```
+877ms   Actor a created
+1000ms  Actor b created
+1000ms  Actor c created
+1000ms  Sending message → TIMEOUT
```

## Solution

### 1. Pre-warm the thread pool before creating actors

```csharp
public static void EnsureThreadPoolWarmed(int minimumThreadCount = -1)
{
    if(minimumThreadCount < 0)
        minimumThreadCount = Environment.ProcessorCount * 2;

    ThreadPool.GetMinThreads(out var minWorker, out var minIo);
    var targetMin = Math.Max(minWorker, minimumThreadCount);
    ThreadPool.SetMinThreads(targetMin, minIo);
}
```

Call this at the start of test constructors before creating the `ActorSystem`.

### 2. Eagerly initialize the Persistence extension

```csharp
Persistence.Instance.Apply(Sys);
```
