### PR TITLE
[xUnit 3] Convert Akka.Remote.Tests

### DIFF
--- a/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
+++ b/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
@@ -23,7 +23,6 @@ using Akka.TestKit.TestEvent;
 using Xunit;
 using FluentAssertions;
 using FluentAssertions.Extensions;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {
@@ -96,6 +95,7 @@ namespace Akka.Remote.Tests
         [Fact(Skip = "EventFilter can receive 1-2 notifications about nodes shutting down depending on timing, which makes this spec racy")]
         public async Task Remoting_must_not_leak_actors()
         {
+            var token = TestContext.Current.CancellationToken;
             var actorRef = Sys.ActorOf(EchoActor.Props(this, true), "echo");
             var echoPath = new RootActorPath(RARP.For(Sys).Provider.DefaultAddress)/"user"/"echo";
 
@@ -103,7 +103,7 @@ namespace Akka.Remote.Tests
                 async x =>
                 {
                     Sys.ActorSelection(x).Tell(new Identify(0));
-                    return (await ExpectMsgAsync<ActorIdentity>()).Subject;
+                    return (await ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject;
                 }));
 
             var initialActors = targets.SelectMany(CollectLiveActors).ToImmutableHashSet();
@@ -119,14 +119,14 @@ namespace Akka.Remote.Tests
                 {
                     var probe = CreateTestProbe(remoteSystem);
                     remoteSystem.ActorSelection(echoPath).Tell(new Identify(1), probe.Ref);
-                    (await probe.ExpectMsgAsync<ActorIdentity>()).Subject.ShouldNotBe(null);
+                    (await probe.ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject.ShouldNotBe(null);
                 }
                 finally
                 {
                     Shutdown(remoteSystem);
                 }
 
-                Assert.True(await remoteSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(10)));
+                await remoteSystem.WhenTerminated.WaitAsync(TimeSpan.FromSeconds(10), token);
             }
 
             // Quarantine an old incarnation case
@@ -145,7 +145,7 @@ namespace Akka.Remote.Tests
                     // the message from remote to local will cause inbound connection established
                     var probe = CreateTestProbe(remoteSystem);
                     remoteSystem.ActorSelection(echoPath).Tell(new Identify(1), probe.Ref);
-                    (await probe.ExpectMsgAsync<ActorIdentity>()).Subject.ShouldNotBe(null);
+                    (await probe.ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject.ShouldNotBe(null);
 
                     var beforeQuarantineActors = targets.SelectMany(CollectLiveActors).ToImmutableHashSet();
 
@@ -155,19 +155,19 @@ namespace Akka.Remote.Tests
 
                     // the message from local to remote should reuse passive inbound connection
                     Sys.ActorSelection(new RootActorPath(remoteAddress) / "user" / "stoppable").Tell(new Identify(1));
-                    (await ExpectMsgAsync<ActorIdentity>()).Subject.ShouldNotBe(null);
+                    (await ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject.ShouldNotBe(null);
 
                     await AwaitAssertAsync(() =>
                     {
                         var afterQuarantineActors = targets.SelectMany(CollectLiveActors).ToImmutableHashSet();
                         AssertActors(beforeQuarantineActors, afterQuarantineActors);
-                    }, TimeSpan.FromSeconds(10));
+                    }, TimeSpan.FromSeconds(10), cancellationToken: token);
                 }
                 finally
                 {
                     Shutdown(remoteSystem);
                 }
-                Assert.True(await remoteSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(10)));
+                await remoteSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(10), token);
             }
             
             // Bugfix: need to filter out the AssociationTermination messages for remote@127.0.0.1:2553 from the quarantine
@@ -189,8 +189,9 @@ namespace Akka.Remote.Tests
                     (await probe.ExpectMsgAsync<ActorIdentity>()).Subject.ShouldNotBe(null);
 
                     // This will make sure that no SHUTDOWN message gets through
-                    Assert.True(await RARP.For(Sys).Provider.Transport.ManagementCommand(new ForceDisassociate(remoteAddress))
-                            .AwaitWithTimeout(TimeSpan.FromSeconds(3)));
+                    await RARP.For(Sys).Provider.Transport
+                        .ManagementCommand(new ForceDisassociate(remoteAddress), token)
+                        .WaitAsync(TimeSpan.FromSeconds(3), token);
                 }
                 finally
                 {
@@ -227,8 +228,9 @@ namespace Akka.Remote.Tests
                 // All system messages have been acked now on this side
 
                 // This will make sure that no SHUTDOWN message gets through
-                Assert.True(await RARP.For(Sys).Provider.Transport.ManagementCommand(new ForceDisassociate(idleRemoteAddress))
-                        .AwaitWithTimeout(TimeSpan.FromSeconds(3)));
+                await RARP.For(Sys).Provider.Transport
+                    .ManagementCommand(new ForceDisassociate(idleRemoteAddress), token)
+                    .WaitAsync(TimeSpan.FromSeconds(3), token);
             }
             finally
             {

--- a/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
+++ b/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
@@ -186,7 +186,7 @@ namespace Akka.Remote.Tests
                 {
                     var probe = CreateTestProbe(remoteSystem);
                     remoteSystem.ActorSelection(echoPath).Tell(new Identify(1), probe.Ref);
-                    (await probe.ExpectMsgAsync<ActorIdentity>()).Subject.ShouldNotBe(null);
+                    (await probe.ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject.ShouldNotBe(null);
 
                     // This will make sure that no SHUTDOWN message gets through
                     await RARP.For(Sys).Provider.Transport
@@ -200,8 +200,8 @@ namespace Akka.Remote.Tests
 
                 await EventFilter.Warning(contains: "Association with remote system").ExpectOneAsync(async () =>
                 {
-                    Assert.True(await remoteSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(10)));
-                });
+                    Assert.True(await remoteSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(10), token));
+                }, cancellationToken: token);
             }
 
             // Remote idle for too long case
@@ -217,14 +217,14 @@ namespace Akka.Remote.Tests
                 var probe = CreateTestProbe(idleRemoteSystem);
 
                 idleRemoteSystem.ActorSelection(echoPath).Tell(new Identify(1), probe.Ref);
-                (await probe.ExpectMsgAsync<ActorIdentity>()).Subject.ShouldNotBe(null);
+                (await probe.ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject.ShouldNotBe(null);
 
                 // Watch a remote actor - this results in system message traffic
                 Sys.ActorSelection(new RootActorPath(idleRemoteAddress) / "user" / "stoppable").Tell(new Identify(1));
-                var remoteActor = (await ExpectMsgAsync<ActorIdentity>()).Subject;
+                var remoteActor = (await ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject;
                 await WatchAsync(remoteActor);
                 remoteActor.Tell("stop");
-                await ExpectTerminatedAsync(remoteActor);
+                await ExpectTerminatedAsync(remoteActor, cancellationToken: token);
                 // All system messages have been acked now on this side
 
                 // This will make sure that no SHUTDOWN message gets through
@@ -239,19 +239,19 @@ namespace Akka.Remote.Tests
 
             await EventFilter.Warning(contains: "Association with remote system").ExpectOneAsync(async () =>
             {
-                Assert.True(await idleRemoteSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(10)));
-            });
+                Assert.True(await idleRemoteSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(10), token));
+            }, cancellationToken: token);
 
             /*
              * Wait for the ReliableDeliverySupervisor to receive its "TooLongIdle" message,
              * which will throw a HopelessAssociation wrapped around a TimeoutException.
              */
-            await EventFilter.Exception<TimeoutException>().ExpectOneAsync(() => { return Task.CompletedTask; });
+            await EventFilter.Exception<TimeoutException>().ExpectOneAsync(() => { return Task.CompletedTask; }, cancellationToken: token);
 
             await AwaitAssertAsync(() =>
             {
                 AssertActors(initialActors, targets.SelectMany(CollectLiveActors).ToImmutableHashSet());
-            }, 10.Seconds());
+            }, 10.Seconds(), cancellationToken: token);
         }
     }
 }

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -47,9 +47,6 @@
     <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
     <PackageReference Include="FsCheck" Version="$(FsCheck3Version)" />
     <PackageReference Include="FsCheck.Xunit.v3" Version="$(FsCheck3Version)" />
   </ItemGroup>

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -3,6 +3,8 @@
 
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <!-- disable .NET Framework on Linux-->
@@ -13,7 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\contrib\serializers\Akka.Serialization.Hyperion\Akka.Serialization.Hyperion.csproj" />
     <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj" />
-    <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
 
     <None Include="Resources\akka-validcert.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -42,14 +44,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <PackageReference Include="FsCheck" Version="$(FsCheckVersion)" />
-    <PackageReference Include="FsCheck.Xunit" Version="$(FsCheckVersion)" />
+    <PackageReference Include="FsCheck" Version="$(FsCheck3Version)" />
+    <PackageReference Include="FsCheck.Xunit.v3" Version="$(FsCheck3Version)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">

--- a/src/core/Akka.Remote.Tests/BugFixes/BugFix4384Spec.cs
+++ b/src/core/Akka.Remote.Tests/BugFixes/BugFix4384Spec.cs
@@ -15,11 +15,10 @@ using Akka.Configuration;
 using Akka.Routing;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.BugFixes
 {
-    public class BugFix4384Spec : TestKit.Xunit2.TestKit
+    public class BugFix4384Spec : TestKit.Xunit.TestKit
     {
         public ActorSystem Sys1 { get; }
         public Address Sys1Address { get; }
@@ -57,6 +56,7 @@ namespace Akka.Remote.Tests.BugFixes
         [Fact]
         public async Task Ask_from_local_actor_without_remote_association_should_work()
         {
+            var token = TestContext.Current.CancellationToken;
             // create actor in Sys1
             const string actorName = "actor1";
             Sys1.ActorOf(dsl => dsl.ReceiveAny((m, _) => TestActor.Tell(m)), actorName);
@@ -66,13 +66,14 @@ namespace Akka.Remote.Tests.BugFixes
             
             // make sure that actor1 is able to resolve temporary actor's path
             // see https://github.com/akkadotnet/akka.net/issues/4384 - tmp actor should belong to Sys2 here
-            var msg = await sel.Ask<ActorIdentity>(new Identify("foo"), TimeSpan.FromSeconds(30));
+            var msg = await sel.Ask<ActorIdentity>(new Identify("foo"), TimeSpan.FromSeconds(30), token);
             msg.MessageId.Should().Be("foo");
         }
         
         [Fact(Skip = "The spec above contains the reproduction of the real issue")]
         public async Task ConsistentHashingPoolRoutersShouldWorkAsExpectedWithHashMapping()
         {
+            var token = TestContext.Current.CancellationToken;
             var poolRouter =
                 Sys1.ActorOf(Props.Create(() => new ReporterActor(TestActor)).WithRouter(new ConsistentHashingPool(5,
                         msg =>
@@ -84,23 +85,23 @@ namespace Akka.Remote.Tests.BugFixes
                     "router1");
 
             // use some auto-received messages to ensure that those still work
-            var numRoutees = (await poolRouter.Ask<Routees>(new GetRoutees(), TimeSpan.FromSeconds(2))).Members.Count();
+            var numRoutees = (await poolRouter.Ask<Routees>(new GetRoutees(), TimeSpan.FromSeconds(2), cancellationToken: token)).Members.Count();
             
             // establish association between ActorSystems
             var sys2Probe = CreateTestProbe(Sys2);
             var secondActor = Sys1.ActorOf(act => act.ReceiveAny((o, ctx) => ctx.Sender.Tell(o)), "foo");
 
             Sys2.ActorSelection(new RootActorPath(Sys1Address) / "user" / secondActor.Path.Name).Tell("foo", sys2Probe);
-            await sys2Probe.ExpectMsgAsync("foo");
+            await sys2Probe.ExpectMsgAsync("foo", cancellationToken: token);
 
             // have ActorSystem2 message it via tell
             var sel = Sys2.ActorSelection(new RootActorPath(Sys1Address) / "user" / "router1");
             sel.Tell(new HashableString("foo"));
-            await ExpectMsgAsync<HashableString>(str => str.Str.Equals("foo"));
+            await ExpectMsgAsync<HashableString>(str => str.Str.Equals("foo"), cancellationToken: token);
 
             // have ActorSystem2 message it via Ask. Task is intentionally not awaited.
-            var task = sel.Ask(new Identify("bar2"), TimeSpan.FromSeconds(3)).PipeTo(sys2Probe);
-            var remoteRouter = (await sys2Probe.ExpectMsgAsync<ActorIdentity>(x => x.MessageId.Equals("bar2"), TimeSpan.FromSeconds(5))).Subject;
+            var task = sel.Ask(new Identify("bar2"), TimeSpan.FromSeconds(3), cancellationToken: token).PipeTo(sys2Probe);
+            var remoteRouter = (await sys2Probe.ExpectMsgAsync<ActorIdentity>(x => x.MessageId.Equals("bar2"), TimeSpan.FromSeconds(5), cancellationToken: token)).Subject;
 
             var s2Actor = Sys2.ActorOf(act =>
             {
@@ -111,7 +112,7 @@ namespace Akka.Remote.Tests.BugFixes
                 });
             });
             s2Actor.Tell("hit");
-            await sys2Probe.ExpectMsgAsync<ActorIdentity>(x => x.MessageId.Equals("hit"), TimeSpan.FromSeconds(5));
+            await sys2Probe.ExpectMsgAsync<ActorIdentity>(x => x.MessageId.Equals("hit"), TimeSpan.FromSeconds(5), cancellationToken: token);
         }
 
         class ReporterActor : ReceiveActor

--- a/src/core/Akka.Remote.Tests/ExceptionSupportSpec.cs
+++ b/src/core/Akka.Remote.Tests/ExceptionSupportSpec.cs
@@ -6,10 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Dispatch;
@@ -17,10 +13,8 @@ using Akka.IO.Buffers;
 using Akka.Pattern;
 using Akka.Remote.Serialization;
 using Akka.Remote.Transport;
-using Akka.Serialization;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Remote.Tests

--- a/src/core/Akka.Remote.Tests/RemoteActorTelemetrySpecs.cs
+++ b/src/core/Akka.Remote.Tests/RemoteActorTelemetrySpecs.cs
@@ -5,14 +5,12 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Akka.TestKit.TestActors;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {
@@ -105,6 +103,7 @@ namespace Akka.Remote.Tests
         [Fact]
         public async Task RemoteActorRefs_should_not_produce_telemetry()
         {
+            var token = TestContext.Current.CancellationToken;
             // create a second ActorSystem that connects to Sys
             var system2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
             try
@@ -114,7 +113,7 @@ namespace Akka.Remote.Tests
 
                 // send a request for the current telemetry counters
                 var telemetry = await subscriber
-                    .Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance);
+                    .Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, token);
 
                 // verify that the counters are all correct
                 Assert.Equal(0, telemetry.ActorCreated);
@@ -131,11 +130,11 @@ namespace Akka.Remote.Tests
                 var actor1Path = new RootActorPath(address) / "user" / "actor1";
 
                 // have system2 send a request to actor1 via Akka.Remote
-                var actor2 = await system2.ActorSelection(actor1Path).ResolveOne(RemainingOrDefault);
+                var actor2 = await system2.ActorSelection(actor1Path).ResolveOne(RemainingOrDefault, token);
 
                 // send a request for the current telemetry counters
                 telemetry = await subscriber
-                    .Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance);
+                    .Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, token);
 
                 // verify that no actors have been created yet (subscriber filters out its own events)
                 var previouslyCreated = telemetry.ActorCreated;
@@ -148,7 +147,7 @@ namespace Akka.Remote.Tests
 
                 // send a request for the current telemetry counters
                 telemetry = await subscriber
-                    .Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance);
+                    .Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, token);
 
                 // verify that the counters are all zero (we filter out system actors)
                 Assert.Equal(previouslyCreated, telemetry.ActorCreated); // should not have changed

--- a/src/core/Akka.Remote.Tests/RemoteDaemonSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteDaemonSpec.cs
@@ -62,6 +62,7 @@ akka {
         [Fact]
         public async Task Can_create_actor_using_remote_daemon_and_interact_with_child()
         {
+            var token = TestContext.Current.CancellationToken;
             var p = CreateTestProbe();
             Sys.EventStream.Subscribe(p.Ref, typeof(string));
             var supervisor = Sys.ActorOf<SomeActor>();
@@ -76,14 +77,14 @@ akka {
             daemon.Tell(new DaemonMsgCreate(Props.Create(() => new MyRemoteActor(childCreatedEvent)), null, path, supervisor));
 
             //Wait for the child to be created (actors are instantiated async)
-            childCreatedEvent.Wait();
+            childCreatedEvent.Wait(token);
 
             //try to resolve the child actor "child"
             var child = provider.ResolveActorRef(provider.RootPath / "remote/user/foo/child".Split('/'));
             //pass a message to the child
             child.Tell("hello");
             //expect the child to forward the message to the eventstream
-            await p.ExpectMsgAsync("hello");
+            await p.ExpectMsgAsync("hello", cancellationToken: token);
         }
     }
 }

--- a/src/core/Akka.Remote.Tests/RemoteDeathWatchSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteDeathWatchSpec.cs
@@ -60,6 +60,7 @@ namespace Akka.Remote.Tests
         [Fact]
         public async Task Must_receive_Terminated_when_system_of_deserialized_ActorRef_is_not_running()
         {
+            var token = TestContext.Current.CancellationToken;
             var probe = CreateTestProbe();
             Sys.EventStream.Subscribe(probe.Ref, typeof(QuarantinedEvent));
             var rarp = RARP.For(Sys).Provider;
@@ -82,18 +83,19 @@ namespace Akka.Remote.Tests
             };
             Sys.ActorOf(Props.Create(() => new Act(act)).WithDeploy(Deploy.Local));
 
-            await ExpectMsgAsync(@ref, TimeSpan.FromSeconds(20));
+            await ExpectMsgAsync(@ref, TimeSpan.FromSeconds(20), cancellationToken: token);
             // we don't expect real quarantine when the UID is unknown, i.e. QuarantinedEvent is not published 
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3), token);
             // The following verifies that re-delivery of Watch message is stopped.
             // It was observed as periodic logging of "address is now gated" when the gate was lifted.
             Sys.EventStream.Subscribe(probe.Ref, typeof(Warning));
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(rarp.RemoteSettings.RetryGateClosedFor.TotalSeconds*2));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(rarp.RemoteSettings.RetryGateClosedFor.TotalSeconds*2), token);
         }
 
         [Fact]
         public async Task Must_receive_terminated_when_watched_node_is_unknown_host()
         {
+            var token = TestContext.Current.CancellationToken;
             var path = new RootActorPath(new Address("akka.tcp", Sys.Name, "unknownhost", 2552)) / "user" / "subject";
             var rarp = RARP.For(Sys).Provider;
             Action<IActorDsl> act = dsl =>
@@ -110,15 +112,16 @@ namespace Akka.Remote.Tests
 
             Sys.ActorOf(Props.Create(() => new Act(act)).WithDeploy(Deploy.Local), "observer2");
 
-            await ExpectMsgAsync(path, TimeSpan.FromSeconds(60));
+            await ExpectMsgAsync(path, TimeSpan.FromSeconds(60), cancellationToken: token);
         }
 
         [Fact]
         public async Task Must_receive_ActorIdentity_null_when_identified_node_is_unknown_host()
         {
+            var token = TestContext.Current.CancellationToken;
             var path = new RootActorPath(new Address("akka.tcp", Sys.Name, "unknownhost2", 2552)) / "user" / "subject";
             Sys.ActorSelection(path).Tell(new Identify(path));
-            var identify = await ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(60));
+            var identify = await ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(60), cancellationToken: token);
             identify.Subject.ShouldBe(null);
             identify.MessageId.ShouldBe(path);
         }
