### PR TITLE
Correct self-comparison in ShardCoordinator ResendShardHost handler

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
@@ -1792,7 +1792,7 @@ namespace Akka.Cluster.Sharding
 
                 case ResendShardHost m:
                     {
-                        if (State.Shards.TryGetValue(m.Shard, out var region) && region.Equals(region))
+                        if (State.Shards.TryGetValue(m.Shard, out var region) && region.Equals(m.Region))
                             SendHostShardMsg(m.Shard, region);
                         else
                         {


### PR DESCRIPTION
## Changes

I'm new to contributing to Akka.NET, and as I was reading / reviewing code, I noticed that `region.Equals(region)` compared the variable to itself, making the condition always true and the else branch (which is empty) unreachable. Changed to region.Equals(m.Region) to compare the current region from state against the original region captured when the ResendShardHost timer was scheduled.

I believe that this is wasteful but has no user visible impact. However, I spent enough time looking at it that I thought it was worth fixing just to prevent future confusion.

If there's anything I did incorrect, I apologize in advance, please let me know. Thanks!

## Checklist

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [X] Changes in public API reviewed, if any.