### PR TITLE
Fix flaky ReceiveTimeoutSpec CI timeout

### DIFF
--- a/src/core/Akka.Tests/Actor/ReceiveTimeoutSpec.cs
+++ b/src/core/Akka.Tests/Actor/ReceiveTimeoutSpec.cs
@@ -279,7 +279,7 @@ namespace Akka.Tests.Actor
             Watch(timeoutActor);
 
             // wait for first ReceiveTimeout message, in which the latch is opened
-            timeoutLatch.Ready(TimeSpan.FromSeconds(2));
+            timeoutLatch.Ready(TestKitSettings.DefaultTimeout);
 
             //Stop and wait for the actor to terminate
             Sys.Stop(timeoutActor);


### PR DESCRIPTION
## Summary
- Replace hardcoded `TimeSpan.FromSeconds(2)` latch timeout with `TestKitSettings.DefaultTimeout` in `Issue469_An_actor_with_receive_timeout_must_cancel_receive_timeout_when_terminated`
- `DefaultTimeout` is 5s and supports time dilation via `akka.test.timefactor`, matching the pattern used by every other latch call in `ReceiveTimeoutSpec.cs`
- The latch is event-driven (opens when `ReceiveTimeout` fires); the timeout is a safety net, not a timing assertion

Observed flaking in PR #8143 build 125566 (Linux, net8.0): `System.TimeoutException: Timeout of 00:00:02` at `TestLatch.Ready()`

## Test plan
- [x] Run `ReceiveTimeoutSpec.Issue469` test locally — passes