### PR TITLE
[1.5] Port #8145 - Fix broken xUnit 3 explicit sender (IAsyncLifetime)

### DIFF
--- a/src/contrib/testkits/Akka.TestKit.Xunit.Tests/Bugfix8144Spec.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit.Tests/Bugfix8144Spec.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Bugfix8144Spec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.TestKit.TestActors;
+using Xunit;
+
+namespace Akka.TestKit.Tests;
+
+/// <summary>
+/// Verifies that implicit sender (TestActor) is preserved across async boundaries.
+/// Regression test for https://github.com/akkadotnet/akka.net/issues/8144
+/// </summary>
+public class Bugfix8144Spec: Xunit.TestKit, IAsyncLifetime
+{
+    public ValueTask DisposeAsync()
+    {
+        return new ValueTask(Task.CompletedTask);
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        // Any await here can cause a thread switch, which previously
+        // lost the [ThreadStatic] InternalCurrentActorCellKeeper.Current
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact]
+    public void Should_use_implicit_TestActor_sender_after_async_initialization()
+    {
+        // SimpleEchoActor echoes back to Sender - tests that implicit sender works
+        var actor = Sys.ActorOf(SimpleEchoActor.Props());
+
+        // This uses ActorRefImplicitSenderExtensions.Tell which resolves
+        // the sender via ActorCell.GetCurrentSelfOrNoSender()
+        actor.Tell("hello");
+
+        // Should receive the echo back at TestActor
+        ExpectMsg("hello");
+    }
+}

--- a/src/contrib/testkits/Akka.TestKit.Xunit/TestKit.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/TestKit.cs
@@ -140,6 +140,47 @@ public class TestKit : TestKitBase, IDisposable
     }
 
     /// <summary>
+    /// Ensures the implicit sender (<see cref="InternalCurrentActorCellKeeper.Current"/>) is set
+    /// on the current thread. This is needed because the <c>[ThreadStatic]</c> value can be lost
+    /// when <c>IAsyncLifetime.InitializeAsync</c> contains an <c>await</c> that causes a thread switch.
+    /// Called automatically when accessing <see cref="Sys"/> or <see cref="TestActor"/>.
+    /// </summary>
+    private void EnsureImplicitSender()
+    {
+        // Only set the implicit sender if Current is not already set.
+        // During actor message processing, Mailbox.Run() sets Current to the actor's cell.
+        // Overwriting it here would corrupt the actor context for the rest of that mailbox run.
+        if (this is not INoImplicitSender && InternalCurrentActorCellKeeper.Current == null)
+            InternalCurrentActorCellKeeper.Current = (ActorCell)((ActorRefWithCell)base.TestActor).Underlying;
+    }
+
+    /// <summary>
+    /// The <see cref="ActorSystem"/> used for testing. Accessing this property ensures the
+    /// implicit sender is set on the current thread.
+    /// </summary>
+    public new ActorSystem Sys
+    {
+        get
+        {
+            EnsureImplicitSender();
+            return base.Sys;
+        }
+    }
+
+    /// <summary>
+    /// The default test actor. Accessing this property ensures the implicit sender
+    /// is set on the current thread.
+    /// </summary>
+    public new IActorRef TestActor
+    {
+        get
+        {
+            EnsureImplicitSender();
+            return base.TestActor;
+        }
+    }
+
+    /// <summary>
     /// A configuration that has just the default log settings enabled. The default settings can be found in
     /// <a href="https://github.com/akkadotnet/akka.net/blob/master/src/core/Akka.TestKit/Internal/Reference.conf">Akka.TestKit.Internal.Reference.conf</a>.
     /// </summary>

--- a/src/contrib/testkits/Akka.TestKit.Xunit2.Tests/Bugfix8144Spec.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit2.Tests/Bugfix8144Spec.cs
@@ -1,0 +1,47 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Bugfix8144Spec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.TestKit.TestActors;
+using Xunit;
+
+namespace Akka.TestKit.Tests;
+
+/// <summary>
+/// Verifies that implicit sender (TestActor) is preserved across async boundaries.
+/// Regression test for https://github.com/akkadotnet/akka.net/issues/8144
+/// </summary>
+public class Bugfix8144Spec: Xunit2.TestKit, IAsyncLifetime
+{
+    public Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Any await here can cause a thread switch, which previously
+        // lost the [ThreadStatic] InternalCurrentActorCellKeeper.Current
+        await Task.Delay(TimeSpan.FromMilliseconds(100));
+    }
+
+    [Fact]
+    public void Should_use_implicit_TestActor_sender_after_async_initialization()
+    {
+        // SimpleEchoActor echoes back to Sender - tests that implicit sender works
+        var actor = Sys.ActorOf(SimpleEchoActor.Props());
+
+        // This uses ActorRefImplicitSenderExtensions.Tell which resolves
+        // the sender via ActorCell.GetCurrentSelfOrNoSender()
+        actor.Tell("hello");
+
+        // Should receive the echo back at TestActor
+        ExpectMsg("hello");
+    }
+}


### PR DESCRIPTION
## Summary

- Backport of #8145 to v1.5 branch
- Fixes broken xUnit 3 explicit sender support with `IAsyncLifetime`
- Adds reproduction tests (`Bugfix8144Spec`) for both Xunit and Xunit2 test kits

Fixes #8144