### PR TITLE
[xUnit 3] Convert Akka.Persistence.Query.Tests

### DIFF
--- a/src/core/Akka.Persistence.Query.Tests/Akka.Persistence.Query.Tests.csproj
+++ b/src/core/Akka.Persistence.Query.Tests/Akka.Persistence.Query.Tests.csproj
@@ -3,17 +3,19 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
  
   <ItemGroup>
     <ProjectReference Include="..\Akka.Persistence.Query\Akka.Persistence.Query.csproj" />
-    <ProjectReference Include="..\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 

--- a/src/core/Akka.Persistence.Query.Tests/PersistenceQuerySpec.cs
+++ b/src/core/Akka.Persistence.Query.Tests/PersistenceQuerySpec.cs
@@ -8,12 +8,11 @@
 using System;
 using Akka.Configuration;
 using Xunit;
-using Xunit.Abstractions;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;
 
 namespace Akka.Persistence.Query.Tests
 {
-    public class PersistenceQuerySpec : TestKit.Xunit2.TestKit
+    public class PersistenceQuerySpec : TestKit.Xunit.TestKit
     {
         public static readonly Config Config = DummyReadJournalProvider.Config.WithFallback(ConfigurationFactory.Default());
 


### PR DESCRIPTION
Part of #7742

## Changes

Convert Akka.Persistence.Query.Tests to comply to xUnit 3 conventions. No logic change, all changes are done to comply to new xUnit3 and FsCheck conventions only.