### PR TITLE
[xUnit 3] Convert Akka.Tests

### DIFF
--- a/src/core/Akka.Tests/Actor/ActorBecomeTests.cs
+++ b/src/core/Akka.Tests/Actor/ActorBecomeTests.cs
@@ -5,16 +5,20 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     
     public class ActorBecomeTests : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
 
         [Fact]
         public async Task When_calling_become_Then_the_new_handler_is_used()
@@ -29,7 +33,7 @@ namespace Akka.Tests.Actor
             actor.Tell("hello", TestActor);
 
             //Then
-            await ExpectMsgAsync("2:hello");
+            await ExpectMsgAsync("2:hello", cancellationToken: Token);
         }
 
 
@@ -55,7 +59,7 @@ namespace Akka.Tests.Actor
             actor.Tell("hello", TestActor);
 
             //Then
-            await ExpectMsgAsync("1:hello");
+            await ExpectMsgAsync("1:hello", cancellationToken: Token);
         }
 
 
@@ -80,7 +84,7 @@ namespace Akka.Tests.Actor
             actor.Tell("hello", TestActor);
 
             //Then
-            await ExpectMsgAsync("2:hello");
+            await ExpectMsgAsync("2:hello", cancellationToken: Token);
         }
 
         [Fact]
@@ -98,10 +102,10 @@ namespace Akka.Tests.Actor
             //which means this message should never be handled, because only B() has a receive for this.
             actor.Tell(2, TestActor);
 
-            await ExpectMsgAsync("A says: hi");
-            await ExpectMsgAsync("A says: True");
+            await ExpectMsgAsync("A says: hi", cancellationToken: Token);
+            await ExpectMsgAsync("A says: True", cancellationToken: Token);
             //we dont expect any further messages
-            await ExpectNoMsgAsync(default);
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
         }
 
         private class BecomeActor : UntypedActor

--- a/src/core/Akka.Tests/Actor/ActorCellSerializeMessagesTests.cs
+++ b/src/core/Akka.Tests/Actor/ActorCellSerializeMessagesTests.cs
@@ -8,7 +8,6 @@
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Tests.Actor;

--- a/src/core/Akka.Tests/Actor/ActorCellSerializeMessagesTests.cs
+++ b/src/core/Akka.Tests/Actor/ActorCellSerializeMessagesTests.cs
@@ -9,11 +9,14 @@ using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
 using FluentAssertions;
+using System.Threading;
 
 namespace Akka.Tests.Actor;
 
 public class ActorCellSerializeMessagesTests: AkkaSpec
 {
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
     private class InnerMessage
     {
         public InnerMessage(string payload)
@@ -51,7 +54,7 @@ public class ActorCellSerializeMessagesTests: AkkaSpec
     {
         var actor = Sys.ActorOf(Props.Create(() => new EchoActor()));
         actor.Tell(new MessageWrapper(new InnerMessage("payload")));
-        var receivedMsg = ExpectMsg<MessageWrapper>();
+        var receivedMsg = ExpectMsg<MessageWrapper>(cancellationToken: Token);
         receivedMsg.Message.Should().BeOfType<InnerMessage>().Which.Payload.Should().Be("payload");
     }
 }

--- a/src/core/Akka.Tests/Actor/ActorCellSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorCellSpec.cs
@@ -20,6 +20,8 @@ namespace Akka.Tests.Actor
 
     public class ActorCellSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public class DummyActor : ReceiveActor
         {
             public DummyActor()
@@ -47,13 +49,13 @@ namespace Akka.Tests.Actor
             var actor = Sys.ActorOf(Props.Create(() => new DummyActor()));
             
             // act
-            await actor.Ask<string>("hello", RemainingOrDefault);
+            await actor.Ask<string>("hello", RemainingOrDefault, cancellationToken: Token);
             
             // assert
             var refCell = (ActorRefWithCell)actor;
             //wait while current message is not null (that is, receive is not yet completed/exited)
 
-            AwaitCondition(() => refCell.Underlying is ActorCell { CurrentMessage: null });
+            AwaitCondition(() => refCell.Underlying is ActorCell { CurrentMessage: null }, cancellationToken: Token);
         }
 
         [Fact]
@@ -63,14 +65,14 @@ namespace Akka.Tests.Actor
             var actor = Sys.ActorOf(Props.Create(() => new DummyAsyncActor()));
             
             // act
-            await actor.Ask<string>("hello", RemainingOrDefault);
+            await actor.Ask<string>("hello", RemainingOrDefault, cancellationToken: Token);
 
             // assert
             
             var refCell = (ActorRefWithCell)actor;
             //wait while current message is not null (that is, receive is not yet completed/exited)
 
-            AwaitCondition(() => refCell.Underlying is ActorCell { CurrentMessage: null });
+            AwaitCondition(() => refCell.Underlying is ActorCell { CurrentMessage: null }, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/ActorCellTests_SerializationOfUserMessages.cs
+++ b/src/core/Akka.Tests/Actor/ActorCellTests_SerializationOfUserMessages.cs
@@ -11,11 +11,14 @@ using Akka.Actor;
 using Akka.TestKit;
 using Akka.Tests.TestUtils;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class WhenSerializeAllMessagesIsOff : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public class SomeUserMessage : Comparable
         {
             public string A { get; set; }
@@ -39,7 +42,7 @@ namespace Akka.Tests.Actor
             };
             TestActor.Tell(message);
 
-            var result = await ExpectMsgAsync<SomeUserMessage>();
+            var result = await ExpectMsgAsync<SomeUserMessage>(cancellationToken: Token);
 
             Assert.False(Sys.Settings.SerializeAllMessages);
             Assert.Equal(message, result);
@@ -50,6 +53,8 @@ namespace Akka.Tests.Actor
 
     public class WhenSerializeAllMessagesIsOn : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+
         public class SomeUserMessage : Comparable
         {
             public string A { get; set; }
@@ -72,7 +77,7 @@ namespace Akka.Tests.Actor
             };
             TestActor.Tell(message);
 
-            var result = await ExpectMsgAsync<SomeUserMessage>();
+            var result = await ExpectMsgAsync<SomeUserMessage>(cancellationToken: Token);
 
             Assert.True(Sys.Settings.SerializeAllMessages);
             Assert.Equal(message, result);

--- a/src/core/Akka.Tests/Actor/ActorDslSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorDslSpec.cs
@@ -11,11 +11,14 @@ using Akka.Actor;
 using Akka.Actor.Dsl;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class ActorDslSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact]
         public async Task A_lightweight_creator_must_support_creating_regular_actors()
         {
@@ -23,7 +26,7 @@ namespace Akka.Tests.Actor
                 c.Receive<string>(msg => msg == "hello", (msg, ctx) => TestActor.Tell("hi")))));
 
             a.Tell("hello");
-            await ExpectMsgAsync("hi");
+            await ExpectMsgAsync("hi", cancellationToken: Token);
         }
 
         [Fact]
@@ -52,15 +55,15 @@ namespace Akka.Tests.Actor
             }));
 
             a.Tell("info");
-            await ExpectMsgAsync("A");
+            await ExpectMsgAsync("A", cancellationToken: Token);
 
             a.Tell("switch");
             a.Tell("info");
-            await ExpectMsgAsync("B");
+            await ExpectMsgAsync("B", cancellationToken: Token);
 
             a.Tell("switch");
             a.Tell("info");
-            await ExpectMsgAsync("A");
+            await ExpectMsgAsync("A", cancellationToken: Token);
         }
 
         [Fact]
@@ -76,8 +79,8 @@ namespace Akka.Tests.Actor
             });
 
             Sys.Stop(a);
-            await ExpectMsgAsync(started);
-            await ExpectMsgAsync(stopped);
+            await ExpectMsgAsync(started, cancellationToken: Token);
+            await ExpectMsgAsync(stopped, cancellationToken: Token);
         }
 
         [Fact(Skip = "TODO: requires event filters")]
@@ -104,7 +107,7 @@ namespace Akka.Tests.Actor
                 act.ReceiveAny((x, _) => TestActor.Tell(x));
             }, "fred");
 
-            await ExpectMsgAsync("hello from akka://" + Sys.Name + "/user/fred/barney");
+            await ExpectMsgAsync("hello from akka://" + Sys.Name + "/user/fred/barney", cancellationToken: Token);
             LastSender.ShouldBe(a);
         }
 
@@ -134,11 +137,11 @@ namespace Akka.Tests.Actor
             }, "parent");
             
             parent.Tell("ping");
-            await ExpectMsgAsync("pong");
+            await ExpectMsgAsync("pong", cancellationToken: Token);
 
             parent.Tell("crash");
-            await ExpectMsgAsync("restarting parent");
-            await ExpectMsgAsync("stopping child");
+            await ExpectMsgAsync("restarting parent", cancellationToken: Token);
+            await ExpectMsgAsync("stopping child", cancellationToken: Token);
         }
 
         [Fact]
@@ -176,13 +179,13 @@ namespace Akka.Tests.Actor
             });
 
             parent.Tell("ping");
-            await ExpectMsgAsync("pong");
+            await ExpectMsgAsync("pong", cancellationToken: Token);
 
             parent.Tell("pong");
-            await ExpectMsgAsync("ping");
+            await ExpectMsgAsync("ping", cancellationToken: Token);
 
             parent.Tell("hi");
-            await ExpectMsgAsync("hello");
+            await ExpectMsgAsync("hello", cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/ActorLifeCycleFlowSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLifeCycleFlowSpec.cs
@@ -15,7 +15,6 @@ using Akka.TestKit;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor;
 

--- a/src/core/Akka.Tests/Actor/ActorLifeCycleFlowSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLifeCycleFlowSpec.cs
@@ -15,12 +15,15 @@ using Akka.TestKit;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor;
 
 #nullable enable
 public class ActorLifeCycleFlowSpec : AkkaSpec
 {
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
     internal static class Msg
     {
         public enum CallTime
@@ -235,7 +238,7 @@ public class ActorLifeCycleFlowSpec : AkkaSpec
         await AssertActorStartFlow(1, _emptyTimers);
 
         testActor.Tell(new Msg.Crash("I crashed"));
-        await ExpectMsgAsync(new Msg.Crashed(1));
+        await ExpectMsgAsync(new Msg.Crashed(1), cancellationToken: Token);
         await AssertActorRestartFlow(1, _emptyTimers, _emptyTimers);
         
         testActor.Tell(new Msg.Stop());
@@ -250,17 +253,17 @@ public class ActorLifeCycleFlowSpec : AkkaSpec
 
         var startedKeys = new[] { new Msg.StartTimer(Msg.Methods.None, Msg.CallTime.Single) }.ToImmutableArray();
         testActor.Tell(startedKeys[0]);
-        await ExpectMsgAsync<Msg.TimerStarted>();
+        await ExpectMsgAsync<Msg.TimerStarted>(cancellationToken: Token);
         testActor.Tell(new Msg.GetTimers());
-        var timers = await ExpectMsgAsync<Msg.Timers>();
+        var timers = await ExpectMsgAsync<Msg.Timers>(cancellationToken: Token);
         timers.ActiveTimers.Length.Should().Be(1);
         
         testActor.Tell(new Msg.Crash("I crashed"));
-        await ExpectMsgAsync(new Msg.Crashed(1));
+        await ExpectMsgAsync(new Msg.Crashed(1), cancellationToken: Token);
         await AssertActorRestartFlow(1, startedKeys, _emptyTimers);
         
         testActor.Tell(new Msg.GetTimers());
-        timers = await ExpectMsgAsync<Msg.Timers>();
+        timers = await ExpectMsgAsync<Msg.Timers>(cancellationToken: Token);
         timers.ActiveTimers.Length.Should().Be(0);
         
         testActor.Tell(new Msg.Stop());
@@ -280,11 +283,11 @@ public class ActorLifeCycleFlowSpec : AkkaSpec
         await AssertActorStartFlow(1, timerKeys);
 
         testActor.Tell(new Msg.Crash("I crashed"));
-        await ExpectMsgAsync(new Msg.Crashed(1));
+        await ExpectMsgAsync(new Msg.Crashed(1), cancellationToken: Token);
         await AssertActorRestartFlow(1, _emptyTimers, timerKeys);
         
         testActor.Tell(new Msg.GetTimers());
-        var timers = await ExpectMsgAsync<Msg.Timers>();
+        var timers = await ExpectMsgAsync<Msg.Timers>(cancellationToken: Token);
         timers.ActiveTimers.Length.Should().Be(0);
         
         testActor.Tell(new Msg.Stop());
@@ -305,11 +308,11 @@ public class ActorLifeCycleFlowSpec : AkkaSpec
         await AssertActorStartFlow(1, timerKeys);
 
         testActor.Tell(new Msg.Crash("I crashed"));
-        await ExpectMsgAsync(new Msg.Crashed(1));
+        await ExpectMsgAsync(new Msg.Crashed(1), cancellationToken: Token);
         await AssertActorRestartFlow(1, _emptyTimers, timerKeys);
 
         testActor.Tell(new Msg.GetTimers());
-        var timers = await ExpectMsgAsync<Msg.Timers>();
+        var timers = await ExpectMsgAsync<Msg.Timers>(cancellationToken: Token);
         timers.ActiveTimers.Length.Should().Be(4);
         timers.ActiveTimers[0].Should().Be(new Msg.StartTimer(Msg.Methods.AroundPostRestart, Msg.CallTime.PreBase));
         timers.ActiveTimers[1].Should().Be(new Msg.StartTimer(Msg.Methods.PostRestart, Msg.CallTime.PreBase));

--- a/src/core/Akka.Tests/Actor/ActorLifeCycleSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLifeCycleSpec.cs
@@ -116,27 +116,27 @@ namespace Akka.Tests
             string id = Guid.NewGuid().ToString();
             var supervisor = Sys.ActorOf(Props.Create(() => new Supervisor(new OneForOneStrategy(3, TimeSpan.FromSeconds(1000), x => Directive.Restart))));
             var restarterProps = Props.Create(() => new LifeCycleTestActor(TestActor, id, generationProvider));
-            var restarter = await supervisor.Ask<IActorRef>(restarterProps, Token);
+            var restarter = await supervisor.Ask<IActorRef>(restarterProps, cancellationToken: Token);
 
-            await ExpectMsgAsync(("preStart", id, 0));
+            await ExpectMsgAsync(("preStart", id, 0), cancellationToken: Token);
             restarter.Tell(Kill.Instance);
-            await ExpectMsgAsync(("preRestart", id, 0));
-            await ExpectMsgAsync(("postRestart", id, 1));
+            await ExpectMsgAsync(("preRestart", id, 0), cancellationToken: Token);
+            await ExpectMsgAsync(("postRestart", id, 1), cancellationToken: Token);
             restarter.Tell("status");
-            await ExpectMsgAsync(("OK", id, 1));
+            await ExpectMsgAsync(("OK", id, 1), cancellationToken: Token);
             restarter.Tell(Kill.Instance);
-            await ExpectMsgAsync(("preRestart", id, 1));
-            await ExpectMsgAsync(("postRestart", id, 2));
+            await ExpectMsgAsync(("preRestart", id, 1), cancellationToken: Token);
+            await ExpectMsgAsync(("postRestart", id, 2), cancellationToken: Token);
             restarter.Tell("status");
-            await ExpectMsgAsync(("OK", id, 2));
+            await ExpectMsgAsync(("OK", id, 2), cancellationToken: Token);
             restarter.Tell(Kill.Instance);
-            await ExpectMsgAsync(("preRestart", id, 2));
-            await ExpectMsgAsync(("postRestart", id, 3));
+            await ExpectMsgAsync(("preRestart", id, 2), cancellationToken: Token);
+            await ExpectMsgAsync(("postRestart", id, 3), cancellationToken: Token);
             restarter.Tell("status");
-            await ExpectMsgAsync(("OK", id, 3));
+            await ExpectMsgAsync(("OK", id, 3), cancellationToken: Token);
             restarter.Tell(Kill.Instance);
-            await ExpectMsgAsync(("postStop", id, 3));
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectMsgAsync(("postStop", id, 3), cancellationToken: Token);
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
             Sys.Stop(supervisor);
         }
 
@@ -147,27 +147,27 @@ namespace Akka.Tests
             string id = Guid.NewGuid().ToString();            
             var supervisor = Sys.ActorOf(Props.Create(() => new Supervisor(new OneForOneStrategy(3, TimeSpan.FromSeconds(1000), x => Directive.Restart))));
             var restarterProps = Props.Create(() => new LifeCycleTest2Actor(TestActor, id, generationProvider));
-            var restarter = await supervisor.Ask<IActorRef>(restarterProps, Token);
+            var restarter = await supervisor.Ask<IActorRef>(restarterProps, cancellationToken: Token);
 
-            await ExpectMsgAsync(("preStart", id, 0));
+            await ExpectMsgAsync(("preStart", id, 0), cancellationToken: Token);
             restarter.Tell(Kill.Instance);
-            await ExpectMsgAsync(("postStop", id, 0));
-            await ExpectMsgAsync(("preStart", id, 1));
+            await ExpectMsgAsync(("postStop", id, 0), cancellationToken: Token);
+            await ExpectMsgAsync(("preStart", id, 1), cancellationToken: Token);
             restarter.Tell("status");
-            await ExpectMsgAsync(("OK", id, 1));
+            await ExpectMsgAsync(("OK", id, 1), cancellationToken: Token);
             restarter.Tell(Kill.Instance);
-            await ExpectMsgAsync(("postStop", id, 1));
-            await ExpectMsgAsync(("preStart", id, 2));
+            await ExpectMsgAsync(("postStop", id, 1), cancellationToken: Token);
+            await ExpectMsgAsync(("preStart", id, 2), cancellationToken: Token);
             restarter.Tell("status");
-            await ExpectMsgAsync(("OK", id, 2));
+            await ExpectMsgAsync(("OK", id, 2), cancellationToken: Token);
             restarter.Tell(Kill.Instance);
-            await ExpectMsgAsync(("postStop", id, 2));
-            await ExpectMsgAsync(("preStart", id, 3));
+            await ExpectMsgAsync(("postStop", id, 2), cancellationToken: Token);
+            await ExpectMsgAsync(("preStart", id, 3), cancellationToken: Token);
             restarter.Tell("status");
-            await ExpectMsgAsync(("OK", id, 3));
+            await ExpectMsgAsync(("OK", id, 3), cancellationToken: Token);
             restarter.Tell(Kill.Instance);
-            await ExpectMsgAsync(("postStop", id, 3));
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectMsgAsync(("postStop", id, 3), cancellationToken: Token);
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
             Sys.Stop(supervisor);
         } 
 
@@ -178,14 +178,14 @@ namespace Akka.Tests
             string id = Guid.NewGuid().ToString();            
             var supervisor = Sys.ActorOf(Props.Create(() => new Supervisor(new OneForOneStrategy(3, TimeSpan.FromSeconds(1000), x => Directive.Restart))));
             var restarterProps = Props.Create(() => new LifeCycleTest2Actor(TestActor, id, generationProvider));
-            var restarter = await supervisor.Ask<IInternalActorRef>(restarterProps, Token);
+            var restarter = await supervisor.Ask<IInternalActorRef>(restarterProps, cancellationToken: Token);
 
-            await ExpectMsgAsync(("preStart", id, 0));
+            await ExpectMsgAsync(("preStart", id, 0), cancellationToken: Token);
             restarter.Tell("status");
-            await ExpectMsgAsync(("OK", id, 0));
+            await ExpectMsgAsync(("OK", id, 0), cancellationToken: Token);
             restarter.Stop();
-            await ExpectMsgAsync(("postStop", id, 0));
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectMsgAsync(("postStop", id, 0), cancellationToken: Token);
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
         }
 
 
@@ -208,7 +208,7 @@ namespace Akka.Tests
             await EventFilter.Exception<Exception>(message: "hurrah").ExpectOneAsync(() => {
                 a.Tell(PoisonPill.Instance);
                 return Task.CompletedTask;
-            });            
+            }, cancellationToken: Token);
         }
 
         public class Become
@@ -253,20 +253,20 @@ namespace Akka.Tests
             var a = Sys.ActorOf(Props.Create(() => new BecomeActor(TestActor)));
 
             a.Tell("hello");
-            await ExpectMsgAsync(42);
+            await ExpectMsgAsync(42, cancellationToken: Token);
             a.Tell(new Become());
-            await ExpectMsgAsync("ok");
+            await ExpectMsgAsync("ok", cancellationToken: Token);
             a.Tell("hello");
-            await ExpectMsgAsync(43);
+            await ExpectMsgAsync(43, cancellationToken: Token);
 
             await EventFilter.Exception<Exception>("buh").ExpectOneAsync(async () =>
             {
                 a.Tell("fail");
                 await Task.CompletedTask;
-            });
+            }, cancellationToken: Token);
             
             a.Tell("hello");
-            await ExpectMsgAsync(42);
+            await ExpectMsgAsync(42, cancellationToken: Token);
         }
 
         public class SupervisorTestActor : UntypedActor
@@ -349,35 +349,35 @@ namespace Akka.Tests
             var names = new[] {"Bob", "Jameson", "Natasha"};
             var supervisor = Sys.ActorOf(Props.Create(() => new SupervisorTestActor(TestActor)));
             supervisor.Tell(new SupervisorTestActor.Spawn(){ Name = names[0] });
-            await ExpectMsgAsync(("Created",names[0]));
+            await ExpectMsgAsync(("Created",names[0]), cancellationToken: Token);
             supervisor.Tell(new SupervisorTestActor.Count());
-            await ExpectMsgAsync(1);
+            await ExpectMsgAsync(1, cancellationToken: Token);
             supervisor.Tell(new SupervisorTestActor.Spawn() { Name = names[1] });
-            await ExpectMsgAsync(("Created", names[1]));
+            await ExpectMsgAsync(("Created", names[1]), cancellationToken: Token);
             supervisor.Tell(new SupervisorTestActor.Count());
-            await ExpectMsgAsync(2);
+            await ExpectMsgAsync(2, cancellationToken: Token);
             supervisor.Tell(new SupervisorTestActor.ContextStop() { Name = names[1] });
-            await ExpectMsgAsync(("Terminated", names[1]));
+            await ExpectMsgAsync(("Terminated", names[1]), cancellationToken: Token);
        
             //we need to wait for the child actor to unregister itself from the parent.
             //this is done after PostStop so we have no way to wait for it
             //ideas?
-            await Task.Delay(100, Token);
+            await Task.Delay(100, cancellationToken: Token);
             supervisor.Tell(new SupervisorTestActor.Count());
-            await ExpectMsgAsync(1);
+            await ExpectMsgAsync(1, cancellationToken: Token);
             supervisor.Tell(new SupervisorTestActor.Spawn() { Name = names[2] });
-            await ExpectMsgAsync(("Created", names[2]));
-            await Task.Delay(100, Token);
+            await ExpectMsgAsync(("Created", names[2]), cancellationToken: Token);
+            await Task.Delay(100, cancellationToken: Token);
             supervisor.Tell(new SupervisorTestActor.Count());
-            await ExpectMsgAsync(2);
+            await ExpectMsgAsync(2, cancellationToken: Token);
             supervisor.Tell(new SupervisorTestActor.Stop() { Name = names[0] });
-            await ExpectMsgAsync(("Terminated", names[0]));
+            await ExpectMsgAsync(("Terminated", names[0]), cancellationToken: Token);
             supervisor.Tell(new SupervisorTestActor.Stop() { Name = names[2] });
-            await ExpectMsgAsync(("Terminated", names[2]));
+            await ExpectMsgAsync(("Terminated", names[2]), cancellationToken: Token);
 
-            await Task.Delay(100, Token);
+            await Task.Delay(100, cancellationToken: Token);
             supervisor.Tell(new SupervisorTestActor.Count());
-            await ExpectMsgAsync(0);
+            await ExpectMsgAsync(0, cancellationToken: Token);
         }
 
 
@@ -410,14 +410,14 @@ namespace Akka.Tests
 
             broken.Tell(message);
 
-            await ExpectMsgAsync<MyCustomException>();
-            await ExpectMsgAsync(message);
-            await ExpectMsgAsync(TestActor);
+            await ExpectMsgAsync<MyCustomException>(cancellationToken: Token);
+            await ExpectMsgAsync(message, cancellationToken: Token);
+            await ExpectMsgAsync(TestActor, cancellationToken: Token);
             
             // test the `Restart` built-in message
             broken.Tell(IntentionalRestart.Instance);
-            await ExpectMsgAsync<IntentionalActorRestartException>();
-            await ExpectMsgAsync(TestActor);
+            await ExpectMsgAsync<IntentionalActorRestartException>(cancellationToken: Token);
+            await ExpectMsgAsync(TestActor, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/ActorLifeCycleSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLifeCycleSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
@@ -106,6 +107,8 @@ namespace Akka.Tests
             }
         }
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [Fact(DisplayName = "invoke preRestart, preStart, postRestart when using OneForOneStrategy")]
         public async Task Actor_lifecycle_test1()
         {
@@ -113,7 +116,7 @@ namespace Akka.Tests
             string id = Guid.NewGuid().ToString();
             var supervisor = Sys.ActorOf(Props.Create(() => new Supervisor(new OneForOneStrategy(3, TimeSpan.FromSeconds(1000), x => Directive.Restart))));
             var restarterProps = Props.Create(() => new LifeCycleTestActor(TestActor, id, generationProvider));
-            var restarter = await supervisor.Ask<IActorRef>(restarterProps);
+            var restarter = await supervisor.Ask<IActorRef>(restarterProps, Token);
 
             await ExpectMsgAsync(("preStart", id, 0));
             restarter.Tell(Kill.Instance);
@@ -144,7 +147,7 @@ namespace Akka.Tests
             string id = Guid.NewGuid().ToString();            
             var supervisor = Sys.ActorOf(Props.Create(() => new Supervisor(new OneForOneStrategy(3, TimeSpan.FromSeconds(1000), x => Directive.Restart))));
             var restarterProps = Props.Create(() => new LifeCycleTest2Actor(TestActor, id, generationProvider));
-            var restarter = await supervisor.Ask<IActorRef>(restarterProps);
+            var restarter = await supervisor.Ask<IActorRef>(restarterProps, Token);
 
             await ExpectMsgAsync(("preStart", id, 0));
             restarter.Tell(Kill.Instance);
@@ -175,7 +178,7 @@ namespace Akka.Tests
             string id = Guid.NewGuid().ToString();            
             var supervisor = Sys.ActorOf(Props.Create(() => new Supervisor(new OneForOneStrategy(3, TimeSpan.FromSeconds(1000), x => Directive.Restart))));
             var restarterProps = Props.Create(() => new LifeCycleTest2Actor(TestActor, id, generationProvider));
-            var restarter = await supervisor.Ask<IInternalActorRef>(restarterProps);
+            var restarter = await supervisor.Ask<IInternalActorRef>(restarterProps, Token);
 
             await ExpectMsgAsync(("preStart", id, 0));
             restarter.Tell("status");
@@ -359,12 +362,12 @@ namespace Akka.Tests
             //we need to wait for the child actor to unregister itself from the parent.
             //this is done after PostStop so we have no way to wait for it
             //ideas?
-            await Task.Delay(100);
+            await Task.Delay(100, Token);
             supervisor.Tell(new SupervisorTestActor.Count());
             await ExpectMsgAsync(1);
             supervisor.Tell(new SupervisorTestActor.Spawn() { Name = names[2] });
             await ExpectMsgAsync(("Created", names[2]));
-            await Task.Delay(100);
+            await Task.Delay(100, Token);
             supervisor.Tell(new SupervisorTestActor.Count());
             await ExpectMsgAsync(2);
             supervisor.Tell(new SupervisorTestActor.Stop() { Name = names[0] });
@@ -372,7 +375,7 @@ namespace Akka.Tests
             supervisor.Tell(new SupervisorTestActor.Stop() { Name = names[2] });
             await ExpectMsgAsync(("Terminated", names[2]));
 
-            await Task.Delay(100);
+            await Task.Delay(100, Token);
             supervisor.Tell(new SupervisorTestActor.Count());
             await ExpectMsgAsync(0);
         }

--- a/src/core/Akka.Tests/Actor/ActorLookupSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLookupSpec.cs
@@ -144,10 +144,10 @@ namespace Akka.Tests.Actor
             var a1 = Sys.ActorOf(P, name);
             Watch(a1);
             a1.Tell(PoisonPill.Instance);
-            await ExpectTerminatedAsync(a1);
+            await ExpectTerminatedAsync(a1, cancellationToken: Token);
 
             // let it be completely removed from the user guardian
-            await ExpectNoMsgAsync(1.Seconds());
+            await ExpectNoMsgAsync(1.Seconds(), cancellationToken: Token);
 
             // not equal, because it's terminated
             Provider.ResolveActorRef(a1.Path.ToString()).Should().NotBe(a1);
@@ -160,14 +160,14 @@ namespace Akka.Tests.Actor
 
             Watch(a2);
             a2.Tell(PoisonPill.Instance);
-            await ExpectTerminatedAsync(a2);
+            await ExpectTerminatedAsync(a2, cancellationToken: Token);
         }
 
         [Fact]
         public async Task ActorSystem_must_find_temporary_actors()
         {
-            var f = c1.Ask(new GetSender(TestActor), Token);
-            var a = ExpectMsg<IInternalActorRef>();
+            var f = c1.Ask(new GetSender(TestActor), cancellationToken: Token);
+            var a = ExpectMsg<IInternalActorRef>(cancellationToken: Token);
             a.Path.Elements.Head().Should().Be("temp");
             Provider.ResolveActorRef(a.Path).Should().Be(a);
             Provider.ResolveActorRef(a.Path.ToString()).Should().Be(a);
@@ -175,12 +175,12 @@ namespace Akka.Tests.Actor
             // should already be dead
             var shouldBeDead = Provider.ResolveActorRef(a.Path + "/hello");
             await WatchAsync(shouldBeDead);
-            await ExpectTerminatedAsync(shouldBeDead);
+            await ExpectTerminatedAsync(shouldBeDead, cancellationToken: Token);
             
             f.IsCompleted.Should().Be(false);
             a.Tell(42);
-            await AwaitAssertAsync(() => f.IsCompleted.Should().Be(true));
-            await AwaitAssertAsync(() => f.Result.Should().Be(42));
+            await AwaitAssertAsync(() => f.IsCompleted.Should().Be(true), cancellationToken: Token);
+            await AwaitAssertAsync(() => f.Result.Should().Be(42), cancellationToken: Token);
         }
 
         /*

--- a/src/core/Akka.Tests/Actor/ActorLookupSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorLookupSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
@@ -73,6 +74,8 @@ namespace Akka.Tests.Actor
 
         public static readonly Props P = Props.Create<Node>();
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public class Node : ReceiveActor
         {
             private IActorRefProvider Provider { get { return Context.System.AsInstanceOf<ActorSystemImpl>().Provider; } }
@@ -163,7 +166,7 @@ namespace Akka.Tests.Actor
         [Fact]
         public async Task ActorSystem_must_find_temporary_actors()
         {
-            var f = c1.Ask(new GetSender(TestActor));
+            var f = c1.Ask(new GetSender(TestActor), Token);
             var a = ExpectMsg<IInternalActorRef>();
             a.Path.Elements.Head().Should().Be("temp");
             Provider.ResolveActorRef(a.Path).Should().Be(a);

--- a/src/core/Akka.Tests/Actor/ActorProducerPipelineTests.cs
+++ b/src/core/Akka.Tests/Actor/ActorProducerPipelineTests.cs
@@ -11,11 +11,14 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class ActorProducerPipelineTests : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         #region internal test classes
 
         internal class TestException : Exception
@@ -136,7 +139,7 @@ namespace Akka.Tests.Actor
                 var ask = await actor.Ask<string[]>("plugins", TimeSpan.FromSeconds(1));
 
                 ask.ShouldOnlyContainInOrder("failing plugin", "working plugin");
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -160,8 +163,8 @@ namespace Akka.Tests.Actor
             var plugA = ActorOf<PlugActorA>();
             var plugB = ActorOf<PlugActorB>();
 
-            (await plugA.Ask<string[]>("plugins", TimeSpan.FromSeconds(3))).ShouldOnlyContainInOrder("working plugin", typeof(PlugActorA).ToString());
-            (await plugB.Ask<string[]>("plugins", TimeSpan.FromSeconds(3))).ShouldOnlyContainInOrder("working plugin", typeof(PlugActorB).ToString());
+            (await plugA.Ask<string[]>("plugins", TimeSpan.FromSeconds(3), cancellationToken: Token)).ShouldOnlyContainInOrder("working plugin", typeof(PlugActorA).ToString());
+            (await plugB.Ask<string[]>("plugins", TimeSpan.FromSeconds(3), cancellationToken: Token)).ShouldOnlyContainInOrder("working plugin", typeof(PlugActorB).ToString());
         }
 
         [Fact]
@@ -172,14 +175,14 @@ namespace Akka.Tests.Actor
             _resolver.Insert(1, new OrderedPlugin2()).ShouldBeTrue();
 
             var actor = ActorOf<PlugActor>();
-            (await actor.Ask<string[]>("plugins", TimeSpan.FromSeconds(3))).ShouldOnlyContainInOrder("plugin-1", "plugin-2", "plugin-3");
+            (await actor.Ask<string[]>("plugins", TimeSpan.FromSeconds(3), cancellationToken: Token)).ShouldOnlyContainInOrder("plugin-1", "plugin-2", "plugin-3");
         }
 
         [Fact]
         public async Task DefaultPipeline_should_apply_stashing_to_actors_implementing_it()
         {
             var actor = ActorOf<StashingActor>();
-            (await actor.Ask<string>(StashStatus.Instance, TimeSpan.FromSeconds(3))).ShouldBe("actor stash is initialized");
+            (await actor.Ask<string>(StashStatus.Instance, TimeSpan.FromSeconds(3), cancellationToken: Token)).ShouldBe("actor stash is initialized");
         }
 
         [Fact]
@@ -197,7 +200,7 @@ namespace Akka.Tests.Actor
                 // stop actor
                 actor.Tell(PoisonPill.Instance);
                 return Task.CompletedTask;
-            });
+            }, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefIgnoreSpec.cs
@@ -21,6 +21,8 @@ namespace Akka.Tests.Actor
 {
     public class ActorRefIgnoreSpec : AkkaSpec, INoImplicitSender
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact]
         public async Task IgnoreActorRef_should_ignore_all_incoming_messages()
         {
@@ -28,17 +30,17 @@ namespace Akka.Tests.Actor
 
             var probe = CreateTestProbe("response-probe");
             askMeRef.Tell(new Request(probe.Ref));
-            await probe.ExpectMsgAsync(1);
+            await probe.ExpectMsgAsync(1, cancellationToken: Token);
 
             // this is more a compile-time proof
             // since the reply is ignored, we can't check that a message was sent to it
             askMeRef.Tell(new Request(Sys.IgnoreRef));
 
-            await probe.ExpectNoMsgAsync(default);
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
 
             // but we do check that the counter has increased when we used the ActorRef.ignore
             askMeRef.Tell(new Request(probe.Ref));
-            await probe.ExpectMsgAsync(3);
+            await probe.ExpectMsgAsync(3, cancellationToken: Token);
         }
 
         [Fact]
@@ -51,7 +53,7 @@ namespace Akka.Tests.Actor
 
             Assert.Throws<AskTimeoutException>(() =>
             {
-                _ = askMeRef.Ask(new Request(Sys.IgnoreRef), timeout).GetAwaiter().GetResult();
+                _ = askMeRef.Ask(new Request(Sys.IgnoreRef), timeout, cancellationToken: Token).GetAwaiter().GetResult();
             });
         }
 
@@ -63,7 +65,7 @@ namespace Akka.Tests.Actor
 
             // this proves that the actor started and is operational and 'watch' didn't impact it
             forwardMessageRef.Tell("abc");
-            await probe.ExpectMsgAsync("abc");
+            await probe.ExpectMsgAsync("abc", cancellationToken: Token);
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Actor/ActorRefSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefSpec.cs
@@ -123,7 +123,7 @@ namespace Akka.Tests.Actor
 
             aref.Tell(PoisonPill.Instance);
 
-            await ExpectMsgAsync<Terminated>();
+            await ExpectMsgAsync<Terminated>(cancellationToken: Token);
 
             var bserializer = Sys.Serialization.FindSerializerForType(typeof (IActorRef));
 
@@ -141,7 +141,7 @@ namespace Akka.Tests.Actor
                 {
                     return Task.FromResult(false);
                 }
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace Akka.Tests.Actor
                 boss.Tell("send kill");
                 latch.Ready(TimeSpan.FromSeconds(5));
                 return Task.CompletedTask;
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -255,7 +255,7 @@ namespace Akka.Tests.Actor
         {
             var a = Sys.ActorOf(NonPublicActor.CreateProps());
             a.Tell("pigdog", TestActor);
-            await ExpectMsgAsync("pigdog");
+            await ExpectMsgAsync("pigdog", cancellationToken: Token);
             Sys.Stop(a);
         }
 
@@ -265,8 +265,8 @@ namespace Akka.Tests.Actor
             var timeout = TimeSpan.FromSeconds(20);
             var actorRef = Sys.ActorOf(Props.Create(() => new PoisonPilledActor()));
 
-            var t1 = actorRef.Ask(5, timeout, Token);
-            var t2 = actorRef.Ask(0, timeout, Token);
+            var t1 = actorRef.Ask(5, timeout, cancellationToken: Token);
+            var t2 = actorRef.Ask(0, timeout, cancellationToken: Token);
             actorRef.Tell(PoisonPill.Instance);
 
             Func<Task> f1 = async () => await t1;
@@ -306,7 +306,7 @@ namespace Akka.Tests.Actor
         {          
             var actor = ActorOfAsTestActorRef<NonPublicActor>(Props.Create<NonPublicActor>(SupervisorStrategy.StoppingStrategy));
             // actors with a null sender should always write to deadletters
-            await EventFilter.DeadLetter<object>().ExpectOneAsync(() => { actor.Tell(new object(), null); return Task.CompletedTask; });
+            await EventFilter.DeadLetter<object>().ExpectOneAsync(() => { actor.Tell(new object(), null); return Task.CompletedTask; }, cancellationToken: Token);
 
             // will throw an exception if there's a bug
             await ExpectNoMsgAsync(CancellationToken.None);

--- a/src/core/Akka.Tests/Actor/ActorRefSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorRefSpec.cs
@@ -22,6 +22,8 @@ namespace Akka.Tests.Actor
 {
     public class ActorRefSpec : AkkaSpec, INoImplicitSender
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [Fact]
         public void An_ActorRef_should_equal_itself()
         {
@@ -263,8 +265,8 @@ namespace Akka.Tests.Actor
             var timeout = TimeSpan.FromSeconds(20);
             var actorRef = Sys.ActorOf(Props.Create(() => new PoisonPilledActor()));
 
-            var t1 = actorRef.Ask(5, timeout);
-            var t2 = actorRef.Ask(0, timeout);
+            var t1 = actorRef.Ask(5, timeout, Token);
+            var t2 = actorRef.Ask(0, timeout, Token);
             actorRef.Tell(PoisonPill.Instance);
 
             Func<Task> f1 = async () => await t1;

--- a/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.Actor.Dsl;
@@ -30,6 +31,8 @@ namespace Akka.Tests.Actor
             akka.loglevel=DEBUG
             ";
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         private readonly IActorRef _c1;
         private readonly IActorRef _c2;
         private readonly IActorRef _c21;
@@ -526,10 +529,10 @@ namespace Akka.Tests.Actor
         {
             var creator = CreateTestProbe();
             var top = Sys.ActorOf(Props, "a");
-            var b1 = await top.Ask<IActorRef>(new Create("b1"), TimeSpan.FromSeconds(3));
-            var b2 = await top.Ask<IActorRef>(new Create("b2"), TimeSpan.FromSeconds(3));
-            var c = await b2.Ask<IActorRef>(new Create("c"), TimeSpan.FromSeconds(3));
-            var d = await c.Ask<IActorRef>(new Create("d"), TimeSpan.FromSeconds(3));
+            var b1 = await top.Ask<IActorRef>(new Create("b1"), TimeSpan.FromSeconds(3), Token);
+            var b2 = await top.Ask<IActorRef>(new Create("b2"), TimeSpan.FromSeconds(3), Token);
+            var c = await b2.Ask<IActorRef>(new Create("c"), TimeSpan.FromSeconds(3), Token);
+            var d = await c.Ask<IActorRef>(new Create("d"), TimeSpan.FromSeconds(3), Token);
 
             var probe = CreateTestProbe();
             Sys.ActorSelection("/user/a/*").Tell(new Identify(1), probe.Ref);
@@ -578,12 +581,12 @@ namespace Akka.Tests.Actor
         {
             var creator = CreateTestProbe();
             var top = Sys.ActorOf(Props, "a");
-            var b1 = await top.Ask<IActorRef>(new Create("b1"), TimeSpan.FromSeconds(3));
-            var b2 = await top.Ask<IActorRef>(new Create("b2"), TimeSpan.FromSeconds(3));
-            var b3 = await top.Ask<IActorRef>(new Create("b3"), TimeSpan.FromSeconds(3));
-            var c1 = await b2.Ask<IActorRef>(new Create("c1"), TimeSpan.FromSeconds(3));
-            var c2 = await b2.Ask<IActorRef>(new Create("c2"), TimeSpan.FromSeconds(3));
-            var d = await c1.Ask<IActorRef>(new Create("d"), TimeSpan.FromSeconds(3));
+            var b1 = await top.Ask<IActorRef>(new Create("b1"), TimeSpan.FromSeconds(3), Token);
+            var b2 = await top.Ask<IActorRef>(new Create("b2"), TimeSpan.FromSeconds(3), Token);
+            var b3 = await top.Ask<IActorRef>(new Create("b3"), TimeSpan.FromSeconds(3), Token);
+            var c1 = await b2.Ask<IActorRef>(new Create("c1"), TimeSpan.FromSeconds(3), Token);
+            var c2 = await b2.Ask<IActorRef>(new Create("c2"), TimeSpan.FromSeconds(3), Token);
+            var d = await c1.Ask<IActorRef>(new Create("d"), TimeSpan.FromSeconds(3), Token);
 
             var probe = CreateTestProbe();
 

--- a/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSelectionSpec.cs
@@ -138,7 +138,7 @@ namespace Akka.Tests.Actor
             var a1 = Sys.ActorOf(Props, name);
             Watch(a1);
             a1.Tell(PoisonPill.Instance);
-            var msg = await ExpectMsgAsync<Terminated>();
+            var msg = await ExpectMsgAsync<Terminated>(cancellationToken: Token);
             msg.ActorRef.ShouldBe(a1);
 
             //not equal because it's terminated
@@ -153,7 +153,7 @@ namespace Akka.Tests.Actor
 
             Watch(a2);
             a2.Tell(PoisonPill.Instance);
-            msg = await ExpectMsgAsync<Terminated>();
+            msg = await ExpectMsgAsync<Terminated>(cancellationToken: Token);
             msg.ActorRef.ShouldBe(a2);
         }
 
@@ -405,7 +405,7 @@ namespace Akka.Tests.Actor
         public async Task An_ActorSelection_must_send_messages_directly()
         {
             new ActorSelection(_c1, "").Tell(new GetSender(TestActor));
-            await ExpectMsgAsync(TestActor);
+            await ExpectMsgAsync(TestActor, cancellationToken: Token);
             LastSender.ShouldBe(_c1);
         }
 
@@ -413,7 +413,7 @@ namespace Akka.Tests.Actor
         public async Task An_ActorSelection_must_send_messages_to_string_path()
         {
             Sys.ActorSelection("/user/c2/c21").Tell(new GetSender(TestActor));
-            await ExpectMsgAsync(TestActor);
+            await ExpectMsgAsync(TestActor, cancellationToken: Token);
             LastSender.ShouldBe(_c21);
         }
 
@@ -421,7 +421,7 @@ namespace Akka.Tests.Actor
         public async Task An_ActorSelection_must_send_messages_to_actor_path()
         {
             Sys.ActorSelection(_c2.Path / "c21").Tell(new GetSender(TestActor));
-            await ExpectMsgAsync(TestActor);
+            await ExpectMsgAsync(TestActor, cancellationToken: Token);
             LastSender.ShouldBe(_c21);
         }
 
@@ -430,9 +430,9 @@ namespace Akka.Tests.Actor
         {
             new ActorSelection(_c21, "../../*").Tell(new GetSender(TestActor), _c1);
             //Three messages because the selection includes the TestActor, GetSender -> TestActor + response from c1 and c2 to TestActor
-            var actors = (await ReceiveWhileAsync(_ => LastSender, msgs: 3).ToListAsync()).Distinct();
+            var actors = (await ReceiveWhileAsync(_ => LastSender, msgs: 3, cancellationToken: Token).ToListAsync(Token)).Distinct();
             actors.Should().BeEquivalentTo(_c1, _c2);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
         }
 
         [Fact]
@@ -440,9 +440,9 @@ namespace Akka.Tests.Actor
         {
             new ActorSelection(_c21, "../../*/c21").Tell(new GetSender(TestActor), _c2);
 
-            var actors = (await ReceiveWhileAsync(_ => LastSender, msgs: 2).ToListAsync()).Distinct();
+            var actors = (await ReceiveWhileAsync(_ => LastSender, msgs: 2, cancellationToken: Token).ToListAsync(Token)).Distinct();
             actors.Should().HaveCount(1).And.Subject.First().ShouldBe(_c21);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
 
         }
 
@@ -450,7 +450,7 @@ namespace Akka.Tests.Actor
         public async Task An_ActorSelection_must_resolve_one_actor_with_timeout()
         {
             var s = Sys.ActorSelection("user/c2");
-            (await s.ResolveOne(Dilated(TimeSpan.FromSeconds(1)))).ShouldBe(_c2);
+            (await s.ResolveOne(Dilated(TimeSpan.FromSeconds(1)), ct: Token)).ShouldBe(_c2);
         }
 
         [Fact]
@@ -492,7 +492,7 @@ namespace Akka.Tests.Actor
             var p = CreateTestProbe();
             Sys.EventStream.Subscribe(p.Ref, typeof(DeadLetter));
             Sys.ActorSelection("/user/missing").Tell("boom", TestActor);
-            var d = await p.ExpectMsgAsync<DeadLetter>();
+            var d = await p.ExpectMsgAsync<DeadLetter>(cancellationToken: Token);
             d.Message.ShouldBe("boom");
             d.Sender.ShouldBe(TestActor);
             d.Recipient.Path.ToStringWithoutAddress().ShouldBe("/user/missing");
@@ -516,11 +516,11 @@ namespace Akka.Tests.Actor
             // deliver two ActorSelections - one from outside any actors, one from inside
             // they have different anchors to start with, so the results may differ
             Sys.ActorSelection(actorPathStr).Tell("foo");
-            var msg = await ExpectMsgAsync<DeadLetter>();
+            var msg = await ExpectMsgAsync<DeadLetter>(cancellationToken: Token);
             msg.Message.Should().Be("foo");
 
             actorA.Tell("foo");
-            msg = await ExpectMsgAsync<DeadLetter>();
+            msg = await ExpectMsgAsync<DeadLetter>(cancellationToken: Token);
             msg.Message.Should().Be("foo");
         }
 
@@ -529,51 +529,51 @@ namespace Akka.Tests.Actor
         {
             var creator = CreateTestProbe();
             var top = Sys.ActorOf(Props, "a");
-            var b1 = await top.Ask<IActorRef>(new Create("b1"), TimeSpan.FromSeconds(3), Token);
-            var b2 = await top.Ask<IActorRef>(new Create("b2"), TimeSpan.FromSeconds(3), Token);
-            var c = await b2.Ask<IActorRef>(new Create("c"), TimeSpan.FromSeconds(3), Token);
-            var d = await c.Ask<IActorRef>(new Create("d"), TimeSpan.FromSeconds(3), Token);
+            var b1 = await top.Ask<IActorRef>(new Create("b1"), TimeSpan.FromSeconds(3), cancellationToken: Token);
+            var b2 = await top.Ask<IActorRef>(new Create("b2"), TimeSpan.FromSeconds(3), cancellationToken: Token);
+            var c = await b2.Ask<IActorRef>(new Create("c"), TimeSpan.FromSeconds(3), cancellationToken: Token);
+            var d = await c.Ask<IActorRef>(new Create("d"), TimeSpan.FromSeconds(3), cancellationToken: Token);
 
             var probe = CreateTestProbe();
             Sys.ActorSelection("/user/a/*").Tell(new Identify(1), probe.Ref);
-            var received = await probe.ReceiveNAsync(2, default)
+            var received = await probe.ReceiveNAsync(2, RemainingOrDefault, cancellationToken: Token)
                 .Cast<ActorIdentity>()
                 .Select(i => i.Subject)
-                .ToListAsync();
+                .ToListAsync(Token);
             received.Should().BeEquivalentTo(new[] { b1, b2 });
-            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200), cancellationToken: Token);
 
             Sys.ActorSelection("/user/a/b1/*").Tell(new Identify(2), probe.Ref);
-            var identity = await probe.ExpectMsgAsync<ActorIdentity>();
+            var identity = await probe.ExpectMsgAsync<ActorIdentity>(cancellationToken: Token);
             identity.Should().BeEquivalentTo(new ActorIdentity(2, null));
 
             Sys.ActorSelection("/user/a/*/c").Tell(new Identify(3), probe.Ref);
-            identity = await probe.ExpectMsgAsync<ActorIdentity>();
+            identity = await probe.ExpectMsgAsync<ActorIdentity>(cancellationToken: Token);
             identity.Should().BeEquivalentTo(new ActorIdentity(3, c));
-            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200), cancellationToken: Token);
 
             Sys.ActorSelection("/user/a/b2/*/d").Tell(new Identify(4), probe.Ref);
-            identity = await probe.ExpectMsgAsync<ActorIdentity>();
+            identity = await probe.ExpectMsgAsync<ActorIdentity>(cancellationToken: Token);
             identity.Should().BeEquivalentTo(new ActorIdentity(4, d));
-            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200), cancellationToken: Token);
 
             Sys.ActorSelection("/user/a/*/*/d").Tell(new Identify(5), probe.Ref);
-            identity = await probe.ExpectMsgAsync<ActorIdentity>();
+            identity = await probe.ExpectMsgAsync<ActorIdentity>(cancellationToken: Token);
             identity.Should().BeEquivalentTo(new ActorIdentity(5, d));
-            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200), cancellationToken: Token);
 
             Sys.ActorSelection("/user/a/*/c/*").Tell(new Identify(6), probe.Ref);
-            identity = await probe.ExpectMsgAsync<ActorIdentity>();
+            identity = await probe.ExpectMsgAsync<ActorIdentity>(cancellationToken: Token);
             identity.Should().BeEquivalentTo(new ActorIdentity(6, d));
-            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200), cancellationToken: Token);
 
             Sys.ActorSelection("/user/a/b2/*/d/e").Tell(new Identify(7), probe.Ref);
-            identity = await probe.ExpectMsgAsync<ActorIdentity>();
+            identity = await probe.ExpectMsgAsync<ActorIdentity>(cancellationToken: Token);
             identity.Should().BeEquivalentTo(new ActorIdentity(7, null));
-            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200), cancellationToken: Token);
 
             Sys.ActorSelection("/user/a/*/c/d/e").Tell(new Identify(8), probe.Ref);
-            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), cancellationToken: Token);
         }
 
         [Fact]
@@ -581,36 +581,36 @@ namespace Akka.Tests.Actor
         {
             var creator = CreateTestProbe();
             var top = Sys.ActorOf(Props, "a");
-            var b1 = await top.Ask<IActorRef>(new Create("b1"), TimeSpan.FromSeconds(3), Token);
-            var b2 = await top.Ask<IActorRef>(new Create("b2"), TimeSpan.FromSeconds(3), Token);
-            var b3 = await top.Ask<IActorRef>(new Create("b3"), TimeSpan.FromSeconds(3), Token);
-            var c1 = await b2.Ask<IActorRef>(new Create("c1"), TimeSpan.FromSeconds(3), Token);
-            var c2 = await b2.Ask<IActorRef>(new Create("c2"), TimeSpan.FromSeconds(3), Token);
-            var d = await c1.Ask<IActorRef>(new Create("d"), TimeSpan.FromSeconds(3), Token);
+            var b1 = await top.Ask<IActorRef>(new Create("b1"), TimeSpan.FromSeconds(3), cancellationToken: Token);
+            var b2 = await top.Ask<IActorRef>(new Create("b2"), TimeSpan.FromSeconds(3), cancellationToken: Token);
+            var b3 = await top.Ask<IActorRef>(new Create("b3"), TimeSpan.FromSeconds(3), cancellationToken: Token);
+            var c1 = await b2.Ask<IActorRef>(new Create("c1"), TimeSpan.FromSeconds(3), cancellationToken: Token);
+            var c2 = await b2.Ask<IActorRef>(new Create("c2"), TimeSpan.FromSeconds(3), cancellationToken: Token);
+            var d = await c1.Ask<IActorRef>(new Create("d"), TimeSpan.FromSeconds(3), cancellationToken: Token);
 
             var probe = CreateTestProbe();
 
             // grab everything below /user/a
             Sys.ActorSelection("/user/a/**").Tell(new Identify(1), probe.Ref);
-            var received = await probe.ReceiveNAsync(6, default)
+            var received = await probe.ReceiveNAsync(6, RemainingOrDefault, cancellationToken: Token)
                 .Cast<ActorIdentity>()
                 .Select(i => i.Subject)
-                .ToListAsync();
+                .ToListAsync(Token);
             received.Should().BeEquivalentTo(b1, b2, b3, c1, c2, d);
-            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), cancellationToken: Token);
 
             // grab everything below /user/a/b2
             Sys.ActorSelection("/user/a/b2/**").Tell(new Identify(2), probe.Ref);
-            received = await probe.ReceiveNAsync(3, default)
+            received = await probe.ReceiveNAsync(3, RemainingOrDefault, cancellationToken: Token)
                 .Cast<ActorIdentity>()
                 .Select(i => i.Subject)
-                .ToListAsync();
+                .ToListAsync(Token);
             received.Should().BeEquivalentTo(c1, c2, d);
-            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), cancellationToken: Token);
 
             // nothing under /user/a/b2/c1/d
             Sys.ActorSelection("/user/a/b2/c1/d/**").Tell(new Identify(3), probe.Ref);
-            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500), cancellationToken: Token);
 
             Invoking(() => Sys.ActorSelection("/user/a/**/d").Tell(new Identify(4), probe.Ref))
                 .Should().Throw<IllegalActorNameException>();
@@ -620,7 +620,7 @@ namespace Akka.Tests.Actor
         public async Task An_ActorSelection_must_forward_to_selection()
         {
             _c2.Tell(new Forward("c21", "hello"), TestActor);
-            await ExpectMsgAsync("hello");
+            await ExpectMsgAsync("hello", cancellationToken: Token);
             LastSender.ShouldBe(_c21);
         }
 

--- a/src/core/Akka.Tests/Actor/ActorSystemDispatcherSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemDispatcherSpec.cs
@@ -6,21 +6,13 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
-using Akka.Actor.Setup;
 using Akka.Configuration;
-using Akka.Dispatch;
 using Akka.TestKit;
-using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor
 {

--- a/src/core/Akka.Tests/Actor/ActorSystemDispatcherSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemDispatcherSpec.cs
@@ -13,11 +13,14 @@ using Akka.Configuration;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class ActorSystemDispatcherSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         private static Config Config => ConfigurationFactory.ParseString(@"
     dispatcher-loop-1 = dispatcher-loop-2
     dispatcher-loop-2 = dispatcher-loop-1
@@ -41,7 +44,7 @@ namespace Akka.Tests.Actor
 
                 actor.Tell("ping", probe);
 
-                await probe.ExpectMsgAsync("ping", TimeSpan.FromSeconds(1));
+                await probe.ExpectMsgAsync("ping", TimeSpan.FromSeconds(1), cancellationToken: Token);
             }
             finally
             {

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -22,7 +22,6 @@ using Akka.Dispatch;
 using Akka.Event;
 using Akka.TestKit.Extensions;
 using FluentAssertions.Execution;
-using Akka.Tests.Util;
 
 namespace Akka.Tests.Actor
 {
@@ -37,6 +36,7 @@ namespace Akka.Tests.Actor
         {
         }
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
 
         [Fact]
         public void Reject_invalid_names()
@@ -74,11 +74,15 @@ namespace Akka.Tests.Actor
             // Actor system should be started to attach the EventFilterFactory
             system.Start();
 
-            var eventFilter = new EventFilterFactory(new TestKit.Xunit2.TestKit(system));
+            var eventFilter = new EventFilterFactory(new TestKit.Xunit.TestKit(system));
 
             // Notice here we forcedly start actor system again to monitor how it processes
             var expected = "log-config-on-start : on";
-            await eventFilter.Info(contains:expected).ExpectOneAsync(() => { system.Start(); return Task.CompletedTask; });
+            await eventFilter.Info(contains:expected).ExpectOneAsync(() =>
+            {
+                system.Start();
+                return Task.CompletedTask;
+            }, Token);
 
             await system.Terminate();
         }
@@ -93,10 +97,14 @@ namespace Akka.Tests.Actor
             // Actor system should be started to attach the EventFilterFactory
             system.Start();
 
-            var eventFilter = new EventFilterFactory(new TestKit.Xunit2.TestKit(system));
+            var eventFilter = new EventFilterFactory(new TestKit.Xunit.TestKit(system));
 
             // Notice here we forcedly start actor system again to monitor how it processes
-            await eventFilter.Info().ExpectAsync(0, () => { system.Start(); return Task.CompletedTask; });
+            await eventFilter.Info().ExpectAsync(0, () =>
+            {
+                system.Start();
+                return Task.CompletedTask;
+            }, Token);
 
             await system.Terminate();
         }
@@ -117,7 +125,7 @@ namespace Akka.Tests.Actor
 
             try
             {
-                var testKit = new TestKit.Xunit2.TestKit(sys);
+                var testKit = new TestKit.Xunit.TestKit(sys);
                 var probe = testKit.CreateTestProbe();
                 var a = sys.ActorOf(Props.Create<Terminater>());
 
@@ -135,7 +143,7 @@ namespace Akka.Tests.Actor
 
                     // Now send the message that should become a dead letter
                     a.Tell("boom");
-                });
+                }, Token);
             }
             finally { Shutdown(sys); }
         }
@@ -146,8 +154,8 @@ namespace Akka.Tests.Actor
             var actorSystem = ActorSystem
                 .Create(Guid.NewGuid().ToString());
             var st = Stopwatch.StartNew();
-            var asyncShutdownTask = Task.Delay(TimeSpan.FromSeconds(1)).ContinueWith(_ => actorSystem.Terminate());
-            (await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(2))).ShouldBeTrue();
+            var asyncShutdownTask = Task.Delay(TimeSpan.FromSeconds(1), Token).ContinueWith(_ => actorSystem.Terminate());
+            (await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(2), Token)).ShouldBeTrue();
             Assert.True(st.Elapsed.TotalSeconds >= .9);
         }
 
@@ -155,7 +163,7 @@ namespace Akka.Tests.Actor
         public async Task Given_a_system_that_isnt_going_to_shutdown_When_waiting_for_system_shutdown_Then_it_times_out()
         {
             var actorSystem = ActorSystem.Create(Guid.NewGuid().ToString());
-            (await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromMilliseconds(10))).ShouldBeFalse();
+            (await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromMilliseconds(10), Token)).ShouldBeFalse();
         }
 
         [Fact]
@@ -196,19 +204,19 @@ namespace Akka.Tests.Actor
 
             actorSystem.RegisterOnTermination(() =>
             {
-                Task.Delay(Dilated(TimeSpan.FromMilliseconds(50))).Wait();
+                Task.Delay(Dilated(TimeSpan.FromMilliseconds(50))).Wait(Token);
                 callbackWasRun = true;
             });
 
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             new TaskFactory().StartNew(() =>
             {
-                Task.Delay(Dilated(TimeSpan.FromMilliseconds(200))).Wait();
+                Task.Delay(Dilated(TimeSpan.FromMilliseconds(200))).Wait(Token);
                 actorSystem.Terminate();
             });
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
-            await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(5));
+            await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(5), Token);
             Assert.True(callbackWasRun);
         }
 
@@ -217,7 +225,7 @@ namespace Akka.Tests.Actor
         {
             var actorSystem = ActorSystem.Create(Guid.NewGuid().ToString());
 
-            await actorSystem.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(10));
+            await actorSystem.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(10), Token);
             
             var ex = Assert.Throws<InvalidOperationException>(() => actorSystem.RegisterOnTermination(() => { }));
             Assert.Equal("ActorSystem already terminated.", ex.Message);
@@ -228,9 +236,9 @@ namespace Akka.Tests.Actor
         {
             var timeout = Dilated(TimeSpan.FromSeconds(20));
             var waves = Task.WhenAll(
-                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000),
-                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000),
-                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000));
+                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000, Token),
+                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000, Token),
+                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000, Token));
 
             await waves.AwaitWithTimeout(timeout.Duration() + TimeSpan.FromSeconds(5));
 
@@ -368,7 +376,7 @@ namespace Akka.Tests.Actor
 
             a.Tell("die");
 
-            Assert.True(system.WhenTerminated.Wait(1000));
+            Assert.True(system.WhenTerminated.Wait(1000, Token));
         }
     }
 

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -82,7 +82,7 @@ namespace Akka.Tests.Actor
             {
                 system.Start();
                 return Task.CompletedTask;
-            }, Token);
+            }, cancellationToken: Token);
 
             await system.Terminate();
         }
@@ -104,7 +104,7 @@ namespace Akka.Tests.Actor
             {
                 system.Start();
                 return Task.CompletedTask;
-            }, Token);
+            }, cancellationToken: Token);
 
             await system.Terminate();
         }
@@ -143,7 +143,7 @@ namespace Akka.Tests.Actor
 
                     // Now send the message that should become a dead letter
                     a.Tell("boom");
-                }, Token);
+                }, cancellationToken: Token);
             }
             finally { Shutdown(sys); }
         }
@@ -154,8 +154,8 @@ namespace Akka.Tests.Actor
             var actorSystem = ActorSystem
                 .Create(Guid.NewGuid().ToString());
             var st = Stopwatch.StartNew();
-            var asyncShutdownTask = Task.Delay(TimeSpan.FromSeconds(1), Token).ContinueWith(_ => actorSystem.Terminate());
-            (await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(2), Token)).ShouldBeTrue();
+            var asyncShutdownTask = Task.Delay(TimeSpan.FromSeconds(1), cancellationToken: Token).ContinueWith(_ => actorSystem.Terminate());
+            (await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(2), cancellationToken: Token)).ShouldBeTrue();
             Assert.True(st.Elapsed.TotalSeconds >= .9);
         }
 
@@ -163,7 +163,7 @@ namespace Akka.Tests.Actor
         public async Task Given_a_system_that_isnt_going_to_shutdown_When_waiting_for_system_shutdown_Then_it_times_out()
         {
             var actorSystem = ActorSystem.Create(Guid.NewGuid().ToString());
-            (await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromMilliseconds(10), Token)).ShouldBeFalse();
+            (await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromMilliseconds(10), cancellationToken: Token)).ShouldBeFalse();
         }
 
         [Fact]
@@ -204,19 +204,19 @@ namespace Akka.Tests.Actor
 
             actorSystem.RegisterOnTermination(() =>
             {
-                Task.Delay(Dilated(TimeSpan.FromMilliseconds(50))).Wait(Token);
+                Task.Delay(Dilated(TimeSpan.FromMilliseconds(50))).Wait(cancellationToken: Token);
                 callbackWasRun = true;
             });
 
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            new TaskFactory().StartNew(() =>
+            new TaskFactory(cancellationToken: Token).StartNew(() =>
             {
-                Task.Delay(Dilated(TimeSpan.FromMilliseconds(200))).Wait(Token);
+                Task.Delay(Dilated(TimeSpan.FromMilliseconds(200))).Wait(cancellationToken: Token);
                 actorSystem.Terminate();
-            });
+            }, Token);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 
-            await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(5), Token);
+            await actorSystem.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(5), cancellationToken: Token);
             Assert.True(callbackWasRun);
         }
 
@@ -225,7 +225,7 @@ namespace Akka.Tests.Actor
         {
             var actorSystem = ActorSystem.Create(Guid.NewGuid().ToString());
 
-            await actorSystem.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(10), Token);
+            await actorSystem.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(10), cancellationToken: Token);
             
             var ex = Assert.Throws<InvalidOperationException>(() => actorSystem.RegisterOnTermination(() => { }));
             Assert.Equal("ActorSystem already terminated.", ex.Message);
@@ -236,11 +236,11 @@ namespace Akka.Tests.Actor
         {
             var timeout = Dilated(TimeSpan.FromSeconds(20));
             var waves = Task.WhenAll(
-                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000, Token),
-                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000, Token),
-                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000, Token));
+                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000, cancellationToken: Token),
+                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000, cancellationToken: Token),
+                Sys.ActorOf(Props.Create<Wave>()).Ask<string>(50000, cancellationToken: Token));
 
-            await waves.AwaitWithTimeout(timeout.Duration() + TimeSpan.FromSeconds(5));
+            await waves.AwaitWithTimeout(timeout.Duration() + TimeSpan.FromSeconds(5), cancellationToken: Token);
 
             Assert.Equal(new[] { "done", "done", "done" }, await waves);
         }
@@ -249,7 +249,7 @@ namespace Akka.Tests.Actor
         public async Task Find_actors_that_just_have_been_created()
         {
             Sys.ActorOf(Props.Create(() => new FastActor(new TestLatch(), TestActor)).WithDispatcher("slow"));
-            Assert.Equal(typeof(LocalActorRef), await ExpectMsgAsync<Type>());
+            Assert.Equal(typeof(LocalActorRef), await ExpectMsgAsync<Type>(cancellationToken: Token));
         }
 
         [Fact()]
@@ -353,7 +353,7 @@ namespace Akka.Tests.Actor
 
             a.Tell("die");
 
-            var t = await probe.ExpectTerminatedAsync(a);
+            var t = await probe.ExpectTerminatedAsync(a, cancellationToken: Token);
 
             Assert.True(t.ExistenceConfirmed);
             Assert.False(t.AddressTerminated);
@@ -376,7 +376,7 @@ namespace Akka.Tests.Actor
 
             a.Tell("die");
 
-            Assert.True(system.WhenTerminated.Wait(1000, Token));
+            Assert.True(system.WhenTerminated.Wait(1000, cancellationToken: Token));
         }
     }
 

--- a/src/core/Akka.Tests/Actor/ActorTelemetrySpecs.cs
+++ b/src/core/Akka.Tests/Actor/ActorTelemetrySpecs.cs
@@ -6,13 +6,13 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Routing;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor
 {
@@ -23,6 +23,8 @@ namespace Akka.Tests.Actor
         public ActorTelemetrySpecs(ITestOutputHelper output) : base(WithTelemetry, output)
         {
         }
+        
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
 
         // create an actor that will subscribe to all of the IActorTelemetryEvents in the EventStream
         private class TelemetrySubscriber : ReceiveActor
@@ -131,7 +133,7 @@ namespace Akka.Tests.Actor
             }
         }
 
-        private static async Task WaitUntilStableAsync(IActorRef subscriber, TimeSpan timeout)
+        private static async Task WaitUntilStableAsync(IActorRef subscriber, TimeSpan timeout, CancellationToken token)
         {
             var start = DateTime.Now;
             var end = start + timeout;
@@ -141,7 +143,9 @@ namespace Akka.Tests.Actor
             var count = 0;
             while (DateTime.Now < end)
             {
-                var reply = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance);
+                token.ThrowIfCancellationRequested();
+                
+                var reply = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, token);
                 if (reply == last)
                 {
                     count++;
@@ -153,7 +157,7 @@ namespace Akka.Tests.Actor
                     count = 0;
                 }
                 last = reply;
-                await Task.Delay(200);
+                await Task.Delay(200, token);
             }
             
             throw new Exception($"Failed to wait for a stable actor telemetry count after {DateTime.Now - start}. Timeout: {timeout}");
@@ -166,10 +170,10 @@ namespace Akka.Tests.Actor
             var subscriber = Sys.ActorOf(Props.Create<TelemetrySubscriber>(), "subscriber");
             
             // wait until telemetry value is stable
-            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5));
+            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5), Token);
             
             // request current telemetry values (ensure that the actor has started, so counter values will be accurate)
-            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance);
+            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, Token);
             
             // create a parent actor
             var parent = Sys.ActorOf(Props.Create<ParentActor>(), "parent");
@@ -189,7 +193,7 @@ namespace Akka.Tests.Actor
                 // assert no restarts or stops recorded
                 Assert.Equal(0, telemetry.ActorRestarted - baseline.ActorRestarted);
                 Assert.Equal(0, telemetry.ActorStopped - baseline.ActorStopped);
-            }, RemainingOrDefault);
+            }, RemainingOrDefault, cancellationToken: Token);
             
             // send a message to the parent to restart all children
             parent.Tell(RestartChildren.Instance);
@@ -206,7 +210,7 @@ namespace Akka.Tests.Actor
                 Assert.Equal(100, telemetry.ActorRestarted - baseline.ActorRestarted);
                 // assert no stops recorded
                 Assert.Equal(0, telemetry.ActorStopped - baseline.ActorStopped);
-            }, RemainingOrDefault);
+            }, RemainingOrDefault, cancellationToken: Token);
             
             // GracefulStop parent actor and assert that 101 actors have been stopped
             await parent.GracefulStop(RemainingOrDefault);
@@ -217,7 +221,7 @@ namespace Akka.Tests.Actor
                 Assert.Equal(101, telemetry.ActorCreated - baseline.ActorCreated);
                 Assert.Equal(100, telemetry.ActorRestarted - baseline.ActorRestarted);
                 Assert.Equal(101, telemetry.ActorStopped - baseline.ActorStopped);
-            }, RemainingOrDefault);
+            }, RemainingOrDefault, cancellationToken: Token);
         }
         
         // create a unit test where a parent actor spawns 100 children and then restarts
@@ -227,10 +231,10 @@ namespace Akka.Tests.Actor
             // create a TelemetrySubscriber actor
             var subscriber = Sys.ActorOf(Props.Create<TelemetrySubscriber>(), "subscriber");
             
-            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5));
+            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5), Token);
             
             // request current telemetry values (ensure that the actor has started, so counter values will be accurate)
-            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance);
+            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, Token);
             
             // create a parent actor
             var parent = Sys.ActorOf(Props.Create<ParentActor>(), "parent");
@@ -250,7 +254,7 @@ namespace Akka.Tests.Actor
                 // assert no restarts or stops recorded
                 Assert.Equal(0, telemetry.ActorRestarted - baseline.ActorRestarted);
                 Assert.Equal(0, telemetry.ActorStopped - baseline.ActorStopped);
-            }, RemainingOrDefault);
+            }, RemainingOrDefault, cancellationToken: Token);
             
             // send a message to the parent to restart
             parent.Tell("restart");
@@ -266,7 +270,7 @@ namespace Akka.Tests.Actor
                 Assert.Equal(1, telemetry.ActorRestarted - baseline.ActorRestarted);
                 // assert 100 stops recorded (only the child actors)
                 Assert.Equal(100, telemetry.ActorStopped - baseline.ActorStopped);
-            }, RemainingOrDefault);
+            }, RemainingOrDefault, cancellationToken: Token);
         }
         
         /// <summary>
@@ -278,10 +282,10 @@ namespace Akka.Tests.Actor
             // create a TelemetrySubscriber actor
             var subscriber = Sys.ActorOf(Props.Create<TelemetrySubscriber>(), "subscriber");
             
-            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5));
+            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5), Token);
             
             // request current telemetry values (ensure that the actor has started, so counter values will be accurate)
-            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance);
+            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, Token);
             
             // create a pool router
             var router = Sys.ActorOf(Props.Create<ChildActor>().WithRouter(new RoundRobinPool(10)), "router");
@@ -294,7 +298,7 @@ namespace Akka.Tests.Actor
                 // assert no restarts or stops recorded
                 Assert.Equal(0, telemetry.ActorRestarted - baseline.ActorRestarted);
                 Assert.Equal(0, telemetry.ActorStopped - baseline.ActorStopped);
-            }, RemainingOrDefault);
+            }, RemainingOrDefault, cancellationToken: Token);
             
             // send a message to the router to restart all children
             router.Tell(new Broadcast(RestartChildren.Instance));
@@ -309,7 +313,7 @@ namespace Akka.Tests.Actor
                 Assert.Equal(10, telemetry.ActorRestarted - baseline.ActorRestarted);
                 // assert no stops recorded
                 Assert.Equal(0, telemetry.ActorStopped - baseline.ActorStopped);
-            }, RemainingOrDefault);
+            }, RemainingOrDefault, cancellationToken: Token);
             
             // GracefulStop router actor and assert that 10 actors have been stopped
             await router.GracefulStop(RemainingOrDefault);
@@ -320,7 +324,7 @@ namespace Akka.Tests.Actor
                 Assert.Equal(11, telemetry.ActorCreated - baseline.ActorCreated);
                 Assert.Equal(10, telemetry.ActorRestarted - baseline.ActorRestarted);
                 Assert.Equal(11, telemetry.ActorStopped - baseline.ActorStopped);
-            }, RemainingOrDefault);
+            }, RemainingOrDefault, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/ActorTelemetrySpecs.cs
+++ b/src/core/Akka.Tests/Actor/ActorTelemetrySpecs.cs
@@ -170,10 +170,10 @@ namespace Akka.Tests.Actor
             var subscriber = Sys.ActorOf(Props.Create<TelemetrySubscriber>(), "subscriber");
             
             // wait until telemetry value is stable
-            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5), Token);
+            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5), token: Token);
             
             // request current telemetry values (ensure that the actor has started, so counter values will be accurate)
-            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, Token);
+            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, cancellationToken: Token);
             
             // create a parent actor
             var parent = Sys.ActorOf(Props.Create<ParentActor>(), "parent");
@@ -182,7 +182,7 @@ namespace Akka.Tests.Actor
             parent.Tell(new CreateChildren(100));
 
             // wait for the parent to reply back
-            ExpectMsg("done");
+            ExpectMsg("done", cancellationToken: Token);
             
             // awaitassert collecting data from the telemetry subscriber until we can see that 101 actors have been created
             // 100 children + parent
@@ -199,7 +199,7 @@ namespace Akka.Tests.Actor
             parent.Tell(RestartChildren.Instance);
             
             // wait for the parent to reply back
-            ExpectMsg("done");
+            ExpectMsg("done", cancellationToken: Token);
 
             // await assert collecting data from the telemetry subscriber until we can see that 102 actors have been restarted
             await AwaitAssertAsync(async () =>
@@ -231,10 +231,10 @@ namespace Akka.Tests.Actor
             // create a TelemetrySubscriber actor
             var subscriber = Sys.ActorOf(Props.Create<TelemetrySubscriber>(), "subscriber");
             
-            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5), Token);
+            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5), token: Token);
             
             // request current telemetry values (ensure that the actor has started, so counter values will be accurate)
-            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, Token);
+            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, cancellationToken: Token);
             
             // create a parent actor
             var parent = Sys.ActorOf(Props.Create<ParentActor>(), "parent");
@@ -243,7 +243,7 @@ namespace Akka.Tests.Actor
             parent.Tell(new CreateChildren(100));
 
             // wait for the parent to reply back
-            ExpectMsg("done");
+            ExpectMsg("done", cancellationToken: Token);
             
             // awaitassert collecting data from the telemetry subscriber until we can see that 102 actors have been created
             // 100 children + parent
@@ -282,10 +282,10 @@ namespace Akka.Tests.Actor
             // create a TelemetrySubscriber actor
             var subscriber = Sys.ActorOf(Props.Create<TelemetrySubscriber>(), "subscriber");
             
-            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5), Token);
+            await WaitUntilStableAsync(subscriber, TimeSpan.FromSeconds(5), token: Token);
             
             // request current telemetry values (ensure that the actor has started, so counter values will be accurate)
-            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, Token);
+            var baseline = await subscriber.Ask<TelemetrySubscriber.GetTelemetry>(TelemetrySubscriber.GetTelemetryRequest.Instance, cancellationToken: Token);
             
             // create a pool router
             var router = Sys.ActorOf(Props.Create<ChildActor>().WithRouter(new RoundRobinPool(10)), "router");

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -126,7 +126,7 @@ namespace Akka.Tests.Actor
         public async Task Can_Ask_actor()
         {
             var actor = Sys.ActorOf<SomeActor>();
-            var res = await actor.Ask<string>("answer", Token);
+            var res = await actor.Ask<string>("answer", cancellationToken: Token);
             res.ShouldBe("answer");
         }
 
@@ -134,7 +134,7 @@ namespace Akka.Tests.Actor
         public async Task Can_Ask_actor_with_timeout()
         {
             var actor = Sys.ActorOf<SomeActor>();
-            var res = await actor.Ask<string>("answer", TimeSpan.FromSeconds(10), Token);
+            var res = await actor.Ask<string>("answer", TimeSpan.FromSeconds(10), cancellationToken: Token);
             res.ShouldBe("answer");
         }
 
@@ -142,7 +142,7 @@ namespace Akka.Tests.Actor
         public async Task Can_get_timeout_when_asking_actor()
         {
             var actor = Sys.ActorOf<SomeActor>();
-            await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("timeout", TimeSpan.FromSeconds(3), Token));
+            await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("timeout", TimeSpan.FromSeconds(3), cancellationToken: Token));
         }
 
         [Fact]
@@ -150,10 +150,10 @@ namespace Akka.Tests.Actor
         {
             var actor = Sys.ActorOf<SomeActor>();            
             
-            await EventFilter.DeadLetter<object>().ExpectOneAsync(TimeSpan.FromSeconds(5), async () => 
+            await EventFilter.DeadLetter<object>().ExpectOneAsync(TimeSpan.FromSeconds(5), async () =>
             {
-                await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("delay", TimeSpan.FromSeconds(1), Token));
-            });
+                await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("delay", TimeSpan.FromSeconds(1), cancellationToken: Token));
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -165,7 +165,7 @@ namespace Akka.Tests.Actor
             {
                 var result = await actor.Ask<string>("many", TimeSpan.FromSeconds(1));
                 result.ShouldBe("answer1");
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace Akka.Tests.Actor
             {
                 using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
                     await Assert.ThrowsAsync<TaskCanceledException>(async () => await actor.Ask<string>("delay", Timeout.InfiniteTimeSpan, cts.Token));
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -187,8 +187,8 @@ namespace Akka.Tests.Actor
 
             await EventFilter.DeadLetter<object>().ExpectOne(async () =>
             {
-                await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<string>("invalid", TimeSpan.FromSeconds(1), Token));
-            });
+                await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<string>("invalid", TimeSpan.FromSeconds(1), cancellationToken: Token));
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -196,7 +196,7 @@ namespace Akka.Tests.Actor
         {
             var actor = Sys.ActorOf<SomeActor>();
 
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await actor.Ask<ISystemMessage>("system", TimeSpan.FromSeconds(1), Token));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await actor.Ask<ISystemMessage>("system", TimeSpan.FromSeconds(1), cancellationToken: Token));
         }
 
         [Fact]
@@ -215,7 +215,7 @@ namespace Akka.Tests.Actor
             var actor = Sys.ActorOf<SomeActor>();
             try
             {
-                await actor.Ask<string>("timeout", Token);
+                await actor.Ask<string>("timeout", cancellationToken: Token);
                 Assert.Fail("the ask should have timed out with default timeout");
             }
             catch (AskTimeoutException e)
@@ -254,7 +254,7 @@ namespace Akka.Tests.Actor
         {
             var actor = Sys.ActorOf<SomeActor>();
 
-            await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("timeout", Token));
+            await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("timeout", cancellationToken: Token));
 
             await Are_Temp_Actors_Removed(actor);
         }
@@ -265,7 +265,7 @@ namespace Akka.Tests.Actor
             var actor = Sys.ActorOf<SomeActor>();
 
             // expect int, but in fact string
-            await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<int>("answer", Token));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<int>("answer", cancellationToken: Token));
         }
         
         /// <summary>
@@ -280,7 +280,7 @@ namespace Akka.Tests.Actor
             }));
 
             // expect a string, but the answer should be `null`
-            var resp = await actor.Ask<string>(1, Token);
+            var resp = await actor.Ask<string>(1, cancellationToken: Token);
             resp.Should().BeNullOrEmpty();
         }
 
@@ -297,10 +297,10 @@ namespace Akka.Tests.Actor
                 context.Sender.Tell(new Status.Failure(new Exception(textExceptionMessage)));
             }));
 
-            var ex = await Assert.ThrowsAsync<Exception>(async () => await actor.Ask("answer", Token));
+            var ex = await Assert.ThrowsAsync<Exception>(async () => await actor.Ask("answer", cancellationToken: Token));
             ex.Message.ShouldBe(textExceptionMessage);
 
-            ex = await Assert.ThrowsAsync<Exception>(async () => await actor.Ask<object>("answer", Token));
+            ex = await Assert.ThrowsAsync<Exception>(async () => await actor.Ask<object>("answer", cancellationToken: Token));
             ex.Message.ShouldBe(textExceptionMessage);
         }
 
@@ -317,10 +317,10 @@ namespace Akka.Tests.Actor
                 context.Sender.Tell(new Status.Failure(new Exception(textExceptionMessage)));
             }));
 
-            var failure = await actor.Ask<Status.Failure>("answer", Token);
+            var failure = await actor.Ask<Status.Failure>("answer", cancellationToken: Token);
             failure.Cause.Message.ShouldBe(textExceptionMessage);
 
-            var status = await actor.Ask<Status>("answer", Token);
+            var status = await actor.Ask<Status>("answer", cancellationToken: Token);
             Assert.IsType<Status.Failure>(status);
             ((Status.Failure)status).Cause.Message.ShouldBe(textExceptionMessage);
         }
@@ -363,7 +363,7 @@ namespace Akka.Tests.Actor
             var replyActor = Sys.ActorOf<ReplyActor>();
             var waitActor = Sys.ActorOf(Props.Create(() => new WaitActor(replyActor, TestActor)));
             waitActor.Tell("ask");
-            await ExpectMsgAsync("bar");
+            await ExpectMsgAsync("bar", cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/AskSpec.cs
+++ b/src/core/Akka.Tests/Actor/AskSpec.cs
@@ -23,6 +23,8 @@ namespace Akka.Tests.Actor
 {
     public class AskSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public AskSpec()
             : base(@"akka.actor.ask-timeout = 3000ms")
         { }
@@ -124,7 +126,7 @@ namespace Akka.Tests.Actor
         public async Task Can_Ask_actor()
         {
             var actor = Sys.ActorOf<SomeActor>();
-            var res = await actor.Ask<string>("answer");
+            var res = await actor.Ask<string>("answer", Token);
             res.ShouldBe("answer");
         }
 
@@ -132,7 +134,7 @@ namespace Akka.Tests.Actor
         public async Task Can_Ask_actor_with_timeout()
         {
             var actor = Sys.ActorOf<SomeActor>();
-            var res = await actor.Ask<string>("answer", TimeSpan.FromSeconds(10));
+            var res = await actor.Ask<string>("answer", TimeSpan.FromSeconds(10), Token);
             res.ShouldBe("answer");
         }
 
@@ -140,7 +142,7 @@ namespace Akka.Tests.Actor
         public async Task Can_get_timeout_when_asking_actor()
         {
             var actor = Sys.ActorOf<SomeActor>();
-            await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("timeout", TimeSpan.FromSeconds(3)));
+            await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("timeout", TimeSpan.FromSeconds(3), Token));
         }
 
         [Fact]
@@ -150,7 +152,7 @@ namespace Akka.Tests.Actor
             
             await EventFilter.DeadLetter<object>().ExpectOneAsync(TimeSpan.FromSeconds(5), async () => 
             {
-                await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("delay", TimeSpan.FromSeconds(1)));
+                await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("delay", TimeSpan.FromSeconds(1), Token));
             });
         }
 
@@ -185,7 +187,7 @@ namespace Akka.Tests.Actor
 
             await EventFilter.DeadLetter<object>().ExpectOne(async () =>
             {
-                await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<string>("invalid", TimeSpan.FromSeconds(1)));
+                await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<string>("invalid", TimeSpan.FromSeconds(1), Token));
             });
         }
 
@@ -194,7 +196,7 @@ namespace Akka.Tests.Actor
         {
             var actor = Sys.ActorOf<SomeActor>();
 
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await actor.Ask<ISystemMessage>("system", TimeSpan.FromSeconds(1)));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await actor.Ask<ISystemMessage>("system", TimeSpan.FromSeconds(1), Token));
         }
 
         [Fact]
@@ -213,7 +215,7 @@ namespace Akka.Tests.Actor
             var actor = Sys.ActorOf<SomeActor>();
             try
             {
-                await actor.Ask<string>("timeout");
+                await actor.Ask<string>("timeout", Token);
                 Assert.Fail("the ask should have timed out with default timeout");
             }
             catch (AskTimeoutException e)
@@ -252,7 +254,7 @@ namespace Akka.Tests.Actor
         {
             var actor = Sys.ActorOf<SomeActor>();
 
-            await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("timeout"));
+            await Assert.ThrowsAsync<AskTimeoutException>(async () => await actor.Ask<string>("timeout", Token));
 
             await Are_Temp_Actors_Removed(actor);
         }
@@ -263,7 +265,7 @@ namespace Akka.Tests.Actor
             var actor = Sys.ActorOf<SomeActor>();
 
             // expect int, but in fact string
-            await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<int>("answer"));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await actor.Ask<int>("answer", Token));
         }
         
         /// <summary>
@@ -278,7 +280,7 @@ namespace Akka.Tests.Actor
             }));
 
             // expect a string, but the answer should be `null`
-            var resp = await actor.Ask<string>(1);
+            var resp = await actor.Ask<string>(1, Token);
             resp.Should().BeNullOrEmpty();
         }
 
@@ -295,10 +297,10 @@ namespace Akka.Tests.Actor
                 context.Sender.Tell(new Status.Failure(new Exception(textExceptionMessage)));
             }));
 
-            var ex = await Assert.ThrowsAsync<Exception>(async () => await actor.Ask("answer"));
+            var ex = await Assert.ThrowsAsync<Exception>(async () => await actor.Ask("answer", Token));
             ex.Message.ShouldBe(textExceptionMessage);
 
-            ex = await Assert.ThrowsAsync<Exception>(async () => await actor.Ask<object>("answer"));
+            ex = await Assert.ThrowsAsync<Exception>(async () => await actor.Ask<object>("answer", Token));
             ex.Message.ShouldBe(textExceptionMessage);
         }
 
@@ -315,10 +317,10 @@ namespace Akka.Tests.Actor
                 context.Sender.Tell(new Status.Failure(new Exception(textExceptionMessage)));
             }));
 
-            var failure = await actor.Ask<Status.Failure>("answer");
+            var failure = await actor.Ask<Status.Failure>("answer", Token);
             failure.Cause.Message.ShouldBe(textExceptionMessage);
 
-            var status = await actor.Ask<Status>("answer");
+            var status = await actor.Ask<Status>("answer", Token);
             Assert.IsType<Status.Failure>(status);
             ((Status.Failure)status).Cause.Message.ShouldBe(textExceptionMessage);
         }

--- a/src/core/Akka.Tests/Actor/BugFix2176Spec.cs
+++ b/src/core/Akka.Tests/Actor/BugFix2176Spec.cs
@@ -9,11 +9,14 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class BugFix2176Spec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         private class Actor1 : ReceiveActor
         {
             private readonly IActorRef _testActor;
@@ -59,14 +62,14 @@ namespace Akka.Tests.Actor
         public async Task Fix2176_Constructor_Should_create_valid_child_actor()
         {
             var actor = Sys.ActorOf(Props.Create(() => new Actor1NonAsync(TestActor)), "actor1");
-            await ExpectMsgAsync("started");
+            await ExpectMsgAsync("started", cancellationToken: Token);
         }
 
         [Fact]
         public async Task Fix2176_RunTask_Should_create_valid_child_actor()
         {
             var actor = Sys.ActorOf(Props.Create(() => new Actor1(TestActor)), "actor1");
-            await ExpectMsgAsync("started");
+            await ExpectMsgAsync("started", cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/BugFix4376Spec.cs
+++ b/src/core/Akka.Tests/Actor/BugFix4376Spec.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Routing;
@@ -16,7 +15,6 @@ using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor
 {

--- a/src/core/Akka.Tests/Actor/BugFix4376Spec.cs
+++ b/src/core/Akka.Tests/Actor/BugFix4376Spec.cs
@@ -15,6 +15,7 @@ using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
@@ -23,6 +24,8 @@ namespace Akka.Tests.Actor
     /// </summary>
     public class BugFix4376Spec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public BugFix4376Spec(ITestOutputHelper output): base(output) { }
 
         private class SimpleActor : ReceiveActor
@@ -129,12 +132,12 @@ namespace Akka.Tests.Actor
             {
                 var result = await poolActorRef.Ask<int>(2, RemainingOrDefault);
                 result.Should().Be(2);
-            });
+            }, cancellationToken: Token);
 
             // Verify router can handle sustained traffic after recovery
             for (var i = 0; i < 19; i++)
             {
-                var result = await poolActorRef.Ask<int>(2, RemainingOrDefault);
+                var result = await poolActorRef.Ask<int>(2, RemainingOrDefault, cancellationToken: Token);
                 result.Should().Be(2);
             }
         }
@@ -158,12 +161,12 @@ namespace Akka.Tests.Actor
             {
                 var result = await poolActorRef.Ask<int>(2, RemainingOrDefault);
                 result.Should().Be(2);
-            });
+            }, cancellationToken: Token);
 
             // Verify router can handle sustained traffic after recovery
             for (var i = 0; i < 19; i++)
             {
-                var result = await poolActorRef.Ask<int>(2, RemainingOrDefault);
+                var result = await poolActorRef.Ask<int>(2, RemainingOrDefault, cancellationToken: Token);
                 result.Should().Be(2);
             }
         }
@@ -183,12 +186,12 @@ namespace Akka.Tests.Actor
             }
 
             poolActorRef.Tell(2);
-            await ExpectMsgAsync<int>();
-            await ExpectMsgAsync<int>();
-            await ExpectMsgAsync<int>();
-            await ExpectMsgAsync<int>();
-            await ExpectMsgAsync<int>();
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectMsgAsync<int>(cancellationToken: Token);
+            await ExpectMsgAsync<int>(cancellationToken: Token);
+            await ExpectMsgAsync<int>(cancellationToken: Token);
+            await ExpectMsgAsync<int>(cancellationToken: Token);
+            await ExpectMsgAsync<int>(cancellationToken: Token);
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
         }
 
         [Fact]
@@ -220,12 +223,12 @@ namespace Akka.Tests.Actor
             {
                 var result = await groupActorRef.Ask<int>(2, RemainingOrDefault);
                 result.Should().Be(2);
-            });
+            }, cancellationToken: Token);
 
             // Verify router can handle sustained traffic after recovery
             for (var i = 0; i < 19; i++)
             {
-                var result = await groupActorRef.Ask<int>(2, RemainingOrDefault);
+                var result = await groupActorRef.Ask<int>(2, RemainingOrDefault, cancellationToken: Token);
                 result.Should().Be(2);
             }
         }
@@ -259,12 +262,12 @@ namespace Akka.Tests.Actor
             {
                 var result = await groupActorRef.Ask<int>(2, RemainingOrDefault);
                 result.Should().Be(2);
-            });
+            }, cancellationToken: Token);
 
             // Verify router can handle sustained traffic after recovery
             for (var i = 0; i < 19; i++)
             {
-                var result = await groupActorRef.Ask<int>(2, RemainingOrDefault);
+                var result = await groupActorRef.Ask<int>(2, RemainingOrDefault, cancellationToken: Token);
                 result.Should().Be(2);
             }
         }
@@ -284,7 +287,7 @@ namespace Akka.Tests.Actor
             await AwaitAssertAsync(() =>
             {
                 counter.Current.Should().Be(0);
-            });
+            }, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/BugFix4823Spec.cs
+++ b/src/core/Akka.Tests/Actor/BugFix4823Spec.cs
@@ -7,9 +7,7 @@
 
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Event;
 using Akka.TestKit;
-using Xunit.Abstractions;
 using FluentAssertions;
 using Xunit;
 

--- a/src/core/Akka.Tests/Actor/BugFix4823Spec.cs
+++ b/src/core/Akka.Tests/Actor/BugFix4823Spec.cs
@@ -10,11 +10,14 @@ using Akka.Actor;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class BugFix4823Spec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public BugFix4823Spec(ITestOutputHelper outputHelper) : base(outputHelper)
         {
         }
@@ -24,8 +27,8 @@ namespace Akka.Tests.Actor
         {
             var identity = ActorOfAsTestActorRef<MyActor>(Props.Create(() => new MyActor(TestActor)), TestActor);
             identity.Tell(NotUsed.Instance);
-            var selfBefore = await ExpectMsgAsync<IActorRef>();
-            var selfAfter = await ExpectMsgAsync<IActorRef>();
+            var selfBefore = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
+            var selfAfter = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             selfAfter.Should().Be(selfBefore);
         }
 

--- a/src/core/Akka.Tests/Actor/Bugfix7501Specs.cs
+++ b/src/core/Akka.Tests/Actor/Bugfix7501Specs.cs
@@ -9,9 +9,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Dsl;
 using Akka.TestKit;
-using Akka.TestKit.TestActors;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor;
 

--- a/src/core/Akka.Tests/Actor/Bugfix7501Specs.cs
+++ b/src/core/Akka.Tests/Actor/Bugfix7501Specs.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 //  <copyright file="Bugfix7501Specs.cs" company="Akka.NET Project">
 //      Copyright (C) 2009-2025 Lightbend Inc. <http://www.lightbend.com>
 //      Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -10,11 +10,14 @@ using Akka.Actor;
 using Akka.Actor.Dsl;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor;
 
 public class Bugfix7501Specs : AkkaSpec
 {
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
     public Bugfix7501Specs(ITestOutputHelper output) : base(output)
     {
         
@@ -48,15 +51,15 @@ public class Bugfix7501Specs : AkkaSpec
 
         // act
         await customDeathWatchProbe.WatchAsync(watcher);
-        await watcher.Ask<string>("boo", RemainingOrDefault);
-        var futureActorRef = await ExpectMsgAsync<IActorRef>();
+        await watcher.Ask<string>("boo", RemainingOrDefault, cancellationToken: Token);
+        var futureActorRef = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
         await WatchAsync(futureActorRef); // Ask is finished - should immediately dead-letter
         
         // assert
-        await ExpectTerminatedAsync(futureActorRef);
+        await ExpectTerminatedAsync(futureActorRef, cancellationToken: Token);
         
         // get the DeathWatch notification from the original actor
         // this can only be received if the original actor got a Terminated message from FutureActorRef
-        await customDeathWatchProbe.ExpectTerminatedAsync(watcher);
+        await customDeathWatchProbe.ExpectTerminatedAsync(watcher, cancellationToken: Token);
     }
 }

--- a/src/core/Akka.Tests/Actor/ContextWatchWithSpec.cs
+++ b/src/core/Akka.Tests/Actor/ContextWatchWithSpec.cs
@@ -7,16 +7,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
-using FluentAssertions;
 using FluentAssertions.Extensions;
-using Newtonsoft.Json;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor
 {
@@ -29,6 +25,8 @@ namespace Akka.Tests.Actor
             _outputHelper = outputHelper;
         }
         
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [Fact(Skip = "This test is used with Performance Profiler to check memory leaks")]
         public async Task Context_WatchWith_Should_not_have_memory_leak()
         {
@@ -36,7 +34,7 @@ namespace Akka.Tests.Actor
             {
                 actorSystem.ActorOf(Props.Create<LoadHandler>());
 
-                await Task.Delay(60.Seconds());
+                await Task.Delay(60.Seconds(), Token);
             }
         }
         

--- a/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
+++ b/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
@@ -12,6 +12,7 @@ using Akka.Util.Internal;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.TestKit.Extensions;
@@ -23,6 +24,8 @@ namespace Akka.Tests.Actor
 {
     public class CoordinatedShutdownSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public ExtendedActorSystem ExtSys => Sys.AsInstanceOf<ExtendedActorSystem>();
 
         private Phase Phase(params string[] dependsOn)
@@ -397,7 +400,7 @@ namespace Akka.Tests.Actor
         public async Task CoordinatedShutdown_must_terminate_ActorSystem()
         {
             (await CoordinatedShutdown.Get(Sys).Run(customReason)
-                .AwaitWithTimeout(TimeSpan.FromSeconds(10))).Should().BeTrue();
+                .AwaitWithTimeout(TimeSpan.FromSeconds(10), Token)).Should().BeTrue();
 
             Sys.WhenTerminated.IsCompleted.Should().BeTrue();
             CoordinatedShutdown.Get(Sys).ShutdownReason.Should().BeEquivalentTo(customReason);

--- a/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
+++ b/src/core/Akka.Tests/Actor/CoordinatedShutdownSpec.cs
@@ -212,8 +212,8 @@ namespace Akka.Tests.Actor
                 return TaskEx.Completed;
             });
 
-            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault);
-            (await ReceiveNAsync(4, default).ToListAsync()).Should().Equal(new object[] { "A", "B", "B", "C" });
+            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault, cancellationToken: Token);
+            (await ReceiveNAsync(4, RemainingOrDefault, cancellationToken: Token).ToListAsync(Token)).Should().Equal(new object[] { "A", "B", "B", "C" });
         }
 
         [Fact]
@@ -245,8 +245,8 @@ namespace Akka.Tests.Actor
                 return TaskEx.Completed;
             });
 
-            await co.Run(customReason, "b").AwaitWithTimeout(RemainingOrDefault);
-            (await ReceiveNAsync(2, default).ToListAsync()).Should().Equal(new object[] { "B", "C" });
+            await co.Run(customReason, "b").AwaitWithTimeout(RemainingOrDefault, cancellationToken: Token);
+            (await ReceiveNAsync(2, RemainingOrDefault, cancellationToken: Token).ToListAsync(Token)).Should().Equal(new object[] { "B", "C" });
             co.ShutdownReason.Should().BeEquivalentTo(customReason);
         }
 
@@ -266,12 +266,12 @@ namespace Akka.Tests.Actor
             });
 
             co.ShutdownReason.Should().BeNull();
-            await co.Run(customReason).AwaitWithTimeout(RemainingOrDefault);
+            await co.Run(customReason).AwaitWithTimeout(RemainingOrDefault, cancellationToken: Token);
             co.ShutdownReason.Should().BeEquivalentTo(customReason);
-            await ExpectMsgAsync("A");
-            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault);
+            await ExpectMsgAsync("A", cancellationToken: Token);
+            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault, cancellationToken: Token);
             TestActor.Tell("done");
-            await ExpectMsgAsync("done"); // no additional A
+            await ExpectMsgAsync("done", cancellationToken: Token); // no additional A
             co.ShutdownReason.Should().BeEquivalentTo(customReason);
         }
 
@@ -311,11 +311,11 @@ namespace Akka.Tests.Actor
                 return TaskEx.Completed;
             });
 
-            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault);
-            await ExpectMsgAsync("A");
-            await ExpectMsgAsync("A");
-            await ExpectMsgAsync("B");
-            await ExpectMsgAsync("C");
+            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault, cancellationToken: Token);
+            await ExpectMsgAsync("A", cancellationToken: Token);
+            await ExpectMsgAsync("A", cancellationToken: Token);
+            await ExpectMsgAsync("B", cancellationToken: Token);
+            await ExpectMsgAsync("C", cancellationToken: Token);
         }
 
         [Fact]
@@ -341,9 +341,9 @@ namespace Akka.Tests.Actor
             });
 
             var task = co.Run(CoordinatedShutdown.UnknownReason.Instance);
-            await ExpectMsgAsync("B");
-            await Assert.ThrowsAsync<TimeoutException>(async() => await task.AwaitWithTimeout(RemainingOrDefault));
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200)); // C not run
+            await ExpectMsgAsync("B", cancellationToken: Token);
+            await Assert.ThrowsAsync<TimeoutException>(async() => await task.AwaitWithTimeout(RemainingOrDefault, cancellationToken: Token));
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200), cancellationToken: Token); // C not run
         }
 
         [Fact]
@@ -367,9 +367,9 @@ namespace Akka.Tests.Actor
                 return TaskEx.Completed;
             });
 
-            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault);
-            await ExpectMsgAsync("A");
-            await ExpectMsgAsync("B");
+            await co.Run(CoordinatedShutdown.UnknownReason.Instance).AwaitWithTimeout(RemainingOrDefault, cancellationToken: Token);
+            await ExpectMsgAsync("A", cancellationToken: Token);
+            await ExpectMsgAsync("B", cancellationToken: Token);
         }
 
         [Fact]
@@ -400,7 +400,7 @@ namespace Akka.Tests.Actor
         public async Task CoordinatedShutdown_must_terminate_ActorSystem()
         {
             (await CoordinatedShutdown.Get(Sys).Run(customReason)
-                .AwaitWithTimeout(TimeSpan.FromSeconds(10), Token)).Should().BeTrue();
+                .AwaitWithTimeout(TimeSpan.FromSeconds(10), cancellationToken: Token)).Should().BeTrue();
 
             Sys.WhenTerminated.IsCompleted.Should().BeTrue();
             CoordinatedShutdown.Get(Sys).ShutdownReason.Should().BeEquivalentTo(customReason);

--- a/src/core/Akka.Tests/Actor/DeadLetterSupressionSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeadLetterSupressionSpec.cs
@@ -19,6 +19,8 @@ namespace Akka.Tests.Actor
 {
     public class DeadLetterSupressionSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         private class NormalMessage
         {
         }
@@ -133,7 +135,7 @@ namespace Akka.Tests.Actor
             allDeadLetter.Sender.Should().Be(TestActor);
             allDeadLetter.Recipient.Should().Be(Sys.DeadLetters);
 
-            await Task.Delay(200);
+            await Task.Delay(200, Token);
             await deadListener.ExpectNoMsgAsync(TimeSpan.Zero);
             await suppressedListener.ExpectNoMsgAsync(TimeSpan.Zero);
             await allListener.ExpectNoMsgAsync(TimeSpan.Zero);

--- a/src/core/Akka.Tests/Actor/DeadLetterSupressionSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeadLetterSupressionSpec.cs
@@ -62,42 +62,42 @@ namespace Akka.Tests.Actor
             deadActor.Tell(new SuppressedMessage());
             deadActor.Tell(new NormalMessage());
 
-            var deadLetter = await deadListener.ExpectMsgAsync<DeadLetter>();
+            var deadLetter = await deadListener.ExpectMsgAsync<DeadLetter>(cancellationToken: Token);
             deadLetter.Message.Should().BeOfType<NormalMessage>();
             deadLetter.Sender.Should().Be(TestActor);
             deadLetter.Recipient.Should().Be(deadActor);
-            await deadListener.ExpectNoMsgAsync(200.Milliseconds());
+            await deadListener.ExpectNoMsgAsync(200.Milliseconds(), cancellationToken: Token);
 
-            var suppressedDeadLetter = await suppressedListener.ExpectMsgAsync<SuppressedDeadLetter>();
+            var suppressedDeadLetter = await suppressedListener.ExpectMsgAsync<SuppressedDeadLetter>(cancellationToken: Token);
             suppressedDeadLetter.Message.Should().BeOfType<SuppressedMessage>();
             suppressedDeadLetter.Sender.Should().Be(TestActor);
             suppressedDeadLetter.Recipient.Should().Be(Sys.DeadLetters);
-            await suppressedListener.ExpectNoMsgAsync(200.Milliseconds());
+            await suppressedListener.ExpectNoMsgAsync(200.Milliseconds(), cancellationToken: Token);
 
-            var allSuppressedDeadLetter = await allListener.ExpectMsgAsync<SuppressedDeadLetter>();
+            var allSuppressedDeadLetter = await allListener.ExpectMsgAsync<SuppressedDeadLetter>(cancellationToken: Token);
             allSuppressedDeadLetter.Message.Should().BeOfType<SuppressedMessage>();
             allSuppressedDeadLetter.Sender.Should().Be(TestActor);
             allSuppressedDeadLetter.Recipient.Should().Be(Sys.DeadLetters);
 
-            var allDeadLetter = await allListener.ExpectMsgAsync<DeadLetter>();
+            var allDeadLetter = await allListener.ExpectMsgAsync<DeadLetter>(cancellationToken: Token);
             allDeadLetter.Message.Should().BeOfType<NormalMessage>();
             allDeadLetter.Sender.Should().Be(TestActor);
             allDeadLetter.Recipient.Should().Be(deadActor);
 
-            await allListener.ExpectNoMsgAsync(200.Milliseconds());
+            await allListener.ExpectNoMsgAsync(200.Milliseconds(), cancellationToken: Token);
 
             // unwrap for ActorSelection
             Sys.ActorSelection(deadActor.Path).Tell(new SuppressedMessage());
             Sys.ActorSelection(deadActor.Path).Tell(new NormalMessage());
 
             // the recipient ref isn't the same as deadActor here so only checking the message
-            deadLetter = await deadListener.ExpectMsgAsync<DeadLetter>();//
+            deadLetter = await deadListener.ExpectMsgAsync<DeadLetter>(cancellationToken: Token);//
             deadLetter.Message.Should().BeOfType<NormalMessage>();
-            suppressedDeadLetter = await suppressedListener.ExpectMsgAsync<SuppressedDeadLetter>();
+            suppressedDeadLetter = await suppressedListener.ExpectMsgAsync<SuppressedDeadLetter>(cancellationToken: Token);
             suppressedDeadLetter.Message.Should().BeOfType<SuppressedMessage>();
 
-            await deadListener.ExpectNoMsgAsync(200.Milliseconds());
-            await suppressedListener.ExpectNoMsgAsync(200.Milliseconds());
+            await deadListener.ExpectNoMsgAsync(200.Milliseconds(), cancellationToken: Token);
+            await suppressedListener.ExpectNoMsgAsync(200.Milliseconds(), cancellationToken: Token);
         }
 
         [Fact]
@@ -115,46 +115,46 @@ namespace Akka.Tests.Actor
             Sys.DeadLetters.Tell(new SuppressedMessage());
             Sys.DeadLetters.Tell(new NormalMessage());
 
-            var deadLetter = await deadListener.ExpectMsgAsync<DeadLetter>(200.Milliseconds());
+            var deadLetter = await deadListener.ExpectMsgAsync<DeadLetter>(200.Milliseconds(), cancellationToken: Token);
             deadLetter.Message.Should().BeOfType<NormalMessage>();
             deadLetter.Sender.Should().Be(TestActor);
             deadLetter.Recipient.Should().Be(Sys.DeadLetters);
 
-            var suppressedDeadLetter = await suppressedListener.ExpectMsgAsync<SuppressedDeadLetter>(200.Milliseconds());
+            var suppressedDeadLetter = await suppressedListener.ExpectMsgAsync<SuppressedDeadLetter>(200.Milliseconds(), cancellationToken: Token);
             suppressedDeadLetter.Message.Should().BeOfType<SuppressedMessage>();
             suppressedDeadLetter.Sender.Should().Be(TestActor);
             suppressedDeadLetter.Recipient.Should().Be(Sys.DeadLetters);
 
-            var allSuppressedDeadLetter = await allListener.ExpectMsgAsync<SuppressedDeadLetter>(200.Milliseconds());
+            var allSuppressedDeadLetter = await allListener.ExpectMsgAsync<SuppressedDeadLetter>(200.Milliseconds(), cancellationToken: Token);
             allSuppressedDeadLetter.Message.Should().BeOfType<SuppressedMessage>();
             allSuppressedDeadLetter.Sender.Should().Be(TestActor);
             allSuppressedDeadLetter.Recipient.Should().Be(Sys.DeadLetters);
 
-            var allDeadLetter = await allListener.ExpectMsgAsync<DeadLetter>(200.Milliseconds());
+            var allDeadLetter = await allListener.ExpectMsgAsync<DeadLetter>(200.Milliseconds(), cancellationToken: Token);
             allDeadLetter.Message.Should().BeOfType<NormalMessage>();
             allDeadLetter.Sender.Should().Be(TestActor);
             allDeadLetter.Recipient.Should().Be(Sys.DeadLetters);
 
-            await Task.Delay(200, Token);
-            await deadListener.ExpectNoMsgAsync(TimeSpan.Zero);
-            await suppressedListener.ExpectNoMsgAsync(TimeSpan.Zero);
-            await allListener.ExpectNoMsgAsync(TimeSpan.Zero);
+            await Task.Delay(200, cancellationToken: Token);
+            await deadListener.ExpectNoMsgAsync(TimeSpan.Zero, cancellationToken: Token);
+            await suppressedListener.ExpectNoMsgAsync(TimeSpan.Zero, cancellationToken: Token);
+            await allListener.ExpectNoMsgAsync(TimeSpan.Zero, cancellationToken: Token);
 
             // unwrap for ActorSelection
             Sys.ActorSelection(Sys.DeadLetters.Path).Tell(new SuppressedMessage());
             Sys.ActorSelection(Sys.DeadLetters.Path).Tell(new NormalMessage());
 
-            deadLetter = await deadListener.ExpectMsgAsync<DeadLetter>();
+            deadLetter = await deadListener.ExpectMsgAsync<DeadLetter>(cancellationToken: Token);
             deadLetter.Message.Should().BeOfType<NormalMessage>();
             deadLetter.Sender.Should().Be(TestActor);
             deadLetter.Recipient.Should().Be(Sys.DeadLetters);
-            suppressedDeadLetter = await suppressedListener.ExpectMsgAsync<SuppressedDeadLetter>();
+            suppressedDeadLetter = await suppressedListener.ExpectMsgAsync<SuppressedDeadLetter>(cancellationToken: Token);
             suppressedDeadLetter.Message.Should().BeOfType<SuppressedMessage>();
             suppressedDeadLetter.Sender.Should().Be(TestActor);
             suppressedDeadLetter.Recipient.Should().Be(Sys.DeadLetters);
 
-            await deadListener.ExpectNoMsgAsync(200.Milliseconds());
-            await suppressedListener.ExpectNoMsgAsync(200.Milliseconds());
+            await deadListener.ExpectNoMsgAsync(200.Milliseconds(), cancellationToken: Token);
+            await suppressedListener.ExpectNoMsgAsync(200.Milliseconds(), cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/DeadLetterSuspensionSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeadLetterSuspensionSpec.cs
@@ -87,34 +87,34 @@ namespace Akka.Tests.Actor
         {
             await EventFilter
                 .Info(start: ExpectedDeadLettersLogMessage(1))
-                .ExpectAsync(1, () => { _deadActor.Tell(1); return Task.CompletedTask; });
+                .ExpectAsync(1, () => { _deadActor.Tell(1); return Task.CompletedTask; }, cancellationToken: Token);
 
             await EventFilter
                 .Info(start: ExpectedDroppedLogMessage(2))
-                .ExpectAsync(1, () => { _droppingActor.Tell(2); return Task.CompletedTask; });
+                .ExpectAsync(1, () => { _droppingActor.Tell(2); return Task.CompletedTask; }, cancellationToken: Token);
 
             await EventFilter
                 .Info(start: ExpectedUnhandledLogMessage(3))
-                .ExpectAsync(1, () => { _unhandledActor.Tell(3); return Task.CompletedTask; });
+                .ExpectAsync(1, () => { _unhandledActor.Tell(3); return Task.CompletedTask; }, cancellationToken: Token);
 
             await EventFilter
                 .Info(start: ExpectedDeadLettersLogMessage(4) + ", no more dead letters will be logged in next")
-                .ExpectAsync(1, () => { _deadActor.Tell(4); return Task.CompletedTask; });
+                .ExpectAsync(1, () => { _deadActor.Tell(4); return Task.CompletedTask; }, cancellationToken: Token);
             _deadActor.Tell(5);
             _droppingActor.Tell(6);
 
             // let suspend-duration elapse
-            await Task.Delay(2050, Token);
+            await Task.Delay(2050, cancellationToken: Token);
 
             // re-enabled
             await EventFilter
                 .Info(start: ExpectedDeadLettersLogMessage(7) + ", of which 2 were not logged")
-                .ExpectAsync(1, () => { _deadActor.Tell(7); return Task.CompletedTask; });
+                .ExpectAsync(1, () => { _deadActor.Tell(7); return Task.CompletedTask; }, cancellationToken: Token);
 
             // reset count
             await EventFilter
                 .Info(start: ExpectedDeadLettersLogMessage(1))
-                .ExpectAsync(1, () => { _deadActor.Tell(8); return Task.CompletedTask; });
+                .ExpectAsync(1, () => { _deadActor.Tell(8); return Task.CompletedTask; }, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/DeadLetterSuspensionSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeadLetterSuspensionSpec.cs
@@ -49,6 +49,8 @@ namespace Akka.Tests.Actor
             }
         }
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         private static readonly Config Config = ConfigurationFactory.ParseString(@"
             akka.loglevel = INFO
             akka.log-dead-letters = 4
@@ -102,7 +104,7 @@ namespace Akka.Tests.Actor
             _droppingActor.Tell(6);
 
             // let suspend-duration elapse
-            await Task.Delay(2050);
+            await Task.Delay(2050, Token);
 
             // re-enabled
             await EventFilter

--- a/src/core/Akka.Tests/Actor/DeadLettersSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeadLettersSpec.cs
@@ -10,17 +10,20 @@ using Akka.Actor;
 using Akka.Event;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests
 {
     public class DeadLettersSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact]
         public async Task Can_send_messages_to_dead_letters()
         {
             Sys.EventStream.Subscribe(TestActor, typeof(DeadLetter));
             Sys.DeadLetters.Tell("foobar");
-            await ExpectMsgAsync<DeadLetter>(deadLetter=>deadLetter.Message.Equals("foobar"));
+            await ExpectMsgAsync<DeadLetter>(deadLetter=>deadLetter.Message.Equals("foobar"), cancellationToken: Token);
         }
 
         private sealed record WrappedClass(object Message) : IWrappedMessage;
@@ -35,7 +38,7 @@ namespace Akka.Tests
         {
             Sys.EventStream.Subscribe(TestActor, typeof(DeadLetter));
             Sys.DeadLetters.Tell(new WrappedClass("chocolate-beans"));
-            await ExpectMsgAsync<DeadLetter>();
+            await ExpectMsgAsync<DeadLetter>(cancellationToken: Token);
         }
         
         [Fact]
@@ -43,7 +46,7 @@ namespace Akka.Tests
         {
             Sys.EventStream.Subscribe(TestActor, typeof(AllDeadLetters));
             Sys.DeadLetters.Tell(new WrappedClass(new SuppressedMessage()));
-            var msg = await ExpectMsgAsync<SuppressedDeadLetter>();
+            var msg = await ExpectMsgAsync<SuppressedDeadLetter>(cancellationToken: Token);
             msg.Message.ToString()!.Contains("SuppressedMessage").ShouldBeTrue();
         }
         
@@ -53,7 +56,7 @@ namespace Akka.Tests
             Sys.EventStream.Subscribe(TestActor, typeof(DeadLetter));
             var selection = Sys.ActorSelection("/user/foobar");
             selection.Tell(new WrappedClass("chocolate-beans"));
-            await ExpectMsgAsync<DeadLetter>();
+            await ExpectMsgAsync<DeadLetter>(cancellationToken: Token);
         }
         
         [Fact]
@@ -62,7 +65,7 @@ namespace Akka.Tests
             Sys.EventStream.Subscribe(TestActor, typeof(AllDeadLetters));
             var selection = Sys.ActorSelection("/user/foobar");
             selection.Tell(new WrappedClass(new SuppressedMessage()));
-            var msg = await ExpectMsgAsync<SuppressedDeadLetter>();
+            var msg = await ExpectMsgAsync<SuppressedDeadLetter>(cancellationToken: Token);
             msg.Message.ToString()!.Contains("SuppressedMessage").ShouldBeTrue();
         }
     }

--- a/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
+++ b/src/core/Akka.Tests/Actor/DeathWatchSpec.cs
@@ -26,6 +26,8 @@ namespace Akka.Tests.Actor
 {
     public class DeathWatchSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         private IActorRef _supervisor;
         private IActorRef _terminal;
 
@@ -65,10 +67,10 @@ namespace Akka.Tests.Actor
             Sys.EventStream.Subscribe(TestActor, typeof (DeadLetter));
 
             actor.Tell(PoisonPill.Instance);
-            await ExpectMsgAsync<Terminated>();
+            await ExpectMsgAsync<Terminated>(cancellationToken: Token);
 
             actor.Tell(new Envelope("SomeUserMessage", TestActor));
-            await ExpectMsgAsync<DeadLetter>(d => ((Envelope)d.Message).Message.Equals("SomeUserMessage"));
+            await ExpectMsgAsync<DeadLetter>(d => ((Envelope)d.Message).Message.Equals("SomeUserMessage"), cancellationToken: Token);
 
             //The actor should Terminate, exchange the mailbox to a DeadLetterMailbox and forward the user message to the DeadLetterMailbox
             
@@ -80,7 +82,7 @@ namespace Akka.Tests.Actor
         {
             const string msg = "hello";
             (await StartWatching(_terminal)).Tell(msg);
-            await ExpectMsgAsync(msg);
+            await ExpectMsgAsync(msg, cancellationToken: Token);
             _terminal.Tell(PoisonPill.Instance);
             await ExpectTerminationOf(_terminal);
         }
@@ -91,9 +93,9 @@ namespace Akka.Tests.Actor
             const string msg = "hello";
             const string terminationMsg = "watchee terminated";
             (await StartWatchingWith(_terminal, terminationMsg)).Tell(msg);
-            await ExpectMsgAsync(msg);
+            await ExpectMsgAsync(msg, cancellationToken: Token);
             _terminal.Tell(PoisonPill.Instance);
-            await ExpectMsgAsync(terminationMsg);
+            await ExpectMsgAsync(terminationMsg, cancellationToken: Token);
         }
 
         [Fact]
@@ -122,7 +124,7 @@ namespace Akka.Tests.Actor
             var monitor3 = await StartWatching(_terminal);
 
             monitor2.Tell("ping");
-            await ExpectMsgAsync("pong");      // since Watch and Unwatch are asynchronous, we need some sync
+            await ExpectMsgAsync("pong", cancellationToken: Token);      // since Watch and Unwatch are asynchronous, we need some sync
 
             _terminal.Tell(PoisonPill.Instance);
 
@@ -146,7 +148,7 @@ namespace Akka.Tests.Actor
                 var t1 = supervisor.Ask(Props.Create(() => new EchoTestActor()));
                 await t1.AwaitWithTimeout(timeout);
                 var terminal = (LocalActorRef) t1.Result;
-                
+
                 var t2 = supervisor.Ask(CreateWatchAndForwarderProps(terminal, TestActor));
                 await t2.AwaitWithTimeout(timeout);
                 var monitor = (IActorRef) t2.Result;
@@ -163,7 +165,7 @@ namespace Akka.Tests.Actor
                 terminal.IsTerminated.ShouldBe(true);
 
                 Sys.Stop(supervisor);
-            });
+            }, cancellationToken: Token);
         }
 
         // See issue: #61
@@ -209,7 +211,7 @@ namespace Akka.Tests.Actor
                 ((IInternalActorRef)TestActor).IsTerminated.ShouldBe(false);
 #pragma warning restore CS0618 // Type or member is obsolete
                 result.ShouldOnlyContainInOrder("1", "2", "3");
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -218,9 +220,9 @@ namespace Akka.Tests.Actor
             var parent = Sys.ActorOf(Props.Create(() => new KnobActor(TestActor)).WithDeploy(Deploy.Local));
 
             parent.Tell(Knob);
-            await ExpectMsgAsync(Bonk);
+            await ExpectMsgAsync(Bonk, cancellationToken: Token);
             parent.Tell(Knob);
-            await ExpectMsgAsync(Bonk);
+            await ExpectMsgAsync(Bonk, cancellationToken: Token);
         }
 
         [Fact]
@@ -228,7 +230,7 @@ namespace Akka.Tests.Actor
         {
             var subject = Sys.ActorOf(Props.Create(() => new EchoActor(_terminal)));
             ((IInternalActorRef)TestActor).SendSystemMessage(new DeathWatchNotification(subject, true, false));
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(3));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(3), cancellationToken: Token);
         }
 
         // See issue: #61
@@ -245,7 +247,7 @@ namespace Akka.Tests.Actor
             t1.Ready(TimeSpan.FromSeconds(3));
             Watch(p.Ref);
             Sys.Stop(p.Ref);
-            await ExpectTerminatedAsync(p.Ref);
+            await ExpectTerminatedAsync(p.Ref, cancellationToken: Token);
             w.Tell(new U(p.Ref));
             t2.CountDown();
 
@@ -255,9 +257,9 @@ namespace Akka.Tests.Actor
             // - process the Terminated
             // If it receives the Terminated it will die, which in fact it should not
             w.Tell(new Identify(null));
-            await ExpectMsgAsync<ActorIdentity>(ai => ai.Subject == w);
+            await ExpectMsgAsync<ActorIdentity>(ai => ai.Subject == w, cancellationToken: Token);
             w.Tell(new Identify(null));
-            await ExpectMsgAsync<ActorIdentity>(ai => ai.Subject == w);
+            await ExpectMsgAsync<ActorIdentity>(ai => ai.Subject == w, cancellationToken: Token);
         }
 
         private async Task ExpectTerminationOf(IActorRef actorRef)

--- a/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
@@ -506,7 +506,7 @@ namespace Akka.Tests.Actor.Dispatch
                     {
                         a.Tell(new CountDown(counter));
                     }
-                }, Token);
+                }, cancellationToken: Token);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             }
 
@@ -518,7 +518,7 @@ namespace Akka.Tests.Actor.Dispatch
             }
             finally
             {
-                var stats = await a.Ask<InterceptorStats>(GetStats.Instance, Token);
+                var stats = await a.Ask<InterceptorStats>(GetStats.Instance, cancellationToken: Token);
                 _testOutputHelper.WriteLine("Observed stats: {0}", stats);
 
                 Sys.Stop(a);
@@ -630,7 +630,7 @@ namespace Akka.Tests.Actor.Dispatch
                     f6.Result.ShouldBe("bar2");
                     Assert.False(f3.IsCompleted);
                     Assert.False(f5.IsCompleted);
-                });
+                }, cancellationToken: Token);
         }
 
         [Fact]
@@ -643,8 +643,8 @@ namespace Akka.Tests.Actor.Dispatch
             }
             var a = NewTestActor(dispatcher.Id);
             a.Tell(DoubleStop.Instance);
-            AwaitCondition(() => StatsFor(a, dispatcher).Registers.Current == 1);
-            AwaitCondition(() => StatsFor(a, dispatcher).Unregisters.Current == 1);
+            AwaitCondition(() => StatsFor(a, dispatcher).Registers.Current == 1, cancellationToken: Token);
+            AwaitCondition(() => StatsFor(a, dispatcher).Unregisters.Current == 1, cancellationToken: Token);
         }
     }
 

--- a/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
@@ -9,7 +9,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -21,7 +20,6 @@ using Akka.TestKit;
 using Akka.Util;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor.Dispatch
 {
@@ -428,6 +426,7 @@ namespace Akka.Tests.Actor.Dispatch
 
         protected abstract MessageDispatcherInterceptor InterceptedDispatcher();
         protected abstract string DispatcherType { get; }
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
 
         protected IActorRef NewTestActor(string dispatcher)
         {
@@ -507,7 +506,7 @@ namespace Akka.Tests.Actor.Dispatch
                     {
                         a.Tell(new CountDown(counter));
                     }
-                });
+                }, Token);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             }
 
@@ -519,7 +518,7 @@ namespace Akka.Tests.Actor.Dispatch
             }
             finally
             {
-                var stats = await a.Ask<InterceptorStats>(GetStats.Instance);
+                var stats = await a.Ask<InterceptorStats>(GetStats.Instance, Token);
                 _testOutputHelper.WriteLine("Observed stats: {0}", stats);
 
                 Sys.Stop(a);
@@ -681,6 +680,7 @@ namespace Akka.Tests.Actor.Dispatch
         [Fact]
         public async Task A_dispatcher_must_process_messages_in_parallel()
         {
+            var token = TestContext.Current.CancellationToken;
             var dispatcher = InterceptedDispatcher();
             var aStart = new CountdownEvent(1);
             var aStop = new CountdownEvent(1);
@@ -699,7 +699,7 @@ namespace Akka.Tests.Actor.Dispatch
             Sys.Stop(a);
             Sys.Stop(b);
 
-            await Task.WhenAll(a.WatchAsync(), b.WatchAsync()).WaitAsync(RemainingOrDefault);
+            await Task.WhenAll(a.WatchAsync(token), b.WatchAsync(token)).WaitAsync(RemainingOrDefault, token);
 
             AssertRefDefaultZero(a, dispatcher, registers:1, unregisters:1, msgsReceived:1, msgsProcessed:1);
             AssertRefDefaultZero(b, dispatcher, registers: 1, unregisters: 1, msgsReceived: 1, msgsProcessed: 1);

--- a/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
@@ -16,7 +16,6 @@ using Akka.Routing;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor.Dispatch
 {

--- a/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/Bug2640Spec.cs
@@ -25,6 +25,8 @@ namespace Akka.Tests.Actor.Dispatch
     /// </summary>
     public class Bug2640Spec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public Bug2640Spec(ITestOutputHelper helper) : base(DispatcherConfig, helper)
         {
         }
@@ -75,17 +77,17 @@ namespace Akka.Tests.Actor.Dispatch
                 .WithDispatcher("myapp.my-fork-join-dispatcher").WithRouter(new RoundRobinPool(4)));
 
             Dictionary<int, Thread> threads = null;
-            Watch(actor);
+            await WatchAsync(actor);
             for (var i = 0; i < 100; i++)
                 actor.Tell(GetThread.Instance);
 
-            var objs = await ReceiveNAsync(100, default).ToListAsync();
+            var objs = await ReceiveNAsync(100, RemainingOrDefault, cancellationToken: Token).ToListAsync(Token);
             threads = objs.Cast<Thread>().GroupBy(x => x.ManagedThreadId)
                 .ToDictionary(x => x.Key, grouping => grouping.First());
 
             await Sys.Terminate();
             await AwaitAssertAsync(() =>
-                threads.Values.All(x => x.IsAlive == false).Should().BeTrue("All threads should be stopped"));
+                threads.Values.All(x => x.IsAlive == false).Should().BeTrue("All threads should be stopped"), cancellationToken: Token);
         }
 
         [Fact(DisplayName = "ForkJoinExecutor should terminate all threads upon all attached actors shutting down")]
@@ -95,19 +97,19 @@ namespace Akka.Tests.Actor.Dispatch
                 .WithDispatcher("myapp.my-fork-join-dispatcher").WithRouter(new RoundRobinPool(4)));
 
             Dictionary<int, Thread> threads = null;
-            Watch(actor);
+            await WatchAsync(actor);
             for (var i = 0; i < 100; i++)
                 actor.Tell(GetThread.Instance);
 
-            var objs = await ReceiveNAsync(100, default).ToListAsync();
+            var objs = await ReceiveNAsync(100, RemainingOrDefault, cancellationToken: Token).ToListAsync(Token);
 
             threads = objs.Cast<Thread>().GroupBy(x => x.ManagedThreadId)
                 .ToDictionary(x => x.Key, grouping => grouping.First());
 
             Sys.Stop(actor);
-            await ExpectTerminatedAsync(actor);
+            await ExpectTerminatedAsync(actor, cancellationToken: Token);
             await AwaitAssertAsync(() =>
-                threads.Values.All(x => x.IsAlive == false).Should().BeTrue("All threads should be stopped"));
+                threads.Values.All(x => x.IsAlive == false).Should().BeTrue("All threads should be stopped"), cancellationToken: Token);
         }
 
         [Fact(DisplayName = "PinnedDispatcher should terminate its thread upon actor shutdown")]
@@ -118,12 +120,12 @@ namespace Akka.Tests.Actor.Dispatch
 
             Watch(actor);
             actor.Tell(GetThread.Instance);
-            var thread = await ExpectMsgAsync<Thread>();
+            var thread = await ExpectMsgAsync<Thread>(cancellationToken: Token);
             thread.IsAlive.Should().BeTrue();
 
             Sys.Stop(actor);
-            await ExpectTerminatedAsync(actor);
-            await AwaitConditionAsync(() => Task.FromResult(!thread.IsAlive)); // wait for thread to terminate
+            await ExpectTerminatedAsync(actor, cancellationToken: Token);
+            await AwaitConditionAsync(() => Task.FromResult(!thread.IsAlive), cancellationToken: Token); // wait for thread to terminate
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/Dispatch/Bug2751Spec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/Bug2751Spec.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor.Dispatch
 {
@@ -18,6 +19,8 @@ namespace Akka.Tests.Actor.Dispatch
     /// </summary>
     public class Bug2751Spec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         private class StopActor : ReceiveActor
         {
             private readonly IActorRef _testActor;
@@ -45,10 +48,10 @@ namespace Akka.Tests.Actor.Dispatch
         {
             var stopper = Sys.ActorOf(Props.Create(() => new StopActor(TestActor)));
             stopper.Tell("stop");
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(250));
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(250), cancellationToken: Token);
             Watch(stopper);
-            await ExpectTerminatedAsync(stopper);
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectTerminatedAsync(stopper, cancellationToken: Token);
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token);
         }
     }
 

--- a/src/core/Akka.Tests/Actor/Dispatch/CurrentSynchronizationContextDispatcherSpecs.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/CurrentSynchronizationContextDispatcherSpecs.cs
@@ -15,6 +15,7 @@ using Akka.Configuration;
 using Akka.TestKit;
 using Akka.TestKit.TestActors;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor.Dispatch
 {
@@ -23,6 +24,8 @@ namespace Akka.Tests.Actor.Dispatch
     /// </summary>
     public class CurrentSynchronizationContextDispatcherSpecs : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         private static Config _config = ConfigurationFactory.ParseString(@"
             akka.actor.deployment {
                /some-ui-actor{
@@ -38,7 +41,7 @@ namespace Akka.Tests.Actor.Dispatch
         {
             var uiActor = Sys.ActorOf(EchoActor.Props(this), "some-ui-actor");
             uiActor.Tell("ping");
-            await ExpectMsgAsync("ping");
+            await ExpectMsgAsync("ping", cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/FSMActorSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMActorSpec.cs
@@ -16,11 +16,14 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
 using static Akka.Actor.FSMBase;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class FSMActorSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         #region Actors
         public class Latches
         {
@@ -440,7 +443,7 @@ namespace Akka.Tests.Actor
                 lockFsm.Tell("not_handled");
                 latches.UnhandledLatch.Ready(timeout);
                 return Task.CompletedTask;
-            });
+            }, cancellationToken: Token);
 
             var answerLatch = new TestLatch();
             var tester = Sys.ActorOf(Props.Create(() => new AnswerTester(answerLatch, lockFsm)));
@@ -464,7 +467,7 @@ namespace Akka.Tests.Actor
                 error.LogSource.Should().Contain(name);
                 error.Message.Should().Be("Next state 2 does not exist");
                 Sys.EventStream.Unsubscribe(TestActor);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -474,7 +477,7 @@ namespace Akka.Tests.Actor
             var actorRef = Sys.ActorOf(Props.Create(() => new ActorStopTermination(started, TestActor)));
             started.Ready();
             Sys.Stop(actorRef);
-            var stopEvent = await ExpectMsgAsync<StopEvent<int, object>>(1.Seconds());
+            var stopEvent = await ExpectMsgAsync<StopEvent<int, object>>(1.Seconds(), cancellationToken: Token);
             stopEvent.Reason.Should().BeOfType<Shutdown>();
             stopEvent.TerminatedState.Should().Be(1);
         }
@@ -485,7 +488,7 @@ namespace Akka.Tests.Actor
             var expected = "pigdog";
             var actorRef = Sys.ActorOf(Props.Create(() => new ActorStopReason(expected, TestActor)));
             actorRef.Tell(2);
-            await ExpectMsgAsync("green");
+            await ExpectMsgAsync("green", cancellationToken: Token);
         }
 
         [Fact]
@@ -508,11 +511,11 @@ namespace Akka.Tests.Actor
             CheckTimersActive(false);
 
             fsmRef.Tell("start");
-            await ExpectMsgAsync("starting", 1.Seconds());
+            await ExpectMsgAsync("starting", 1.Seconds(), cancellationToken: Token);
             CheckTimersActive(true);
 
             fsmRef.Tell("stop");
-            await ExpectMsgAsync("stopped", 1.Seconds());
+            await ExpectMsgAsync("stopped", 1.Seconds(), cancellationToken: Token);
         }
 
         [Fact(Skip = "Not implemented yet")]
@@ -525,13 +528,13 @@ namespace Akka.Tests.Actor
         {
             var fsmRef = new TestActorRef<RollingEventLogFsm>(Sys, Props.Create<RollingEventLogFsm>());
             fsmRef.Tell("log");
-            await ExpectMsgAsync<object>(1.Seconds());
+            await ExpectMsgAsync<object>(1.Seconds(), cancellationToken: Token);
             fsmRef.Tell("count");
             fsmRef.Tell("log");
-            await ExpectMsgAsync<object>(1.Seconds());
+            await ExpectMsgAsync<object>(1.Seconds(), cancellationToken: Token);
             fsmRef.Tell("count");
             fsmRef.Tell("log");
-            await ExpectMsgAsync<object>(1.Seconds());
+            await ExpectMsgAsync<object>(1.Seconds(), cancellationToken: Token);
         }
 
         [Fact]
@@ -540,8 +543,8 @@ namespace Akka.Tests.Actor
             var fsmRef = Sys.ActorOf(Props.Create<TransformingStateFsm>());
             fsmRef.Tell(new SubscribeTransitionCallBack(TestActor));
             fsmRef.Tell("go");
-            await ExpectMsgAsync(new CurrentState<int>(fsmRef, 0));
-            await ExpectMsgAsync(new Transition<int>(fsmRef, 0, 1));
+            await ExpectMsgAsync(new CurrentState<int>(fsmRef, 0), cancellationToken: Token);
+            await ExpectMsgAsync(new Transition<int>(fsmRef, 0, 1), cancellationToken: Token);
         }
 
         [Fact(Skip = "Not implemented yet")]
@@ -554,10 +557,10 @@ namespace Akka.Tests.Actor
 
             try
             {
-                await p.ExpectMsgAsync<StateTimeout>();
+                await p.ExpectMsgAsync<StateTimeout>(cancellationToken: Token);
                 fsmRef.Tell(OverrideTimeoutToInf);
-                await p.ExpectMsgAsync(OverrideTimeoutToInf);
-                await p.ExpectNoMsgAsync(3.Seconds());
+                await p.ExpectMsgAsync(OverrideTimeoutToInf, cancellationToken: Token);
+                await p.ExpectNoMsgAsync(3.Seconds(), cancellationToken: Token);
             }
             finally
             {

--- a/src/core/Akka.Tests/Actor/FSMTimingSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMTimingSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -21,6 +22,8 @@ namespace Akka.Tests.Actor
 {
     public class FSMTimingSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public IActorRef FSM { get; }
 
         public FSMTimingSpec()
@@ -144,7 +147,7 @@ namespace Akka.Tests.Actor
             FSM.Tell(Tick.Instance);
             await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestCancelStateTimerInNamedTimerMessage));
             await ExpectMsgAsync<Tick>(500.Milliseconds());
-            await Task.Delay(200.Milliseconds());
+            await Task.Delay(200.Milliseconds(), Token);
             Resume(FSM);
             await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestCancelStateTimerInNamedTimerMessage, FsmState.TestCancelStateTimerInNamedTimerMessage2), 500.Milliseconds());
             FSM.Tell(Cancel.Instance);

--- a/src/core/Akka.Tests/Actor/FSMTimingSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMTimingSpec.cs
@@ -37,9 +37,9 @@ namespace Akka.Tests.Actor
         public async Task FSM_must_receive_StateTimeout()
         {
             FSM.Tell(FsmState.TestStateTimeout);
-            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestStateTimeout));
-            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestStateTimeout, FsmState.Initial));
-            await ExpectNoMsgAsync(50.Milliseconds());
+            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestStateTimeout), cancellationToken: Token);
+            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestStateTimeout, FsmState.Initial), cancellationToken: Token);
+            await ExpectNoMsgAsync(50.Milliseconds(), cancellationToken: Token);
 
         }
 
@@ -48,10 +48,10 @@ namespace Akka.Tests.Actor
         {
             FSM.Tell(FsmState.TestStateTimeout);
             FSM.Tell(Cancel.Instance);
-            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestStateTimeout));
-            await ExpectMsgAsync<Cancel>();
-            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestStateTimeout, FsmState.Initial));
-            await ExpectNoMsgAsync(50.Milliseconds());
+            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestStateTimeout), cancellationToken: Token);
+            await ExpectMsgAsync<Cancel>(cancellationToken: Token);
+            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestStateTimeout, FsmState.Initial), cancellationToken: Token);
+            await ExpectNoMsgAsync(50.Milliseconds(), cancellationToken: Token);
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace Akka.Tests.Actor
             Sys.EventStream.Subscribe(TestActor, typeof(DeadLetter));
             stoppingActor.Tell(FsmState.TestStoppingActorStateTimeout);
 
-            await ExpectNoMsgAsync(300.Milliseconds());
+            await ExpectNoMsgAsync(300.Milliseconds(), cancellationToken: Token);
 
         }
 
@@ -74,14 +74,14 @@ namespace Akka.Tests.Actor
                 FSM.Tell(FsmState.TestStateTimeoutOverride);
                 await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestStateTimeout));
                 await ExpectNoMsgAsync(300.Milliseconds());
-            });
+            }, cancellationToken: Token);
 
             await WithinAsync(1.Seconds(), async () =>
             {
                 FSM.Tell(Cancel.Instance);
                 await ExpectMsgAsync<Cancel>();
                 await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestStateTimeout, FsmState.Initial));
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace Akka.Tests.Actor
                     await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestSingleTimer, FsmState.Initial));
                 });
                 await ExpectNoMsgAsync(500.Milliseconds());
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -118,26 +118,26 @@ namespace Akka.Tests.Actor
                     await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestSingleTimerResubmit, FsmState.Initial));
                 });
                 await ExpectNoMsgAsync(500.Milliseconds());
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
         public async Task FSM_must_correctly_cancel_a_named_timer()
         {
             FSM.Tell(FsmState.TestCancelTimer);
-            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestCancelTimer));
+            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestCancelTimer), cancellationToken: Token);
             await WithinAsync(500.Milliseconds(), async() =>
             {
                 FSM.Tell(Tick.Instance);
                 await ExpectMsgAsync<Tick>();
-            });
+            }, cancellationToken: Token);
 
             await WithinAsync(300.Milliseconds(), 1.Seconds(), async() =>
             {
                 await ExpectMsgAsync<Tock>();
-            });
+            }, cancellationToken: Token);
             FSM.Tell(Cancel.Instance);
-            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestCancelTimer, FsmState.Initial), 1.Seconds());
+            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestCancelTimer, FsmState.Initial), 1.Seconds(), cancellationToken: Token);
         }
 
         [Fact]
@@ -145,35 +145,35 @@ namespace Akka.Tests.Actor
         {
             FSM.Tell(FsmState.TestCancelStateTimerInNamedTimerMessage);
             FSM.Tell(Tick.Instance);
-            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestCancelStateTimerInNamedTimerMessage));
-            await ExpectMsgAsync<Tick>(500.Milliseconds());
-            await Task.Delay(200.Milliseconds(), Token);
+            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestCancelStateTimerInNamedTimerMessage), cancellationToken: Token);
+            await ExpectMsgAsync<Tick>(500.Milliseconds(), cancellationToken: Token);
+            await Task.Delay(200.Milliseconds(), cancellationToken: Token);
             Resume(FSM);
-            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestCancelStateTimerInNamedTimerMessage, FsmState.TestCancelStateTimerInNamedTimerMessage2), 500.Milliseconds());
+            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestCancelStateTimerInNamedTimerMessage, FsmState.TestCancelStateTimerInNamedTimerMessage2), 500.Milliseconds(), cancellationToken: Token);
             FSM.Tell(Cancel.Instance);
             await WithinAsync(500.Milliseconds(), async() =>
             {
                 await ExpectMsgAsync<Cancel>();
                 await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestCancelStateTimerInNamedTimerMessage2, FsmState.Initial));
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
         public async Task FSM_must_receive_and_cancel_a_repeated_timer()
         {
             FSM.Tell(FsmState.TestRepeatedTimer);
-            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestRepeatedTimer));
+            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestRepeatedTimer), cancellationToken: Token);
             var seq = await ReceiveWhileAsync(2.Seconds(), o =>
             {
                 if (o is Tick)
                     return o;
                 return null;
-            }).ToListAsync();
+            }, cancellationToken: Token).ToListAsync(Token);
             seq.Should().HaveCount(5);
             await WithinAsync(500.Milliseconds(), async() =>
             {
                 await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.TestRepeatedTimer, FsmState.Initial));
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -187,7 +187,7 @@ namespace Akka.Tests.Actor
             //    () =>
             //    {
             FSM.Tell(FsmState.TestUnhandled);
-            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestUnhandled));
+            await ExpectMsgAsync(new Transition<FsmState>(FSM, FsmState.Initial, FsmState.TestUnhandled), cancellationToken: Token);
             await WithinAsync(3.Seconds(), async() =>
             {
                 FSM.Tell(Tick.Instance);
@@ -200,7 +200,7 @@ namespace Akka.Tests.Actor
                 transition.FsmRef.Should().Be(FSM);
                 transition.From.Should().Be(FsmState.TestUnhandled);
                 transition.To.Should().Be(FsmState.Initial);
-            });
+            }, cancellationToken: Token);
             //    });
         }
 

--- a/src/core/Akka.Tests/Actor/FSMTransitionSpec.cs
+++ b/src/core/Akka.Tests/Actor/FSMTransitionSpec.cs
@@ -13,20 +13,23 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
 using static Akka.Actor.FSMBase;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class FSMTransitionSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact]
         public async Task FSMTransitionNotifier_must_not_trigger_onTransition_for_stay()
         {
             var fsm = Sys.ActorOf(Props.Create(() => new SendAnyTransitionFSM(TestActor)));
-            await ExpectMsgAsync((0, 0)); // caused by initialize(), OK.
+            await ExpectMsgAsync((0, 0), cancellationToken: Token); // caused by initialize(), OK.
             fsm.Tell("stay"); // no transition event
-            await ExpectNoMsgAsync(500.Milliseconds());
+            await ExpectNoMsgAsync(500.Milliseconds(), cancellationToken: Token);
             fsm.Tell("goto"); // goto(current state)
-            await ExpectMsgAsync((0, 0));
+            await ExpectMsgAsync((0, 0), cancellationToken: Token);
         }
 
         [Fact]
@@ -42,7 +45,7 @@ namespace Akka.Tests.Actor
                 await ExpectMsgAsync(new Transition<int>(fsm, 0, 1));
                 fsm.Tell("tick");
                 await ExpectMsgAsync(new Transition<int>(fsm, 1, 0));
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -58,7 +61,7 @@ namespace Akka.Tests.Actor
                 await forward.GracefulStop(5.Seconds());
                 fsm.Tell("tick");
                 await ExpectNoMsgAsync(200.Milliseconds());
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -70,7 +73,7 @@ namespace Akka.Tests.Actor
             {
                 fsm.Tell("tick");
                 await ExpectMsgAsync((0, 1));
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -89,7 +92,7 @@ namespace Akka.Tests.Actor
                 fsm.Tell("tick");
                 await ExpectMsgAsync((1, 1));
                 await ExpectMsgAsync(new Transition<int>(fsm, 1, 1));
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -99,9 +102,9 @@ namespace Akka.Tests.Actor
             var fsm = Sys.ActorOf(Props.Create(() => new OtherFSM(TestActor)));
 
             fsm.Tell(new SubscribeTransitionCallBack(forward));
-            await ExpectMsgAsync(new CurrentState<int>(fsm, 0));
+            await ExpectMsgAsync(new CurrentState<int>(fsm, 0), cancellationToken: Token);
             fsm.Tell("stay");
-            await ExpectNoMsgAsync(500.Milliseconds());
+            await ExpectNoMsgAsync(500.Milliseconds(), cancellationToken: Token);
         }
 
         [Fact]
@@ -110,9 +113,9 @@ namespace Akka.Tests.Actor
             var fsmref = Sys.ActorOf<LeakyFSM>();
 
             fsmref.Tell("switch");
-            await ExpectMsgAsync((0, 1));
+            await ExpectMsgAsync((0, 1), cancellationToken: Token);
             fsmref.Tell("test");
-            await ExpectMsgAsync("ok");
+            await ExpectMsgAsync("ok", cancellationToken: Token);
         }
 
         #region Test actors

--- a/src/core/Akka.Tests/Actor/FunctionRefSpecs.cs
+++ b/src/core/Akka.Tests/Actor/FunctionRefSpecs.cs
@@ -11,11 +11,14 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class FunctionRefSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         
         #region internal classes
 
@@ -142,7 +145,7 @@ namespace Akka.Tests.Actor
             var forwarder = await GetFunctionRef(s);
 
             forwarder.Tell("hello");
-            await ExpectMsgAsync(new Forwarded("hello", TestActor));
+            await ExpectMsgAsync(new Forwarded("hello", TestActor), cancellationToken: Token);
         }
 
         [Fact]
@@ -153,7 +156,7 @@ namespace Akka.Tests.Actor
             
             await WatchAsync(forwarder);
             s.Tell(new DropForwarder(forwarder));
-            await ExpectTerminatedAsync(forwarder);
+            await ExpectTerminatedAsync(forwarder, cancellationToken: Token);
         }
 
         [Fact]
@@ -163,10 +166,10 @@ namespace Akka.Tests.Actor
             var forwarder = await GetFunctionRef(s);
 
             s.Tell(new GetForwarder(TestActor));
-            var f = await ExpectMsgAsync<FunctionRef>();
+            var f = await ExpectMsgAsync<FunctionRef>(cancellationToken: Token);
             forwarder.Watch(f);
             s.Tell(new DropForwarder(f));
-            await ExpectMsgAsync(new Forwarded(new Terminated(f, true, false), f));
+            await ExpectMsgAsync(new Forwarded(new Terminated(f, true, false), f), cancellationToken: Token);
         }
 
         [Fact]
@@ -177,7 +180,7 @@ namespace Akka.Tests.Actor
 
             await WatchAsync(forwarder);
             s.Tell(PoisonPill.Instance);
-            await ExpectTerminatedAsync(forwarder);
+            await ExpectTerminatedAsync(forwarder, cancellationToken: Token);
         }
 
         private async Task<FunctionRef> GetFunctionRef(IActorRef s)
@@ -199,7 +202,7 @@ namespace Akka.Tests.Actor
             var forwarder = await GetFunctionRef(s);
 
             forwarder.Tell("hello");
-            await ExpectMsgAsync(new Forwarded("hello", TestActor));
+            await ExpectMsgAsync(new Forwarded("hello", TestActor), cancellationToken: Token);
         }
 
         [Fact]
@@ -210,7 +213,7 @@ namespace Akka.Tests.Actor
             
             await WatchAsync(forwarder);
             s.Tell(new DropForwarder(forwarder));
-            await ExpectTerminatedAsync(forwarder);
+            await ExpectTerminatedAsync(forwarder, cancellationToken: Token);
         }
 
         [Fact]
@@ -220,10 +223,10 @@ namespace Akka.Tests.Actor
             var forwarder = await GetFunctionRef(s);
 
             s.Tell(new GetForwarder(TestActor));
-            var f = await ExpectMsgAsync<FunctionRef>();
+            var f = await ExpectMsgAsync<FunctionRef>(cancellationToken: Token);
             forwarder.Watch(f);
             s.Tell(new DropForwarder(f));
-            await ExpectMsgAsync(new Forwarded(new Terminated(f, true, false), f));
+            await ExpectMsgAsync(new Forwarded(new Terminated(f, true, false), f), cancellationToken: Token);
         }
 
         [Fact]
@@ -234,7 +237,7 @@ namespace Akka.Tests.Actor
 
             await WatchAsync(forwarder);
             s.Tell(PoisonPill.Instance);
-            await ExpectTerminatedAsync(forwarder);
+            await ExpectTerminatedAsync(forwarder, cancellationToken: Token);
         }
 
         private IActorRef SupSuperActor() => Sys.ActorOf(Props.Create<SupSuper>(), "supsuper");
@@ -252,7 +255,7 @@ namespace Akka.Tests.Actor
                 // this relies upon serialize-messages during tests
                 TestActor.Tell(new DropForwarder(fref));
                 await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
-            });
+            }, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/FunctionRefSpecs.cs
+++ b/src/core/Akka.Tests/Actor/FunctionRefSpecs.cs
@@ -9,10 +9,8 @@ using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
-using Akka.Event;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor
 {

--- a/src/core/Akka.Tests/Actor/GracefulStopSpecs.cs
+++ b/src/core/Akka.Tests/Actor/GracefulStopSpecs.cs
@@ -13,11 +13,14 @@ using Akka.TestKit;
 using Akka.TestKit.TestActors;
 using Xunit;
 using FluentAssertions;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class GracefulStopSpecs : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact(DisplayName = "GracefulStop should terminate target actor on-time")]
         public async Task GracefulStopShouldTerminateOnTime()
         {
@@ -27,7 +30,7 @@ namespace Akka.Tests.Actor
 
             // act
             var stopped = await actor.GracefulStop(TimeSpan.FromSeconds(3));
-            await ExpectTerminatedAsync(actor);
+            await ExpectTerminatedAsync(actor, cancellationToken: Token);
 
             // assert
             stopped.Should().BeTrue();
@@ -42,7 +45,7 @@ namespace Akka.Tests.Actor
 
             // act
             Sys.Stop(actor);
-            await ExpectTerminatedAsync(actor);
+            await ExpectTerminatedAsync(actor, cancellationToken: Token);
             var stopped = await actor.GracefulStop(TimeSpan.FromSeconds(3));
 
             // assert

--- a/src/core/Akka.Tests/Actor/HotSwapSpec.cs
+++ b/src/core/Akka.Tests/Actor/HotSwapSpec.cs
@@ -10,9 +10,12 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor {
     public class HotSwapSpec : AkkaSpec {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
 
         [Fact]
         public async Task Must_be_able_to_become_in_its_constructor() 
@@ -20,7 +23,7 @@ namespace Akka.Tests.Actor {
             var a = Sys.ActorOf<ConstructorBecomer>();
 
             a.Tell("pigdog");
-            await ExpectMsgAsync("pigdog");
+            await ExpectMsgAsync("pigdog", cancellationToken: Token);
         }
 
         [Fact]
@@ -28,7 +31,7 @@ namespace Akka.Tests.Actor {
             var a = Sys.ActorOf<MultipleConstructorBecomer>();
 
             a.Tell("pigdog");
-            await ExpectMsgAsync("4:pigdog");
+            await ExpectMsgAsync("4:pigdog", cancellationToken: Token);
         }
 
         [Fact]
@@ -36,9 +39,9 @@ namespace Akka.Tests.Actor {
             var a = Sys.ActorOf<StackingConstructorBecomer>();
 
             a.Tell("pigdog");
-            await ExpectMsgAsync("pigdog:pigdog");
+            await ExpectMsgAsync("pigdog:pigdog", cancellationToken: Token);
             a.Tell("badass");
-            await ExpectMsgAsync("badass:badass");
+            await ExpectMsgAsync("badass:badass", cancellationToken: Token);
         }
 
         [Fact]
@@ -49,10 +52,10 @@ namespace Akka.Tests.Actor {
             a.Tell("pigdog");
             a.Tell("pigdog");
             a.Tell("pigdog");
-            await ExpectMsgAsync("4:pigdog");
-            await ExpectMsgAsync("3:pigdog");
-            await ExpectMsgAsync("2:pigdog");
-            await ExpectMsgAsync("1:pigdog");
+            await ExpectMsgAsync("4:pigdog", cancellationToken: Token);
+            await ExpectMsgAsync("3:pigdog", cancellationToken: Token);
+            await ExpectMsgAsync("2:pigdog", cancellationToken: Token);
+            await ExpectMsgAsync("1:pigdog", cancellationToken: Token);
         }
 
         [Fact]
@@ -61,10 +64,10 @@ namespace Akka.Tests.Actor {
             var a = Sys.ActorOf<HotSwapWithBecome>();
 
             a.Tell("init");
-            await ExpectMsgAsync("init");
+            await ExpectMsgAsync("init", cancellationToken: Token);
             a.Tell("swap");
             a.Tell("swapped");
-            await ExpectMsgAsync("swapped");
+            await ExpectMsgAsync("swapped", cancellationToken: Token);
         }
 
         [Fact]
@@ -72,14 +75,14 @@ namespace Akka.Tests.Actor {
             var a = Sys.ActorOf<HotSwapRevertUnBecome>();
 
             a.Tell("init");
-            await ExpectMsgAsync("init");
+            await ExpectMsgAsync("init", cancellationToken: Token);
             a.Tell("swap");
             a.Tell("swapped");
-            await ExpectMsgAsync("swapped");
+            await ExpectMsgAsync("swapped", cancellationToken: Token);
 
             a.Tell("revert");
             a.Tell("init");
-            await ExpectMsgAsync("init");
+            await ExpectMsgAsync("init", cancellationToken: Token);
         }
 
         [Fact]
@@ -87,22 +90,22 @@ namespace Akka.Tests.Actor {
             var a = Sys.ActorOf<RevertToInitialState>();
 
             a.Tell("state");
-            await ExpectMsgAsync("0");
+            await ExpectMsgAsync("0", cancellationToken: Token);
 
             a.Tell("swap");
-            await ExpectMsgAsync("swapped");
+            await ExpectMsgAsync("swapped", cancellationToken: Token);
 
             a.Tell("state");
-            await ExpectMsgAsync("1");
+            await ExpectMsgAsync("1", cancellationToken: Token);
 
             await EventFilter.Exception<Exception>("Crash (expected)!").ExpectAsync(1, () =>
             {
                 a.Tell("crash");
                 return Task.CompletedTask;
-            });
+            }, cancellationToken: Token);
 
             a.Tell("state");
-            await ExpectMsgAsync("0");
+            await ExpectMsgAsync("0", cancellationToken: Token);
 
         }
 

--- a/src/core/Akka.Tests/Actor/InboxSpec.cs
+++ b/src/core/Akka.Tests/Actor/InboxSpec.cs
@@ -66,7 +66,7 @@ namespace Akka.Tests.Actor
             _inbox.Receiver.Tell("hello");
             _inbox.Receiver.Tell("world");
 
-            Task.WaitAll(tasks.Cast<Task>().ToArray(), Token);
+            Task.WaitAll(tasks.Cast<Task>().ToArray(), cancellationToken: Token);
 
             tasks[0].Result.ShouldBe(42);
             tasks[1].Result.ShouldBe("world");
@@ -93,14 +93,14 @@ namespace Akka.Tests.Actor
                 foreach (var zero in Enumerable.Repeat(0, 1000))
                     _inbox.Receiver.Tell(zero);
 
-                await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+                await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
 
                 //The inbox is full. Sending another message should result in a Warning message
-                await EventFilter.Warning(start: "Dropping message").ExpectOneAsync(() => { _inbox.Receiver.Tell(42); return Task.CompletedTask; });
+                await EventFilter.Warning(start: "Dropping message").ExpectOneAsync(() => { _inbox.Receiver.Tell(42); return Task.CompletedTask; }, cancellationToken: Token);
 
                 //The inbox is still full. But since the warning message has already been sent, no more warnings should be sent
                 _inbox.Receiver.Tell(42);
-                await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+                await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
 
                 //Receive all messages from the inbox
                 var gotit = Enumerable.Repeat(0, 1000).Select(_ => _inbox.Receive());
@@ -133,7 +133,7 @@ namespace Akka.Tests.Actor
                 Assert.NotNull(ex);
                 Assert.True(IsTimeoutException(ex), $"Expected TimeoutException but got: {ex.GetType().Name}");
                 return Task.CompletedTask;
-            });
+            }, cancellationToken: Token);
 
             await WithinAsync(TimeSpan.FromSeconds(1), () =>
             {
@@ -141,7 +141,7 @@ namespace Akka.Tests.Actor
                 Assert.NotNull(ex);
                 Assert.True(IsTimeoutException(ex), $"Expected TimeoutException but got: {ex.GetType().Name}");
                 return Task.CompletedTask;
-            });
+            }, cancellationToken: Token);
         }
 
         private static bool IsTimeoutException(Exception ex)
@@ -170,7 +170,7 @@ namespace Akka.Tests.Actor
         public async Task Inbox_Receive_will_timeout_gracefully_if_timeout_is_already_expired()
         {
             var task = _inbox.ReceiveAsync(TimeSpan.FromSeconds(-1));
-            await Assert.ThrowsAnyAsync<Exception>(() => task.AwaitWithTimeout(TimeSpan.FromMilliseconds(1000), Token));
+            await Assert.ThrowsAnyAsync<Exception>(() => task.AwaitWithTimeout(TimeSpan.FromMilliseconds(1000), cancellationToken: Token));
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/InboxSpec.cs
+++ b/src/core/Akka.Tests/Actor/InboxSpec.cs
@@ -14,13 +14,14 @@ using Akka.Actor.Internal;
 using Akka.Event;
 using Akka.TestKit;
 using Akka.TestKit.Extensions;
-using Akka.Tests.Util;
 using Xunit;
 
 namespace Akka.Tests.Actor
 {
     public class InboxSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         private readonly Inbox _inbox;
 
         public InboxSpec()
@@ -65,7 +66,7 @@ namespace Akka.Tests.Actor
             _inbox.Receiver.Tell("hello");
             _inbox.Receiver.Tell("world");
 
-            Task.WaitAll(tasks.Cast<Task>().ToArray());
+            Task.WaitAll(tasks.Cast<Task>().ToArray(), Token);
 
             tasks[0].Result.ShouldBe(42);
             tasks[1].Result.ShouldBe("world");
@@ -169,7 +170,7 @@ namespace Akka.Tests.Actor
         public async Task Inbox_Receive_will_timeout_gracefully_if_timeout_is_already_expired()
         {
             var task = _inbox.ReceiveAsync(TimeSpan.FromSeconds(-1));
-            await Assert.ThrowsAnyAsync<Exception>(() => task.AwaitWithTimeout(TimeSpan.FromMilliseconds(1000)));
+            await Assert.ThrowsAnyAsync<Exception>(() => task.AwaitWithTimeout(TimeSpan.FromMilliseconds(1000), Token));
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
+++ b/src/core/Akka.Tests/Actor/LocalActorRefProviderSpec.cs
@@ -15,28 +15,31 @@ using Akka.TestKit.Extensions;
 using Xunit;
 using Akka.TestKit.TestActors;
 using Akka.Tests.Util;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class LocalActorRefProviderSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact]
         public async Task A_LocalActorRefs_ActorCell_must_not_retain_its_original_Props_when_Terminated()
         {
             var parent = Sys.ActorOf(Props.Create(() => new ParentActor()));
             parent.Tell("GetChild", TestActor);
-            var child = await ExpectMsgAsync<IActorRef>();
+            var child = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             var childPropsBeforeTermination = ((LocalActorRef)child).Underlying.Props;
             Assert.Equal(Props.Empty, childPropsBeforeTermination);
             Watch(parent);
             Sys.Stop(parent);
-            await ExpectTerminatedAsync(parent);
+            await ExpectTerminatedAsync(parent, cancellationToken: Token);
             await AwaitAssertAsync(() =>
                 {
                     var childPropsAfterTermination = ((LocalActorRef)child).Underlying.Props;
                     Assert.NotEqual(childPropsBeforeTermination, childPropsAfterTermination);
                     Assert.Equal(ActorCell.TerminatedProps, childPropsAfterTermination);
-                });
+                }, cancellationToken: Token);
         }
 
         [Fact]
@@ -54,7 +57,7 @@ namespace Akka.Tests.Actor
                 var actors = Enumerable.Range(0, 4)
                     .Select(_ => Task.Run(() => Sys.ActorOf(Props.Create(() => new BlackHoleActor()), address))).ToArray();
                 // Use WhenAll with empty ContinueWith to swallow all exceptions, so we can inspect the tasks afterwards.
-                await Task.WhenAll(actors).ContinueWith(_ => { }).AwaitWithTimeout(timeout);
+                await Task.WhenAll(actors).ContinueWith(_ => { }, Token).AwaitWithTimeout(timeout, cancellationToken: Token);
                 Assert.True(actors.Any(x => x.Status == TaskStatus.RanToCompletion && x.Result != null), "Failed to create any Actors");
                 Assert.True(actors.Any(x => x.Status == TaskStatus.Faulted && x.Exception.InnerException is InvalidActorNameException), "Succeeded in creating all Actors. Some should have failed.");
             }
@@ -67,7 +70,7 @@ namespace Akka.Tests.Actor
             await EventFilter.Exception<InvalidActorNameException>(message: "Actor name \"duplicate\" is not unique!").ExpectOneAsync(() => {
                 supervisor.Tell("");
                 return Task.CompletedTask;
-            });
+            }, cancellationToken: Token);
         }
 
         [Theory]

--- a/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
+++ b/src/core/Akka.Tests/Actor/PipeToSupportSpec.cs
@@ -14,11 +14,14 @@ using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class PipeToSupportSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         private readonly TaskCompletionSource<string> _taskCompletionSource;
         private readonly Task<string> _task;
         private readonly Task _taskWithoutResult;
@@ -45,7 +48,7 @@ namespace Akka.Tests.Actor
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             task.PipeTo(TestActor);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            await ExpectMsgAsync("foo");
+            await ExpectMsgAsync("foo", cancellationToken: Token);
         }
 
         [Fact]
@@ -55,7 +58,7 @@ namespace Akka.Tests.Actor
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             task.PipeTo(TestActor);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-            await ExpectMsgAsync("foo");
+            await ExpectMsgAsync("foo", cancellationToken: Token);
         }
 
         [Fact]
@@ -65,7 +68,7 @@ namespace Akka.Tests.Actor
             _task.PipeTo(TestActor);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("Hello");
-            await ExpectMsgAsync("Hello");
+            await ExpectMsgAsync("Hello", cancellationToken: Token);
         }
 
         [Fact]
@@ -75,7 +78,7 @@ namespace Akka.Tests.Actor
             _valueTask.PipeTo(TestActor);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("Hello");
-            await ExpectMsgAsync("Hello");
+            await ExpectMsgAsync("Hello", cancellationToken: Token);
         }
 
         [Fact]
@@ -85,7 +88,7 @@ namespace Akka.Tests.Actor
             _taskWithoutResult.PipeTo(TestActor);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("Hello");
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token);
         }
 
         [Fact]
@@ -95,7 +98,7 @@ namespace Akka.Tests.Actor
             _valueTaskWithoutResult.PipeTo(TestActor);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("Hello");
-            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token);
         }
 
         [Fact]
@@ -108,8 +111,8 @@ namespace Akka.Tests.Actor
             _taskWithoutResult.PipeTo(TestActor);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetException(new Exception("Boom"));
-            await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom");
-            await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom");
+            await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom", cancellationToken: Token);
+            await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom", cancellationToken: Token);
         }
 
         [Fact]
@@ -122,8 +125,8 @@ namespace Akka.Tests.Actor
             _valueTaskWithoutResult.PipeTo(TestActor);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetException(new Exception("Boom"));
-            await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom");
-            await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom");
+            await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom", cancellationToken: Token);
+            await ExpectMsgAsync<Status.Failure>(x => x.Cause.Message == "Boom", cancellationToken: Token);
         }
 
         [Fact]
@@ -136,7 +139,7 @@ namespace Akka.Tests.Actor
             _taskWithoutResult.PipeTo(TestActor, success: () => "Hello");
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("World");
-            var pipeTo = await ReceiveNAsync(2, default).Cast<string>().ToListAsync();
+            var pipeTo = await ReceiveNAsync(2, RemainingOrDefault, cancellationToken: Token).Cast<string>().ToListAsync(Token);
             pipeTo.Should().Contain("Hello");
             pipeTo.Should().Contain("Hello World");
         }
@@ -151,7 +154,7 @@ namespace Akka.Tests.Actor
             _valueTaskWithoutResult.PipeTo(TestActor, success: () => "Hello");
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetResult("World");
-            var pipeTo = await ReceiveNAsync(2, default).Cast<string>().ToListAsync();
+            var pipeTo = await ReceiveNAsync(2, RemainingOrDefault, cancellationToken: Token).Cast<string>().ToListAsync(Token);
             pipeTo.Should().Contain("Hello");
             pipeTo.Should().Contain("Hello World");
         }
@@ -166,8 +169,8 @@ namespace Akka.Tests.Actor
             _taskWithoutResult.PipeTo(TestActor, failure: e => "Such a " + e.Message);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetException(new Exception("failure..."));
-            await ExpectMsgAsync("Such a failure...");
-            await ExpectMsgAsync("Such a failure...");
+            await ExpectMsgAsync("Such a failure...", cancellationToken: Token);
+            await ExpectMsgAsync("Such a failure...", cancellationToken: Token);
         }
 
         [Fact]
@@ -180,8 +183,8 @@ namespace Akka.Tests.Actor
             _valueTaskWithoutResult.PipeTo(TestActor, failure: e => "Such a " + e.Message);
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             _taskCompletionSource.SetException(new Exception("failure..."));
-            await ExpectMsgAsync("Such a failure...");
-            await ExpectMsgAsync("Such a failure...");
+            await ExpectMsgAsync("Such a failure...", cancellationToken: Token);
+            await ExpectMsgAsync("Such a failure...", cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/ReceiveActorTests.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorTests.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="ReceiveActorTests.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -19,6 +19,8 @@ namespace Akka.Tests.Actor
 
     public partial class ReceiveActorTests : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact]
         public async Task Given_actor_with_no_receive_specified_When_receiving_message_Then_it_should_be_unhandled()
         {
@@ -31,7 +33,7 @@ namespace Akka.Tests.Actor
             actor.Tell("Something");
 
             //Then
-            await ExpectMsgAsync<UnhandledMessage>(m => ((string)m.Message) == "Something" && m.Recipient == actor);
+            await ExpectMsgAsync<UnhandledMessage>(m => ((string)m.Message) == "Something" && m.Recipient == actor, cancellationToken: Token);
             system.EventStream.Unsubscribe(TestActor, typeof(UnhandledMessage));
         }
 
@@ -48,7 +50,7 @@ namespace Akka.Tests.Actor
 
             //Then
             //We expect a exception was thrown when the actor called Receive, and that it was sent back to us
-            await ExpectMsgAsync<InvalidOperationException>();
+            await ExpectMsgAsync<InvalidOperationException>(cancellationToken: Token);
         }
 
         [Fact]
@@ -63,8 +65,8 @@ namespace Akka.Tests.Actor
             actor.Tell("Something else", TestActor);
 
             //Then
-            await ExpectMsgAsync((object) "Something");
-            await ExpectMsgAsync((object) "Something else");
+            await ExpectMsgAsync((object) "Something", cancellationToken: Token);
+            await ExpectMsgAsync((object) "Something else", cancellationToken: Token);
         }
 
         [Fact]
@@ -81,10 +83,10 @@ namespace Akka.Tests.Actor
             actor.Tell(15, TestActor);
 
             //Then
-            await ExpectMsgAsync((object) "int<5:0");
-            await ExpectMsgAsync((object) "int<10:5");
-            await ExpectMsgAsync((object) "int<15:10");
-            await ExpectMsgAsync((object) "int:15");
+            await ExpectMsgAsync((object) "int<5:0", cancellationToken: Token);
+            await ExpectMsgAsync((object) "int<10:5", cancellationToken: Token);
+            await ExpectMsgAsync((object) "int<15:10", cancellationToken: Token);
+            await ExpectMsgAsync((object) "int:15", cancellationToken: Token);
         }
 
         [Fact]
@@ -102,11 +104,11 @@ namespace Akka.Tests.Actor
             actor.Tell("hello", TestActor);
 
             //Then
-            await ExpectMsgAsync((object) "int<5:0");
-            await ExpectMsgAsync((object) "int<10:5");
-            await ExpectMsgAsync((object) "int<15:10");
-            await ExpectMsgAsync((object) "int:15");
-            await ExpectMsgAsync((object) "string:hello");
+            await ExpectMsgAsync((object) "int<5:0", cancellationToken: Token);
+            await ExpectMsgAsync((object) "int<10:5", cancellationToken: Token);
+            await ExpectMsgAsync((object) "int<15:10", cancellationToken: Token);
+            await ExpectMsgAsync((object) "int:15", cancellationToken: Token);
+            await ExpectMsgAsync((object) "string:hello", cancellationToken: Token);
         }
 
 
@@ -122,8 +124,8 @@ namespace Akka.Tests.Actor
             actor.Tell("hello", TestActor);
 
             //Then
-            await ExpectMsgAsync((object)"int:4711");
-            await ExpectMsgAsync((object)"any:hello");
+            await ExpectMsgAsync((object)"int:4711", cancellationToken: Token);
+            await ExpectMsgAsync((object)"any:hello", cancellationToken: Token);
         }
 
         [Fact]
@@ -136,7 +138,7 @@ namespace Akka.Tests.Actor
             actor.Tell(4711, TestActor);
 
             //Then
-            await ExpectMsgAsync(4711);
+            await ExpectMsgAsync(4711, cancellationToken: Token);
         }
 
         [Fact]
@@ -165,7 +167,7 @@ namespace Akka.Tests.Actor
             actor.Tell(new ReceiveCanHandleBaseMessage(), TestActor);
 
             //Then
-            await ExpectMsgAsync("Handled");
+            await ExpectMsgAsync("Handled", cancellationToken: Token);
         }
 
         private class NoReceiveActor : ReceiveActor

--- a/src/core/Akka.Tests/Actor/ReceiveActorTests_Become.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorTests_Become.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
@@ -27,16 +28,16 @@ namespace Akka.Tests.Actor
             actor.Tell("hello", TestActor);
             actor.Tell(4711, TestActor);
             //Then
-            await ExpectMsgAsync((object) "string2:hello");
-            await ExpectMsgAsync<UnhandledMessage>( m => ((int)m.Message) == 4711 && m.Recipient == actor);
+            await ExpectMsgAsync((object) "string2:hello", cancellationToken: Token);
+            await ExpectMsgAsync<UnhandledMessage>( m => ((int)m.Message) == 4711 && m.Recipient == actor, cancellationToken: Token);
 
             //When
             actor.Tell("BECOME", TestActor);    //Switch to state3
             actor.Tell("hello", TestActor);
             actor.Tell(4711, TestActor);
             //Then
-            await ExpectMsgAsync((object) "string3:hello");
-            await ExpectMsgAsync<UnhandledMessage>(m => ((int)m.Message) == 4711 && m.Recipient == actor);
+            await ExpectMsgAsync((object) "string3:hello", cancellationToken: Token);
+            await ExpectMsgAsync<UnhandledMessage>(m => ((int)m.Message) == 4711 && m.Recipient == actor, cancellationToken: Token);
         }
 
         [Fact]
@@ -53,7 +54,7 @@ namespace Akka.Tests.Actor
             actor.Tell("hello", TestActor);
 
             //Then
-            await ExpectMsgAsync((object) "string2:hello");
+            await ExpectMsgAsync((object) "string2:hello", cancellationToken: Token);
         }
 
         [Fact]
@@ -66,25 +67,25 @@ namespace Akka.Tests.Actor
             //When
             actor.Tell("hello", TestActor);
             //Then
-            await ExpectMsgAsync((object) "string3:hello");
+            await ExpectMsgAsync((object) "string3:hello", cancellationToken: Token);
 
             //When
             actor.Tell("UNBECOME", TestActor);  //Switch back to state2
             actor.Tell("hello", TestActor);
             //Then
-            await ExpectMsgAsync((object) "string2:hello");
+            await ExpectMsgAsync((object) "string2:hello", cancellationToken: Token);
 
             //When
             actor.Tell("UNBECOME", TestActor);  //Switch back to state1
             actor.Tell("hello", TestActor);
             //Then
-            await ExpectMsgAsync((object) "string1:hello");
+            await ExpectMsgAsync((object) "string1:hello", cancellationToken: Token);
 
             //When
             actor.Tell("UNBECOME", TestActor);  //should still be in state1
             actor.Tell("hello", TestActor);
             //Then
-            await ExpectMsgAsync((object) "string1:hello");
+            await ExpectMsgAsync((object) "string1:hello", cancellationToken: Token);
         }
 
         private class BecomeActor : ReceiveActor

--- a/src/core/Akka.Tests/Actor/ReceiveActorTests_LifeCycle.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveActorTests_LifeCycle.cs
@@ -9,6 +9,7 @@ using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
@@ -26,7 +27,7 @@ namespace Akka.Tests.Actor
 
             //Then
             actor.Tell("hello", TestActor);
-            await ExpectMsgAsync((object) "1:hello");
+            await ExpectMsgAsync((object) "1:hello", cancellationToken: Token);
         }
 
         [Fact]
@@ -42,7 +43,7 @@ namespace Akka.Tests.Actor
 
             //Then
             actor.Tell("hello", TestActor);
-            await ExpectMsgAsync((object) "1:hello");
+            await ExpectMsgAsync((object) "1:hello", cancellationToken: Token);
         }
 
 
@@ -59,7 +60,7 @@ namespace Akka.Tests.Actor
 
             //Then
             actor.Tell("hello", TestActor);
-            await ExpectMsgAsync((object) "1:hello");
+            await ExpectMsgAsync((object) "1:hello", cancellationToken: Token);
         }
 
         private class CrashActor : ReceiveActor

--- a/src/core/Akka.Tests/Actor/ReceiveTimeoutSpec.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveTimeoutSpec.cs
@@ -6,17 +6,14 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Dsl;
 using Akka.Event;
 using Akka.TestKit;
 using Akka.Util.Internal;
-using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 
 namespace Akka.Tests.Actor

--- a/src/core/Akka.Tests/Actor/ReceiveTimeoutSpec.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveTimeoutSpec.cs
@@ -14,6 +14,7 @@ using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions.Extensions;
 using Xunit;
+using System.Threading;
 
 
 namespace Akka.Tests.Actor
@@ -21,9 +22,10 @@ namespace Akka.Tests.Actor
     public class Tick { }
 
     public class TransparentTick : INotInfluenceReceiveTimeout { }
-    
+
     public class ReceiveTimeoutSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public class TimeoutActor : ActorBase
         {
             private TestLatch _timeoutLatch;
@@ -281,11 +283,11 @@ namespace Akka.Tests.Actor
 
             //Stop and wait for the actor to terminate
             Sys.Stop(timeoutActor);
-            await ExpectTerminatedAsync(timeoutActor);
+            await ExpectTerminatedAsync(timeoutActor, cancellationToken: Token);
 
             //We should not get any messages now. If we get a message now, 
             //it's a DeadLetter with ReceiveTimeout, meaning the receivetimeout wasn't cancelled.
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Actor/RemotePathParsingSpec.cs
+++ b/src/core/Akka.Tests/Actor/RemotePathParsingSpec.cs
@@ -80,12 +80,7 @@ namespace Akka.Tests.Actor
     /// </summary>
     public class RemotePathParsingSpec : AkkaSpec
     {
-        public RemotePathParsingSpec()
-        {
-            Arb.Register(typeof(EndpointGenerators));
-        }
-
-        [Property]
+        [Property(Arbitrary = [typeof(EndpointGenerators)])]
         public Property Address_should_parse_from_any_valid_EndPoint(EndPoint ep)
         {
             var addr = EndpointGenerators.ParseAddress(ep);
@@ -93,7 +88,7 @@ namespace Akka.Tests.Actor
             return parsedAddr.Equals(addr).Label($"Should be able to parse endpoint to address and back; expected {addr} but was {parsedAddr}");
         }
 
-        [Property]
+        [Property(Arbitrary = [typeof(EndpointGenerators)])]
         public Property ActorPath_Should_parse_from_any_valid_EndPoint(EndPoint ep)
         {
             var addr = EndpointGenerators.ParseAddress(ep);

--- a/src/core/Akka.Tests/Actor/RemotePathParsingSpec.cs
+++ b/src/core/Akka.Tests/Actor/RemotePathParsingSpec.cs
@@ -11,6 +11,7 @@ using System.Net.Sockets;
 using Akka.Actor;
 using Akka.TestKit;
 using FsCheck;
+using FsCheck.Fluent;
 using FsCheck.Xunit;
 using static Akka.Util.RuntimeDetector;
 

--- a/src/core/Akka.Tests/Actor/RepointableActorRefSpecs.cs
+++ b/src/core/Akka.Tests/Actor/RepointableActorRefSpecs.cs
@@ -10,11 +10,14 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class RepointableActorRefSpecs : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public class Bug2182Actor : ReceiveActor, IWithUnboundedStash
         {
             public Bug2182Actor()
@@ -51,7 +54,7 @@ namespace Akka.Tests.Actor
         {
             var actor = Sys.ActorOf(Props.Create(() => new Bug2182Actor()).WithDispatcher("akka.test.calling-thread-dispatcher"), "buggy");
             actor.Tell("foo");
-            await ExpectMsgAsync("foo");
+            await ExpectMsgAsync("foo", cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/Scheduler/BugFix7247Spec.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/BugFix7247Spec.cs
@@ -19,6 +19,8 @@ using Xunit;
 namespace Akka.Tests.Actor.Scheduler;
 
 public class BugFix7247Spec : AkkaSpec {
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
     public sealed class NoCellActorRef : MinimalActorRef
     {
         public NoCellActorRef(ActorPath path, TaskCompletionSource<object> firstMessage)
@@ -52,7 +54,7 @@ public class BugFix7247Spec : AkkaSpec {
         {
             var allRoutees = await router.Ask<Routees>(GetRoutees.Instance);
             allRoutees.Members.Count().ShouldBeGreaterThan(0);
-        });
+        }, cancellationToken: Token);
         
         // act
         var msg = "hit";

--- a/src/core/Akka.Tests/Actor/Scheduler/SchedulerShutdownSpec.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/SchedulerShutdownSpec.cs
@@ -83,6 +83,8 @@ namespace Akka.Tests.Actor.Scheduler
 
         public static readonly Config Config = ConfigurationFactory.ParseString("akka.scheduler.implementation = \""+ typeof(ShutdownScheduler).AssemblyQualifiedName + "\"");
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [Fact]
         public async Task ActorSystem_must_terminate_scheduler_on_shutdown()
         {
@@ -92,12 +94,13 @@ namespace Akka.Tests.Actor.Scheduler
                 sys = ActorSystem.Create("SchedulerShutdownSys1", Config);
                 var scheduler = (ShutdownScheduler)sys.Scheduler;
                 var currentCounter = scheduler.Shutdown.Current;
-                (await sys.Terminate().AwaitWithTimeout(sys.Settings.SchedulerShutdownTimeout)).Should().BeTrue();
+                (await sys.Terminate().AwaitWithTimeout(sys.Settings.SchedulerShutdownTimeout, Token)).Should().BeTrue();
                 (scheduler.Shutdown.Current).Should().Be(currentCounter + 1);
             }
             finally
             {
-                await sys?.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(5));
+                if(sys is not null)
+                    await sys.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(5), Token);
             }
         }
 
@@ -111,18 +114,19 @@ namespace Akka.Tests.Actor.Scheduler
                 sys = ActorSystem.Create("SchedulerShutdownSys1", Config);
                 var scheduler = (ShutdownScheduler)sys.Scheduler;
                 sys.Scheduler.Advanced.ScheduleRepeatedly(TimeSpan.FromMilliseconds(0), TimeSpan.FromMilliseconds(10), () => i++);
-                await Task.Delay(100); // give the scheduler a chance to start and run
+                await Task.Delay(100, Token); // give the scheduler a chance to start and run
                 var currentCounter = scheduler.Shutdown.Current;
-                (await sys.Terminate().AwaitWithTimeout(sys.Settings.SchedulerShutdownTimeout)).Should().BeTrue();
+                (await sys.Terminate().AwaitWithTimeout(sys.Settings.SchedulerShutdownTimeout, Token)).Should().BeTrue();
                 (scheduler.Shutdown.Current).Should().Be(currentCounter + 1);
                 var stoppedValue = i;
                 stoppedValue.Should().BeGreaterThan(0, "should have incremented at least once");
-                await Task.Delay(100);
+                await Task.Delay(100, Token);
                 i.Should().Be(stoppedValue, "Scheduler shutdown; should not still be incrementing values.");
             }
             finally
             {
-                sys?.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(5));
+                if(sys is not null)
+                    await sys.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(5), Token);
             }
         }
 
@@ -131,7 +135,7 @@ namespace Akka.Tests.Actor.Scheduler
         {
             ActorSystem sys = ActorSystem.Create("SchedulerShutdownSys2");
             Assert.True(sys.Scheduler is IDisposable);
-            await sys.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(5));
+            await sys.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(5), Token);
         }
 
 
@@ -159,11 +163,11 @@ namespace Akka.Tests.Actor.Scheduler
             ActorSystem sys = ActorSystem.Create("SchedulerShutdownSys3");
             var receiver = sys.ActorOf(Props.Create(() => new MyScheduledActor()));
             sys.Scheduler.ScheduleTellOnce(0, receiver, "set", ActorRefs.NoSender);
-            await Task.Delay(50); // let the scheduler run
-            var received = await receiver.Ask<bool>("get", TimeSpan.FromSeconds(3));
+            await Task.Delay(50, Token); // let the scheduler run
+            var received = await receiver.Ask<bool>("get", TimeSpan.FromSeconds(3), Token);
             Assert.True(received);
 
-            var terminated = await sys.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(5));
+            var terminated = await sys.Terminate().AwaitWithTimeout(TimeSpan.FromSeconds(5), Token);
             if (!terminated)
                 Assert.Fail("Expected ActorSystem to terminate within 5s. Took longer.");
 

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Cancellation_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Cancellation_Tests.cs
@@ -9,7 +9,7 @@ using System;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit.Attributes;
 using Akka.Util.Internal;
 using Xunit;
 

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Cancellation_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Cancellation_Tests.cs
@@ -12,12 +12,15 @@ using Akka.TestKit;
 using Akka.TestKit.Xunit.Attributes;
 using Akka.Util.Internal;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor.Scheduler
 {
     // ReSharper disable once InconsistentNaming
     public class DefaultScheduler_ActionScheduler_Cancellation_Tests : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact]
         public async Task When_ScheduleOnce_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked()
         {
@@ -30,7 +33,7 @@ namespace Akka.Tests.Actor.Scheduler
                 scheduler.ScheduleOnce(0, () => TestActor.Tell("Test"), canceled);
 
                 //Validate that no messages were sent
-                await ExpectNoMsgAsync(100);
+                await ExpectNoMsgAsync(100, cancellationToken: Token);
             }
             finally
             {
@@ -51,7 +54,7 @@ namespace Akka.Tests.Actor.Scheduler
                 scheduler.ScheduleRepeatedly(50, 100, () => TestActor.Tell("Test2"), canceled);
 
                 //Validate that no messages were sent
-                await ExpectNoMsgAsync(150);
+                await ExpectNoMsgAsync(150, cancellationToken: Token);
             }
             finally
             {
@@ -72,7 +75,7 @@ namespace Akka.Tests.Actor.Scheduler
                 cancelable.Cancel();
 
                 //Validate that no messages were sent
-                await ExpectNoMsgAsync(150);
+                await ExpectNoMsgAsync(150, cancellationToken: Token);
             }
             finally
             {
@@ -93,7 +96,7 @@ namespace Akka.Tests.Actor.Scheduler
                 cancelable.Cancel();
 
                 //Validate that no messages were sent
-                await ExpectNoMsgAsync(150);
+                await ExpectNoMsgAsync(150, cancellationToken: Token);
             }
             finally
             {
@@ -111,11 +114,11 @@ namespace Akka.Tests.Actor.Scheduler
             {
                 var cancelable = new Cancelable(scheduler);
                 scheduler.ScheduleRepeatedly(0, 150, () => TestActor.Tell("Test"), cancelable);
-                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test", cancellationToken: Token);
                 cancelable.Cancel();
 
                 //Validate that no more messages were sent
-                await ExpectNoMsgAsync(200);
+                await ExpectNoMsgAsync(200, cancellationToken: Token);
             }
             finally
             {

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Schedule_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Schedule_Tests.cs
@@ -50,7 +50,7 @@ namespace Akka.Tests.Actor.Scheduler
                 scheduler.ScheduleRepeatedly(initialDelay, interval, () => receiver.Tell(""), cancelable);
 
                 //Expect to get a list from receiver after it has received three messages
-                var dateTimeOffsets = await ExpectMsgAsync<List<DateTimeOffset>>();
+                var dateTimeOffsets = await ExpectMsgAsync<List<DateTimeOffset>>(cancellationToken: Token);
                 dateTimeOffsets.ShouldHaveCount(3);
                 // CI machines can have significant timing variability due to CPU contention,
                 // virtualization overhead, and GC pauses. Use 30% tolerance to accommodate
@@ -92,9 +92,9 @@ namespace Akka.Tests.Actor.Scheduler
                 testScheduler.ScheduleRepeatedly(initialDelay, interval, () => TestActor.Tell("Test"));
 
                 //Just check that we receives more than one message
-                await ExpectMsgAsync("Test");
-                await ExpectMsgAsync("Test");
-                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test", cancellationToken: Token);
+                await ExpectMsgAsync("Test", cancellationToken: Token);
+                await ExpectMsgAsync("Test", cancellationToken: Token);
             }
             finally
             {
@@ -116,9 +116,9 @@ namespace Akka.Tests.Actor.Scheduler
                     TimeSpan.FromMilliseconds(interval), () => TestActor.Tell("Test"));
 
                 //Just check that we receives more than one message
-                await ExpectMsgAsync("Test");
-                await ExpectMsgAsync("Test");
-                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test", cancellationToken: Token);
+                await ExpectMsgAsync("Test", cancellationToken: Token);
+                await ExpectMsgAsync("Test", cancellationToken: Token);
             }
             finally
             {
@@ -138,10 +138,10 @@ namespace Akka.Tests.Actor.Scheduler
                 testScheduler.ScheduleOnce(50, () => TestActor.Tell("Test1"));
                 testScheduler.ScheduleOnce(100, () => TestActor.Tell("Test2"));
 
-                await ExpectMsgAsync("Test1");
-                await ExpectMsgAsync("Test2");
+                await ExpectMsgAsync("Test1", cancellationToken: Token);
+                await ExpectMsgAsync("Test2", cancellationToken: Token);
 
-                await ExpectNoMsgAsync(100);
+                await ExpectNoMsgAsync(100, cancellationToken: Token);
             }
             finally
             {
@@ -167,13 +167,13 @@ namespace Akka.Tests.Actor.Scheduler
                 }
 
                 //Perform the test
-                await ExpectMsgAsync("Test1");
-                await ExpectMsgAsync("Test1");
-                await ExpectMsgAsync("Test50");
-                await ExpectMsgAsync("Test50");
-                await ExpectMsgAsync("Test100");
-                await ExpectMsgAsync("Test100");
-                await ExpectNoMsgAsync(50);
+                await ExpectMsgAsync("Test1", cancellationToken: Token);
+                await ExpectMsgAsync("Test1", cancellationToken: Token);
+                await ExpectMsgAsync("Test50", cancellationToken: Token);
+                await ExpectMsgAsync("Test50", cancellationToken: Token);
+                await ExpectMsgAsync("Test100", cancellationToken: Token);
+                await ExpectMsgAsync("Test100", cancellationToken: Token);
+                await ExpectNoMsgAsync(50, cancellationToken: Token);
             }
             finally
             {
@@ -251,7 +251,7 @@ namespace Akka.Tests.Actor.Scheduler
                 manualResetEvent.IsSet.ShouldBeFalse();
                 testScheduler.ScheduleOnce(0, () => manualResetEvent.Set());
 
-                manualResetEvent.Wait(500, Token).ShouldBeTrue();
+                manualResetEvent.Wait(500, cancellationToken: Token).ShouldBeTrue();
             }
             finally
             {
@@ -270,7 +270,7 @@ namespace Akka.Tests.Actor.Scheduler
                 manualResetEvent.IsSet.ShouldBeFalse();
                 testScheduler.ScheduleRepeatedly(0, 100, () => manualResetEvent.Set());
 
-                manualResetEvent.Wait(500, Token).ShouldBeTrue();
+                manualResetEvent.Wait(500, cancellationToken: Token).ShouldBeTrue();
             }
             finally
             {
@@ -291,8 +291,8 @@ namespace Akka.Tests.Actor.Scheduler
                     Interlocked.Increment(ref timesCalled);
                     throw new Exception("Crash");
                 });
-                await AwaitConditionAsync(() => Task.FromResult(timesCalled >= 1), Token);
-                await Task.Delay(200, Token); //Allow any scheduled actions to be fired. 
+                await AwaitConditionAsync(() => Task.FromResult(timesCalled >= 1), cancellationToken: Token);
+                await Task.Delay(200, cancellationToken: Token); //Allow any scheduled actions to be fired. 
 
                 //We expect only one of the scheduled actions to actually fire
                 timesCalled.ShouldBe(1);

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Schedule_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_ActionScheduler_Schedule_Tests.cs
@@ -13,13 +13,14 @@ using Akka.Actor;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Akka.Tests.Actor.Scheduler
 {
     // ReSharper disable once InconsistentNaming
     public class DefaultScheduler_ActionScheduler_Schedule_Tests : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [Theory]
         [InlineData(10, 1000)]
         public async Task ScheduleRepeatedly_in_milliseconds_Tests_and_verify_the_interval(int initialDelay, int interval)
@@ -250,7 +251,7 @@ namespace Akka.Tests.Actor.Scheduler
                 manualResetEvent.IsSet.ShouldBeFalse();
                 testScheduler.ScheduleOnce(0, () => manualResetEvent.Set());
 
-                manualResetEvent.Wait(500).ShouldBeTrue();
+                manualResetEvent.Wait(500, Token).ShouldBeTrue();
             }
             finally
             {
@@ -269,7 +270,7 @@ namespace Akka.Tests.Actor.Scheduler
                 manualResetEvent.IsSet.ShouldBeFalse();
                 testScheduler.ScheduleRepeatedly(0, 100, () => manualResetEvent.Set());
 
-                manualResetEvent.Wait(500).ShouldBeTrue();
+                manualResetEvent.Wait(500, Token).ShouldBeTrue();
             }
             finally
             {
@@ -290,8 +291,8 @@ namespace Akka.Tests.Actor.Scheduler
                     Interlocked.Increment(ref timesCalled);
                     throw new Exception("Crash");
                 });
-                await AwaitConditionAsync(() => Task.FromResult(timesCalled >= 1));
-                await Task.Delay(200); //Allow any scheduled actions to be fired. 
+                await AwaitConditionAsync(() => Task.FromResult(timesCalled >= 1), Token);
+                await Task.Delay(200, Token); //Allow any scheduled actions to be fired. 
 
                 //We expect only one of the scheduled actions to actually fire
                 timesCalled.ShouldBe(1);

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Cancellation_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Cancellation_Tests.cs
@@ -11,12 +11,15 @@ using Akka.Actor;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor.Scheduler
 {
     // ReSharper disable once InconsistentNaming
     public class DefaultScheduler_TellScheduler_Cancellation_Tests : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact]
         public async Task When_ScheduleTellOnce_using_canceled_Cancelable_Then_their_actions_should_not_be_invoked()
         {
@@ -30,7 +33,7 @@ namespace Akka.Tests.Actor.Scheduler
                 scheduler.ScheduleTellOnce(1, TestActor, "Test", ActorRefs.NoSender, canceled);
 
                 //Validate that no messages were sent
-                await ExpectNoMsgAsync(100);
+                await ExpectNoMsgAsync(100, cancellationToken: Token);
             }
             finally
             {
@@ -51,7 +54,7 @@ namespace Akka.Tests.Actor.Scheduler
                 scheduler.ScheduleTellRepeatedly(1, 2, TestActor, "Test", ActorRefs.NoSender, canceled);
 
                 //Validate that no messages were sent
-                await ExpectNoMsgAsync(100);
+                await ExpectNoMsgAsync(100, cancellationToken: Token);
             }
             finally
             {
@@ -72,7 +75,7 @@ namespace Akka.Tests.Actor.Scheduler
                 cancelable.Cancel();
 
                 //Validate that no messages were sent
-                await ExpectNoMsgAsync(150);
+                await ExpectNoMsgAsync(150, cancellationToken: Token);
             }
             finally
             {
@@ -94,7 +97,7 @@ namespace Akka.Tests.Actor.Scheduler
                 cancelable.Cancel();
 
                 //Validate that no messages were sent
-                await ExpectNoMsgAsync(150);
+                await ExpectNoMsgAsync(150, cancellationToken: Token);
             }
             finally
             {
@@ -113,11 +116,11 @@ namespace Akka.Tests.Actor.Scheduler
             {
                 var cancelable = new Cancelable(scheduler);
                 scheduler.ScheduleTellRepeatedly(0, 150, TestActor, "Test", ActorRefs.NoSender, cancelable);
-                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test", cancellationToken: Token);
                 cancelable.Cancel();
 
                 //Validate that no more messages were sent
-                await ExpectNoMsgAsync(200);
+                await ExpectNoMsgAsync(200, cancellationToken: Token);
             }
             finally
             {
@@ -139,10 +142,10 @@ namespace Akka.Tests.Actor.Scheduler
                 cancelableOdd.CancelAfter(50);
 
                 //Expect one message
-                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test", cancellationToken: Token);
 
                 //Validate that no messages were sent
-                await ExpectNoMsgAsync(200);
+                await ExpectNoMsgAsync(200, cancellationToken: Token);
             }
             finally
             {

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Schedule_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Schedule_Tests.cs
@@ -10,10 +10,9 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit.Attributes;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Extensions;
 
 namespace Akka.Tests.Actor.Scheduler
 {

--- a/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Schedule_Tests.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TaskBasedScheduler_TellScheduler_Schedule_Tests.cs
@@ -13,12 +13,15 @@ using Akka.TestKit;
 using Akka.TestKit.Xunit.Attributes;
 using Akka.Util.Internal;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor.Scheduler
 {
     // ReSharper disable once InconsistentNaming
     public class DefaultScheduler_TellScheduler_Schedule_Tests : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
 #pragma warning disable xUnit1008
         [LocalTheory(SkipLocal = "Tests that messages are sent with the specified interval, however due to inaccuracy " +
                                  "of Task.Delay this often fails. Run this especially if you've made changes to DedicatedThreadScheduler")]
@@ -91,9 +94,9 @@ namespace Akka.Tests.Actor.Scheduler
                     TimeSpan.FromMilliseconds(interval), TestActor, "Test", ActorRefs.NoSender);
 
                 //Just check that we receives more than one message
-                await ExpectMsgAsync("Test");
-                await ExpectMsgAsync("Test");
-                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test", cancellationToken: Token);
+                await ExpectMsgAsync("Test", cancellationToken: Token);
+                await ExpectMsgAsync("Test", cancellationToken: Token);
             }
             finally
             {
@@ -116,11 +119,11 @@ namespace Akka.Tests.Actor.Scheduler
                     scheduler.ScheduleTellOnce(time, TestActor, "Test" + time, ActorRefs.NoSender);
                 }
 
-                await ExpectMsgAsync("Test1");
-                await ExpectMsgAsync("Test50");
-                await ExpectMsgAsync("Test110");
+                await ExpectMsgAsync("Test1", cancellationToken: Token);
+                await ExpectMsgAsync("Test50", cancellationToken: Token);
+                await ExpectMsgAsync("Test110", cancellationToken: Token);
 
-                await ExpectNoMsgAsync(50);
+                await ExpectNoMsgAsync(50, cancellationToken: Token);
             }
             finally
             {
@@ -144,13 +147,13 @@ namespace Akka.Tests.Actor.Scheduler
                 }
 
                 //Perform the test
-                await ExpectMsgAsync("Test1");
-                await ExpectMsgAsync("Test1");
-                await ExpectMsgAsync("Test50");
-                await ExpectMsgAsync("Test50");
-                await ExpectMsgAsync("Test100");
-                await ExpectMsgAsync("Test100");
-                await ExpectNoMsgAsync(50);
+                await ExpectMsgAsync("Test1", cancellationToken: Token);
+                await ExpectMsgAsync("Test1", cancellationToken: Token);
+                await ExpectMsgAsync("Test50", cancellationToken: Token);
+                await ExpectMsgAsync("Test50", cancellationToken: Token);
+                await ExpectMsgAsync("Test100", cancellationToken: Token);
+                await ExpectMsgAsync("Test100", cancellationToken: Token);
+                await ExpectNoMsgAsync(50, cancellationToken: Token);
             }
             finally
             {
@@ -171,7 +174,7 @@ namespace Akka.Tests.Actor.Scheduler
                 XAssert.Throws<ArgumentOutOfRangeException>(() =>
                             scheduler.ScheduleTellOnce(invalidTime, TestActor, "Test", ActorRefs.NoSender)
                 );
-                await ExpectNoMsgAsync(50);
+                await ExpectNoMsgAsync(50, cancellationToken: Token);
 
             }
             finally
@@ -192,7 +195,7 @@ namespace Akka.Tests.Actor.Scheduler
                 XAssert.Throws<ArgumentOutOfRangeException>(() =>
                             scheduler.ScheduleTellRepeatedly(invalidTime, 100, TestActor, "Test", ActorRefs.NoSender)
                 );
-                await ExpectNoMsgAsync(50);
+                await ExpectNoMsgAsync(50, cancellationToken: Token);
             }
             finally
             {
@@ -213,7 +216,7 @@ namespace Akka.Tests.Actor.Scheduler
                 XAssert.Throws<ArgumentOutOfRangeException>(() =>
                             scheduler.ScheduleTellRepeatedly(42, invalidInterval, TestActor, "Test", ActorRefs.NoSender)
                 );
-                await ExpectNoMsgAsync(50);
+                await ExpectNoMsgAsync(50, cancellationToken: Token);
             }
             finally
             {
@@ -228,7 +231,7 @@ namespace Akka.Tests.Actor.Scheduler
             try
             {
                 scheduler.ScheduleTellOnce(0, TestActor, "Test", ActorRefs.NoSender);
-                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test", cancellationToken: Token);
             }
             finally
             {
@@ -244,7 +247,7 @@ namespace Akka.Tests.Actor.Scheduler
             try
             {
                 scheduler.ScheduleTellRepeatedly(0, 60*1000, TestActor, "Test", ActorRefs.NoSender);
-                await ExpectMsgAsync("Test");
+                await ExpectMsgAsync("Test", cancellationToken: Token);
             }
             finally
             {

--- a/src/core/Akka.Tests/Actor/Scheduler/TimerSchedulerDebugSpec.cs
+++ b/src/core/Akka.Tests/Actor/Scheduler/TimerSchedulerDebugSpec.cs
@@ -10,11 +10,8 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Configuration;
-using Akka.TestKit;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 using Debug = Akka.Event.Debug;
 
 namespace Akka.Tests.Actor.Scheduler;
@@ -39,25 +36,29 @@ internal sealed class TimerTestActor: UntypedActor, IWithTimers
     public ITimerScheduler Timers { get; set; }
 }
     
-public class TimerSchedulerDebug: TestKit.Xunit2.TestKit
+public class TimerSchedulerDebug: TestKit.Xunit.TestKit
 {
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
     public TimerSchedulerDebug(ITestOutputHelper output) : base("akka.actor.debug.log-timers = true", null, output)
     {
     }
 
     [Fact]
-    public void ShouldHonorDebugFlag()
+    public async Task ShouldHonorDebugFlag()
     {
         Sys.EventStream.Subscribe(TestActor, typeof(Debug));
         var timerActor = Sys.ActorOf<TimerTestActor>();
         timerActor.Tell("startTimer");
 
-        FishForMessage(msg => msg is Debug dbg && dbg.Message.ToString()!.StartsWith("Start timer ["));
+        await FishForMessageAsync(msg => msg is Debug dbg && dbg.Message.ToString()!.StartsWith("Start timer ["), cancellationToken: Token);
     }
 }
 
-public class TimerSchedulerSuppressDebug: TestKit.Xunit2.TestKit
+public class TimerSchedulerSuppressDebug: TestKit.Xunit.TestKit
 {
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
     public TimerSchedulerSuppressDebug(ITestOutputHelper output) : base("akka.actor.debug.log-timers = false", null, output)
     {
     }
@@ -71,7 +72,8 @@ public class TimerSchedulerSuppressDebug: TestKit.Xunit2.TestKit
 
         await ExpectNoMsgAsync(
             predicate: msg => msg is Debug dbg && dbg.Message.ToString()!.StartsWith("Start timer ["), 
-            timeout: 1.Seconds());
+            timeout: 1.Seconds(),
+            cancellationToken: Token);
     }
     
     private async Task ExpectNoMsgAsync(

--- a/src/core/Akka.Tests/Actor/Setup/ActorSystemSetupSpec.cs
+++ b/src/core/Akka.Tests/Actor/Setup/ActorSystemSetupSpec.cs
@@ -13,6 +13,7 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor.Setup
 {
@@ -48,6 +49,8 @@ namespace Akka.Tests.Actor.Setup
 
     public class ActorSystemSetupSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+
         [Fact]
         public void ActorSystemSettingsShouldStoreAndRetrieveSetup()
         {
@@ -105,7 +108,7 @@ namespace Akka.Tests.Actor.Setup
             }
             finally
             {
-                system?.Terminate().Wait(TimeSpan.FromSeconds(5));
+                system?.Terminate().Wait((int)TimeSpan.FromSeconds(5).TotalMilliseconds, Token);
             }
         }
 

--- a/src/core/Akka.Tests/Actor/Stash/ActorWithBoundedStashSpec.cs
+++ b/src/core/Akka.Tests/Actor/Stash/ActorWithBoundedStashSpec.cs
@@ -7,14 +7,12 @@
 
 using System;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Event;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor.Stash
 {

--- a/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
+++ b/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
@@ -21,6 +22,9 @@ namespace Akka.Tests.Actor.Stash
     public class ActorWithStashSpec : AkkaSpec
     {
         private static StateObj _state;
+        
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public ActorWithStashSpec()
         {
             _state = new StateObj(this);
@@ -100,7 +104,7 @@ namespace Akka.Tests.Actor.Stash
             var slaveProps = Props.Create(() => new SlaveActor(restartLatch, hasMsgLatch, "stashme"));
 
             //Send the props to supervisor, which will create an actor and return the ActorRef
-            var slave = await boss.Ask<IActorRef>(slaveProps).WithTimeout(TestKitSettings.DefaultTimeout);
+            var slave = await boss.Ask<IActorRef>(slaveProps).WaitAsync(TestKitSettings.DefaultTimeout, Token);
 
             //send a message that will be stashed
             slave.Tell("stashme");
@@ -123,7 +127,7 @@ namespace Akka.Tests.Actor.Stash
             var slaveProps = Props.Create(() => new ActorsThatClearsStashOnPreRestart(restartLatch));
 
             //Send the props to supervisor, which will create an actor and return the ActorRef
-            var slave = await boss.Ask<IActorRef>(slaveProps).WithTimeout(TestKitSettings.DefaultTimeout);;
+            var slave = await boss.Ask<IActorRef>(slaveProps).WaitAsync(TestKitSettings.DefaultTimeout, Token);
 
             //send messages that will be stashed
             slave.Tell("stashme 1");

--- a/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
+++ b/src/core/Akka.Tests/Actor/Stash/ActorWithStashSpec.cs
@@ -71,9 +71,9 @@ namespace Akka.Tests.Actor.Stash
             _state.ExpectedException = new TestLatch();
             var stasher = ActorOf<StashAndReplyActor>("stashing-actor");
             stasher.Tell("hello");
-            await ExpectMsgAsync("bye");
+            await ExpectMsgAsync("bye", cancellationToken: Token);
             stasher.Tell("hello");
-            await ExpectMsgAsync("bye");
+            await ExpectMsgAsync("bye", cancellationToken: Token);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace Akka.Tests.Actor.Stash
                 {
                     Sys.Stop(stasher);
                     await ExpectTerminatedAsync(stasher);
-                });
+                }, cancellationToken: Token);
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace Akka.Tests.Actor.Stash
             var slaveProps = Props.Create(() => new SlaveActor(restartLatch, hasMsgLatch, "stashme"));
 
             //Send the props to supervisor, which will create an actor and return the ActorRef
-            var slave = await boss.Ask<IActorRef>(slaveProps).WaitAsync(TestKitSettings.DefaultTimeout, Token);
+            var slave = await boss.Ask<IActorRef>(slaveProps, cancellationToken: Token).WaitAsync(TestKitSettings.DefaultTimeout, cancellationToken: Token);
 
             //send a message that will be stashed
             slave.Tell("stashme");
@@ -127,7 +127,7 @@ namespace Akka.Tests.Actor.Stash
             var slaveProps = Props.Create(() => new ActorsThatClearsStashOnPreRestart(restartLatch));
 
             //Send the props to supervisor, which will create an actor and return the ActorRef
-            var slave = await boss.Ask<IActorRef>(slaveProps).WaitAsync(TestKitSettings.DefaultTimeout, Token);
+            var slave = await boss.Ask<IActorRef>(slaveProps, cancellationToken: Token).WaitAsync(TestKitSettings.DefaultTimeout, cancellationToken: Token);
 
             //send messages that will be stashed
             slave.Tell("stashme 1");
@@ -145,15 +145,15 @@ namespace Akka.Tests.Actor.Stash
             //So when the cell tries to unstash, it will not unstash messages. If it would TestActor
             //would receive all stashme messages instead of "this should bounce back"
             restartLatch.Ready(TimeSpan.FromSeconds(1110));
-            await ExpectMsgAsync("this should bounce back");
+            await ExpectMsgAsync("this should bounce back", cancellationToken: Token);
         }
 
         [Fact]
         public async Task An_actor_must_rereceive_unstashed_Terminated_messages()
         {
             ActorOf(Props.Create(() => new TerminatedMessageStashingActor(TestActor)), "terminated-message-stashing-actor");
-            await ExpectMsgAsync("terminated1");
-            await ExpectMsgAsync("terminated2");
+            await ExpectMsgAsync("terminated1", cancellationToken: Token);
+            await ExpectMsgAsync("terminated2", cancellationToken: Token);
         }
 
         private class UnboundedStashActor : BlackHoleActor, IWithUnboundedStash

--- a/src/core/Akka.Tests/Actor/Stash/Bugfix7398Specs.cs
+++ b/src/core/Akka.Tests/Actor/Stash/Bugfix7398Specs.cs
@@ -8,7 +8,6 @@
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor.Stash;
 

--- a/src/core/Akka.Tests/Actor/Stash/Bugfix7398Specs.cs
+++ b/src/core/Akka.Tests/Actor/Stash/Bugfix7398Specs.cs
@@ -8,11 +8,14 @@
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor.Stash;
 
 public class Bugfix7398Specs : AkkaSpec
 {
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
     public Bugfix7398Specs(ITestOutputHelper output)
         : base(output)
     {
@@ -41,6 +44,6 @@ public class Bugfix7398Specs : AkkaSpec
         {
             var actor = Sys.ActorOf(Props.Create<IllegalStashActor>());
             actor.Tell("hello");
-        });
+        }, cancellationToken: Token);
     }
 }

--- a/src/core/Akka.Tests/Actor/Stash/StashCapacitySpecs.cs
+++ b/src/core/Akka.Tests/Actor/Stash/StashCapacitySpecs.cs
@@ -11,7 +11,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Tests.Actor.Stash;

--- a/src/core/Akka.Tests/Actor/Stash/StashCapacitySpecs.cs
+++ b/src/core/Akka.Tests/Actor/Stash/StashCapacitySpecs.cs
@@ -12,11 +12,14 @@ using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
 using FluentAssertions;
+using System.Threading;
 
 namespace Akka.Tests.Actor.Stash;
 
 public class StashCapacitySpecs : AkkaSpec
 {
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
     public StashCapacitySpecs(ITestOutputHelper output) : base(Config.Empty, output: output)
     {
         
@@ -30,7 +33,7 @@ public class StashCapacitySpecs : AkkaSpec
         stashActor.Tell(new StashMessage("1"));
         stashActor.Tell(new StashMessage("2"));
         stashActor.Tell(GetStashReadout.Instance);
-        var readout1 = await ExpectMsgAsync<StashReadout>();
+        var readout1 = await ExpectMsgAsync<StashReadout>(cancellationToken: Token);
         readout1.Capacity.Should().Be(-1); // unbounded stash returns -1 for capacity
         readout1.Size.Should().Be(2);
         readout1.IsEmpty.Should().BeFalse();
@@ -38,7 +41,7 @@ public class StashCapacitySpecs : AkkaSpec
         
         stashActor.Tell(UnstashMessage.Instance);
         stashActor.Tell(GetStashReadout.Instance);
-        var readout2 = await ExpectMsgAsync<StashReadout>();
+        var readout2 = await ExpectMsgAsync<StashReadout>(cancellationToken: Token);
         readout2.Capacity.Should().Be(-1);
         readout2.Size.Should().Be(1);
         readout2.IsEmpty.Should().BeFalse();
@@ -46,7 +49,7 @@ public class StashCapacitySpecs : AkkaSpec
         
         stashActor.Tell(UnstashMessage.Instance);
         stashActor.Tell(GetStashReadout.Instance);
-        var readout3 = await ExpectMsgAsync<StashReadout>();
+        var readout3 = await ExpectMsgAsync<StashReadout>(cancellationToken: Token);
         readout3.Capacity.Should().Be(-1);
         readout3.Size.Should().Be(0);
         readout3.IsEmpty.Should().BeTrue();

--- a/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
@@ -128,12 +128,12 @@ namespace Akka.Tests.Actor
 
             Func<Exception, Directive> decider = _ => { return Directive.Escalate; };
             var managerProps = new PropsWithName(Props.Create(() => new CountDownActor(countDown, new AllForOneStrategy(decider))), "manager");
-            var manager = await boss.Ask<IActorRef>(managerProps, TestKitSettings.DefaultTimeout);
+            var manager = await boss.Ask<IActorRef>(managerProps, TestKitSettings.DefaultTimeout, cancellationToken: Token);
 
             var workerProps = Props.Create(() => new CountDownActor(countDown, SupervisorStrategy.DefaultStrategy));
-            var worker1 = await manager.Ask<IActorRef>(new PropsWithName(workerProps, "worker1"), TestKitSettings.DefaultTimeout);
-            var worker2 = await manager.Ask<IActorRef>(new PropsWithName(workerProps, "worker2"), TestKitSettings.DefaultTimeout);
-            var worker3 = await manager.Ask<IActorRef>(new PropsWithName(workerProps, "worker3"), TestKitSettings.DefaultTimeout);
+            var worker1 = await manager.Ask<IActorRef>(new PropsWithName(workerProps, "worker1"), TestKitSettings.DefaultTimeout, cancellationToken: Token);
+            var worker2 = await manager.Ask<IActorRef>(new PropsWithName(workerProps, "worker2"), TestKitSettings.DefaultTimeout, cancellationToken: Token);
+            var worker3 = await manager.Ask<IActorRef>(new PropsWithName(workerProps, "worker3"), TestKitSettings.DefaultTimeout, cancellationToken: Token);
 
             await EventFilter.Exception<ActorKilledException>().ExpectOneAsync(async () =>
             {
@@ -143,7 +143,7 @@ namespace Akka.Tests.Actor
 
                 await countDown.WaitAsync().WaitAsync(5.Seconds());
                 //countDown.Wait(TimeSpan.FromSeconds(5)).ShouldBe(true);
-            });
+            }, cancellationToken: Token);
 
         }
 
@@ -176,9 +176,9 @@ namespace Akka.Tests.Actor
                 boss.Tell("killCrasher");
                 boss.Tell("killCrasher");
                 return Task.CompletedTask;
-            });
-            await countDownMessages.WaitAsync(Token).WaitAsync(2.Seconds(), cancellationToken: Token);
-            await countDownMax.WaitAsync(Token).WaitAsync(2.Seconds(), cancellationToken: Token);
+            }, cancellationToken: Token);
+            await countDownMessages.WaitAsync(cancellationToken: Token).WaitAsync(2.Seconds(), cancellationToken: Token);
+            await countDownMax.WaitAsync(cancellationToken: Token).WaitAsync(2.Seconds(), cancellationToken: Token);
         }
 
         private async Task Helper_A_supervisor_hierarchy_must_resume_children_after_Resume<T>() 
@@ -242,18 +242,18 @@ namespace Akka.Tests.Actor
             //      |
             //    worker
             slowResumer.Tell("spawn:boss");
-            var boss = await ExpectMsgAsync<IActorRef>();
+            var boss = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             boss.Tell("spawn:middle");
-            var middle = await ExpectMsgAsync<IActorRef>();
+            var middle = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             middle.Tell("spawn:worker");
-            var worker = await ExpectMsgAsync<IActorRef>();
+            var worker = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
 
             //Check everything is in place by sending ping to worker and expect it to respond with pong
             worker.Tell("ping");
-            await ExpectMsgAsync("pong");
+            await ExpectMsgAsync("pong", cancellationToken: Token);
             await EventFilter.Warning("expected").ExpectOneAsync(async () => //expected exception is thrown by the boss when it crashes
             {
-                //Let boss crash, this means any child under boss should be suspended, so we wait for worker to become suspended.                
+                //Let boss crash, this means any child under boss should be suspended, so we wait for worker to become suspended.
                 boss.Tell("fail");
                 await AwaitConditionAsync(() => Task.FromResult(((LocalActorRef)worker).Cell.Mailbox.IsSuspended()));
 
@@ -265,10 +265,10 @@ namespace Akka.Tests.Actor
 
                 //By counting down the latch slowResumer will continue in the supervisorstrategy and will return Resume.
                 latch.CountDown();
-            });
+            }, cancellationToken: Token);
 
             //Check that all children, and especially worker is resumed. It should receive the ping and respond with a pong
-            await ExpectMsgAsync("pong", TimeSpan.FromMinutes(10));
+            await ExpectMsgAsync("pong", TimeSpan.FromMinutes(10), cancellationToken: Token);
         }
 
         [Fact]
@@ -310,7 +310,7 @@ namespace Akka.Tests.Actor
                     //Send failresumer some meatballs. This message will be forwarded to failingChild
                     failresumer.Tell("Köttbullar");
                     ExpectMsg("Köttbullar");
-                });
+                }, cancellationToken: Token);
 
             createAttempt.Current.ShouldBe(6);
             preStartCalled.Current.ShouldBe(1);

--- a/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
+++ b/src/core/Akka.Tests/Actor/SupervisorHierarchySpec.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Dsl;
 using Akka.TestKit;
-using Akka.TestKit.Extensions;
 using Akka.TestKit.TestActors;
 using Akka.Tests.TestUtils;
 using Akka.Util.Internal;
@@ -23,6 +22,8 @@ namespace Akka.Tests.Actor
 {
     public class SupervisorHierarchySpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         private class CountDownActor : ReceiveActor
         {
             private readonly AsyncCountdownEvent _restartsCountdown;
@@ -176,8 +177,8 @@ namespace Akka.Tests.Actor
                 boss.Tell("killCrasher");
                 return Task.CompletedTask;
             });
-            await countDownMessages.WaitAsync().WaitAsync(2.Seconds());
-            await countDownMax.WaitAsync().WaitAsync(2.Seconds());
+            await countDownMessages.WaitAsync(Token).WaitAsync(2.Seconds(), cancellationToken: Token);
+            await countDownMax.WaitAsync(Token).WaitAsync(2.Seconds(), cancellationToken: Token);
         }
 
         private async Task Helper_A_supervisor_hierarchy_must_resume_children_after_Resume<T>() 

--- a/src/core/Akka.Tests/Actor/SystemGuardianTests.cs
+++ b/src/core/Akka.Tests/Actor/SystemGuardianTests.cs
@@ -11,11 +11,14 @@ using Akka.Dispatch.SysMsg;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
     public class SystemGuardianTests : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         readonly IInternalActorRef _userGuardian;
         readonly IInternalActorRef _systemGuardian;
 
@@ -32,7 +35,7 @@ namespace Akka.Tests.Actor
             _systemGuardian.Tell(RegisterTerminationHook.Instance);
             _userGuardian.Tell(PoisonPill.Instance);
             
-            await ExpectMsgAsync<TerminationHook>();
+            await ExpectMsgAsync<TerminationHook>(cancellationToken: Token);
         }
 
         [Fact]
@@ -43,9 +46,9 @@ namespace Akka.Tests.Actor
             _systemGuardian.Tell(RegisterTerminationHook.Instance);
             _userGuardian.Tell(PoisonPill.Instance);
 
-            await ExpectMsgAsync<TerminationHook>();
+            await ExpectMsgAsync<TerminationHook>(cancellationToken: Token);
             _systemGuardian.Tell(TerminationHookDone.Instance);
-            await probe.ExpectTerminatedAsync(_systemGuardian);
+            await probe.ExpectTerminatedAsync(_systemGuardian, cancellationToken: Token);
         }
 
         [Fact]
@@ -60,7 +63,7 @@ namespace Akka.Tests.Actor
 
             _userGuardian.Tell(PoisonPill.Instance);
 
-            await guardianWatcher.ExpectTerminatedAsync(_systemGuardian);
+            await guardianWatcher.ExpectTerminatedAsync(_systemGuardian, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Actor/TerminationSignalHandlerSpec.cs
+++ b/src/core/Akka.Tests/Actor/TerminationSignalHandlerSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -16,7 +17,6 @@ using Akka.TestKit.Extensions;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Actor.CoordinatedShutdown;
 
 namespace Akka.Tests.Actor;
@@ -34,6 +34,8 @@ public class TerminationSignalHandlerSpec : AkkaSpec
 
     private static readonly Phase EmptyPhase = new(ImmutableHashSet<string>.Empty, TimeSpan.FromSeconds(10), true);
 
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+    
     /// <summary>
     /// Test double for <see cref="ITerminationSignalHandler"/> that allows simulating termination signals.
     /// </summary>
@@ -125,7 +127,7 @@ public class TerminationSignalHandlerSpec : AkkaSpec
             testHandler.SimulateTerminationSignal();
 
             // Assert
-            var result = await taskExecuted.Task.AwaitWithTimeout(TimeSpan.FromSeconds(10));
+            var result = await taskExecuted.Task.AwaitWithTimeout(TimeSpan.FromSeconds(10), Token);
             result.Should().BeTrue();
             coord.ShutdownReason.Should().Be(ClrExitReason.Instance);
         }
@@ -168,7 +170,7 @@ public class TerminationSignalHandlerSpec : AkkaSpec
             testHandler.SimulateTerminationSignal();
 
             // Assert
-            var result = await flagObserved.Task.AwaitWithTimeout(TimeSpan.FromSeconds(10));
+            var result = await flagObserved.Task.AwaitWithTimeout(TimeSpan.FromSeconds(10), Token);
             result.Should().BeTrue();
         }
         finally
@@ -197,7 +199,7 @@ public class TerminationSignalHandlerSpec : AkkaSpec
         await sys.Terminate();
 
         // Give continuation time to run
-        await Task.Delay(100);
+        await Task.Delay(100, Token);
 
         // Assert
         testHandler.IsDisposed.Should().BeTrue();
@@ -235,7 +237,7 @@ public class TerminationSignalHandlerSpec : AkkaSpec
             testHandler.SimulateTerminationSignal();
 
             // Wait for shutdown to complete
-            await sys.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(10));
+            await sys.WhenTerminated.AwaitWithTimeout(TimeSpan.FromSeconds(10), Token);
 
             // Assert - task should only have executed once
             executionCount.Should().Be(1);
@@ -283,7 +285,7 @@ public class TerminationSignalHandlerSpec : AkkaSpec
             testHandler.SimulateTerminationSignal();
 
             // Assert - second task should still execute despite first task throwing
-            var result = await secondTaskExecuted.Task.AwaitWithTimeout(TimeSpan.FromSeconds(10));
+            var result = await secondTaskExecuted.Task.AwaitWithTimeout(TimeSpan.FromSeconds(10), Token);
             result.Should().BeTrue();
         }
         finally

--- a/src/core/Akka.Tests/Actor/TimerSpec.cs
+++ b/src/core/Akka.Tests/Actor/TimerSpec.cs
@@ -15,6 +15,7 @@ using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
 using static Akka.Actor.FSMBase;
+using System.Threading;
 
 namespace Akka.Tests.Actor
 {
@@ -32,6 +33,8 @@ namespace Akka.Tests.Actor
 
     public abstract class AbstractTimerSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+
         int interval = 1;
         TimeSpan dilatedInterval;
 
@@ -48,11 +51,11 @@ namespace Akka.Tests.Actor
             var probe = CreateTestProbe();
             var actor = Sys.ActorOf(TargetProps(probe.Ref, TimeSpan.FromMilliseconds(10), false));
 
-            await probe.ExpectMsgAsync(new Tock(1));
-            await probe.ExpectNoMsgAsync(100);
+            await probe.ExpectMsgAsync(new Tock(1), cancellationToken: Token);
+            await probe.ExpectNoMsgAsync(100, cancellationToken: Token);
 
             actor.Tell(End.Instance);
-            await probe.ExpectMsgAsync(new GotPostStop(false));
+            await probe.ExpectMsgAsync(new GotPostStop(false), cancellationToken: Token);
         }
 
         [Fact]
@@ -64,12 +67,12 @@ namespace Akka.Tests.Actor
             // Use individual per-message timeouts instead of aggregate window
             // to avoid cumulative variance causing timeout when scheduler delays accumulate
             var tickTimeout = dilatedInterval + dilatedInterval; // 2x interval per tick
-            await probe.ExpectMsgAsync(new Tock(1), tickTimeout);
-            await probe.ExpectMsgAsync(new Tock(1), tickTimeout);
-            await probe.ExpectMsgAsync(new Tock(1), tickTimeout);
+            await probe.ExpectMsgAsync(new Tock(1), tickTimeout, cancellationToken: Token);
+            await probe.ExpectMsgAsync(new Tock(1), tickTimeout, cancellationToken: Token);
+            await probe.ExpectMsgAsync(new Tock(1), tickTimeout, cancellationToken: Token);
 
             actor.Tell(End.Instance);
-            await probe.ExpectMsgAsync(new GotPostStop(false));
+            await probe.ExpectMsgAsync(new GotPostStop(false), cancellationToken: Token);
         }
 
         [Fact]
@@ -78,17 +81,17 @@ namespace Akka.Tests.Actor
             var probe = CreateTestProbe();
             var actor = Sys.ActorOf(TargetProps(probe.Ref, dilatedInterval, true));
 
-            await probe.ExpectMsgAsync(new Tock(1));
+            await probe.ExpectMsgAsync(new Tock(1), cancellationToken: Token);
 
             var latch = CreateTestLatch(1);
             // next Tock(1) enqueued in mailboxed, but should be discarded because of new timer
             actor.Tell(new SlowThenBump(latch));
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(interval) + TimeSpan.FromMilliseconds(100));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(interval) + TimeSpan.FromMilliseconds(100), cancellationToken: Token);
             latch.CountDown();
-            await probe.ExpectMsgAsync(new Tock(2));
+            await probe.ExpectMsgAsync(new Tock(2), cancellationToken: Token);
 
             actor.Tell(End.Instance);
-            await probe.ExpectMsgAsync(new GotPostStop(false));
+            await probe.ExpectMsgAsync(new GotPostStop(false), cancellationToken: Token);
         }
 
         [Fact]
@@ -97,13 +100,13 @@ namespace Akka.Tests.Actor
             var probe = CreateTestProbe();
             var actor = Sys.ActorOf(TargetProps(probe.Ref, dilatedInterval, true));
 
-            await probe.ExpectMsgAsync(new Tock(1));
+            await probe.ExpectMsgAsync(new Tock(1), cancellationToken: Token);
 
             actor.Tell(Cancel.Instance);
-            await probe.ExpectNoMsgAsync(dilatedInterval + TimeSpan.FromMilliseconds(100));
+            await probe.ExpectNoMsgAsync(dilatedInterval + TimeSpan.FromMilliseconds(100), cancellationToken: Token);
 
             actor.Tell(End.Instance);
-            await probe.ExpectMsgAsync(new GotPostStop(false));
+            await probe.ExpectMsgAsync(new GotPostStop(false), cancellationToken: Token);
         }
 
         [Fact]
@@ -113,10 +116,10 @@ namespace Akka.Tests.Actor
             var actor = Sys.ActorOf(TargetProps(probe.Ref, dilatedInterval, true));
 
             actor.Tell(new Throw(new Exc()));
-            await probe.ExpectMsgAsync(new GotPreRestart(false));
+            await probe.ExpectMsgAsync(new GotPreRestart(false), cancellationToken: Token);
 
             actor.Tell(End.Instance);
-            await probe.ExpectMsgAsync(new GotPostStop(false));
+            await probe.ExpectMsgAsync(new GotPostStop(false), cancellationToken: Token);
         }
 
         [Fact]
@@ -126,19 +129,19 @@ namespace Akka.Tests.Actor
             var startCounter = new AtomicCounter(0);
             var actor = Sys.ActorOf(TargetProps(probe.Ref, dilatedInterval, true, () => startCounter.IncrementAndGet()));
 
-            await probe.ExpectMsgAsync(new Tock(1));
+            await probe.ExpectMsgAsync(new Tock(1), cancellationToken: Token);
 
             var latch = CreateTestLatch(1);
             // next Tock(1) is enqueued in mailbox, but should be discarded by new incarnation
             actor.Tell(new SlowThenThrow(latch, new Exc()));
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(interval) + TimeSpan.FromMilliseconds(100));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(interval) + TimeSpan.FromMilliseconds(100), cancellationToken: Token);
             latch.CountDown();
-            await probe.ExpectMsgAsync(new GotPreRestart(false));
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(interval / 2));
-            await probe.ExpectMsgAsync(new Tock(2)); // this is from the startCounter increment
+            await probe.ExpectMsgAsync(new GotPreRestart(false), cancellationToken: Token);
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(interval / 2), cancellationToken: Token);
+            await probe.ExpectMsgAsync(new Tock(2), cancellationToken: Token); // this is from the startCounter increment
 
             actor.Tell(End.Instance);
-            await probe.ExpectMsgAsync(new GotPostStop(false));
+            await probe.ExpectMsgAsync(new GotPostStop(false), cancellationToken: Token);
         }
 
         [Fact]
@@ -147,22 +150,22 @@ namespace Akka.Tests.Actor
             var probe = CreateTestProbe();
             var actor = Sys.ActorOf(TargetProps(probe.Ref, dilatedInterval, true));
 
-            await probe.ExpectMsgAsync(new Tock(1));
+            await probe.ExpectMsgAsync(new Tock(1), cancellationToken: Token);
             // change state so that we see that the restart starts over again
             actor.Tell(Bump.Instance);
 
-            await probe.ExpectMsgAsync(new Tock(2));
+            await probe.ExpectMsgAsync(new Tock(2), cancellationToken: Token);
 
             var latch = CreateTestLatch(1);
             // next Tock(2) is enqueued in mailbox, but should be discarded by new incarnation
             actor.Tell(new SlowThenThrow(latch, new Exc()));
-            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(interval) + TimeSpan.FromMilliseconds(100));
+            await probe.ExpectNoMsgAsync(TimeSpan.FromSeconds(interval) + TimeSpan.FromMilliseconds(100), cancellationToken: Token);
             latch.CountDown();
-            await probe.ExpectMsgAsync(new GotPreRestart(false));
-            await probe.ExpectMsgAsync(new Tock(1));
+            await probe.ExpectMsgAsync(new GotPreRestart(false), cancellationToken: Token);
+            await probe.ExpectMsgAsync(new Tock(1), cancellationToken: Token);
 
             actor.Tell(End.Instance);
-            await probe.ExpectMsgAsync(new GotPostStop(false));
+            await probe.ExpectMsgAsync(new GotPostStop(false), cancellationToken: Token);
         }
 
         [Fact]
@@ -172,7 +175,7 @@ namespace Akka.Tests.Actor
             var actor = Sys.ActorOf(TargetProps(probe.Ref, dilatedInterval, true));
 
             actor.Tell(End.Instance);
-            await probe.ExpectMsgAsync(new GotPostStop(false));
+            await probe.ExpectMsgAsync(new GotPostStop(false), cancellationToken: Token);
         }
 
         [Fact]
@@ -184,7 +187,7 @@ namespace Akka.Tests.Actor
             Watch(actor);
             actor.Tell(AutoReceive.Instance);
 
-            await ExpectTerminatedAsync(actor);
+            await ExpectTerminatedAsync(actor, cancellationToken: Token);
         }
 
 
@@ -538,15 +541,17 @@ namespace Akka.Tests.Actor
 
     public class TimersAndStashSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+
         [Fact]
         public async Task Timers_combined_with_stashing_should_work()
         {
 
             var probe = CreateTestProbe();
             var actor = Sys.ActorOf(Props.Create(() => new ActorWithTimerAndStash(probe.Ref)));
-            await probe.ExpectMsgAsync("saw-scheduled");
+            await probe.ExpectMsgAsync("saw-scheduled", cancellationToken: Token);
             actor.Tell(StopStashing.Instance);
-            await probe.ExpectMsgAsync("scheduled");
+            await probe.ExpectMsgAsync("scheduled", cancellationToken: Token);
         }
 
         #region actors

--- a/src/core/Akka.Tests/Actor/TimerStartupCrashBugFixSpec.cs
+++ b/src/core/Akka.Tests/Actor/TimerStartupCrashBugFixSpec.cs
@@ -11,12 +11,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
-using Akka.Routing;
 using Akka.TestKit;
 using FluentAssertions;
-using FsCheck;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Actor;
 

--- a/src/core/Akka.Tests/Actor/TimerStartupCrashBugFixSpec.cs
+++ b/src/core/Akka.Tests/Actor/TimerStartupCrashBugFixSpec.cs
@@ -14,11 +14,14 @@ using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Actor;
 
 public class TimerStartupCrashBugFixSpec : AkkaSpec
 {
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
     public TimerStartupCrashBugFixSpec(ITestOutputHelper output) : base(output: output, Akka.Configuration.Config.Empty)
     {
         Sys.Log.Info("Starting TimerStartupCrashBugFixSpec");
@@ -85,7 +88,7 @@ public class TimerStartupCrashBugFixSpec : AkkaSpec
         while (i == 0)
         {
             // guarantee that the actor has started and processed a message from scheduler
-            i = await actors[0].Ask<int>(TimerActor.Check.Instance);
+            i = await actors[0].Ask<int>(TimerActor.Check.Instance, cancellationToken: Token);
         }
 
 

--- a/src/core/Akka.Tests/Actor/WatchAsyncSpecs.cs
+++ b/src/core/Akka.Tests/Actor/WatchAsyncSpecs.cs
@@ -18,6 +18,8 @@ namespace Akka.Tests.Actor
 {
     public class WatchAsyncSpecs : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact(DisplayName = "WatchAsync should return true when actor is terminated")]
         public async Task WatchAsync_should_return_true_when_actor_is_terminated()
         {
@@ -41,7 +43,7 @@ namespace Akka.Tests.Actor
             var actor = Sys.ActorOf(BlackHoleActor.Props);
             Watch(actor);
             Sys.Stop(actor);
-            await ExpectTerminatedAsync(actor);
+            await ExpectTerminatedAsync(actor, cancellationToken: Token);
 
             // act
 

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
     <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">$(NetTestVersion)</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Tests/Akka.Tests.csproj
+++ b/src/core/Akka.Tests/Akka.Tests.csproj
@@ -11,16 +11,17 @@
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
     <ProjectReference Include="..\Akka\Akka.csproj" />
-    <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Include="FsCheck.Xunit" Version="$(FsCheckVersion)" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="FsCheck" Version="$(FsCheck3Version)" />
+    <PackageReference Include="FsCheck.Xunit.v3" Version="$(FsCheck3Version)" />
+    <!-- <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" /> -->
   </ItemGroup>
 
   <!-- Exclude System.Linq.Async for .NET 10+ as it conflicts with built-in BCL methods -->

--- a/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
+++ b/src/core/Akka.Tests/Configuration/ConfigurationSpec.cs
@@ -6,18 +6,14 @@
 //-----------------------------------------------------------------------
 #if !CORECLR
 using System;
-using System.IO;
 using Akka.Configuration.Hocon;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Event;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;
 

--- a/src/core/Akka.Tests/Delivery/ConsumerControllerSpecs.cs
+++ b/src/core/Akka.Tests/Delivery/ConsumerControllerSpecs.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -15,12 +16,11 @@ using Akka.Delivery.Internal;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Tests.Delivery.TestConsumer;
 
 namespace Akka.Tests.Delivery;
 
-public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
+public class ConsumerControllerSpecs : TestKit.Xunit.TestKit
 {
     public static readonly Config Config = @"
         akka.reliable-delivery.consumer-controller {
@@ -28,6 +28,8 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         resend-interval-min = 1s
     }";
 
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
     public ConsumerControllerSpecs(ITestOutputHelper outputHelper) : base(
         Config.WithFallback(TestSerializer.Config).WithFallback(ZeroLengthSerializer.Config), output: outputHelper)
     {
@@ -50,10 +52,10 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
 
         consumerController.Tell(
             new ConsumerController.RegisterToProducerController<TestConsumer.Job>(producerControllerProbe.Ref));
-        await producerControllerProbe.ExpectMsgAsync<ProducerController.RegisterConsumer<TestConsumer.Job>>();
+        await producerControllerProbe.ExpectMsgAsync<ProducerController.RegisterConsumer<TestConsumer.Job>>(cancellationToken: Token);
 
         // expected resend
-        await producerControllerProbe.ExpectMsgAsync<ProducerController.RegisterConsumer<TestConsumer.Job>>();
+        await producerControllerProbe.ExpectMsgAsync<ProducerController.RegisterConsumer<TestConsumer.Job>>(cancellationToken: Token);
     }
 
     [Fact]
@@ -67,18 +69,18 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
 
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe.Ref));
         consumerController.Tell(new ConsumerController.RegisterToProducerController<Job>(producerControllerProbe1.Ref));
-        await producerControllerProbe1.ExpectMsgAsync<ProducerController.RegisterConsumer<Job>>();
+        await producerControllerProbe1.ExpectMsgAsync<ProducerController.RegisterConsumer<Job>>(cancellationToken: Token);
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe1.Ref));
 
         // change producer
         var producerControllerProbe2 = CreateTestProbe();
         consumerController.Tell(new ConsumerController.RegisterToProducerController<Job>(producerControllerProbe2.Ref));
-        await producerControllerProbe2.ExpectMsgAsync<ProducerController.RegisterConsumer<Job>>();
-        var msg = await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await producerControllerProbe2.ExpectMsgAsync<ProducerController.RegisterConsumer<Job>>(cancellationToken: Token);
+        var msg = await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         msg.ConfirmTo.Tell(ConsumerController.Confirmed.Instance);
 
         // expected resend
-        await producerControllerProbe2.ExpectMsgAsync<ProducerController.RegisterConsumer<Job>>();
+        await producerControllerProbe2.ExpectMsgAsync<ProducerController.RegisterConsumer<Job>>(cancellationToken: Token);
     }
 
     [Fact]
@@ -94,12 +96,12 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         var consumerProbe = CreateTestProbe();
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe.Ref));
 
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false), cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false), cancellationToken: Token);
 
         // resend (viaTimeout will be 'true' this time)
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, true));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, true), cancellationToken: Token);
     }
 
     [Fact]
@@ -119,26 +121,26 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
             consumerController.Tell(SequencedMessage(ProducerId, i, producerControllerProbe.Ref));
         }
 
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, windowSize, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, windowSize, true, false), cancellationToken: Token);
         foreach (var i in Enumerable.Range(1, windowSize / 2 - 1))
         {
-            await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+            await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
             consumerController.Tell(ConsumerController.Confirmed.Instance);
             if (i == 1)
             {
                 await producerControllerProbe.ExpectMsgAsync(
-                    new ProducerController.Request(1, windowSize, true, false));
+                    new ProducerController.Request(1, windowSize, true, false), cancellationToken: Token);
             }
         }
 
-        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), Token);
         consumerController.Tell(SequencedMessage(ProducerId, windowSize / 2, producerControllerProbe.Ref));
 
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
-        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
+        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
         await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(windowSize / 2,
-            windowSize + windowSize / 2, true, false));
+            windowSize + windowSize / 2, true, false), cancellationToken: Token);
     }
 
     [Fact]
@@ -153,29 +155,29 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe));
 
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe.Ref));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false), cancellationToken: Token);
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false), cancellationToken: Token);
 
         consumerController.Tell(SequencedMessage(ProducerId, 2, producerControllerProbe));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
         // skip messages 3 and 4
         consumerController.Tell(SequencedMessage(ProducerId, 5, producerControllerProbe));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Resend(3));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Resend(3), cancellationToken: Token);
 
         consumerController.Tell(SequencedMessage(ProducerId, 3, producerControllerProbe));
         consumerController.Tell(SequencedMessage(ProducerId, 4, producerControllerProbe));
         consumerController.Tell(SequencedMessage(ProducerId, 5, producerControllerProbe));
 
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(3);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(3);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(4);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(4);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(5);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(5);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
     }
 
@@ -190,25 +192,25 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         var consumerProbe = CreateTestProbe();
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe));
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false), cancellationToken: Token);
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false), cancellationToken: Token);
 
         consumerController.Tell(SequencedMessage(ProducerId, 2, producerControllerProbe));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(2, 20, true, true));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(2, 20, true, true), cancellationToken: Token);
 
         consumerController.Tell(SequencedMessage(ProducerId, 3, producerControllerProbe));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(3);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(3);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(3, 20, true, true));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(3, 20, true, true), cancellationToken: Token);
 
         // exponential backoff, so now the resend should take longer than 1 second
-        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromSeconds(1.1));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(3, 20, true, true));
+        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromSeconds(1.1), cancellationToken: Token);
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(3, 20, true, true), cancellationToken: Token);
     }
 
     [Fact]
@@ -223,24 +225,24 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe));
 
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false), cancellationToken: Token);
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false), cancellationToken: Token);
 
         consumerController.Tell(SequencedMessage(ProducerId, 2, producerControllerProbe));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
 
         // deliver messages to be stashed while we wait for the consumer's confirmation
         consumerController.Tell(SequencedMessage(ProducerId, 3, producerControllerProbe));
         consumerController.Tell(SequencedMessage(ProducerId, 4, producerControllerProbe));
-        await consumerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        await consumerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token);
 
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(3);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(3);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(4);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(4);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
         consumerController.Tell(SequencedMessage(ProducerId, 5, producerControllerProbe));
@@ -253,15 +255,15 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(SequencedMessage(ProducerId, 7, producerControllerProbe));
         consumerController.Tell(SequencedMessage(ProducerId, 8, producerControllerProbe));
 
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(5);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(5);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(6);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(6);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(7);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(7);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(8);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(8);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await consumerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        await consumerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token);
     }
 
     [Fact]
@@ -276,29 +278,29 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe));
 
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe, ack: true));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false), cancellationToken: Token);
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false), cancellationToken: Token);
 
         consumerController.Tell(SequencedMessage(ProducerId, 2, producerControllerProbe, ack: true));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(2));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(2), cancellationToken: Token);
 
         consumerController.Tell(SequencedMessage(ProducerId, 3, producerControllerProbe, ack: true));
         consumerController.Tell(SequencedMessage(ProducerId, 4, producerControllerProbe, ack: false)); // skip ACK here
         consumerController.Tell(SequencedMessage(ProducerId, 5, producerControllerProbe, ack: true));
 
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(3);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(3);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(3));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(4);
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(3), cancellationToken: Token);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(4);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(5);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(5);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(5));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(5), cancellationToken: Token);
     }
 
     [Fact]
@@ -313,28 +315,28 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe1));
 
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe));
-        await consumerProbe1.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe1.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false), cancellationToken: Token);
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false), cancellationToken: Token);
 
         consumerController.Tell(SequencedMessage(ProducerId, 2, producerControllerProbe));
-        await consumerProbe1.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe1.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
         consumerController.Tell(SequencedMessage(ProducerId, 3, producerControllerProbe));
-        (await consumerProbe1.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(3);
+        (await consumerProbe1.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(3);
 
         // restart consumer, before message 3 is confirmed
         var consumerProbe2 = CreateTestProbe();
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe2));
 
-        (await consumerProbe2.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(3);
+        (await consumerProbe2.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(3);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
         consumerController.Tell(SequencedMessage(ProducerId, 4, producerControllerProbe));
-        (await consumerProbe2.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(4);
+        (await consumerProbe2.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(4);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
     }
 
@@ -350,7 +352,7 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe1));
         await consumerProbe1.GracefulStop(RemainingOrDefault);
 
-        await ExpectTerminatedAsync(consumerController);
+        await ExpectTerminatedAsync(consumerController, cancellationToken: Token);
     }
 
     [Fact]
@@ -365,24 +367,24 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe));
 
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false), cancellationToken: Token);
         // that Request will typically cancel the resending of first, but in unlucky timing it may happen
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).ConfirmTo.Tell(ConsumerController
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).ConfirmTo.Tell(ConsumerController
             .Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false), cancellationToken: Token);
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe));
 
         // deduplicated, expect no message
-        await consumerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        await consumerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token);
 
         // but if the ProducerController is changed it will not be deduplicated
         var producerControllerProbe2 = CreateTestProbe();
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe2));
-        await producerControllerProbe2.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).ConfirmTo.Tell(ConsumerController
+        await producerControllerProbe2.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false), cancellationToken: Token);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).ConfirmTo.Tell(ConsumerController
             .Confirmed.Instance);
-        await producerControllerProbe2.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false));
+        await producerControllerProbe2.ExpectMsgAsync(new ProducerController.Request(1, 20, true, false), cancellationToken: Token);
     }
 
     [Fact]
@@ -398,24 +400,24 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe));
 
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, flowControlWindow, true, false));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).ConfirmTo.Tell(ConsumerController
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, flowControlWindow, true, false), cancellationToken: Token);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).ConfirmTo.Tell(ConsumerController
             .Confirmed.Instance);
 
         // and if the ProducerController is changed
         var producerControllerProbe2 = CreateTestProbe();
         consumerController.Tell(SequencedMessage(ProducerId, 23, producerControllerProbe2).AsFirst());
         await producerControllerProbe2.ExpectMsgAsync(new ProducerController.Request(0, 23 + flowControlWindow - 1,
-            true, false));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).ConfirmTo.Tell(ConsumerController
+            true, false), cancellationToken: Token);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).ConfirmTo.Tell(ConsumerController
             .Confirmed.Instance);
 
         // and if the ProducerController is changed again
         var producerControllerProbe3 = CreateTestProbe();
         consumerController.Tell(SequencedMessage(ProducerId, 7, producerControllerProbe3).AsFirst());
         await producerControllerProbe3.ExpectMsgAsync(new ProducerController.Request(0, 7 + flowControlWindow - 1, true,
-            false));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).ConfirmTo.Tell(ConsumerController
+            false), cancellationToken: Token);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).ConfirmTo.Tell(ConsumerController
             .Confirmed.Instance);
     }
 
@@ -439,7 +441,7 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
 
         // unstashed 44, 41, 45
         // 44 is not first, so this will trigger a full Resend, and also clears stashed messages
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Resend(0));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Resend(0), cancellationToken: Token);
         consumerController.Tell(SequencedMessage(ProducerId, 41, producerControllerProbe).AsFirst());
         consumerController.Tell(SequencedMessage(ProducerId, 42, producerControllerProbe));
         consumerController.Tell(SequencedMessage(ProducerId, 43, producerControllerProbe));
@@ -447,23 +449,23 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(SequencedMessage(ProducerId, 45, producerControllerProbe));
 
         // 41 is first, which will trigger the initial Request
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 60, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 60, true, false), cancellationToken: Token);
 
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(41);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(41);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(41, 60, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(41, 60, true, false), cancellationToken: Token);
 
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(42);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(42);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(43);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(43);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(44);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(44);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(45);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(45);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
         consumerController.Tell(SequencedMessage(ProducerId, 46, producerControllerProbe));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(46);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(46);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
     }
 
@@ -479,22 +481,22 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe));
 
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
-        await producerControllerProbe.ExpectMsgAsync<ProducerController.Request>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
+        await producerControllerProbe.ExpectMsgAsync<ProducerController.Request>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync<ProducerController.Request>();
+        await producerControllerProbe.ExpectMsgAsync<ProducerController.Request>(cancellationToken: Token);
 
         consumerController.Tell(SequencedMessage(ProducerId, 2, producerControllerProbe));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
         consumerController.Tell(SequencedMessage(ProducerId, 3, producerControllerProbe));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
 
         // now we know that the ConsumerController has received Confirmed for 2,
         // and 3 is still not confirmed
         Sys.Stop(consumerController);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(2));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(2), cancellationToken: Token);
     }
 
     [Fact]
@@ -511,31 +513,31 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe));
 
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
-        await producerControllerProbe.ExpectMsgAsync<ProducerController.Request>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
+        await producerControllerProbe.ExpectMsgAsync<ProducerController.Request>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync<ProducerController.Request>();
+        await producerControllerProbe.ExpectMsgAsync<ProducerController.Request>(cancellationToken: Token);
 
         consumerController.Tell(SequencedMessage(ProducerId, 2, producerControllerProbe));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).Message.Should().Be(new Job("msg-2"));
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).Message.Should().Be(new Job("msg-2"));
         consumerController.Tell(SequencedMessage(ProducerId, 3, producerControllerProbe));
         consumerController.Tell(SequencedMessage(ProducerId, 4, producerControllerProbe));
 
         consumerController.Tell(ConsumerController.DeliverThenStop<Job>.Instance);
 
         consumerController.Tell(ConsumerController.Confirmed.Instance); // msg 2
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).Message.Should().Be(new Job("msg-3"));
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).Message.Should().Be(new Job("msg-3"));
         consumerController.Tell(SequencedMessage(ProducerId, 5, producerControllerProbe));
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).Message.Should().Be(new Job("msg-4"));
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).Message.Should().Be(new Job("msg-4"));
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).Message.Should().Be(new Job("msg-5"));
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).Message.Should().Be(new Job("msg-5"));
         consumerController.Tell(ConsumerController.Confirmed.Instance);
 
-        await ExpectTerminatedAsync(consumerController);
+        await ExpectTerminatedAsync(consumerController, cancellationToken: Token);
 
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(4));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(5));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(4), cancellationToken: Token);
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(5), cancellationToken: Token);
     }
 
     [Fact]
@@ -556,13 +558,13 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
             ConsumerController.SequencedMessage<Job>.FromChunkedMessage(ProducerId, 1 + i, c, i == 0, false,
                 producerControllerProbe)).ToList();
         consumerController.Tell(seqMessages1.First());
-        await consumerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false));
+        await consumerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token);
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false), cancellationToken: Token);
         consumerController.Tell(seqMessages1[1]);
         consumerController.Tell(seqMessages1[2]);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).Message.Payload.Should().Be("123");
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).Message.Payload.Should().Be("123");
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(3, 22, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(3, 22, true, false), cancellationToken: Token);
         
         // going to ACK the chunks this time
         var chunks2 = ProducerController<Job>.CreateChunks(new Job("45"), chunkSize: 1, Sys.Serialization);
@@ -572,9 +574,9 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         
         consumerController.Tell(seqMessages2.First());
         consumerController.Tell(seqMessages2[1]);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).Message.Payload.Should().Be("45");
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).Message.Payload.Should().Be("45");
         consumerController.Tell(ConsumerController.Confirmed.Instance);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(5));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Ack(5), cancellationToken: Token);
     }
 
     [Fact]
@@ -597,28 +599,28 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
                 producerControllerProbe)).ToList();
         
         consumerController.Tell(seqMessages1.First());
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false));
-        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100)); // no more Request yet
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, true, false), cancellationToken: Token);
+        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token); // no more Request yet
         foreach(var i in Enumerable.Range(1,8))
             consumerController.Tell(seqMessages1[i]);
-        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100)); // sent 9, no more Request yet
+        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token); // sent 9, no more Request yet
         
         consumerController.Tell(seqMessages1[9]);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 30, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 30, true, false), cancellationToken: Token);
         
         for(var i = 10; i < 19; i++)
             consumerController.Tell(seqMessages1[i]);
-        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100)); // sent 19, no more Request yet
+        await producerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token); // sent 19, no more Request yet
         
         consumerController.Tell(seqMessages1[19]);
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 40, true, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 40, true, false), cancellationToken: Token);
         
         // not sending more for a while, timeout will trigger a new Request
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 40, true, true));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 40, true, true), cancellationToken: Token);
 
         for(var i = 20; i < 25; i++)
             consumerController.Tell(seqMessages1[i]);
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).Message.Payload.Should()
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).Message.Payload.Should()
             .Be("1234567890123456789012345");
         consumerController.Tell(ConsumerController.Confirmed.Instance);
     }
@@ -635,24 +637,24 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
         consumerController.Tell(new ConsumerController.Start<Job>(consumerProbe));
         
         consumerController.Tell(SequencedMessage(ProducerId, 1, producerControllerProbe));
-        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
         
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, false, false));
-        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, false, false));
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(0, 20, false, false), cancellationToken: Token);
+        await producerControllerProbe.ExpectMsgAsync(new ProducerController.Request(1, 20, false, false), cancellationToken: Token);
         
         // skipping 2
         consumerController.Tell(SequencedMessage(ProducerId, 3, producerControllerProbe));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(3);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(3);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
         
         consumerController.Tell(SequencedMessage(ProducerId, 4, producerControllerProbe));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(4);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(4);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
         
         // skip many
         consumerController.Tell(SequencedMessage(ProducerId, 35, producerControllerProbe));
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>()).SeqNr.Should().Be(35);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token)).SeqNr.Should().Be(35);
         consumerController.Tell(ConsumerController.Confirmed.Instance);
     }
 
@@ -677,6 +679,6 @@ public class ConsumerControllerSpecs : TestKit.Xunit2.TestKit
             ConsumerController.SequencedMessage<ZeroLengthSerializer.TestMsg>.FromChunkedMessage(ProducerId, 1 + i, c, i == 0, false,
                 producerControllerProbe)).ToList();
         consumerController.Tell(seqMessages1.First());
-        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<ZeroLengthSerializer.TestMsg>>()).Message.Should().Be(ZeroLengthSerializer.TestMsg.Instance);
+        (await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<ZeroLengthSerializer.TestMsg>>(cancellationToken: Token)).Message.Should().Be(ZeroLengthSerializer.TestMsg.Instance);
     }
 }

--- a/src/core/Akka.Tests/Delivery/DurableProducerControllerSpecs.cs
+++ b/src/core/Akka.Tests/Delivery/DurableProducerControllerSpecs.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -17,14 +18,13 @@ using Akka.IO;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Tests.Delivery.TestConsumer;
 using static Akka.Delivery.DurableProducerQueue;
 using static Akka.Tests.Delivery.TestDurableProducerQueue;
 
 namespace Akka.Tests.Delivery;
 
-public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
+public class DurableProducerControllerSpecs : TestKit.Xunit.TestKit
 {
     private static readonly Config Config = @"akka.reliable-delivery.consumer-controller.flow-control-window = 20
      akka.reliable-delivery.consumer-controller.resend-interval-min = 1s";
@@ -34,6 +34,8 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
     {
     }
 
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
     private int _idCount = 0;
     private int NextId() => _idCount++;
 
@@ -60,16 +62,16 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe));
 
         // no request to producer since it has unconfirmed to begin with
-        await producerProbe.ExpectNoMsgAsync(100);
+        await producerProbe.ExpectNoMsgAsync(100, cancellationToken: Token);
 
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController).AsFirst());
-        await consumerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController).AsFirst(), cancellationToken: Token);
+        await consumerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), Token);
         producerController.Tell(new ProducerController.Request(3L, 13L, true, false));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController), cancellationToken: Token);
 
-        var sendTo = (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo;
+        var sendTo = (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo;
         sendTo.Tell(new Job("msg-5"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController), cancellationToken: Token);
     }
 
     [Fact]
@@ -89,8 +91,8 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
 
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-1"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-1"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController), cancellationToken: Token);
 
         await AwaitAssertAsync(() =>
         {
@@ -98,7 +100,7 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
                 ImmutableList.Create<MessageSent<Job>>()
                     .Add(new MessageSent<Job>(1, new Job("msg-1"), false, NoQualifier, TestTimestamp))));
             return Task.CompletedTask;
-        });
+        }, cancellationToken: Token);
 
         producerController.Tell(new ProducerController.Request(1L, 10L, true, false));
         await AwaitAssertAsync(() =>
@@ -108,18 +110,18 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
                     .Add(NoQualifier, (1L, TestTimestamp)),
                 ImmutableList<MessageSent<Job>>.Empty));
             return Task.CompletedTask;
-        });
+        }, cancellationToken: Token);
 
         var replyTo = CreateTestProbe();
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).AskNextTo(
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).AskNextTo(
             new ProducerController.MessageWithConfirmation<Job>(new Job("msg-2"), replyTo.Ref));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController, ack: true));
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).AskNextTo(
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController, ack: true), cancellationToken: Token);
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).AskNextTo(
             new ProducerController.MessageWithConfirmation<Job>(new Job("msg-3"), replyTo.Ref));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController, ack: true));
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).AskNextTo(
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController, ack: true), cancellationToken: Token);
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).AskNextTo(
             new ProducerController.MessageWithConfirmation<Job>(new Job("msg-4"), replyTo.Ref));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController, ack: true));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController, ack: true), cancellationToken: Token);
         producerController.Tell(new ProducerController.Ack(3L));
 
         await AwaitAssertAsync(() =>
@@ -130,7 +132,7 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
                 ImmutableList<MessageSent<Job>>.Empty.Add(new MessageSent<Job>(4, new Job("msg-4"), true, NoQualifier,
                     TestTimestamp))));
             return Task.CompletedTask;
-        });
+        }, cancellationToken: Token);
     }
 
     [Fact]
@@ -151,16 +153,16 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
 
         var replyTo = CreateTestProbe();
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).AskNextTo(
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).AskNextTo(
             new ProducerController.MessageWithConfirmation<Job>(new Job("msg-1"), replyTo.Ref));
-        await replyTo.ExpectMsgAsync(1L);
+        await replyTo.ExpectMsgAsync(1L, cancellationToken: Token);
 
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController, ack: true));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController, ack: true), cancellationToken: Token);
         producerController.Tell(new ProducerController.Request(1L, 10L, true, false));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).AskNextTo(
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).AskNextTo(
             new ProducerController.MessageWithConfirmation<Job>(new Job("msg-2"), replyTo.Ref));
-        replyTo.ExpectMsg(2L);
+        replyTo.ExpectMsg(2L, cancellationToken: Token);
     }
 
     [Fact]
@@ -182,8 +184,8 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
 
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("abc"));
-        await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("abc"));
+        await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
 
         await AwaitAssertAsync(() =>
         {
@@ -192,13 +194,13 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
             durableState.Unconfirmed.Count.Should().Be(1);
             durableState.Unconfirmed.First().Message.IsMessage.Should().BeFalse();
             return Task.CompletedTask;
-        });
+        }, cancellationToken: Token);
 
         producerController.Tell(new ProducerController.Request(0L, 10L, true, false));
 
-        await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
 
-        var seqMsg3 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg3 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg3.Message.IsMessage.Should().BeFalse();
         seqMsg3.IsFirstChunk.Should().BeFalse();
         seqMsg3.IsLastChunk.Should().BeTrue();
@@ -211,7 +213,7 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
             durableState.Unconfirmed.Count.Should().Be(3);
             durableState.Unconfirmed.First().Message.IsMessage.Should().BeFalse();
             return Task.CompletedTask;
-        });
+        }, cancellationToken: Token);
     }
 
     [Fact]
@@ -251,7 +253,7 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
         
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe));
 
-        var seqMsg3 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg3 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg3.SeqNr.Should().Be(3);
         seqMsg3.IsFirstChunk.Should().BeTrue();
         seqMsg3.IsLastChunk.Should().BeTrue();
@@ -259,11 +261,11 @@ public class DurableProducerControllerSpecs : TestKit.Xunit2.TestKit
         producerController.Tell(new ProducerController.Request(0L, 10L, true, false));
         
         // 4 and 5 discarded because missing last chunk
-        await consumerControllerProbe.ExpectNoMsgAsync();
+        await consumerControllerProbe.ExpectNoMsgAsync(cancellationToken: Token);
         
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("g"));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("g"));
         
-        var seqMsg4 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg4 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg4.SeqNr.Should().Be(4);
         seqMsg4.IsFirstChunk.Should().BeTrue();
         seqMsg4.IsLastChunk.Should().BeTrue();

--- a/src/core/Akka.Tests/Delivery/ProducerControllerSpec.cs
+++ b/src/core/Akka.Tests/Delivery/ProducerControllerSpec.cs
@@ -6,7 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -15,12 +15,11 @@ using Akka.Util;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Tests.Delivery.TestConsumer;
 
 namespace Akka.Tests.Delivery;
 
-public class ProducerControllerSpec : TestKit.Xunit2.TestKit
+public class ProducerControllerSpec : TestKit.Xunit.TestKit
 {
     private static readonly Config Config = "akka.reliable-delivery.consumer-controller.flow-control-window = 20";
 
@@ -29,6 +28,8 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
     {
     }
 
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
     private int _idCount = 0;
     private int NextId() => _idCount++;
 
@@ -46,11 +47,11 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         producerController.Tell(new ProducerController.Start<Job>(producerProbe.Ref));
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe.Ref));
 
-        var sendTo = (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        var sendTo = (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo;
         sendTo.Tell(new Job("msg-1"));
 
-        var seqMsg = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
 
         seqMsg.ProducerId.Should().Be(ProducerId);
         seqMsg.SeqNr.Should().Be(1);
@@ -58,10 +59,10 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
 
         // the ConsumerController will send initial `Request` back, but if that is lost or if the first
         // `SequencedMessage` is lost the ProducerController will resend the SequencedMessage
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController), cancellationToken: Token);
 
         producerController.Tell(new ProducerController.Request(1L, 10L, true, false));
-        await consumerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(1100));
+        await consumerControllerProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(1100), cancellationToken: Token);
     }
 
     [Fact]
@@ -77,28 +78,28 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
 
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe.Ref));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job("msg-1"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController), cancellationToken: Token);
 
         producerController.Tell(new ProducerController.Request(1L, 10L, true, false));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-2"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-2"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController), cancellationToken: Token);
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-3"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController));
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-4"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-3"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController), cancellationToken: Token);
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-4"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController), cancellationToken: Token);
 
         // let's say 3 is lost, when 4 is received the ConsumerController detects the gap and sends Resend(3)
         producerController.Tell(new ProducerController.Resend(3L));
 
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController), cancellationToken: Token);
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController), cancellationToken: Token);
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-5"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-5"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController), cancellationToken: Token);
     }
 
     [Fact]
@@ -114,29 +115,29 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
 
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe.Ref));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job("msg-1"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController), cancellationToken: Token);
 
         producerController.Tell(new ProducerController.Request(1L, 10L, true, false));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-2"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-2"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController), cancellationToken: Token);
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-3"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController));
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-4"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-3"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController), cancellationToken: Token);
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-4"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController), cancellationToken: Token);
 
         // let's say 3 and 4 are lost, and no more messages are sent from producer
         // ConsumerController will resend Request periodically
         producerController.Tell(new ProducerController.Request(2L, 10L, true, true));
 
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController), cancellationToken: Token);
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController), cancellationToken: Token);
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-5"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-5"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController), cancellationToken: Token);
     }
 
     [Fact]
@@ -151,32 +152,32 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         var consumerControllerProbe1 = CreateTestProbe();
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe1.Ref));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job("msg-1"));
-        await consumerControllerProbe1.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController));
+        await consumerControllerProbe1.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController), cancellationToken: Token);
 
         producerController.Tell(new ProducerController.Request(1L, 10L, true, false));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job("msg-2"));
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job("msg-3"));
 
         var consumerControllerProbe2 = CreateTestProbe();
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe2.Ref));
 
-        await consumerControllerProbe2.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController).AsFirst());
-        await consumerControllerProbe2.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+        await consumerControllerProbe2.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController).AsFirst(), cancellationToken: Token);
+        await consumerControllerProbe2.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token);
         // if no Request confirming the first (seqNr=2) it will resend it
-        await consumerControllerProbe2.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController).AsFirst());
+        await consumerControllerProbe2.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController).AsFirst(), cancellationToken: Token);
 
         producerController.Tell(new ProducerController.Request(2L, 10L, true, false));
         // then the other unconfirmed should be resent
-        await consumerControllerProbe2.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController));
+        await consumerControllerProbe2.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController), cancellationToken: Token);
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job("msg-4"));
-        await consumerControllerProbe2.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController));
+        await consumerControllerProbe2.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController), cancellationToken: Token);
     }
 
     [Fact]
@@ -194,35 +195,35 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
 
         var replyTo = CreateTestProbe();
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .AskNextTo(new ProducerController.MessageWithConfirmation<Job>(new Job("msg-1"), replyTo.Ref));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController, ack: true));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController, ack: true), cancellationToken: Token);
         producerController.Tell(new ProducerController.Request(1L, 10L, true, false));
-        await replyTo.ExpectMsgAsync(1L);
+        await replyTo.ExpectMsgAsync(1L, cancellationToken: Token);
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .AskNextTo(new ProducerController.MessageWithConfirmation<Job>(new Job("msg-2"), replyTo.Ref));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController, ack: true));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController, ack: true), cancellationToken: Token);
         producerController.Tell(new ProducerController.Ack(2L));
-        await replyTo.ExpectMsgAsync(2L);
+        await replyTo.ExpectMsgAsync(2L, cancellationToken: Token);
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .AskNextTo(new ProducerController.MessageWithConfirmation<Job>(new Job("msg-3"), replyTo.Ref));
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .AskNextTo(new ProducerController.MessageWithConfirmation<Job>(new Job("msg-4"), replyTo.Ref));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController, ack: true));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController, ack: true));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController, ack: true), cancellationToken: Token);
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController, ack: true), cancellationToken: Token);
         // Ack(3 lost, but Ack(4) triggers reply for 3 and 4
         producerController.Tell(new ProducerController.Ack(4L));
-        await replyTo.ExpectMsgAsync(3L);
-        await replyTo.ExpectMsgAsync(4L);
+        await replyTo.ExpectMsgAsync(3L, cancellationToken: Token);
+        await replyTo.ExpectMsgAsync(4L, cancellationToken: Token);
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .AskNextTo(new ProducerController.MessageWithConfirmation<Job>(new Job("msg-5"), replyTo.Ref));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController, ack: true));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController, ack: true), cancellationToken: Token);
         // Ack(5) lost, but eventually a Request will trigger the reply
         producerController.Tell(new ProducerController.Request(5L, 15L, true, false));
-        await replyTo.ExpectMsgAsync(5L);
+        await replyTo.ExpectMsgAsync(5L, cancellationToken: Token);
     }
     
     [Fact]
@@ -243,11 +244,11 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe.Ref));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .AskNextTo(new ProducerController.MessageWithConfirmation<Job>(new Job("abc"), replyProbe.Ref));
         
         // gather all 3 chunks
-        var seqMsg1 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg1 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg1.Message.IsMessage.Should().BeFalse();
         seqMsg1.Message.Chunk.HasValue.Should().BeTrue();
         seqMsg1.IsFirstChunk.Should().BeTrue();
@@ -255,9 +256,9 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         seqMsg1.SeqNr.Should().Be(1);
         
         producerController.Tell(new ProducerController.Request(0L, 10L, true, false));
-        await replyProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100)); // no reply yet
+        await replyProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token); // no reply yet
 
-        var seqMsg2 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg2 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg2.Message.IsMessage.Should().BeFalse();
         seqMsg2.Message.Chunk.HasValue.Should().BeTrue();
         seqMsg2.IsFirstChunk.Should().BeFalse();
@@ -266,7 +267,7 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         
         producerController.Tell(new ProducerController.Request(0L, 10L, true, false));
         
-        var seqMsg3 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg3 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg3.Message.IsMessage.Should().BeFalse();
         seqMsg3.Message.Chunk.HasValue.Should().BeTrue();
         seqMsg3.IsFirstChunk.Should().BeFalse();
@@ -277,7 +278,7 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         producerController.Tell(new ProducerController.Request(3L, 10L, true, false));
         
         // expect confirmation to come to reply probe
-        await replyProbe.ExpectMsgAsync(3L);
+        await replyProbe.ExpectMsgAsync(3L, cancellationToken: Token);
     }
 
     [Fact]
@@ -292,27 +293,27 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         var consumerControllerProbe = CreateTestProbe();
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe.Ref));
 
-        (await producerProbe1.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe1.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job("msg-1"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController), cancellationToken: Token);
 
         producerController.Tell(new ProducerController.Request(1L, 10L, true, false));
 
-        (await producerProbe1.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe1.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job("msg-2"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController), cancellationToken: Token);
 
-        (await producerProbe1.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).CurrentSeqNr.Should().Be(3);
+        (await producerProbe1.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).CurrentSeqNr.Should().Be(3);
 
         // restart producer, new Start
         var producerProbe2 = CreateTestProbe();
         producerController.Tell(new ProducerController.Start<Job>(producerProbe2.Ref));
 
-        (await producerProbe2.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-3"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController));
+        (await producerProbe2.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-3"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController), cancellationToken: Token);
 
-        (await producerProbe2.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-4"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController));
+        (await producerProbe2.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-4"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController), cancellationToken: Token);
     }
 
     [Fact]
@@ -332,9 +333,9 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe.Ref));
         
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job("abc"));
-        var seqMsg1 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg1 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg1.Message.IsMessage.Should().BeFalse();
         seqMsg1.Message.Chunk.HasValue.Should().BeTrue();
         seqMsg1.IsFirstChunk.Should().BeTrue();
@@ -343,7 +344,7 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         
         producerController.Tell(new ProducerController.Request(0L, 10L, true, false));
         
-        var seqMsg2 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg2 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg2.Message.IsMessage.Should().BeFalse();
         seqMsg2.Message.Chunk.HasValue.Should().BeTrue();
         seqMsg2.IsFirstChunk.Should().BeFalse();
@@ -352,16 +353,16 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         
         producerController.Tell(new ProducerController.Request(0L, 10L, true, false));
         
-        var seqMsg3 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg3 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg3.Message.IsMessage.Should().BeFalse();
         seqMsg3.Message.Chunk.HasValue.Should().BeTrue();
         seqMsg3.IsFirstChunk.Should().BeFalse();
         seqMsg3.IsLastChunk.Should().BeTrue();
         seqMsg3.SeqNr.Should().Be(3);
         
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job("d"));
-        var seqMsg4 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg4 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg4.Message.IsMessage.Should().BeFalse();
         seqMsg4.Message.Chunk.HasValue.Should().BeTrue();
         seqMsg4.IsFirstChunk.Should().BeTrue();
@@ -383,29 +384,29 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
 
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe.Ref));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job("msg-1"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController), cancellationToken: Token);
 
         producerController.Tell(new ProducerController.Request(1L, 10L, false, false));
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-2"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-2"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController), cancellationToken: Token);
 
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-3"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController));
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-4"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-3"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController), cancellationToken: Token);
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-4"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController), cancellationToken: Token);
 
         // let's say 3 and 4 are lost, and no more messages are sent from producer
         // ConsumerController will resend Request periodically
         producerController.Tell(new ProducerController.Request(2L, 10L, false, true));
         
         // but 3 and 4 are not resent because supportResend=false
-        await consumerControllerProbe.ExpectNoMsgAsync(100.Milliseconds());
+        await consumerControllerProbe.ExpectNoMsgAsync(100.Milliseconds(), cancellationToken: Token);
         
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-5"));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController));
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-5"));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController), cancellationToken: Token);
     }
 
     [Fact]
@@ -424,35 +425,35 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         
         var replyTo = CreateTestProbe();
         
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .AskNextTo(new ProducerController.MessageWithConfirmation<Job>(new Job("msg-1"), replyTo.Ref));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController, ack:true));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 1, producerController, ack:true), cancellationToken: Token);
         producerController.Tell(new ProducerController.Request(1L, 10L, false, false));
-        await replyTo.ExpectMsgAsync(1L);
+        await replyTo.ExpectMsgAsync(1L, cancellationToken: Token);
         
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .AskNextTo(new ProducerController.MessageWithConfirmation<Job>(new Job("msg-2"), replyTo.Ref));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController, ack:true));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 2, producerController, ack:true), cancellationToken: Token);
         producerController.Tell(new ProducerController.Ack(2L));
-        await replyTo.ExpectMsgAsync(2L);
+        await replyTo.ExpectMsgAsync(2L, cancellationToken: Token);
         
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .AskNextTo(new ProducerController.MessageWithConfirmation<Job>(new Job("msg-3"), replyTo.Ref));
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .AskNextTo(new ProducerController.MessageWithConfirmation<Job>(new Job("msg-4"), replyTo.Ref));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController, ack:true));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController, ack:true));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 3, producerController, ack:true), cancellationToken: Token);
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 4, producerController, ack:true), cancellationToken: Token);
         // Ack(3 lost, but Ack(4) triggers reply for 3 and 4
         producerController.Tell(new ProducerController.Ack(4L));
-        await replyTo.ExpectMsgAsync(3L);
-        await replyTo.ExpectMsgAsync(4L);
+        await replyTo.ExpectMsgAsync(3L, cancellationToken: Token);
+        await replyTo.ExpectMsgAsync(4L, cancellationToken: Token);
         
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .AskNextTo(new ProducerController.MessageWithConfirmation<Job>(new Job("msg-5"), replyTo.Ref));
-        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController, ack:true));
+        await consumerControllerProbe.ExpectMsgAsync(SequencedMessage(ProducerId, 5, producerController, ack:true), cancellationToken: Token);
         // Ack(5) lost, but eventually a Request will trigger the reply
         producerController.Tell(new ProducerController.Request(5L, 15L, false, false));
-        await replyTo.ExpectMsgAsync(5L);
+        await replyTo.ExpectMsgAsync(5L, cancellationToken: Token);
     }
 
     /// <summary>
@@ -476,9 +477,9 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         
         producerController.Tell(new ProducerController.RegisterConsumer<Job>(consumerControllerProbe.Ref));
         
-        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>())
+        (await producerProbe.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token))
             .SendNextTo.Tell(new Job(msg));
-        var seqMsg1 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg1 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg1.Message.IsMessage.Should().BeFalse();
         seqMsg1.Message.Chunk.HasValue.Should().BeTrue();
         seqMsg1.IsFirstChunk.Should().BeTrue();
@@ -487,7 +488,7 @@ public class ProducerControllerSpec : TestKit.Xunit2.TestKit
         
         producerController.Tell(new ProducerController.Request(0L, 10L, true, false));
         
-        var seqMsg2 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>();
+        var seqMsg2 = await consumerControllerProbe.ExpectMsgAsync<ConsumerController.SequencedMessage<Job>>(cancellationToken: Token);
         seqMsg2.Message.IsMessage.Should().BeFalse();
         seqMsg2.Message.Chunk.HasValue.Should().BeTrue();
         seqMsg2.IsFirstChunk.Should().BeFalse();

--- a/src/core/Akka.Tests/Delivery/ReliableDeliveryRandomSpecs.cs
+++ b/src/core/Akka.Tests/Delivery/ReliableDeliveryRandomSpecs.cs
@@ -14,11 +14,10 @@ using Akka.Event;
 using Akka.Util;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Delivery;
 
-public class ReliableDeliveryRandomSpecs : TestKit.Xunit2.TestKit
+public class ReliableDeliveryRandomSpecs : TestKit.Xunit.TestKit
 {
     private static readonly Config Config = @"akka.reliable-delivery.consumer-controller{
             flow-control-window = 20

--- a/src/core/Akka.Tests/Delivery/ReliableDeliverySpecs.cs
+++ b/src/core/Akka.Tests/Delivery/ReliableDeliverySpecs.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -15,16 +16,17 @@ using Akka.Util;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Tests.Delivery.TestConsumer;
 using static Akka.Tests.Delivery.TestProducer;
 
 namespace Akka.Tests.Delivery;
 
-public class ReliableDeliverySpecs : TestKit.Xunit2.TestKit
+public class ReliableDeliverySpecs : TestKit.Xunit.TestKit
 {
     internal static readonly Config Config = @"akka.reliable-delivery.consumer-controller.flow-control-window = 20";
 
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
     public ReliableDeliverySpecs(ITestOutputHelper output) : this(output, Config)
     {
     }
@@ -55,7 +57,7 @@ public class ReliableDeliverySpecs : TestKit.Xunit2.TestKit
         
         consumerController.Tell(new ConsumerController.RegisterToProducerController<Job>(producerController));
 
-        var collected = await consumerEndProbe.ExpectMsgAsync<Collected>(TimeSpan.FromSeconds(5));
+        var collected = await consumerEndProbe.ExpectMsgAsync<Collected>(TimeSpan.FromSeconds(5), cancellationToken: Token);
     }
 
     [Fact]
@@ -73,11 +75,11 @@ public class ReliableDeliverySpecs : TestKit.Xunit2.TestKit
         
         consumerController.Tell(new ConsumerController.RegisterToProducerController<Job>(producerController));
 
-        var messageCount = (await consumerEndProbe.ExpectMsgAsync<Collected>(TimeSpan.FromSeconds(5))).MessageCount;
+        var messageCount = (await consumerEndProbe.ExpectMsgAsync<Collected>(TimeSpan.FromSeconds(5), cancellationToken: Token)).MessageCount;
         if (Chunked)
-            replyProbe.ReceiveN(messageCount, 5.Seconds());
+            replyProbe.ReceiveN(messageCount, 5.Seconds(), Token);
         else
-            replyProbe.ReceiveN(messageCount, 5.Seconds()).Should().BeEquivalentTo(Enumerable.Range(1, messageCount));
+            replyProbe.ReceiveN(messageCount, 5.Seconds(), Token).Should().BeEquivalentTo(Enumerable.Range(1, messageCount));
         
     }
 
@@ -128,8 +130,8 @@ public class ReliableDeliverySpecs : TestKit.Xunit2.TestKit
         Watch(consumerController);
         consumerController.Tell(new ConsumerController.RegisterToProducerController<Job>(producerController));
 
-        await consumerEndProbe.ExpectMsgAsync<Collected>(TimeSpan.FromSeconds(5));
-        await ExpectTerminatedAsync(consumerController);
+        await consumerEndProbe.ExpectMsgAsync<Collected>(TimeSpan.FromSeconds(5), cancellationToken: Token);
+        await ExpectTerminatedAsync(consumerController, cancellationToken: Token);
         
         var consumerEndProbe2 = CreateTestProbe();
         var consumerController2 = Sys.ActorOf(ConsumerController.Create<Job>(Sys, Option<IActorRef>.None), $"consumerController2-{_idCount}");
@@ -137,7 +139,7 @@ public class ReliableDeliverySpecs : TestKit.Xunit2.TestKit
         
         consumerController2.Tell(new ConsumerController.RegisterToProducerController<Job>(producerController));
         
-        await consumerEndProbe2.ExpectMsgAsync<Collected>(TimeSpan.FromSeconds(5));
+        await consumerEndProbe2.ExpectMsgAsync<Collected>(TimeSpan.FromSeconds(5), cancellationToken: Token);
     }
 
     [Fact]
@@ -155,13 +157,13 @@ public class ReliableDeliverySpecs : TestKit.Xunit2.TestKit
         
         consumerController.Tell(new ConsumerController.RegisterToProducerController<Job>(producerController1));
 
-        (await producerProbe1.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-1"));
-        var delivery1 = await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        (await producerProbe1.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-1"));
+        var delivery1 = await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         delivery1.Message.Should().Be(new Job("msg-1"));
         delivery1.ConfirmTo.Tell(ConsumerController.Confirmed.Instance);
         
-        (await producerProbe1.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-2"));
-        var delivery2 = await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        (await producerProbe1.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-2"));
+        var delivery2 = await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         delivery2.Message.Should().Be(new Job("msg-2"));
         delivery2.ConfirmTo.Tell(ConsumerController.Confirmed.Instance);
         
@@ -172,13 +174,13 @@ public class ReliableDeliverySpecs : TestKit.Xunit2.TestKit
         producerController2.Tell(new ProducerController.Start<Job>(producerProbe2.Ref));
         producerController2.Tell(new ProducerController.RegisterConsumer<Job>(consumerController));
         
-        (await producerProbe2.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-3"));
-        var delivery3 = await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        (await producerProbe2.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-3"));
+        var delivery3 = await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         delivery3.Message.Should().Be(new Job("msg-3"));
         delivery3.ConfirmTo.Tell(ConsumerController.Confirmed.Instance);
         
-        (await producerProbe2.ExpectMsgAsync<ProducerController.RequestNext<Job>>()).SendNextTo.Tell(new Job("msg-4"));
-        var delivery4 = await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>();
+        (await producerProbe2.ExpectMsgAsync<ProducerController.RequestNext<Job>>(cancellationToken: Token)).SendNextTo.Tell(new Job("msg-4"));
+        var delivery4 = await consumerProbe.ExpectMsgAsync<ConsumerController.Delivery<Job>>(cancellationToken: Token);
         delivery4.Message.Should().Be(new Job("msg-4"));
         delivery4.ConfirmTo.Tell(ConsumerController.Confirmed.Instance);
     }

--- a/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
@@ -286,7 +286,7 @@ namespace Akka.Tests.Dispatch
         {
             var actor = Sys.ActorOf(Props.Create<UntypedAsyncAwaitActor>(), "Worker");
             var asker = Sys.ActorOf(Props.Create(() => new UntypedAsker(actor)), "Asker");
-            var task = asker.Ask("start", TimeSpan.FromSeconds(5), Token);
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5), cancellationToken: Token);
             actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
@@ -296,7 +296,7 @@ namespace Akka.Tests.Dispatch
         public async Task Actors_should_be_able_to_async_await_in_message_loop()
         {
             var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>());
-            var task = actor.Ask<string>("start", TimeSpan.FromSeconds(5), Token);
+            var task = actor.Ask<string>("start", TimeSpan.FromSeconds(5), cancellationToken: Token);
             actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
@@ -307,7 +307,7 @@ namespace Akka.Tests.Dispatch
         {
             var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>(), "Worker");
             var asker = Sys.ActorOf(Props.Create(() => new Asker(actor)), "Asker");
-            var task = asker.Ask("start", TimeSpan.FromSeconds(5), Token);
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5), cancellationToken: Token);
             actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
@@ -318,7 +318,7 @@ namespace Akka.Tests.Dispatch
         {
             var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>().WithDispatcher("akka.actor.task-dispatcher"), "Worker");
             var asker = Sys.ActorOf(Props.Create(() => new BlockingAsker(actor)).WithDispatcher("akka.actor.task-dispatcher"), "Asker");
-            var task = asker.Ask("start", TimeSpan.FromSeconds(5), Token);
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5), cancellationToken: Token);
             actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
@@ -328,7 +328,7 @@ namespace Akka.Tests.Dispatch
         public async Task Actors_should_be_able_to_block_ask_self_message_loop()
         {
             var asker = Sys.ActorOf(Props.Create(() => new BlockingAskSelf()), "Asker");
-            var task = asker.Ask("start", TimeSpan.FromSeconds(5), Token);
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5), cancellationToken: Token);
             var res = await task;
             Assert.Equal("done", res);
         }
@@ -338,14 +338,14 @@ namespace Akka.Tests.Dispatch
         {
             var asker = Sys.ActorOf(Props.Create(() => new AsyncExceptionActor(TestActor)));
             asker.Tell("start");
-            await ExpectMsgAsync("done", TimeSpan.FromSeconds(5));
+            await ExpectMsgAsync("done", TimeSpan.FromSeconds(5), cancellationToken: Token);
         }
 
         [Fact]
         public async Task Actors_should_be_able_to_use_ContinueWith()
         {
             var asker = Sys.ActorOf(Props.Create<AsyncTplActor>());
-            var res = await asker.Ask("start", TimeSpan.FromSeconds(5), Token);
+            var res = await asker.Ask("start", TimeSpan.FromSeconds(5), cancellationToken: Token);
             Assert.Equal("done", res);
         }
 
@@ -354,7 +354,7 @@ namespace Akka.Tests.Dispatch
         {
             var asker = Sys.ActorOf(Props.Create(() => new AsyncTplExceptionActor(TestActor)));
             asker.Tell("start");
-            await ExpectMsgAsync("done", TimeSpan.FromSeconds(5));
+            await ExpectMsgAsync("done", TimeSpan.FromSeconds(5), cancellationToken: Token);
         }
 
 
@@ -362,7 +362,7 @@ namespace Akka.Tests.Dispatch
         public async Task Actors_should_be_able_to_suspend_reentrancy()
         {
             var asker = Sys.ActorOf(Props.Create(() => new SuspendActor()));
-            var res = await asker.Ask<int>("start", TimeSpan.FromSeconds(5), Token);
+            var res = await asker.Ask<int>("start", TimeSpan.FromSeconds(5), cancellationToken: Token);
             res.ShouldBe(0);
         }
 
@@ -376,7 +376,7 @@ namespace Akka.Tests.Dispatch
                 asker.Tell("msg #" + i);
             }
 
-            var res = await asker.Ask<string>("stop", TimeSpan.FromSeconds(5), Token);
+            var res = await asker.Ask<string>("stop", TimeSpan.FromSeconds(5), cancellationToken: Token);
             res.ShouldBe("done");
         }
 
@@ -386,7 +386,7 @@ namespace Akka.Tests.Dispatch
             var actor = Sys.ActorOf<ReceiveTimeoutAsyncActor>();
 
             actor.Tell("hello");
-            await ExpectMsgAsync<string>(m => m == "GotIt");
+            await ExpectMsgAsync<string>(m => m == "GotIt", cancellationToken: Token);
         }
 
         public class AsyncExceptionCatcherActor : ReceiveActor
@@ -422,7 +422,7 @@ namespace Akka.Tests.Dispatch
 
             actor.Tell("hello");
 
-            var lastMessage = await actor.Ask(123, Token);
+            var lastMessage = await actor.Ask(123, cancellationToken: Token);
 
             lastMessage.ShouldBe("hello");
         }
@@ -461,7 +461,7 @@ namespace Akka.Tests.Dispatch
 
             actor.Tell("hello");
 
-            await ExpectMsgAsync<RestartMessage>(m => "hello".Equals(m.Message));
+            await ExpectMsgAsync<RestartMessage>(m => "hello".Equals(m.Message), cancellationToken: Token);
         }
 
         public class AsyncPipeToDelayActor : ReceiveActor
@@ -520,7 +520,7 @@ namespace Akka.Tests.Dispatch
             var actor = Sys.ActorOf<AsyncReentrantActor>();
             actor.Tell("hello");
 
-            await ExpectNoMsgAsync(1000);
+            await ExpectNoMsgAsync(1000, cancellationToken: Token);
         }
 
         [Fact]
@@ -529,7 +529,7 @@ namespace Akka.Tests.Dispatch
             var actor = Sys.ActorOf<AsyncPipeToDelayActor>();
 
             actor.Tell("hello");
-            await ExpectMsgAsync<string>(m => "hello".Equals(m), TimeSpan.FromMilliseconds(1000));
+            await ExpectMsgAsync<string>(m => "hello".Equals(m), TimeSpan.FromMilliseconds(1000), cancellationToken: Token);
         }
 
         [Fact]
@@ -538,13 +538,13 @@ namespace Akka.Tests.Dispatch
             var actor = Sys.ActorOf<AsyncAwaitActor>();
 
             actor.Tell(11);
-            await ExpectMsgAsync<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000));
+            await ExpectMsgAsync<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000), cancellationToken: Token);
 
             actor.Tell(9);
-            await ExpectMsgAsync<string>(m => "receiveany".Equals(m), TimeSpan.FromMilliseconds(1000));
+            await ExpectMsgAsync<string>(m => "receiveany".Equals(m), TimeSpan.FromMilliseconds(1000), cancellationToken: Token);
 
             actor.Tell(1.0);
-            await ExpectMsgAsync<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000));
+            await ExpectMsgAsync<string>(m => "handled".Equals(m), TimeSpan.FromMilliseconds(1000), cancellationToken: Token);
 
 
         }

--- a/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/AsyncAwaitSpec.cs
@@ -279,12 +279,14 @@ namespace Akka.Tests.Dispatch
 
     public class ActorAsyncAwaitSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [Fact]
         public async Task UntypedActors_should_be_able_to_async_await_ask_message_loop()
         {
             var actor = Sys.ActorOf(Props.Create<UntypedAsyncAwaitActor>(), "Worker");
             var asker = Sys.ActorOf(Props.Create(() => new UntypedAsker(actor)), "Asker");
-            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5), Token);
             actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
@@ -294,7 +296,7 @@ namespace Akka.Tests.Dispatch
         public async Task Actors_should_be_able_to_async_await_in_message_loop()
         {
             var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>());
-            var task = actor.Ask<string>("start", TimeSpan.FromSeconds(5));
+            var task = actor.Ask<string>("start", TimeSpan.FromSeconds(5), Token);
             actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
@@ -305,7 +307,7 @@ namespace Akka.Tests.Dispatch
         {
             var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>(), "Worker");
             var asker = Sys.ActorOf(Props.Create(() => new Asker(actor)), "Asker");
-            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5), Token);
             actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
@@ -316,7 +318,7 @@ namespace Akka.Tests.Dispatch
         {
             var actor = Sys.ActorOf(Props.Create<AsyncAwaitActor>().WithDispatcher("akka.actor.task-dispatcher"), "Worker");
             var asker = Sys.ActorOf(Props.Create(() => new BlockingAsker(actor)).WithDispatcher("akka.actor.task-dispatcher"), "Asker");
-            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5), Token);
             actor.Tell(123, ActorRefs.NoSender);
             var res = await task;
             Assert.Equal("done", res);
@@ -326,7 +328,7 @@ namespace Akka.Tests.Dispatch
         public async Task Actors_should_be_able_to_block_ask_self_message_loop()
         {
             var asker = Sys.ActorOf(Props.Create(() => new BlockingAskSelf()), "Asker");
-            var task = asker.Ask("start", TimeSpan.FromSeconds(5));
+            var task = asker.Ask("start", TimeSpan.FromSeconds(5), Token);
             var res = await task;
             Assert.Equal("done", res);
         }
@@ -343,7 +345,7 @@ namespace Akka.Tests.Dispatch
         public async Task Actors_should_be_able_to_use_ContinueWith()
         {
             var asker = Sys.ActorOf(Props.Create<AsyncTplActor>());
-            var res = await asker.Ask("start", TimeSpan.FromSeconds(5));
+            var res = await asker.Ask("start", TimeSpan.FromSeconds(5), Token);
             Assert.Equal("done", res);
         }
 
@@ -360,7 +362,7 @@ namespace Akka.Tests.Dispatch
         public async Task Actors_should_be_able_to_suspend_reentrancy()
         {
             var asker = Sys.ActorOf(Props.Create(() => new SuspendActor()));
-            var res = await asker.Ask<int>("start", TimeSpan.FromSeconds(5));
+            var res = await asker.Ask<int>("start", TimeSpan.FromSeconds(5), Token);
             res.ShouldBe(0);
         }
 
@@ -374,7 +376,7 @@ namespace Akka.Tests.Dispatch
                 asker.Tell("msg #" + i);
             }
 
-            var res = await asker.Ask<string>("stop", TimeSpan.FromSeconds(5));
+            var res = await asker.Ask<string>("stop", TimeSpan.FromSeconds(5), Token);
             res.ShouldBe("done");
         }
 
@@ -420,7 +422,7 @@ namespace Akka.Tests.Dispatch
 
             actor.Tell("hello");
 
-            var lastMessage = await actor.Ask(123);
+            var lastMessage = await actor.Ask(123, Token);
 
             lastMessage.ShouldBe("hello");
         }

--- a/src/core/Akka.Tests/Dispatch/DispatchersSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/DispatchersSpec.cs
@@ -13,7 +13,6 @@ using Akka.Dispatch;
 using Akka.Routing;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Dispatch
 {

--- a/src/core/Akka.Tests/Dispatch/DispatchersSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/DispatchersSpec.cs
@@ -13,11 +13,14 @@ using Akka.Dispatch;
 using Akka.Routing;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Dispatch
 {
     public class DispatchersSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
 
         #region Test Config
         public static Config DispatcherConfiguration
@@ -128,7 +131,7 @@ namespace Akka.Tests.Dispatch
                 var expected = "myapp.mydispatcher";
                 var actual = await ExpectMsgAsync<string>(TimeSpan.FromMilliseconds(50));
                 actual.ShouldBe(expected);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -142,7 +145,7 @@ namespace Akka.Tests.Dispatch
                 var expected = "myapp.mydispatcher";
                 var actual = await ExpectMsgAsync<string>(TimeSpan.FromMilliseconds(50));
                 actual.ShouldBe(expected);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -156,7 +159,7 @@ namespace Akka.Tests.Dispatch
                 var expected = "myapp.my-fork-join-dispatcher";
                 var actual = await ExpectMsgAsync<string>(TimeSpan.FromMilliseconds(200));
                 actual.ShouldBe(expected);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -171,7 +174,7 @@ namespace Akka.Tests.Dispatch
                 var expected = "akka.actor.deployment./pool1.pool-dispatcher";
                 var actual = await ExpectMsgAsync<string>(TimeSpan.FromMilliseconds(50));
                 actual.ShouldBe(expected);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Dispatch/MailboxesSpec.cs
+++ b/src/core/Akka.Tests/Dispatch/MailboxesSpec.cs
@@ -24,6 +24,7 @@ using FsCheck;
 using FsCheck.Xunit;
 using Xunit;
 using Config = Akka.Configuration.Config;
+using System.Threading;
 
 namespace Akka.Tests.Dispatch
 {
@@ -145,6 +146,8 @@ namespace Akka.Tests.Dispatch
 
     public class MailboxesSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+
         public MailboxesSpec() : base(GetConfig())
         {            
         }
@@ -204,7 +207,7 @@ stable-prio-mailbox{
             actor.SendSystemMessage(new Suspend());
 
             // wait until we can confirm that the mailbox is suspended before we begin sending messages
-            await AwaitConditionAsync(() => Task.FromResult(((ActorRefWithCell)actor).Underlying is ActorCell actorCell && actorCell.Mailbox.IsSuspended()));
+            await AwaitConditionAsync(() => Task.FromResult(((ActorRefWithCell)actor).Underlying is ActorCell actorCell && actorCell.Mailbox.IsSuspended()), cancellationToken: Token);
 
             actor.Tell(true);
             for (var i = 0; i < 30; i++)
@@ -222,15 +225,15 @@ stable-prio-mailbox{
             //resume mailbox, this prevents the mailbox from running to early
             //priority mailbox is best effort only
             
-            await ExpectMsgAsync("a");
-            await ExpectMsgAsync(true);
+            await ExpectMsgAsync("a", cancellationToken: Token);
+            await ExpectMsgAsync(true, cancellationToken: Token);
             for (var i = 0; i < 60; i++)
             {
-                await ExpectMsgAsync(1);
+                await ExpectMsgAsync(1, cancellationToken: Token);
             }
-            await ExpectMsgAsync(2.0);
+            await ExpectMsgAsync(2.0, cancellationToken: Token);
 
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.3));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.3), cancellationToken: Token);
         }
 
         [Fact]
@@ -242,7 +245,7 @@ stable-prio-mailbox{
             actor.SendSystemMessage(new Suspend());
 
             // wait until we can confirm that the mailbox is suspended before we begin sending messages
-            await AwaitConditionAsync(() => Task.FromResult(((ActorRefWithCell)actor).Underlying is ActorCell actorCell && actorCell.Mailbox.IsSuspended()));
+            await AwaitConditionAsync(() => Task.FromResult(((ActorRefWithCell)actor).Underlying is ActorCell actorCell && actorCell.Mailbox.IsSuspended()), cancellationToken: Token);
 
             actor.Tell(true);
             for (var i = 0; i < 30; i++)
@@ -260,15 +263,15 @@ stable-prio-mailbox{
             //resume mailbox, this prevents the mailbox from running to early
             //priority mailbox is best effort only
 
-            await ExpectMsgAsync("a");
-            await ExpectMsgAsync(true);
+            await ExpectMsgAsync("a", cancellationToken: Token);
+            await ExpectMsgAsync(true, cancellationToken: Token);
             for (var i = 0; i < 60; i++)
             {
-                await ExpectMsgAsync(i);
+                await ExpectMsgAsync(i, cancellationToken: Token);
             }
-            await ExpectMsgAsync(2.0);
+            await ExpectMsgAsync(2.0, cancellationToken: Token);
 
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.3));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.3), cancellationToken: Token);
         }
 
         [Fact]
@@ -279,7 +282,7 @@ stable-prio-mailbox{
             //pause mailbox until all messages have been told
             actor.SendSystemMessage(new Suspend());
 
-            await AwaitConditionAsync(()=> Task.FromResult(((ActorRefWithCell)actor).Underlying is ActorCell actorCell && actorCell.Mailbox.IsSuspended()));
+            await AwaitConditionAsync(()=> Task.FromResult(((ActorRefWithCell)actor).Underlying is ActorCell actorCell && actorCell.Mailbox.IsSuspended()), cancellationToken: Token);
             // creates 50 messages with values spanning from Int32.MinValue to Int32.MaxValue
             var values = new int[50];
             var increment = (int)(UInt32.MaxValue / values.Length);
@@ -301,12 +304,12 @@ stable-prio-mailbox{
             // expect the messages in the correct order
             foreach (var value in values)
             {
-                await ExpectMsgAsync(value);
-                await ExpectMsgAsync(value);
-                await ExpectMsgAsync(value);
+                await ExpectMsgAsync(value, cancellationToken: Token);
+                await ExpectMsgAsync(value, cancellationToken: Token);
+                await ExpectMsgAsync(value, cancellationToken: Token);
             }
 
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.3));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.3), cancellationToken: Token);
         }
 
         [Fact]
@@ -317,7 +320,7 @@ stable-prio-mailbox{
             //pause mailbox until all messages have been told
             actor.SendSystemMessage(new Suspend());
 
-            await AwaitConditionAsync(() => Task.FromResult(((ActorRefWithCell)actor).Underlying is ActorCell actorCell && actorCell.Mailbox.IsSuspended()));
+            await AwaitConditionAsync(() => Task.FromResult(((ActorRefWithCell)actor).Underlying is ActorCell actorCell && actorCell.Mailbox.IsSuspended()), cancellationToken: Token);
 
             var values = new int[10];
             var increment = (int)(UInt32.MaxValue / values.Length);
@@ -347,9 +350,9 @@ stable-prio-mailbox{
                     await ExpectMsgAsync(value);
                     await ExpectMsgAsync(value);
                 }
-            }); 
+            }, cancellationToken: Token); 
 
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.3));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.3), cancellationToken: Token);
         }
 
         [Fact]
@@ -360,7 +363,7 @@ stable-prio-mailbox{
             //pause mailbox until all messages have been told
             actor.SendSystemMessage(new Suspend());
 
-            await AwaitConditionAsync(() => Task.FromResult(((ActorRefWithCell)actor).Underlying is ActorCell actorCell && actorCell.Mailbox.IsSuspended()));
+            await AwaitConditionAsync(() => Task.FromResult(((ActorRefWithCell)actor).Underlying is ActorCell actorCell && actorCell.Mailbox.IsSuspended()), cancellationToken: Token);
 
             var values = new int[10];
             var increment = (int)(UInt32.MaxValue / values.Length);
@@ -390,9 +393,9 @@ stable-prio-mailbox{
                     await ExpectMsgAsync(value);
                     await ExpectMsgAsync(value);
                 }
-            });
+            }, cancellationToken: Token);
 
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.3));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(0.3), cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Dispatch/XUnitAsyncTestsSanityCheck.cs
+++ b/src/core/Akka.Tests/Dispatch/XUnitAsyncTestsSanityCheck.cs
@@ -5,12 +5,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
-using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.TestKit;
 using Xunit;
@@ -19,6 +16,8 @@ namespace Akka.Tests.Dispatch
 {
 	public class XUnitAsyncTestsSanityCheck : AkkaSpec
 	{
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
 		[Fact]
 		public async Task Async_tests_should_not_lose_ambient_context()
 		{
@@ -35,7 +34,7 @@ namespace Akka.Tests.Dispatch
 			for (var t = 0; t < 1000; t++)
 			{
 				Assert.Equal(ambientContext, InternalCurrentActorCellKeeper.Current);
-				await Task.Delay(1);
+				await Task.Delay(1, Token);
 			}
 			await Task.WhenAll(backgroundOps);
 		}

--- a/src/core/Akka.Tests/Event/Bugfix5717Specs.cs
+++ b/src/core/Akka.Tests/Event/Bugfix5717Specs.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Event
 {

--- a/src/core/Akka.Tests/Event/Bugfix5717Specs.cs
+++ b/src/core/Akka.Tests/Event/Bugfix5717Specs.cs
@@ -10,11 +10,14 @@ using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Event
 {
     public class Bugfix5717Specs : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public Bugfix5717Specs(ITestOutputHelper output) : base(Config.Empty, output){}
         
         /// <summary>
@@ -34,14 +37,14 @@ namespace Akka.Tests.Event
             es.Subscribe(a2.Ref, typeof(string));
             es.Publish(tm1);
             es.Publish(tm2);
-            await a1.ExpectMsgAsync(tm1);
-            await a2.ExpectMsgAsync(tm1);
-            await a2.ExpectMsgAsync(tm2);
+            await a1.ExpectMsgAsync(tm1, cancellationToken: Token);
+            await a2.ExpectMsgAsync(tm1, cancellationToken: Token);
+            await a2.ExpectMsgAsync(tm2, cancellationToken: Token);
 
             // kill second test probe
             Watch(a2);
             Sys.Stop(a2);
-            await ExpectTerminatedAsync(a2);
+            await ExpectTerminatedAsync(a2, cancellationToken: Token);
 
             /*
              * It's possible that the `Terminate` message may not have been processed by the
@@ -59,7 +62,7 @@ namespace Akka.Tests.Event
                     es.Publish(tm2);
                     await a1.ExpectMsgAsync(tm1);
                 });
-            }, interval:TimeSpan.FromSeconds(250));
+            }, interval:TimeSpan.FromSeconds(250), cancellationToken: Token);
         }       
     }
 }

--- a/src/core/Akka.Tests/Event/EventBusSpec.cs
+++ b/src/core/Akka.Tests/Event/EventBusSpec.cs
@@ -14,6 +14,7 @@ using Akka.Actor;
 using Akka.Event;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Event
 {
@@ -74,6 +75,8 @@ namespace Akka.Tests.Event
 
     public class EventBusSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+
         internal ActorEventBus<object, Type> _bus;
 
         protected object _evt;
@@ -151,8 +154,8 @@ namespace Akka.Tests.Event
         {
             _bus.Subscribe(_subscriber, _classifier);
             _bus.Publish(_evt);
-            await ExpectMsgAsync(_evt);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectMsgAsync(_evt, cancellationToken: Token);
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
             _bus.Unsubscribe(_subscriber);
         }
 
@@ -164,11 +167,11 @@ namespace Akka.Tests.Event
             _bus.Publish(_evt);
             _bus.Publish(_evt);
 
-            await ExpectMsgAsync(_evt);
-            await ExpectMsgAsync(_evt);
-            await ExpectMsgAsync(_evt);
+            await ExpectMsgAsync(_evt, cancellationToken: Token);
+            await ExpectMsgAsync(_evt, cancellationToken: Token);
+            await ExpectMsgAsync(_evt, cancellationToken: Token);
 
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
             _bus.Unsubscribe(_subscriber, _classifier);
         }
 
@@ -182,11 +185,11 @@ namespace Akka.Tests.Event
             _bus.Subscribe(otherSubscriber, otherClassifier);
             _bus.Publish(_evt);
 
-            await ExpectMsgAsync(_evt);
+            await ExpectMsgAsync(_evt, cancellationToken: Token);
 
             _bus.Unsubscribe(_subscriber, _classifier);
             _bus.Unsubscribe(otherSubscriber, otherClassifier);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
         }
 
         [Fact]
@@ -195,7 +198,7 @@ namespace Akka.Tests.Event
             _bus.Subscribe(_subscriber, _classifier);
             _bus.Unsubscribe(_subscriber, _classifier);
             _bus.Publish(_evt);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Event/EventStreamSpec.cs
+++ b/src/core/Akka.Tests/Event/EventStreamSpec.cs
@@ -12,17 +12,17 @@ using Akka.TestKit;
 using Akka.Tests.TestUtils;
 using System;
 using System.Linq;
+using System.Threading;
 using Akka.Util.Internal;
 using Xunit;
 using System.Threading.Tasks;
-using FluentAssertions;
-using FluentAssertions.Extensions;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Event
 {
     public class EventStreamSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public EventStreamSpec(ITestOutputHelper output)
             : base(GetConfig(), output)
         {
@@ -106,7 +106,7 @@ namespace Akka.Tests.Event
         [Fact]
         public async Task Be_able_to_log_unhandled_messages()
         {
-            var testKit = new TestKit.Xunit2.TestKit(config: GetDebugUnhandledMessagesConfig(), output: Output);
+            var testKit = new TestKit.Xunit.TestKit(config: GetDebugUnhandledMessagesConfig(), output: Output);
             try
             {
                 var msg = new UnhandledMessage(42, testKit.Sys.DeadLetters, testKit.Sys.DeadLetters);
@@ -115,7 +115,7 @@ namespace Akka.Tests.Event
                     {
                         testKit.Sys.EventStream.Publish(msg);
                         return Task.CompletedTask;
-                    });
+                    }, Token);
             }
             finally
             {
@@ -129,7 +129,7 @@ namespace Akka.Tests.Event
         [Fact]
         public async Task Bugfix3267_able_to_log_unhandled_messages_with_nosender()
         {
-            var testKit = new TestKit.Xunit2.TestKit(config: GetDebugUnhandledMessagesConfig(), output: Output);
+            var testKit = new TestKit.Xunit.TestKit(config: GetDebugUnhandledMessagesConfig(), output: Output);
             try
             {
                 // sender is NoSender
@@ -139,7 +139,7 @@ namespace Akka.Tests.Event
                     {
                         testKit.Sys.EventStream.Publish(msg);
                         return Task.CompletedTask;
-                    });
+                    }, Token);
             }
             finally
             {

--- a/src/core/Akka.Tests/Event/EventStreamSpec.cs
+++ b/src/core/Akka.Tests/Event/EventStreamSpec.cs
@@ -73,10 +73,10 @@ namespace Akka.Tests.Event
             bus.Subscribe(TestActor, typeof(M));
 
             bus.Publish(new M { Value = 42 });
-            await ExpectMsgAsync(new M { Value = 42 });
+            await ExpectMsgAsync(new M { Value = 42 }, cancellationToken: Token);
             bus.Unsubscribe(TestActor);
             bus.Publish(new M { Value = 43 });
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace Akka.Tests.Event
                     {
                         testKit.Sys.EventStream.Publish(msg);
                         return Task.CompletedTask;
-                    }, Token);
+                    }, cancellationToken: Token);
             }
             finally
             {
@@ -139,7 +139,7 @@ namespace Akka.Tests.Event
                     {
                         testKit.Sys.EventStream.Publish(msg);
                         return Task.CompletedTask;
-                    }, Token);
+                    }, cancellationToken: Token);
             }
             finally
             {
@@ -158,20 +158,20 @@ namespace Akka.Tests.Event
             bus.Subscribe(TestActor, typeof(B2));
             bus.Publish(c);
             bus.Publish(b2);
-            await ExpectMsgAsync(b2);
+            await ExpectMsgAsync(b2, cancellationToken: Token);
             bus.Subscribe(TestActor, typeof(A));
             bus.Publish(c);
-            await ExpectMsgAsync(c);
+            await ExpectMsgAsync(c, cancellationToken: Token);
             bus.Publish(b1);
-            await ExpectMsgAsync(b1);
+            await ExpectMsgAsync(b1, cancellationToken: Token);
 
             bus.Unsubscribe(TestActor, typeof(B1));
             bus.Publish(c); //should not publish
             bus.Publish(b2); //should publish
             bus.Publish(a); //should publish
-            await ExpectMsgAsync(b2);
-            await ExpectMsgAsync(a);
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectMsgAsync(b2, cancellationToken: Token);
+            await ExpectMsgAsync(a, cancellationToken: Token);
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
         }
 
         [Fact(DisplayName = "manage sub-channels using classes and traits (update on subscribe)")]
@@ -191,11 +191,11 @@ namespace Akka.Tests.Event
             es.Subscribe(a4.Ref, typeof(CCATBT)).ShouldBeTrue();
             es.Publish(tm1);
             es.Publish(tm2);
-            await a1.ExpectMsgAsync((object)tm2);
-            await a2.ExpectMsgAsync((object)tm2);
-            await a3.ExpectMsgAsync((object)tm1);
-            await a3.ExpectMsgAsync((object)tm2);
-            await a4.ExpectMsgAsync((object)tm2);
+            await a1.ExpectMsgAsync((object)tm2, cancellationToken: Token);
+            await a2.ExpectMsgAsync((object)tm2, cancellationToken: Token);
+            await a3.ExpectMsgAsync((object)tm1, cancellationToken: Token);
+            await a3.ExpectMsgAsync((object)tm2, cancellationToken: Token);
+            await a4.ExpectMsgAsync((object)tm2, cancellationToken: Token);
             es.Unsubscribe(a1.Ref, typeof(AT)).ShouldBeTrue();
             es.Unsubscribe(a2.Ref, typeof(BT)).ShouldBeTrue();
             es.Unsubscribe(a3.Ref, typeof(CC)).ShouldBeTrue();
@@ -221,10 +221,10 @@ namespace Akka.Tests.Event
             es.Unsubscribe(a3.Ref, typeof(CC));
             es.Publish(tm1);
             es.Publish(tm2);
-            await a1.ExpectMsgAsync((object)tm2);
-            await a2.ExpectMsgAsync((object)tm2);
-            await a3.ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
-            await a4.ExpectMsgAsync((object)tm2);
+            await a1.ExpectMsgAsync((object)tm2, cancellationToken: Token);
+            await a2.ExpectMsgAsync((object)tm2, cancellationToken: Token);
+            await a3.ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
+            await a4.ExpectMsgAsync((object)tm2, cancellationToken: Token);
             es.Unsubscribe(a1.Ref, typeof(AT)).ShouldBeTrue();
             es.Unsubscribe(a2.Ref, typeof(BT)).ShouldBeTrue();
             es.Unsubscribe(a3.Ref, typeof(CC)).ShouldBeFalse();
@@ -249,10 +249,10 @@ namespace Akka.Tests.Event
             es.Unsubscribe(a3.Ref).ShouldBeTrue();
             es.Publish(tm1);
             es.Publish(tm2);
-            await a1.ExpectMsgAsync((object)tm2);
-            await a2.ExpectMsgAsync((object)tm2);
-            await a3.ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
-            await a4.ExpectMsgAsync((object)tm2);
+            await a1.ExpectMsgAsync((object)tm2, cancellationToken: Token);
+            await a2.ExpectMsgAsync((object)tm2, cancellationToken: Token);
+            await a3.ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
+            await a4.ExpectMsgAsync((object)tm2, cancellationToken: Token);
             es.Unsubscribe(a1.Ref, typeof(AT)).ShouldBeTrue();
             es.Unsubscribe(a2.Ref, typeof(BT)).ShouldBeTrue();
             es.Unsubscribe(a3.Ref, typeof(CC)).ShouldBeFalse();
@@ -275,7 +275,7 @@ namespace Akka.Tests.Event
             var bus = new EventStream(false);
             bus.StartDefaultLoggers((ActorSystemImpl)Sys);
             bus.Publish(new SetTarget(TestActor));
-            await ExpectMsgAsync("OK", TimeSpan.FromSeconds(5));
+            await ExpectMsgAsync("OK", TimeSpan.FromSeconds(5), cancellationToken: Token);
 
             verifyLevel(bus, LogLevel.InfoLevel);
             bus.SetLogLevel(LogLevel.WarningLevel);

--- a/src/core/Akka.Tests/Event/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Event/LoggerSpec.cs
@@ -12,7 +12,6 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;
 

--- a/src/core/Akka.Tests/Event/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Event/LoggerSpec.cs
@@ -14,11 +14,14 @@ using Akka.TestKit;
 using Xunit;
 using FluentAssertions;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;
+using System.Threading;
 
 namespace Akka.Tests.Event
 {
     public class LoggerSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public static readonly Config Config = @"akka.loglevel = DEBUG";
 
         public LoggerSpec(ITestOutputHelper helper) : base(Config, helper) { }
@@ -97,10 +100,10 @@ namespace Akka.Tests.Event
                     logEvent.Cause.Should().BeNull();
             }
 
-            var log = await ExpectMsgAsync<LogEvent>();
+            var log = await ExpectMsgAsync<LogEvent>(cancellationToken: Token);
             ProcessLog(log);
 
-            var log2 = await ExpectMsgAsync<LogEvent>();
+            var log2 = await ExpectMsgAsync<LogEvent>(cancellationToken: Token);
             ProcessLog(log2);
         }
 
@@ -116,19 +119,19 @@ namespace Akka.Tests.Event
             {
                 var shutdownInitiated = await ExpectMsgAsync<Debug>(TestKitSettings.DefaultTimeout);
                 shutdownInitiated.Message.ShouldBe("System shutdown initiated");
-            });
+            }, cancellationToken: Token);
             
-            var loggerStarted = await ExpectMsgAsync<Debug>(TestKitSettings.DefaultTimeout);
+            var loggerStarted = await ExpectMsgAsync<Debug>(TestKitSettings.DefaultTimeout, cancellationToken: Token);
             loggerStarted.Message.ShouldBe("Shutting down: StandardOutLogger started");
             loggerStarted.LogClass.ShouldBe(typeof(EventStream));
             loggerStarted.LogSource.ShouldBe(typeof(EventStream).Name);
 
-            var loggerStopped = await ExpectMsgAsync<Debug>(TestKitSettings.DefaultTimeout);
+            var loggerStopped = await ExpectMsgAsync<Debug>(TestKitSettings.DefaultTimeout, cancellationToken: Token);
             loggerStopped.Message.ShouldBe("All default loggers stopped");
             loggerStopped.LogClass.ShouldBe(typeof(EventStream));
             loggerStopped.LogSource.ShouldBe(typeof(EventStream).Name);
 
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/IO/SimpleDnsCacheSpec.cs
+++ b/src/core/Akka.Tests/IO/SimpleDnsCacheSpec.cs
@@ -5,11 +5,13 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.IO;
 using Akka.TestKit;
 using Xunit;
+using Dns = Akka.IO.Dns;
 
 namespace Akka.Tests.IO
 {
@@ -31,12 +33,23 @@ namespace Akka.Tests.IO
             }
         }
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+
+        private Task<IPHostEntry> GetHostEntryAsync(string hostName)
+        {
+            #if NETFRAMEWORK
+            return System.Net.Dns.GetHostEntryAsync(hostName);
+            #else
+            return System.Net.Dns.GetHostEntryAsync(hostName, Token);
+            #endif
+        }
+        
         [Fact]
         public async Task Cache_should_not_reply_with_expired_but_not_yet_swept_out_entries()
         {
             var localClock = new AtomicReference<long>(0);
             var cache = new SimpleDnsCacheTestDouble(localClock);
-            var hostEntry = await System.Net.Dns.GetHostEntryAsync("127.0.0.1");
+            var hostEntry = await GetHostEntryAsync("127.0.0.1");
             var cacheEntry = Dns.Resolved.Create("test.local", hostEntry.AddressList);
             cache.Put(cacheEntry, 5000);
 
@@ -53,7 +66,7 @@ namespace Akka.Tests.IO
         {
             var localClock = new AtomicReference<long>(0);
             var cache = new SimpleDnsCacheTestDouble(localClock);
-            var hostEntry = await System.Net.Dns.GetHostEntryAsync("127.0.0.1");
+            var hostEntry = await GetHostEntryAsync("127.0.0.1");
             var cacheEntry = Dns.Resolved.Create("test.local", hostEntry.AddressList);
             cache.Put(cacheEntry, 5000);
 
@@ -75,7 +88,7 @@ namespace Akka.Tests.IO
         {
             var localClock = new AtomicReference<long>(0);
             var cache = new SimpleDnsCacheTestDouble(localClock);
-            var hostEntry = await System.Net.Dns.GetHostEntryAsync("127.0.0.1");
+            var hostEntry = await GetHostEntryAsync("127.0.0.1");
             var cacheEntryOne = Dns.Resolved.Create("test.local", hostEntry.AddressList);
             var cacheEntryTwo = Dns.Resolved.Create("test.local", hostEntry.AddressList);
             long ttl = 500;

--- a/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
@@ -18,9 +18,7 @@ using Akka.IO;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
-using System.Runtime.InteropServices;
 using Akka.Util;
 
 namespace Akka.Tests.IO

--- a/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="TcpIntegrationSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -20,11 +20,14 @@ using Akka.Util.Internal;
 using Xunit;
 using FluentAssertions;
 using Akka.Util;
+using System.Threading;
 
 namespace Akka.Tests.IO
 {
     public class TcpIntegrationSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public const int InternalConnectionActorMaxQueueSize = 10000;
         
         class Aye : Tcp.Event { public static readonly Aye Instance = new(); }
@@ -173,26 +176,26 @@ namespace Akka.Tests.IO
             var bindCommander = CreateTestProbe();
             bindCommander.Send(Sys.Tcp(), new Tcp.Bind(serverHandler.Ref, new IPEndPoint(family == AddressFamily.InterNetwork ? IPAddress.Loopback 
                 : IPAddress.IPv6Loopback, 0)));
-            var boundMsg = await bindCommander.ExpectMsgAsync<Tcp.Bound>();
+            var boundMsg = await bindCommander.ExpectMsgAsync<Tcp.Bound>(cancellationToken: Token);
 
             // setup client to connect 
             var targetAddress = new DnsEndPoint("localhost", boundMsg.LocalAddress.AsInstanceOf<IPEndPoint>().Port);
             var clientHandler = CreateTestProbe();
             Sys.Tcp().Tell(new Tcp.Connect(targetAddress), clientHandler);
-            await clientHandler.ExpectMsgAsync<Tcp.Connected>(TimeSpan.FromSeconds(3));
+            await clientHandler.ExpectMsgAsync<Tcp.Connected>(TimeSpan.FromSeconds(3), cancellationToken: Token);
             var clientEp = clientHandler.Sender;
             clientEp.Tell(new Tcp.Register(clientHandler));
-            await serverHandler.ExpectMsgAsync<Tcp.Connected>();
+            await serverHandler.ExpectMsgAsync<Tcp.Connected>(cancellationToken: Token);
             serverHandler.Sender.Tell(new Tcp.Register(serverHandler));
 
             var str = Enumerable.Repeat("f", 567).Join("");
             var testData = ByteString.FromString(str);
             clientEp.Tell(Tcp.Write.Create(testData, Ack.Instance), clientHandler);
-            await clientHandler.ExpectMsgAsync<Ack>();
+            await clientHandler.ExpectMsgAsync<Ack>(cancellationToken: Token);
             var received = await serverHandler
-                .ReceiveWhileAsync(o => o as Tcp.Received, 
-                    RemainingOrDefault, 
-                    TimeSpan.FromSeconds(0.5)).ToListAsync();
+                .ReceiveWhileAsync(o => o as Tcp.Received,
+                    RemainingOrDefault,
+                    TimeSpan.FromSeconds(0.5), cancellationToken: Token).ToListAsync(Token);
 
             received.Sum(s => s.Data.Count).Should().Be(testData.Count);
         }
@@ -485,7 +488,7 @@ namespace Akka.Tests.IO
             var endpoint = new IPEndPoint(IPAddress.Parse("192.0.2.1"), 23825);
             connectCommander.Send(Sys.Tcp(), new Tcp.Connect(endpoint));
             // expecting CommandFailed or no reply (within timeout)
-            var replies = await connectCommander.ReceiveWhileAsync(TimeSpan.FromSeconds(1), x => x as Tcp.Connected).ToListAsync();
+            var replies = await connectCommander.ReceiveWhileAsync(TimeSpan.FromSeconds(1), x => x as Tcp.Connected, cancellationToken: Token).ToListAsync(Token);
             replies.Count.ShouldBe(0);
         }
 
@@ -497,7 +500,7 @@ namespace Akka.Tests.IO
             Sys.Tcp().Tell(new Tcp.Connect(endpoint), probe.Ref);
             
             // expecting CommandFailed or no reply (within timeout)
-            var replies = await probe.ReceiveWhileAsync(TimeSpan.FromSeconds(5), x => x as Tcp.CommandFailed).ToListAsync();
+            var replies = await probe.ReceiveWhileAsync(TimeSpan.FromSeconds(5), x => x as Tcp.CommandFailed, cancellationToken: Token).ToListAsync(Token);
             replies.Count.ShouldBe(1);
         }
 

--- a/src/core/Akka.Tests/IO/TcpListenerSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpListenerSpec.cs
@@ -13,7 +13,6 @@ using Akka.Actor;
 using Akka.IO;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using TcpListener = Akka.IO.TcpListener;
 
 namespace Akka.Tests.IO

--- a/src/core/Akka.Tests/IO/UdpConnectedIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/UdpConnectedIntegrationSpec.cs
@@ -17,12 +17,13 @@ using Akka.TestKit;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.IO
 {
     public class UdpConnectedIntegrationSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public UdpConnectedIntegrationSpec(ITestOutputHelper output)
             : base("""
                    
@@ -199,7 +200,7 @@ namespace Akka.Tests.IO
             await clientProbe.ExpectMsgAsync<UdpConnected.Disconnected>();
             
             // wait for all SocketAsyncEventArgs to be released
-            await Task.Delay(1000);
+            await Task.Delay(1000, Token);
             
             poolInfo = udpConnection.SocketEventArgsPool.BufferPoolInfo;
             poolInfo.Type.Should().Be(typeof(DirectBufferPool));

--- a/src/core/Akka.Tests/IO/UdpConnectedIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/UdpConnectedIntegrationSpec.cs
@@ -102,11 +102,11 @@ namespace Akka.Tests.IO
                 received.Data.ShouldBe(data1);
                 received.Sender.ShouldBe(clientLocalEndpoint);
                 return received.Sender;
-            });
+            }, cancellationToken: Token);
 
             server.Tell(Udp.Send.Create(data2, clientAddress));
 
-            await ExpectMsgAsync<UdpConnected.Received>(x => x.Data.ShouldBe(data2));
+            await ExpectMsgAsync<UdpConnected.Received>(x => x.Data.ShouldBe(data2), cancellationToken: Token);
         }
 
         [Fact]
@@ -125,11 +125,11 @@ namespace Akka.Tests.IO
                 if (msg is not Udp.Received received) throw new Exception();
                 received.Data.ShouldBe(data1);
                 return received.Sender;
-            });
+            }, cancellationToken: Token);
 
             server.Tell(Udp.Send.Create(data2, clientLocalEndpoint));
 
-            await clientProbe.ExpectMsgAsync<UdpConnected.Received>(x => x.Data.ShouldBe(data2));
+            await clientProbe.ExpectMsgAsync<UdpConnected.Received>(x => x.Data.ShouldBe(data2), cancellationToken: Token);
         }
 
         [Fact]
@@ -147,17 +147,17 @@ namespace Akka.Tests.IO
             client.Tell(UdpConnected.Send.Create(data));
             client.Tell(UdpConnected.Send.Create(data));
 
-            var raw = await serverProbe.ReceiveNAsync(3, default).ToListAsync();
+            var raw = await serverProbe.ReceiveNAsync(3, RemainingOrDefault, cancellationToken: Token).ToListAsync(Token);
             var serverMsgs = raw.Cast<Udp.Received>();
             serverMsgs.Sum(x => x.Data.Count).Should().Be(data.Count * 3);
-            await serverProbe.ExpectNoMsgAsync(100.Milliseconds());
+            await serverProbe.ExpectNoMsgAsync(100.Milliseconds(), cancellationToken: Token);
 
             // repeat in the other direction
             server.Tell(Udp.Send.Create(data, clientEndPoint));
             server.Tell(Udp.Send.Create(data, clientEndPoint));
             server.Tell(Udp.Send.Create(data, clientEndPoint));
 
-            raw = await clientProbe.ReceiveNAsync(3, default).ToListAsync();
+            raw = await clientProbe.ReceiveNAsync(3, RemainingOrDefault, cancellationToken: Token).ToListAsync(Token);
             var clientMsgs = raw.Cast<UdpConnected.Received>();
             clientMsgs.Sum(x => x.Data.Count).Should().Be(data.Count * 3);
         }
@@ -188,19 +188,19 @@ namespace Akka.Tests.IO
                 for (var j = 0; j < batchSize; ++j)
                     client.Tell(UdpConnected.Send.Create(data));
 
-                var msgs = await serverProbe.ReceiveNAsync(batchSize, TimeSpan.FromSeconds(10))
-                    .Cast<Udp.Received>().ToListAsync();
+                var msgs = await serverProbe.ReceiveNAsync(batchSize, TimeSpan.FromSeconds(10), cancellationToken: Token)
+                    .Cast<Udp.Received>().ToListAsync(Token);
                 msgs.Sum(m => m.Data.Count).Should().Be(data.Count * batchSize);
             }
 
             // stop all connections so all receives are stopped and all pending SocketAsyncEventArgs are collected
             server.Tell(Udp.Unbind.Instance, serverProbe);
-            await serverProbe.ExpectMsgAsync<Udp.Unbound>();
+            await serverProbe.ExpectMsgAsync<Udp.Unbound>(cancellationToken: Token);
             client.Tell(UdpConnected.Disconnect.Instance, clientProbe);
-            await clientProbe.ExpectMsgAsync<UdpConnected.Disconnected>();
+            await clientProbe.ExpectMsgAsync<UdpConnected.Disconnected>(cancellationToken: Token);
             
             // wait for all SocketAsyncEventArgs to be released
-            await Task.Delay(1000, Token);
+            await Task.Delay(1000, cancellationToken: Token);
             
             poolInfo = udpConnection.SocketEventArgsPool.BufferPoolInfo;
             poolInfo.Type.Should().Be(typeof(DirectBufferPool));

--- a/src/core/Akka.Tests/IO/UdpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/UdpIntegrationSpec.cs
@@ -15,7 +15,6 @@ using Akka.IO;
 using Akka.IO.Buffers;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using System.Threading.Tasks;
@@ -24,6 +23,8 @@ namespace Akka.Tests.IO
 {
     public class UdpIntegrationSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public UdpIntegrationSpec(ITestOutputHelper output)
             : base(@"
                     akka.actor.serialize-creators = on
@@ -230,7 +231,7 @@ namespace Akka.Tests.IO
             await clientProbe.ExpectMsgAsync<Udp.Unbound>();
             
             // wait for all SocketAsyncEventArgs to be released
-            await Task.Delay(1000);
+            await Task.Delay(1000, Token);
             
             poolInfo = udp.SocketEventArgsPool.BufferPoolInfo;
             poolInfo.Type.Should().Be(typeof(DirectBufferPool));
@@ -272,7 +273,7 @@ namespace Akka.Tests.IO
             await serverProbe.ExpectMsgAsync<Udp.Unbound>();
             
             // wait for all SocketAsyncEventArgs to be released
-            await Task.Delay(1000);
+            await Task.Delay(1000, Token);
             
             poolInfo = udp.SocketEventArgsPool.BufferPoolInfo;
             poolInfo.Type.Should().Be(typeof(DirectBufferPool));

--- a/src/core/Akka.Tests/IO/UdpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/UdpIntegrationSpec.cs
@@ -67,7 +67,7 @@ namespace Akka.Tests.IO
             var data = ByteString.FromString("To infinity and beyond!");
             (await SimpleSender()).Tell(Udp.Send.Create(data, localEndpoint));
 
-            await ExpectMsgAsync<Udp.Received>(x => x.Data.ShouldBe(data));
+            await ExpectMsgAsync<Udp.Received>(x => x.Data.ShouldBe(data), cancellationToken: Token);
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace Akka.Tests.IO
                 + ByteString.FromString(" string!");
             (await SimpleSender()).Tell(Udp.Send.Create(data, localEndpoint));
 
-            await ExpectMsgAsync<Udp.Received>(x => x.Data.ShouldBe(data));
+            await ExpectMsgAsync<Udp.Received>(x => x.Data.ShouldBe(data), cancellationToken: Token);
         }
 
         [Fact]
@@ -95,17 +95,17 @@ namespace Akka.Tests.IO
             client.Tell(Udp.Send.Create(data, serverLocalEndpoint));
             client.Tell(Udp.Send.Create(data, serverLocalEndpoint));
 
-            var raw = await ReceiveNAsync(3, default).ToListAsync();
+            var raw = await ReceiveNAsync(3, RemainingOrDefault, cancellationToken: Token).ToListAsync(Token);
             var msgs = raw.Cast<Udp.Received>();
             msgs.Sum(x => x.Data.Count).Should().Be(data.Count*3);
-            await ExpectNoMsgAsync(100.Milliseconds()); 
+            await ExpectNoMsgAsync(100.Milliseconds(), cancellationToken: Token);
 
             // repeat in the other direction
             server.Tell(Udp.Send.Create(data, clientLocalEndpoint));
             server.Tell(Udp.Send.Create(data, clientLocalEndpoint));
             server.Tell(Udp.Send.Create(data, clientLocalEndpoint));
 
-            raw = await ReceiveNAsync(3, default).ToListAsync();
+            raw = await ReceiveNAsync(3, RemainingOrDefault, cancellationToken: Token).ToListAsync(Token);
             msgs = raw.Cast<Udp.Received>();
             msgs.Sum(x => x.Data.Count).Should().Be(data.Count * 3);
         }
@@ -219,19 +219,19 @@ namespace Akka.Tests.IO
                 for (var i = 0; i < batchSize; i++) 
                     server.Tell(Udp.Send.Create(data, clientLocalEndpoint));
 
-                var msgs = await clientProbe.ReceiveNAsync(batchSize, default).ToListAsync();
+                var msgs = await clientProbe.ReceiveNAsync(batchSize, RemainingOrDefault, cancellationToken: Token).ToListAsync(Token);
                 var receives = msgs.Cast<Udp.Received>();
                 receives.Sum(r => r.Data.Count).Should().Be(data.Count * batchSize);
             }
             
             // stop all connections so all receives are stopped and all pending SocketAsyncEventArgs are collected
             server.Tell(Udp.Unbind.Instance, serverProbe);
-            await serverProbe.ExpectMsgAsync<Udp.Unbound>();
+            await serverProbe.ExpectMsgAsync<Udp.Unbound>(cancellationToken: Token);
             client.Tell(Udp.Unbind.Instance, clientProbe);
-            await clientProbe.ExpectMsgAsync<Udp.Unbound>();
+            await clientProbe.ExpectMsgAsync<Udp.Unbound>(cancellationToken: Token);
             
             // wait for all SocketAsyncEventArgs to be released
-            await Task.Delay(1000, Token);
+            await Task.Delay(1000, cancellationToken: Token);
             
             poolInfo = udp.SocketEventArgsPool.BufferPoolInfo;
             poolInfo.Type.Should().Be(typeof(DirectBufferPool));
@@ -263,17 +263,17 @@ namespace Akka.Tests.IO
                 for (int i = 0; i < batchSize; i++) 
                     sender.Tell(Udp.Send.Create(data, serverLocalEndpoint));
 
-                var msgs = await serverProbe.ReceiveNAsync(batchSize, 10.Seconds())
-                    .Cast<Udp.Received>().ToListAsync();
+                var msgs = await serverProbe.ReceiveNAsync(batchSize, 10.Seconds(), cancellationToken: Token)
+                    .Cast<Udp.Received>().ToListAsync(Token);
                 msgs.Sum(r => r.Data.Count).Should().Be(data.Count * batchSize);
             }
             
             // stop all connections so all receives are stopped and all pending SocketAsyncEventArgs are collected
             server.Tell(Udp.Unbind.Instance, serverProbe);
-            await serverProbe.ExpectMsgAsync<Udp.Unbound>();
+            await serverProbe.ExpectMsgAsync<Udp.Unbound>(cancellationToken: Token);
             
             // wait for all SocketAsyncEventArgs to be released
-            await Task.Delay(1000, Token);
+            await Task.Delay(1000, cancellationToken: Token);
             
             poolInfo = udp.SocketEventArgsPool.BufferPoolInfo;
             poolInfo.Type.Should().Be(typeof(DirectBufferPool));
@@ -289,7 +289,7 @@ namespace Akka.Tests.IO
             commander.Send(
                 Udp.Instance.Apply(Sys).Manager, 
                 new Udp.Bind(TestActor, new IPEndPoint(IPAddress.Loopback, 0), options: new[] {assertOption}));
-            await commander.ExpectMsgAsync<Udp.Bound>();
+            await commander.ExpectMsgAsync<Udp.Bound>(cancellationToken: Token);
             Assert.Equal(1, assertOption.BeforeCalled);
         }
 
@@ -301,7 +301,7 @@ namespace Akka.Tests.IO
             commander.Send(
                 Udp.Instance.Apply(Sys).Manager,
                 new Udp.Bind(TestActor, new IPEndPoint(IPAddress.Loopback, 0), options: new[] { assertOption }));
-            await commander.ExpectMsgAsync<Udp.Bound>();
+            await commander.ExpectMsgAsync<Udp.Bound>(cancellationToken: Token);
             Assert.Equal(1, assertOption.AfterCalled);
         }
 
@@ -316,7 +316,7 @@ namespace Akka.Tests.IO
                     TestActor, 
                     new IPEndPoint(IPAddress.Loopback, 0), 
                     options: new[] { assertOption }));
-            await commander.ExpectMsgAsync<Udp.Bound>();
+            await commander.ExpectMsgAsync<Udp.Bound>(cancellationToken: Token);
             Assert.Equal(1, assertOption.OpenCalled);
         }
 

--- a/src/core/Akka.Tests/IO/UdpListenerSpec.cs
+++ b/src/core/Akka.Tests/IO/UdpListenerSpec.cs
@@ -13,7 +13,6 @@ using Akka.Actor;
 using Akka.IO;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using UdpListener = Akka.IO.UdpListener;
 using FluentAssertions;
 using System.Threading.Tasks;

--- a/src/core/Akka.Tests/IO/UdpListenerSpec.cs
+++ b/src/core/Akka.Tests/IO/UdpListenerSpec.cs
@@ -16,11 +16,14 @@ using Xunit;
 using UdpListener = Akka.IO.UdpListener;
 using FluentAssertions;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Akka.Tests.IO
 {
     public class UdpListenerSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public UdpListenerSpec(ITestOutputHelper output)
             : base(@"
                     akka.actor.serialize-creators = on
@@ -40,7 +43,7 @@ namespace Akka.Tests.IO
                 var endpoint = new IPEndPoint(IPAddress.Loopback, 12345);
                 var handler = Sys.ActorOf(Props.Create(() => new MockUdpHandler()));
                 Sys.Udp().Tell(new Udp.Bind(handler, endpoint), probe.Ref);
-                var bound = await probe.ExpectMsgAsync<Udp.Bound>();
+                var bound = await probe.ExpectMsgAsync<Udp.Bound>(cancellationToken: Token);
                 
                 bound.LocalAddress.Should().BeOfType<IPEndPoint>();
                 var boundEndpoint = (IPEndPoint)bound.LocalAddress;
@@ -64,7 +67,7 @@ namespace Akka.Tests.IO
                 var endpoint = new IPEndPoint(IPAddress.IPv6Loopback, 12345);
                 var handler = Sys.ActorOf(Props.Create(() => new MockUdpHandler()));
                 Sys.Udp().Tell(new Udp.Bind(handler, endpoint), probe.Ref);
-                var bound = await probe.ExpectMsgAsync<Udp.Bound>();
+                var bound = await probe.ExpectMsgAsync<Udp.Bound>(cancellationToken: Token);
                 
                 bound.LocalAddress.Should().BeOfType<IPEndPoint>();
                 var boundEndpoint = (IPEndPoint)bound.LocalAddress;

--- a/src/core/Akka.Tests/Loggers/CustomLogFormatterSpec.cs
+++ b/src/core/Akka.Tests/Loggers/CustomLogFormatterSpec.cs
@@ -13,7 +13,6 @@ using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Loggers
 {

--- a/src/core/Akka.Tests/Loggers/CustomLogFormatterSpec.cs
+++ b/src/core/Akka.Tests/Loggers/CustomLogFormatterSpec.cs
@@ -13,11 +13,14 @@ using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Loggers
 {
     public class CustomLogFormatterSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         // <CustomLogFormatter>
         private class CustomLogFormatter : ILogMessageFormatter
         {
@@ -52,7 +55,7 @@ namespace Akka.Tests.Loggers
             Sys.Log.Error("This is a test {0}", 1); // formatters aren't used when we're logging const strings
             
             // assert
-            var msg = await probe.ExpectMsgAsync<Error>();
+            var msg = await probe.ExpectMsgAsync<Error>(cancellationToken: Token);
             msg.Message.Should().BeAssignableTo<LogMessage>();
             msg.ToString().Should().Contain("Custom: This is a test 1");
             
@@ -60,7 +63,7 @@ namespace Akka.Tests.Loggers
             {
                 Sys.Log.Error("This is a test {0}", 1);
                 return Task.CompletedTask;
-            });
+            }, cancellationToken: Token);
         }
         
         [Fact]
@@ -71,7 +74,7 @@ namespace Akka.Tests.Loggers
             {
                 Sys.Log.Error("This is a test {0}", 1);
                 return Task.CompletedTask;
-            });
+            }, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Loggers/LogFilterEvaluatorSpecs.cs
+++ b/src/core/Akka.Tests/Loggers/LogFilterEvaluatorSpecs.cs
@@ -15,7 +15,6 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Loggers;
 

--- a/src/core/Akka.Tests/Loggers/LogFilterEvaluatorSpecs.cs
+++ b/src/core/Akka.Tests/Loggers/LogFilterEvaluatorSpecs.cs
@@ -15,6 +15,7 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Loggers;
 
@@ -24,6 +25,8 @@ namespace Akka.Tests.Loggers;
 // ReSharper disable once ClassNeverInstantiated.Global
 public class LogFilterEvaluatorSpecs
 {
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
     public class LogFilterSetupSpecs : AkkaSpec
     {
         // <CreateLoggerSetup>
@@ -93,10 +96,10 @@ public class LogFilterEvaluatorSpecs
             loggingAdapter2.Warning("baz");
             
             // expect only the last message to be received
-            ReceiveN(3);
+            ReceiveN(3, cancellationToken: Token);
             
             // check that the last message was the one that was allowed through
-            await AwaitAssertAsync(() => _logger.Events.Count.Should().Be(1));
+            await AwaitAssertAsync(() => _logger.Events.Count.Should().Be(1), cancellationToken: Token);
             var msg = _logger.Events[0];
             msg.Message.Should().Be("baz");
             msg.LogSource.Should().StartWith("Akka.Util.Test2");

--- a/src/core/Akka.Tests/Loggers/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/LoggerSpec.cs
@@ -39,12 +39,12 @@ akka.stdout-loglevel = DEBUG");
             var events = new List<LogEvent>();
 
             // Need to wait until TestOutputLogger initializes
-            await Task.Delay(500, Token);
+            await Task.Delay(500, cancellationToken: Token);
             Sys.EventStream.Subscribe(TestActor, typeof(LogEvent));
 
             Sys.Log.Error(new FakeException("BOOM"), Case.t, Case.p);
-            events.Add(await ExpectMsgAsync<Error>());
-            events.Add(await ExpectMsgAsync<Error>());
+            events.Add(await ExpectMsgAsync<Error>(cancellationToken: Token));
+            events.Add(await ExpectMsgAsync<Error>(cancellationToken: Token));
 
             events.All(e => e is Error).Should().BeTrue();
             events.Select(e => e.Cause).Any(c => c is FakeException).Should().BeTrue();
@@ -52,22 +52,22 @@ akka.stdout-loglevel = DEBUG");
 
             events.Clear();
             Sys.Log.Warning(Case.t, Case.p);
-            events.Add(await ExpectMsgAsync<LogEvent>());
-            events.Add(await ExpectMsgAsync<LogEvent>());
+            events.Add(await ExpectMsgAsync<LogEvent>(cancellationToken: Token));
+            events.Add(await ExpectMsgAsync<LogEvent>(cancellationToken: Token));
             events.Any(e => e is Warning).Should().BeTrue();
             events.First(e => e is Error).Cause.Should().BeOfType<FormatException>();
 
             events.Clear();
             Sys.Log.Info(Case.t, Case.p);
-            events.Add(await ExpectMsgAsync<LogEvent>());
-            events.Add(await ExpectMsgAsync<LogEvent>());
+            events.Add(await ExpectMsgAsync<LogEvent>(cancellationToken: Token));
+            events.Add(await ExpectMsgAsync<LogEvent>(cancellationToken: Token));
             events.Any(e => e is Info).Should().BeTrue();
             events.First(e => e is Error).Cause.Should().BeOfType<FormatException>();
 
             events.Clear();
             Sys.Log.Debug(Case.t, Case.p);
-            events.Add(await ExpectMsgAsync<LogEvent>());
-            events.Add(await ExpectMsgAsync<LogEvent>());
+            events.Add(await ExpectMsgAsync<LogEvent>(cancellationToken: Token));
+            events.Add(await ExpectMsgAsync<LogEvent>(cancellationToken: Token));
             events.Any(e => e is Debug).Should().BeTrue();
             events.First(e => e is Error).Cause.Should().BeOfType<FormatException>();
         }
@@ -82,16 +82,16 @@ akka.stdout-loglevel = DEBUG");
             sys2.EventStream.Subscribe(probe, typeof(LogEvent));
 
             sys2.Log.Error(new FakeException("BOOM"), Case.t, Case.p);
-            (await probe.ExpectMsgAsync<Error>()).Cause.Should().BeOfType<FakeException>();
+            (await probe.ExpectMsgAsync<Error>(cancellationToken: Token)).Cause.Should().BeOfType<FakeException>();
 
             sys2.Log.Warning(Case.t, Case.p);
-            await probe.ExpectMsgAsync<Warning>();
+            await probe.ExpectMsgAsync<Warning>(cancellationToken: Token);
 
             sys2.Log.Info(Case.t, Case.p);
-            await probe.ExpectMsgAsync<Info>();
+            await probe.ExpectMsgAsync<Info>(cancellationToken: Token);
 
             sys2.Log.Debug(Case.t, Case.p);
-            await probe.ExpectMsgAsync<Debug>();
+            await probe.ExpectMsgAsync<Debug>(cancellationToken: Token);
 
             await sys2.Terminate();
         }
@@ -106,16 +106,16 @@ akka.stdout-loglevel = DEBUG");
             sys2.EventStream.Subscribe(probe, typeof(LogEvent));
 
             sys2.Log.Error(new FakeException("BOOM"), Case.t, Case.p);
-            (await probe.ExpectMsgAsync<Error>()).Cause.Should().BeOfType<FakeException>();
+            (await probe.ExpectMsgAsync<Error>(cancellationToken: Token)).Cause.Should().BeOfType<FakeException>();
 
             sys2.Log.Warning(Case.t, Case.p);
-            await probe.ExpectMsgAsync<Warning>();
+            await probe.ExpectMsgAsync<Warning>(cancellationToken: Token);
 
             sys2.Log.Info(Case.t, Case.p);
-            await probe.ExpectMsgAsync<Info>();
+            await probe.ExpectMsgAsync<Info>(cancellationToken: Token);
 
             sys2.Log.Debug(Case.t, Case.p);
-            await probe.ExpectMsgAsync<Debug>();
+            await probe.ExpectMsgAsync<Debug>(cancellationToken: Token);
 
             await sys2.Terminate();
         }

--- a/src/core/Akka.Tests/Loggers/LoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/LoggerSpec.cs
@@ -11,14 +11,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Actor.Internal;
-using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit;
-using Akka.Tests.Shared.Internals;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Tests.Loggers
@@ -32,6 +28,8 @@ akka.stdout-loglevel = DEBUG");
         public static readonly (string t, string[] p) Case =  
             ("This is {0} a {1} janky formatting. {4}", new []{"also", "very", "not cool"});
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public LoggerSpec(ITestOutputHelper output) : base(Config, output)
         { }
 
@@ -41,7 +39,7 @@ akka.stdout-loglevel = DEBUG");
             var events = new List<LogEvent>();
 
             // Need to wait until TestOutputLogger initializes
-            await Task.Delay(500);
+            await Task.Delay(500, Token);
             Sys.EventStream.Subscribe(TestActor, typeof(LogEvent));
 
             Sys.Log.Error(new FakeException("BOOM"), Case.t, Case.p);

--- a/src/core/Akka.Tests/Loggers/LoggerStartupSpec.cs
+++ b/src/core/Akka.Tests/Loggers/LoggerStartupSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -14,14 +15,15 @@ using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Loggers
 {
-    public class LoggerStartupSpec : TestKit.Xunit2.TestKit
+    public class LoggerStartupSpec : TestKit.Xunit.TestKit
     {
         private const int LoggerResponseDelayMs = 1_000;
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public LoggerStartupSpec(ITestOutputHelper helper) : base(nameof(LoggerStartupSpec), helper)
         {
             XUnitOutLogger.Helper = helper;
@@ -59,14 +61,14 @@ akka.logger-startup-timeout = 100ms").WithFallback(DefaultConfig);
                 {
                     var dbg = logProbe.ExpectMsg<Debug>();
                     dbg.Message.ToString().Should().Contain(nameof(SlowLoggerActor)).And.Contain("started");
-                });
+                }, cancellationToken: Token);
                 
                 var logger = Logging.GetLogger(sys, this);
                 logger.Error("TEST");
                 await AwaitAssertAsync(() =>
                 {
                     probe.ExpectMsg<string>().Should().Be("TEST");
-                });
+                }, cancellationToken: Token);
             }
             finally
             {

--- a/src/core/Akka.Tests/Loggers/LoggingContextSpecs.cs
+++ b/src/core/Akka.Tests/Loggers/LoggingContextSpecs.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Loggers
 {

--- a/src/core/Akka.Tests/Loggers/LoggingContextSpecs.cs
+++ b/src/core/Akka.Tests/Loggers/LoggingContextSpecs.cs
@@ -1,4 +1,4 @@
-// <copyright file="LoggingContextSpecs.cs" company="Akka.NET Project">
+﻿// <copyright file="LoggingContextSpecs.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2025 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
@@ -11,11 +11,14 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Loggers
 {
     public class LoggingContextSpecs : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         private static readonly Config SpecConfig = ConfigurationFactory.ParseString(@"
             akka.loglevel = INFO
             akka.stdout-loglevel = OFF
@@ -55,7 +58,7 @@ namespace Akka.Tests.Loggers
 
             contextLog.Info("Processing {RequestId}", 123);
 
-            var logEvent = ExpectMsg<Info>(e => e.Message.ToString().Contains("Processing"));
+            var logEvent = ExpectMsg<Info>(e => e.Message.ToString().Contains("Processing"), cancellationToken: Token);
 
             logEvent.LogSource.Should().StartWith("context-spec");
             logEvent.TryGetProperties(out var properties).Should().BeTrue();
@@ -78,13 +81,13 @@ namespace Akka.Tests.Loggers
             using (var scope = log.BeginScope("Tenant", "foo"))
             {
                 scope.Log.Info("Scoped {Id}", 1);
-                var scopedEvent = ExpectMsg<Info>(e => e.Message.ToString().Contains("Scoped"));
+                var scopedEvent = ExpectMsg<Info>(e => e.Message.ToString().Contains("Scoped"), cancellationToken: Token);
                 scopedEvent.TryGetProperties(out var scopedProperties).Should().BeTrue();
                 scopedProperties.Should().ContainEquivalentOf(new KeyValuePair<string, object>("Tenant", "foo"));
             }
 
             log.Info("Outside {Id}", 2);
-            var outsideEvent = ExpectMsg<Info>(e => e.Message.ToString().Contains("Outside"));
+            var outsideEvent = ExpectMsg<Info>(e => e.Message.ToString().Contains("Outside"), cancellationToken: Token);
             outsideEvent.TryGetProperties(out var outsideProperties).Should().BeTrue();
             outsideProperties.Any(p => p.Key == "Tenant").Should().BeFalse();
         }

--- a/src/core/Akka.Tests/Loggers/SemanticLoggingSpecs.cs
+++ b/src/core/Akka.Tests/Loggers/SemanticLoggingSpecs.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="SemanticLoggingSpecs.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2025 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -13,11 +13,14 @@ using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Loggers
 {
     public class SemanticLoggingSpecs : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public SemanticLoggingSpecs() : base(ConfigurationFactory.ParseString(@"
             akka {
                 loglevel = INFO
@@ -350,7 +353,7 @@ namespace Akka.Tests.Loggers
             EventFilter.Info("OnCreateBet BetId:{BetId} created").ExpectOne(() =>
             {
                 Log.Info("OnCreateBet BetId:{BetId} created", 12345);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact(DisplayName = "EventFilter should match semantic logging templates with contains")]
@@ -359,7 +362,7 @@ namespace Akka.Tests.Loggers
             EventFilter.Info(contains: "BetId:{BetId}").ExpectOne(() =>
             {
                 Log.Info("OnCreateBet BetId:{BetId} created", 12345);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact(DisplayName = "EventFilter should match semantic logging templates with partial pattern")]
@@ -368,7 +371,7 @@ namespace Akka.Tests.Loggers
             EventFilter.Info(start: "User {UserId}").ExpectOne(() =>
             {
                 Log.Info("User {UserId} logged in from {IpAddress}", 123, "192.168.1.1");
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact(DisplayName = "EventFilter should still match formatted output when template doesn't match")]
@@ -378,7 +381,7 @@ namespace Akka.Tests.Loggers
             EventFilter.Info(contains: "12345").ExpectOne(() =>
             {
                 Log.Info("OnCreateBet BetId:{BetId} created", 12345);
-            });
+            }, cancellationToken: Token);
         }
 
         // BUG: Placeholder followed by }} fails

--- a/src/core/Akka.Tests/Loggers/ShutdownLoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/ShutdownLoggerSpec.cs
@@ -40,11 +40,11 @@ akka.stdout-logger-class = ""Akka.Tests.Loggers.ThrowingLogger, Akka.Tests""");
             
             var probeRef = Sys.ActorOf(Props.Create(() => new LogProbe()));
             probeRef.Tell(new InitializeLogger(Sys.EventStream));
-            var probe = await probeRef.Ask<LogProbe>("hey", Token);
+            var probe = await probeRef.Ask<LogProbe>("hey", cancellationToken: Token);
             
             await Sys.Terminate();
 
-            await Task.Delay(RemainingOrDefault);
+            await Task.Delay(RemainingOrDefault, cancellationToken: Token);
             if (probe.Events.Any(o => o is Error err && err.Cause is ShutdownLogException))
                 throw new Exception("Test failed, log should not be called after shutdown.");
         }

--- a/src/core/Akka.Tests/Loggers/ShutdownLoggerSpec.cs
+++ b/src/core/Akka.Tests/Loggers/ShutdownLoggerSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -16,7 +17,6 @@ using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Loggers
 {
@@ -27,6 +27,8 @@ akka.loglevel = OFF
 akka.stdout-loglevel = OFF
 akka.stdout-logger-class = ""Akka.Tests.Loggers.ThrowingLogger, Akka.Tests""");
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public ShutdownLoggerSpec(ITestOutputHelper output) : base(Config, output)
         {
         }
@@ -38,7 +40,7 @@ akka.stdout-logger-class = ""Akka.Tests.Loggers.ThrowingLogger, Akka.Tests""");
             
             var probeRef = Sys.ActorOf(Props.Create(() => new LogProbe()));
             probeRef.Tell(new InitializeLogger(Sys.EventStream));
-            var probe = await probeRef.Ask<LogProbe>("hey");
+            var probe = await probeRef.Ask<LogProbe>("hey", Token);
             
             await Sys.Terminate();
 

--- a/src/core/Akka.Tests/Loggers/StandardOutWriterSpec.cs
+++ b/src/core/Akka.Tests/Loggers/StandardOutWriterSpec.cs
@@ -7,11 +7,11 @@
 
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.TestKit;
 using Akka.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Loggers
 {
@@ -21,6 +21,8 @@ namespace Akka.Tests.Loggers
     /// </summary>
     public class StandardOutWriterSpec : AkkaSpec
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public StandardOutWriterSpec(ITestOutputHelper output) : base(output)
         {
         }
@@ -45,7 +47,7 @@ namespace Akka.Tests.Loggers
                         StandardOutWriter.WriteLine($"Task {taskId} - Line {j}");
                         StandardOutWriter.Write($"Task {taskId} - Write {j} ");
                     }
-                });
+                }, Token);
             }
 
             // Should complete without throwing IndexOutOfRangeException

--- a/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
@@ -153,11 +153,11 @@ namespace Akka.Tests.Pattern
         {
             var probe = CreateTestProbe();
             var supervisor = Sys.ActorOf(SupervisorProps(probe.Ref));
-            await probe.ExpectMsgAsync("STARTED");
+            await probe.ExpectMsgAsync("STARTED", cancellationToken: Token);
 
             probe.Watch(supervisor);
             supervisor.Tell("DIE");
-            await probe.ExpectTerminatedAsync(supervisor);
+            await probe.ExpectTerminatedAsync(supervisor, cancellationToken: Token);
         }
 
         [Fact(Skip = "This test is very over-fitted for time and will never run reliably on busy CI/CD")]
@@ -165,7 +165,7 @@ namespace Akka.Tests.Pattern
         {
             var probe = CreateTestProbe();
             var supervisor = Sys.ActorOf(SupervisorProps(probe.Ref));
-            await probe.ExpectMsgAsync("STARTED");
+            await probe.ExpectMsgAsync("STARTED", cancellationToken: Token);
 
             await EventFilter.Exception<TestException>().ExpectAsync(3, () =>
             {
@@ -184,15 +184,15 @@ namespace Akka.Tests.Pattern
                     // numRestart = 2 ~ 800 millis
                     await probe.ExpectMsgAsync<string>(900.Milliseconds(), "STARTED");
                 });
-            });
+            }, cancellationToken: Token);
 
             // Verify that we only have one child at this point by selecting all the children
             // under the supervisor and broadcasting to them.
             // If there exists more than one child, we will get more than one reply.
             var supervisionChildSelection = Sys.ActorSelection(supervisor.Path / "*");
             supervisionChildSelection.Tell("testmsg", probe.Ref);
-            await probe.ExpectMsgAsync("testmsg");
-            await probe.ExpectNoMsgAsync();
+            await probe.ExpectMsgAsync("testmsg", cancellationToken: Token);
+            await probe.ExpectNoMsgAsync(cancellationToken: Token);
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace Akka.Tests.Pattern
         {
             var probe = CreateTestProbe();
             var supervisor = Sys.ActorOf(SupervisorProps(probe.Ref));
-            await probe.ExpectMsgAsync("STARTED");
+            await probe.ExpectMsgAsync("STARTED", cancellationToken: Token);
 
             await EventFilter.Exception<TestException>().ExpectAsync(1, async() =>
             {
@@ -209,7 +209,7 @@ namespace Akka.Tests.Pattern
                 // subsequently stop itself.
                 supervisor.Tell("THROW_STOPPING_EXCEPTION");
                 await probe.ExpectTerminatedAsync(supervisor);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -217,11 +217,11 @@ namespace Akka.Tests.Pattern
         {
             var probe = CreateTestProbe();
             var parent = Sys.ActorOf(TestParentActor.Props(probe.Ref, SupervisorProps(probe.Ref)));
-            await probe.ExpectMsgAsync("STARTED");
+            await probe.ExpectMsgAsync("STARTED", cancellationToken: Token);
             var child = probe.LastSender;
 
             child.Tell(("TO_PARENT", "TEST_MESSAGE"));
-            await probe.ExpectMsgAsync("TEST_MESSAGE");
+            await probe.ExpectMsgAsync("TEST_MESSAGE", cancellationToken: Token);
         }
 
         [Fact]
@@ -236,22 +236,22 @@ namespace Akka.Tests.Pattern
 
             supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
             // new instance
-            var child = (await ExpectMsgAsync<BackoffSupervisor.CurrentChild>()).Ref;
+            var child = (await ExpectMsgAsync<BackoffSupervisor.CurrentChild>(cancellationToken: Token)).Ref;
 
             child.Tell("PING");
-            await ExpectMsgAsync("PONG");
+            await ExpectMsgAsync("PONG", cancellationToken: Token);
 
             supervisor.Tell("THROW");
-            await ExpectMsgAsync("THROWN");
+            await ExpectMsgAsync("THROWN", cancellationToken: Token);
 
             child.Tell("PING");
-            await ExpectNoMsgAsync(100.Milliseconds()); // Child is in limbo due to latch in postStop. There is no Terminated message yet
+            await ExpectNoMsgAsync(100.Milliseconds(), cancellationToken: Token); // Child is in limbo due to latch in postStop. There is no Terminated message yet
 
             supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
-            (await ExpectMsgAsync<BackoffSupervisor.CurrentChild>()).Ref.Should().BeSameAs(child);
+            (await ExpectMsgAsync<BackoffSupervisor.CurrentChild>(cancellationToken: Token)).Ref.Should().BeSameAs(child);
 
             supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
-            (await ExpectMsgAsync<BackoffSupervisor.RestartCount>()).Count.Should().Be(0);
+            (await ExpectMsgAsync<BackoffSupervisor.RestartCount>(cancellationToken: Token)).Count.Should().Be(0);
 
             postStopLatch.CountDown();
 
@@ -261,7 +261,7 @@ namespace Akka.Tests.Pattern
                 supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
                 // new instance
                 (await ExpectMsgAsync<BackoffSupervisor.CurrentChild>()).Ref.Should().NotBeSameAs(child);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -269,7 +269,7 @@ namespace Akka.Tests.Pattern
         {
             var probe = CreateTestProbe();
             var supervisor = Sys.ActorOf(SupervisorProps(probe.Ref));
-            await probe.ExpectMsgAsync("STARTED");
+            await probe.ExpectMsgAsync("STARTED", cancellationToken: Token);
 
             await EventFilter.Exception<TestException>().ExpectAsync(5, async() =>
             {
@@ -286,7 +286,7 @@ namespace Akka.Tests.Pattern
                 }
 
                 await probe.ExpectTerminatedAsync(supervisor);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -303,25 +303,25 @@ namespace Akka.Tests.Pattern
             var supervisor = Sys.ActorOf(BackoffSupervisor.Props(options));
 
             supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
-            await probe.ExpectMsgAsync("STARTED");
+            await probe.ExpectMsgAsync("STARTED", cancellationToken: Token);
 
             probe.Watch(supervisor);
             // Throw three times rapidly
             for (var i = 1; i <= 3; i++)
             {
                 supervisor.Tell("THROW");
-                await probe.ExpectMsgAsync("STARTED");
+                await probe.ExpectMsgAsync("STARTED", cancellationToken: Token);
             }
 
             // Now wait the length of our window, and throw again. We should still restart.
-            await Task.Delay(2100, Token);
+            await Task.Delay(2100, cancellationToken: Token);
 
             var stopwatch = Stopwatch.StartNew();
             // Throw three times rapidly
             for (var i = 1; i <= 3; i++)
             {
                 supervisor.Tell("THROW");
-                await probe.ExpectMsgAsync("STARTED");
+                await probe.ExpectMsgAsync("STARTED", cancellationToken: Token);
             }
             stopwatch.Stop();
             if(stopwatch.ElapsedMilliseconds > 1500)
@@ -329,7 +329,7 @@ namespace Akka.Tests.Pattern
             
             // Now we'll issue another request and should be terminated.
             supervisor.Tell("THROW");
-            await probe.ExpectTerminatedAsync(supervisor);
+            await probe.ExpectTerminatedAsync(supervisor, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
@@ -7,12 +7,12 @@
 
 using System;
 using System.Diagnostics;
+using System.Threading;
 using Akka.Actor;
 using Akka.Pattern;
 using Akka.TestKit;
 using Xunit;
 using FluentAssertions;
-using System.Threading;
 using FluentAssertions.Extensions;
 using System.Threading.Tasks;
 
@@ -146,6 +146,8 @@ namespace Akka.Tests.Pattern
         }
         #endregion
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [Fact]
         public async Task BackoffOnRestartSupervisor_must_terminate_when_child_terminates()
         {

--- a/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffOnRestartSupervisorSpec.cs
@@ -289,7 +289,7 @@ namespace Akka.Tests.Pattern
             });
         }
 
-        [SkippableFact]
+        [Fact]
         public async Task BackoffOnRestartSupervisor_must_respect_withinTimeRange_property_of_OneForOneStrategy()
         {
             var probe = CreateTestProbe();
@@ -314,7 +314,7 @@ namespace Akka.Tests.Pattern
             }
 
             // Now wait the length of our window, and throw again. We should still restart.
-            await Task.Delay(2100);
+            await Task.Delay(2100, Token);
 
             var stopwatch = Stopwatch.StartNew();
             // Throw three times rapidly
@@ -324,7 +324,8 @@ namespace Akka.Tests.Pattern
                 await probe.ExpectMsgAsync("STARTED");
             }
             stopwatch.Stop();
-            Skip.If(stopwatch.ElapsedMilliseconds > 1500, "Could not satisfy test condition. Execution time exceeds the prescribed 2 seconds limit.");
+            if(stopwatch.ElapsedMilliseconds > 1500)
+                Assert.Fail("Could not satisfy test condition. Execution time exceeds the prescribed 2 seconds limit.");
             
             // Now we'll issue another request and should be terminated.
             supervisor.Tell("THROW");

--- a/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
@@ -13,8 +13,8 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Pattern;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit;
+using Akka.TestKit.Xunit.Attributes;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
@@ -92,6 +92,8 @@ namespace Akka.Tests.Pattern
         private IActorRef Create(BackoffOptions options) => Sys.ActorOf(BackoffSupervisor.Props(options));
         #endregion
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [LocalFact(SkipLocal = "Racy on Azure DevOps")]
         public async Task BackoffSupervisor_must_start_child_again_when_it_stops_when_using_Backoff_OnStop()
         {
@@ -515,7 +517,7 @@ namespace Akka.Tests.Pattern
             });
 
             // Supervisor should still be alive (no final stop message received yet)
-            await supervisorWatcher.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100));
+            await supervisorWatcher.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), Token);
 
             // Now send the final stop message and kill the new child
             // The supervisor should terminate because it received the final stop message
@@ -524,7 +526,7 @@ namespace Akka.Tests.Pattern
             await ExpectMsgAsync(stopMessage); // Child echoes the message
             c2.Tell(PoisonPill.Instance);
             await ExpectTerminatedAsync(c2);
-            await supervisorWatcher.ExpectTerminatedAsync(supervisor);
+            await supervisorWatcher.ExpectTerminatedAsync(supervisor, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
+++ b/src/core/Akka.Tests/Pattern/BackoffSupervisorSpec.cs
@@ -152,7 +152,7 @@ namespace Akka.Tests.Pattern
 
                 await AssertCustomStrategy(Create(OnStopOptions().WithSupervisorStrategy(stoppingStrategy)));
                 await AssertCustomStrategy(Create(OnFailureOptions().WithSupervisorStrategy(restartingStrategy)));
-            });
+            }, cancellationToken: Token);
             return;
 
             async Task AssertCustomStrategy(IActorRef supervisor)
@@ -194,7 +194,7 @@ namespace Akka.Tests.Pattern
                 });
                 supervisor.Tell(BackoffSupervisor.GetRestartCount.Instance);
                 (await ExpectMsgAsync<BackoffSupervisor.RestartCount>()).Count.Should().Be(1);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -269,7 +269,7 @@ namespace Akka.Tests.Pattern
                     Create(OnFailureOptions(ManualChild.Props(TestActor))
                         .WithManualReset()
                         .WithSupervisorStrategy(restartingStrategy)));
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -297,7 +297,7 @@ namespace Akka.Tests.Pattern
 
                 supervisor.Tell("boom");
                 await ExpectMsgAsync("child was stopped");
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -324,7 +324,7 @@ namespace Akka.Tests.Pattern
 
                 supervisor.Tell("boom"); //this will be sent to deadLetters
                await ExpectNoMsgAsync(500);
-            });
+            }, cancellationToken: Token);
         }
 
         [Theory, ClassData(typeof(DelayTable))]
@@ -478,16 +478,16 @@ namespace Akka.Tests.Pattern
             const string stopMessage = "stop";
             var supervisor = Create(OnStopOptions(maxNrOfRetries: 100).WithFinalStopMessage(message => ReferenceEquals(message, stopMessage)));
             supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
-            var c1 = (await  ExpectMsgAsync<BackoffSupervisor.CurrentChild>()).Ref;
+            var c1 = (await  ExpectMsgAsync<BackoffSupervisor.CurrentChild>(cancellationToken: Token)).Ref;
             var parentSupervisor = CreateTestProbe();
             await WatchAsync(c1);
             await parentSupervisor.WatchAsync(supervisor);
 
             supervisor.Tell(stopMessage);
-            await ExpectMsgAsync("stop");
+            await ExpectMsgAsync("stop", cancellationToken: Token);
             c1.Tell(PoisonPill.Instance);
-            await ExpectTerminatedAsync(c1);
-            await parentSupervisor.ExpectTerminatedAsync(supervisor);
+            await ExpectTerminatedAsync(c1, cancellationToken: Token);
+            await parentSupervisor.ExpectTerminatedAsync(supervisor, cancellationToken: Token);
         }
 
         [Fact]
@@ -497,13 +497,13 @@ namespace Akka.Tests.Pattern
             var supervisorWatcher = new TestProbe(Sys, new XunitAssertions());
             var supervisor = Create(OnStopOptions(maxNrOfRetries: 100).WithFinalStopMessage(message => ReferenceEquals(message, stopMessage)));
             supervisor.Tell(BackoffSupervisor.GetCurrentChild.Instance);
-            var c1 = (await ExpectMsgAsync<BackoffSupervisor.CurrentChild>()).Ref;
+            var c1 = (await ExpectMsgAsync<BackoffSupervisor.CurrentChild>(cancellationToken: Token)).Ref;
             await WatchAsync(c1);
             await supervisorWatcher.WatchAsync(supervisor);
 
             // Kill child without sending final stop message first
             c1.Tell(PoisonPill.Instance);
-            await ExpectTerminatedAsync(c1);
+            await ExpectTerminatedAsync(c1, cancellationToken: Token);
 
             // Wait for the supervisor to restart the child (backoff delay is 100ms minimum)
             // This verifies that supervisor didn't stop - it restarted the child instead
@@ -514,18 +514,18 @@ namespace Akka.Tests.Pattern
                 c2 = (await ExpectMsgAsync<BackoffSupervisor.CurrentChild>()).Ref;
                 c2.Should().NotBeSameAs(c1);
                 c2.IsNobody().Should().BeFalse();
-            });
+            }, cancellationToken: Token);
 
             // Supervisor should still be alive (no final stop message received yet)
-            await supervisorWatcher.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), Token);
+            await supervisorWatcher.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(100), cancellationToken: Token);
 
             // Now send the final stop message and kill the new child
             // The supervisor should terminate because it received the final stop message
             await WatchAsync(c2);
             supervisor.Tell(stopMessage);
-            await ExpectMsgAsync(stopMessage); // Child echoes the message
+            await ExpectMsgAsync(stopMessage, cancellationToken: Token); // Child echoes the message
             c2.Tell(PoisonPill.Instance);
-            await ExpectTerminatedAsync(c2);
+            await ExpectTerminatedAsync(c2, cancellationToken: Token);
             await supervisorWatcher.ExpectTerminatedAsync(supervisor, cancellationToken: Token);
         }
     }

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
@@ -23,6 +23,8 @@ namespace Akka.Tests.Pattern
 {
     public class ASynchronousCircuitBreakerThatIsClosed : CircuitBreakerSpecBase
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact(DisplayName = "A synchronous circuit breaker that is closed must allow calls through")]
         public void Must_allow_calls_through()
         {
@@ -86,11 +88,11 @@ namespace Akka.Tests.Pattern
             var breaker = ShortCallTimeoutCb();
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             // meant to run as detached task
-            var t = Task.Run(() => breaker.Instance.WithSyncCircuitBreaker(() => Thread.Sleep(Dilated(TimeSpan.FromSeconds(1)))));
-            await AwaitConditionAsync(() => t.Status >= TaskStatus.Running); // need to kick off the task before we can check the latch
+            var t = Task.Run(() => breaker.Instance.WithSyncCircuitBreaker(() => Thread.Sleep(Dilated(TimeSpan.FromSeconds(1)))), cancellationToken: Token);
+            await AwaitConditionAsync(() => t.Status >= TaskStatus.Running, cancellationToken: Token); // need to kick off the task before we can check the latch
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
             var epsilon = TimeSpan.FromMilliseconds(500); // need to pad timeouts due to non-determinism of OS scheduler
-            await AwaitConditionAsync(() => breaker.Instance.CurrentFailureCount == 1, TimeSpan.FromMilliseconds(900) + epsilon, TimeSpan.FromMilliseconds(100));
+            await AwaitConditionAsync(() => breaker.Instance.CurrentFailureCount == 1, TimeSpan.FromMilliseconds(900) + epsilon, TimeSpan.FromMilliseconds(100), cancellationToken: Token);
         }
     }
 
@@ -196,11 +198,13 @@ namespace Akka.Tests.Pattern
 
     public class AnAsynchronousCircuitBreakerThatIsClosed : CircuitBreakerSpecBase
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+
         [Fact(DisplayName = "An asynchronous circuit breaker that is closed must allow calls through")]
         public async Task Must_allow_calls_through()
         {
             var breaker = LongCallTimeoutCb();
-            var result = await breaker.Instance.WithCircuitBreaker(ct => Task.Run(SayHi, ct)).WaitAsync(AwaitTimeout);
+            var result = await breaker.Instance.WithCircuitBreaker(ct => Task.Run(SayHi, ct)).WaitAsync(AwaitTimeout, Token);
             Assert.Equal("hi", result);
         }
 
@@ -229,9 +233,9 @@ namespace Akka.Tests.Pattern
             var breaker = MultiFailureCb();
             await WaitForTaskToBeScheduled(breaker.Instance.WithCircuitBreaker(ct => Task.Run(SayHi, ct)));
             await WaitForTaskToBeScheduled(Enumerable.Range(1, 4).Select(_ => breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct))).ToList());
-            await AwaitAssertAsync(() => breaker.Instance.CurrentFailureCount.ShouldBe(4), AwaitTimeout);
+            await AwaitAssertAsync(() => breaker.Instance.CurrentFailureCount.ShouldBe(4), AwaitTimeout, cancellationToken: Token);
             await WaitForTaskToBeScheduled(breaker.Instance.WithCircuitBreaker(ct => Task.Run(SayHi, ct)));
-            await AwaitAssertAsync(() => breaker.Instance.CurrentFailureCount.ShouldBe(0), AwaitTimeout);
+            await AwaitAssertAsync(() => breaker.Instance.CurrentFailureCount.ShouldBe(0), AwaitTimeout, cancellationToken: Token);
         }
 
         [Fact(DisplayName = "An asynchronous circuit breaker that is closed must increment failure count on callTimeout")]
@@ -264,13 +268,15 @@ namespace Akka.Tests.Pattern
 
     public class AnAsynchronousCircuitBreakerThatIsHalfOpen : CircuitBreakerSpecBase
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+
         [Fact(DisplayName = "An asynchronous circuit breaker that is half open must pass through next call and close on success")]
         public async Task Must_pass_through_next_call_and_close_on_success()
         {
             var breaker = ShortResetTimeoutCb();
             _ = breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct));
             Assert.True(CheckLatch(breaker.HalfOpenLatch));
-            var result = await breaker.Instance.WithCircuitBreaker(ct => Task.Run(SayHi, ct)).WaitAsync(AwaitTimeout);
+            var result = await breaker.Instance.WithCircuitBreaker(ct => Task.Run(SayHi, ct)).WaitAsync(AwaitTimeout, Token);
             Assert.Equal("hi", result);
             Assert.True(CheckLatch(breaker.ClosedLatch));
         }
@@ -302,6 +308,8 @@ namespace Akka.Tests.Pattern
 
     public class AnAsynchronousCircuitBreakerThatIsOpen : CircuitBreakerSpecBase
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+
         [Fact(DisplayName = "An asynchronous circuit breaker that is open must throw exceptions when called before reset timeout")]
         public async Task Must_throw_exceptions_when_called_before_reset_timeout()
         {
@@ -333,7 +341,7 @@ namespace Akka.Tests.Pattern
                 () => breaker.Instance.WithCircuitBreaker(ct => Task.Run(ThrowException, ct)));
             var shortRemainingDuration = e1.RemainingDuration;
 
-            await Task.Delay(Dilated(TimeSpan.FromMilliseconds(1000)));
+            await Task.Delay(Dilated(TimeSpan.FromMilliseconds(1000)), cancellationToken: Token);
             Assert.True(CheckLatch(breaker.HalfOpenLatch));
 
             // transit to open again

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
@@ -120,12 +120,12 @@ namespace Akka.Tests.Pattern
                 }
 
             // let them work for a while
-            await Task.Delay(3000, Token);
+            await Task.Delay(3000, cancellationToken: Token);
 
             foreach (var stressActor in stressActors)
             {
                 stressActor.Tell(GetResult.Instance);
-                var result = ExpectMsg<Result>();
+                var result = ExpectMsg<Result>(cancellationToken: Token);
                 Output.WriteLine("FailCount:{0}, DoneCount:{1}, CircCount:{2}, TimeoutCount:{3}", 
                     result.FailCount, result.DoneCount, result.CircCount, result.TimeoutCount);
                 

--- a/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerStressSpec.cs
@@ -14,7 +14,6 @@ using Akka.Pattern;
 using Akka.TestKit;
 using Akka.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Pattern
 {
@@ -102,6 +101,8 @@ namespace Akka.Tests.Pattern
             }
         }
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public CircuitBreakerStressSpec(ITestOutputHelper output) 
             : base(output)
         { }
@@ -119,7 +120,7 @@ namespace Akka.Tests.Pattern
                 }
 
             // let them work for a while
-            await Task.Delay(3000);
+            await Task.Delay(3000, Token);
 
             foreach (var stressActor in stressActors)
             {

--- a/src/core/Akka.Tests/Pattern/RetrySpec.cs
+++ b/src/core/Akka.Tests/Pattern/RetrySpec.cs
@@ -10,11 +10,14 @@ using System.Threading.Tasks;
 using Akka.TestKit;
 using Xunit;
 using static Akka.Pattern.RetrySupport;
+using System.Threading;
 
 namespace Akka.Tests.Pattern
 {
     public class RetrySpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         [Fact]
         public async Task Pattern_Retry_must_run_a_successful_task_immediately()
         {
@@ -22,7 +25,7 @@ namespace Akka.Tests.Pattern
             {
                 var remaining = await Retry(() => Task.FromResult(5), 5, TimeSpan.FromSeconds(1), Sys.Scheduler);
                 Assert.Equal(5, remaining);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -37,7 +40,7 @@ namespace Akka.Tests.Pattern
                     return Task.FromResult(counter);
                 }, 5, TimeSpan.FromSeconds(1), Sys.Scheduler);
                 Assert.Equal(1, remaining);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -49,7 +52,7 @@ namespace Akka.Tests.Pattern
                     await Retry(() => Task.FromException<int>(new InvalidOperationException("Mexico")), 
                         5, TimeSpan.FromMilliseconds(100), Sys.Scheduler));
                 Assert.Equal("Mexico", exception.Message);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -74,7 +77,7 @@ namespace Akka.Tests.Pattern
             {
                 var remaining = await Retry(Attempt, 10, TimeSpan.FromMilliseconds(100), Sys.Scheduler);
                 Assert.Equal(5, remaining);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -100,7 +103,7 @@ namespace Akka.Tests.Pattern
                 var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => 
                     await Retry(Attempt, 5, TimeSpan.FromMilliseconds(100), Sys.Scheduler));
                 Assert.Equal("6", exception.Message);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -132,7 +135,7 @@ namespace Akka.Tests.Pattern
                     }, Sys.Scheduler));
                 Assert.Equal("6", exception.Message);
                 Assert.Equal(5, attemptedCount);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -161,7 +164,7 @@ namespace Akka.Tests.Pattern
 
                 var elapse = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - start;
                 Assert.True(elapse <= 100);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -186,7 +189,7 @@ namespace Akka.Tests.Pattern
             {
                 var remaining = await Retry(Attempt, 10, TimeSpan.FromMilliseconds(100), Sys.Scheduler);
                 Assert.Equal(5, remaining);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -198,7 +201,7 @@ namespace Akka.Tests.Pattern
                     () => Task.FromResult(5), 5,
                     TimeSpan.FromMilliseconds(100), TimeSpan.FromSeconds(1), 0.2, Sys.Scheduler);
                 Assert.Equal(5, remaining);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -222,7 +225,7 @@ namespace Akka.Tests.Pattern
                     Attempt, 5,
                     TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(500), 0.0, Sys.Scheduler);
                 Assert.Equal(5, remaining);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -243,7 +246,7 @@ namespace Akka.Tests.Pattern
                         Attempt, 3,
                         TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(200), 0.0, Sys.Scheduler));
                 Assert.Equal("4", exception.Message);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]
@@ -268,7 +271,7 @@ namespace Akka.Tests.Pattern
                     Attempt, 5,
                     TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(500), 0.2, Sys.Scheduler);
                 Assert.Equal(42, remaining);
-            });
+            }, cancellationToken: Token);
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Routing/BroadcastSpec.cs
+++ b/src/core/Akka.Tests/Routing/BroadcastSpec.cs
@@ -5,14 +5,13 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
+using System.Threading;
 using Akka.Actor;
 using Akka.Routing;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Tests.Routing
@@ -34,6 +33,8 @@ namespace Akka.Tests.Routing
             }
         }
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [Fact]
         public void BroadcastGroup_router_must_broadcast_message_using_Tell()
         {
@@ -69,7 +70,7 @@ namespace Akka.Tests.Routing
 
             var paths = new List<string> { actor1.Path.ToString(), actor2.Path.ToString() };
             var routedActor = Sys.ActorOf(new BroadcastGroup(paths).Props());
-            routedActor.Ask(new Broadcast(1));
+            routedActor.Ask(new Broadcast(1), Token);
             routedActor.Tell(new Broadcast("end"));
 
             doneLatch.Ready(RemainingOrDefault);

--- a/src/core/Akka.Tests/Routing/ConfiguredLocalRoutingSpec.cs
+++ b/src/core/Akka.Tests/Routing/ConfiguredLocalRoutingSpec.cs
@@ -18,11 +18,14 @@ using Akka.Configuration;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Routing
 {
     public class ConfiguredLocalRoutingSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public ConfiguredLocalRoutingSpec() : base(GetConfig())
         {
         }
@@ -289,7 +292,7 @@ namespace Akka.Tests.Routing
             var expected = new List<string> { "a", "b", "c" }.Select( i => Sys.ActorSelection("/user/weird/$" + i).ResolveOne(RemainingOrDefault).Result).ToList();
 
             received.Should().BeEquivalentTo(expected);
-            await ExpectNoMsgAsync(1.Seconds());
+            await ExpectNoMsgAsync(1.Seconds(), cancellationToken: Token);
         }
 
         [Fact]
@@ -297,7 +300,7 @@ namespace Akka.Tests.Routing
         {
             var myRouter = Sys.ActorOf(FromConfig.Instance.Props(), "myrouter");
             myRouter.Tell("foo");
-            await ExpectMsgAsync("bar");
+            await ExpectMsgAsync("bar", cancellationToken: Token);
         }
 
         [Fact(Skip = "SystemActors DSN has not implemented yet")]
@@ -307,14 +310,14 @@ namespace Akka.Tests.Routing
             var parent = Sys.AsInstanceOf<ExtendedActorSystem>().SystemActorOf(Props.Create<Parent>(), "sys-parent");
             parent.Tell(new PropsName(Props.Create<EchoActor>(), "round"), probe.Ref);
 
-            var router = await probe.ExpectMsgAsync<IActorRef>();
+            var router = await probe.ExpectMsgAsync<IActorRef>(cancellationToken: Token);
 
             var replies = new List<ActorPath>();
             for (int i = 0; i < 10; i++)
             {
                 var msg = i.ToString();
                 router.Tell(msg, probe.Ref);
-                await probe.ExpectMsgAsync(msg);
+                await probe.ExpectMsgAsync(msg, cancellationToken: Token);
                 replies.Add(probe.LastSender.Path);
             }
 

--- a/src/core/Akka.Tests/Routing/ConsistentHashingRouterSpec.cs
+++ b/src/core/Akka.Tests/Routing/ConsistentHashingRouterSpec.cs
@@ -14,11 +14,14 @@ using Akka.Routing;
 using Akka.TestKit;
 using Xunit;
 using FluentAssertions;
+using System.Threading;
 
 namespace Akka.Tests.Routing
 {
     public class ConsistentHashingRouterSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         #region Actors & Message Classes
 
         public class Echo : UntypedActor
@@ -114,7 +117,7 @@ namespace Akka.Tests.Routing
         [Fact]
         public async Task Consistent_hashing_pool_router_must_create_routees_from_configuration()
         {
-            var currentRoutees = await _router1.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
+            var currentRoutees = await _router1.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null), cancellationToken: Token);
             currentRoutees.Members.Count().Should().Be(3);
         }
 
@@ -122,19 +125,19 @@ namespace Akka.Tests.Routing
         public async Task Consistent_hashing_pool_router_must_select_destination_based_on_consistent_hash_key_of_message()
         {
             _router1.Tell(new Msg("a", "A"));
-            var destinationA = await ExpectMsgAsync<IActorRef>();
+            var destinationA = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             _router1.Tell(new ConsistentHashableEnvelope("AA", "a"));
-            await ExpectMsgAsync(destinationA);
+            await ExpectMsgAsync(destinationA, cancellationToken: Token);
 
             _router1.Tell(new Msg(17, "A"));
-            var destinationB = await ExpectMsgAsync<IActorRef>();
+            var destinationB = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             _router1.Tell(new ConsistentHashableEnvelope("BB", 17));
-            await ExpectMsgAsync(destinationB);
+            await ExpectMsgAsync(destinationB, cancellationToken: Token);
 
             _router1.Tell(new Msg(new MsgKey("c"), "C"));
-            var destinationC = await ExpectMsgAsync<IActorRef>();
+            var destinationC = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             _router1.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
-            await ExpectMsgAsync(destinationC);
+            await ExpectMsgAsync(destinationC, cancellationToken: Token);
         }
 
         [Fact]
@@ -153,25 +156,25 @@ namespace Akka.Tests.Routing
             var router2 = Sys.ActorOf(new ConsistentHashingPool(1, hashMapping).Props(Props.Create<Echo>()), "router2");
 
             router2.Tell(new Msg2("a", "A"));
-            var destinationA = await ExpectMsgAsync<IActorRef>();
+            var destinationA = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             router2.Tell(new ConsistentHashableEnvelope("AA", "a"));
-            await ExpectMsgAsync(destinationA);
+            await ExpectMsgAsync(destinationA, cancellationToken: Token);
 
             router2.Tell(new Msg2(17, "A"));
-            var destinationB = await ExpectMsgAsync<IActorRef>();
+            var destinationB = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             router2.Tell(new ConsistentHashableEnvelope("BB", 17));
-            await ExpectMsgAsync(destinationB);
+            await ExpectMsgAsync(destinationB, cancellationToken: Token);
 
             router2.Tell(new Msg2(new MsgKey("c"), "C"));
-            var destinationC = await ExpectMsgAsync<IActorRef>();
+            var destinationC = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             router2.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
-            await ExpectMsgAsync(destinationC);
+            await ExpectMsgAsync(destinationC, cancellationToken: Token);
         }
 
         [Fact]
         public async Task Consistent_hashing_group_router_must_create_routees_from_configuration()
         {
-            var currentRoutees = await _router3.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null));
+            var currentRoutees = await _router3.Ask<Routees>(new GetRoutees(), GetTimeoutOrDefault(null), cancellationToken: Token);
             currentRoutees.Members.Count().ShouldBe(3);
         }
 
@@ -179,19 +182,19 @@ namespace Akka.Tests.Routing
         public async Task Consistent_hashing_group_router_must_select_destination_based_on_consistent_hash_key_of_message()
         {
             _router3.Tell(new Msg("a", "A"));
-            var destinationA = await ExpectMsgAsync<IActorRef>();
+            var destinationA = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             _router3.Tell(new ConsistentHashableEnvelope("AA", "a"));
-            await ExpectMsgAsync(destinationA);
+            await ExpectMsgAsync(destinationA, cancellationToken: Token);
 
             _router3.Tell(new Msg(17, "A"));
-            var destinationB = await ExpectMsgAsync<IActorRef>();
+            var destinationB = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             _router3.Tell(new ConsistentHashableEnvelope("BB", 17));
-            await ExpectMsgAsync(destinationB);
+            await ExpectMsgAsync(destinationB, cancellationToken: Token);
 
             _router3.Tell(new Msg(new MsgKey("c"), "C"));
-            var destinationC = await ExpectMsgAsync<IActorRef>();
+            var destinationC = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             _router3.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
-            await ExpectMsgAsync(destinationC);
+            await ExpectMsgAsync(destinationC, cancellationToken: Token);
         }
 
         [Fact]
@@ -212,19 +215,19 @@ namespace Akka.Tests.Routing
             var router4 = Sys.ActorOf(new ConsistentHashingGroup(paths, hashMapping).Props(), "router4");
 
             router4.Tell(new Msg2("a", "A"));
-            var destinationA = await ExpectMsgAsync<IActorRef>();
+            var destinationA = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             router4.Tell(new ConsistentHashableEnvelope("AA", "a"));
-            await ExpectMsgAsync(destinationA);
+            await ExpectMsgAsync(destinationA, cancellationToken: Token);
 
             router4.Tell(new Msg2(17, "A"));
-            var destinationB = await ExpectMsgAsync<IActorRef>();
+            var destinationB = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             router4.Tell(new ConsistentHashableEnvelope("BB", 17));
-            await ExpectMsgAsync(destinationB);
+            await ExpectMsgAsync(destinationB, cancellationToken: Token);
 
             router4.Tell(new Msg2(new MsgKey("c"), "C"));
-            var destinationC = await ExpectMsgAsync<IActorRef>();
+            var destinationC = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
             router4.Tell(new ConsistentHashableEnvelope("CC", new MsgKey("c")));
-            await ExpectMsgAsync(destinationC);
+            await ExpectMsgAsync(destinationC, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Routing/RandomSpec.cs
+++ b/src/core/Akka.Tests/Routing/RandomSpec.cs
@@ -161,7 +161,7 @@ namespace Akka.Tests.Routing
                 {
                     await ExpectMsgAsync("world");
                 }
-            });
+            }, cancellationToken: Token);
 
             Sys.Stop(actor);
             testLatch.Ready(5.Seconds());
@@ -188,7 +188,7 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    int id = await actor.Ask<int>("hit", Token);
+                    int id = await actor.Ask<int>("hit", cancellationToken: Token);
                     replies[id] = replies[id] + 1;
                 }
             }
@@ -264,7 +264,7 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    string id = await actor.Ask<string>("hit", Token);
+                    string id = await actor.Ask<string>("hit", cancellationToken: Token);
                     replies[id] = replies[id] + 1;
                 }
             }
@@ -298,14 +298,14 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    string id = await actor.Ask<string>("hit", Token);
+                    string id = await actor.Ask<string>("hit", cancellationToken: Token);
                     replies[id] = replies[id] + 1;
                 }
             }
 
             Watch(actor);
             actor.Tell(new Broadcast("end"));
-            await ExpectTerminatedAsync(actor);
+            await ExpectTerminatedAsync(actor, cancellationToken: Token);
 
             replies.Values.ForEach(c => c.Should().BeGreaterThan(0));
             replies.Values.Any(c => c != iterationCount).ShouldBeTrue();

--- a/src/core/Akka.Tests/Routing/RandomSpec.cs
+++ b/src/core/Akka.Tests/Routing/RandomSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Routing;
@@ -133,6 +134,8 @@ namespace Akka.Tests.Routing
             }
         }
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         private async Task<int> RouteeSize(IActorRef router)
         {
             return (await router.Ask<Routees>(new GetRoutees())).Members.Count();
@@ -185,7 +188,7 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    int id = await actor.Ask<int>("hit");
+                    int id = await actor.Ask<int>("hit", Token);
                     replies[id] = replies[id] + 1;
                 }
             }
@@ -261,7 +264,7 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    string id = await actor.Ask<string>("hit");
+                    string id = await actor.Ask<string>("hit", Token);
                     replies[id] = replies[id] + 1;
                 }
             }
@@ -295,7 +298,7 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    string id = await actor.Ask<string>("hit");
+                    string id = await actor.Ask<string>("hit", Token);
                     replies[id] = replies[id] + 1;
                 }
             }

--- a/src/core/Akka.Tests/Routing/ResizerSpec.cs
+++ b/src/core/Akka.Tests/Routing/ResizerSpec.cs
@@ -21,6 +21,8 @@ namespace Akka.Tests.Routing
 {
     public class ResizerSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public ResizerSpec() : base(GetConfig())
         {
         }
@@ -252,7 +254,7 @@ namespace Akka.Tests.Routing
 
             // first message should create the minimum number of routees
             router.Tell("echo");
-            await ExpectMsgAsync("reply");
+            await ExpectMsgAsync("reply", cancellationToken: Token);
 
             (await RouteeSize(router)).Should().Be(resizer.LowerBound);
 
@@ -301,7 +303,7 @@ namespace Akka.Tests.Routing
 
             // first message should create the minimum number of routees
             router.Tell("echo");
-            await ExpectMsgAsync("reply");
+            await ExpectMsgAsync("reply", cancellationToken: Token);
 
             (await RouteeSize(router)).Should().Be(resizer.LowerBound);
 
@@ -373,7 +375,7 @@ namespace Akka.Tests.Routing
                     await Task.Delay(Dilated(20.Milliseconds()));
                     return (await RouteeSize(router)) < z;
                 }, Dilated(500.Milliseconds()));
-            });
+            }, cancellationToken: Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Routing/RoundRobinSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoundRobinSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Routing;
@@ -141,6 +142,8 @@ namespace Akka.Tests.Routing
             }
         }
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         private async Task<int> RouteeSize(IActorRef router)
         {
             return (await router.Ask<Routees>(new GetRoutees())).Members.Count();
@@ -191,7 +194,7 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    int id = await actor.Ask<int>("hit");
+                    int id = await actor.Ask<int>("hit", Token);
                     replies[id] = replies[id] + 1;
                 }
             }
@@ -264,7 +267,7 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    string id = await actor.Ask<string>("hit");
+                    string id = await actor.Ask<string>("hit", Token);
                     replies[id] = replies[id] + 1;
                 }
             }
@@ -296,7 +299,7 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    string id = await actor.Ask<string>("hit");
+                    string id = await actor.Ask<string>("hit", Token);
                     replies[id] = replies[id] + 1;
                 }
             }

--- a/src/core/Akka.Tests/Routing/RoundRobinSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoundRobinSpec.cs
@@ -194,7 +194,7 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    int id = await actor.Ask<int>("hit", Token);
+                    int id = await actor.Ask<int>("hit", cancellationToken: Token);
                     replies[id] = replies[id] + 1;
                 }
             }
@@ -267,7 +267,7 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    string id = await actor.Ask<string>("hit", Token);
+                    string id = await actor.Ask<string>("hit", cancellationToken: Token);
                     replies[id] = replies[id] + 1;
                 }
             }
@@ -299,14 +299,14 @@ namespace Akka.Tests.Routing
             {
                 for (int k = 0; k < connectionCount; k++)
                 {
-                    string id = await actor.Ask<string>("hit", Token);
+                    string id = await actor.Ask<string>("hit", cancellationToken: Token);
                     replies[id] = replies[id] + 1;
                 }
             }
 
             Watch(actor);
             actor.Tell(new Broadcast("end"));
-            await ExpectTerminatedAsync(actor);
+            await ExpectTerminatedAsync(actor, cancellationToken: Token);
 
             replies.Values.ForEach(c => c.Should().Be(iterationCount));
         }

--- a/src/core/Akka.Tests/Routing/RouteeCreationSpec.cs
+++ b/src/core/Akka.Tests/Routing/RouteeCreationSpec.cs
@@ -15,11 +15,14 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Threading;
 
 namespace Akka.Tests.Routing
 {
     public class RouteeCreationSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         private class RouteeActor : ReceiveActor
         {
             public RouteeActor(IActorRef testActor)
@@ -52,7 +55,7 @@ namespace Akka.Tests.Routing
 
             for (int i = 1; i <= n; i++)
             {
-                (await ExpectMsgAsync<ActorIdentity>()).Subject.Should().NotBeNull();
+                (await ExpectMsgAsync<ActorIdentity>(cancellationToken: Token)).Subject.Should().NotBeNull();
             }
         }
 
@@ -69,9 +72,9 @@ namespace Akka.Tests.Routing
                 }
 
                 return null;
-            }, msgs: n).ToListAsync();
+            }, msgs: n, cancellationToken: Token).ToListAsync(Token);
 
-            await ExpectNoMsgAsync(100.Milliseconds());
+            await ExpectNoMsgAsync(100.Milliseconds(), cancellationToken: Token);
 
             gotIt.Count.Should().Be(n, $"Got only {gotIt.Count} from [{string.Join(", ", gotIt)}]");
         }

--- a/src/core/Akka.Tests/Routing/RoutingSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoutingSpec.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using Akka.Configuration;
 using Akka.Actor;
@@ -15,13 +14,11 @@ using Akka.Dispatch;
 using Akka.Routing;
 using Akka.TestKit;
 using Akka.TestKit.TestActors;
-using Akka.Tests.TestUtils;
 using Akka.Util.Internal;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
 using System.Threading.Tasks;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Routing
 {

--- a/src/core/Akka.Tests/Routing/RoutingSpec.cs
+++ b/src/core/Akka.Tests/Routing/RoutingSpec.cs
@@ -19,11 +19,14 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace Akka.Tests.Routing
 {
     public class RoutingSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         public RoutingSpec(ITestOutputHelper output) : base(GetConfig(), output:output)
         {
         }
@@ -167,13 +170,13 @@ namespace Akka.Tests.Routing
             router.Tell("");
             router.Tell("");
 
-            var c1 = await ExpectMsgAsync<IActorRef>();
-            var c2 = await ExpectMsgAsync<IActorRef>();
+            var c1 = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
+            var c2 = await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
 
             Watch(router);
             Watch(c2);
             Sys.Stop(c2);
-            (await ExpectTerminatedAsync(c2)).ExistenceConfirmed.Should().BeTrue();
+            (await ExpectTerminatedAsync(c2, cancellationToken: Token)).ExistenceConfirmed.Should().BeTrue();
 
             // it might take a while until the Router has actually processed the Terminated message
             await AwaitConditionAsync(async () =>
@@ -190,10 +193,10 @@ namespace Akka.Tests.Routing
                 }, msgs: 2).ToListAsync();
 
                 return res.Count == 2 && res.All(c => c.Equals(c1));
-            });
+            }, cancellationToken: Token);
 
             Sys.Stop(c1);
-            (await ExpectTerminatedAsync(router)).ExistenceConfirmed.Should().BeTrue();
+            (await ExpectTerminatedAsync(router, cancellationToken: Token)).ExistenceConfirmed.Should().BeTrue();
         }
 
         [Fact]
@@ -206,13 +209,13 @@ namespace Akka.Tests.Routing
             latch.Ready(RemainingOrDefault);
 
             router.Tell(new GetRoutees());
-            var routees = (await ExpectMsgAsync<Routees>()).Members.ToList();
+            var routees = (await ExpectMsgAsync<Routees>(cancellationToken: Token)).Members.ToList();
             routees.Count.Should().Be(2);
 
             routees.ForEach(r => r.Send(PoisonPill.Instance, TestActor));
             
             // expect no Terminated
-            await ExpectNoMsgAsync(2.Seconds());
+            await ExpectNoMsgAsync(2.Seconds(), cancellationToken: Token);
         }
 
         [Fact]
@@ -220,10 +223,10 @@ namespace Akka.Tests.Routing
         {
             var router = Sys.ActorOf(FromConfig.Instance.Props(Props.Create<BlackHoleActor>()), "router1");
             router.Tell(new GetRoutees());
-            (await ExpectMsgAsync<Routees>()).Members.Count().Should().Be(3);
+            (await ExpectMsgAsync<Routees>(cancellationToken: Token)).Members.Count().Should().Be(3);
             Watch(router);
             Sys.Stop(router);
-            await ExpectTerminatedAsync(router);
+            await ExpectTerminatedAsync(router, cancellationToken: Token);
         }
 
         [Fact]
@@ -231,7 +234,7 @@ namespace Akka.Tests.Routing
         {
             var router = Sys.ActorOf(new RoundRobinPool(0).Props(Props.Create<BlackHoleActor>()), "router2");
             router.Tell(new GetRoutees());
-            (await ExpectMsgAsync<Routees>()).Members.Count().Should().Be(3);
+            (await ExpectMsgAsync<Routees>(cancellationToken: Token)).Members.Count().Should().Be(3);
             Sys.Stop(router);
         }
 
@@ -243,7 +246,7 @@ namespace Akka.Tests.Routing
             var router = Sys.ActorOf(new RoundRobinPool(0, resizer).Props(Props.Create<BlackHoleActor>()), "router3");
             latch.Ready(RemainingOrDefault);
             router.Tell(new GetRoutees());
-            (await ExpectMsgAsync<Routees>()).Members.Count().Should().Be(3);
+            (await ExpectMsgAsync<Routees>(cancellationToken: Token)).Members.Count().Should().Be(3);
             Sys.Stop(router);
         }
 
@@ -261,17 +264,17 @@ namespace Akka.Tests.Routing
             await EventFilter.Exception<ActorKilledException>().ExpectOneAsync(async() =>
             {
                 (await ExpectMsgAsync<Routees>()).Members.First().Send(Kill.Instance, TestActor);
-            });
-            await ExpectMsgAsync<ActorKilledException>();
+            }, cancellationToken: Token);
+            await ExpectMsgAsync<ActorKilledException>(cancellationToken: Token);
 
             var router2 = Sys.ActorOf(new RoundRobinPool(1).WithSupervisorStrategy(escalator).Props(Props.Create<BlackHoleActor>()));
             router2.Tell(new GetRoutees());
             await EventFilter.Exception<ActorKilledException>().ExpectOneAsync(async () =>
             {
                 (await ExpectMsgAsync<Routees>()).Members.First().Send(Kill.Instance, TestActor);
-            });
+            }, cancellationToken: Token);
 
-            await ExpectMsgAsync<ActorKilledException>();
+            await ExpectMsgAsync<ActorKilledException>(cancellationToken: Token);
         }
 
         [Fact]
@@ -288,8 +291,8 @@ namespace Akka.Tests.Routing
             await EventFilter.Exception<ActorKilledException>().ExpectOneAsync(async() =>
             {
                 (await ExpectMsgAsync<Routees>()).Members.First().Send(Kill.Instance, TestActor);
-            });
-            await ExpectMsgAsync<ActorKilledException>();
+            }, cancellationToken: Token);
+            await ExpectMsgAsync<ActorKilledException>(cancellationToken: Token);
         }
 
         [Fact]
@@ -301,7 +304,7 @@ namespace Akka.Tests.Routing
             for (var i = 0; i < 3; i++)
             {
                 router.Tell("die");
-                ExpectMsg("restarted");
+                ExpectMsg("restarted", cancellationToken: Token);
                 restarted.Add(LastSender.Path.Name);
             }
 
@@ -314,7 +317,7 @@ namespace Akka.Tests.Routing
         {
             var actor = Sys.ActorOf<InlineRouterActor>();
             actor.Tell("start");
-            await ExpectMsgAsync("hello");
+            await ExpectMsgAsync("hello", cancellationToken: Token);
         }
 
         [Fact]
@@ -324,8 +327,8 @@ namespace Akka.Tests.Routing
             routedActor.Tell("hello");
             routedActor.Tell("end");
 
-            await ExpectMsgAsync("hello");
-            await ExpectMsgAsync("end");
+            await ExpectMsgAsync("hello", cancellationToken: Token);
+            await ExpectMsgAsync("end", cancellationToken: Token);
         }
 
         [Fact]
@@ -363,12 +366,12 @@ namespace Akka.Tests.Routing
         {
             var router = Sys.ActorOf(new BroadcastPool(5).Props(Props.Create<Echo>()));
             router.Tell("hello", TestActor);
-            await ExpectMsgAsync<IActorRef>();
-            await ExpectMsgAsync<IActorRef>();
-            await ExpectMsgAsync<IActorRef>();
-            await ExpectMsgAsync<IActorRef>();
-            await ExpectMsgAsync<IActorRef>();
-            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1));
+            await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
+            await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
+            await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
+            await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
+            await ExpectMsgAsync<IActorRef>(cancellationToken: Token);
+            await ExpectNoMsgAsync(TimeSpan.FromSeconds(1), cancellationToken: Token);
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Routing/ScatterGatherFirstCompletedSpec.cs
+++ b/src/core/Akka.Tests/Routing/ScatterGatherFirstCompletedSpec.cs
@@ -82,6 +82,8 @@ namespace Akka.Tests.Routing
             }
         }
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [Fact]
         public void Scatter_gather_group_must_deliver_a_broadcast_message_using_tell()
         {
@@ -117,7 +119,7 @@ namespace Akka.Tests.Routing
 
             routedActor.Tell(new Broadcast(new Stop(1)));
             shutdownLatch.Ready(TestKitSettings.DefaultTimeout);
-            var res = await routedActor.Ask<int>(0, TimeSpan.FromSeconds(10));
+            var res = await routedActor.Ask<int>(0, TimeSpan.FromSeconds(10), Token);
             res.Should().Be(14);
         }
 
@@ -157,7 +159,7 @@ namespace Akka.Tests.Routing
             var paths = new List<string> { actor1.Path.ToString() };
             var routedActor = Sys.ActorOf(new ScatterGatherFirstCompletedGroup(paths, TimeSpan.FromSeconds(3)).Props());
 
-            var exception = await routedActor.Ask<Status.Failure>(0, TimeSpan.FromSeconds(5));
+            var exception = await routedActor.Ask<Status.Failure>(0, TimeSpan.FromSeconds(5), Token);
             exception.Should().NotBeNull();
             exception.Cause.Should().BeOfType<AskTimeoutException>();
         }

--- a/src/core/Akka.Tests/Routing/ScatterGatherFirstCompletedSpec.cs
+++ b/src/core/Akka.Tests/Routing/ScatterGatherFirstCompletedSpec.cs
@@ -119,7 +119,7 @@ namespace Akka.Tests.Routing
 
             routedActor.Tell(new Broadcast(new Stop(1)));
             shutdownLatch.Ready(TestKitSettings.DefaultTimeout);
-            var res = await routedActor.Ask<int>(0, TimeSpan.FromSeconds(10), Token);
+            var res = await routedActor.Ask<int>(0, TimeSpan.FromSeconds(10), cancellationToken: Token);
             res.Should().Be(14);
         }
 
@@ -129,7 +129,7 @@ namespace Akka.Tests.Routing
             var probe = CreateTestProbe();
             var routedActor = Sys.ActorOf(new ScatterGatherFirstCompletedPool(0, TimeSpan.FromSeconds(5)).Props(Props.Empty));
             routedActor.Tell("hello", probe.Ref);
-            var message = await probe.ExpectMsgAsync<Status.Failure>(2.Seconds());
+            var message = await probe.ExpectMsgAsync<Status.Failure>(2.Seconds(), cancellationToken: Token);
             message.Should().NotBeNull();
             message.Cause.Should().BeOfType<AskTimeoutException>();
         }
@@ -146,8 +146,8 @@ namespace Akka.Tests.Routing
 
             routedActor.Tell(0);
 
-            await ExpectMsgAsync<int>();
-            await ExpectNoMsgAsync();
+            await ExpectMsgAsync<int>(cancellationToken: Token);
+            await ExpectNoMsgAsync(cancellationToken: Token);
         }
 
         // Resolved https://github.com/akkadotnet/akka.net/issues/1718
@@ -159,7 +159,7 @@ namespace Akka.Tests.Routing
             var paths = new List<string> { actor1.Path.ToString() };
             var routedActor = Sys.ActorOf(new ScatterGatherFirstCompletedGroup(paths, TimeSpan.FromSeconds(3)).Props());
 
-            var exception = await routedActor.Ask<Status.Failure>(0, TimeSpan.FromSeconds(5), Token);
+            var exception = await routedActor.Ask<Status.Failure>(0, TimeSpan.FromSeconds(5), cancellationToken: Token);
             exception.Should().NotBeNull();
             exception.Cause.Should().BeOfType<AskTimeoutException>();
         }

--- a/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
+++ b/src/core/Akka.Tests/Routing/TailChoppingSpec.cs
@@ -22,6 +22,8 @@ namespace Akka.Tests.Routing
 {
     public class TailChoppingSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         class TailChopTestActor : ReceiveActor
         {
             private readonly TimeSpan _sleepTime;
@@ -118,7 +120,7 @@ namespace Akka.Tests.Routing
             var routedActor = Sys.ActorOf(new TailChoppingGroup(paths, TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(50)).Props());
 
             probe.Send(routedActor, "");
-            await probe.ExpectMsgAsync("ack");
+            await probe.ExpectMsgAsync("ack", cancellationToken: Token);
 
             var actorList = new List<IActorRef> { actor1, actor2 };
             OneOfShouldEqual(1, actorList)(x => (int)x.Ask("times").Result).Should().BeTrue();
@@ -138,7 +140,7 @@ namespace Akka.Tests.Routing
             var routedActor = Sys.ActorOf(new TailChoppingGroup(paths, TimeSpan.FromMilliseconds(300), TimeSpan.FromMilliseconds(50)).Props());
 
             probe.Send(routedActor, "");
-            var failure = await probe.ExpectMsgAsync<Status.Failure>();
+            var failure = await probe.ExpectMsgAsync<Status.Failure>(cancellationToken: Token);
             failure.Cause.Should().BeOfType<AskTimeoutException>();
 
             var actorList = new List<IActorRef> { actor1, actor2 };
@@ -158,7 +160,7 @@ namespace Akka.Tests.Routing
             var routedActor = Sys.ActorOf(new TailChoppingGroup(paths, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(100)).Props());
 
             probe.Send(routedActor, "");
-            await probe.ExpectMsgAsync("ack", 2.Seconds());
+            await probe.ExpectMsgAsync("ack", 2.Seconds(), cancellationToken: Token);
 
             routedActor.Tell(new Broadcast("stop"));
         }

--- a/src/core/Akka.Tests/Serialization/CustomSerializerSpec.cs
+++ b/src/core/Akka.Tests/Serialization/CustomSerializerSpec.cs
@@ -7,20 +7,14 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Text;
 using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.Event;
 using Akka.Serialization;
-using Akka.TestKit;
-using Akka.TestKit.Xunit2.Internals;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using Xunit;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Serialization
 {

--- a/src/core/Akka.Tests/Serialization/NewtonSoftJsonSerializerSetupSpec.cs
+++ b/src/core/Akka.Tests/Serialization/NewtonSoftJsonSerializerSetupSpec.cs
@@ -5,14 +5,10 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Setup;
-using Akka.Configuration;
 using Akka.Serialization;
 using Akka.TestKit;
 using Akka.TestKit.Configs;
@@ -21,7 +17,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Serialization
 {

--- a/src/core/Akka.Tests/Serialization/SerializationSetupSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSetupSpec.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Threading;
 using Akka.Actor;
 using Akka.Actor.Setup;
 using Akka.Configuration;
@@ -17,7 +18,6 @@ using Akka.TestKit.Configs;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Serialization
 {
@@ -82,6 +82,8 @@ namespace Akka.Tests.Serialization
 
         public static readonly ActorSystemSetup ActorSystemSettings = ActorSystemSetup.Create(SerializationSettings, Bootstrap);
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         public SerializationSetupSpec(ITestOutputHelper output) 
             : base(ActorSystem.Create("SerializationSettingsSpec", ActorSystemSettings), output) { }
 
@@ -138,7 +140,7 @@ namespace Akka.Tests.Serialization
             var serializer = sys2.Serialization.FindSerializerFor(new ProgammaticDummy());
             serializer.Should().BeOfType<TestSerializer>();
 
-            sys2.Terminate().Wait();
+            sys2.Terminate().Wait(Token);
         }
     }
 }

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -521,8 +521,8 @@ namespace Akka.Tests.Serialization
         {
             Sys.EventStream.Subscribe(TestActor, typeof(object));
             var empty = Sys.ActorOf<EmptyActor>();
-            empty.Ask("hello", Token);
-            var f = ExpectMsg<FutureActorRef<object>>();
+            empty.Ask("hello", cancellationToken: Token);
+            var f = ExpectMsg<FutureActorRef<object>>(cancellationToken: Token);
 
 
             var message = new SomeMessage

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -6,15 +6,11 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
 using System.Runtime.Serialization;
-using System.Text.RegularExpressions;
+using System.Threading;
 using Akka.Actor;
 using Akka.Configuration;
-using Akka.Dispatch.SysMsg;
 using Akka.Routing;
 using Akka.Serialization;
 using Akka.TestKit;
@@ -164,6 +160,8 @@ namespace Akka.Tests.Serialization
             public IActorRef ActorRef { get; set; }
         }
 
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [Fact]
         public void Can_serialize_address_message()
         {
@@ -523,7 +521,7 @@ namespace Akka.Tests.Serialization
         {
             Sys.EventStream.Subscribe(TestActor, typeof(object));
             var empty = Sys.ActorOf<EmptyActor>();
-            empty.Ask("hello");
+            empty.Ask("hello", Token);
             var f = ExpectMsg<FutureActorRef<object>>();
 
 

--- a/src/core/Akka.Tests/Serialization/SerializeAllMessagesSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializeAllMessagesSpec.cs
@@ -8,10 +8,8 @@
 using System;
 using System.Threading.Tasks;
 using Akka.Actor;
-using Akka.Event;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Serialization;
 

--- a/src/core/Akka.Tests/Serialization/SerializeAllMessagesSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializeAllMessagesSpec.cs
@@ -10,11 +10,14 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
+using System.Threading;
 
 namespace Akka.Tests.Serialization;
 
 public class SerializeAllMessagesSpec : AkkaSpec
 {
+
+    private static CancellationToken Token => TestContext.Current.CancellationToken;
     public SerializeAllMessagesSpec(ITestOutputHelper output) : base("akka.actor.serialize-messages = on", output)
     {
     }
@@ -69,6 +72,6 @@ public class SerializeAllMessagesSpec : AkkaSpec
             // Act
             myActor.Tell(wrappedMessage);
             await myProbe.ExpectMsgAsync("worked");
-        });
+        }, cancellationToken: Token);
     }
 }

--- a/src/core/Akka.Tests/Util/ByteStringSpec.cs
+++ b/src/core/Akka.Tests/Util/ByteStringSpec.cs
@@ -24,32 +24,20 @@ namespace Akka.Tests.Util
     /// </summary>
     public class ByteStringSpec
     {
-        class Generators
-        {
-
-            // TODO: Align with JVM Akka Generator
-            public static Arbitrary<ByteString> ByteStrings()
-            {
-                return Arb.From(Arb.Generate<byte[]>().Select(ByteString.CopyFrom));
-            }
-        }
-
-        public ByteStringSpec()
-        {
-            Arb.Register<Generators>();
-        }
+        private static readonly Arbitrary<ByteString> ByteStringArb =
+            Arb.From(ArbMap.Default.GeneratorFor<byte[]>().Select(ByteString.CopyFrom));
 
         [Fact]
         public void A_ByteString_must_have_correct_size_when_concatenating()
         {
-            Prop.ForAll((ByteString a, ByteString b) => (a + b).Count == a.Count + b.Count)
+            Prop.ForAll(ByteStringArb, ByteStringArb, (a, b) => (a + b).Count == a.Count + b.Count)
                 .QuickCheckThrowOnFailure();
         }
 
         [Fact]
         public void A_ByteString_ToReadOnlySpan_must_have_correct_size()
         {
-            Prop.ForAll((ByteString a, ByteString b) =>
+            Prop.ForAll(ByteStringArb, ByteStringArb, (a, b) =>
             {
                 a.ToReadOnlySpan().Length.Should().Be(a.Count);
                 b.ToReadOnlySpan().Length.Should().Be(b.Count);
@@ -111,7 +99,7 @@ namespace Akka.Tests.Util
         [Fact]
         public void A_ByteString_must_be_sequential_when_slicing_from_start()
         {
-            Prop.ForAll((ByteString a, ByteString b) => (a + b).Slice(0, a.Count).SequenceEqual(a))
+            Prop.ForAll(ByteStringArb, ByteStringArb, (ByteString a, ByteString b) => (a + b).Slice(0, a.Count).SequenceEqual(a))
                 .QuickCheckThrowOnFailure();
         }
         [Fact]
@@ -126,7 +114,7 @@ namespace Akka.Tests.Util
         [Fact]
         public void A_ByteString_must_be_equal_to_the_original_when_compacting()
         {
-            Prop.ForAll((ByteString xs) =>
+            Prop.ForAll(ByteStringArb, (ByteString xs) =>
             {
                 var ys = xs.Compact();
                 return xs.SequenceEqual(ys) && ys.IsCompact;
@@ -161,7 +149,7 @@ namespace Akka.Tests.Util
         [Fact]
         public void A_ByteString_must_behave_as_expected_when_compacting()
         {
-            Prop.ForAll((ByteString a) =>
+            Prop.ForAll(ByteStringArb, (ByteString a) =>
             {
                 var wasCompact = a.IsCompact;
                 var b = a.Compact();

--- a/src/core/Akka.Tests/Util/ByteStringSpec.cs
+++ b/src/core/Akka.Tests/Util/ByteStringSpec.cs
@@ -13,6 +13,7 @@ using Akka.IO;
 using Akka.TestKit;
 using FluentAssertions;
 using FsCheck;
+using FsCheck.Fluent;
 using Xunit;
 
 namespace Akka.Tests.Util
@@ -29,13 +30,21 @@ namespace Akka.Tests.Util
             // TODO: Align with JVM Akka Generator
             public static Arbitrary<ByteString> ByteStrings()
             {
+                return Arb.From(ArbMap.Default.GeneratorFor<byte[]>().Select(ByteString.CopyFrom));
+            }
+        
+            /*
+            public static Arbitrary<ByteString> ByteStrings()
+            {
                 return Arb.From(Arb.Generate<byte[]>().Select(ByteString.CopyFrom));
             }
+            */
         }
 
         public ByteStringSpec()
         {
-            Arb.Register<Generators>();
+            ArbMap.Default = ArbMap.Merge(ArbMap.Default, typeof(Generators));
+            //Arb.Register<Generators>();
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Util/ByteStringSpec.cs
+++ b/src/core/Akka.Tests/Util/ByteStringSpec.cs
@@ -30,21 +30,13 @@ namespace Akka.Tests.Util
             // TODO: Align with JVM Akka Generator
             public static Arbitrary<ByteString> ByteStrings()
             {
-                return Arb.From(ArbMap.Default.GeneratorFor<byte[]>().Select(ByteString.CopyFrom));
-            }
-        
-            /*
-            public static Arbitrary<ByteString> ByteStrings()
-            {
                 return Arb.From(Arb.Generate<byte[]>().Select(ByteString.CopyFrom));
             }
-            */
         }
 
         public ByteStringSpec()
         {
-            ArbMap.Default = ArbMap.Merge(ArbMap.Default, typeof(Generators));
-            //Arb.Register<Generators>();
+            Arb.Register<Generators>();
         }
 
         [Fact]

--- a/src/core/Akka.Tests/Util/IndexSpec.cs
+++ b/src/core/Akka.Tests/Util/IndexSpec.cs
@@ -14,11 +14,14 @@ using Akka.TestKit.Extensions;
 using Akka.Util;
 using Xunit;
 using FluentAssertions;
+using System.Threading;
 
 namespace Akka.Tests.Util
 {
     public class IndexSpec : AkkaSpec
     {
+
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
         private Index<string, int> Empty => new();
 
         private Index<string, int> IndexWithValues
@@ -164,7 +167,7 @@ namespace Akka.Tests.Util
 
             var tasks = Enumerable.Repeat(randomTask(), nrOfTasks).Select(Task.Run);
 
-            (await Task.WhenAll(tasks.ToArray()).AwaitWithTimeout(GetTimeoutOrDefault(null))).Should().BeTrue();
+            (await Task.WhenAll(tasks.ToArray()).AwaitWithTimeout(GetTimeoutOrDefault(null), cancellationToken: Token)).Should().BeTrue();
         }
     }
 }

--- a/src/core/Akka.Tests/Util/Internal/ExtensionsTests.cs
+++ b/src/core/Akka.Tests/Util/Internal/ExtensionsTests.cs
@@ -105,13 +105,11 @@ namespace Akka.Tests.Util.Internal
         }
 
 #if FSCHECK
-        [Property]
-        public void SplitDottedPathHonouringQuotesWithTestOracle()
+        [Property(Arbitrary = [typeof(ConfigStringsGen)])]
+        public void SplitDottedPathHonouringQuotesWithTestOracle(string s)
         {
-            Arb.Register<ConfigStringsGen>();
-            Prop.ForAll<string>(s =>
-                    SplitDottedPathHonouringQuotesOracle(s).SequenceEqual(s.SplitDottedPathHonouringQuotes()))
-                .QuickCheckThrowOnFailure();
+            SplitDottedPathHonouringQuotesOracle(s).SequenceEqual(s.SplitDottedPathHonouringQuotes())
+                .Should().BeTrue();
         }
 #endif
 
@@ -133,13 +131,13 @@ namespace Akka.Tests.Util.Internal
             {
                 var z =
                     from size in Gen.Choose(1, 50)
-                    let letters = Arb.toGen(Arb.Default.Char().Filter(c => (c >= 'A' && c <= 'z') || c == '.'))
+                    let letters = ArbMap.Default.ArbFor<char>().Generator.Where(c => (c >= 'A' && c <= 'z') || c == '.')
                     let len = Gen.Choose(1, 200)
                     let words = len
-                        .SelectMany(i => Gen.ArrayOf(i, letters)
-                            .SelectMany(ls => Arb.Generate<bool>()
+                        .SelectMany(i => letters.ArrayOf(i)
+                            .SelectMany(ls => ArbMap.Default.GeneratorFor<bool>()
                                 .Select(b => ls.Contains('.') || b ? "\"" + new string(ls) + "\"" : new string(ls))))
-                    from wx in Gen.ArrayOf(size, words).Select(ww => String.Join(".", ww))
+                    from wx in words.ArrayOf(size).Select(ww => string.Join(".", ww))
                     select wx;
                 return z;
             }

--- a/src/core/Akka.Tests/Util/Internal/ExtensionsTests.cs
+++ b/src/core/Akka.Tests/Util/Internal/ExtensionsTests.cs
@@ -8,10 +8,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions;
 using FsCheck;
+using FsCheck.Fluent;
 using FsCheck.Xunit;
 using Xunit;
 

--- a/src/core/Akka.Tests/Util/Internal/InterlockedSpinTests.cs
+++ b/src/core/Akka.Tests/Util/Internal/InterlockedSpinTests.cs
@@ -18,6 +18,8 @@ namespace Akka.Tests.Util.Internal
 {
     public class InterlockedSpinTests
     {
+        private static CancellationToken Token => TestContext.Current.CancellationToken;
+        
         [Fact]
         public async Task When_a_shared_variable_is_updated_on_another_thread_Then_the_update_method_is_rerun()
         {
@@ -57,7 +59,7 @@ namespace Akka.Tests.Util.Internal
             hasEnteredUpdateMethod.WaitOne(TimeSpan.FromSeconds(2)); //Wait for THREAD 2 to enter updateWhenSignaled
             sharedVariable = "-";
             okToContinue.Set();	//Signal THREAD 1 it can continue in updateWhenSignaled
-            await task.AwaitWithTimeout(2.Seconds()); //Wait for THREAD 1
+            await task.WaitAsync(2.Seconds(), Token); //Wait for THREAD 1
 
             sharedVariable.ShouldBe("updated");
             numberOfCallsToUpdateWhenSignaled.ShouldBe(2);
@@ -98,11 +100,14 @@ namespace Akka.Tests.Util.Internal
                 return (true, "updated", "returnValue");
             };
             string result;
-            var task = Task.Run(() => { result= InterlockedSpin.ConditionallySwap(ref sharedVariable, updateWhenSignaled); });
+            var task = Task.Run(() =>
+            {
+                result = InterlockedSpin.ConditionallySwap(ref sharedVariable, updateWhenSignaled);
+            }, Token);
             hasEnteredUpdateMethod.WaitOne(TimeSpan.FromSeconds(2)); //Wait for THREAD 2 to enter updateWhenSignaled
             sharedVariable = "-";
             okToContinue.Set();	//Signal THREAD 1 it can continue in updateWhenSignaled
-            await task.AwaitWithTimeout(2.Seconds());	//Wait for THREAD 1
+            await task.WaitAsync(2.Seconds(), Token);	//Wait for THREAD 1
 
             sharedVariable.ShouldBe("updated");
             numberOfCallsToUpdateWhenSignaled.ShouldBe(2);
@@ -147,11 +152,14 @@ namespace Akka.Tests.Util.Internal
                 return (shouldUpdate, "updated", shouldUpdate ? "update" : "break");
             };
             string result = "";
-            var task = Task.Run(() => { result = InterlockedSpin.ConditionallySwap(ref sharedVariable, updateWhenSignaled); });
+            var task = Task.Run(() =>
+            {
+                result = InterlockedSpin.ConditionallySwap(ref sharedVariable, updateWhenSignaled);
+            }, Token);
             hasEnteredUpdateMethod.WaitOne(TimeSpan.FromSeconds(2));
             sharedVariable = "-";
             okToContinue.Set();
-            await task.AwaitWithTimeout(2.Seconds());
+            await task.WaitAsync(2.Seconds(), Token);
 
             sharedVariable.ShouldBe("-");
             numberOfCallsToUpdateWhenSignaled.ShouldBe(2);

--- a/src/core/Akka.Tests/Util/StableListPriorityQueueSpec.cs
+++ b/src/core/Akka.Tests/Util/StableListPriorityQueueSpec.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Akka.Actor;
 using Akka.Util;
 using FsCheck;
+using FsCheck.Fluent;
 using FsCheck.Xunit;
 
 #pragma warning disable xUnit1028

--- a/src/core/Akka.Tests/Util/TokenBucketSpec.cs
+++ b/src/core/Akka.Tests/Util/TokenBucketSpec.cs
@@ -10,7 +10,6 @@ using System.Diagnostics.CodeAnalysis;
 using Akka.TestKit;
 using Akka.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.Util
 {


### PR DESCRIPTION
Closes #8071
Part of #7742

## Changes

Convert Akka.Tests to comply to xUnit 3 conventions:
* Make sure that project only references xUnit 3
* All cancellation token arguments should be filled with `TestContext.Current.CancellationToken`

No logic change, all changes are done to comply to xUnit3 conventions only.

`TestContext.Current.CancellationToken` is being cancelled by xUnit timeout code, which defaults to 0 (disabled). The only way to override this is via the `Timeout` argument in the `FactAttribute` or `TheoryAttribute`.