### PR TITLE
AppVersion.CompareTo missing else if breaks comparison symmetry

### DIFF
--- a/src/core/Akka.Tests/Util/AkkaVersionSpec.cs
+++ b/src/core/Akka.Tests/Util/AkkaVersionSpec.cs
@@ -66,8 +66,11 @@ namespace Akka.Tests.Util
             AppVersion.Create("1.2.0-M1").Should().Be(AppVersion.Create("1.2-M1"));
             AppVersion.Create("1.2.3-M1").Should().NotBe(AppVersion.Create("1.2.3-M2"));
             AppVersion.Create("1.2-M1").Should().BeLessThan(AppVersion.Create("1.2.0"));
-            AppVersion.Create("1.2.0-M1").Should().BeLessThan(AppVersion.Create("1.2.0"));
             AppVersion.Create("1.2.3-M2").Should().BeGreaterThan(AppVersion.Create("1.2.3-M1"));
+
+            // ensure comparisons are symmetrical
+            AppVersion.Create("1.2.0-M1").Should().BeLessThan(AppVersion.Create("1.2.0"));
+            AppVersion.Create("1.2.0").Should().BeGreaterThan(AppVersion.Create("1.2.0-M1"));
         }
 
         [Fact]

--- a/src/core/Akka/Util/AppVersion.cs
+++ b/src/core/Akka/Util/AppVersion.cs
@@ -229,7 +229,7 @@ namespace Akka.Util
                             {
                                 if (_rest == "" && other._rest != "")
                                     diff = 1;
-                                if (other._rest == "" && _rest != "")
+                                else if (other._rest == "" && _rest != "")
                                     diff = -1;
                                 else
                                     diff = string.Compare(_rest, other._rest, StringComparison.Ordinal);


### PR DESCRIPTION
## Changes

The second condition in the rest-string comparison was an 'if' instead of 'else if', causing the first branch's result (diff = 1) to be immediately overwritten by the else branch. This made release versions appear less than their pre-release counterparts (e.g. '1.2.0' < '1.2.0-M1'), violating IComparable<T> symmetry.

I believe this could cause non-deterministic shard allocation ordering during rolling updates from pre-release to release versions via AbstractLeastShardAllocationStrategy. I also added regression test for the reverse comparison direction.

## Checklist

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).