### PR TITLE
[xUnit 3] Convert Akka.TestKit.Tests

### DIFF
--- a/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
+++ b/src/core/Akka.TestKit.Tests/Akka.TestKit.Tests.csproj
@@ -2,20 +2,19 @@
   <Import Project="..\..\xunitSettings.props" />
   <PropertyGroup>
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Akka\Akka.csproj" />
     <ProjectReference Include="..\Akka.TestKit\Akka.TestKit.csproj" />
-    <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj" />
-    <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit\Akka.TestKit.Xunit.csproj" />
+    <ProjectReference Include="..\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/ExceptionHandling.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/ExceptionHandling.cs
@@ -10,12 +10,11 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static FluentAssertions.FluentActions;
 
 namespace Akka.TestKit.Tests.TestActorRefTests
 {
-    public class ExceptionHandling: TestKit.Xunit2.TestKit
+    public class ExceptionHandling: TestKit.Xunit.TestKit
     {
         private class GiveError
         { }

--- a/src/core/Akka.TestKit.Tests/TestActorRefTests/ParallelTestActorDeadlockSpec.cs
+++ b/src/core/Akka.TestKit.Tests/TestActorRefTests/ParallelTestActorDeadlockSpec.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.TestKit.Tests.TestActorRefTests
 {
@@ -46,7 +45,7 @@ namespace Akka.TestKit.Tests.TestActorRefTests
                 {
                     _output.WriteLine($"[{id}] Creating TestKit...");
                     // Create TestKit synchronously like a normal test would
-                    using var testKit = new Akka.TestKit.Xunit2.TestKit($"test-{id}", output: _output);
+                    using var testKit = new Akka.TestKit.Xunit.TestKit($"test-{id}", output: _output);
                     _output.WriteLine($"[{id}] TestKit created");
 
                     // Simulate what happens in Akka.Hosting - actor creation during startup

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/ConfigTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/ConfigTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Akka.TestKit.Tests.TestEventListenerTests
 {
-    public class ConfigTests : TestKit.Xunit2.TestKit
+    public class ConfigTests : TestKit.Xunit.TestKit
     {
         [Fact]
         public void TestEventListener_is_in_config_by_default()

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Akka.TestKit.Tests.TestEventListenerTests
 {
-    public abstract class EventFilterTestBase : TestKit.Xunit2.TestKit, IAsyncLifetime
+    public abstract class EventFilterTestBase : TestKit.Xunit.TestKit, IAsyncLifetime
     {
         /// <summary>
         /// Used to signal that the test was successful and that we should ensure no more messages were logged
@@ -24,7 +24,7 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         {
         }
 
-        public async Task InitializeAsync()
+        public async ValueTask InitializeAsync()
         {
             //We send a ForwardAllEventsTo containing message to the TestEventListenerToForwarder logger (configured as a logger above).
             //It should respond with an "OK" message when it has received the message.
@@ -40,9 +40,9 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
             //From now on we know that all messages will be forwarded to TestActor
         }
 
-        public Task DisposeAsync()
+        public ValueTask DisposeAsync()
         {
-            return Task.CompletedTask;
+            return new ValueTask(Task.CompletedTask);
         }
 
         protected abstract void SendRawLogEventMessage(object message);

--- a/src/core/Akka.TestKit.Tests/TestKitAsyncCancellationSpec.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitAsyncCancellationSpec.cs
@@ -3,7 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Tests.TestKit
 {

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/AwaitAssertTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/AwaitAssertTests.cs
@@ -14,7 +14,7 @@ using static FluentAssertions.FluentActions;
 
 namespace Akka.TestKit.Tests.TestKitBaseTests
 {
-    public class AwaitAssertTests : TestKit.Xunit2.TestKit
+    public class AwaitAssertTests : TestKit.Xunit.TestKit
     {
         public AwaitAssertTests() : base("akka.test.timefactor=2")
         {

--- a/src/core/Akka.TestKit.Tests/TestKitBaseTests/RemainingTests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitBaseTests/RemainingTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Akka.TestKit.Tests.Xunit2.TestKitBaseTests
 {
-    public class RemainingTests : TestKit.Xunit2.TestKit
+    public class RemainingTests : TestKit.Xunit.TestKit
     {
         [Fact]
         public void Throw_if_remaining_is_called_outside_Within()

--- a/src/core/Akka.TestKit.Tests/TestKitSpec.cs
+++ b/src/core/Akka.TestKit.Tests/TestKitSpec.cs
@@ -9,7 +9,6 @@ using Akka.Actor;
 using Akka.Actor.Dsl;
 using Akka.Configuration;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 using static FluentAssertions.FluentActions;
 
@@ -29,7 +28,7 @@ namespace Akka.TestKit.Tests
         {
             using (var sys = ActorSystem.Create(nameof(TestKitSpec)))
             {
-                var testkit = new TestKit.Xunit2.TestKit(sys, _output);
+                var testkit = new TestKit.Xunit.TestKit(sys, _output);
                 var echoActor = testkit.Sys.ActorOf(c => c.ReceiveAny((m, _) => testkit.TestActor.Tell(m))); 
                 Invoking(() =>
                 {
@@ -43,9 +42,9 @@ namespace Akka.TestKit.Tests
         [Fact(DisplayName = "TestKit should accept ActorSystem with TestKit.DefaultConfig")]
         public void TestKitConfigTest()
         {
-            using (var sys = ActorSystem.Create(nameof(TestKitSpec), TestKit.Xunit2.TestKit.DefaultConfig))
+            using (var sys = ActorSystem.Create(nameof(TestKitSpec), TestKit.Xunit.TestKit.DefaultConfig))
             {
-                var testkit = new TestKit.Xunit2.TestKit(sys, _output);
+                var testkit = new TestKit.Xunit.TestKit(sys, _output);
                 var echoActor = testkit.Sys.ActorOf(c => c.ReceiveAny((m, _) => testkit.TestActor.Tell(m))); 
                 Invoking(() =>
                 {

--- a/src/core/Akka.TestKit.Tests/TestKit_Config_Tests.cs
+++ b/src/core/Akka.TestKit.Tests/TestKit_Config_Tests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Akka.TestKit.Tests.Xunit2
 {
     // ReSharper disable once InconsistentNaming
-    public class TestKit_Config_Tests : TestKit.Xunit2.TestKit
+    public class TestKit_Config_Tests : TestKit.Xunit.TestKit
     {
         [Fact]
         public void DefaultValues_should_be_correct()
@@ -33,7 +33,7 @@ namespace Akka.TestKit.Tests.Xunit2
         }
     }
     
-    public class TestKitCustomConfigTests : TestKit.Xunit2.TestKit
+    public class TestKitCustomConfigTests : TestKit.Xunit.TestKit
     {
         private static readonly Config Config = """
         akka.test {


### PR DESCRIPTION
Part of #7742

## Changes

Convert Akka.TestKit.Tests to comply to xUnit 3 conventions. No logic change, all changes are done to comply to new xUnit3 and FsCheck conventions only.