@@ -126,6 +129,7 @@ namespace Akka.Remote.Tests
         [Fact]
         public async Task Must_quarantine_systems_after_unsuccessful_system_message_delivery_if_have_not_communicated_before()
         {
+            var token = TestContext.Current.CancellationToken;
             // Synthesize an ActorRef to a remote system this one has never talked to before.
             // This forces ReliableDeliverySupervisor to start with unknown remote system UID.
             var rarp = RARP.For(Sys).Provider;
@@ -140,12 +144,13 @@ namespace Akka.Remote.Tests
 
             var probe = CreateTestProbe();
             probe.Watch(extinctRef);
-            (await probe.ExpectMsgAsync<Terminated>()).ActorRef.ShouldBe(extinctRef);
+            (await probe.ExpectMsgAsync<Terminated>(cancellationToken: token))
+                .ActorRef.ShouldBe(extinctRef);
             probe.Unwatch(extinctRef);
 
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(5));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(5), token);
             Sys.EventStream.Subscribe(probe.Ref, typeof(Warning));
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(rarp.RemoteSettings.RetryGateClosedFor.TotalSeconds * 2));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(rarp.RemoteSettings.RetryGateClosedFor.TotalSeconds * 2), token);
         }
     }
 }

--- a/src/core/Akka.Remote.Tests/RemoteMessageLocalDeliverySpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteMessageLocalDeliverySpec.cs
@@ -6,9 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -17,7 +14,6 @@ using Akka.TestKit;
 using Akka.TestKit.Extensions;
 using Akka.TestKit.TestActors;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {
@@ -74,6 +70,7 @@ namespace Akka.Remote.Tests
         [Fact]
         public async Task RemoteActorRefProvider_should_correctly_resolve_valid_LocalActorRef_from_second_remote_system()
         {
+            var token = TestContext.Current.CancellationToken;
             var sys2 = ActorSystem.Create("Sys2", RemoteConfiguration);
             try
             {
@@ -84,30 +81,30 @@ namespace Akka.Remote.Tests
                     var actorPath = new RootActorPath(sys2Address) / "user" / "myActor";
 
                     // get a remoteactorref for the second system
-                    var remoteActorRef = await Sys.ActorSelection(actorPath).ResolveOne(TimeSpan.FromSeconds(3));
+                    var remoteActorRef = await Sys.ActorSelection(actorPath).ResolveOne(TimeSpan.FromSeconds(3), token);
 
                     // disconnect us from the second actorsystem
                     Assert.True(await RARP.For(Sys)
                         .Provider.Transport.ManagementCommand(new SetThrottle(sys2Address,
-                            ThrottleTransportAdapter.Direction.Both, Blackhole.Instance))
-                        .WithTimeout(TimeSpan.FromSeconds(3)));
+                            ThrottleTransportAdapter.Direction.Both, Blackhole.Instance), token)
+                        .WaitAsync(TimeSpan.FromSeconds(3), token));
 
                     // start deathwatch (won't be delivered initially)
                     Watch(remoteActorRef);
-                    await Task.Delay(TimeSpan.FromSeconds(3)); // if we delay the initial send, this spec will fail
+                    await Task.Delay(TimeSpan.FromSeconds(3), token); // if we delay the initial send, this spec will fail
 
                     Assert.True(await RARP.For(Sys)
                         .Provider.Transport.ManagementCommand(new SetThrottle(sys2Address,
-                            ThrottleTransportAdapter.Direction.Both, Unthrottled.Instance))
-                        .WithTimeout(TimeSpan.FromSeconds(3)));
+                            ThrottleTransportAdapter.Direction.Both, Unthrottled.Instance), token)
+                        .WaitAsync(TimeSpan.FromSeconds(3), token));
 
                     // fire off another non-system message
                     var ai = 
                         await Sys.ActorSelection(actorPath).Ask<ActorIdentity>(new Identify(null), TimeSpan.FromSeconds(3));
 
                     remoteActorRef.Tell(PoisonPill.Instance); // WATCH should be applied first
-                    await ExpectTerminatedAsync(remoteActorRef);
-                });
+                    await ExpectTerminatedAsync(remoteActorRef, cancellationToken: token);
+                }, cancellationToken: token);
             }
             finally
             {

--- a/src/core/Akka.Remote.Tests/RemoteMetricsSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteMetricsSpec.cs
@@ -5,8 +5,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -14,7 +12,6 @@ using Akka.Event;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {
@@ -62,7 +59,7 @@ namespace Akka.Remote.Tests
         {
             var sel = _client.ActorSelection(new RootActorPath(_address)/_subject.Path.Elements);
             sel.Tell(new byte[200]);
-            await ExpectMsgAsync<PayloadSize>();
+            await ExpectMsgAsync<PayloadSize>(cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -70,9 +67,9 @@ namespace Akka.Remote.Tests
         {
             var sel = _client.ActorSelection(new RootActorPath(_address)/_subject.Path.Elements);
             sel.Tell(new byte[200]);
-            await ExpectMsgAsync<PayloadSize>();
+            await ExpectMsgAsync<PayloadSize>(cancellationToken: TestContext.Current.CancellationToken);
             sel.Tell(new byte[300]);
-            await ExpectMsgAsync<NewMaximum>();
+            await ExpectMsgAsync<NewMaximum>(cancellationToken: TestContext.Current.CancellationToken);
         }
 
 
@@ -81,7 +78,7 @@ namespace Akka.Remote.Tests
         {
             var sel = _client.ActorSelection(new RootActorPath(_address)/_subject.Path.Elements);
             sel.Tell(new byte[1]);
-            await ExpectNoMsgAsync();
+            await ExpectNoMsgAsync(cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -89,9 +86,9 @@ namespace Akka.Remote.Tests
         {
             var sel = _client.ActorSelection(new RootActorPath(_address)/_subject.Path.Elements);
             sel.Tell(new byte[200]);
-            await ExpectMsgAsync<PayloadSize>();
+            await ExpectMsgAsync<PayloadSize>(cancellationToken: TestContext.Current.CancellationToken);
             sel.Tell(new byte[200]);
-            await ExpectNoMsgAsync();
+            await ExpectNoMsgAsync(cancellationToken: TestContext.Current.CancellationToken);
         }
 
         private class Subject : ActorBase

--- a/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
@@ -18,7 +18,6 @@ using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {
@@ -150,7 +149,7 @@ namespace Akka.Remote.Tests
         {
             var probe = CreateTestProbe(_masterSystem);
             var router = _masterSystem.ActorOf(new RoundRobinPool(2).Props(EchoActorProps), "blub");
-            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync();
+            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync(TestContext.Current.CancellationToken);
             var children = new HashSet<ActorPath>(replies);
             children.Should().HaveCount(2);
             children.Select(x => x.Parent).Distinct().Should().HaveCount(1);
@@ -166,7 +165,7 @@ namespace Akka.Remote.Tests
                 new RoundRobinPool(2),
                 new[] { new Address("akka.tcp", _sysName, "127.0.0.1", _port) })
                 .Props(EchoActorProps), "blub2");
-            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync();
+            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync(TestContext.Current.CancellationToken);
             var children = new HashSet<ActorPath>(replies);
             children.Should().HaveCount(2);
             children.Select(x => x.Parent).Distinct().Should().HaveCount(1);
@@ -179,7 +178,7 @@ namespace Akka.Remote.Tests
         {
             var probe = CreateTestProbe(_masterSystem);
             var router = _masterSystem.ActorOf(FromConfig.Instance.Props(EchoActorProps), "elastic-blub");
-            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync();
+            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync(TestContext.Current.CancellationToken);
             var children = new HashSet<ActorPath>(replies);
             children.Should().HaveCount(2);
             children.Select(x => x.Parent).Distinct().Should().HaveCount(1);
@@ -194,7 +193,7 @@ namespace Akka.Remote.Tests
             var router = _masterSystem.ActorOf(FromConfig.Instance.Props(EchoActorProps), "remote-blub");
             router.Path.Address.Should().Be(_intendedRemoteAddress);
 
-            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync();
+            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync(TestContext.Current.CancellationToken);
             var children = new HashSet<ActorPath>(replies);
             children.Should().HaveCount(2);
 
@@ -216,7 +215,7 @@ namespace Akka.Remote.Tests
 
             router.Path.Address.Should().Be(_intendedRemoteAddress);
 
-            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync();
+            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync(TestContext.Current.CancellationToken);
             var children = new HashSet<ActorPath>(replies);
             children.Should().HaveCount(2);
 
@@ -238,7 +237,7 @@ namespace Akka.Remote.Tests
                 .WithDeploy(new Deploy(new RemoteScope(_intendedRemoteAddress))), "local-blub");
             router.Path.Address.ToString().Should().Be($"akka://{_masterSystem.Name}");
 
-            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync();
+            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync(TestContext.Current.CancellationToken);
             var children = new HashSet<ActorPath>(replies);
             children.Should().HaveCount(2);
 
@@ -261,7 +260,7 @@ namespace Akka.Remote.Tests
 
             router.Path.Address.Should().Be(_intendedRemoteAddress);
 
-            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync();
+            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync(TestContext.Current.CancellationToken);
             var children = new HashSet<ActorPath>(replies);
             children.Should().HaveCount(4);
 
@@ -284,7 +283,7 @@ namespace Akka.Remote.Tests
 
             router.Path.Address.Should().Be(_intendedRemoteAddress);
 
-            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync();
+            var replies = await CollectRouteePaths(probe, router, 5).ToListAsync(TestContext.Current.CancellationToken);
             var children = new HashSet<ActorPath>(replies);
             children.Should().HaveCount(4);
 
@@ -299,6 +298,7 @@ namespace Akka.Remote.Tests
         [Fact]
         public async Task RemoteRouter_must_set_supplied_SupervisorStrategy()
         {
+            var token = TestContext.Current.CancellationToken;
             var probe = CreateTestProbe(_masterSystem);
             var escalator = new OneForOneStrategy(ex =>
             {
@@ -314,9 +314,10 @@ namespace Akka.Remote.Tests
 
             // Need to be able to bind EventFilter to additional actor system (masterActorSystem in this case) before this code works
             // EventFilter.Exception<ActorKilledException>().ExpectOne(() => 
-            (await probe.ExpectMsgAsync<Routees>(TimeSpan.FromSeconds(10))).Members.Head().Send(Kill.Instance, TestActor);
+            (await probe.ExpectMsgAsync<Routees>(TimeSpan.FromSeconds(10), cancellationToken: token))
+                .Members.Head().Send(Kill.Instance, TestActor);
             //);
-            await probe.ExpectMsgAsync<ActorKilledException>(TimeSpan.FromSeconds(10));
+            await probe.ExpectMsgAsync<ActorKilledException>(TimeSpan.FromSeconds(10), cancellationToken: token);
         }
 
         [Fact(Skip = "Remote actor's DCN is currently not supported")]
@@ -324,7 +325,7 @@ namespace Akka.Remote.Tests
         {
             var probe = CreateTestProbe(_masterSystem);
             var router = _masterSystem.ActorOf(FromConfig.Instance.Props(EchoActorProps), "round");
-            var replies = await CollectRouteePaths(probe, router, 10).ToListAsync();
+            var replies = await CollectRouteePaths(probe, router, 10).ToListAsync(TestContext.Current.CancellationToken);
             var children = new HashSet<ActorPath>(replies);
             children.Should().HaveCount(5);
             _masterSystem.Stop(router);
@@ -333,13 +334,14 @@ namespace Akka.Remote.Tests
         [Fact(Skip = "Remote actor's DCN is currently not supported")]
         public async Task RemoteRouter_must_load_settings_from_config_for_local_child_router_of_system_actor()
         {
+            var token = TestContext.Current.CancellationToken;
             // we don't really support deployment configuration of system actors, but
             // it's used for the pool of the SimpleDnsManager "/IO-DNS/inet-address"
             var probe = CreateTestProbe(_masterSystem);
             var parent = ((ExtendedActorSystem)_masterSystem).SystemActorOf(FromConfig.Instance.Props(Props.Create<Parent>()), "sys-parent");
             parent.Tell((FromConfig.Instance.Props(EchoActorProps), "round"), probe);
-            var router = probe.ExpectMsg<IActorRef>();
-            var replies = await CollectRouteePaths(probe, router, 10).ToListAsync();
+            var router = await probe.ExpectMsgAsync<IActorRef>(cancellationToken: token);
+            var replies = await CollectRouteePaths(probe, router, 10).ToListAsync(token);
             var children = new HashSet<ActorPath>(replies);
             children.Should().HaveCount(6);
             _masterSystem.Stop(router);

--- a/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
@@ -6,14 +6,13 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
-using Akka.TestKit.Extensions;
 using Akka.Util.Internal;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {
@@ -188,98 +187,100 @@ namespace Akka.Remote.Tests
             get { return AddressUidExtension.Uid(_remoteSystem); }
         }
 
-        private async Task<IInternalActorRef> CreateRemoteActor(Props props, string name)
+        private async Task<IInternalActorRef> CreateRemoteActor(Props props, string name, CancellationToken cancellationToken)
         {
             _remoteSystem.ActorOf(props, name);
             Sys.ActorSelection(new RootActorPath(_remoteAddress) / "user" / name).Tell(new Identify(name), TestActor);
-            return (await ExpectMsgAsync<ActorIdentity>()).Subject.AsInstanceOf<IInternalActorRef>();
+            return (await ExpectMsgAsync<ActorIdentity>(cancellationToken: cancellationToken)).Subject.AsInstanceOf<IInternalActorRef>();
         }
 
         [Fact]
         public async Task A_RemoteWatcher_must_have_correct_interaction_when_watching()
         {
+            var token = TestContext.Current.CancellationToken;
             var fd = CreateFailureDetectorRegistry();
             var monitorA = Sys.ActorOf(Props.Create<TestRemoteWatcher>(), "monitor1");
             //TODO: Better way to write this?
-            var monitorB = await CreateRemoteActor(new Props(new Deploy(), typeof(TestActorProxy), TestActor), "monitor1");
+            var monitorB = await CreateRemoteActor(new Props(new Deploy(), typeof(TestActorProxy), TestActor), "monitor1", token);
 
             var a1 = Sys.ActorOf(Props.Create<MyActor>(), "a1").AsInstanceOf<IInternalActorRef>();
             var a2 = Sys.ActorOf(Props.Create<MyActor>(), "a2").AsInstanceOf<IInternalActorRef>();
-            var b1 = await CreateRemoteActor(Props.Create<MyActor>(), "b1");
-            var b2 = await CreateRemoteActor(Props.Create<MyActor>(), "b2");
+            var b1 = await CreateRemoteActor(Props.Create<MyActor>(), "b1", token);
+            var b2 = await CreateRemoteActor(Props.Create<MyActor>(), "b2", token);
 
             monitorA.Tell(new RemoteWatcher.WatchRemote(b1, a1));
             monitorA.Tell(new RemoteWatcher.WatchRemote(b2, a1));
             monitorA.Tell(new RemoteWatcher.WatchRemote(b2, a2));
             monitorA.Tell(RemoteWatcher.Stats.Empty, TestActor);
             // (a1->b1), (a1->b2), (a2->b2)
-            await ExpectMsgAsync(RemoteWatcher.Stats.Counts(3, 1));
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectMsgAsync(RemoteWatcher.Stats.Counts(3, 1), cancellationToken: token);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), token);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), token);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), token);
             monitorA.Tell(_heartbeatRspB, monitorB);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), token);
 
             monitorA.Tell(new RemoteWatcher.UnwatchRemote(b1, a1));
             // still (a1->b2) and (a2->b2) left
             monitorA.Tell(RemoteWatcher.Stats.Empty, TestActor);
-            await ExpectMsgAsync(RemoteWatcher.Stats.Counts(2, 1));
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectMsgAsync(RemoteWatcher.Stats.Counts(2, 1), cancellationToken: token);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), token);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), token);
 
             monitorA.Tell(new RemoteWatcher.UnwatchRemote(b2, a2));
             // still (a1->b2) left
             monitorA.Tell(RemoteWatcher.Stats.Empty, TestActor);
-            await ExpectMsgAsync(RemoteWatcher.Stats.Counts(1, 1));
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectMsgAsync(RemoteWatcher.Stats.Counts(1, 1), cancellationToken: token);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), token);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), token);
 
             monitorA.Tell(new RemoteWatcher.UnwatchRemote(b2, a1));
             // all unwatched
             monitorA.Tell(RemoteWatcher.Stats.Empty, TestActor);
-            await ExpectMsgAsync(RemoteWatcher.Stats.Empty);
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectMsgAsync(RemoteWatcher.Stats.Empty, cancellationToken: token);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), token);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), token);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), token);
 
             // make sure nothing floods over to next test
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(2));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(2), token);
         }
 
         [Fact]
         public async Task A_RemoteWatcher_must_generate_address_terminated_when_missing_heartbeats()
         {
+            var token = TestContext.Current.CancellationToken;
             var p = CreateTestProbe();
             var q = CreateTestProbe();
             Sys.EventStream.Subscribe(p.Ref, typeof (TestRemoteWatcher.AddressTerm));
             Sys.EventStream.Subscribe(q.Ref, typeof(TestRemoteWatcher.Quarantined));
 
             var monitorA = Sys.ActorOf(Props.Create<TestRemoteWatcher>(), "monitor4");
-            var monitorB = await CreateRemoteActor(new Props(new Deploy(), typeof(TestActorProxy), TestActor), "monitor4");
+            var monitorB = await CreateRemoteActor(new Props(new Deploy(), typeof(TestActorProxy), TestActor), "monitor4", token);
 
             var a = Sys.ActorOf(Props.Create<MyActor>(), "a4").AsInstanceOf<IInternalActorRef>();
-            var b = await CreateRemoteActor(Props.Create<MyActor>(), "b4");
+            var b = await CreateRemoteActor(Props.Create<MyActor>(), "b4", token);
 
             monitorA.Tell(new RemoteWatcher.WatchRemote(b, a));
 
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
             monitorA.Tell(_heartbeatRspB, monitorB);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
             monitorA.Tell(_heartbeatRspB, monitorB);
 
             await WithinAsync(10.Seconds(), async () =>
@@ -287,21 +288,22 @@ namespace Akka.Remote.Tests
                 await AwaitAssertAsync(async () =>
                 {
                     monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-                    await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+                    await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
                     //but no HeartbeatRsp
                     monitorA.Tell(RemoteWatcher.ReapUnreachableTick.Instance);
-                    await p.ExpectMsgAsync(new TestRemoteWatcher.AddressTerm(b.Path.Address), TimeSpan.FromSeconds(1));
-                    await q.ExpectMsgAsync(new TestRemoteWatcher.Quarantined(b.Path.Address, RemoteAddressUid), TimeSpan.FromSeconds(1));
-                });
+                    await p.ExpectMsgAsync(new TestRemoteWatcher.AddressTerm(b.Path.Address), TimeSpan.FromSeconds(1), cancellationToken: token);
+                    await q.ExpectMsgAsync(new TestRemoteWatcher.Quarantined(b.Path.Address, RemoteAddressUid), TimeSpan.FromSeconds(1), cancellationToken: token);
+                }, cancellationToken: token);
                 return true;
