### PR TITLE
Remove FluentAssertions from Akka.Persistence.TCK and Akka.Persistence.TCK.Xunit2

### DIFF
--- a/src/core/Akka.Persistence.TCK.Xunit2/Akka.Persistence.TCK.Xunit2.csproj
+++ b/src/core/Akka.Persistence.TCK.Xunit2/Akka.Persistence.TCK.Xunit2.csproj
@@ -15,7 +15,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)"/>
         <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     </ItemGroup>
 

--- a/src/core/Akka.Persistence.TCK/Akka.Persistence.TCK.csproj
+++ b/src/core/Akka.Persistence.TCK/Akka.Persistence.TCK.csproj
@@ -15,7 +15,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)"/>
         <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     </ItemGroup>
 

--- a/src/core/Akka.Persistence.TCK/Query/CurrentEventsByPersistenceIdSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/CurrentEventsByPersistenceIdSpec.cs
@@ -15,7 +15,6 @@ using Akka.Streams;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Util.Internal;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Persistence.TCK.Query
@@ -199,9 +198,9 @@ namespace Akka.Persistence.TCK.Query
 
             var probe = src.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
             probe.Request(5);
-            probe.ExpectNext().Timestamp.Should().BeGreaterThan(0);
-            probe.ExpectNext().Timestamp.Should().BeGreaterThan(0);
-            probe.ExpectNext().Timestamp.Should().BeGreaterThan(0);
+            Assert.True( probe.ExpectNext().Timestamp > 0 );
+            Assert.True( probe.ExpectNext().Timestamp > 0 );
+            Assert.True( probe.ExpectNext().Timestamp > 0 );
             probe.ExpectComplete();
         }
 

--- a/src/core/Akka.Persistence.TCK/Query/CurrentEventsByTagSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/CurrentEventsByTagSpec.cs
@@ -14,7 +14,6 @@ using Akka.Persistence.Query;
 using Akka.Streams;
 using Akka.Streams.TestKit;
 using Akka.Streams.Dsl;
-using FluentAssertions;
 using Xunit;
 using Xunit.Sdk;
 using static Akka.Persistence.Query.Offset;
@@ -244,8 +243,8 @@ namespace Akka.Persistence.TCK.Query
             var greenSrc = queries.CurrentEventsByTag("green", offset: NoOffset());
             var probe = greenSrc.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
             probe.Request(2);
-            probe.ExpectNext().Timestamp.Should().BeGreaterThan(0);
-            probe.ExpectNext().Timestamp.Should().BeGreaterThan(0);
+            Assert.True( probe.ExpectNext().Timestamp > 0 );
+            Assert.True( probe.ExpectNext().Timestamp > 0 );
             probe.Cancel();
         }
 
@@ -267,13 +266,13 @@ namespace Akka.Persistence.TCK.Query
         private EventEnvelope ExpectEnvelope(TestSubscriber.Probe<EventEnvelope> probe, string persistenceId, long sequenceNr, string @event, string tag)
         {
             var envelope = probe.ExpectNext<EventEnvelope>(_ => true);
-            envelope.PersistenceId.Should().Be(persistenceId);
-            envelope.SequenceNr.Should().Be(sequenceNr);
-            envelope.Event.Should().Be(@event);
+            Assert.Equal(persistenceId, envelope.PersistenceId);
+            Assert.Equal(sequenceNr, envelope.SequenceNr);
+            Assert.Equal(@event, envelope.Event);
             if (SupportsTagsInEventEnvelope)
             {
-                envelope.Tags.Should().NotBeNull();
-                envelope.Tags.Should().Contain(tag);
+                Assert.NotNull(envelope.Tags);
+                Assert.Contains(tag, envelope.Tags);
             }
             return envelope;
         }

--- a/src/core/Akka.Persistence.TCK/Query/EventsByPersistenceIdSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/EventsByPersistenceIdSpec.cs
@@ -15,7 +15,6 @@ using Akka.Streams;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
 using Akka.Util.Internal;
