### PR TITLE
Akka.Streams #8161: non-blocking materialized-value TCS — core stage infra + Fusing

### DIFF
--- a/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
@@ -16,6 +16,7 @@ using Akka.Streams.Dsl;
 using Akka.Streams.Implementation.Stages;
 using Akka.Streams.Stage;
 using Akka.Util;
+using Akka.Util.Internal;
 
 namespace Akka.Streams.Implementation.Fusing
 {
@@ -376,7 +377,7 @@ namespace Akka.Streams.Implementation.Fusing
         /// <returns>TBD</returns>
         public override ILogicAndMaterializedValue<Task<Done>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var finishPromise = new TaskCompletionSource<Done>();
+            var finishPromise = TaskEx.NonBlockingTaskCompletionSource<Done>();
             return new LogicAndMaterializedValue<Task<Done>>(new Logic(this, finishPromise), finishPromise.Task);
         }
 
@@ -708,7 +709,7 @@ namespace Akka.Streams.Implementation.Fusing
         /// </summary>
         public readonly Outlet<T> Outlet;
 
-        private readonly TaskCompletionSource<T> _promise = new();
+        private readonly TaskCompletionSource<T> _promise = TaskEx.NonBlockingTaskCompletionSource<T>();
 
         /// <summary>
         /// TBD
@@ -932,7 +933,7 @@ namespace Akka.Streams.Implementation.Fusing
 
         public override ILogicAndMaterializedValue<Task<M>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var materialized = new TaskCompletionSource<M>();
+            var materialized = TaskEx.NonBlockingTaskCompletionSource<M>();
             return new LogicAndMaterializedValue<Task<M>>(new Logic(this, materialized), materialized.Task);
         }
 
@@ -1065,7 +1066,7 @@ namespace Akka.Streams.Implementation.Fusing
 
         public override ILogicAndMaterializedValue<Task<Done>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var completion = new TaskCompletionSource<Done>();
+            var completion = TaskEx.NonBlockingTaskCompletionSource<Done>();
             var logic = new Logic(this, completion);
             return new LogicAndMaterializedValue<Task<Done>>(logic, completion.Task);
         }

--- a/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/Ops.cs
@@ -4416,7 +4416,7 @@ namespace Akka.Streams.Implementation.Fusing
         /// <returns>TBD</returns>
         public override ILogicAndMaterializedValue<Task<Option<TMat>>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var promise = new TaskCompletionSource<Option<TMat>>();
+            var promise = TaskEx.NonBlockingTaskCompletionSource<Option<TMat>>();
             var stageLogic = new Logic(this, promise);
             return new LogicAndMaterializedValue<Task<Option<TMat>>>(stageLogic, promise.Task);
         }

--- a/src/core/Akka.Streams/Implementation/SetupStage.cs
+++ b/src/core/Akka.Streams/Implementation/SetupStage.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Akka.Annotations;
 using Akka.Streams.Dsl;
 using Akka.Streams.Stage;
+using Akka.Util.Internal;
 
 namespace Akka.Streams.Implementation
 {
@@ -94,7 +95,7 @@ namespace Akka.Streams.Implementation
 
         public override ILogicAndMaterializedValue<Task<TMat>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var matPromise = new TaskCompletionSource<TMat>();
+            var matPromise = TaskEx.NonBlockingTaskCompletionSource<TMat>();
             var logic = new Logic(this, matPromise, inheritedAttributes);
             return new LogicAndMaterializedValue<Task<TMat>>(logic, matPromise.Task);
         }
@@ -168,7 +169,7 @@ namespace Akka.Streams.Implementation
 
         public override ILogicAndMaterializedValue<Task<TMat>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var matPromise = new TaskCompletionSource<TMat>();
+            var matPromise = TaskEx.NonBlockingTaskCompletionSource<TMat>();
             var logic = new Logic(this, matPromise, inheritedAttributes);
             return new LogicAndMaterializedValue<Task<TMat>>(logic, matPromise.Task);
         }

--- a/src/core/Akka.Streams/Stage/GraphStage.cs
+++ b/src/core/Akka.Streams/Stage/GraphStage.cs
@@ -495,7 +495,7 @@ namespace Akka.Streams.Stage
 
         static GraphStageLogic()
         {
-            NoPromise = new TaskCompletionSource<Done>();
+            NoPromise = TaskEx.NonBlockingTaskCompletionSource<Done>();
             NoPromise.SetResult(Done.Instance);
         }
         
@@ -949,7 +949,7 @@ namespace Akka.Streams.Stage
             // External call
             public Task<Done> InvokeWithFeedback(T input)
             {
-                var promise = new TaskCompletionSource<Done>();
+                var promise = TaskEx.NonBlockingTaskCompletionSource<Done>();
 
                 if (AddToWaiting())
                 {


### PR DESCRIPTION
## Summary

Part of the epic tracked by #8161. This PR flips default `TaskCompletionSource<T>()` to `TaskEx.NonBlockingTaskCompletionSource<T>()` for materialized-value / feedback TCS in:

- `Stage/GraphStage.cs` — `GraphStageLogic.NoPromise` sentinel and `ConcurrentAsyncCallback.InvokeWithFeedback`
- `Implementation/SetupStage.cs` — `SetupFlowStage`, `SetupSourceStage`
- `Implementation/Fusing/GraphStages.cs` — `TerminationWatcher`, `MaterializedValueSource`, `TaskFlattenSource`, `IgnoreSink`
- `Implementation/Fusing/Ops.cs` — `LazyFlow`

Prevents user continuations from inlining on the stream interpreter thread when the TCS fires. See #8161 for the full write-up.

This is one of six independent slices of the epic — all slices touch disjoint files and can be merged in any order.

## Scope

- 4 files, 9 call sites (2 of which are benign/internal but flipped for consistency: `NoPromise`, `MaterializedValueSource._promise`)
- No public API, wire-format, or serialization changes

## Test plan

- [x] `dotnet build src/core/Akka.Streams/Akka.Streams.csproj -c Release` — 0 warnings, 0 errors
- [x] `dotnet test src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release --framework net10.0` — 1801 passed, 0 failed, 34 skipped