-            });
+            }, cancellationToken: token);
 
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(2));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(2), token);
         }
 
         [Fact]
         public async Task A_RemoteWatcher_must_generate_address_terminated_when_missing_first_heartbeat()
         {
+            var token = TestContext.Current.CancellationToken;
             var p = CreateTestProbe();
             var q = CreateTestProbe();
             Sys.EventStream.Subscribe(p.Ref, typeof (TestRemoteWatcher.AddressTerm));
@@ -310,15 +312,15 @@ namespace Akka.Remote.Tests
             var fd = CreateFailureDetectorRegistry();
             var heartbeatExpectedResponseAfter = TimeSpan.FromSeconds(2);
             var monitorA = Sys.ActorOf(new Props(new Deploy(), typeof(TestRemoteWatcher), heartbeatExpectedResponseAfter), "monitor5");
-            var monitorB = await CreateRemoteActor(new Props(new Deploy(), typeof(TestActorProxy), TestActor), "monitor5");
+            var monitorB = await CreateRemoteActor(new Props(new Deploy(), typeof(TestActorProxy), TestActor), "monitor5", token);
 
             var a = Sys.ActorOf(Props.Create<MyActor>(), "a5").AsInstanceOf<IInternalActorRef>();
-            var b = await CreateRemoteActor(Props.Create<MyActor>(), "b5");
+            var b = await CreateRemoteActor(Props.Create<MyActor>(), "b5", token);
 
             monitorA.Tell(new RemoteWatcher.WatchRemote(b, a));
 
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
             // no HeartbeatRsp sent
 
             await WithinAsync(20.Seconds(), async () =>
@@ -326,42 +328,43 @@ namespace Akka.Remote.Tests
                 await AwaitAssertAsync(async () =>
                 {
                     monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-                    await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+                    await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
                     //but no HeartbeatRsp
                     monitorA.Tell(RemoteWatcher.ReapUnreachableTick.Instance);
-                    await p.ExpectMsgAsync(new TestRemoteWatcher.AddressTerm(b.Path.Address), TimeSpan.FromSeconds(1));
+                    await p.ExpectMsgAsync(new TestRemoteWatcher.AddressTerm(b.Path.Address), TimeSpan.FromSeconds(1), cancellationToken: token);
                     // no real quarantine when missing first heartbeat, uid unknown
-                    await q.ExpectMsgAsync(new TestRemoteWatcher.Quarantined(b.Path.Address, null), TimeSpan.FromSeconds(1));
-                });
+                    await q.ExpectMsgAsync(new TestRemoteWatcher.Quarantined(b.Path.Address, null), TimeSpan.FromSeconds(1), cancellationToken: token);
+                }, cancellationToken: token);
                 return true;
-            });
+            }, cancellationToken: token);
 
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(2));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(2), token);
         }
 
         [Fact]
         public async Task
             A_RemoteWatcher_must_generate_address_terminated_for_new_watch_after_broken_connection_was_reestablished_and_broken_again()
         {
+            var token = TestContext.Current.CancellationToken;
             var p = CreateTestProbe();
             var q = CreateTestProbe();
             Sys.EventStream.Subscribe(p.Ref, typeof(TestRemoteWatcher.AddressTerm));
             Sys.EventStream.Subscribe(q.Ref, typeof(TestRemoteWatcher.Quarantined));
 
             var monitorA = Sys.ActorOf(Props.Create<TestRemoteWatcher>(), "monitor6");
-            var monitorB = await CreateRemoteActor(new Props(new Deploy(), typeof(TestActorProxy), new[] { TestActor }), "monitor6");
+            var monitorB = await CreateRemoteActor(new Props(new Deploy(), typeof(TestActorProxy), new[] { TestActor }), "monitor6", token);
 
             var a = Sys.ActorOf(Props.Create<MyActor>(), "a6").AsInstanceOf<IInternalActorRef>();
-            var b = await CreateRemoteActor(Props.Create<MyActor>(), "b6");
+            var b = await CreateRemoteActor(Props.Create<MyActor>(), "b6", token);
 
             monitorA.Tell(new RemoteWatcher.WatchRemote(b, a));
 
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
             monitorA.Tell(_heartbeatRspB, monitorB);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
             monitorA.Tell(_heartbeatRspB, monitorB);
 
             await WithinAsync(10.Seconds(), async () =>
@@ -369,48 +372,48 @@ namespace Akka.Remote.Tests
                 await AwaitAssertAsync(async () =>
                 {
                     monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-                    await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+                    await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
                     //but no HeartbeatRsp
                     monitorA.Tell(RemoteWatcher.ReapUnreachableTick.Instance);
-                    await p.ExpectMsgAsync(new TestRemoteWatcher.AddressTerm(b.Path.Address), TimeSpan.FromSeconds(1));
+                    await p.ExpectMsgAsync(new TestRemoteWatcher.AddressTerm(b.Path.Address), TimeSpan.FromSeconds(1), cancellationToken: token);
                     await q.ExpectMsgAsync(new TestRemoteWatcher.Quarantined(b.Path.Address, RemoteAddressUid),
-                        TimeSpan.FromSeconds(1));
-                });
+                        TimeSpan.FromSeconds(1), cancellationToken: token);
+                }, cancellationToken: token);
                 return true;
-            });
+            }, cancellationToken: token);
 
             //real AddressTerminated would trigger Terminated for b6, simulate that here
             _remoteSystem.Stop(b);
             await AwaitAssertAsync(async () =>
             {
                 monitorA.Tell(RemoteWatcher.Stats.Empty, TestActor);
-                await ExpectMsgAsync(RemoteWatcher.Stats.Empty);
-            });
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(2));
+                await ExpectMsgAsync(RemoteWatcher.Stats.Empty, cancellationToken: token);
+            }, cancellationToken: token);
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(2), token);
 
             //assume that connection comes up again, or remote system is restarted
-            var c = await CreateRemoteActor(Props.Create<MyActor>(), "c6");
+            var c = await CreateRemoteActor(Props.Create<MyActor>(), "c6", token);
             monitorA.Tell(new RemoteWatcher.WatchRemote(c,a));
 
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
             monitorA.Tell(_heartbeatRspB, monitorB);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
             monitorA.Tell(_heartbeatRspB, monitorB);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
             monitorA.Tell(RemoteWatcher.ReapUnreachableTick.Instance, TestActor);
-            await p.ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await p.ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
             monitorA.Tell(_heartbeatRspB, monitorB);
             monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-            await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+            await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
             monitorA.Tell(RemoteWatcher.ReapUnreachableTick.Instance, TestActor);
-            await p.ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
-            await q.ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await p.ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
+            await q.ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
 
             //then stop heartbeating again; should generate a new AddressTerminated
             await WithinAsync(10.Seconds(), async () =>
@@ -418,17 +421,17 @@ namespace Akka.Remote.Tests
                 await AwaitAssertAsync(async () =>
                 {
                     monitorA.Tell(RemoteWatcher.HeartbeatTick.Instance, TestActor);
-                    await ExpectMsgAsync<RemoteWatcher.Heartbeat>();
+                    await ExpectMsgAsync<RemoteWatcher.Heartbeat>(cancellationToken: token);
                     //but no HeartbeatRsp
                     monitorA.Tell(RemoteWatcher.ReapUnreachableTick.Instance);
-                    await p.ExpectMsgAsync(new TestRemoteWatcher.AddressTerm(b.Path.Address), TimeSpan.FromSeconds(1));
-                    await q.ExpectMsgAsync(new TestRemoteWatcher.Quarantined(b.Path.Address, RemoteAddressUid), TimeSpan.FromSeconds(1));
-                });
+                    await p.ExpectMsgAsync(new TestRemoteWatcher.AddressTerm(b.Path.Address), TimeSpan.FromSeconds(1), cancellationToken: token);
+                    await q.ExpectMsgAsync(new TestRemoteWatcher.Quarantined(b.Path.Address, RemoteAddressUid), TimeSpan.FromSeconds(1), cancellationToken: token);
+                }, cancellationToken: token);
                 return true;
-            });
+            }, cancellationToken: token);
 
             //make sure nothing floods over to next test
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(2));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(2), token);
         }
 
     }

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -588,6 +588,7 @@ namespace Akka.Remote.Tests
             var thisSystem = ActorSystem.Create("this-system", config);
             MuteSystem(thisSystem);
 
+            var token = TestContext.Current.CancellationToken;
             try
             {
                 // Set up a mock remote system using the test transport
@@ -599,7 +600,7 @@ namespace Akka.Remote.Tests
                     (new ActorAssociationEventListener(remoteTransportProbe)));
 
                 // Hijack associations through the test transport
-                await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(rawLocalAddress, rawRemoteAddress)));
+                await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(rawLocalAddress, rawRemoteAddress)), cancellationToken: token);
                 var testTransport = registry.TransportFor(rawLocalAddress).Value.Item1;
                 testTransport.WriteBehavior.PushConstant(true);
 
@@ -609,21 +610,21 @@ namespace Akka.Remote.Tests
                 dummySelection.Tell("ping", Sys.DeadLetters);
 
                 var remoteHandle =
-                    await remoteTransportProbe.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromMinutes(4));
+                    await remoteTransportProbe.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromMinutes(4), cancellationToken: token);
                 remoteHandle.Association.ReadHandlerSource.TrySetResult(new ActionHandleEventListener(_ => { }));
 
                 // Now we initiate an emulated inbound connection to the real system
                 var inboundHandleProbe = CreateTestProbe();
 
                 var inboundHandle =
-                    await remoteTransport.Associate(rawLocalAddress).WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
+                    await remoteTransport.Associate(rawLocalAddress).WaitAsync(TimeSpan.FromSeconds(3), token);
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(inboundHandleProbe));
 
                 await AwaitAssertAsync(() =>
                 {
                     registry.GetRemoteReadHandlerFor(inboundHandle.AsInstanceOf<TestAssociationHandle>()).Should()
                         .NotBeNull();
-                });
+                }, cancellationToken: token);
 
                 var pduCodec = new AkkaPduProtobuffCodec(Sys);
 
@@ -633,17 +634,17 @@ namespace Akka.Remote.Tests
                 inboundHandle.Write(handshakePacket);
 
                 // No disassociation now, the connection is still stashed
-                await inboundHandleProbe.ExpectNoMsgAsync(1000);
+                await inboundHandleProbe.ExpectNoMsgAsync(1000, token);
 
                 // Quarantine unrelated connection
                 RARP.For(thisSystem).Provider.Quarantine(remoteAddress, -1);
-                await inboundHandleProbe.ExpectNoMsgAsync(1000);
+                await inboundHandleProbe.ExpectNoMsgAsync(1000, token);
 
                 // Quarantine the connection
                 RARP.For(thisSystem).Provider.Quarantine(remoteAddress, remoteUID);
 
                 // Even though the connection is stashed it will be disassociated
-                await inboundHandleProbe.ExpectMsgAsync<Disassociated>();
+                await inboundHandleProbe.ExpectMsgAsync<Disassociated>(cancellationToken: token);
             }
             finally
             {
@@ -654,12 +655,13 @@ namespace Akka.Remote.Tests
         [Fact]
         public async Task Drop_sent_messages_over_payload_size()
         {
+            var token = TestContext.Current.CancellationToken;
             var oversized = ByteStringOfSize(MaxPayloadBytes + 1);
             await EventFilter.Exception<OversizedPayloadException>(start: "Discarding oversized payload sent to ")
                 .ExpectOneAsync(async () =>
                 {
-                    await VerifySendAsync(oversized, async () => { await ExpectNoMsgAsync(); });
-                });
+                    await VerifySendAsync(oversized, async () => { await ExpectNoMsgAsync(cancellationToken: token); });
+                }, token);
         }
 
         /// <summary>
@@ -680,18 +682,20 @@ namespace Akka.Remote.Tests
         [Fact]
         public async Task Drop_received_messages_over_payload_size()
         {
+            var token = TestContext.Current.CancellationToken;
             await EventFilter.Exception<OversizedPayloadException>(start: "Discarding oversized payload received")
                 .ExpectOneAsync(async () =>
                 {
-                    await VerifySendAsync(MaxPayloadBytes + 1, async () => { await ExpectNoMsgAsync(); });
-                });
+                    await VerifySendAsync(MaxPayloadBytes + 1, async () => { await ExpectNoMsgAsync(cancellationToken: token); });
+                }, token);
         }
 
         [Fact]
         public async Task Nobody_should_be_converted_back_to_its_singleton()
         {
+            var token = TestContext.Current.CancellationToken;
             _here.Tell(ActorRefs.Nobody, TestActor);
-            await ExpectMsgAsync(ActorRefs.Nobody, TimeSpan.FromSeconds(1.5));
+            await ExpectMsgAsync(ActorRefs.Nobody, TimeSpan.FromSeconds(1.5), cancellationToken: token);
         }
 
         [Fact]

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -19,11 +19,10 @@ using Akka.Util.Internal;
 using FluentAssertions;
 using Google.Protobuf;
 using Xunit;
-using Xunit.Abstractions;
 using Nito.AsyncEx;
 using ThreadLocalRandom = Akka.Util.ThreadLocalRandom;
 using Akka.TestKit.Extensions;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit.Attributes;
 using FluentAssertions.Extensions;
 
 namespace Akka.Remote.Tests
