### PR TITLE
Downgrade VirtualPathContainer RemoveChild log from Warning to Debug

### DIFF
--- a/src/core/Akka/Actor/ActorRef.cs
+++ b/src/core/Akka/Actor/ActorRef.cs
@@ -879,7 +879,7 @@ namespace Akka.Actor
             IInternalActorRef tmp;
             if (!_children.TryRemove(name, out tmp))
             {
-                Log.Warning("{0} trying to remove non-child {1}", Path, name);
+                Log.Debug("{0} trying to remove non-child {1}", Path, name);
             }
         }
 
@@ -893,7 +893,7 @@ namespace Akka.Actor
             IInternalActorRef tmp;
             if (!_children.TryRemove(name, out tmp))
             {
-                Log.Warning("{0} trying to remove non-child {1}", Path, name);
+                Log.Debug("{0} trying to remove non-child {1}", Path, name);
             }
         }
 


### PR DESCRIPTION
## Summary
- Changed `Log.Warning` to `Log.Debug` in both `VirtualPathContainer.RemoveChild` overloads
- `TryRemove` returning `false` on the `ConcurrentDictionary` simply means "already removed" — not an error condition
- Eliminates noisy warnings during high-load `Ask` operations that alarm users during load testing

Fixes #8037