-using FluentAssertions;
 using Xunit;
 
 namespace Akka.Persistence.TCK.Query
@@ -103,8 +102,8 @@ namespace Akka.Persistence.TCK.Query
 
             var probe = src.RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
             probe.Request(5);
-            probe.ExpectNext().Timestamp.Should().BeGreaterThan(0);
-            probe.ExpectNext().Timestamp.Should().BeGreaterThan(0);
+            Assert.True( probe.ExpectNext().Timestamp > 0 );
+            Assert.True( probe.ExpectNext().Timestamp > 0 );
             probe.Cancel();
         }
 

--- a/src/core/Akka.Persistence.TCK/Query/EventsByTagSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/EventsByTagSpec.cs
@@ -12,7 +12,6 @@ using Akka.Persistence.Query;
 using Akka.Streams;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
-using FluentAssertions;
 using Xunit;
 using Xunit.Sdk;
 using static Akka.Persistence.Query.Offset;
@@ -114,13 +113,13 @@ namespace Akka.Persistence.TCK.Query
         private EventEnvelope ExpectEnvelope(TestSubscriber.Probe<EventEnvelope> probe, string persistenceId, long sequenceNr, string @event, string tag)
         {
             var envelope = probe.ExpectNext<EventEnvelope>(_ => true);
-            envelope.PersistenceId.Should().Be(persistenceId);
-            envelope.SequenceNr.Should().Be(sequenceNr);
-            envelope.Event.Should().Be(@event);
+            Assert.Equal(persistenceId, envelope.PersistenceId);
+            Assert.Equal(sequenceNr, envelope.SequenceNr);
+            Assert.Equal(@event, envelope.Event);
             if (SupportsTagsInEventEnvelope)
             {
-                envelope.Tags.Should().NotBeNull();
-                envelope.Tags.Should().Contain(tag);
+                Assert.NotNull(envelope.Tags);
+                Assert.Contains(tag, envelope.Tags);
             }
             return envelope;
         }

--- a/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/PersistenceIdsSpec.cs
@@ -17,7 +17,6 @@ using Akka.Streams;
 using Akka.Streams.TestKit;
 using Akka.TestKit;
 using Akka.Util.Internal;
-using FluentAssertions;
 using Reactive.Streams;
 using Xunit;
 
@@ -80,7 +79,7 @@ namespace Akka.Persistence.TCK.Query
             var expected = new List<string> { "h", "i", "j" };
             probe.Within(TimeSpan.FromSeconds(10), () =>
             {
-                expected.Remove(probe.Request(1).ExpectNext()).Should().BeTrue();
+                Assert.True(expected.Remove(probe.Request(1).ExpectNext()));
                 return probe.ExpectNoMsg(TimeSpan.FromMilliseconds(500));
             });
 

--- a/src/core/Akka.Persistence.TCK/Serialization/SnapshotStoreSerializationSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Serialization/SnapshotStoreSerializationSpec.cs
@@ -14,7 +14,6 @@ using Akka.Persistence.Fsm;
 using Akka.Serialization;
 using Xunit;
 using Akka.Util.Internal;
-using FluentAssertions;
 
 #nullable enable
 namespace Akka.Persistence.TCK.Serialization

--- a/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSaveSnapshotSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSaveSnapshotSpec.cs
@@ -14,8 +14,6 @@ using Akka.Configuration;
 using Akka.Persistence.Snapshot;
 using Akka.Persistence.TCK.Serialization;
 using Akka.TestKit;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Akka.Persistence.TCK.Snapshot;
