### PR TITLE
[dev] Port #8150 - Fix cluster sharding lease coordination bugs

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardWithLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/ShardWithLeaseSpec.cs
@@ -225,5 +225,79 @@ namespace Akka.Cluster.Sharding.Tests
                 probe.ExpectNoMsg(shortDuration);
             });
         }
+
+        /// <summary>
+        /// Reproduces https://github.com/akkadotnet/akka.net/issues/8147
+        /// When a shard is in AwaitingLease state, HandOff messages should be handled
+        /// immediately (not stashed) since the shard has no active entities.
+        /// </summary>
+        [Fact]
+        public async Task Lease_handling_in_sharding_should_respond_to_HandOff_while_awaiting_lease()
+        {
+            var setup = new Setup(this);
+            var probe = CreateTestProbe();
+
+            // Send a message to trigger shard creation - shard enters AwaitingLease
+            setup.Sharding.Tell(new EntityEnvelope(1, "hello"), probe.Ref);
+
+            // Wait for the shard to start and enter AwaitingLease (don't resolve the lease)
+            setup.LeaseFor("1");
+
+            // Verify shard is blocked on lease
+            await probe.ExpectNoMsgAsync(shortDuration);
+
+            // Send HandOff to the ShardRegion - it should forward to the shard via Forward
+            var handOffProbe = CreateTestProbe();
+            setup.Sharding.Tell(new ShardCoordinator.HandOff("1"), handOffProbe.Ref);
+
+            // The shard should respond with ShardStopped immediately since it has no entities.
+            // BUG: Currently fails because AwaitingLease stashes HandOff indefinitely.
+            await handOffProbe.ExpectMsgAsync<ShardCoordinator.ShardStopped>(TimeSpan.FromSeconds(3));
+        }
+
+        /// <summary>
+        /// Reproduces https://github.com/akkadotnet/akka.net/issues/8146
+        /// When a ShardStopped is received from a region that is NOT the current owner
+        /// of the shard, the coordinator should ignore it (stale backup from completed rebalance).
+        /// </summary>
+        [Fact]
+        public async Task Coordinator_should_ignore_stale_ShardStopped_from_non_owner_region()
+        {
+            var setup = new Setup(this);
+            var probe = CreateTestProbe();
+
+            // Create shard and acquire lease
+            setup.Sharding.Tell(new EntityEnvelope(1, "hello"), probe.Ref);
+            var lease = setup.LeaseFor("1");
+            lease.InitialPromise.SetResult(true);
+            await probe.ExpectMsgAsync("ack hello");
+
+            // Resolve the coordinator actor
+            var encName = Uri.EscapeDataString(setup.TypeName);
+            var coordinatorPath = $"/system/sharding/{encName}Coordinator/singleton/coordinator";
+            IActorRef coordinator = null;
+            await AwaitAssertAsync(async () =>
+            {
+                coordinator = await Sys.ActorSelection(coordinatorPath).ResolveOne(TimeSpan.FromSeconds(1));
+            });
+
+            // Send ShardStopped from a TestProbe (simulating a stale backup from a
+            // dead/old region that no longer owns the shard)
+            var staleRegionProbe = CreateTestProbe();
+
+            // The coordinator should ignore ShardStopped from a non-owner sender.
+            // Use Identify as a FIFO mailbox barrier to prove the coordinator has
+            // processed the ShardStopped before we check for the log message.
+            await EventFilter.Info(contains: "late deallocation").ExpectAsync(0, async () =>
+            {
+                coordinator.Tell(new ShardCoordinator.ShardStopped("1"), staleRegionProbe.Ref);
+                coordinator.Tell(new Identify("flush"), probe.Ref);
+                await probe.ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(3));
+            });
+
+            // Shard should still be functioning without any disruption
+            setup.Sharding.Tell(new EntityEnvelope(1, "hello2"), probe.Ref);
+            await probe.ExpectMsgAsync("ack hello2", TimeSpan.FromSeconds(3));
+        }
     }
 }

--- a/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/Shard.cs
@@ -1129,6 +1129,20 @@ namespace Akka.Cluster.Sharding
                 case LeaseLost ll:
                     ReceiveLeaseLost(ll);
                     return true;
