### PR TITLE
Widen ActorTaskScheduler(ActorCell) ctor to protected internal

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -2724,6 +2724,7 @@ namespace Akka.Dispatch
     }
     public class ActorTaskScheduler : System.Threading.Tasks.TaskScheduler
     {
+        protected ActorTaskScheduler(Akka.Actor.ActorCell actorCell) { }
         public object CurrentMessage { get; }
         public override int MaximumConcurrencyLevel { get; }
         protected override System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task> GetScheduledTasks() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.Net.verified.txt
@@ -2742,6 +2742,7 @@ namespace Akka.Dispatch
     }
     public class ActorTaskScheduler : System.Threading.Tasks.TaskScheduler
     {
+        protected ActorTaskScheduler(Akka.Actor.ActorCell actorCell) { }
         public object CurrentMessage { get; }
         public override int MaximumConcurrencyLevel { get; }
         protected override System.Collections.Generic.IEnumerable<System.Threading.Tasks.Task> GetScheduledTasks() { }

--- a/src/core/Akka/Dispatch/ActorTaskScheduler.cs
+++ b/src/core/Akka/Dispatch/ActorTaskScheduler.cs
@@ -37,10 +37,23 @@ namespace Akka.Dispatch
         protected virtual void OnAfterTaskCompleted() { }
         
         /// <summary>
-        /// TBD
+        /// Creates a new <see cref="ActorTaskScheduler"/> bound to the given
+        /// <see cref="ActorCell"/>.
+        ///
+        /// Exposed as <c>protected internal</c> so external libraries (notably
+        /// Phobos, the Akka.NET observability plugin) can subclass
+        /// <see cref="ActorTaskScheduler"/> and override
+        /// <see cref="OnBeforeTaskStarted"/> / <see cref="OnAfterTaskCompleted"/>
+        /// to observe async message handler lifetimes without reflection or
+        /// runtime codegen. The two virtual hooks have always been
+        /// <c>protected</c>, so widening the constructor to match finishes an
+        /// extension point that was already half-exposed. The <c>internal</c>
+        /// portion preserves the existing <c>new ActorTaskScheduler(this)</c>
+        /// call site inside <see cref="ActorCell"/> without requiring a
+        /// derived type.
         /// </summary>
-        /// <param name="actorCell">TBD</param>
-        internal ActorTaskScheduler(ActorCell actorCell)
+        /// <param name="actorCell">The cell this scheduler is bound to.</param>
+        protected internal ActorTaskScheduler(ActorCell actorCell)
         {
             _actorCell = actorCell;
         }


### PR DESCRIPTION
## Summary

Widen the `ActorTaskScheduler(ActorCell)` constructor from `internal` to `protected internal`, so external libraries can subclass `ActorTaskScheduler` and override the existing `OnBeforeTaskStarted` / `OnAfterTaskCompleted` hooks without reflection or runtime codegen.

No behavior change — this is a pure access widening. The `internal` half of `protected internal` preserves the existing `new ActorTaskScheduler(this)` call site inside `ActorCell`, so no other source in `Akka.dll` had to move.

## Why

`OnBeforeTaskStarted` / `OnAfterTaskCompleted` have always been `protected virtual`. They're clearly intended as an extension point — the whole reason for their existence is to let subclasses observe the async handler lifecycle inside `ActorTaskScheduler.RunTask`. But the base constructor is `internal`, so in practice no assembly outside `Akka.dll` can actually subclass and wire them up. The extension point has been half-exposed ever since it was added.

## Motivation (Phobos)

This blocks a real fix in Phobos (the Akka.NET observability plugin from Petabridge).

Phobos's `PhobosActorCell` opens an `akka.msg.recv` span at the start of each message and disposes it synchronously in a `finally` block when `base.ReceiveMessage` returns. For `ReceiveAsync<T>` / `CommandAsync<T>` handlers, `base.ReceiveMessage` returns at the first `await` yield point — `ActorTaskScheduler.RunTask` has suspended the mailbox and scheduled the continuation, but the user's Task is still running. Phobos closes the span immediately. All post-await work (`Task.WhenAll`, HTTP calls, external validation, nested `Ask`s) is invisible in traces, and downstream customer-facing spans show durations of ~1 ms for handlers that actually take 100+ ms.

The correct fix is for Phobos to subclass `ActorTaskScheduler`, override `OnBeforeTaskStarted` to capture the span, override `OnAfterTaskCompleted` to dispose it once the Task truly completes, and expose the custom scheduler via a `PhobosActorCell.TaskScheduler` override. Clean, zero-reflection, runs on every TFM.

Today that's blocked on the `internal` ctor. Alternatives we looked at and rejected:

- **`IgnoresAccessChecksToGenerator`** — compile-time trick that widens the reference assembly's view and ships `[assembly: IgnoresAccessChecksTo("Akka")]` in Phobos. Works beautifully on CoreCLR, but `IgnoresAccessChecksTo` is *not* honored by the .NET Framework JIT. Phobos has .NET Framework customers, and the type load would throw `MethodAccessException` on first use — worse than the bug we're fixing.
- **Reflection / `UnsafeAccessor`** — neither lets a derived class chain to an inaccessible base ctor. The derived class's IL needs a valid `call base::.ctor(...)` at compile time.
- **Runtime `Reflection.Emit` subclass** — technically cross-runtime but adds codegen surface area, cold-start cost, and is AOT-hostile.
- **Deferring span close until the next message** — works but gives wrong end-times during idle periods and needs a bunch of bookkeeping to handle stop/restart.

Widening one keyword here is by a wide margin the cleanest option, and it's the right API shape regardless of Phobos — the hooks deserved to be genuinely usable from outside the assembly the whole time.

## Backport

This needs to ship on both branches:
- `dev` (target of this PR) → 1.6.x line
- `v1.5` — a trivial cherry-pick; Phobos 2.11.x depends on Akka 1.5.x and that's where the customer-facing fix lands. Happy to open the backport PR myself once this merges.

## Test plan

- [x] `dotnet build src/core/Akka/Akka.csproj -c Release` — clean
- [x] `dotnet test src/core/Akka.API.Tests/Akka.API.Tests.csproj --filter "FullyQualifiedName~CoreAPISpec"` — 15/15 pass, including the updated ApproveCore snapshots
- [x] API verify snapshots updated for both `.Net` and `.DotNet` variants (public API generator reports `protected internal` ctors as `protected` in the snapshot view)