### PR TITLE
[xUnit 3] Convert Akka.Cluster.Tests and Akka.Cluster.Metrics.Tests

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/Akka.Cluster.Metrics.Tests.MultiNode.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests.MultiNode/Akka.Cluster.Metrics.Tests.MultiNode.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Akka.Cluster.Metrics.Tests\Akka.Cluster.Metrics.Tests.csproj" />
+         <!-- <ProjectReference Include="..\Akka.Cluster.Metrics.Tests\Akka.Cluster.Metrics.Tests.csproj" /> -->
         <ProjectReference Include="..\Akka.Cluster.Metrics\Akka.Cluster.Metrics.csproj" />
         <ProjectReference Include="..\..\..\core\Akka.Cluster.TestKit\Akka.Cluster.TestKit.csproj" />
     </ItemGroup>
@@ -19,6 +19,12 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Include="..\Akka.Cluster.Metrics.Tests\Helpers\ClusterMetricsView.cs">
+        <Link>ClusterMetricsView.cs</Link>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Akka.Cluster.Metrics.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Akka.Cluster.Metrics.Tests.csproj
@@ -12,8 +12,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-        <PackageReference Include="xunit" Version="$(XunitVersion)" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+        <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
         <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     </ItemGroup>
 

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Akka.Cluster.Metrics.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Akka.Cluster.Metrics.Tests.csproj
@@ -3,6 +3,8 @@
 
     <PropertyGroup>
         <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Base/AkkaSpecWithCollector.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Base/AkkaSpecWithCollector.cs
