### PR TITLE
Replace TBD XML doc placeholders in Inet and IP IO files

### DIFF
--- a/src/core/Akka/IO/IPExtensions.cs
+++ b/src/core/Akka/IO/IPExtensions.cs
@@ -21,12 +21,12 @@ namespace Akka.IO
     internal static class IpExtensions
     {
         /// <summary>
-        /// TBD
+        /// Retrieves the value of a private or internal instance field via reflection.
         /// </summary>
-        /// <param name="type">TBD</param>
-        /// <param name="instance">TBD</param>
-        /// <param name="fieldName">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="type">The <see cref="Type"/> that declares the field.</param>
+        /// <param name="instance">The object instance from which to read the field value.</param>
+        /// <param name="fieldName">The name of the field to retrieve.</param>
+        /// <returns>The value of the specified field, or <see langword="null"/> if the field is not found.</returns>
         internal static object GetInstanceField(Type type, object instance, string fieldName)
         {
             BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
@@ -36,10 +36,10 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// Maps an IPv6 address to its equivalent IPv4 address. Returns the original address if it is already IPv4.
         /// </summary>
-        /// <param name="ipa">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="ipa">The <see cref="IPAddress"/> to convert.</param>
+        /// <returns>The mapped <see cref="IPAddress"/> in IPv4 form.</returns>
         public static IPAddress MapToIPv4(this IPAddress ipa)
         {
             ushort[] m_Numbers = GetInstanceField(typeof(IPAddress), ipa, "m_Numbers") as ushort[];
@@ -63,10 +63,10 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// Maps an IPv4 address to its IPv4-mapped IPv6 representation. Returns the original address if it is already IPv6.
         /// </summary>
-        /// <param name="ipa">TBD</param>
-        /// <returns>TBD</returns>
+        /// <param name="ipa">The <see cref="IPAddress"/> to convert.</param>
+        /// <returns>The mapped <see cref="IPAddress"/> in IPv6 form.</returns>
         public static IPAddress MapToIPv6(this IPAddress ipa)
         {
             if (ipa.AddressFamily == AddressFamily.InterNetworkV6)

--- a/src/core/Akka/IO/Inet.cs
+++ b/src/core/Akka/IO/Inet.cs
@@ -11,68 +11,68 @@ using System.Net.Sockets;
 namespace Akka.IO
 {
     /// <summary>
-    /// TBD
+    /// Contains socket option classes used to configure TCP, UDP, and other socket-based I/O channels.
     /// </summary>
     public class Inet
     {
         /// <summary>
-        /// TBD
+        /// Base class for socket options that can be applied at various stages of a socket's lifecycle.
         /// </summary>
         public abstract class SocketOption
         {
             /// <summary>
-            /// TBD
+            /// Called before binding a datagram (UDP) socket. Override to configure socket options prior to binding.
             /// </summary>
-            /// <param name="ds">TBD</param>
+            /// <param name="ds">The datagram socket to configure.</param>
             public virtual void BeforeDatagramBind(Socket ds) 
             { }
 
             /// <summary>
-            /// TBD
+            /// Called before binding a server (TCP listener) socket. Override to configure socket options prior to binding.
             /// </summary>
-            /// <param name="ss">TBD</param>
+            /// <param name="ss">The server socket to configure.</param>
             public virtual void BeforeServerSocketBind(Socket ss)
             { }
 
             /// <summary>
-            /// TBD
+            /// Called before a client socket connects. Override to configure socket options prior to connecting.
             /// </summary>
-            /// <param name="s">TBD</param>
+            /// <param name="s">The socket to configure.</param>
             public virtual void BeforeConnect(Socket s)
             { }
             /// <summary>
-            /// TBD
+            /// Called after a client socket connects. Override to configure socket options after connecting.
             /// </summary>
-            /// <param name="s">TBD</param>
+            /// <param name="s">The connected socket to configure.</param>
             public virtual void AfterConnect(Socket s)
             { }
         }
 
         /// <summary>
-        /// TBD
+        /// Abstract base class for user-defined socket options. Inherits from <see cref="SocketOption"/>.
         /// </summary>
         public abstract class AbstractSocketOption : SocketOption { }
 
         /// <summary>
-        /// TBD
+        /// Extended socket option that adds an <see cref="AfterBind"/> hook called after a socket is bound.
         /// </summary>
         public abstract class SocketOptionV2 : SocketOption
         {
             /// <summary>
-            /// TBD
+            /// Called after a socket is bound to an address. Override to configure socket options after binding.
             /// </summary>
-            /// <param name="s">TBD</param>
+            /// <param name="s">The bound socket to configure.</param>
             public virtual void AfterBind(Socket s)
             { }
         }
 
         /// <summary>
-        /// TBD
+        /// Abstract base class for user-defined extended socket options. Inherits from <see cref="SocketOptionV2"/>.
         /// </summary>
         public abstract class AbstractSocketOptionV2 : SocketOptionV2 { }
 
         /// <summary>
-        /// TBD
+        /// A <see cref="SocketOption"/> that creates datagram (UDP) sockets for the specified address family.
         /// </summary>
         public class DatagramChannelCreator : SocketOption
         {
@@ -83,46 +83,46 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// Contains standard socket option implementations (receive buffer size, send buffer size, reuse address, traffic class).
         /// </summary>
         public static class SO
         {
             /// <summary>
-            /// TBD
+            /// Socket option that sets the <see cref="SocketOptionName.ReceiveBuffer"/> size on a socket.
             /// </summary>
             public class ReceiveBufferSize : SocketOption
             {
                 private readonly int _size;
 
                 /// <summary>
-                /// TBD
+                /// Creates a new <see cref="ReceiveBufferSize"/> option with the specified buffer size.
                 /// </summary>
-                /// <param name="size">TBD</param>
+                /// <param name="size">The receive buffer size in bytes.</param>
                 public ReceiveBufferSize(int size)
                 {
                     _size = size;
                 }
 
                 /// <summary>
-                /// TBD
+                /// Sets the receive buffer size on the server socket before binding.
                 /// </summary>
-                /// <param name="ss">TBD</param>
+                /// <param name="ss">The server socket to configure.</param>
                 public override void BeforeServerSocketBind(Socket ss)
                 {
                     ss.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, _size);
                 }
                 /// <summary>
-                /// TBD
+                /// Sets the receive buffer size on the datagram socket before binding.
                 /// </summary>
-                /// <param name="ds">TBD</param>
+                /// <param name="ds">The datagram socket to configure.</param>
                 public override void BeforeDatagramBind(Socket ds)
                 {
                     ds.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, _size);
                 }
                 /// <summary>
-                /// TBD
+                /// Sets the receive buffer size on the socket before connecting.
                 /// </summary>
-                /// <param name="s">TBD</param>
+                /// <param name="s">The socket to configure.</param>
                 public override void BeforeConnect(Socket s)
                 {
                     s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, _size);
@@ -130,41 +130,41 @@ namespace Akka.IO
             }
 
             /// <summary>
-            /// TBD
+            /// Socket option that enables or disables <see cref="SocketOptionName.ReuseAddress"/> on a socket.
             /// </summary>
             public class ReuseAddress : SocketOption
             {
                 private readonly bool _on;
 
                 /// <summary>
-                /// TBD
+                /// Creates a new <see cref="ReuseAddress"/> option.
                 /// </summary>
-                /// <param name="on">TBD</param>
+                /// <param name="on"><see langword="true"/> to enable address reuse; <see langword="false"/> to disable it.</param>
                 public ReuseAddress(bool on)
                 {
                     _on = @on;
                 }
 
                 /// <summary>
-                /// TBD
+                /// Sets the reuse address option on the server socket before binding.
                 /// </summary>
-                /// <param name="ss">TBD</param>
+                /// <param name="ss">The server socket to configure.</param>
                 public override void BeforeServerSocketBind(Socket ss)
                 {
                     ss.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, _on);
                 }
                 /// <summary>
-                /// TBD
+                /// Sets the reuse address option on the datagram socket before binding.
                 /// </summary>
-                /// <param name="ds">TBD</param>
+                /// <param name="ds">The datagram socket to configure.</param>
                 public override void BeforeDatagramBind(Socket ds)
                 {
                     ds.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, _on);
                 }
                 /// <summary>
-                /// TBD
+                /// Sets the reuse address option on the socket before connecting.
                 /// </summary>
-                /// <param name="s">TBD</param>
+                /// <param name="s">The socket to configure.</param>
                 public override void BeforeConnect(Socket s)
                 {
                     s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, _on);
@@ -172,25 +172,25 @@ namespace Akka.IO
             }
 
             /// <summary>
-            /// TBD
+            /// Socket option that sets the <see cref="SocketOptionName.SendBuffer"/> size on a socket after connecting.
             /// </summary>
             public class SendBufferSize : SocketOption
             {
                 private readonly int _size;
 
                 /// <summary>
-                /// TBD
+                /// Creates a new <see cref="SendBufferSize"/> option with the specified buffer size.
                 /// </summary>
-                /// <param name="size">TBD</param>
+                /// <param name="size">The send buffer size in bytes.</param>
                 public SendBufferSize(int size)
                 {
                     _size = size;
                 }
 
                 /// <summary>
-                /// TBD
+                /// Sets the send buffer size on the socket after connecting.
                 /// </summary>
-                /// <param name="s">TBD</param>
+                /// <param name="s">The connected socket to configure.</param>
                 public override void AfterConnect(Socket s)
                 {
                     s.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer, _size);
@@ -198,25 +198,25 @@ namespace Akka.IO
             }
 
             /// <summary>
-            /// TBD
+            /// Socket option that sets the IP traffic class (type-of-service) on a socket after connecting.
             /// </summary>
             public class TrafficClass : SocketOption
             {
                 private readonly int _tc;
 
                 /// <summary>
-                /// TBD
+                /// Creates a new <see cref="TrafficClass"/> option with the specified traffic class value.
                 /// </summary>
-                /// <param name="tc">TBD</param>
+                /// <param name="tc">The traffic class (type-of-service) value.</param>
                 public TrafficClass(int tc)
                 {
                     _tc = tc;
                 }
 
                 /// <summary>
-                /// TBD
+                /// Intended to set the traffic class on the socket after connecting. Currently not implemented.
                 /// </summary>
-                /// <param name="s">TBD</param>
+                /// <param name="s">The connected socket to configure.</param>
                 public override void AfterConnect(Socket s)
                 {
                     //TODO: What is the .NET equivalent
@@ -225,7 +225,7 @@ namespace Akka.IO
         }
 
         /// <summary>
-        /// TBD
+        /// Abstract base class for forwarding standard socket option definitions.
         /// </summary>
         public abstract class SoForwarders
         {


### PR DESCRIPTION
Partially fixes #3435, contributes to #647.

## Changes

Document all TBD XML doc blocks in Inet.cs and IPExtensions.cs, covering socket option types (`SocketOption`, `DatagramChannelCreator`, `Inet.SO.*`) and IP address helper methods.

Doc-only change - no behavioral modifications.

## Checklist

- [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
- [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
- [x] Changes in public API reviewed, if any.
