### PR TITLE
[xUnit 3] Convert Akka.Cluster.Tools.Tests

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Akka.Cluster.Tools.Tests.csproj
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Akka.Cluster.Tools.Tests.csproj
@@ -3,17 +3,19 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetFrameworkTestVersion);$(NetTestVersion)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Akka.Cluster.Tools\Akka.Cluster.Tools.csproj" />
-    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals\Akka.Tests.Shared.Internals.csproj" />
+    <ProjectReference Include="..\..\..\core\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
   </ItemGroup>
 

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/ClusterClient/ClusterClientSerializerSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/ClusterClient/ClusterClientSerializerSpec.cs
@@ -17,7 +17,6 @@ using Akka.Configuration;
 using Akka.Serialization;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 using FluentAssertions;
 
 namespace Akka.Cluster.Tools.Tests.ClusterClient;

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubDeadLetterSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubDeadLetterSpec.cs
@@ -13,7 +13,6 @@ using Akka.Configuration;
 using Akka.Event;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.PublishSubscribe
 {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorRouterSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubMediatorRouterSpec.cs
@@ -13,7 +13,6 @@ using Akka.Event;
 using Akka.Routing;
 using Akka.TestKit;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.PublishSubscribe
 {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubPublishWithAckSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/PublishSubscribe/DistributedPubSubPublishWithAckSpec.cs
@@ -13,7 +13,6 @@ using Akka.Configuration;
 using Akka.TestKit;
 using FluentAssertions.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.PublishSubscribe;
 

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonApiSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonApiSpec.cs
@@ -14,7 +14,6 @@ using Akka.TestKit;
 using Akka.TestKit.Configs;
 using Akka.TestKit.Extensions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.Singleton
 {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonConfigSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonConfigSpec.cs
@@ -16,7 +16,7 @@ using Xunit;
 namespace Akka.Cluster.Tools.Tests.Singleton
 {
     // <ClusterSingletonConfigSpec>
-    public class ClusterSingletonConfigSpec : TestKit.Xunit2.TestKit
+    public class ClusterSingletonConfigSpec : TestKit.Xunit.TestKit
     {
         public ClusterSingletonConfigSpec() : base(GetConfig())
         {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonLeaseSpec.cs
@@ -23,7 +23,6 @@ using DotNetty.Common.Concurrency;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.Singleton
 {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonProxySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonProxySpec.cs
@@ -17,11 +17,10 @@ using Akka.TestKit;
 using Xunit;
 using FluentAssertions;
 using FluentAssertions.Extensions;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.Singleton
 {
-    public class ClusterSingletonProxySpec : TestKit.Xunit2.TestKit
+    public class ClusterSingletonProxySpec : TestKit.Xunit.TestKit
     {
         public ClusterSingletonProxySpec(ITestOutputHelper output): base(output: output)
         {
@@ -235,7 +234,7 @@ namespace Akka.Cluster.Tools.Tests.Singleton
             }
         }
         
-        private class ActorSys : TestKit.Xunit2.TestKit
+        private class ActorSys : TestKit.Xunit.TestKit
         {
             public Cluster Cluster { get; }
 

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestart2Spec.cs
@@ -15,7 +15,6 @@ using Akka.Configuration;
 using Akka.TestKit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.Singleton
 {

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests/Singleton/ClusterSingletonRestartSpec.cs
@@ -16,7 +16,6 @@ using Akka.TestKit;
 using Akka.TestKit.TestActors;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Akka.Cluster.Tools.Tests.Singleton
 {


### PR DESCRIPTION
Part of #7742

## Changes

Convert Akka.Cluster.Tools.Tests to comply to xUnit 3 conventions. No logic change, all changes are done to comply to new xUnit3 and FsCheck conventions only.