### PR TITLE
[xUnit 3] Convert Akka.DependencyInjection.Tests

### DIFF
--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ActorServiceProviderPropsWithScopesSpecs.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ActorServiceProviderPropsWithScopesSpecs.cs
@@ -14,7 +14,6 @@ using Akka.TestKit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.DependencyInjection.Tests
 {

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ActorWithStashSpec.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ActorWithStashSpec.cs
@@ -10,7 +10,6 @@ using Akka.TestKit;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.DependencyInjection.Tests;
 

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/Akka.DependencyInjection.Tests.csproj
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/Akka.DependencyInjection.Tests.csproj
@@ -3,18 +3,20 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
     <ProjectReference Include="..\Akka.DependencyInjection\Akka.DependencyInjection.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="$(MsExtVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 </Project>

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/BugFixSpec.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/BugFixSpec.cs
@@ -14,7 +14,6 @@ using Akka.TestKit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 using static FluentAssertions.FluentActions;
 
@@ -60,7 +59,7 @@ namespace Akka.DependencyInjection.Tests
         }
         
         
-        public async Task InitializeAsync()
+        public async ValueTask InitializeAsync()
         {
             await _akkaService.StartAsync(default);
             InitializeLogger(_akkaService.ActorSystem);
@@ -73,9 +72,9 @@ namespace Akka.DependencyInjection.Tests
             base.AfterAll();
         }
 
-        public Task DisposeAsync()
+        public ValueTask DisposeAsync()
         {
-            return Task.CompletedTask;
+            return new ValueTask(Task.CompletedTask);
         }
         
         internal class AkkaService : IHostedService

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/DelegateInjectionSpecs.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/DelegateInjectionSpecs.cs
@@ -13,7 +13,6 @@ using Akka.TestKit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.DependencyInjection.Tests
 {

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/DiPropsSpecs.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/DiPropsSpecs.cs
@@ -14,7 +14,6 @@ using Akka.Util.Internal;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.DependencyInjection.Tests;
 
@@ -23,7 +22,7 @@ public class DiPropsSpecs : IAsyncLifetime
     private readonly IServiceProvider _serviceProvider;
     private readonly AkkaService _akkaService;
     private readonly ITestOutputHelper _output;
-    private TestKit.Xunit2.TestKit _testKit;
+    private TestKit.Xunit.TestKit _testKit;
 
     public DiPropsSpecs(ITestOutputHelper output)
     {
@@ -60,13 +59,13 @@ public class DiPropsSpecs : IAsyncLifetime
         actorRef.MailboxType.GetType().Should().Be(typeof(CustomMailbox));
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _akkaService.StartAsync(default);
-        _testKit = new TestKit.Xunit2.TestKit(_akkaService.ActorSystem, _output);
+        _testKit = new TestKit.Xunit.TestKit(_akkaService.ActorSystem, _output);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _akkaService.StopAsync();
     }

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/RouterIntegrationSpec.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/RouterIntegrationSpec.cs
@@ -15,7 +15,6 @@ using Akka.Routing;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.DependencyInjection.Tests
 {
@@ -24,7 +23,7 @@ namespace Akka.DependencyInjection.Tests
         private readonly IServiceProvider _serviceProvider;
         private readonly AkkaService _akkaService;
         private readonly ITestOutputHelper _output;
-        private TestKit.Xunit2.TestKit _testKit;
+        private TestKit.Xunit.TestKit _testKit;
         
         public RouterIntegrationSpec(ITestOutputHelper output)
         {
@@ -145,13 +144,13 @@ namespace Akka.DependencyInjection.Tests
             counterHash.Count.Should().BeGreaterOrEqualTo(50); // at least half of the 100 possible routes have to be hit
         }
         
-        public async Task InitializeAsync()
+        public async ValueTask InitializeAsync()
         {
             await _akkaService.StartAsync(default);
-            _testKit = new TestKit.Xunit2.TestKit(_akkaService.ActorSystem, _output);
+            _testKit = new TestKit.Xunit.TestKit(_akkaService.ActorSystem, _output);
         }
 
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             await _akkaService.StopAsync();
         }

--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ServiceProviderSetupSpecs.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/ServiceProviderSetupSpecs.cs
@@ -12,7 +12,6 @@ using Akka.TestKit;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.DependencyInjection.Tests
 {


### PR DESCRIPTION
Part of #7742

## Changes

Convert Akka.DependencyInjection.Tests to comply to xUnit 3 conventions. No logic change, all changes are done to comply to new xUnit3 and FsCheck conventions only.