### PR TITLE
Remove stray dollar signs from interpolated strings

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardRegion.cs
@@ -1073,7 +1073,7 @@ namespace Akka.Cluster.Sharding
             {
                 var qr = ShardsQueryResult<T>.Create(tasks, _shards.Count, timeout);
                 if (qr.Failed.Count > 0)
-                    _log.Warning($"{0}: {qr}", _typeName);
+                    _log.Warning("{0}: {1}", _typeName, qr);
                 return qr;
             });
         }

--- a/src/core/Akka.Cluster.Tests/HeartbeatNodeRingSpec.cs
+++ b/src/core/Akka.Cluster.Tests/HeartbeatNodeRingSpec.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Collections.Immutable;
 using Akka.Actor;
 using Xunit;
@@ -85,6 +86,16 @@ namespace Akka.Cluster.Tests
         {
             var ring = new HeartbeatNodeRing(cc, ImmutableHashSet.Create(cc), ImmutableHashSet<UniqueAddress>.Empty, 3);
             ring.MyReceivers.Value.Should().BeEquivalentTo(ImmutableHashSet<UniqueAddress>.Empty);
+        }
+
+        [Fact]
+        public void HeartbeatNodeRing_must_not_have_stray_dollar_in_error_message()
+        {
+            var notInNodes = new UniqueAddress(new Address("akka.tcp", "sys", "zz", 2552), 99);
+            var ex = Assert.Throws<ArgumentException>(() =>
+                new HeartbeatNodeRing(notInNodes, ImmutableHashSet<UniqueAddress>.Empty, ImmutableHashSet<UniqueAddress>.Empty, 3));
+
+            ex.Message.Should().Be("Nodes [] must contain selfAddress [UniqueAddress: (akka.tcp://sys@zz:2552, 99)]");
         }
     }
 }

--- a/src/core/Akka.Cluster/ClusterHeartbeat.cs
+++ b/src/core/Akka.Cluster/ClusterHeartbeat.cs
@@ -591,7 +591,7 @@ namespace Akka.Cluster
             MonitoredByNumberOfNodes = monitoredByNumberOfNodes;
 
             if (!nodes.Contains(selfAddress))
-                throw new ArgumentException($"Nodes [${string.Join(", ", nodes)}] must contain selfAddress [{selfAddress}]");
+                throw new ArgumentException($"Nodes [{string.Join(", ", nodes)}] must contain selfAddress [{selfAddress}]");
 
             _useAllAsReceivers = MonitoredByNumberOfNodes >= (NodeRing.Count - 1);
             _myReceivers = Option<IImmutableSet<UniqueAddress>>.None;

--- a/src/core/Akka.Streams/Implementation/StreamRef/SinkRefImpl.cs
+++ b/src/core/Akka.Streams/Implementation/StreamRef/SinkRefImpl.cs
@@ -201,8 +201,8 @@ namespace Akka.Streams.Implementation.StreamRef
                 if ((string)timerKey == SubscriptionTimeoutKey)
                 {
                     // we know the future has been competed by now, since it is in preStart
-                    var ex = new StreamRefSubscriptionTimeoutException($"[{StageActorName}] Remote side did not subscribe (materialize) handed out Sink reference [${_promise.Task.Result}], " +
-                                                                       $"within subscription timeout: ${SubscriptionTimeout.Timeout}!");
+                    var ex = new StreamRefSubscriptionTimeoutException($"[{StageActorName}] Remote side did not subscribe (materialize) handed out Sink reference [{_promise.Task.Result}], " +
+                                                                       $"within subscription timeout: {SubscriptionTimeout.Timeout}!");
 
                     throw ex; // this will also log the exception, unlike failStage; this should fail rarely, but would be good to have it "loud"
                 }


### PR DESCRIPTION
## Changes

Fix three string interpolation bugs where a $ prefix was combined with positional {0} formatting or produced literal $ in output:

- ClusterHeartbeat.cs: [${string.Join...}] -> [{string.Join...}]
- ShardRegion.cs: $"{0}: {qr}" -> $"{_typeName}: {qr}"
- SinkRefImpl.cs: [${_promise.Task.Result}] and ${SubscriptionTimeout.Timeout}

Add regression test for the HeartbeatNodeRing error message.

## Checklist

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).