@@ -164,7 +163,7 @@ namespace Akka.Remote.Tests
         public async Task Remoting_must_support_remote_lookups()
         {
             _here.Tell("ping", TestActor);
-            await ExpectMsgAsync(("pong", TestActor));
+            await ExpectMsgAsync(("pong", TestActor), cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -173,7 +172,7 @@ namespace Akka.Remote.Tests
             //TODO: using smaller numbers for the cancellation here causes a bug.
             //the remoting layer uses some "initialdelay task.delay" for 4 seconds.
             //so the token is cancelled before the delay completed.. 
-            var (msg, actorRef) = await _here.Ask<(string, IActorRef)>("ping", DefaultTimeout);
+            var (msg, actorRef) = await _here.Ask<(string, IActorRef)>("ping", DefaultTimeout, TestContext.Current.CancellationToken);
             Assert.Equal("pong", msg);
             Assert.IsType<FutureActorRef<(string, IActorRef)>>(actorRef);
         }
@@ -197,7 +196,7 @@ namespace Akka.Remote.Tests
         {
             // here is really an ActorSelection
             var actorSelection = (ActorSelection)_here;
-            Assert.True(await actorSelection.ResolveOne(10.Seconds()).AwaitWithTimeout(10.2.Seconds()),
+            Assert.True(await actorSelection.ResolveOne(10.Seconds(), TestContext.Current.CancellationToken).AwaitWithTimeout(10.2.Seconds(), TestContext.Current.CancellationToken),
                 "ResolveOne failed to resolve within 10 seconds");
             // the only test is that the ResolveOne works, so if we got here, the test passes
         }
@@ -218,33 +217,36 @@ namespace Akka.Remote.Tests
         [Fact]
         public async Task Remoting_must_not_send_remote_recreated_actor_with_same_name()
         {
+            var token = TestContext.Current.CancellationToken;
             var echo = _remoteSystem.ActorOf(Props.Create(() => new Echo1()), "otherEcho1");
             echo.Tell(71);
-            await ExpectMsgAsync(71);
+            await ExpectMsgAsync(71, cancellationToken: token);
             echo.Tell(PoisonPill.Instance);
-            await ExpectMsgAsync("postStop");
+            await ExpectMsgAsync("postStop", cancellationToken: token);
             echo.Tell(72);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
 
             var echo2 = _remoteSystem.ActorOf(Props.Create(() => new Echo1()), "otherEcho1");
             echo2.Tell(73);
-            await ExpectMsgAsync(73);
+            await ExpectMsgAsync(73, cancellationToken: token);
 
             // msg to old IActorRef (different UID) should not get through
             echo2.Path.Uid.ShouldNotBe(echo.Path.Uid);
             echo.Tell(74);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
 
             _remoteSystem.ActorSelection("/user/otherEcho1").Tell(75);
-            await ExpectMsgAsync(75);
+            await ExpectMsgAsync(75, cancellationToken: token);
 
             Sys.ActorSelection("akka.test://remote-sys@localhost:12346/user/otherEcho1").Tell(76);
-            await ExpectMsgAsync(76);
+            await ExpectMsgAsync(76, cancellationToken: token);
         }
 
         [LocalFact(SkipLocal = "Racy in AzDo CI/CD")]
         public async Task Remoting_must_lookup_actors_across_node_boundaries()
         {
+            var token = TestContext.Current.CancellationToken;
+            
             Action<IActorDsl> act = dsl =>
             {
                 dsl.Receive<(Props, string)>((t, ctx) => ctx.Sender.Tell(ctx.ActorOf(t.Item1, t.Item2)));
@@ -260,52 +262,54 @@ namespace Akka.Remote.Tests
 
             // child is configured to be deployed on remote-sys (remoteSystem)
             l.Tell((Props.Create<Echo1>(), "child"));
-            var child = await ExpectMsgAsync<IActorRef>();
+            var child = await ExpectMsgAsync<IActorRef>(cancellationToken: token);
 
             // grandchild is configured to be deployed on RemotingSpec (Sys)
             child.Tell((Props.Create<Echo1>(), "grandchild"));
-            var grandchild = await ExpectMsgAsync<IActorRef>();
+            var grandchild = await ExpectMsgAsync<IActorRef>(cancellationToken: token);
             grandchild.AsInstanceOf<IActorRefScope>().IsLocal.ShouldBeTrue();
             grandchild.Tell(43);
-            await ExpectMsgAsync(43);
-            var myRef = await Sys.ActorSelection("/user/looker/child/grandchild").ResolveOne(TimeSpan.FromSeconds(3));
+            await ExpectMsgAsync(43, cancellationToken: token);
+            var myRef = await Sys.ActorSelection("/user/looker/child/grandchild").ResolveOne(TimeSpan.FromSeconds(3), token);
             (myRef is LocalActorRef)
                 .ShouldBeTrue(); // due to a difference in how ActorFor and ActorSelection are implemented, this will return a LocalActorRef
             myRef.Tell(44);
-            await ExpectMsgAsync(44);
+            await ExpectMsgAsync(44, cancellationToken: token);
             LastSender.ShouldBe(grandchild);
             LastSender.ShouldBeSame(grandchild);
             child.AsInstanceOf<RemoteActorRef>().Parent.ShouldBe(l);
 
-            var cRef = await Sys.ActorSelection("/user/looker/child").ResolveOne(TimeSpan.FromSeconds(3));
+            var cRef = await Sys.ActorSelection("/user/looker/child").ResolveOne(TimeSpan.FromSeconds(3), token);
             cRef.ShouldBe(child);
             (await l.Ask<IActorRef>("child/..", TimeSpan.FromSeconds(3))).ShouldBe(l);
             var selection = await Sys.ActorSelection("/user/looker/child")
                 .Ask<ActorSelection>(new ActorSelReq(".."), TimeSpan.FromSeconds(3));
-            var resolved = await selection.ResolveOne(TimeSpan.FromSeconds(3));
+            var resolved = await selection.ResolveOne(TimeSpan.FromSeconds(3), token);
             resolved.ShouldBe(l);
 
             Watch(child);
             child.Tell(PoisonPill.Instance);
-            await ExpectMsgAsync("postStop");
-            await ExpectTerminatedAsync(child);
+            await ExpectMsgAsync("postStop", cancellationToken: token);
+            await ExpectTerminatedAsync(child, cancellationToken: token);
             l.Tell((Props.Create<Echo1>(), "child"));
             var child2 = ExpectMsg<IActorRef>();
             child2.Tell(45);
-            await ExpectMsgAsync(45);
+            await ExpectMsgAsync(45, cancellationToken: token);
 
             // msg to old IActorRef (different uid) should not get through
             child2.Path.Uid.ShouldNotBe(child.Path.Uid);
             child.Tell(46);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
 
             Sys.ActorSelection("user/looker/child").Tell(47);
-            await ExpectMsgAsync(47);
+            await ExpectMsgAsync(47, cancellationToken: token);
         }
 
         [Fact]
         public async Task Remoting_must_select_actors_across_node_boundaries()
         {
+            var token = TestContext.Current.CancellationToken;
+            
             Action<IActorDsl> act = dsl =>
             {
                 dsl.Receive<(Props, string)>((t, ctx) => ctx.Sender.Tell(ctx.ActorOf(t.Item1, t.Item2)));
@@ -315,76 +319,76 @@ namespace Akka.Remote.Tests
             var l = Sys.ActorOf(Props.Create(() => new Act(act)), "looker");
             // child is configured to be deployed on remoteSystem
             l.Tell((Props.Create<Echo1>(), "child"));
-            var child = await ExpectMsgAsync<IActorRef>();
+            var child = await ExpectMsgAsync<IActorRef>(cancellationToken: token);
 
             // grandchild is configured to be deployed on RemotingSpec (system)
             child.Tell((Props.Create<Echo1>(), "grandchild"));
-            var grandchild = await ExpectMsgAsync<IActorRef>();
+            var grandchild = await ExpectMsgAsync<IActorRef>(cancellationToken: token);
             ((IActorRefScope)grandchild).IsLocal.ShouldBeTrue();
             grandchild.Tell(53);
-            await ExpectMsgAsync(53);
+            await ExpectMsgAsync(53, cancellationToken: token);
 
             var myself = Sys.ActorSelection("user/looker/child/grandchild");
             myself.Tell(54);
-            await ExpectMsgAsync(54);
+            await ExpectMsgAsync(54, cancellationToken: token);
             LastSender.ShouldBe(grandchild);
             LastSender.ShouldBeSame(grandchild);
 
             myself.Tell(new Identify(myself));
-            var grandchild2 = (await ExpectMsgAsync<ActorIdentity>()).Subject;
+            var grandchild2 = (await ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject;
             grandchild2.ShouldBe(grandchild);
 
             Sys.ActorSelection("user/looker/child").Tell(new Identify(null));
-            (await ExpectMsgAsync<ActorIdentity>()).Subject.ShouldBe(child);
+            (await ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject.ShouldBe(child);
 
             l.Tell(new ActorSelReq("child/.."));
-            (await ExpectMsgAsync<ActorSelection>()).Tell(new Identify(null));
-            (await ExpectMsgAsync<ActorIdentity>()).Subject.ShouldBeSame(l);
+            (await ExpectMsgAsync<ActorSelection>(cancellationToken: token)).Tell(new Identify(null));
+            (await ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject.ShouldBeSame(l);
 
             Sys.ActorSelection("user/looker/child").Tell(new ActorSelReq(".."));
-            (await ExpectMsgAsync<ActorSelection>()).Tell(new Identify(null));
-            (await ExpectMsgAsync<ActorIdentity>()).Subject.ShouldBeSame(l);
+            (await ExpectMsgAsync<ActorSelection>(cancellationToken: token)).Tell(new Identify(null));
+            (await ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject.ShouldBeSame(l);
 
             grandchild.Tell((Props.Create<Echo1>(), "grandgrandchild"));
-            var grandgrandchild = await ExpectMsgAsync<IActorRef>();
+            var grandgrandchild = await ExpectMsgAsync<IActorRef>(cancellationToken: token);
 
             Sys.ActorSelection("/user/looker/child").Tell(new Identify("idReq1"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq1")))
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq1"), cancellationToken: token))
                 .Subject.ShouldBe(child);
 
             Sys.ActorSelection(child.Path).Tell(new Identify("idReq2"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq2")))
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq2"), cancellationToken: token))
                 .Subject.ShouldBe(child);
             Sys.ActorSelection("/user/looker/*").Tell(new Identify("idReq3"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq3")))
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq3"), cancellationToken: token))
                 .Subject.ShouldBe(child);
 
             Sys.ActorSelection("/user/looker/child/grandchild").Tell(new Identify("idReq4"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq4")))
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq4"), cancellationToken: token))
                 .Subject.ShouldBe(grandchild);
 
             Sys.ActorSelection(child.Path / "grandchild").Tell(new Identify("idReq5"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq5"))).Subject.ShouldBe(grandchild);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq5"), cancellationToken: token)).Subject.ShouldBe(grandchild);
             Sys.ActorSelection("/user/looker/*/grandchild").Tell(new Identify("idReq6"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq6"))).Subject.ShouldBe(grandchild);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq6"), cancellationToken: token)).Subject.ShouldBe(grandchild);
             Sys.ActorSelection("/user/looker/child/*").Tell(new Identify("idReq7"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq7"))).Subject.ShouldBe(grandchild);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq7"), cancellationToken: token)).Subject.ShouldBe(grandchild);
 
             Sys.ActorSelection(child.Path / "*").Tell(new Identify("idReq8"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq8"))).Subject.ShouldBe(grandchild);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq8"), cancellationToken: token)).Subject.ShouldBe(grandchild);
 
             Sys.ActorSelection("/user/looker/child/grandchild/grandgrandchild").Tell(new Identify("idReq9"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq9"))).Subject.ShouldBe(grandgrandchild);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq9"), cancellationToken: token)).Subject.ShouldBe(grandgrandchild);
 
             Sys.ActorSelection(child.Path / "grandchild" / "grandgrandchild").Tell(new Identify("idReq10"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq10"))).Subject.ShouldBe(grandgrandchild);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq10"), cancellationToken: token)).Subject.ShouldBe(grandgrandchild);
             Sys.ActorSelection("/user/looker/child/*/grandgrandchild").Tell(new Identify("idReq11"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq11"))).Subject.ShouldBe(grandgrandchild);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq11"), cancellationToken: token)).Subject.ShouldBe(grandgrandchild);
             Sys.ActorSelection("/user/looker/child/*/*").Tell(new Identify("idReq12"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq12"))).Subject.ShouldBe(grandgrandchild);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq12"), cancellationToken: token)).Subject.ShouldBe(grandgrandchild);
 
             Sys.ActorSelection(child.Path / "*" / "grandgrandchild").Tell(new Identify("idReq13"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq13"))).Subject.ShouldBe(grandgrandchild);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq13"), cancellationToken: token)).Subject.ShouldBe(grandgrandchild);
 
             //ActorSelection doesn't support ToSerializationFormat directly
             //var sel1 = Sys.ActorSelection("/user/looker/child/grandchild/grandgrandchild");
@@ -392,29 +396,29 @@ namespace Akka.Remote.Tests
             //ExpectMsg<ActorIdentity>(i => i.MessageId.Equals("idReq18")).Subject.ShouldBe(grandgrandchild);
 
             child.Tell(new Identify("idReq14"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq14"))).Subject.ShouldBe(child);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq14"), cancellationToken: token)).Subject.ShouldBe(child);
             Watch(child);
             child.Tell(PoisonPill.Instance);
-            await ExpectMsgAsync("postStop");
-            (await ExpectMsgAsync<Terminated>()).ActorRef.ShouldBe(child);
+            await ExpectMsgAsync("postStop", cancellationToken: token);
+            (await ExpectMsgAsync<Terminated>(cancellationToken: token)).ActorRef.ShouldBe(child);
             l.Tell((Props.Create<Echo1>(), "child"));
-            var child2 = await ExpectMsgAsync<IActorRef>();
+            var child2 = await ExpectMsgAsync<IActorRef>(cancellationToken: token);
             child2.Tell(new Identify("idReq15"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq15"))).Subject.ShouldBe(child2);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq15"), cancellationToken: token)).Subject.ShouldBe(child2);
 
             Sys.ActorSelection(child.Path).Tell(new Identify("idReq16"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq16"))).Subject.ShouldBe(child2);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq16"), cancellationToken: token)).Subject.ShouldBe(child2);
             child.Tell(new Identify("idReq17"));
-            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq17"))).Subject.ShouldBe(null);
+            (await ExpectMsgAsync<ActorIdentity>(i => i.MessageId.Equals("idReq17"), cancellationToken: token)).Subject.ShouldBe(null);
 
             child2.Tell(55);
-            await ExpectMsgAsync(55);
+            await ExpectMsgAsync(55, cancellationToken: token);
             // msg to old ActorRef (different uid) should not get through
             child2.Path.Uid.ShouldNotBe(child.Path.Uid);
             child.Tell(56);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
             Sys.ActorSelection("user/looker/child").Tell(57);
-            await ExpectMsgAsync(57);
+            await ExpectMsgAsync(57, cancellationToken: token);
         }
 
         [Fact]
@@ -443,19 +447,20 @@ namespace Akka.Remote.Tests
                 "akka.test://remote-sys@localhost:12346/remote/akka.test/RemotingSpec@localhost:12345/user/echo",
                 r.Path.ToString());
             r.Tell("ping", TestActor);
-            await ExpectMsgAsync(("pong", TestActor), TimeSpan.FromSeconds(1.5));
+            await ExpectMsgAsync(("pong", TestActor), TimeSpan.FromSeconds(1.5), cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact()]
         public async Task Bug_884_Remoting_must_support_reply_to_Routee()
         {
+            var token = TestContext.Current.CancellationToken;
             var router = Sys.ActorOf(new RoundRobinPool(3).Props(Props.Create(() => new Reporter(TestActor))));
-            var routees = await router.Ask<Routees>(new GetRoutees());
+            var routees = await router.Ask<Routees>(new GetRoutees(), token);
 
             //have one of the routees send the message
             var targetRoutee = routees.Members.Cast<ActorRefRoutee>().Select(x => x.Actor).First();
             _here.Tell("ping", targetRoutee);
-            var msg = await ExpectMsgAsync<(string, IActorRef)>();
+            var msg = await ExpectMsgAsync<(string, IActorRef)>(cancellationToken: token);
             Assert.Equal("pong", msg.Item1);
             Assert.Equal(targetRoutee, msg.Item2);
         }
@@ -463,15 +468,16 @@ namespace Akka.Remote.Tests
         [Fact]
         public async Task Bug_884_Remoting_must_support_reply_to_child_of_Routee()
         {
+            var token = TestContext.Current.CancellationToken;
             var props = Props.Create(() => new Reporter(TestActor));
             var router = Sys.ActorOf(new RoundRobinPool(3).Props(Props.Create(() => new NestedDeployer(props))));
-            var routees = await router.Ask<Routees>(new GetRoutees());
+            var routees = await router.Ask<Routees>(new GetRoutees(), token);
 
             //have one of the routees send the message
             var targetRoutee = routees.Members.Cast<ActorRefRoutee>().Select(x => x.Actor).First();
-            var reporter = await targetRoutee.Ask<IActorRef>(new NestedDeployer.GetNestedReporter());
+            var reporter = await targetRoutee.Ask<IActorRef>(new NestedDeployer.GetNestedReporter(), token);
             _here.Tell("ping", reporter);
-            var msg = await ExpectMsgAsync<(string, IActorRef)>();
+            var msg = await ExpectMsgAsync<(string, IActorRef)>(cancellationToken: token);
             Assert.Equal("pong", msg.Item1);
             Assert.Equal(reporter, msg.Item2);
         }
@@ -479,6 +485,7 @@ namespace Akka.Remote.Tests
         [Fact]
         public async Task Stash_inbound_connections_until_UID_is_known_for_pending_outbound()
         {
+            var token = TestContext.Current.CancellationToken;
             var localAddress = new Address("akka.test", "system1", "localhost", 1);
             var rawLocalAddress = new Address("test", "system1", "localhost", 1);
             var remoteAddress = new Address("akka.test", "system2", "localhost", 2);
@@ -509,7 +516,7 @@ namespace Akka.Remote.Tests
                     (new ActorAssociationEventListener(remoteTransportProbe)));
 
                 // Hijack associations through the test transport
-                await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(rawLocalAddress, rawRemoteAddress)));
+                await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(rawLocalAddress, rawRemoteAddress)), token);
                 var testTransport = registry.TransportFor(rawLocalAddress).Value.Item1;
                 testTransport.WriteBehavior.PushConstant(true);
 
@@ -519,20 +526,20 @@ namespace Akka.Remote.Tests
                 dummySelection.Tell("ping", Sys.DeadLetters);
 
                 var remoteHandle =
-                    await remoteTransportProbe.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromMinutes(4));
+                    await remoteTransportProbe.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromMinutes(4), cancellationToken: token);
                 remoteHandle.Association.ReadHandlerSource.TrySetResult(new ActionHandleEventListener(_ => { }));
 
                 // Now we initiate an emulated inbound connection to the real system
                 var inboundHandleProbe = CreateTestProbe();
                 var inboundHandle =
-                    await remoteTransport.Associate(rawLocalAddress).WithTimeout(TimeSpan.FromSeconds(3));
+                    await remoteTransport.Associate(rawLocalAddress).WaitAsync(TimeSpan.FromSeconds(3), token);
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(inboundHandleProbe));
 
                 await AwaitAssertAsync(() =>
                 {
                     registry.GetRemoteReadHandlerFor(inboundHandle.AsInstanceOf<TestAssociationHandle>()).Should()
                         .NotBeNull();
-                });
+                }, cancellationToken: token);
 
                 var pduCodec = new AkkaPduProtobuffCodec(Sys);
 
@@ -546,12 +553,12 @@ namespace Akka.Remote.Tests
                 inboundHandle.Write(brokenPacket);
 
                 // No disassociation now - the connection is still stashed
-                await inboundHandleProbe.ExpectNoMsgAsync(1000);
+                await inboundHandleProbe.ExpectNoMsgAsync(1000, token);
 
                 // Finish the handshake for the outbound connection - this will unstash the inbound pending connection.
                 remoteHandle.Association.Write(handshakePacket);
 
