### PR TITLE
Fix Shard remember-entities flag mismatch causing entity restart failures

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -1007,7 +1007,7 @@ namespace Akka.Cluster.Sharding
             var failOnInvalidStateTransition =
                 Context.System.Settings.Config.GetBoolean(
                     "akka.cluster.sharding.fail-on-invalid-entity-state-transition");
-            _entities = new Entities(Log, settings.RememberEntities, _verboseDebug, failOnInvalidStateTransition);
+            _entities = new Entities(Log, _rememberEntities, _verboseDebug, failOnInvalidStateTransition);
 
             var idleInterval = TimeSpan.FromTicks(_settings.PassivateIdleEntityAfter.Ticks / 2);
             _passivateIdleTask = _settings.ShouldPassivateIdleEntities


### PR DESCRIPTION
## Summary

- Fixed a bug in `Shard.cs` where the `Entities` class was initialized with `settings.RememberEntities` (from HOCON config, default `false`) instead of `_rememberEntities` (derived from whether a `rememberEntitiesProvider` was passed to the constructor)
- This mismatch caused the `Entities._remembering` HashSet to never be populated, so `OnUpdateDone` would see no pending work and incorrectly transition the shard to `Idle` while a store write was in-flight
- The dropped `UpdateDone` prevented entity restarts after transient failures (constructor/PreStart exceptions), causing the `ShardEntityFailureSpec` test to flake

## Root Cause

The `Shard` constructor had two independent "remember entities enabled" flags:
1. `_rememberEntities = rememberEntitiesProvider != null` (true when provider passed)
2. `Entities.RememberingEntities = settings.RememberEntities` (from HOCON config)

When a `rememberEntitiesProvider` was supplied without the config flag being set, `PassivateCompleted` would trigger a store write and `Context.Become(WaitingForRememberEntitiesStore)`, but then `OnUpdateDone`'s pending check against the empty `_remembering` set would overwrite this with `Context.Become(Idle)`, causing subsequent `UpdateDone` messages to be dropped with "Id must not be empty".

## Test plan

- [x] `ShardEntityFailureSpec` passes (both `ConstructorFailActor` and `PreStartFailActor` variants)
- [x] All 24 shard-related tests pass
- [x] Validated with 200 consecutive passes by stress testing