### PR TITLE
[xUnit 3] Convert Akka.Discovery.Tests

### DIFF
--- a/src/core/Akka.Discovery.Tests/Aggregate/AggregateServiceDiscoverySpec.cs
+++ b/src/core/Akka.Discovery.Tests/Aggregate/AggregateServiceDiscoverySpec.cs
@@ -13,7 +13,6 @@ using Akka.Configuration;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Discovery.Tests.Aggregate
 {
@@ -34,7 +33,7 @@ namespace Akka.Discovery.Tests.Aggregate
         }
     }
 
-    public class AggregateServiceDiscoverySpec : TestKit.Xunit2.TestKit
+    public class AggregateServiceDiscoverySpec : TestKit.Xunit.TestKit
     {
         private static Configuration.Config Config => ConfigurationFactory.ParseString(@"
             akka {

--- a/src/core/Akka.Discovery.Tests/Akka.Discovery.Tests.csproj
+++ b/src/core/Akka.Discovery.Tests/Akka.Discovery.Tests.csproj
@@ -3,18 +3,20 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="FluentDateTime" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj" />
+    <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit\Akka.TestKit.Xunit.csproj" />
     <ProjectReference Include="..\Akka.Discovery\Akka.Discovery.csproj" />
   </ItemGroup>
 

--- a/src/core/Akka.Discovery.Tests/Config/ConfigServiceDiscoverySpec.cs
+++ b/src/core/Akka.Discovery.Tests/Config/ConfigServiceDiscoverySpec.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Akka.Discovery.Tests.Config
 {
-    public class ConfigServiceDiscoverySpec : TestKit.Xunit2.TestKit
+    public class ConfigServiceDiscoverySpec : TestKit.Xunit.TestKit
     {
         private static Configuration.Config Config => ConfigurationFactory.ParseString(@"
             akka {

--- a/src/core/Akka.Discovery.Tests/DiscoveryConfigurationSpec.cs
+++ b/src/core/Akka.Discovery.Tests/DiscoveryConfigurationSpec.cs
@@ -18,7 +18,7 @@ using static FluentAssertions.FluentActions;
 
 namespace Akka.Discovery.Tests
 {
-    public class DiscoveryConfigurationSpec : TestKit.Xunit2.TestKit
+    public class DiscoveryConfigurationSpec : TestKit.Xunit.TestKit
     {
         [Fact]
         public void ServiceDiscovery_should_give_warning_when_no_default_discovery_configured()

--- a/src/core/Akka.Discovery.Tests/LookupSpec.cs
+++ b/src/core/Akka.Discovery.Tests/LookupSpec.cs
@@ -10,11 +10,10 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Discovery.Tests
 {
-    public class LookupSpec : TestKit.Xunit2.TestKit
+    public class LookupSpec : TestKit.Xunit.TestKit
     {
         private readonly List<string> srvWithInvalidDomainNames;
         private readonly List<string> srvWithValidDomainNames;


### PR DESCRIPTION
Part of #7742

## Changes

Convert Akka.Discovery.Tests to comply to xUnit 3 conventions. No logic change, all changes are done to comply to new xUnit3 and FsCheck conventions only.