### PR TITLE
[xUnit 3] Convert Akka.Cluster.Sharding.Tests

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Akka.Cluster.Sharding.Tests.csproj
@@ -3,6 +3,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,13 +23,13 @@
   <ItemGroup>
     <ProjectReference Include="..\Akka.Cluster.Sharding\Akka.Cluster.Sharding.csproj" />
     <ProjectReference Include="..\..\..\core\Akka.Persistence\Akka.Persistence.csproj" />
-    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/AutomaticallyHandledExtractorMessagesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/AutomaticallyHandledExtractorMessagesSpec.cs
@@ -49,11 +49,11 @@ public class AutomaticallyHandledExtractorMessagesSpec
     }
 
     public static readonly TheoryData<(object shardingInput, object realMsg, string entityId, string shardId)>
-        Messages = new()
-        {
-            // (new ShardRegion.StartEntity("foo"), new ShardRegion.StartEntity("foo"), "foo", "foo"),
-            (new ShardingEnvelope("bar", "baz"), "baz", "bar", "bar"), ("bar", "bar", "bar", "bar"),
-        };
+        Messages =
+        [
+            new TheoryDataRow<(object shardingInput, object realMsg, string entityId, string shardId)>((new ShardingEnvelope("bar", "baz"), "baz", "bar", "bar")),
+            new TheoryDataRow<(object shardingInput, object realMsg, string entityId, string shardId)>(("bar", "bar", "bar", "bar"))
+        ];
 
     [Theory]
     [MemberData(nameof(Messages))]

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Bugfix7399Specs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Bugfix7399Specs.cs
@@ -20,7 +20,6 @@ using Akka.TestKit;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingInternalsSpec.cs
@@ -14,7 +14,6 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingLeaseSpec.cs
@@ -15,7 +15,6 @@ using Akka.TestKit;
 using Akka.TestKit.TestActors;
 using Akka.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingSettingsSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ClusterShardingSettingsSpec.cs
@@ -10,7 +10,6 @@ using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/CoordinatedShutdownShardingSpec.cs
@@ -16,7 +16,6 @@ using Akka.Util;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DDataClusterShardingConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DDataClusterShardingConfigSpec.cs
@@ -12,7 +12,6 @@ using Akka.DistributedData.Serialization;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/DurableRememberEntitiesShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/DurableRememberEntitiesShardingSpec.cs
@@ -17,7 +17,6 @@ using Akka.Event;
 using Akka.Persistence.Delivery;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 using static Akka.Tests.Delivery.TestConsumer;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/DurableShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/DurableShardingSpec.cs
@@ -16,7 +16,6 @@ using Akka.Event;
 using Akka.Persistence.Delivery;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 using static Akka.Tests.Delivery.TestConsumer;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/ReliableDeliveryShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Delivery/ReliableDeliveryShardingSpec.cs
@@ -19,12 +19,11 @@ using Akka.Util;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Tests.Delivery.TestConsumer;
 
 namespace Akka.Cluster.Sharding.Tests.Delivery;
 
