### PR TITLE
[xUnit 3] Convert Akka.Remote.Tests

### DIFF
--- a/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
+++ b/src/core/Akka.Remote.Tests/ActorsLeakSpec.cs
@@ -23,7 +23,6 @@ using Akka.TestKit.TestEvent;
 using Xunit;
 using FluentAssertions;
 using FluentAssertions.Extensions;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {

--- a/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
+++ b/src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj
@@ -3,6 +3,8 @@
 
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <!-- disable .NET Framework on Linux-->
@@ -12,8 +14,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\contrib\serializers\Akka.Serialization.Hyperion\Akka.Serialization.Hyperion.csproj" />
+    <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit\Akka.TestKit.Xunit.csproj" />
     <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj" />
-    <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
 
     <None Include="Resources\akka-validcert.pfx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -42,14 +45,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">
-    <PackageReference Include="FsCheck" Version="$(FsCheckVersion)" />
-    <PackageReference Include="FsCheck.Xunit" Version="$(FsCheckVersion)" />
+    <PackageReference Include="FsCheck" Version="$(FsCheck3Version)" />
+    <PackageReference Include="FsCheck.Xunit.v3" Version="$(FsCheck3Version)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == '$(NetFrameworkTestVersion)' ">

--- a/src/core/Akka.Remote.Tests/BugFixes/BugFix4384Spec.cs
+++ b/src/core/Akka.Remote.Tests/BugFixes/BugFix4384Spec.cs
@@ -15,11 +15,10 @@ using Akka.Configuration;
 using Akka.Routing;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.BugFixes
 {
-    public class BugFix4384Spec : TestKit.Xunit2.TestKit
+    public class BugFix4384Spec : TestKit.Xunit.TestKit
     {
         public ActorSystem Sys1 { get; }
         public Address Sys1Address { get; }

--- a/src/core/Akka.Remote.Tests/ExceptionSupportSpec.cs
+++ b/src/core/Akka.Remote.Tests/ExceptionSupportSpec.cs
@@ -20,7 +20,6 @@ using Akka.Remote.Transport;
 using Akka.Serialization;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Remote.Tests

--- a/src/core/Akka.Remote.Tests/RemoteActorTelemetrySpecs.cs
+++ b/src/core/Akka.Remote.Tests/RemoteActorTelemetrySpecs.cs
@@ -12,7 +12,6 @@ using Akka.TestKit;
 using Akka.TestKit.TestActors;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {

--- a/src/core/Akka.Remote.Tests/RemoteMessageLocalDeliverySpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteMessageLocalDeliverySpec.cs
@@ -17,7 +17,6 @@ using Akka.TestKit;
 using Akka.TestKit.Extensions;
 using Akka.TestKit.TestActors;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {

--- a/src/core/Akka.Remote.Tests/RemoteMetricsSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteMetricsSpec.cs
@@ -14,7 +14,6 @@ using Akka.Event;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {

--- a/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteRouterSpec.cs
@@ -18,7 +18,6 @@ using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {

--- a/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteWatcherSpec.cs
@@ -13,7 +13,6 @@ using Akka.TestKit.Extensions;
 using Akka.Util.Internal;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {

--- a/src/core/Akka.Remote.Tests/RemotingSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemotingSpec.cs
@@ -19,11 +19,10 @@ using Akka.Util.Internal;
 using FluentAssertions;
 using Google.Protobuf;
 using Xunit;
-using Xunit.Abstractions;
 using Nito.AsyncEx;
 using ThreadLocalRandom = Akka.Util.ThreadLocalRandom;
 using Akka.TestKit.Extensions;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit.Attributes;
 using FluentAssertions.Extensions;
 
 namespace Akka.Remote.Tests

--- a/src/core/Akka.Remote.Tests/RemotingTerminatorSpecs.cs
+++ b/src/core/Akka.Remote.Tests/RemotingTerminatorSpecs.cs
@@ -14,7 +14,6 @@ using Akka.TestKit.Extensions;
 using Akka.TestKit.TestActors;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {

--- a/src/core/Akka.Remote.Tests/Serialization/BugFix5062Spec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/BugFix5062Spec.cs
@@ -20,7 +20,6 @@ using Akka.TestKit;
 using FluentAssertions;
 using Google.Protobuf;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Serialization
 {

--- a/src/core/Akka.Remote.Tests/Serialization/Bugfix3903Spec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/Bugfix3903Spec.cs
@@ -12,7 +12,6 @@ using Akka.Configuration;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Remote.Tests.Serialization

--- a/src/core/Akka.Remote.Tests/Serialization/Bugfix7215Spec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/Bugfix7215Spec.cs
@@ -10,13 +10,12 @@ using System.IO;
 using Akka.Actor;
 using Akka.Remote.Serialization;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 using static FluentAssertions.FluentActions;
 
 namespace Akka.Remote.Tests.Serialization;
 
-public class Bugfix7215Spec: TestKit.Xunit2.TestKit
+public class Bugfix7215Spec: TestKit.Xunit.TestKit
 {
     public Bugfix7215Spec(ITestOutputHelper output) : base(nameof(Bugfix7215Spec), output)
     {

--- a/src/core/Akka.Remote.Tests/Serialization/RemoteAskFailureSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/RemoteAskFailureSpec.cs
@@ -14,12 +14,11 @@ using Akka.Event;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 using static  FluentAssertions.FluentActions;
 
 namespace Akka.Remote.Tests.Serialization
 {
-    public class RemoteAskFailureSpec: TestKit.Xunit2.TestKit
+    public class RemoteAskFailureSpec: TestKit.Xunit.TestKit
     {
         private static Config Config(int port) => @$"
 akka.actor.ask-timeout = 5s

--- a/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/SerializationTransportInformationSpec.cs
@@ -19,7 +19,6 @@ using Akka.TestKit.TestActors;
 using FluentAssertions;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Serialization
 {

--- a/src/core/Akka.Remote.Tests/Serialization/SystemMessageSerializationSpec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/SystemMessageSerializationSpec.cs
@@ -16,7 +16,6 @@ using Akka.TestKit.TestActors;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Serialization
 {

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
@@ -19,7 +19,6 @@ using FluentAssertions;
 using FluentAssertions.Extensions;
 using Google.Protobuf;
 using Xunit;
-using Xunit.Abstractions;
 using SerializedMessage = Akka.Remote.Serialization.Proto.Msg.Payload;
 using static FluentAssertions.FluentActions;
 

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolStressTest.cs
@@ -19,7 +19,6 @@ using Akka.TestKit.TestEvent;
 using Akka.Util.Internal;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {

--- a/src/core/Akka.Remote.Tests/Transport/CertificateValidationHelpersSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/CertificateValidationHelpersSpec.cs
@@ -12,7 +12,6 @@ using Akka.Event;
 using Akka.Remote.Transport.DotNetty;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyBatchWriterSpecs.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyBatchWriterSpecs.cs
@@ -19,7 +19,6 @@ using DotNetty.Transport.Channels.Embedded;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyCertificateValidationSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyCertificateValidationSpec.cs
@@ -12,7 +12,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyMutualTlsSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyMutualTlsSpec.cs
@@ -11,7 +11,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -14,7 +14,6 @@ using Akka.Configuration;
 using Akka.Remote.Transport.DotNetty;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Util.RuntimeDetector;
 
 namespace Akka.Remote.Tests.Transport

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSupportSpec.cs
@@ -13,10 +13,9 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit.Attributes;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Util.RuntimeDetector;
 
 namespace Akka.Remote.Tests.Transport

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTlsHandshakeFailureSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTlsHandshakeFailureSpec.cs
@@ -16,7 +16,6 @@ using Akka.Configuration;
 using Akka.TestKit;
 using Akka.Event;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTransportDnsResolutionSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTransportDnsResolutionSpec.cs
@@ -16,7 +16,6 @@ using Akka.TestKit;
 using FsCheck;
 using FsCheck.Xunit;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Util.RuntimeDetector;
 using Config = Akka.Configuration.Config;
 using FluentAssertions;

--- a/src/core/Akka.Remote.Tests/Transport/MultiTransportAddressingSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/MultiTransportAddressingSpec.cs
@@ -11,14 +11,13 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport;
 
 /// <summary>
 /// Added this spec to prove the existence of https://github.com/akkadotnet/akka.net/issues/7378
 /// </summary>
-public class MultiTransportAddressingSpec : TestKit.Xunit2.TestKit
+public class MultiTransportAddressingSpec : TestKit.Xunit.TestKit
 {
     public MultiTransportAddressingSpec(ITestOutputHelper output) : base(GetConfig(Sys1Port1, Sys1Port2), "MultiTransportSpec", output)
     {

--- a/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/ThrottlerTransportAdapterSpec.cs
@@ -22,7 +22,6 @@ using Akka.Util.Internal;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests.Transport
 {

--- a/src/core/Akka.Remote.Tests/UntrustedSpec.cs
+++ b/src/core/Akka.Remote.Tests/UntrustedSpec.cs
@@ -13,7 +13,6 @@ using Akka.Event;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Remote.Tests
 {


### PR DESCRIPTION
Replaces #8068
Part of #7742

## Changes

Convert Akka.Remote.Tests to comply to xUnit 3 conventions. No logic change, all changes are done to comply to new xUnit3 and FsCheck conventions only.