+
+                // #8147: safe to stop immediately — no entities started before lease acquisition
+                case HandOff ho when ho.Shard == _shardId:
+                    Log.Info("{0}: HandOff shard [{1}] received while awaiting lease. " +
+                             "No active entities, replying ShardStopped immediately.",
+                        _typeName, _shardId);
+                    Sender.Tell(new ShardStopped(_shardId));
+                    Context.Stop(Self);
+                    return true;
+
+                case HandOff ho:
+                    Log.Warning("{0}: Shard [{1}] can not hand off for another Shard [{2}]",
+                        _typeName, _shardId, ho.Shard);
+                    return true;
             }
 
             if (_verboseDebug)

--- a/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding/ShardCoordinator.cs
@@ -1801,17 +1801,31 @@ namespace Akka.Cluster.Sharding
                     // Safety net: if no rebalance is in progress for this shard (RebalanceWorker
                     // already timed out), deallocate the shard so it can be reallocated elsewhere.
                     // This prevents the shard from being endlessly recreated via GetShardHome/ShardHome.
-                    if (!_rebalanceInProgress.ContainsKey(m.Shard) && State.Shards.ContainsKey(m.Shard))
+                    if (!_rebalanceInProgress.ContainsKey(m.Shard)
+                        && State.Shards.TryGetValue(m.Shard, out var currentOwner))
                     {
-                        Log.Info("{0}: Shard [{1}] stopped - performing late deallocation (rebalance worker timed out).",
-                            TypeName, m.Shard);
-                        Update(new ShardHomeDeallocated(m.Shard), evt =>
+                        // #8146: only deallocate if the sender is the current owner (legitimate
+                        // late arrival after RebalanceWorker timeout). Ignore stale backups from
+                        // an old region after the shard was successfully reallocated elsewhere.
+                        if (currentOwner.Equals(_context.Sender))
                         {
-                            State = State.Updated(evt);
-                            Log.Debug("{0}: Shard [{1}] deallocated (late)", TypeName, m.Shard);
-                            AllocateShardHomesForRememberEntities();
-                            _context.Self.Tell(new GetShardHome(m.Shard), _ignoreRef);
-                        });
+                            Log.Info("{0}: Shard [{1}] stopped - performing late deallocation " +
+                                     "(rebalance worker timed out). Sender [{2}] matches current owner.",
+                                TypeName, m.Shard, _context.Sender);
+                            Update(new ShardHomeDeallocated(m.Shard), evt =>
+                            {
+                                State = State.Updated(evt);
+                                Log.Debug("{0}: Shard [{1}] deallocated (late)", TypeName, m.Shard);
+                                AllocateShardHomesForRememberEntities();
+                                _context.Self.Tell(new GetShardHome(m.Shard), _ignoreRef);
+                            });
+                        }
+                        else
+                        {
+                            Log.Debug("{0}: Ignoring stale ShardStopped for shard [{1}] from [{2}] - " +
+                                      "shard is now allocated to [{3}].",
+                                TypeName, m.Shard, _context.Sender, currentOwner);
+                        }
                     }
                     return true;
 
@@ -2294,6 +2308,16 @@ namespace Akka.Cluster.Sharding
                         State.Regions.Keys.Union(State.RegionProxies),
                         isRebalance: isRebalance)
                     .WithDispatcher(_context.Props.Dispatcher)));
+            }
+            else if (!isRebalance)
+            {
+                // Graceful shutdown requested for a shard that is already being rebalanced (#8148).
+                // The existing RebalanceWorker will continue; the shutdown intent is deferred
+                // until the current rebalance completes.
+                Log.Info(
+                    "{0}: Graceful shutdown handoff for shard [{1}] from [{2}] skipped - " +
+                    "rebalance already in progress. The existing rebalance worker will complete first.",
+                    TypeName, shard, from);
             }
         }
 


### PR DESCRIPTION
Cherry-pick of #8150 from `v1.5` to `dev`.

Closes #8146
Closes #8147
Closes #8148

## Summary

Fixes three chained bugs that cause shard unavailability during rolling restarts when using distributed lease coordination (e.g. Kubernetes leases):

- **#8146**: Backup `ShardStopped` safety net fires spuriously after successful rebalance, causing double-allocation. Added sender validation to only perform late deallocation when sender matches current owner.
- **#8147**: `AwaitingLease` stashes `HandOff` indefinitely. Now handled immediately since no entities exist before lease acquisition.
- **#8148**: `StartShardRebalanceIfNeeded` silently skips shards during graceful shutdown. Added info-level logging.

## Test plan

- [x] All `ShardWithLeaseSpec` tests pass (6 total, including 2 new)
- [x] All `ClusterShardingInternalsSpec` tests pass
- [ ] CI: full test suite