### PR TITLE
[xUnit 3] Convert Akka.Serialization.Hyperion.Tests

### DIFF
--- a/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/Akka.Serialization.Hyperion.Tests.csproj
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/Akka.Serialization.Hyperion.Tests.csproj
@@ -2,18 +2,20 @@
   <Import Project="..\..\..\xunitSettings.props" />
   <PropertyGroup>
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
  
   <ItemGroup>
     <ProjectReference Include="..\Akka.Serialization.Hyperion\Akka.Serialization.Hyperion.csproj" />
     <ProjectReference Include="..\Akka.Serialization.TestKit\Akka.Serialization.TestKit.csproj" />
-    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 

--- a/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/HyperionSerializerSetupSpec.cs
+++ b/src/contrib/serializers/Akka.Serialization.Hyperion.Tests/HyperionSerializerSetupSpec.cs
@@ -21,7 +21,6 @@ using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 using Hyperion;
 using Hyperion.Internal;

--- a/src/contrib/serializers/Akka.Serialization.TestKit/Akka.Serialization.TestKit.csproj
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/Akka.Serialization.TestKit.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
+++ b/src/contrib/serializers/Akka.Serialization.TestKit/AkkaSerializationSpec.cs
@@ -38,7 +38,7 @@ namespace Akka.Tests.Serialization
             };
         }
     }
-    public abstract class AkkaSerializationSpec : TestKit.Xunit2.TestKit
+    public abstract class AkkaSerializationSpec : TestKit.Xunit.TestKit
     {
         protected AkkaSerializationSpec(Type serializerType):base(GetConfig(serializerType))
         {


### PR DESCRIPTION
Part of #7742

## Changes

Convert Akka.Serialization.TestKit and Akka.Serialization.Hyperion.Tests to comply to xUnit 3 conventions. No logic change, all changes are done to comply to new xUnit3 and FsCheck conventions only.