-                await inboundHandleProbe.ExpectMsgAsync<Disassociated>(TimeSpan.FromMinutes(5));
+                await inboundHandleProbe.ExpectMsgAsync<Disassociated>(TimeSpan.FromMinutes(5), cancellationToken: token);
             }
             finally
             {
@@ -609,7 +616,7 @@ namespace Akka.Remote.Tests
                 var inboundHandleProbe = CreateTestProbe();
 
                 var inboundHandle =
-                    await remoteTransport.Associate(rawLocalAddress).WithTimeout(TimeSpan.FromSeconds(3));
+                    await remoteTransport.Associate(rawLocalAddress).WaitAsync(TimeSpan.FromSeconds(3), TestContext.Current.CancellationToken);
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(inboundHandleProbe));
 
                 await AwaitAssertAsync(() =>

--- a/src/core/Akka.Remote.Tests/RemotingTerminatorSpecs.cs
+++ b/src/core/Akka.Remote.Tests/RemotingTerminatorSpecs.cs
@@ -14,7 +14,6 @@ using Akka.TestKit.Extensions;
 using Akka.TestKit.TestActors;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {
@@ -51,33 +50,37 @@ namespace Akka.Remote.Tests
                 Sys.EventStream.Subscribe(TestActor, typeof (RemotingShutdownEvent));
                 Sys.EventStream.Subscribe(TestActor, typeof (RemotingErrorEvent));
                 Assert.True(await Sys.Terminate().AwaitWithTimeout(RemainingOrDefault), "Expected to terminate within 10 seconds, but didn't.");
-            });
+            }, cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task RemotingTerminator_should_shutdown_promptly_with_some_associations()
         {
+            var token = TestContext.Current.CancellationToken;
             _sys2 = ActorSystem.Create("System2", RemoteConfig);
             InitializeLogger(_sys2);
             var sys2Address = RARP.For(_sys2).Provider.DefaultAddress;
 
             // open an association
             var associated = await Sys.ActorSelection(new RootActorPath(sys2Address)/"system"/"remote-watcher")
-                .ResolveOne(TimeSpan.FromSeconds(4));
+                .ResolveOne(TimeSpan.FromSeconds(4), token);
 
             Sys.EventStream.Subscribe(TestActor, typeof(RemotingShutdownEvent));
             Sys.EventStream.Subscribe(TestActor, typeof(RemotingErrorEvent));
             var terminationTask = Sys.Terminate();
-            await ExpectMsgAsync<RemotingShutdownEvent>();
-            Assert.True(await terminationTask.AwaitWithTimeout(10.Seconds()), "Expected to terminate within 10 seconds, but didn't.");
+            await ExpectMsgAsync<RemotingShutdownEvent>(cancellationToken: token);
+            Assert.True(await terminationTask.AwaitWithTimeout(10.Seconds(), token), 
+                "Expected to terminate within 10 seconds, but didn't.");
 
             // now terminate the second system
-            Assert.True(await _sys2.Terminate().AwaitWithTimeout(10.Seconds()), "Expected to terminate within 10 seconds, but didn't.");
+            Assert.True(await _sys2.Terminate().AwaitWithTimeout(10.Seconds(), token), 
+                "Expected to terminate within 10 seconds, but didn't.");
         }
 
         [Fact]
         public async Task RemotingTerminator_should_shutdown_properly_with_remotely_deployed_actor()
         {
+            var token = TestContext.Current.CancellationToken;
             _sys2 = ActorSystem.Create("System2", RemoteConfig);
             InitializeLogger(_sys2);
             var sys2Address = RARP.For(_sys2).Provider.DefaultAddress;
@@ -89,20 +92,23 @@ namespace Akka.Remote.Tests
             Watch(associated);
 
             // verify that the association is open (don't terminate until handshake is finished)
-            var actorIdentity = await associated.Ask<ActorIdentity>(new Identify("foo"), RemainingOrDefault);
+            var actorIdentity = await associated.Ask<ActorIdentity>(new Identify("foo"), RemainingOrDefault, token);
             actorIdentity.MessageId.ShouldBe("foo");
 
             // terminate the DEPLOYED system
-            Assert.True(await _sys2.Terminate().AwaitWithTimeout(10.Seconds()), "Expected to terminate within 10 seconds, but didn't.");
-            await ExpectTerminatedAsync(associated); // expect that the remote deployed actor is dead
+            Assert.True(await _sys2.Terminate().AwaitWithTimeout(10.Seconds(), token), 
+                "Expected to terminate within 10 seconds, but didn't.");
+            await ExpectTerminatedAsync(associated, cancellationToken: token); // expect that the remote deployed actor is dead
 
             // now terminate the DEPLOYER system
-            Assert.True(await Sys.Terminate().AwaitWithTimeout(10.Seconds()), "Expected to terminate within 10 seconds, but didn't.");
+            Assert.True(await Sys.Terminate().AwaitWithTimeout(10.Seconds(), token), 
+                "Expected to terminate within 10 seconds, but didn't.");
         }
 
         [Fact]
         public async Task RemotingTerminator_should_shutdown_properly_without_exception_logging_while_graceful_shutdown()
         {
+            var token = TestContext.Current.CancellationToken;
             await EventFilter.Exception<ShutDownAssociation>().ExpectAsync(0,
                 async () =>
                 {
@@ -116,19 +122,19 @@ namespace Akka.Remote.Tests
                     Watch(associated);
 
                     // verify that the association is open (don't terminate until handshake is finished)
-                    (await associated.Ask<ActorIdentity>(new Identify("foo"), RemainingOrDefault)).MessageId.ShouldBe("foo");
+                    (await associated.Ask<ActorIdentity>(new Identify("foo"), RemainingOrDefault, token)).MessageId.ShouldBe("foo");
 
                     // terminate the DEPLOYED system
                     await WithinAsync(TimeSpan.FromSeconds(10), async () =>
                     {
                         var terminationTask = _sys2.Terminate(); // start termination process
-                        await ExpectTerminatedAsync(associated);  // expect that the remote deployed actor is dead
-                        Assert.True(await terminationTask.AwaitWithTimeout(RemainingOrDefault), "Expected to terminate within 10 seconds, but didn't.");
-                    });
+                        await ExpectTerminatedAsync(associated, cancellationToken: token);  // expect that the remote deployed actor is dead
+                        Assert.True(await terminationTask.AwaitWithTimeout(RemainingOrDefault, cancellationToken: token), "Expected to terminate within 10 seconds, but didn't.");
+                    }, cancellationToken: token);
 
                     // now terminate the DEPLOYER system
-                    Assert.True(await Sys.Terminate().AwaitWithTimeout(10.Seconds()), "Expected to terminate within 10 seconds, but didn't.");
-                });
+                    Assert.True(await Sys.Terminate().AwaitWithTimeout(10.Seconds(), cancellationToken: token), "Expected to terminate within 10 seconds, but didn't.");
+                }, token);
         }
     }
 }

--- a/src/core/Akka.Remote.Tests/Serialization/BugFix5062Spec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/BugFix5062Spec.cs
@@ -6,21 +6,14 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.Configuration;
 using Akka.Serialization;
 using Akka.TestKit;
 using FluentAssertions;
-using Google.Protobuf;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Serialization
 {

--- a/src/core/Akka.Remote.Tests/Serialization/Bugfix3903Spec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/Bugfix3903Spec.cs
@@ -12,7 +12,6 @@ using Akka.Configuration;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Remote.Tests.Serialization
@@ -81,6 +80,7 @@ namespace Akka.Remote.Tests.Serialization
         [Fact]
         public async Task ParentActor_should_be_able_to_deploy_EchoActor_to_remote_system()
         {
+            var token = TestContext.Current.CancellationToken;
             // create a second ActorSystem
             var system2 = ActorSystem.Create(Sys.Name, Sys.Settings.Config);
             InitializeLogger(system2);
@@ -99,20 +99,20 @@ namespace Akka.Remote.Tests.Serialization
                 // have the ParentActor remotely deploy an EchoActor onto the second ActorSystem
                 var child = await parent
                     .Ask<IActorRef>(new ParentActor.DeployChild(
-                        system2.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress), RemainingOrDefault);
+                        system2.AsInstanceOf<ExtendedActorSystem>().Provider.DefaultAddress), RemainingOrDefault, token);
 
                 // assert that Child is a remote actor reference
                 child.Should().BeOfType<RemoteActorRef>();
                 Watch(child);
                 
                 // send a message to the EchoActor and verify that it is received
-                (await child.Ask<string>("hello", RemainingOrDefault)).Should().Be("hello");
+                (await child.Ask<string>("hello", RemainingOrDefault, token)).Should().Be("hello");
                 
                 // cause the child to crash
                 child.Tell(EchoActor.Fail.Instance);
-                var exception = ExpectMsg<ApplicationException>();
+                var exception = ExpectMsg<ApplicationException>(cancellationToken: token);
                 exception.Message.Should().Be("fail");
-                ExpectTerminated(child);
+                await ExpectTerminatedAsync(child, cancellationToken: token);
             }
             finally
             {

--- a/src/core/Akka.Remote.Tests/Serialization/Bugfix7215Spec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/Bugfix7215Spec.cs
@@ -10,13 +10,12 @@ using System.IO;
 using Akka.Actor;
 using Akka.Remote.Serialization;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 using static FluentAssertions.FluentActions;
 
 namespace Akka.Remote.Tests.Serialization;
 
-public class Bugfix7215Spec: TestKit.Xunit2.TestKit
+public class Bugfix7215Spec: TestKit.Xunit.TestKit
 {
     public Bugfix7215Spec(ITestOutputHelper output) : base(nameof(Bugfix7215Spec), output)
     {

--- a/src/core/Akka.Remote.Tests/Serialization/RemoteAskFailureSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/RemoteAskFailureSpec.cs
@@ -14,12 +14,11 @@ using Akka.Event;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 using static  FluentAssertions.FluentActions;
 
 namespace Akka.Remote.Tests.Serialization
 {
-    public class RemoteAskFailureSpec: TestKit.Xunit2.TestKit
+    public class RemoteAskFailureSpec: TestKit.Xunit.TestKit
     {
         private static Config Config(int port) => @$"
 akka.actor.ask-timeout = 5s
@@ -50,11 +49,12 @@ akka.remote.dot-netty.tcp.port = {port}";
         [Fact(DisplayName = "Ask operation using selector to a remote actor that expects Status.Failure should return Status.Failure")]
         public async Task RemoteSelectorFailureMessageTest()
         {
+            var token = TestContext.Current.CancellationToken;
             _sys2.ActorOf(Props.Create(() => new FailActor()), "fail");
             var sys2Address = RARP.For(_sys2).Provider.DefaultAddress;
             var selector = _sys1.ActorSelection($"akka.tcp://{_sys2.Name}@{sys2Address.Host}:{sys2Address.Port}/user/fail");
 
-            var fail = await selector.Ask<Status.Failure>("doesn't matter");
+            var fail = await selector.Ask<Status.Failure>("doesn't matter", token);
             fail.Cause.Should().NotBeNull();
             fail.Cause.Should().BeOfType<TestException>();
             fail.Cause.Message.Should().Be("BOOM");
@@ -76,13 +76,14 @@ akka.remote.dot-netty.tcp.port = {port}";
         [Fact(DisplayName = "Ask operation using deployment to a remote actor that expects Status.Failure should return Status.Failure")]
         public async Task RemoteDeploymentFailureMessageTest()
         {
+            var token = TestContext.Current.CancellationToken;
             var sys2Address = RARP.For(_sys2).Provider.DefaultAddress;
             var remote = _sys1.ActorOf(
                 Props.Create(() => new FailActor())
                     .WithDeploy(new Deploy(new RemoteScope(sys2Address))), 
                 "fail");
 
-            var fail = await remote.Ask<Status.Failure>("doesn't matter");
+            var fail = await remote.Ask<Status.Failure>("doesn't matter", token);
             fail.Cause.Should().NotBeNull();
             fail.Cause.Should().BeOfType<TestException>();
             fail.Cause.Message.Should().Be("BOOM");

--- a/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
@@ -6,8 +6,6 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -15,11 +13,9 @@ using Akka.Actor.Dsl;
 using Akka.Configuration;
 using Akka.Serialization;
 using Akka.TestKit;
-using Akka.TestKit.TestActors;
 using FluentAssertions;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Serialization
 {

--- a/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
@@ -149,6 +149,7 @@ namespace Akka.Remote.Tests.Serialization
         [Fact]
         public async Task Serialization_of_ActorRef_in_remote_message_must_resolve_Address()
         {
+            var token = TestContext.Current.CancellationToken;
             System2.ActorOf(act =>
             {
                 act.ReceiveAny((o, context) => context.Sender.Tell(o));
@@ -156,23 +157,23 @@ namespace Akka.Remote.Tests.Serialization
 
             var echoSel = Sys.ActorSelection(new RootActorPath(System2Address) / "user" / "echo");
             echoSel.Tell(new Identify(1));
-            var echo = (await ExpectMsgAsync<ActorIdentity>()).Subject;
+            var echo = (await ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject;
 
             echo.Tell(new TestMessage(TestActor, echo));
-            var t1 = await ExpectMsgAsync<TestMessage>();
+            var t1 = await ExpectMsgAsync<TestMessage>(cancellationToken: token);
             t1.From.Should().Be(TestActor);
             t1.To.Should().Be(echo);
 
             echo.Tell(new JsonSerTestMessage(TestActor, echo));
-            var t2 = await ExpectMsgAsync<JsonSerTestMessage>();
+            var t2 = await ExpectMsgAsync<JsonSerTestMessage>(cancellationToken: token);
             t2.From.Should().Be(TestActor);
             t2.To.Should().Be(echo);
 
             echo.Tell(TestActor);
-            await ExpectMsgAsync(TestActor);
+            await ExpectMsgAsync(TestActor, cancellationToken: token);
 
             echo.Tell(echo);
-            await ExpectMsgAsync(echo);
+            await ExpectMsgAsync(echo, cancellationToken: token);
         }
 
         protected override void AfterAll()

--- a/src/core/Akka.Remote.Tests/Serialization/SystemMessageSerializationSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/SystemMessageSerializationSpec.cs
@@ -7,7 +7,6 @@
 
 using System;
 using Akka.Actor;
-using Akka.Configuration;
 using Akka.Dispatch.SysMsg;
 using Akka.Remote.Configuration;
 using Akka.Remote.Serialization;
@@ -16,7 +15,6 @@ using Akka.TestKit.TestActors;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Serialization
 {

--- a/src/core/Akka.Remote.Tests/TransientSerializationErrorSpec.cs
+++ b/src/core/Akka.Remote.Tests/TransientSerializationErrorSpec.cs
@@ -178,12 +178,13 @@ namespace Akka.Remote.Tests
         [Fact]
         public async Task The_transport_must_stay_alive_after_a_transient_exception_from_the_serializer()
         {
+            var token = TestContext.Current.CancellationToken;
             _system2.ActorOf(EchoActor.Props(), "echo");
 
             var selection = Sys.ActorSelection(new RootActorPath(_system2Address) / "user" / "echo");
 
             selection.Tell("ping", this.TestActor);
-            await ExpectMsgAsync("ping");
+            await ExpectMsgAsync("ping",cancellationToken: token);
 
             // none of these should tear down the connection
             selection.Tell(ManifestIllegal.Instance, this.TestActor);
@@ -195,7 +196,7 @@ namespace Akka.Remote.Tests
 
             // make sure we still have a connection
             selection.Tell("ping", this.TestActor);
-            await ExpectMsgAsync("ping");
+            await ExpectMsgAsync("ping", cancellationToken: token);
         }
     }
 

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -19,7 +18,6 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using Google.Protobuf;
 using Xunit;
-using Xunit.Abstractions;
 using SerializedMessage = Akka.Remote.Serialization.Proto.Msg.Payload;
 using static FluentAssertions.FluentActions;
 
@@ -133,6 +131,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task ProtocolStateActor_must_register_itself_as_reader_on_injected_handles()
         {
+            var token = TestContext.Current.CancellationToken;
             var collaborators = GetCollaborators();
             Sys.ActorOf(ProtocolStateActor.InboundProps(
                 handshakeInfo: new HandshakeInfo(_localAddress, 42), 
@@ -142,12 +141,13 @@ namespace Akka.Remote.Tests.Transport
                 codec: _codec,
                 failureDetector: collaborators.FailureDetector));
 
-            await collaborators.Handle.ReadHandlerSource.Task.WithTimeout(DefaultTimeout);
+            await collaborators.Handle.ReadHandlerSource.Task.WaitAsync(DefaultTimeout, token);
         }
 
         [Fact]
         public async Task ProtocolStateActor_must_in_inbound_mode_accept_payload_after_Associate_PDU_received()
         {
+            var token = TestContext.Current.CancellationToken;
             var collaborators = GetCollaborators();
             var reader = Sys.ActorOf(ProtocolStateActor.InboundProps(
                 handshakeInfo: new HandshakeInfo(_localAddress, 42),
@@ -159,7 +159,7 @@ namespace Akka.Remote.Tests.Transport
 
             reader.Tell(TestAssociate(33), TestActor);
 
-            await AwaitConditionAsync(() => Task.FromResult(collaborators.FailureDetector.IsMonitoring), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(collaborators.FailureDetector.IsMonitoring), DefaultTimeout, token);
 
             var wrappedHandle = await ExpectMsgOfAsync(DefaultTimeout, "expected InboundAssociation", o =>
             {
@@ -168,7 +168,7 @@ namespace Akka.Remote.Tests.Transport
                 var association = (AkkaProtocolHandle)inbound.Association;
                 Assert.Equal(33, association.HandshakeInfo.Uid);
                 return association;
-            });
+            }, token);
             Assert.NotNull(wrappedHandle);
 
             wrappedHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
@@ -176,18 +176,19 @@ namespace Akka.Remote.Tests.Transport
             Assert.True(collaborators.FailureDetector.IsMonitoring);
 
             // Heartbeat was sent in response to Associate
-            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsHeartbeat(collaborators.Registry)), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsHeartbeat(collaborators.Registry)), DefaultTimeout, token);
 
             reader.Tell(_testPayload, TestActor);
             await ExpectMsgAsync<InboundPayload>(inbound =>
             {
                 Assert.Equal(_testEnvelope, inbound.Payload);
-            }, hint: "expected InboundPayload");
+            }, hint: "expected InboundPayload", cancellationToken: token);
         }
 
         [Fact]
         public async Task ProtocolStateActor_must_in_inbound_mode_disassociate_when_an_unexpected_message_arrives_instead_of_Associate()
         {
+            var token = TestContext.Current.CancellationToken;
             var collaborators = GetCollaborators();
 
             var reader = Sys.ActorOf(ProtocolStateActor.InboundProps(
@@ -208,12 +209,13 @@ namespace Akka.Remote.Tests.Transport
             {
                 var snapshots = collaborators.Registry.LogSnapshot();
                 return Task.FromResult(snapshots.Any(x => x is DisassociateAttempt));
-            }, DefaultTimeout);
+            }, DefaultTimeout, token);
         }
 
         [Fact]
         public async Task ProtocolStateActor_must_in_outbound_mode_delay_readiness_until_handshake_finished()
         {
+            var token = TestContext.Current.CancellationToken;
             var collaborators = GetCollaborators();
             collaborators.Transport.AssociateBehavior.PushConstant(collaborators.Handle);
 
@@ -227,19 +229,19 @@ namespace Akka.Remote.Tests.Transport
                 codec: _codec,
                 failureDetector: collaborators.FailureDetector));
 
-            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout, token);
             
-            await AwaitConditionAsync(() => Task.FromResult(collaborators.FailureDetector.IsMonitoring), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(collaborators.FailureDetector.IsMonitoring), DefaultTimeout, token);
 
             //keeps sending heartbeats
-            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsHeartbeat(collaborators.Registry)), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsHeartbeat(collaborators.Registry)), DefaultTimeout, token);
 
             Assert.False(statusPromise.Task.IsCompleted);
 
             //finish the connection by sending back an associate message
             reader.Tell(TestAssociate(33), TestActor);
 
-            await statusPromise.Task.WithTimeout(3.Seconds());
+            await statusPromise.Task.WaitAsync(3.Seconds(), token);
             switch (statusPromise.Task.Result)
             {
                 case AkkaProtocolHandle h:
@@ -255,6 +257,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task ProtocolStateActor_must_handle_explicit_disassociate_messages()
         {
+            var token = TestContext.Current.CancellationToken;
             var collaborators = GetCollaborators();
             collaborators.Transport.AssociateBehavior.PushConstant(collaborators.Handle);
 
@@ -268,11 +271,11 @@ namespace Akka.Remote.Tests.Transport
                 codec: _codec,
                 failureDetector: collaborators.FailureDetector));
 
-            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout, token);
 
             reader.Tell(TestAssociate(33), TestActor);
 
-            await statusPromise.Task.WithTimeout(3.Seconds());
+            await statusPromise.Task.WaitAsync(3.Seconds(), token);
             var result = await statusPromise.Task;
             switch (result)
             {
@@ -297,12 +300,13 @@ namespace Akka.Remote.Tests.Transport
                 Assert.Equal(DisassociateInfo.Unknown, disassociated.Info);
 
                 return disassociated;
-            });
+            }, token);
         }
 
         [Fact]
         public async Task ProtocolStateActor_must_handle_transport_level_disassociations()
         {
+            var token = TestContext.Current.CancellationToken;
             var collaborators = GetCollaborators();
             collaborators.Transport.AssociateBehavior.PushConstant(collaborators.Handle);
 
@@ -316,11 +320,11 @@ namespace Akka.Remote.Tests.Transport
                 codec: _codec,
                 failureDetector: collaborators.FailureDetector));
 
-            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout, token);
 
             reader.Tell(TestAssociate(33), TestActor);
 
