### PR TITLE
Fix stale ACK causing irrecoverable quarantine after transient network disruption

### DIFF
--- a/src/core/Akka.Remote.Tests/AckedDeliverySpec.cs
+++ b/src/core/Akka.Remote.Tests/AckedDeliverySpec.cs
@@ -205,6 +205,33 @@ namespace Akka.Remote.Tests
         }
 
         [Fact]
+        public void SendBuffer_must_ignore_stale_ack_from_previous_association()
+        {
+            // Reproduces GitHub #6414: a fresh send buffer (MaxSeq = -1) receives a stale ACK
+            // from a previous association. This must be a no-op, not a throw.
+            var b0 = new AckedSendBuffer<Sequenced>(10);
+
+            // ACK[0] from stale receiver state - MaxSeq is -1, CumulativeAck is 0
+            var result = b0.Acknowledge(new Ack(new SeqNo(0)));
+            Assert.Same(b0, result); // should return the same instance (no-op)
+        }
+
+        [Fact]
+        public void SendBuffer_must_ignore_stale_ack_when_buffer_has_messages_with_lower_seqnos()
+        {
+            // A buffer with some messages receives a stale ACK referencing a higher sequence
+            // number than anything buffered - should be a no-op.
+            var b0 = new AckedSendBuffer<Sequenced>(10);
+            var msg0 = Msg(0);
+            var msg1 = Msg(1);
+            var b1 = b0.Buffer(msg0).Buffer(msg1); // MaxSeq = 1
+
+            // Stale ACK referencing SeqNo(5) which we never sent
+            var result = b1.Acknowledge(new Ack(new SeqNo(5)));
+            Assert.Same(b1, result); // should return the same instance (no-op)
+        }
+
+        [Fact]
         public void SendBuffer_must_throw_exception_if_nonbuffered_sequence_number_is_NACKed()
         {
             var b0 = new AckedSendBuffer<Sequenced>(10);

--- a/src/core/Akka.Remote/AckedDelivery.cs
+++ b/src/core/Akka.Remote/AckedDelivery.cs
@@ -431,9 +431,13 @@ namespace Akka.Remote
         /// <returns>An updated buffer containing the remaining unacknowledged messages</returns>
         public AckedSendBuffer<T> Acknowledge(Ack ack)
         {
+            // If the ACK references a sequence number higher than anything we've sent,
+            // it's a stale ACK from a previous association. The buffer is empty or has
+            // only messages with lower sequence numbers — there's nothing to acknowledge.
+            // Throwing here would cause an irrecoverable quarantine (see GitHub #6414).
             if (ack.CumulativeAck > MaxSeq)
             {
-                throw new ArgumentException(nameof(ack), $"Highest SEQ so far was {MaxSeq} but cumulative ACK is {ack.CumulativeAck}");
+                return this;
             }
 
             var newNacked = ack.Nacks.Count == 0

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -611,9 +611,8 @@ namespace Akka.Remote
                 {
                     try
                     {
-                        var oldBuffer = _resendBuffer;
                         _resendBuffer = _resendBuffer.Acknowledge(ack);
-                        if (ReferenceEquals(_resendBuffer, oldBuffer) && ack.CumulativeAck > _resendBuffer.MaxSeq)
+                        if (ack.CumulativeAck > _resendBuffer.MaxSeq)
                         {
                             _log.Warning(
                                 "Ignoring stale ACK [{0}] for send buffer [{1}] - likely from a previous association to [{2}]",

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -611,7 +611,14 @@ namespace Akka.Remote
                 {
                     try
                     {
+                        var oldBuffer = _resendBuffer;
                         _resendBuffer = _resendBuffer.Acknowledge(ack);
+                        if (ReferenceEquals(_resendBuffer, oldBuffer) && ack.CumulativeAck > _resendBuffer.MaxSeq)
+                        {
+                            _log.Warning(
+                                "Ignoring stale ACK [{0}] for send buffer [{1}] - likely from a previous association to [{2}]",
+                                ack, _resendBuffer, _remoteAddress);
+                        }
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Fixes #6414

### Problem

When a transient network disruption occurs and a node reconnects with the same UID (process stayed alive), a stale ACK from the remote node's previous receive buffer state can trigger an `ArgumentException` in `AckedSendBuffer<T>.Acknowledge()`. This exception is wrapped in a `HopelessAssociation`, which causes an **irrecoverable quarantine** of the remote node.

In production, this quarantine creates an "indirectly connected" topology that can cause SBR's `keep-majority` strategy to down an entire cluster.

The root cause is a guard check that throws when `ack.CumulativeAck > MaxSeq`:

```
Error encountered while processing system message acknowledgement buffer: [-1 []] ack: ACK[0, []]
---> System.ArgumentException: Highest SEQ so far was -1 but cumulative ACK is 0
```

This happens because:
1. The sender's `ReliableDeliverySupervisor` creates a fresh `AckedSendBuffer` with `MaxSeq = -1` (new endpoint)
2. The receiver's `EndpointReader.PreStart()` restores a stale `AckedReceiveBuffer` from the shared `_receiveBuffers` dictionary (UID matches), and sends `ACK[0]` based on old state
3. The guard check `0 > -1` fires and throws, quarantining the association

### Fix

Changed the guard in `AckedSendBuffer<T>.Acknowledge()` from a hard throw to a no-op `return this`. When the ACK references a sequence number higher than anything in the buffer, there is nothing to acknowledge and nothing to corrupt - the buffer is either empty or contains only messages with lower sequence numbers.

Added a warning log at the `ReliableDeliverySupervisor` call site so operators have visibility when stale ACKs are being ignored.

### Tests

Added two unit tests to `AckedDeliverySpec` that reproduce the exact failure:
- Fresh buffer (`MaxSeq = -1`) receiving `ACK[0]` - the production scenario from #6414
- Buffer with messages (`MaxSeq = 1`) receiving `ACK[5]` - stale ACK referencing higher sequence numbers

Both tests fail with the original `ArgumentException` on the old code and pass with the fix.
