### PR TITLE
Fix `Settings.RebuildConfig()` stale-write race in `InjectTopLevelFallback`

### DIFF
--- a/src/core/Akka/Actor/Settings.cs
+++ b/src/core/Akka/Actor/Settings.cs
@@ -13,7 +13,6 @@ using Akka.Configuration;
 using Akka.Dispatch;
 using Akka.Event;
 using Akka.Routing;
-using Akka.Util;
 using ConfigurationFactory = Akka.Configuration.ConfigurationFactory;
 
 namespace Akka.Actor
@@ -28,7 +27,8 @@ namespace Akka.Actor
     {
         private readonly Config _userConfig;
         //internal static readonly Config AkkaDllConfig = ConfigurationFactory.FromResource<Settings>("Akka.Configuration.Pigeon.conf");
-        private readonly AtomicReference<Config> _fallbackConfig;
+        private Config _fallbackConfig;
+        private readonly object _configLock = new();
 
         private void RebuildConfig()
         {
@@ -49,15 +49,11 @@ namespace Akka.Actor
             if (Config.Contains(config)) 
                 return;
 
-            while(true)
+            lock (_configLock)
             {
-                var oldConfig = _fallbackConfig.Value;
-                var newConfig = config.SafeWithFallback(oldConfig);
-                if (_fallbackConfig.CompareAndSet(oldConfig, newConfig))
-                    break;
+                _fallbackConfig = config.SafeWithFallback(_fallbackConfig);
+                RebuildConfig();
             }
-    
-            RebuildConfig();
         }
 
         /// <summary>
@@ -85,7 +81,7 @@ namespace Akka.Actor
         {
             Setup = setup;
             _userConfig = config;
-            _fallbackConfig = new AtomicReference<Config>(ConfigurationFactory.Default());
+            _fallbackConfig = ConfigurationFactory.Default();
             RebuildConfig();
 
             System = system;


### PR DESCRIPTION
Closes #8114

### Summary

- Replace the lock-free CAS loop + separate `RebuildConfig()` with a `lock` that covers the entire `InjectTopLevelFallback` mutation — `_fallbackConfig` update, `Config` property write, and dispatcher/serialization reload are now atomic
- Revert `_fallbackConfig` from `AtomicReference<Config>` to a plain `Config` field since the lock provides mutual exclusion
- Move the `Config.Contains()` early-exit check outside the lock as a fast-path optimization — a false negative just means we enter the lock and do idempotent work

### The bug

PR #7721 made `_fallbackConfig` an `AtomicReference<Config>` with a CAS loop, which correctly ensures the fallback chain accumulates all injected configs. However, `RebuildConfig()` reads `_fallbackConfig.Value` and writes the result to the `Config` auto-property in a separate non-atomic step. If a thread is preempted between reading `_fallbackConfig` and writing `Config` inside `RebuildConfig()`, another thread can complete the full `InjectTopLevelFallback` cycle and write a newer `Config` — which the first thread then overwrites with a stale value.

### Why a lock

`InjectTopLevelFallback` is only called during extension initialization — it is not a hot path. The simplicity and correctness guarantees of a lock outweigh the negligible cost.