-            await statusPromise.Task.WithTimeout(TimeSpan.FromSeconds(3));
+            await statusPromise.Task.WaitAsync(TimeSpan.FromSeconds(3), token);
             var result = await statusPromise.Task;
             switch (result)
             {
@@ -345,12 +349,13 @@ namespace Akka.Remote.Tests.Transport
                 Assert.Equal(DisassociateInfo.Unknown, disassociated.Info);
 
                 return disassociated;
-            });
+            }, token);
         }
 
         [Fact]
         public async Task ProtocolStateActor_must_disassociate_when_failure_detector_signals_failure()
         {
+            var token = TestContext.Current.CancellationToken;
             var collaborators = GetCollaborators();
             collaborators.Transport.AssociateBehavior.PushConstant(collaborators.Handle);
 
@@ -364,11 +369,11 @@ namespace Akka.Remote.Tests.Transport
                 codec: _codec,
                 failureDetector: collaborators.FailureDetector));
 
-            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout, token);
 
             stateActor.Tell(TestAssociate(33), TestActor);
 
-            await statusPromise.Task.WithTimeout(TimeSpan.FromSeconds(3));
+            await statusPromise.Task.WaitAsync(TimeSpan.FromSeconds(3), token);
             var result = await statusPromise.Task;
             switch (result)
             {
@@ -384,7 +389,7 @@ namespace Akka.Remote.Tests.Transport
             wrappedHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
 
             //wait for one heartbeat
-            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsHeartbeat(collaborators.Registry)), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsHeartbeat(collaborators.Registry)), DefaultTimeout, token);
 
             collaborators.FailureDetector.SetAvailable(false);
 
@@ -396,12 +401,13 @@ namespace Akka.Remote.Tests.Transport
                 Assert.Equal(DisassociateInfo.Unknown, disassociated.Info);
 
                 return disassociated;
-            });
+            }, token);
         }
 
         [Fact]
         public async Task ProtocolStateActor_must_handle_correctly_when_the_handler_is_registered_only_after_the_association_is_already_closed()
         {
+            var token = TestContext.Current.CancellationToken;
             var collaborators = GetCollaborators();
             collaborators.Transport.AssociateBehavior.PushConstant(collaborators.Handle);
 
@@ -415,11 +421,11 @@ namespace Akka.Remote.Tests.Transport
                 codec: _codec,
                 failureDetector: collaborators.FailureDetector));
 
-            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout, token);
 
             stateActor.Tell(TestAssociate(33), TestActor);
 
-            await statusPromise.Task.WithTimeout(TimeSpan.FromSeconds(3));
+            await statusPromise.Task.WaitAsync(TimeSpan.FromSeconds(3), token);
             var result = await statusPromise.Task;
             switch (result)
             {
@@ -445,12 +451,13 @@ namespace Akka.Remote.Tests.Transport
                 Assert.Equal(DisassociateInfo.Unknown, disassociated.Info);
 
                 return disassociated;
-            });
+            }, token);
         }
 
         [Fact]
         public async Task ProtocolStateActor_must_give_up_outbound_after_connection_timeout()
         {
+            var token = TestContext.Current.CancellationToken;
             var collaborators = GetCollaborators();
             collaborators.Handle.Writeable = false;
             collaborators.Transport.AssociateBehavior.PushConstant(collaborators.Handle);
@@ -473,15 +480,16 @@ namespace Akka.Remote.Tests.Transport
 
             await Awaiting(async () =>
             {
-                await statusPromise.Task.WithTimeout(TimeSpan.FromSeconds(5));
+                await statusPromise.Task.WaitAsync(TimeSpan.FromSeconds(5), token);
             }).Should().ThrowAsync<TimeoutException>();
             
-            await ExpectTerminatedAsync(stateActor);
+            await ExpectTerminatedAsync(stateActor, cancellationToken: token);
         }
 
         [Fact]
         public async Task ProtocolStateActor_must_give_up_inbound_after_connection_timeout()
         {
+            var token = TestContext.Current.CancellationToken;
             var collaborators = GetCollaborators();
             collaborators.Handle.Writeable = false;
             collaborators.Transport.AssociateBehavior.PushConstant(collaborators.Handle);
@@ -498,7 +506,7 @@ namespace Akka.Remote.Tests.Transport
                 failureDetector: collaborators.FailureDetector));
 
             Watch(reader);
-            await ExpectTerminatedAsync(reader);
+            await ExpectTerminatedAsync(reader, cancellationToken: token);
         }
 
         #endregion

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
@@ -12,14 +12,12 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.Transport;
 using Akka.TestKit;
-using Akka.TestKit.Extensions;
 using Akka.TestKit.Internal;
 using Akka.TestKit.Internal.StringMatcher;
 using Akka.TestKit.TestEvent;
 using Akka.Util.Internal;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {
@@ -182,25 +180,28 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task AkkaProtocolTransport_must_guarantee_at_most_once_delivery_and_message_ordering_despite_packet_loss()
         {
+            var token = TestContext.Current.CancellationToken;
             //todo mute both systems for deadletters for any type of message
             EventFilter.DeadLetter().Mute();
             CreateEventFilter(_systemB).DeadLetter().Mute();
             Assert.True(await RARP.For(Sys)
-                .Provider.Transport.ManagementCommand(new FailureInjectorTransportAdapter.One(AddressB,
-                    new FailureInjectorTransportAdapter.Drop(0.1, 0.1)))
-                .AwaitWithTimeout(3.Seconds()));
+                .Provider.Transport.ManagementCommand(new FailureInjectorTransportAdapter.One(
+                    remoteAddress: AddressB, 
+                    mode: new FailureInjectorTransportAdapter.Drop(0.1, 0.1)), 
+                    cancellationToken: token)
+                .WaitAsync(3.Seconds(), token));
 
             IActorRef here = null;
             await AwaitConditionAsync(async () =>
             {
                 here = await Here();
                 return here != null && !here.Equals(ActorRefs.Nobody);
-            }, TimeSpan.FromSeconds(3));
+            }, TimeSpan.FromSeconds(3), token);
 
             var tester = Sys.ActorOf(Props.Create(() => new SequenceVerifier(here, TestActor)));
             tester.Tell("start");
 
-            await ExpectMsgAsync<(int,int)>(TimeSpan.FromSeconds(60));
+            await ExpectMsgAsync<(int,int)>(TimeSpan.FromSeconds(60), cancellationToken: token);
         }
 
         #endregion

--- a/src/core/Akka.Remote.Tests/Transport/CertificateValidationHelpersSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/CertificateValidationHelpersSpec.cs
@@ -12,7 +12,6 @@ using Akka.Event;
 using Akka.Remote.Transport.DotNetty;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {
@@ -36,6 +35,7 @@ namespace Akka.Remote.Tests.Transport
         public void PinnedCertificate_should_reject_null_certificate()
         {
             // Arrange
+            var token = TestContext.Current.CancellationToken;
             var validator = CertificateValidation.PinnedCertificate("ABCD1234");
 
             // Act & Assert
@@ -43,7 +43,7 @@ namespace Akka.Remote.Tests.Transport
             {
                 var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
                 Assert.False(result);
-            });
+            }, token);
         }
 
         // Note: X509Certificate2 always has a thumbprint when properly constructed,
@@ -125,6 +125,7 @@ namespace Akka.Remote.Tests.Transport
         public void PinnedCertificate_should_reject_non_matching_thumbprint()
         {
             // Arrange
+            var token = TestContext.Current.CancellationToken;
             var cert = new X509Certificate2(ValidCertPath, Password);
             var validator = CertificateValidation.PinnedCertificate(
                 "1111111111111111111111111111111111111111",
@@ -135,7 +136,7 @@ namespace Akka.Remote.Tests.Transport
             {
                 var result = validator(cert, null, "test-peer", SslPolicyErrors.None, _log);
                 Assert.False(result);
-            });
+            }, token);
         }
 
         #endregion
@@ -146,6 +147,7 @@ namespace Akka.Remote.Tests.Transport
         public void ValidateSubject_should_reject_null_certificate()
         {
             // Arrange
+            var token = TestContext.Current.CancellationToken;
             var validator = CertificateValidation.ValidateSubject("CN=TestSubject");
 
             // Act & Assert
@@ -153,7 +155,7 @@ namespace Akka.Remote.Tests.Transport
             {
                 var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
                 Assert.False(result);
-            });
+            }, token);
         }
 
         [Fact(DisplayName = "ValidateSubject should throw if pattern is null or empty")]
@@ -173,6 +175,7 @@ namespace Akka.Remote.Tests.Transport
         public void ValidateIssuer_should_reject_null_certificate()
         {
             // Arrange
+            var token = TestContext.Current.CancellationToken;
             var validator = CertificateValidation.ValidateIssuer("CN=TestIssuer");
 
             // Act & Assert
@@ -180,14 +183,14 @@ namespace Akka.Remote.Tests.Transport
             {
                 var result = validator(null, null, "test-peer", SslPolicyErrors.None, _log);
                 Assert.False(result);
-            });
+            }, token);
         }
 
         [Fact(DisplayName = "ValidateIssuer should throw if pattern is null or empty")]
         public void ValidateIssuer_should_throw_if_pattern_null_or_empty()
         {
             // Act & Assert
-            Assert.Throws<ArgumentException>(() => CertificateValidation.ValidateIssuer(null));
+            Assert.Throws<ArgumentException>(() => CertificateValidation.ValidateIssuer(null!));
             Assert.Throws<ArgumentException>(() => CertificateValidation.ValidateIssuer(""));
             Assert.Throws<ArgumentException>(() => CertificateValidation.ValidateIssuer("  "));
         }
@@ -200,7 +203,7 @@ namespace Akka.Remote.Tests.Transport
         public void Combine_should_handle_null_validators()
         {
             // Act & Assert - Should throw ArgumentException
-            Assert.Throws<ArgumentException>(() => CertificateValidation.Combine(null));
+            Assert.Throws<ArgumentException>(() => CertificateValidation.Combine(null!));
         }
 
         [Fact(DisplayName = "Combine should handle empty validators array")]
@@ -215,6 +218,7 @@ namespace Akka.Remote.Tests.Transport
         public void Combine_should_short_circuit_on_first_failure()
         {
             // Arrange
+            var token = TestContext.Current.CancellationToken;
             var callCount = 0;
             CertificateValidationCallback validator1 = (cert, chain, peer, errors, log) =>
             {
@@ -238,7 +242,7 @@ namespace Akka.Remote.Tests.Transport
                 var result = combined(cert, null, "test-peer", SslPolicyErrors.None, _log);
                 Assert.False(result);
                 Assert.Equal(1, callCount); // Only first validator should be called - short-circuit behavior
-            });
+            }, cancellationToken: token);
         }
 
         #endregion

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyBatchWriterSpecs.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyBatchWriterSpecs.cs
@@ -6,9 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.Remote.Transport.DotNetty;
@@ -19,7 +17,6 @@ using DotNetty.Transport.Channels.Embedded;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {
@@ -82,6 +79,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task BatchWriter_should_succeed_with_timer()
         {
+            var token = TestContext.Current.CancellationToken;
             var writer = new FlushConsolidationHandler();
             var ch = new EmbeddedChannel(Flush, writer);
 
@@ -107,7 +105,7 @@ namespace Akka.Remote.Tests.Transport
                 {
                     ch.RunPendingTasks(); // force scheduled task to run
                     ch.OutboundMessages.Count.Should().Be(ints.Length);
-                }, interval: 100.Milliseconds());
+                }, interval: 100.Milliseconds(), cancellationToken: token);
 
                 // reset the outbound queue
                 ch.OutboundMessages.Clear();
@@ -120,6 +118,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task BatchWriter_should_flush_messages_during_shutdown()
         {
+            var token = TestContext.Current.CancellationToken;
             var writer = new FlushConsolidationHandler();
             var ch = new EmbeddedChannel(Flush, writer);
 
@@ -147,7 +146,7 @@ namespace Akka.Remote.Tests.Transport
             {
                 ch.RunPendingTasks(); // force scheduled task to run
                 ch.OutboundMessages.Count.Should().Be(ints.Length);
-            }, interval: 100.Milliseconds());
+            }, interval: 100.Milliseconds(), cancellationToken: token);
 
 
         }

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyCertificateValidationSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyCertificateValidationSpec.cs
@@ -12,7 +12,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyMutualTlsSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyMutualTlsSpec.cs
@@ -11,7 +11,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {
@@ -70,6 +69,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Mutual_TLS_should_allow_connection_when_both_nodes_have_valid_certificates()
         {
+            var token = TestContext.Current.CancellationToken;
             // Both server and client have valid certs, mutual TLS enabled
             ActorSystem server = null;
             ActorSystem client = null;
@@ -90,7 +90,7 @@ namespace Akka.Remote.Tests.Transport
                 var serverEchoPath = new RootActorPath(serverAddr) / "user" / "echo";
 
                 // Should successfully connect and communicate
-                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5));
+                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5), token);
                 Assert.Equal("hello", response);
             }
             finally
@@ -105,6 +105,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Mutual_TLS_disabled_should_allow_standard_TLS_connection()
         {
+            var token = TestContext.Current.CancellationToken;
             // Server has mutual TLS disabled (standard server-only TLS)
             ActorSystem server = null;
             ActorSystem client = null;
@@ -125,7 +126,7 @@ namespace Akka.Remote.Tests.Transport
                 var serverEchoPath = new RootActorPath(serverAddr) / "user" / "echo";
 
                 // Should successfully connect with standard TLS
-                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5));
+                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5), token);
                 Assert.Equal("hello", response);
             }
             finally
@@ -166,6 +167,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Mutual_TLS_should_fail_when_client_has_no_certificate()
         {
+            var token = TestContext.Current.CancellationToken;
             // Server requires mutual TLS, client has SSL enabled but no certificate configured
             ActorSystem server = null;
             ActorSystem client = null;
@@ -190,7 +192,7 @@ namespace Akka.Remote.Tests.Transport
                 // Enhanced error message "no client certificate provided" will be logged to server logs
                 await Assert.ThrowsAsync<AskTimeoutException>(async () =>
                 {
-                    await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(3));
+                    await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(3), token);
                 });
             }
             finally
@@ -205,6 +207,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Mutual_TLS_can_be_disabled_for_backward_compatibility()
         {
+            var token = TestContext.Current.CancellationToken;
             // Test that setting require-mutual-authentication = false allows old behavior
             ActorSystem server = null;
             ActorSystem client = null;
@@ -226,7 +229,7 @@ namespace Akka.Remote.Tests.Transport
                 var serverEchoPath = new RootActorPath(serverAddr) / "user" / "echo";
 
                 // Should successfully connect even with mutual TLS disabled
-                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5));
+                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5), token);
                 Assert.Equal("hello", response);
             }
             finally
@@ -241,6 +244,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Mutual_TLS_should_fail_when_client_has_different_valid_certificate()
         {
+            var token = TestContext.Current.CancellationToken;
             // Server and client have different valid certificates - mutual TLS should fail
             // because the certificates are not trusted by each other
             ActorSystem server = null;
@@ -268,7 +272,7 @@ namespace Akka.Remote.Tests.Transport
                 // Enhanced error message with certificate validation details will be logged to server logs
                 await Assert.ThrowsAsync<AskTimeoutException>(async () =>
                 {
-                    await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(3));
+                    await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(3), token);
                 });
             }
             finally
@@ -283,6 +287,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact(DisplayName = "Different certificates with hostname validation disabled should connect successfully")]
         public async Task Hostname_validation_disabled_should_allow_different_certificates()
         {
+            var token = TestContext.Current.CancellationToken;
             // Per-node certificates should work when hostname validation is disabled
             // Note: Using suppressValidation=true to bypass chain validation since test certs are self-signed
             // This isolates the hostname validation logic we're testing
@@ -308,7 +313,7 @@ namespace Akka.Remote.Tests.Transport
                 InitializeLogger(client, "[CLIENT] ");
 
                 // Should successfully connect because hostname validation is disabled
-                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5));
+                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5), token);
                 Assert.Equal("hello", response);
             }
             finally
@@ -323,6 +328,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact(DisplayName = "Different certificates with hostname validation enabled should fail with name mismatch")]
         public async Task Hostname_validation_enabled_should_reject_different_certificates()
         {
+            var token = TestContext.Current.CancellationToken;
             // When hostname validation is enabled, different certificates should fail with RemoteCertificateNameMismatch
             // Note: Using suppressValidation=true to bypass chain validation and test hostname validation specifically
             ActorSystem server = null;
@@ -349,7 +355,7 @@ namespace Akka.Remote.Tests.Transport
                 // Should fail because hostname in certificate doesn't match connection target (127.0.0.1)
                 await Assert.ThrowsAsync<AskTimeoutException>(async () =>
                 {
-                    await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(3));
+                    await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(3), token);
                 });
             }
             finally
@@ -364,6 +370,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact(DisplayName = "Same certificate should connect successfully (typical mutual TLS scenario)")]
         public async Task Same_certificate_should_connect_in_mutual_tls()
         {
+            var token = TestContext.Current.CancellationToken;
             // Typical mutual TLS: Both nodes use the same shared certificate
             // Hostname validation disabled because we're using IPs/per-node certs
             ActorSystem server = null;
@@ -388,7 +395,7 @@ namespace Akka.Remote.Tests.Transport
                 InitializeLogger(client, "[CLIENT] ");
 
                 // Should successfully connect - typical mutual TLS scenario
-                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5));
+                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5), token);
                 Assert.Equal("hello", response);
             }
             finally
@@ -403,6 +410,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact(DisplayName = "Hostname validation unspecified should default to disabled (backward compatibility)")]
         public async Task Hostname_validation_default_should_be_disabled()
         {
+            var token = TestContext.Current.CancellationToken;
             // When validate-certificate-hostname is not specified, it should default to false
             // Note: Using suppressValidation=true to bypass chain validation and test hostname default behavior
             ActorSystem server = null;
@@ -427,7 +435,7 @@ namespace Akka.Remote.Tests.Transport
                 InitializeLogger(client, "[CLIENT] ");
 
                 // Should successfully connect because hostname validation defaults to disabled
-                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5));
+                var response = await client.ActorSelection(serverEchoPath).Ask<string>("hello", TimeSpan.FromSeconds(5), token);
                 Assert.Equal("hello", response);
             }
             finally

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -74,6 +74,7 @@ akka {{
         [Fact]
         public async Task Secure_transport_should_be_possible_between_systems_sharing_the_same_certificate()
         {
+            var token = TestContext.Current.CancellationToken;
             Setup(true);
 
             var probe = CreateTestProbe();
@@ -81,20 +82,21 @@ akka {{
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3), cancellationToken: token);
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100), cancellationToken: token);
         }
 
         [Fact]
         public async Task Secure_transport_should_NOT_be_possible_between_systems_using_SSL_and_one_not_using_it()
         {
+            var token = TestContext.Current.CancellationToken;
             Setup(false);
 
             var probe = CreateTestProbe();
             await Assert.ThrowsAsync<RemoteTransportException>(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectNoMsgAsync();
+                await probe.ExpectNoMsgAsync(cancellationToken: token);
             });
         }
 