@@ -89,8 +87,8 @@ akka.actor {
             var result = await SenderProbe.ExpectMsgAsync<int[]>();
             await StopActorAsync(persistenceActor);
             
-            result.Length.Should().Be(1, $"expecting an array with length 1 (on iteration {iteration}/{RepeatCount})");
-            result[0].Should().Be(3, $"recovered snapshot should be the last snapshot (on iteration {iteration}/{RepeatCount})");
+            Assert.Single(result); // expecting an array with length 1
+            Assert.Equal(3, result[0]); // recovered snapshot should be the last snapshot
             
             Output.WriteLine($"Iteration: {iteration}");
         }
@@ -124,8 +122,8 @@ akka.actor {
             var result = await SenderProbe.ExpectMsgAsync<int[]>();
             await StopActorAsync(persistenceActor);
             
-            result.Length.Should().Be(1, $"expecting an array with length 1 (on iteration {iteration}/{RepeatCount})");
-            result[0].Should().Be(3, $"recovered snapshot should be the last snapshot (on iteration {iteration}/{RepeatCount})");
+            Assert.Single(result); // expecting an array with length 1
+            Assert.Equal(3, result[0]); // recovered snapshot should be the last snapshot
             
             Output.WriteLine($"Iteration: {iteration}");
         }
@@ -140,17 +138,17 @@ akka.actor {
         
         var metadata = new SnapshotMetadata(PersistenceId, 3, DateTime.UtcNow);
         snapshotStore.Tell(new SaveSnapshot(metadata, snap), SenderProbe);
-        var success = await SenderProbe.ExpectMsgAsync<SaveSnapshotSuccess>(10.Minutes());
-        success.Metadata.PersistenceId.Should().Be(metadata.PersistenceId);
-        success.Metadata.Timestamp.Should().Be(metadata.Timestamp);
-        success.Metadata.SequenceNr.Should().Be(metadata.SequenceNr);
+        var success = await SenderProbe.ExpectMsgAsync<SaveSnapshotSuccess>(TimeSpan.FromMinutes(10));
+        Assert.Equal(success.Metadata.PersistenceId, metadata.PersistenceId);
+        Assert.Equal(success.Metadata.Timestamp, metadata.Timestamp);
+        Assert.Equal(success.Metadata.SequenceNr, metadata.SequenceNr);
         
         metadata = new SnapshotMetadata(PersistenceId, 3, DateTime.UtcNow);
         snapshotStore.Tell(new SaveSnapshot(metadata, 3), SenderProbe);
         success = await SenderProbe.ExpectMsgAsync<SaveSnapshotSuccess>();
-        success.Metadata.PersistenceId.Should().Be(metadata.PersistenceId);
-        success.Metadata.Timestamp.Should().Be(metadata.Timestamp);
-        success.Metadata.SequenceNr.Should().Be(metadata.SequenceNr);
+        Assert.Equal(success.Metadata.PersistenceId, metadata.PersistenceId);
+        Assert.Equal(success.Metadata.Timestamp, metadata.Timestamp);
+        Assert.Equal(success.Metadata.SequenceNr, metadata.SequenceNr);
     }
     
     #region Utility

--- a/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Snapshot/SnapshotStoreSpec.cs
@@ -14,8 +14,6 @@ using Akka.Configuration;
 using Akka.Persistence.Fsm;
 using Akka.Persistence.TCK.Serialization;
 using Akka.TestKit;
-using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 
 namespace Akka.Persistence.TCK.Snapshot
@@ -234,7 +232,7 @@ namespace Akka.Persistence.TCK.Snapshot
         {
             var md = Metadata[2];
             // timestamp argument is less than the actual metadata data stored in the database, no deletion occured
-            md = new SnapshotMetadata(md.PersistenceId, md.SequenceNr, md.Timestamp - 2.Seconds());
+            md = new SnapshotMetadata(md.PersistenceId, md.SequenceNr, md.Timestamp - TimeSpan.FromSeconds(2));
             var command = new DeleteSnapshot(md);
             var sub = CreateTestProbe();
 


### PR DESCRIPTION
Part of #8095

## Changes

Remove FluentAssertions from Akka.Persistence.TCK and Akka.Persistence.TCK.Xunit2