### PR TITLE
Fix flaky NodeChurnSpec — enable coordinated shutdown on Down

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/NodeChurnSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/NodeChurnSpec.cs
@@ -33,6 +33,7 @@ namespace Akka.Cluster.Tests.MultiNode
             CommonConfig = DebugConfig(false)
                 .WithFallback(ConfigurationFactory.ParseString(@"
                   akka.cluster.auto-down-unreachable-after = 1s
+                  akka.cluster.run-coordinated-shutdown-when-down = on
                   akka.remote.log-frame-size-exceeding = 2000b
                   akka.remote.dot-netty.tcp.batching.enabled = false # disable batching
                 "))


### PR DESCRIPTION
## Summary
- Override `akka.cluster.run-coordinated-shutdown-when-down = on` in `NodeChurnConfig` (matching the production default in `Cluster.conf`)
- **Root cause:** The base `MultiNodeClusterSpec.ClusterConfig()` sets this to `off` so tests that observe cluster state after downing aren't disrupted by coordinated shutdown. NodeChurnSpec inherits this setting but doesn't need it — it tests gossip payload size, and `AwaitRemoved` finishes observing cluster state before `Shutdown()` is called.
- On **even rounds** (Down path), the transient systems never started coordinated shutdown, so `Shutdown()` had to run the entire termination sequence from scratch within the default 5s. On **odd rounds** (Leave path), systems were already terminating automatically.
- With `on`, both paths start coordinated shutdown when the member is removed. By the time `Shutdown(verifySystemShutdown: true)` runs, the systems are already well into termination. The `verifySystemShutdown` correctness check is preserved.

Observed flaking in PR #8143 build 125566 (Multi-Node Windows): `System.TimeoutException: Failed to stop [NodeChurnSpec] within [00:00:05]` on Node 2 and Node 3.

## Test plan
- [x] Build `Akka.Cluster.Tests.MultiNode` — compiles clean
- [ ] Verify via CI multi-node test run