@@ -243,6 +245,7 @@ akka {{
         [Fact(DisplayName = "DotNettySslSetup with CustomValidator that accepts should allow connection")]
         public async Task CustomValidator_that_accepts_should_allow_connection()
         {
+            var token = TestContext.Current.CancellationToken;
             var validatorCalled = false;
 
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
@@ -284,8 +287,8 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3), cancellationToken: token);
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100), cancellationToken: token);
 
             // Verify that CustomValidator was actually called
             Assert.True(validatorCalled, "CustomValidator should have been invoked during TLS handshake");
@@ -294,6 +297,7 @@ akka {
         [Fact(DisplayName = "DotNettySslSetup with CustomValidator that rejects should prevent connection")]
         public async Task CustomValidator_that_rejects_should_prevent_connection()
         {
+            var token = TestContext.Current.CancellationToken;
             var validatorCalled = false;
 
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
@@ -334,7 +338,7 @@ akka {
 
             // Connection should fail due to custom validator rejection - TLS handshake fails, so message never arrives
             Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3), cancellationToken: token);
 
             // Verify that CustomValidator was actually called
             Assert.True(validatorCalled, "CustomValidator should have been invoked during TLS handshake");
@@ -412,6 +416,7 @@ akka {{
         [Fact(DisplayName = "CertificateValidation.PinnedCertificate should accept certificates with matching thumbprint")]
         public async Task PinnedCertificate_should_accept_matching_thumbprint()
         {
+            var token = TestContext.Current.CancellationToken;
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
 
             // Create validator that pins to this specific certificate
@@ -446,13 +451,14 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3), cancellationToken: token);
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100), cancellationToken: token);
         }
 
         [Fact(DisplayName = "CertificateValidation.PinnedCertificate should reject certificates with non-matching thumbprint")]
         public async Task PinnedCertificate_should_reject_non_matching_thumbprint()
         {
+            var token = TestContext.Current.CancellationToken;
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
 
             // Create validator that pins to a DIFFERENT thumbprint (connection should fail)
@@ -485,12 +491,13 @@ akka {
 
             // Connection should fail due to thumbprint mismatch
             Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3), cancellationToken: token);
         }
 
         [Fact(DisplayName = "CertificateValidation.ValidateSubject should accept certificates with matching subject")]
         public async Task ValidateSubject_should_accept_matching_subject()
         {
+            var token = TestContext.Current.CancellationToken;
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
 
             // Create validator that accepts the certificate's actual subject
@@ -525,13 +532,14 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3), cancellationToken: token);
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100), cancellationToken: token);
         }
 
         [Fact(DisplayName = "CertificateValidation.ValidateSubject should reject certificates with non-matching subject")]
         public async Task ValidateSubject_should_reject_non_matching_subject()
         {
+            var token = TestContext.Current.CancellationToken;
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
 
             // Create validator with a subject that won't match
@@ -564,7 +572,7 @@ akka {
 
             // Connection should fail due to subject mismatch
             Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(3), cancellationToken: token);
         }
 
         [Fact(DisplayName = "CertificateValidation.ValidateSubject should support wildcard patterns")]
@@ -605,6 +613,7 @@ akka {
         [Fact(DisplayName = "CertificateValidation.ValidateIssuer should accept certificates with matching issuer")]
         public async Task ValidateIssuer_should_accept_matching_issuer()
         {
+            var token = TestContext.Current.CancellationToken;
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
 
             // Create validator that accepts the certificate's actual issuer
@@ -639,13 +648,14 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3), cancellationToken: token);
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100), cancellationToken: token);
         }
 
         [Fact(DisplayName = "CertificateValidation.ChainPlusThen should combine chain validation with custom logic")]
         public async Task ChainPlusThen_should_combine_validation()
         {
+            var token = TestContext.Current.CancellationToken;
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
 
             // Create validator that does chain validation PLUS custom check
@@ -695,8 +705,8 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3), cancellationToken: token);
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100), cancellationToken: token);
 
             // Verify custom validation was actually called
             Assert.True(customCheckCalled, "Custom validation logic should have been invoked");
@@ -705,6 +715,7 @@ akka {
         [Fact(DisplayName = "CustomValidator should take precedence over validateCertificateHostname setting")]
         public async Task CustomValidator_should_override_hostname_validation_setting()
         {
+            var token = TestContext.Current.CancellationToken;
             var certificate = new X509Certificate2(ValidCertPath, Password, X509KeyStorageFlags.DefaultKeySet);
 
             // Create a custom validator that accepts everything
@@ -753,8 +764,8 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3), cancellationToken: token);
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100), cancellationToken: token);
 
             // Verify custom validator was called (proving it took precedence)
             Assert.True(customValidatorCalled, "CustomValidator should have been invoked, proving it takes precedence");

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -14,8 +14,6 @@ using Akka.Configuration;
 using Akka.Remote.Transport.DotNetty;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
-using static Akka.Util.RuntimeDetector;
 
 namespace Akka.Remote.Tests.Transport
 {

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
@@ -160,6 +160,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Secure_transport_should_be_possible_between_systems_sharing_the_same_certificate()
         {
+            var token = TestContext.Current.CancellationToken;
             Setup(ValidCertPath, Password);
 
             var probe = CreateTestProbe();
@@ -167,8 +168,8 @@ namespace Akka.Remote.Tests.Transport
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3), cancellationToken: token);
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100), cancellationToken: token);
         }
 
         [LocalFact(SkipLocal = "Racy in Azure AzDo CI/CD")]
@@ -198,13 +199,14 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Secure_transport_should_NOT_be_possible_between_systems_using_SSL_and_one_not_using_it()
         {
+            var token = TestContext.Current.CancellationToken;
             Setup(null, null);
 
             var probe = CreateTestProbe();
             await Assert.ThrowsAsync<RemoteTransportException>(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectNoMsgAsync();
+                await probe.ExpectNoMsgAsync(cancellationToken: token);
             });
         }
 

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
@@ -6,18 +6,14 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2.Attributes;
-using FluentAssertions;
+using Akka.TestKit.Xunit.Attributes;
 using Xunit;
-using Xunit.Abstractions;
-using static Akka.Util.RuntimeDetector;
 
 namespace Akka.Remote.Tests.Transport
 {

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTlsHandshakeFailureSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTlsHandshakeFailureSpec.cs
@@ -14,9 +14,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
-using Akka.Event;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {
@@ -152,6 +150,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact(DisplayName = "Server should NOT shutdown when invalid traffic (like HTTP) hits TLS port")]
         public async Task Server_side_invalid_traffic_should_not_shutdown_server()
         {
+            var token = TestContext.Current.CancellationToken;
             // This test addresses issue https://github.com/akkadotnet/akka.net/issues/7938
             // When invalid traffic (like HTTP requests) hits a TLS-enabled port,
             // the server should reject the connection but NOT shut down
@@ -175,12 +174,16 @@ namespace Akka.Remote.Tests.Transport
                 try
                 {
                     using var tcpClient = new TcpClient();
+                    #if NETFRAMEWORK
                     await tcpClient.ConnectAsync("127.0.0.1", port);
+                    #else
+                    await tcpClient.ConnectAsync("127.0.0.1", port, token);
+                    #endif
 
                     // Send an HTTP OPTIONS request (as described in the bug report)
                     var httpRequest = Encoding.UTF8.GetBytes("OPTIONS / HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
-                    await tcpClient.GetStream().WriteAsync(httpRequest, 0, httpRequest.Length);
-                    await tcpClient.GetStream().FlushAsync();
+                    await tcpClient.GetStream().WriteAsync(httpRequest, 0, httpRequest.Length, token);
+                    await tcpClient.GetStream().FlushAsync(token);
 
                     // Connection should be closed by server after rejecting invalid TLS
                     tcpClient.Close();
@@ -193,7 +196,7 @@ namespace Akka.Remote.Tests.Transport
                 // Verify the server hasn't initiated shutdown
                 // If it was going to shut down due to TLS failure, it would have done so immediately
                 await AwaitConditionAsync(() => !server.WhenTerminated.IsCompleted,
-                    TimeSpan.FromSeconds(3), TimeSpan.FromMilliseconds(100));
+                    TimeSpan.FromSeconds(3), TimeSpan.FromMilliseconds(100), cancellationToken: token);
 
                 // CRITICAL ASSERTION: Server should NOT have shut down
                 Assert.False(server.WhenTerminated.IsCompleted,

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTlsHandshakeFailureSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTlsHandshakeFailureSpec.cs
@@ -107,6 +107,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Client_side_tls_handshake_failure_should_shutdown_client()
         {
+            var token = TestContext.Current.CancellationToken;
             // Server has valid cert; client enforces validation so it should reject the self-signed server cert
             ActorSystem server = null;
             ActorSystem client = null;
@@ -136,7 +137,7 @@ namespace Akka.Remote.Tests.Transport
                 {
                     Assert.True(client.WhenTerminated.IsCompleted);
                     await Task.CompletedTask;
-                }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(200));
+                }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(200), cancellationToken: token);
             }
             finally
             {

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
@@ -6,9 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.Transport;
 using Akka.Remote.Transport.DotNetty;
@@ -73,6 +71,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task DotNettyTcpTransport_should_cleanly_terminate_active_endpoints_upon_outbound_disassociate()
         {
+            var token = TestContext.Current.CancellationToken;
             var config = Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp");
             Assert.False(config.IsNullOrEmpty());
 
@@ -92,11 +91,11 @@ namespace Akka.Remote.Tests.Transport
                 // t1 --> t2 association
                 var handle = await t1.Associate(c2.Item1);
                 handle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
-                var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>()).Association; // wait for the inbound association handle to show up
+                var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>(cancellationToken: token)).Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2));
-                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2));
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2), cancellationToken: token);
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2), cancellationToken: token);
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -105,9 +104,9 @@ namespace Akka.Remote.Tests.Transport
                 handle.Disassociate("Dissociation test", Log);
 
                 // verify that the connections are terminated
-                await p1.ExpectMsgAsync<Disassociated>();
-                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1));
-                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 1));
+                await p1.ExpectMsgAsync<Disassociated>(cancellationToken: token);
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1), cancellationToken: token);
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 1), cancellationToken: token);
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -123,6 +122,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task DotNettyTcpTransport_should_cleanly_terminate_active_endpoints_upon_outbound_shutdown()
         {
+            var token = TestContext.Current.CancellationToken;
             var config = Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp");
             Assert.False(config.IsNullOrEmpty());
 
@@ -142,11 +142,11 @@ namespace Akka.Remote.Tests.Transport
                 // t1 --> t2 association
                 var handle = await t1.Associate(c2.Item1);
                 handle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
-                var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>()).Association; // wait for the inbound association handle to show up
+                var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>(cancellationToken: token)).Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2));
-                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2));
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2), cancellationToken: token);
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2), cancellationToken: token);
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -154,10 +154,10 @@ namespace Akka.Remote.Tests.Transport
                 //  shutdown remoting on t1
                 await t1.Shutdown();
 
-                await p2.ExpectMsgAsync<Disassociated>();
+                await p2.ExpectMsgAsync<Disassociated>(cancellationToken: token);
                 // verify that the connections are terminated
-                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 0), null, message: $"Expected 0 open connection but found {t1.ConnectionGroup.Count}");
-                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 1), null,message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 0), null, message: $"Expected 0 open connection but found {t1.ConnectionGroup.Count}", cancellationToken: token);
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 1), null, message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}", cancellationToken: token);
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -173,6 +173,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task DotNettyTcpTransport_should_cleanly_terminate_active_endpoints_upon_inbound_disassociate()
         {
+            var token = TestContext.Current.CancellationToken;
             var config = Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp");
             Assert.False(config.IsNullOrEmpty());
 
@@ -192,11 +193,11 @@ namespace Akka.Remote.Tests.Transport
                 // t1 --> t2 association
                 var handle = await t1.Associate(c2.Item1);
                 handle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
-                var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>()).Association; // wait for the inbound association handle to show up
+                var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>(cancellationToken: token)).Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2));
-                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2));
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2), cancellationToken: token);
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2), cancellationToken: token);
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -205,8 +206,8 @@ namespace Akka.Remote.Tests.Transport
                 inboundHandle.Disassociate("Dissociation test", Log);
 
                 // verify that the connections are terminated
-                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1), null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
-                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 1), null, message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1), null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}", cancellationToken: token);
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 1), null, message: $"Expected 1 open connection but found {t2.ConnectionGroup.Count}", cancellationToken: token);
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -222,6 +223,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task DotNettyTcpTransport_should_cleanly_terminate_active_endpoints_upon_inbound_shutdown()
         {
+            var token = TestContext.Current.CancellationToken;
             var config = Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp");
             Assert.False(config.IsNullOrEmpty());
 
@@ -241,11 +243,11 @@ namespace Akka.Remote.Tests.Transport
                 // t1 --> t2 association
                 var handle = await t1.Associate(c2.Item1);
                 handle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
-                var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>()).Association; // wait for the inbound association handle to show up
+                var inboundHandle = (await p2.ExpectMsgAsync<InboundAssociation>(cancellationToken: token)).Association; // wait for the inbound association handle to show up
                 inboundHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
 
-                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2));
-                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2));
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 2), cancellationToken: token);
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 2), cancellationToken: token);
 
                 var chan1 = t1.ConnectionGroup.Single(x => !x.Id.Equals(t1.ServerChannel.Id));
                 var chan2 = t2.ConnectionGroup.Single(x => !x.Id.Equals(t2.ServerChannel.Id));
@@ -254,8 +256,8 @@ namespace Akka.Remote.Tests.Transport
                 await t2.Shutdown();
 
                 // verify that the connections are terminated
-                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1), null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}");
-                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 0), null, message: $"Expected 0 open connection but found {t2.ConnectionGroup.Count}");
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1), null, message: $"Expected 1 open connection but found {t1.ConnectionGroup.Count}", cancellationToken: token);
+                await AwaitConditionAsync(() => Task.FromResult(t2.ConnectionGroup.Count == 0), null, message: $"Expected 0 open connection but found {t2.ConnectionGroup.Count}", cancellationToken: token);
 
                 // verify that the connection channels were terminated on both ends
                 chan1.CloseCompletion.IsCompleted.Should().BeTrue();
@@ -271,6 +273,7 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task DotNettyTcpTransport_should_cleanly_terminate_endpoints_upon_failed_outbound_connection()
         {
+            var token = TestContext.Current.CancellationToken;
             var config = Sys.Settings.Config.GetConfig("akka.remote.dot-netty.tcp");
             Assert.False(config.IsNullOrEmpty());
 
@@ -290,7 +293,7 @@ namespace Akka.Remote.Tests.Transport
                 });
 
 
-                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1));
+                await AwaitConditionAsync(() => Task.FromResult(t1.ConnectionGroup.Count == 1), cancellationToken: token);
             }
             finally
             {

--- a/src/core/Akka.Remote.Tests/Transport/GenericTransportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/GenericTransportSpec.cs
@@ -66,10 +66,11 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Transport_must_return_an_Address_and_promise_when_listen_is_called()
         {
+            var token = TestContext.Current.CancellationToken;
             var registry = new AssociationRegistry();
             var transportA = NewTransportA(registry);
 
-            var result = await transportA.Listen().WithTimeout(DefaultTimeout);
+            var result = await transportA.Listen().WaitAsync(DefaultTimeout, token);
 
             Assert.Equal(_addressA, result.Item1);
             Assert.NotNull(result.Item2);
@@ -80,15 +81,18 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Transport_must_associate_successfully_with_another_transport_of_its_kind()
         {
+            var token = TestContext.Current.CancellationToken;
             var registry = new AssociationRegistry();
             var transportA = NewTransportA(registry);
             var transportB = NewTransportB(registry);
 
             // Must complete the returned promise to receive events
-            (await transportA.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
-            (await transportB.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
+            (await transportA.Listen().WaitAsync(DefaultTimeout, token))
+                .Item2.SetResult(new ActorAssociationEventListener(TestActor));
+            (await transportB.Listen().WaitAsync(DefaultTimeout, token))
+                .Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
-            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest, _addressBTest)));
+            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest, _addressBTest)), token);
 
             // task is not awaited deliberately
             var task = transportA.Associate(_addressB);
@@ -98,38 +102,44 @@ namespace Akka.Remote.Tests.Transport
                     return inbound.Association;
 
                 return null;
-            });
+            }, token);
 
             Assert.Contains(registry.LogSnapshot().OfType<AssociateAttempt>(), x => x.LocalAddress == _addressATest && x.RemoteAddress == _addressBTest);
-            await AwaitConditionAsync(() => Task.FromResult(registry.ExistsAssociation(_addressATest, _addressBTest)));
+            await AwaitConditionAsync(() => Task.FromResult(registry.ExistsAssociation(_addressATest, _addressBTest)), token);
         }
 
         [Fact]
         public async Task Transport_must_fail_to_associate_with_non_existing_address()
         {
+            var token = TestContext.Current.CancellationToken;
             var registry = new AssociationRegistry();
             var transportA = NewTransportA(registry);
 
-            (await transportA.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
-            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest)));
+            (await transportA.Listen().WaitAsync(DefaultTimeout, token))
+                .Item2.SetResult(new ActorAssociationEventListener(TestActor));
+            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest)), token);
 
             // Transport throws InvalidAssociationException when trying to associate with non-existing system
             await Assert.ThrowsAsync<InvalidAssociationException>(async () =>
-                await transportA.Associate(_nonExistingAddress).WithTimeout(DefaultTimeout)
+                await transportA.Associate(_nonExistingAddress)
+                    .WaitAsync(DefaultTimeout, token)
             );
         }
 
         [Fact]
         public async Task Transport_must_successfully_send_PDUs()
         {
+            var token = TestContext.Current.CancellationToken;
             var registry = new AssociationRegistry();
             var transportA = NewTransportA(registry);
             var transportB = NewTransportB(registry);
 
-            (await transportA.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
-            (await transportB.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
+            (await transportA.Listen().WaitAsync(DefaultTimeout, token))
+                .Item2.SetResult(new ActorAssociationEventListener(TestActor));
+            (await transportB.Listen().WaitAsync(DefaultTimeout, token))
+                .Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
-            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest, _addressBTest)));
+            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest, _addressBTest)), token);
 
             var associate = transportA.Associate(_addressB);
             var handleB = await ExpectMsgOfAsync(DefaultTimeout, "Expect InboundAssociation from A", o =>
@@ -138,9 +148,9 @@ namespace Akka.Remote.Tests.Transport
                     return handle.Association;
 
                 return null;
-            });
+            }, token);
 
-            var handleA = await associate.WithTimeout(DefaultTimeout);
+            var handleA = await associate.WaitAsync(DefaultTimeout, token);
 
             // Initialize handles
             handleA.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
