### PR TITLE
VectorClock inequality fixes

### DIFF
--- a/src/core/Akka.Cluster.Tests/VectorClockSpec.cs
+++ b/src/core/Akka.Cluster.Tests/VectorClockSpec.cs
@@ -30,6 +30,28 @@ namespace Akka.Cluster.Tests
         }
 
         [Fact]
+        public void A_VectorClock_must_handle_null_equality_correctly()
+        {
+            VectorClock nullClock = null;
+            var clock = VectorClock.Create();
+
+            // null == null should be true
+            (nullClock == null).Should().BeTrue();
+            (null == nullClock).Should().BeTrue();
+
+            // null != null should be false
+            (nullClock != null).Should().BeFalse();
+
+            // clock == null and null == clock should be false
+            (clock == null).Should().BeFalse();
+            (null == clock).Should().BeFalse();
+
+            // clock != null and null != clock should be true
+            (clock != null).Should().BeTrue();
+            (null != clock).Should().BeTrue();
+        }
+
+        [Fact]
         public void A_VectorClock_must_pass_misc_comparison_test1()
         {
             var clock1_1 = VectorClock.Create();

--- a/src/core/Akka.Cluster.Tests/VectorClockSpec.cs
+++ b/src/core/Akka.Cluster.Tests/VectorClockSpec.cs
@@ -60,6 +60,7 @@ namespace Akka.Cluster.Tests
             var clock5_2 = clock4_2.Increment(VectorClock.Node.Create("3"));
 
             (clock4_1 < clock5_2).Should().BeTrue();
+            (clock4_1 != clock5_2).Should().BeTrue("before relationship means not equal");
         }
 
         [Fact]
@@ -106,6 +107,8 @@ namespace Akka.Cluster.Tests
             
             (clock3_1 < clock5_2).Should().BeTrue();
             (clock5_2 > clock3_1).Should().BeTrue();
+            (clock3_1 != clock5_2).Should().BeTrue("before relationship means not equal");
+            (clock5_2 != clock3_1).Should().BeTrue("after relationship means not equal");
         }
 
         [Fact]

--- a/src/core/Akka.Cluster/VectorClock.cs
+++ b/src/core/Akka.Cluster/VectorClock.cs
@@ -339,7 +339,7 @@ namespace Akka.Cluster
             if (ReferenceEquals(left, null))
                 return false;
 
-            return left.IsConcurrentWith(right);
+            return !left.IsSameAs(right);
         }
 
         private static readonly (Node, long) CmpEndMarker = (Node.Create("endmarker"), Timestamp.EndMarker);

--- a/src/core/Akka.Cluster/VectorClock.cs
+++ b/src/core/Akka.Cluster/VectorClock.cs
@@ -322,7 +322,9 @@ namespace Akka.Cluster
         /// <returns><c>true</c> if both vector clocks are equal; otherwise <c>false</c></returns>
         public static bool operator ==(VectorClock left, VectorClock right)
         {
-            if (ReferenceEquals(left, null))
+            if (ReferenceEquals(left, right))
+                return true;
+            if (ReferenceEquals(left, null) || ReferenceEquals(right, null))
                 return false;
 
             return left.IsSameAs(right);
@@ -336,10 +338,7 @@ namespace Akka.Cluster
         /// <returns><c>true</c> if both vector clocks are not equal; otherwise <c>false</c></returns>
         public static bool operator !=(VectorClock left, VectorClock right)
         {
-            if (ReferenceEquals(left, null))
-                return false;
-
-            return !left.IsSameAs(right);
+            return !(left == right);
         }
 
         private static readonly (Node, long) CmpEndMarker = (Node.Create("endmarker"), Timestamp.EndMarker);


### PR DESCRIPTION
## Changes

These two issues were found with the help of Copilot. I read up on Vector clocks to understand better. After investigating, I believe there's no identifiable user impact, however I thought it's still worth a fix to avoid wasting time in the future.

### `!=` operator returns negation of `==` instead of `IsConcurrentWith`

The != operator incorrectly delegated to IsConcurrentWith instead of being the logical negation of ==. This meant a != b returned false when one clock was Before or After the other, violating the fundamental contract that != is the negation of ==.

Changed from IsConcurrentWith to !IsSameAs. Added regression assertions in existing comparison tests that cover Before and After relationships.

### VectorClock `==` and `!=` operators handle null correctly

Previously null == null returned false and something ==/!= null threw NullReferenceException. Now follows standard C# equality pattern: ReferenceEquals for both-null and either-null, then delegate to IsSameAs. The != operator delegates to !(left == right) to guarantee consistency.

-----

The cluster daemon never uses the `==` or `!=` operators. It always calls `.CompareTo()` and switches on the `Ordering` enum; the operators are only used in tests. However, `VectorClock` is a public sealed class, so users could use the operators in custom cluster logic.

These are correctness fixes for a public API contract (!= should negate ==, null handling shouldn't crash).


## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [X] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [X] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [X] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Changes in public API reviewed, if any.