### PR TITLE
Fix wrong randomFactor argument type on RetrySupport.Retry()

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -4524,7 +4524,7 @@ namespace Akka.Pattern
         public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts) { }
         public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.Func<int, Akka.Util.Option<System.TimeSpan>> delayFunction, Akka.Actor.IScheduler scheduler) { }
         public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan delay, Akka.Actor.IScheduler scheduler) { }
-        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, int randomFactor, Akka.Actor.IScheduler scheduler) { }
+        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, Akka.Actor.IScheduler scheduler) { }
     }
     public class UserCalledFailException : Akka.Actor.AkkaException
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -4541,7 +4541,7 @@ namespace Akka.Pattern
         public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts) { }
         public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.Func<int, Akka.Util.Option<System.TimeSpan>> delayFunction, Akka.Actor.IScheduler scheduler) { }
         public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan delay, Akka.Actor.IScheduler scheduler) { }
-        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, int randomFactor, Akka.Actor.IScheduler scheduler) { }
+        public static System.Threading.Tasks.Task<T> Retry<T>(System.Func<System.Threading.Tasks.Task<T>> attempt, int attempts, System.TimeSpan minBackoff, System.TimeSpan maxBackoff, double randomFactor, Akka.Actor.IScheduler scheduler) { }
     }
     public class UserCalledFailException : Akka.Actor.AkkaException
     {

--- a/src/core/Akka.Tests/Pattern/RetrySpec.cs
+++ b/src/core/Akka.Tests/Pattern/RetrySpec.cs
@@ -188,5 +188,129 @@ namespace Akka.Tests.Pattern
                 Assert.Equal(5, remaining);
             });
         }
+
+        [Fact]
+        public async Task Pattern_Retry_with_backoff_must_run_a_successful_task_immediately()
+        {
+            await WithinAsync(TimeSpan.FromSeconds(3), async () =>
+            {
+                var remaining = await Retry(
+                    () => Task.FromResult(5), 5,
+                    TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1), 0.2, Sys.Scheduler);
+                Assert.Equal(5, remaining);
+            });
+        }
+
+        [Fact]
+        public async Task Pattern_Retry_with_backoff_must_return_a_success_for_a_task_that_succeeds_eventually()
+        {
+            var failCount = 0;
+
+            Task<int> Attempt()
+            {
+                if (failCount < 3)
+                {
+                    failCount += 1;
+                    return Task.FromException<int>(new InvalidOperationException(failCount.ToString()));
+                }
+                return Task.FromResult(5);
+            }
+
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
+            {
+                var remaining = await Retry(
+                    Attempt, 5,
+                    TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(500), 0.0, Sys.Scheduler);
+                Assert.Equal(5, remaining);
+            });
+        }
+
+        [Fact]
+        public async Task Pattern_Retry_with_backoff_must_return_a_failure_when_retries_exhausted()
+        {
+            var failCount = 0;
+
+            Task<int> Attempt()
+            {
+                failCount += 1;
+                return Task.FromException<int>(new InvalidOperationException(failCount.ToString()));
+            }
+
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
+            {
+                var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    await Retry(
+                        Attempt, 3,
+                        TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(200), 0.0, Sys.Scheduler));
+                Assert.Equal("4", exception.Message);
+            });
+        }
+
+        [Fact]
+        public async Task Pattern_Retry_with_backoff_must_accept_double_randomFactor()
+        {
+            var failCount = 0;
+
+            Task<int> Attempt()
+            {
+                if (failCount < 2)
+                {
+                    failCount += 1;
+                    return Task.FromException<int>(new InvalidOperationException(failCount.ToString()));
+                }
+                return Task.FromResult(42);
+            }
+
+            await WithinAsync(TimeSpan.FromSeconds(10), async () =>
+            {
+                // This verifies the fix: randomFactor is now double, allowing fractional values like 0.2
+                var remaining = await Retry(
+                    Attempt, 5,
+                    TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(500), 0.2, Sys.Scheduler);
+                Assert.Equal(42, remaining);
+            });
+        }
+
+        [Fact]
+        public void Pattern_Retry_with_backoff_must_throw_on_null_attempt()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                _ = Retry<int>(null, 5,
+                    TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1), 0.2, Sys.Scheduler);
+            });
+        }
+
+        [Fact]
+        public void Pattern_Retry_with_backoff_must_throw_on_invalid_minBackoff()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                _ = Retry(() => Task.FromResult(1), 5,
+                    TimeSpan.Zero, TimeSpan.FromSeconds(1), 0.2, Sys.Scheduler);
+            });
+        }
+
+        [Fact]
+        public void Pattern_Retry_with_backoff_must_throw_when_maxBackoff_less_than_minBackoff()
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                _ = Retry(() => Task.FromResult(1), 5,
+                    TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(1), 0.2, Sys.Scheduler);
+            });
+        }
+
+        [Theory]
+        [InlineData(-0.1)]
+        [InlineData(1.1)]
+        public void Pattern_Retry_with_backoff_must_throw_on_invalid_randomFactor(double randomFactor)
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                _ = Retry(() => Task.FromResult(1), 5,
+                    TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1), randomFactor, Sys.Scheduler);
+            });
+        }
     }
 }

--- a/src/core/Akka/Pattern/RetrySupport.cs
+++ b/src/core/Akka/Pattern/RetrySupport.cs
@@ -45,12 +45,12 @@ namespace Akka.Pattern
         /// <param name="maxBackoff">the exponential back-off is capped to this duration.</param>
         /// <param name="randomFactor">after calculation of the exponential back-off an additional random delay based on this factor is added, e.g. `0.2` adds up to `20%` delay. In order to skip this additional delay pass in `0`.</param>
         /// <param name="scheduler">The scheduler instance to use.</param>
-        public static Task<T> Retry<T>(Func<Task<T>> attempt, int attempts, TimeSpan minBackoff, TimeSpan maxBackoff, int randomFactor, IScheduler scheduler)
+        public static Task<T> Retry<T>(Func<Task<T>> attempt, int attempts, TimeSpan minBackoff, TimeSpan maxBackoff, double randomFactor, IScheduler scheduler)
         {
-            if (attempt == null) throw new ArgumentNullException("Parameter attempt should not be null.");
-            if (minBackoff <= TimeSpan.Zero) throw new ArgumentException("Parameter minBackoff must be > 0");
-            if (maxBackoff < minBackoff) throw new ArgumentException("Parameter maxBackoff must be >= minBackoff");
-            if (randomFactor < 0.0 || randomFactor > 1.0) throw new ArgumentException("RandomFactor must be between 0.0 and 1.0");
+            if (attempt == null) throw new ArgumentNullException(nameof(attempt), "Parameter attempt should not be null.");
+            if (minBackoff <= TimeSpan.Zero) throw new ArgumentException("Parameter minBackoff must be > 0", nameof(minBackoff));
+            if (maxBackoff < minBackoff) throw new ArgumentException("Parameter maxBackoff must be >= minBackoff", nameof(maxBackoff));
+            if (randomFactor is < 0.0 or > 1.0) throw new ArgumentException("RandomFactor must be between 0.0 and 1.0", nameof(randomFactor));
 
             return Retry(attempt, attempts, attempted => BackoffSupervisor.CalculateDelay(attempted, minBackoff, maxBackoff, randomFactor), scheduler);
         }


### PR DESCRIPTION
Fixes #8059

## Changes

* Change randomFactor type from `int` to `double`
* Modernize the thrown exception messages