@@ -16,7 +16,7 @@ using Akka.Cluster.Metrics.Collectors;
 using Akka.Cluster.Metrics.Serialization;
 using Akka.TestKit;
 using FluentAssertions.Extensions;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Cluster.Metrics.Tests.Base
 {

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/ClusterMetricsAutostartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/ClusterMetricsAutostartSpec.cs
@@ -15,7 +15,6 @@ using Akka.TestKit;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Metrics.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/ClusterMetricsExtensionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/ClusterMetricsExtensionSpec.cs
@@ -13,7 +13,6 @@ using Akka.TestKit;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Metrics.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/MetricsCollectorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/MetricsCollectorSpec.cs
@@ -11,11 +11,10 @@ using System.Threading.Tasks;
 using Akka.Cluster.Metrics.Serialization;
 using Akka.Cluster.Metrics.Tests.Base;
 using Akka.Cluster.Metrics.Tests.Helpers;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit.Attributes;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Metrics.Tests
 {

--- a/src/core/Akka.Cluster.Tests/ActorRefIgnoreSerializationSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ActorRefIgnoreSerializationSpec.cs
@@ -16,7 +16,6 @@ using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
 using FluentAssertions;
-using Xunit.Abstractions;
 using Akka.Util;
 
 namespace Akka.Cluster.Tests

--- a/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
+++ b/src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj
@@ -3,18 +3,20 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Akka.Cluster\Akka.Cluster.csproj" />
-    <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
-    <PackageReference Include="FsCheck.Xunit" Version="$(FsCheckVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
+    <PackageReference Include="FsCheck.Xunit.v3" Version="$(FsCheck3Version)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Fsharp.Core" Version="$(FsharpVersion)" />
   </ItemGroup>

--- a/src/core/Akka.Cluster.Tests/Bugfix5962Spec.cs
+++ b/src/core/Akka.Cluster.Tests/Bugfix5962Spec.cs
@@ -12,13 +12,12 @@ using Akka.TestKit;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 using static FluentAssertions.FluentActions;
 
 
 namespace Akka.Cluster.Tests
 {
-     public class Bugfix5962Spec : TestKit.Xunit2.TestKit
+     public class Bugfix5962Spec : TestKit.Xunit.TestKit
     {
         private static readonly Config Config = ConfigurationFactory.ParseString(@"
 akka {

--- a/src/core/Akka.Cluster.Tests/ClusterGenerators.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterGenerators.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="ClusterGenerators.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -10,14 +10,14 @@ using System.Linq;
 using System.Net;
 using Akka.Actor;
 using Akka.Annotations;
-using Akka.Tests.Shared.Internals.Helpers;
 using FsCheck;
+using FsCheck.Fluent;
 
 namespace Akka.Cluster.Tests
 {
     /// <summary>
     /// INTERNAL API.
-    /// 
+    ///
     /// FsCheck data generators for Akka.Cluster types.
     /// </summary>
     [InternalApi]
@@ -29,27 +29,25 @@ namespace Akka.Cluster.Tests
              * In order to help guarantee collisions and duplicates in random tests, we hold all parts
              * of the address other than the port number constant.
              */
-            Func<IPAddress, int, Address> combiner = (address, i) => new Address("akka.tcp", "cluster", address.ToString(), i);
-            var producer = FsharpDelegateHelper.Create(combiner);
+            var gen = ArbMap.Default.GeneratorFor<IPAddress>()
+                .Zip(Gen.Choose(1, 65535))
+                .Select(t => new Address("akka.tcp", "cluster", t.Item1.ToString(), t.Item2));
 
-            return Arb.From(Gen.Map2(producer, Arb.Default.IPAddress().Generator, Gen.Choose(1, 65535)));
+            return Arb.From(gen);
         }
 
         public static Arbitrary<UniqueAddress> UniqueAddressGenerator()
         {
-            var gen1 = Arb.Default.Int32().Generator;
-            var gen2 = AddressGenerator();
+            var gen = ArbMap.Default.GeneratorFor<int>()
+                .Zip(AddressGenerator().Generator)
+                .Select(t => new UniqueAddress(t.Item2, t.Item1));
 
-            // randomize both addresses and ports
-            Func<int, Address, UniqueAddress> combiner = (uid, addr) => new UniqueAddress(addr, uid);
-            var producer = FsharpDelegateHelper.Create(combiner);
-
-            return Arb.From(Gen.Map2(producer, gen1, gen2.Generator));
+            return Arb.From(gen);
         }
 
         public static Arbitrary<MemberStatus> MemberStatusGenerator()
         {
-            return Arb.From(Gen.Elements(Enum.GetValues(typeof(MemberStatus)).Cast<MemberStatus>()));
+            return Arb.From(Gen.Elements((MemberStatus[])Enum.GetValues(typeof(MemberStatus))));
         }
     }
 }

--- a/src/core/Akka.Cluster.Tests/ClusterHeartBeatSenderStateSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterHeartBeatSenderStateSpec.cs
@@ -17,7 +17,6 @@ using Akka.Util;
 using Akka.Util.Internal;
 using Xunit;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tests
 {

--- a/src/core/Akka.Cluster.Tests/ClusterHeartbeatReceiverSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterHeartbeatReceiverSpec.cs
@@ -12,7 +12,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Cluster.ClusterHeartbeatSender;
 
 namespace Akka.Cluster.Tests

--- a/src/core/Akka.Cluster.Tests/ClusterHeartbeatSenderSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterHeartbeatSenderSpec.cs
@@ -13,7 +13,6 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Cluster.ClusterHeartbeatSender;
 
 namespace Akka.Cluster.Tests

--- a/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
@@ -15,7 +15,6 @@ using Akka.TestKit.Extensions;
 using Akka.Util.Internal;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Akka.Cluster.Tests

--- a/src/core/Akka.Cluster.Tests/ClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpec.cs
@@ -18,7 +18,6 @@ using Akka.TestKit.Extensions;
 using Akka.Util.Internal;
 using Xunit;
 using FluentAssertions;
-using Xunit.Abstractions;
 using Akka.Util;
 using FluentAssertions.Extensions;
 using static FluentAssertions.FluentActions;

--- a/src/core/Akka.Cluster.Tests/ClusterSpecBase.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterSpecBase.cs
@@ -7,7 +7,7 @@
 
 using Akka.Configuration;
 using Akka.TestKit;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Cluster.Tests
 {

--- a/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
+++ b/src/core/Akka.Cluster.Tests/DowningProviderSpec.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit.Attributes;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;

--- a/src/core/Akka.Cluster.Tests/HeartbeatNodeRingSpec.cs
+++ b/src/core/Akka.Cluster.Tests/HeartbeatNodeRingSpec.cs
@@ -10,7 +10,6 @@ using System.Collections.Immutable;
 using Akka.Actor;
 using Xunit;
 using FluentAssertions;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tests
 {

--- a/src/core/Akka.Cluster.Tests/InvalidClusterSettingsSpec.cs
+++ b/src/core/Akka.Cluster.Tests/InvalidClusterSettingsSpec.cs
@@ -9,7 +9,6 @@ using Akka.Configuration;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static FluentAssertions.FluentActions;
 
 namespace Akka.Cluster.Tests

--- a/src/core/Akka.Cluster.Tests/MemberOrderingModelBasedTests.cs
+++ b/src/core/Akka.Cluster.Tests/MemberOrderingModelBasedTests.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="MemberOrderingModelBasedTests.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -10,11 +10,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Akka.Actor;
-using Akka.Tests.Shared.Internals.Helpers;
 using Akka.Util;
 using Akka.Util.Internal;
 using FsCheck;
 using FsCheck.Experimental;
+using FsCheck.Fluent;
 using FsCheck.Xunit;
 
 #pragma warning disable xUnit1028
@@ -22,19 +22,13 @@ namespace Akka.Cluster.Tests
 {
     public class MemberOrderingModelBasedTests
     {
-        public MemberOrderingModelBasedTests()
-        {
-            // register the custom generators to make testing easier
-            Arb.Register<ClusterGenerators>();
-        }
-
-        [Property]
+        [Property(Arbitrary = new[] { typeof(ClusterGenerators) })]
         public Property MemberOrderingMustObeyModel()
         {
             return new MembershipMachine().ToProperty();
         }
 
-        [Property(MaxTest = 1000)]
+        [Property(MaxTest = 1000, Arbitrary = new[] { typeof(ClusterGenerators) })]
         public Property DistinctMemberAddressesMustCompareDifferently(Address[] addresses)
         {
             if (addresses.Length == 0)
@@ -62,12 +56,6 @@ namespace Akka.Cluster.Tests
 
     public class MembershipMachine : Machine<MemberOrderingState, MembershipModel>
     {
-        public MembershipMachine()
-        {
-            // register the custom generators to make testing easier
-            Arb.Register<ClusterGenerators>();
-        }
-
         public override Gen<Operation<MemberOrderingState, MembershipModel>> Next(MembershipModel model)
         {
             if (model.AllMembers.Count == 0)
@@ -75,8 +63,10 @@ namespace Akka.Cluster.Tests
             return Gen.OneOf(ChangeMemberStatus.Generator(model.AllMembers.Keys), AddNewMember.Generator());
         }
 
-        public override Arbitrary<Setup<MemberOrderingState, MembershipModel>> Setup => Arb.From(Arb.Generate<MembershipSetup>()
-            .Select(x => (Setup<MemberOrderingState, MembershipModel>)x)); // compiler ceremony :(
+        public override Arbitrary<Setup<MemberOrderingState, MembershipModel>> Setup =>
+            Arb.From(ClusterGenerators.UniqueAddressGenerator().Generator
+                .ArrayOf()
+                .Select(x => (Setup<MemberOrderingState, MembershipModel>)new MembershipSetup(x)));
 
         #region Setup
 
@@ -118,12 +108,10 @@ namespace Akka.Cluster.Tests
             public static Gen<Operation<MemberOrderingState, MembershipModel>> Generator(IEnumerable<Address> addresses)
             {
                 var statusGen = ClusterGenerators.MemberStatusGenerator().Generator;
-                Func<Address, MemberStatus, Operation<MemberOrderingState, MembershipModel>> generator =
-                    (address, status) => new ChangeMemberStatus(address, status);
 
-                var producer = FsharpDelegateHelper.Create(generator);
-
-                return Gen.Map2(producer, Gen.Elements(addresses), statusGen);
+                return Gen.Elements(addresses.ToArray())
+                    .Zip(statusGen)
+                    .Select(t => (Operation<MemberOrderingState, MembershipModel>)new ChangeMemberStatus(t.Item1, t.Item2));
             }
 
             public readonly Address TargetedMember;
@@ -174,7 +162,8 @@ namespace Akka.Cluster.Tests
         {
             public static Gen<Operation<MemberOrderingState, MembershipModel>> Generator()
             {
-                return Arb.Generate<AddNewMember>().Select(x => (Operation<MemberOrderingState, MembershipModel>)x);
+                return ClusterGenerators.UniqueAddressGenerator().Generator
+                    .Select(x => (Operation<MemberOrderingState, MembershipModel>)new AddNewMember(x));
             }
 
             private readonly UniqueAddress _address;

--- a/src/core/Akka.Cluster.Tests/SBR/LeaseMajoritySpec.cs
+++ b/src/core/Akka.Cluster.Tests/SBR/LeaseMajoritySpec.cs
@@ -11,7 +11,6 @@ using Akka.Configuration;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tests.SBR
 {

--- a/src/core/Akka.Cluster.Tests/SBR/SplitBrainResolverSpec.cs
+++ b/src/core/Akka.Cluster.Tests/SBR/SplitBrainResolverSpec.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Coordination;
 using Akka.TestKit;
-using Xunit.Abstractions;
 using Akka.Util.Internal;
 using Xunit;
 using Akka.Cluster.SBR;

--- a/src/core/Akka.Cluster.Tests/Serialization/BugFix3724Spec.cs
+++ b/src/core/Akka.Cluster.Tests/Serialization/BugFix3724Spec.cs
@@ -12,7 +12,6 @@ using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tests.Serialization
 {

--- a/src/core/Akka.Cluster.Tests/Serialization/ClusterMessageSerializerSpec.cs
+++ b/src/core/Akka.Cluster.Tests/Serialization/ClusterMessageSerializerSpec.cs
@@ -17,7 +17,6 @@ using FluentAssertions;
 using Akka.Util;
 using Akka.Util.Internal;
 using Google.Protobuf;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tests.Serialization
 {

--- a/src/core/Akka.Cluster.Tests/Serialization/ReliableDeliverySerializerSpecs.cs
+++ b/src/core/Akka.Cluster.Tests/Serialization/ReliableDeliverySerializerSpecs.cs
@@ -17,7 +17,6 @@ using Akka.Event;
 using Akka.IO;
 using Akka.TestKit;
 using Akka.TestKit.TestActors;
-using Xunit.Abstractions;
 using FluentAssertions;
 using Xunit;
 

--- a/src/core/Akka.Cluster.Tests/SerializationChecksSpec.cs
+++ b/src/core/Akka.Cluster.Tests/SerializationChecksSpec.cs
@@ -8,7 +8,6 @@
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tests
 {

--- a/src/core/Akka.Cluster.Tests/StartupWithOneThreadSpec.cs
+++ b/src/core/Akka.Cluster.Tests/StartupWithOneThreadSpec.cs
@@ -15,7 +15,6 @@ using Akka.Event;
 using Akka.TestKit;
 using Akka.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tests
 {


### PR DESCRIPTION
Part of #7742

## Changes

Convert Akka.Cluster.Tests and Akka.Cluster.Metrics.Tests to comply to xUnit 3 conventions. No logic change, all changes are done to comply to new xUnit3 and FsCheck conventions only.
