### PR TITLE
[xUnit 3] Convert Akka.Persistence.Tests

### DIFF
--- a/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
+++ b/src/core/Akka.Persistence.Tests/Akka.Persistence.Tests.csproj
@@ -3,20 +3,22 @@
 
   <PropertyGroup>
    <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\contrib\serializers\Akka.Serialization.Hyperion\Akka.Serialization.Hyperion.csproj" />
-    <ProjectReference Include="..\Akka.Persistence.TestKit.Xunit2\Akka.Persistence.TestKit.Xunit2.csproj" />
+    <ProjectReference Include="..\Akka.Persistence.TestKit.Xunit\Akka.Persistence.TestKit.Xunit.csproj" />
     <ProjectReference Include="..\Akka.Persistence\Akka.Persistence.csproj" />
     <ProjectReference Include="..\Akka.Remote\Akka.Remote.csproj" />
-    <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryCrashSpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryCrashSpec.cs
@@ -9,9 +9,8 @@ using System;
 using Akka.Actor;
 using Akka.Event;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit.Attributes;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryFailureSpec.cs
@@ -13,7 +13,6 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryReceiveActorSpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryReceiveActorSpec.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit.Attributes;
 using Xunit;
 
 namespace Akka.Persistence.Tests

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliverySpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliverySpec.cs
@@ -12,9 +12,8 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2.Attributes;
+using Akka.TestKit.Xunit.Attributes;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Persistence.Tests

--- a/src/core/Akka.Persistence.Tests/Bugfix7373Specs.cs
+++ b/src/core/Akka.Persistence.Tests/Bugfix7373Specs.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests;
 

--- a/src/core/Akka.Persistence.Tests/Delivery/EventSourcedProducerQueueSpec.cs
+++ b/src/core/Akka.Persistence.Tests/Delivery/EventSourcedProducerQueueSpec.cs
@@ -15,7 +15,6 @@ using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Akka.Delivery.DurableProducerQueue;
 
 namespace Akka.Persistence.Tests.Delivery;

--- a/src/core/Akka.Persistence.Tests/Delivery/ReliableDeliveryWithEventSourcedProducerQueueSpec.cs
+++ b/src/core/Akka.Persistence.Tests/Delivery/ReliableDeliveryWithEventSourcedProducerQueueSpec.cs
@@ -17,7 +17,6 @@ using Akka.TestKit;
 using Akka.Util;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests.Delivery;
 

--- a/src/core/Akka.Persistence.Tests/EndToEndEventAdapterSpec.cs
+++ b/src/core/Akka.Persistence.Tests/EndToEndEventAdapterSpec.cs
@@ -11,7 +11,7 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Journal;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2;
+using Akka.TestKit.Xunit;
 using Xunit;
 
 namespace Akka.Persistence.Tests

--- a/src/core/Akka.Persistence.Tests/FailedSnapshotStoreRecoverySpec.cs
+++ b/src/core/Akka.Persistence.Tests/FailedSnapshotStoreRecoverySpec.cs
@@ -12,7 +12,6 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.Persistence.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests;
 

--- a/src/core/Akka.Persistence.Tests/JournalHealthCheckSpec.cs
+++ b/src/core/Akka.Persistence.Tests/JournalHealthCheckSpec.cs
@@ -15,7 +15,6 @@ using Akka.Persistence.Journal;
 using Akka.TestKit;
 using Akka.TestKit.Configs;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests;
 

--- a/src/core/Akka.Persistence.Tests/LoadPluginSpec.cs
+++ b/src/core/Akka.Persistence.Tests/LoadPluginSpec.cs
@@ -9,7 +9,6 @@ using Akka.Actor;
 using Akka.Configuration;
 using Akka.Persistence.Journal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {

--- a/src/core/Akka.Persistence.Tests/PersistenceCompletionCallbackSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceCompletionCallbackSpec.cs
@@ -12,7 +12,6 @@ using Akka.Actor;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {

--- a/src/core/Akka.Persistence.Tests/PersistenceConfigAutoStartSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceConfigAutoStartSpec.cs
@@ -11,7 +11,6 @@ using Akka.Persistence.Journal;
 using Akka.Persistence.Snapshot;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {

--- a/src/core/Akka.Persistence.Tests/PersistenceConfigSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceConfigSpec.cs
@@ -15,7 +15,6 @@ using Akka.Persistence.Snapshot;
 using Akka.TestKit;
 using Akka.Util;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {

--- a/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
@@ -14,7 +14,7 @@ using Akka.Configuration;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using FluentAssertions;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Persistence.Tests
 {

--- a/src/core/Akka.Persistence.Tests/PersistentActorJournalProtocolSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorJournalProtocolSpec.cs
@@ -11,7 +11,7 @@ using System.Linq;
 using Akka.Actor;
 using Akka.Configuration;
 using Akka.TestKit;
-using Akka.TestKit.Xunit2;
+using Akka.TestKit.Xunit;
 using Xunit;
 
 namespace Akka.Persistence.Tests

--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorAsyncAwaitSpec.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {

--- a/src/core/Akka.Persistence.Tests/ReceivePersistentActorTests.cs
+++ b/src/core/Akka.Persistence.Tests/ReceivePersistentActorTests.cs
@@ -13,7 +13,6 @@ using Akka.Event;
 using Akka.TestKit;
 using Akka.Util.Internal;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests
 {

--- a/src/core/Akka.Persistence.Tests/SnapshotStoreHealthCheckSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotStoreHealthCheckSpec.cs
@@ -13,7 +13,6 @@ using Akka.Persistence.Snapshot;
 using Akka.TestKit;
 using Akka.TestKit.Configs;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Persistence.Tests;
 


### PR DESCRIPTION
Part of #7742

## Changes

Convert Akka.Persistence.Tests to comply to xUnit 3 conventions. No logic change, all changes are done to comply to new xUnit3 and FsCheck conventions only.