### PR TITLE
Correct format index in 3-arg LogInfo overload

### DIFF
--- a/src/core/Akka.Cluster/Cluster.cs
+++ b/src/core/Akka.Cluster/Cluster.cs
@@ -711,11 +711,11 @@ namespace Akka.Cluster
             /// <param name="template">The template being rendered and logged.</param>
             /// <param name="arg1">The first argument that fills in the corresponding template placeholder.</param>
             /// <param name="arg2">The second argument that fills in the corresponding template placeholder.</param>
-            /// <param name="arg3">The second argument that fills in the corresponding template placeholder.</param>
+            /// <param name="arg3">The third argument that fills in the corresponding template placeholder.</param>
             internal void LogInfo(string template, object arg1, object arg2, object arg3)
             {
                 if (_settings.LogInfo)
-                    _log.Info("Cluster Node [{2}] - " + template, arg1, arg2, arg3, _selfAddress);
+                    _log.Info("Cluster Node [{3}] - " + template, arg1, arg2, arg3, _selfAddress);
             }
         }
 


### PR DESCRIPTION
## Changes

The 3-arg LogInfo overload used {2} in its prefix, which resolved to arg3 instead of _selfAddress (at index 3). This caused log messages like 'Cluster Node [1.0.0]' instead of 'Cluster Node [akka://...]'.

The 1-arg and 2-arg overloads correctly used {1} and {2} respectively to reference _selfAddress as the last argument.

Also fixed xmldoc on arg3 parameter ('second' -> 'third').

## Checklist

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).