### PR TITLE
Port Pekko ShardStopped handler + handoff safety net

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
@@ -1790,6 +1790,31 @@ namespace Akka.Cluster.Sharding
                     }
                     return true;
 
+                case ShardStopped m:
+                    // Ported from Pekko: clean up unAckedHostShards when shard reports stopped
+                    if (_unAckedHostShards.TryGetValue(m.Shard, out var stopCancel))
+                    {
+                        stopCancel.Cancel();
+                        _unAckedHostShards = _unAckedHostShards.Remove(m.Shard);
+                    }
+
+                    // Safety net: if no rebalance is in progress for this shard (RebalanceWorker
+                    // already timed out), deallocate the shard so it can be reallocated elsewhere.
+                    // This prevents the shard from being endlessly recreated via GetShardHome/ShardHome.
+                    if (!_rebalanceInProgress.ContainsKey(m.Shard) && State.Shards.ContainsKey(m.Shard))
+                    {
+                        Log.Info("{0}: Shard [{1}] stopped - performing late deallocation (rebalance worker timed out).",
+                            TypeName, m.Shard);
+                        Update(new ShardHomeDeallocated(m.Shard), evt =>
+                        {
+                            State = State.Updated(evt);
+                            Log.Debug("{0}: Shard [{1}] deallocated (late)", TypeName, m.Shard);
+                            AllocateShardHomesForRememberEntities();
+                            _context.Self.Tell(new GetShardHome(m.Shard), _ignoreRef);
+                        });
+                    }
+                    return true;
+
                 case ResendShardHost m:
                     {
                         if (State.Shards.TryGetValue(m.Shard, out var region) && region.Equals(region))

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -1410,6 +1410,12 @@ namespace Akka.Cluster.Sharding
                 {
                     _handingOff = _handingOff.Remove(terminated.ActorRef);
                     _log.Debug("{0}: Shard [{1}] handoff complete", _typeName, shard);
+
+                    // Send backup ShardStopped to coordinator in case the RebalanceWorker
+                    // has already timed out and missed the ShardStopped from HandOffStopper.
+                    // The coordinator's Active handler will only deallocate if no rebalance
+                    // is currently in progress for this shard.
+                    _coordinator?.Tell(new ShardCoordinator.ShardStopped(shard));
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

Fixes #7500 - Shards can fail to `HandOff` indefinitely during scale-up events.

**Root cause**: When a `RebalanceWorker` times out (single 60s timer covers both `BeginHandOffAck` + `ShardStopped` phases), the `ShardStopped` message from `HandOffStopper` goes to the dead `RebalanceWorker` and is lost. The coordinator never deallocates the shard, so entity traffic triggers `GetShardHome` → `ShardHome` → shard recreation → repeat (10-30 minutes of unhandled `HandOff` messages).

**Changes**:

- **ShardCoordinator.cs**: Added `ShardStopped` handler to `Active()` (ported from Pekko). Cleans up `_unAckedHostShards` and performs late deallocation when no `RebalanceWorker` is active for the shard (`!_rebalanceInProgress.ContainsKey`). This is the safety net — if the worker already timed out, the coordinator can still deallocate and reallocate the shard.

- **ShardRegion.cs**: `HandleTerminated()` now sends a backup `ShardStopped` to the coordinator when a handoff completes. This ensures the coordinator receives the stop notification even when the `RebalanceWorker` has already timed out. The coordinator handler is idempotent — if a rebalance is still in progress, the deallocation is skipped (the worker handles it).

## Test plan

- [x] `dotnet build -c Release -warnaserror` — 0 warnings, 0 errors
- [x] `Akka.Cluster.Sharding.Tests` — 188/190 passed (2 failures are pre-existing `RememberEntitiesStarterSpec` flakes, unrelated)
- [ ] `ShardStopped` is an internal message — no public API surface changes
- [ ] Manual verification: coordinator correctly deallocates shards that complete handoff after RebalanceWorker timeout