@@ -149,7 +159,7 @@ namespace Akka.Remote.Tests.Transport
             var payload = ByteString.CopyFromUtf8("PDU");
             var pdu = _withAkkaProtocol ? new AkkaPduProtobuffCodec(Sys).ConstructPayload(payload) : payload;
             
-            await AwaitConditionAsync(() => Task.FromResult(registry.ExistsAssociation(_addressATest, _addressBTest)));
+            await AwaitConditionAsync(() => Task.FromResult(registry.ExistsAssociation(_addressATest, _addressBTest)), token);
 
             handleA.Write(payload);
             await ExpectMsgOfAsync(DefaultTimeout, "Expect InboundPayload from A", o =>
@@ -158,7 +168,7 @@ namespace Akka.Remote.Tests.Transport
                     return inboundPayload.Payload;
 
                 return null;
-            });
+            }, token);
 
             Assert.Contains(registry.LogSnapshot().OfType<WriteAttempt>(), x => x.Sender == _addressATest && x.Recipient == _addressBTest && x.Payload.Equals(pdu));
         }
@@ -166,14 +176,17 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task Transport_must_successfully_disassociate()
         {
+            var token = TestContext.Current.CancellationToken;
             var registry = new AssociationRegistry();
             var transportA = NewTransportA(registry);
             var transportB = NewTransportB(registry);
 
-            (await transportA.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
-            (await transportB.Listen().WithTimeout(DefaultTimeout)).Item2.SetResult(new ActorAssociationEventListener(TestActor));
+            (await transportA.Listen().WaitAsync(DefaultTimeout, token))
+                .Item2.SetResult(new ActorAssociationEventListener(TestActor));
+            (await transportB.Listen().WaitAsync(DefaultTimeout, token))
+                .Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
-            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest, _addressBTest)));
+            await AwaitConditionAsync(() => Task.FromResult(registry.TransportsReady(_addressATest, _addressBTest)), token);
 
             var associate = transportA.Associate(_addressB);
             var handleB = await ExpectMsgOfAsync(DefaultTimeout, "Expect InboundAssociation from A", o =>
@@ -182,26 +195,24 @@ namespace Akka.Remote.Tests.Transport
                     return handle.Association;
 
                 return null;
-            });
+            }, token);
 
-            var handleA = await associate.WithTimeout(DefaultTimeout);
+            var handleA = await associate.WaitAsync(DefaultTimeout, token);
 
             // Initialize handles
             handleA.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
             handleB.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
 
-            await AwaitConditionAsync(() => Task.FromResult(registry.ExistsAssociation(_addressATest, _addressBTest)));
+            await AwaitConditionAsync(() => Task.FromResult(registry.ExistsAssociation(_addressATest, _addressBTest)), token);
 
             handleA.Disassociate("Disassociation test", Log);
 
-            await ExpectMsgOfAsync(DefaultTimeout, "Should receive Disassociated", o => o as Disassociated);
+            await ExpectMsgOfAsync(DefaultTimeout, "Should receive Disassociated", o => o as Disassociated, token);
 
-            await AwaitConditionAsync(() => Task.FromResult(!registry.ExistsAssociation(_addressATest, _addressBTest)));
+            await AwaitConditionAsync(() => Task.FromResult(!registry.ExistsAssociation(_addressATest, _addressBTest)), token);
 
             await AwaitConditionAsync(() =>
-                Task.FromResult(registry.LogSnapshot().OfType<DisassociateAttempt>().Any(x => x.Requestor == _addressATest && x.Remote == _addressBTest))
-
-            );
+                Task.FromResult(registry.LogSnapshot().OfType<DisassociateAttempt>().Any(x => x.Requestor == _addressATest && x.Remote == _addressBTest)), token);
         }
     }
 }

--- a/src/core/Akka.Remote.Tests/Transport/MultiTransportAddressingSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/MultiTransportAddressingSpec.cs
@@ -9,16 +9,14 @@ using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
-using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport;
 
 /// <summary>
 /// Added this spec to prove the existence of https://github.com/akkadotnet/akka.net/issues/7378
 /// </summary>
-public class MultiTransportAddressingSpec : TestKit.Xunit2.TestKit
+public class MultiTransportAddressingSpec : TestKit.Xunit.TestKit
 {
     public MultiTransportAddressingSpec(ITestOutputHelper output) : base(GetConfig(Sys1Port1, Sys1Port2), "MultiTransportSpec", output)
     {

--- a/src/core/Akka.Remote.Tests/Transport/TestTransportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/TestTransportSpec.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Remote.Transport;
 using Akka.TestKit;
-using Akka.TestKit.Extensions;
 using Akka.Util.Internal;
 using Google.Protobuf;
 using Xunit;
@@ -35,11 +34,12 @@ namespace Akka.Remote.Tests.Transport
         public async Task TestTransport_must_return_an_Address_and_TaskCompletionSource_on_Listen()
         {
             //arrange
+            var token = TestContext.Current.CancellationToken;
             var registry = new AssociationRegistry();
             var transportA = new TestTransport(_addressA, registry);
 
             //act
-            var result = await transportA.Listen().WithTimeout(DefaultTimeout);
+            var result = await transportA.Listen().WaitAsync(DefaultTimeout, token);
 
             //assert
             Assert.Equal(_addressA, result.Item1);
@@ -55,6 +55,7 @@ namespace Akka.Remote.Tests.Transport
         public async Task TestTransport_must_associate_successfully_with_another_TestTransport()
         {
             //arrange
+            var token = TestContext.Current.CancellationToken;
             var registry = new AssociationRegistry();
             var transportA = new TestTransport(_addressA, registry);
             var transportB = new TestTransport(_addressB, registry);
@@ -62,10 +63,12 @@ namespace Akka.Remote.Tests.Transport
             //act
 
             //must complete returned promises to receive events
-            var localConnectionFuture = await transportA.Listen().WithTimeout(DefaultTimeout);
+            var localConnectionFuture = await transportA.Listen()
+                .WaitAsync(DefaultTimeout, token);
             localConnectionFuture.Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
-            var remoteConnectionFuture = await transportB.Listen().WithTimeout(DefaultTimeout);
+            var remoteConnectionFuture = await transportB.Listen()
+                .WaitAsync(DefaultTimeout, token);
             remoteConnectionFuture.Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
             var ready = registry.TransportsReady(_addressA, _addressB);
@@ -74,7 +77,7 @@ namespace Akka.Remote.Tests.Transport
             // task is deliberately not awaited
             var task = transportA.Associate(_addressB);
             await ExpectMsgOfAsync(DefaultTimeout, "Expect InboundAssociation from A",
-                m => m.AsInstanceOf<InboundAssociation>().Association);
+                m => m.AsInstanceOf<InboundAssociation>().Association, token);
 
             //assert
             var associateAttempt = (registry.LogSnapshot().Single(x => x is AssociateAttempt)).AsInstanceOf<AssociateAttempt>();
@@ -86,17 +89,20 @@ namespace Akka.Remote.Tests.Transport
         public async Task TestTransport_fail_to_association_with_non_existing_Address()
         {
             //arrange
+            var token = TestContext.Current.CancellationToken;
             var registry = new AssociationRegistry();
             var transportA = new TestTransport(_addressA, registry);
 
             //act
-            var result = await transportA.Listen().WithTimeout(DefaultTimeout);
+            var result = await transportA.Listen()
+                .WaitAsync(DefaultTimeout, token);
             result.Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
             //assert
             await Assert.ThrowsAsync<InvalidAssociationException>(async () =>
             {
-                await transportA.Associate(_nonExistantAddress).WithTimeout(DefaultTimeout);
+                await transportA.Associate(_nonExistantAddress)
+                    .WaitAsync(DefaultTimeout, token);
             });
         }
 
@@ -104,6 +110,7 @@ namespace Akka.Remote.Tests.Transport
         public async Task TestTransport_should_emulate_sending_PDUs()
         {
             //arrange
+            var token = TestContext.Current.CancellationToken;
             var registry = new AssociationRegistry();
             var transportA = new TestTransport(_addressA, registry);
             var transportB = new TestTransport(_addressB, registry);
@@ -111,10 +118,12 @@ namespace Akka.Remote.Tests.Transport
             //act
 
             //must complete returned promises to receive events
-            var localConnectionFuture = await transportA.Listen().WithTimeout(DefaultTimeout);
+            var localConnectionFuture = await transportA.Listen()
+                .WaitAsync(DefaultTimeout, token);
             localConnectionFuture.Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
-            var remoteConnectionFuture = await transportB.Listen().WithTimeout(DefaultTimeout);
+            var remoteConnectionFuture = await transportB.Listen()
+                .WaitAsync(DefaultTimeout, token);
             remoteConnectionFuture.Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
             var ready = registry.TransportsReady(_addressA, _addressB);
@@ -126,10 +135,10 @@ namespace Akka.Remote.Tests.Transport
                 if (o is InboundAssociation handle && handle.Association.RemoteAddress.Equals(_addressA)) 
                     return handle.Association;
                 return null;
-            });
+            }, token);
             handleB.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
 
-            await associate.WithTimeout(DefaultTimeout);
+            await associate.WaitAsync(DefaultTimeout, token);
             var handleA = await associate;
 
             //Initialize handles
@@ -148,7 +157,7 @@ namespace Akka.Remote.Tests.Transport
                 if (o is InboundPayload payload && payload.Payload.Equals(akkaPdu)) 
                     return akkaPdu;
                 return null;
-            });
+            }, token);
 
             var writeAttempt = (registry.LogSnapshot().Single(x => x is WriteAttempt)).AsInstanceOf<WriteAttempt>();
             Assert.True(writeAttempt.Sender.Equals(_addressA) && writeAttempt.Recipient.Equals(_addressB)
@@ -159,6 +168,7 @@ namespace Akka.Remote.Tests.Transport
         public async Task TestTransport_should_emulate_disassociation()
         {
             //arrange
+            var token = TestContext.Current.CancellationToken;
             var registry = new AssociationRegistry();
             var transportA = new TestTransport(_addressA, registry);
             var transportB = new TestTransport(_addressB, registry);
@@ -166,10 +176,10 @@ namespace Akka.Remote.Tests.Transport
             //act
 
             //must complete returned promises to receive events
-            var localConnectionFuture = await transportA.Listen().WithTimeout(DefaultTimeout);
+            var localConnectionFuture = await transportA.Listen().WaitAsync(DefaultTimeout, token);
             localConnectionFuture.Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
-            var remoteConnectionFuture = await transportB.Listen().WithTimeout(DefaultTimeout);
+            var remoteConnectionFuture = await transportB.Listen().WaitAsync(DefaultTimeout, token);
             remoteConnectionFuture.Item2.SetResult(new ActorAssociationEventListener(TestActor));
 
             var ready = registry.TransportsReady(_addressA, _addressB);
@@ -181,10 +191,10 @@ namespace Akka.Remote.Tests.Transport
                 if (o is InboundAssociation handle && handle.Association.RemoteAddress.Equals(_addressA)) 
                     return handle.Association;
                 return null;
-            });
+            }, token);
             handleB.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
 
-            await associate.WithTimeout(DefaultTimeout);
+            await associate.WaitAsync(DefaultTimeout, token);
             var handleA = await associate;
 
             //Initialize handles
@@ -195,7 +205,7 @@ namespace Akka.Remote.Tests.Transport
 
             handleA.Disassociate("Disassociation test", Log);
 
-            var msg = await ExpectMsgOfAsync(DefaultTimeout, "Expected Disassociated", o => o.AsInstanceOf<Disassociated>());
+            var msg = await ExpectMsgOfAsync(DefaultTimeout, "Expected Disassociated", o => o.AsInstanceOf<Disassociated>(), token);
 
             //assert
             Assert.NotNull(msg);

--- a/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
@@ -13,7 +13,6 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.Remote.Transport;
 using Akka.TestKit;
-using Akka.TestKit.Extensions;
 using Akka.TestKit.Internal;
 using Akka.TestKit.Internal.StringMatcher;
 using Akka.TestKit.TestEvent;
@@ -22,7 +21,6 @@ using Akka.Util.Internal;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {
@@ -186,61 +184,62 @@ namespace Akka.Remote.Tests.Transport
         [Fact]
         public async Task ThrottlerTransportAdapter_must_maintain_average_message_rate()
         {
+            var token = TestContext.Current.CancellationToken;
             await Throttle(
                     ThrottleTransportAdapter.Direction.Send,
                     new Remote.Transport.TokenBucket(PingPacketSize * 4, BytesPerSecond, 0, 0))
-                .WaitAsync(TimeSpan.FromSeconds(3));
+                .WaitAsync(TimeSpan.FromSeconds(3), token);
 
             var here = await Here();
             var tester = Sys.ActorOf(Props.Create(() => new ThrottlingTester(here, TestActor)));
             tester.Tell("start");
 
-            var time = TimeSpan.FromTicks(await ExpectMsgAsync<long>(TimeSpan.FromSeconds(TotalTime + 12))).TotalSeconds;
+            var time = TimeSpan.FromTicks(await ExpectMsgAsync<long>(TimeSpan.FromSeconds(TotalTime + 12), cancellationToken: token)).TotalSeconds;
             Log.Warning("Total time of transmission: {0}", time);
             time.Should().BeGreaterThan(TotalTime - 12);
 
             await Throttle(ThrottleTransportAdapter.Direction.Send, Unthrottled.Instance)
-                .WaitAsync(TimeSpan.FromSeconds(3));
+                .WaitAsync(TimeSpan.FromSeconds(3), token);
         }
 
         [Fact]
         public async Task ThrottlerTransportAdapter_must_survive_blackholing()
         {
-            
+            var token = TestContext.Current.CancellationToken;
             var here = await Here();
             here.Tell(new ThrottlingTester.Lost("BlackHole 1"));
-            await ExpectMsgAsync(new ThrottlingTester.Lost("BlackHole 1"));
+            await ExpectMsgAsync(new ThrottlingTester.Lost("BlackHole 1"), cancellationToken: token);
 
             MuteDeadLetters(typeof(ThrottlingTester.Lost));
             MuteDeadLetters(_systemB, typeof(ThrottlingTester.Lost));
 
             await Throttle(ThrottleTransportAdapter.Direction.Both, Blackhole.Instance)
-                .WaitAsync(3.Seconds());
+                .WaitAsync(3.Seconds(), token);
 
             here.Tell(new ThrottlingTester.Lost("BlackHole 2"));
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
-            await Disassociate().WaitAsync(TimeSpan.FromSeconds(3));
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
+            await Disassociate().WaitAsync(TimeSpan.FromSeconds(3), token);
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), token);
 
             await Throttle(ThrottleTransportAdapter.Direction.Both, Unthrottled.Instance)
-                .WaitAsync(TimeSpan.FromSeconds(3));
+                .WaitAsync(TimeSpan.FromSeconds(3), token);
 
             // after we remove the Blackhole we can't be certain of the state
             // of the connection, repeat until success
             here.Tell(new ThrottlingTester.Lost("BlackHole 3"));
             await AwaitConditionAsync(async () =>
             {
-                var received = await ReceiveOneAsync(TimeSpan.Zero);
+                var received = await ReceiveOneAsync(TimeSpan.Zero, token);
                 if (received != null && received.Equals(new ThrottlingTester.Lost("BlackHole 3")))
                     return true;
 
                 here.Tell(new ThrottlingTester.Lost("BlackHole 3"));
 
                 return false;
-            }, TimeSpan.FromSeconds(15));
+            }, TimeSpan.FromSeconds(15), token);
 
             here.Tell("Cleanup");
-            await FishForMessageAsync(o => o.Equals("Cleanup"), TimeSpan.FromSeconds(5));
+            await FishForMessageAsync(o => o.Equals("Cleanup"), TimeSpan.FromSeconds(5), cancellationToken: token);
         }
 
         #endregion

--- a/src/core/Akka.Remote.Tests/UntrustedSpec.cs
+++ b/src/core/Akka.Remote.Tests/UntrustedSpec.cs
@@ -13,7 +13,6 @@ using Akka.Event;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {
@@ -79,7 +78,7 @@ namespace Akka.Remote.Tests
         {
             var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements);
             sel.Tell("hello");
-            await ExpectMsgAsync("hello");
+            await ExpectMsgAsync("hello", cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -93,7 +92,7 @@ namespace Akka.Remote.Tests
 
             var remoteDaemon = await RemoteDaemon(); 
             remoteDaemon.Tell("hello");
-            await logProbe.ExpectMsgAsync<Debug>();
+            await logProbe.ExpectMsgAsync<Debug>(cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -106,18 +105,19 @@ namespace Akka.Remote.Tests
             target2.Tell(PoisonPill.Instance);
             _client.Stop(target2);
             target2.Tell("blech");
-            await ExpectMsgAsync("blech");
+            await ExpectMsgAsync("blech", cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
         public async Task Untrusted_mode_must_discard_watch_messages()
         {
+            var token = TestContext.Current.CancellationToken;
             var target2 = await Target2();
             _client.ActorOf(Props.Create(() => new Target2Watch(target2, TestActor)).WithDeploy(Deploy.Local));
             _receptionist.Tell(new StopChild1("child2"));
-            await ExpectMsgAsync("child2 stopped");
+            await ExpectMsgAsync("child2 stopped", cancellationToken: token);
             // no Terminated msg, since watch was discarded
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: token);
         }
 
         [Fact]
@@ -125,7 +125,7 @@ namespace Akka.Remote.Tests
         {
             var sel = _client.ActorSelection(new RootActorPath(_address)/TestActor.Path.Elements);
             sel.Tell("hello");
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace Akka.Remote.Tests
         {
             var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements/"child1");
             sel.Tell("hello");
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace Akka.Remote.Tests
         {
             var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements/"*");
             sel.Tell("hello");
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
         }
 
         [Fact]
@@ -149,21 +149,22 @@ namespace Akka.Remote.Tests
         {
             var sel = _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements);
             sel.Tell(PoisonPill.Instance);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: TestContext.Current.CancellationToken);
         }
 
 
         [Fact]
         public async Task Untrusted_mode_must_discard_actor_selection_with_non_root_anchor()
         {
+            var token = TestContext.Current.CancellationToken;
             var p = CreateTestProbe(_client);
             _client.ActorSelection(new RootActorPath(_address)/_receptionist.Path.Elements)
                 .Tell(new Identify(null), p.Ref);
-            var clientReceptionistRef = (await p.ExpectMsgAsync<ActorIdentity>()).Subject;
+            var clientReceptionistRef = (await p.ExpectMsgAsync<ActorIdentity>(cancellationToken: token)).Subject;
 
             var sel = ActorSelection(clientReceptionistRef, _receptionist.Path.ToStringWithoutAddress());
             sel.Tell("hello");
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: token);
         }
 
 


### PR DESCRIPTION
Part of #7742

## Changes

Convert Akka.Remote.Tests to comply to xUnit3 conventions:
* Make sure that project only references xUnit 3
* All cancellation token arguments should be filled with `TestContext.Current.CancellationToken`

No logic change, all changes are done to comply to xUnit3 conventions only.