### PR TITLE
Akka.Streams #8161: non-blocking materialized-value TCS — StreamRef + DSL stages

### DIFF
--- a/src/core/Akka.Streams/Dsl/LastElement.cs
+++ b/src/core/Akka.Streams/Dsl/LastElement.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Akka.Streams.Stage;
 using Akka.Streams.Util;
 using Akka.Util;
+using Akka.Util.Internal;
 
 namespace Akka.Streams.Dsl
 {
@@ -60,7 +61,7 @@ namespace Akka.Streams.Dsl
 
         public override ILogicAndMaterializedValue<Task<Option<T>>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var completion = new TaskCompletionSource<Option<T>>();
+            var completion = TaskEx.NonBlockingTaskCompletionSource<Option<T>>();
             var logic = new Logic(this, completion);
 
             return new LogicAndMaterializedValue<Task<Option<T>>>(logic, completion.Task);

--- a/src/core/Akka.Streams/Dsl/Valve.cs
+++ b/src/core/Akka.Streams/Dsl/Valve.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Threading.Tasks;
 using Akka.Streams.Stage;
+using Akka.Util.Internal;
 
 namespace Akka.Streams.Dsl
 {
@@ -52,14 +53,14 @@ namespace Akka.Streams.Dsl
 
         public Task<bool> Flip(SwitchMode flipToMode)
         {
-            var completion = new TaskCompletionSource<bool>();
+            var completion = TaskEx.NonBlockingTaskCompletionSource<bool>();
             _flipCallback((flipToMode, completion));
             return completion.Task;
         }
 
         public Task<SwitchMode> GetMode()
         {
-            var completion = new TaskCompletionSource<SwitchMode>();
+            var completion = TaskEx.NonBlockingTaskCompletionSource<SwitchMode>();
             _getModeCallback(completion);
             return completion.Task;
         }
@@ -176,7 +177,7 @@ namespace Akka.Streams.Dsl
 
         public override ILogicAndMaterializedValue<Task<IValveSwitch>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var completion = new TaskCompletionSource<IValveSwitch>();
+            var completion = TaskEx.NonBlockingTaskCompletionSource<IValveSwitch>();
             var logic = new ValveGraphStageLogic(this, completion);
 
             return new LogicAndMaterializedValue<Task<IValveSwitch>>(logic, completion.Task);

--- a/src/core/Akka.Streams/Implementation/StreamRef/SinkRefImpl.cs
+++ b/src/core/Akka.Streams/Implementation/StreamRef/SinkRefImpl.cs
@@ -17,6 +17,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.Serialization;
 using Akka.Streams.Stage;
 using Akka.Util;
+using Akka.Util.Internal;
 
 namespace Akka.Streams.Implementation.StreamRef
 {
@@ -298,7 +299,7 @@ namespace Akka.Streams.Implementation.StreamRef
         public override SinkShape<TIn> Shape { get; }
         public override ILogicAndMaterializedValue<Task<ISourceRef<TIn>>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var promise = new TaskCompletionSource<ISourceRef<TIn>>();
+            var promise = TaskEx.NonBlockingTaskCompletionSource<ISourceRef<TIn>>();
             return new LogicAndMaterializedValue<Task<ISourceRef<TIn>>>(new Logic(this, promise, inheritedAttributes), promise.Task);
         }
     }

--- a/src/core/Akka.Streams/Implementation/StreamRef/SourceRefImpl.cs
+++ b/src/core/Akka.Streams/Implementation/StreamRef/SourceRefImpl.cs
@@ -17,6 +17,7 @@ using Akka.Streams.Serialization;
 using Akka.Streams.Serialization.Proto.Msg;
 using Akka.Streams.Stage;
 using Akka.Util;
+using Akka.Util.Internal;
 using Google.Protobuf.WellKnownTypes;
 using Debug = System.Diagnostics.Debug;
 using Type = System.Type;
@@ -337,7 +338,7 @@ namespace Akka.Streams.Implementation.StreamRef
 
         public override ILogicAndMaterializedValue<Task<ISinkRef<TOut>>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var promise = new TaskCompletionSource<ISinkRef<TOut>>();
+            var promise = TaskEx.NonBlockingTaskCompletionSource<ISinkRef<TOut>>();
             return new LogicAndMaterializedValue<Task<ISinkRef<TOut>>>(new Logic(this, promise, inheritedAttributes), promise.Task);
         }
     }


### PR DESCRIPTION
## Summary

Part of the epic tracked by #8161. This PR flips default `TaskCompletionSource<T>()` to `TaskEx.NonBlockingTaskCompletionSource<T>()` (equivalent to `TaskCreationOptions.RunContinuationsAsynchronously`) for the following materialized-value TCS:

- `Implementation/StreamRef/SourceRefImpl.cs` — `StreamRefs.SinkRef<T>()` materialized value
- `Implementation/StreamRef/SinkRefImpl.cs` — `StreamRefs.SourceRef<T>()` materialized value
- `Dsl/LastElement.cs` — `LastElement<T>` materialized value
- `Dsl/Valve.cs` — `Valve.Flip`, `Valve.GetMode`, and the `IValveSwitch` materialized value

Without `RunContinuationsAsynchronously`, a user `await materializedTask` or `ContinueWith(..., ExecuteSynchronously)` registered before the TCS fires runs inline on the stream interpreter thread, which can stall other fused stages sharing the same island. See #8161 for the full write-up.

This is one of six independent slices of the epic — all slices touch disjoint files and can be merged in any order.

## Scope

- 4 files, 6 call sites
- No public API, wire-format, or serialization changes
- Existing convention: helper is `TaskEx.NonBlockingTaskCompletionSource<T>()` at `src/core/Akka/Util/Internal/TaskEx.cs`, already used elsewhere in the tree

## Test plan

- [x] `dotnet build src/core/Akka.Streams/Akka.Streams.csproj -c Release` — 0 warnings, 0 errors
- [x] `dotnet test src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release --framework net10.0` — 1801 passed, 0 failed, 34 skipped
- [ ] API compat (`src/core/Akka.API.Tests`) — expected no change (no public surface modification)