-public class ReliableDeliveryShardingSpec : TestKit.Xunit2.TestKit
+public class ReliableDeliveryShardingSpec : TestKit.Xunit.TestKit
 {
     public static Config Configuration = @"
         akka.loglevel = DEBUG

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DeprecatedLeastShardAllocationStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/DeprecatedLeastShardAllocationStrategySpec.cs
@@ -13,7 +13,6 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Cluster.ClusterEvent;
 
 namespace Akka.Cluster.Sharding.Tests

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/EntitiesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/EntitiesSpec.cs
@@ -11,7 +11,6 @@ using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/EntityTerminationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/EntityTerminationSpec.cs
@@ -15,7 +15,6 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/External/ExternalShardAllocationStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/External/ExternalShardAllocationStrategySpec.cs
@@ -18,7 +18,6 @@ using Akka.DistributedData;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests.External
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/GetShardTypeNamesSpec.cs
@@ -13,7 +13,6 @@ using Akka.TestKit.TestActors;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/InactiveEntityPassivationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/InactiveEntityPassivationSpec.cs
@@ -16,7 +16,6 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Internal/RememberEntitiesShardStoreSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Internal/RememberEntitiesShardStoreSpec.cs
@@ -16,7 +16,6 @@ using Akka.DistributedData;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests.Internal
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Internal/RememberEntitiesStarterSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/Internal/RememberEntitiesStarterSpec.cs
@@ -15,11 +15,10 @@ using Akka.Cluster.Sharding.Internal;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit.Attributes;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests.Internal
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategyRandomizedSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategyRandomizedSpec.cs
@@ -14,7 +14,6 @@ using Akka.TestKit;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Cluster.ClusterEvent;
 
 namespace Akka.Cluster.Sharding.Tests

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/LeastShardAllocationStrategySpec.cs
@@ -16,7 +16,6 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Cluster.ClusterEvent;
 
 namespace Akka.Cluster.Sharding.Tests

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentShardingMigrationSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentShardingMigrationSpec.cs
@@ -15,7 +15,6 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentStartEntitySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/PersistentStartEntitySpec.cs
@@ -16,7 +16,6 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ProxyShardingSpec.cs
@@ -18,7 +18,7 @@ using Xunit;
 
 namespace Akka.Cluster.Sharding.Tests
 {
-    public class ProxyShardingSpec : Akka.TestKit.Xunit2.TestKit
+    public class ProxyShardingSpec : Akka.TestKit.Xunit.TestKit
     {
         private ClusterSharding clusterSharding;
         private ClusterShardingSettings shardingSettings;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesBatchedUpdatesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesBatchedUpdatesSpec.cs
@@ -14,7 +14,6 @@ using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesFailureSpec.cs
@@ -19,7 +19,6 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesShardIdExtractorChangeSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesShardIdExtractorChangeSpec.cs
@@ -16,7 +16,6 @@ using Akka.Persistence;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesSupervisionStrategyDecisionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesSupervisionStrategyDecisionSpec.cs
@@ -23,7 +23,6 @@ using Akka.Util.Internal;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardEntityFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardEntityFailureSpec.cs
@@ -20,7 +20,6 @@ using Akka.Util;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionQueriesHashCodeSpecs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionQueriesHashCodeSpecs.cs
@@ -15,7 +15,6 @@ using Akka.TestKit;
 using Akka.TestKit.TestActors;
 using Akka.Util;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionQueriesSpecs.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionQueriesSpecs.cs
@@ -14,7 +14,6 @@ using Akka.TestKit;
 using Akka.TestKit.TestActors;
 using Akka.Util;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardRegionSpec.cs
@@ -16,7 +16,6 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Cluster.ClusterEvent;
 using static FluentAssertions.FluentActions;
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardWithLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardWithLeaseSpec.cs
@@ -120,19 +120,20 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         private static Config SpecConfig =>
-            ConfigurationFactory.ParseString(@"
-
-                akka.loglevel = DEBUG
-                akka.actor.provider = ""cluster""
-                akka.remote.dot-netty.tcp.port = 0
-                test-lease {
-                    lease-class = ""Akka.TestKit.TestLease, Akka.Tests.Shared.Internals""
-                    heartbeat-interval = 1s
-                    heartbeat-timeout = 120s
-                    lease-operation-timeout = 3s
-                }
-                akka.cluster.sharding.verbose-debug-logging = on
-                akka.cluster.sharding.fail-on-invalid-entity-state-transition = on")
+            ConfigurationFactory.ParseString(
+                    $$"""
+                    akka.loglevel = DEBUG
+                    akka.actor.provider = "cluster"
+                    akka.remote.dot-netty.tcp.port = 0
+                    test-lease {
+                        lease-class = "{{typeof(TestLease).FullName}}, {{typeof(TestLease).Assembly.GetName().Name}}"
+                        heartbeat-interval = 1s
+                        heartbeat-timeout = 120s
+                        lease-operation-timeout = 3s
+                    }
+                    akka.cluster.sharding.verbose-debug-logging = on
+                    akka.cluster.sharding.fail-on-invalid-entity-state-transition = on
+                    """)
                 .WithFallback(ClusterSingleton.DefaultConfig())
                 .WithFallback(ClusterSharding.DefaultConfig());
 

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardWithLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardWithLeaseSpec.cs
@@ -19,7 +19,6 @@ using Akka.Util;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessProxySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardedDaemonProcessProxySpec.cs
@@ -13,7 +13,6 @@ using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardingBufferAdapterSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardingBufferAdapterSpec.cs
@@ -15,7 +15,6 @@ using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static FluentAssertions.FluentActions;
 
 namespace Akka.Cluster.Sharding.Tests;

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardingQueriesSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardingQueriesSpec.cs
@@ -15,7 +15,6 @@ using Akka.Configuration;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Cluster.Sharding.Shard;
 
 namespace Akka.Cluster.Sharding.Tests

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/StartEntitySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/StartEntitySpec.cs
@@ -16,7 +16,6 @@ using Akka.Util;
 using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/SupervisionSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/SupervisionSpec.cs
@@ -15,7 +15,6 @@ using Akka.Pattern;
 using Akka.TestKit;
 using Akka.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests
 {

--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/WrappedShardBufferedMessageSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/WrappedShardBufferedMessageSpec.cs
@@ -15,7 +15,6 @@ using Akka.Event;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Sharding.Tests;
 


### PR DESCRIPTION
Part of #7742

## Changes

Convert Akka.Cluster.Sharding.Tests to comply to xUnit 3 conventions. No logic change, all changes are done to comply to new xUnit3 and FsCheck conventions only.