### PR TITLE
[xUnit 3] Convert Akka.Persistence.Query.InMemory.Tests

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/Akka.Persistence.Query.InMemory.Tests.csproj
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/Akka.Persistence.Query.InMemory.Tests.csproj
@@ -4,17 +4,19 @@
     <PropertyGroup>
         <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
         <IsPackable>false</IsPackable>
+        <OutputType>Exe</OutputType>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\..\core\Akka.Persistence.TCK.Xunit2\Akka.Persistence.TCK.Xunit2.csproj" />
+      <ProjectReference Include="..\..\..\core\Akka.Persistence.TCK\Akka.Persistence.TCK.csproj" />
       <ProjectReference Include="..\Akka.Persistence.Query.InMemory\Akka.Persistence.Query.InMemory.csproj" />
     </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-      <PackageReference Include="xunit" Version="$(XunitVersion)" />
-      <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+      <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+      <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
       <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     </ItemGroup>
 

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryAllEventsSpec.cs
@@ -7,7 +7,7 @@
 
 using Akka.Configuration;
 using Akka.Persistence.TCK.Query;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Persistence.Query.InMemory.Tests
 {

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentAllEventsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentAllEventsSpec.cs
@@ -7,7 +7,7 @@
 
 using Akka.Configuration;
 using Akka.Persistence.TCK.Query;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Persistence.Query.InMemory.Tests
 {

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByPersistenceIdSpec.cs
@@ -7,7 +7,7 @@
 
 using Akka.Configuration;
 using Akka.Persistence.TCK.Query;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Persistence.Query.InMemory.Tests
 {

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentEventsByTagSpec.cs
@@ -7,22 +7,24 @@
 
 using Akka.Configuration;
 using Akka.Persistence.TCK.Query;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Persistence.Query.InMemory.Tests
 {
     public class InMemoryCurrentEventsByTagSpec : CurrentEventsByTagSpec
     {
-        private static Config Config() => ConfigurationFactory.ParseString(@"
-            akka.loglevel = INFO
-            akka.persistence.journal.inmem {
-                event-adapters {
-                  color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK.Xunit2""
+        private static Config Config() => ConfigurationFactory.ParseString(
+                $$"""
+                akka.loglevel = INFO
+                akka.persistence.journal.inmem {
+                    event-adapters {
+                      color-tagger  = "{{typeof(ColorFruitTagger).FullName}}, {{typeof(ColorFruitTagger).Assembly.GetName().Name}}"
+                    }
+                    event-adapter-bindings = {
+                      "System.String" = color-tagger
+                    }
                 }
-                event-adapter-bindings = {
-                  ""System.String"" = color-tagger
-                }
-            }")
+                """)
             .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryCurrentEventsByTagSpec(ITestOutputHelper output) : 

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryCurrentPersistenceIdsSpec.cs
@@ -7,7 +7,7 @@
 
 using Akka.Configuration;
 using Akka.Persistence.TCK.Query;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Persistence.Query.InMemory.Tests
 {

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByPersistenceIdSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByPersistenceIdSpec.cs
@@ -7,7 +7,7 @@
 
 using Akka.Configuration;
 using Akka.Persistence.TCK.Query;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Persistence.Query.InMemory.Tests
 {

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryEventsByTagSpec.cs
@@ -7,22 +7,24 @@
 
 using Akka.Configuration;
 using Akka.Persistence.TCK.Query;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Persistence.Query.InMemory.Tests
 {
     public class InMemoryEventsByTagSpec : EventsByTagSpec
     {
-        private static Config Config() => ConfigurationFactory.ParseString(@"
-            akka.loglevel = INFO
-            akka.persistence.journal.inmem {
-                event-adapters {
-                  color-tagger  = ""Akka.Persistence.TCK.Query.ColorFruitTagger, Akka.Persistence.TCK.Xunit2""
+        private static Config Config() => ConfigurationFactory.ParseString(
+                $$"""
+                akka.loglevel = INFO
+                akka.persistence.journal.inmem {
+                    event-adapters {
+                      color-tagger  = "{{typeof(ColorFruitTagger).FullName}}, {{typeof(ColorFruitTagger).Assembly.GetName().Name}}"
+                    }
+                    event-adapter-bindings = {
+                      "System.String" = color-tagger
+                    }
                 }
-                event-adapter-bindings = {
-                  ""System.String"" = color-tagger
-                }
-            }")
+                """)
             .WithFallback(InMemoryPersistenceSpecConfig.Config);
 
         public InMemoryEventsByTagSpec(ITestOutputHelper output) : 

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceIdsSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryPersistenceIdsSpec.cs
@@ -8,7 +8,7 @@
 using System;
 using Akka.Configuration;
 using Akka.Persistence.TCK.Query;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Akka.Persistence.Query.InMemory.Tests
 {


### PR DESCRIPTION
Part of #7742

## Changes

Convert Akka.Persistence.Query.InMemory.Tests to comply to xUnit 3 conventions. No logic change, all changes are done to comply to new xUnit3 and FsCheck conventions only.