### PR TITLE
Replace TBD XML doc placeholders in DNS IO files

### DIFF
--- a/src/core/Akka/IO/Dns.cs
+++ b/src/core/Akka/IO/Dns.cs
@@ -193,11 +193,7 @@ namespace Akka.IO
             return Instance.Apply(system).Cache.Resolve(name, system, sender);
         }
 
-        /// <summary>
-        /// Creates a new <see cref="DnsExt"/> extension instance for the specified actor system.
-        /// </summary>
-        /// <param name="system">The actor system to create the extension for.</param>
-        /// <returns>A new <see cref="DnsExt"/> instance.</returns>
+        /// <inheritdoc/>
         public override DnsExt CreateExtension(ExtendedActorSystem system)
         {
             return new DnsExt(system);
@@ -268,9 +264,7 @@ namespace Akka.IO
             Cache = Provider.Cache;
         }
 
-        /// <summary>
-        /// The DNS manager actor responsible for handling <see cref="Dns.Resolve"/> commands. Created lazily on first access.
-        /// </summary>
+        /// <inheritdoc/>
         public override IActorRef Manager
         {
             get

--- a/src/core/Akka/IO/Dns.cs
+++ b/src/core/Akka/IO/Dns.cs
@@ -59,7 +59,7 @@ namespace Akka.IO
         public static readonly Dns Instance = new();
 
         /// <summary>
-        /// TBD
+        /// Base class for DNS-related commands.
         /// </summary>
         public abstract class Command : INoSerializationVerificationNeeded
         { }
@@ -194,10 +194,10 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// Creates a new <see cref="DnsExt"/> extension instance for the specified actor system.
         /// </summary>
-        /// <param name="system">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="system">The actor system to create the extension for.</param>
+        /// <returns>A new <see cref="DnsExt"/> instance.</returns>
         public override DnsExt CreateExtension(ExtendedActorSystem system)
         {
             return new DnsExt(system);
@@ -205,19 +205,19 @@ namespace Akka.IO
     }
 
     /// <summary>
-    /// TBD
+    /// The Akka.IO DNS extension that manages DNS resolution settings, caching, and the DNS manager actor.
     /// </summary>
     public class DnsExt : IOExtension
     {
         /// <summary>
-        /// TBD
+        /// Configuration settings for the DNS extension.
         /// </summary>
         public class DnsSettings
         {
             /// <summary>
-            /// TBD
+            /// Creates a new <see cref="DnsSettings"/> instance from the provided configuration.
             /// </summary>
-            /// <param name="config">TBD</param>
+            /// <param name="config">The HOCON configuration for the DNS extension.</param>
             public DnsSettings(Config config)
             {
                 if (config.IsNullOrEmpty())
@@ -230,19 +230,19 @@ namespace Akka.IO
             }
 
             /// <summary>
-            /// TBD
+            /// The dispatcher to use for DNS resolution actors.
             /// </summary>
             public string Dispatcher { get; private set; }
             /// <summary>
-            /// TBD
+            /// The name of the configured DNS resolver.
             /// </summary>
             public string Resolver { get; private set; }
             /// <summary>
-            /// TBD
+            /// The HOCON configuration section for the selected resolver.
             /// </summary>
             public Config ResolverConfig { get; private set; }
             /// <summary>
-            /// TBD
+            /// The fully qualified type name of the <see cref="IDnsProvider"/> implementation.
             /// </summary>
             public string ProviderObjectName { get; private set; }
         }
@@ -251,9 +251,9 @@ namespace Akka.IO
         private IActorRef _manager;
 
         /// <summary>
-        /// TBD
+        /// Initializes the DNS extension for the specified actor system, loading settings and creating the DNS provider.
         /// </summary>
-        /// <param name="system">TBD</param>
+        /// <param name="system">The actor system this extension is being created for.</param>
         public DnsExt(ExtendedActorSystem system)
         {
             _system = system;
@@ -269,7 +269,7 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// The DNS manager actor responsible for handling <see cref="Dns.Resolve"/> commands. Created lazily on first access.
         /// </summary>
         public override IActorRef Manager
         {
@@ -282,24 +282,24 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// Returns the DNS manager actor reference.
         /// </summary>
-        /// <returns>TBD</returns>
+        /// <returns>The DNS manager <see cref="IActorRef"/>.</returns>
         public IActorRef GetResolver()
         {
             return _manager;
         }
 
         /// <summary>
-        /// TBD
+        /// The DNS configuration settings.
         /// </summary>
         public DnsSettings Settings { get; private set; }
         /// <summary>
-        /// TBD
+        /// The DNS cache used for storing and retrieving resolved DNS entries.
         /// </summary>
         public DnsBase Cache { get; private set; }
         /// <summary>
-        /// TBD
+        /// The DNS provider that supplies the resolver actor and cache implementations.
         /// </summary>
         public IDnsProvider Provider { get; private set; }
     }

--- a/src/core/Akka/IO/InetAddressDnsResolver.cs
+++ b/src/core/Akka/IO/InetAddressDnsResolver.cs
@@ -16,7 +16,8 @@ using Akka.Configuration;
 namespace Akka.IO
 {
     /// <summary>
-    /// TBD
+    /// DNS resolver actor that uses <see cref="System.Net.Dns.GetHostEntryAsync(string)"/> to resolve hostnames
+    /// and caches results using a <see cref="SimpleDnsCache"/>.
     /// </summary>
     public class InetAddressDnsResolver : ActorBase
     {
@@ -26,10 +27,10 @@ namespace Akka.IO
         private readonly bool _useIpv6;
 
         /// <summary>
-        /// TBD
+        /// Creates a new <see cref="InetAddressDnsResolver"/> with the specified cache and configuration.
         /// </summary>
-        /// <param name="cache">TBD</param>
-        /// <param name="config">TBD</param>
+        /// <param name="cache">The DNS cache for storing resolved entries.</param>
+        /// <param name="config">The HOCON configuration specifying TTL and IPv6 settings.</param>
         public InetAddressDnsResolver(SimpleDnsCache cache, Config config)
         {
             _cache = cache;
@@ -39,10 +40,10 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// Handles incoming <see cref="Dns.Resolve"/> messages by returning cached results or performing an async DNS lookup.
         /// </summary>
-        /// <param name="message">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="message">The message to handle.</param>
+        /// <returns><see langword="true"/> if the message was handled; otherwise <see langword="false"/>.</returns>
         protected override bool Receive(object message)
         {
             if (message is Dns.Resolve resolve)

--- a/src/core/Akka/IO/InetAddressDnsResolver.cs
+++ b/src/core/Akka/IO/InetAddressDnsResolver.cs
@@ -39,11 +39,7 @@ namespace Akka.IO
             _useIpv6 = config.GetBoolean( "use-ipv6" , false);
         }
 
-        /// <summary>
-        /// Handles incoming <see cref="Dns.Resolve"/> messages by returning cached results or performing an async DNS lookup.
-        /// </summary>
-        /// <param name="message">The message to handle.</param>
-        /// <returns><see langword="true"/> if the message was handled; otherwise <see langword="false"/>.</returns>
+        /// <inheritdoc/>
         protected override bool Receive(object message)
         {
             if (message is Dns.Resolve resolve)


### PR DESCRIPTION
Partial fix for #3435, contributes to #647.

## Changes

Document all TBD XML doc blocks in Dns.cs and InetAddressDnsResolver.cs.

Doc-only change - no behavioral modifications.

## Checklist

- [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
- [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
- [x] Changes in public API reviewed, if any.
