### PR TITLE
Akka.Streams #8161: non-blocking materialized-value TCS — Sinks + Sources + Stages

### DIFF
--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -21,6 +21,7 @@ using Akka.Streams.Stage;
 using Akka.Streams.Supervision;
 using Akka.Streams.Util;
 using Akka.Util;
+using Akka.Util.Internal;
 using Reactive.Streams;
 using Decider = Akka.Streams.Supervision.Decider;
 using Directive = Akka.Streams.Supervision.Directive;
@@ -509,7 +510,7 @@ namespace Akka.Streams.Implementation
         public override ILogicAndMaterializedValue<Task<T>> CreateLogicAndMaterializedValue(
             Attributes inheritedAttributes)
         {
-            var promise = new TaskCompletionSource<T>();
+            var promise = TaskEx.NonBlockingTaskCompletionSource<T>();
             return new LogicAndMaterializedValue<Task<T>>(new Logic(promise, this), promise.Task);
         }
     }
@@ -594,7 +595,7 @@ namespace Akka.Streams.Implementation
         public override ILogicAndMaterializedValue<Task<T>> CreateLogicAndMaterializedValue(
             Attributes inheritedAttributes)
         {
-            var promise = new TaskCompletionSource<T>();
+            var promise = TaskEx.NonBlockingTaskCompletionSource<T>();
             return new LogicAndMaterializedValue<Task<T>>(new Logic(promise, this), promise.Task);
         }
     }
@@ -685,7 +686,7 @@ namespace Akka.Streams.Implementation
         public override ILogicAndMaterializedValue<Task<IImmutableList<T>>> CreateLogicAndMaterializedValue(
             Attributes inheritedAttributes)
         {
-            var promise = new TaskCompletionSource<IImmutableList<T>>();
+            var promise = TaskEx.NonBlockingTaskCompletionSource<IImmutableList<T>>();
             return new LogicAndMaterializedValue<Task<IImmutableList<T>>>(new Logic(this, promise), promise.Task);
         }
 
@@ -829,7 +830,7 @@ namespace Akka.Streams.Implementation
 
             public Task<Option<T>> PullAsync()
             {
-                var promise = new TaskCompletionSource<Option<T>>();
+                var promise = TaskEx.NonBlockingTaskCompletionSource<Option<T>>();
                 _invokeLogic(promise);
                 return promise.Task;
             }
@@ -1076,7 +1077,7 @@ namespace Akka.Streams.Implementation
         /// <returns>TBD</returns>
         public override ILogicAndMaterializedValue<Task<Option<TMat>>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var completion = new TaskCompletionSource<Option<TMat>>();
+            var completion = TaskEx.NonBlockingTaskCompletionSource<Option<TMat>>();
             var stageLogic = new Logic(this, inheritedAttributes, completion);
             return new LogicAndMaterializedValue<Task<Option<TMat>>>(stageLogic, completion.Task);
         }

--- a/src/core/Akka.Streams/Implementation/Sources.cs
+++ b/src/core/Akka.Streams/Implementation/Sources.cs
@@ -400,7 +400,7 @@ namespace Akka.Streams.Implementation
         /// <returns>TBD</returns>
         public override ILogicAndMaterializedValue<ISourceQueueWithComplete<TOut>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var completion = new TaskCompletionSource<object>();
+            var completion = TaskEx.NonBlockingTaskCompletionSource<object>();
             var logic = new Logic(this, completion);
             return new LogicAndMaterializedValue<ISourceQueueWithComplete<TOut>>(logic, new Materialized(t => logic.Invoke(t), completion));
         }
@@ -886,7 +886,7 @@ namespace Akka.Streams.Implementation
         /// </summary>
         public override ILogicAndMaterializedValue<Task<TMat>> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
         {
-            var completion = new TaskCompletionSource<TMat>();
+            var completion = TaskEx.NonBlockingTaskCompletionSource<TMat>();
             var logic = new Logic(this, completion, inheritedAttributes);
 
             return new LogicAndMaterializedValue<Task<TMat>>(logic, completion.Task);

--- a/src/core/Akka.Streams/Implementation/Stages/Stages.cs
+++ b/src/core/Akka.Streams/Implementation/Stages/Stages.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Akka.Dispatch;
 using Akka.Streams.Stage;
 using Akka.Streams.Supervision;
+using Akka.Util.Internal;
 
 namespace Akka.Streams.Implementation.Stages
 {
@@ -548,7 +549,7 @@ namespace Akka.Streams.Implementation.Stages
         private sealed class Logic : InGraphStageLogic
         {
             private readonly FirstOrDefault<TIn> _stage;
-            private readonly TaskCompletionSource<TIn> _promise = new();
+            private readonly TaskCompletionSource<TIn> _promise = TaskEx.NonBlockingTaskCompletionSource<TIn>();
 
             public Task<TIn> Task => _promise.Task;
 
@@ -632,7 +633,7 @@ namespace Akka.Streams.Implementation.Stages
         private sealed class Logic : InGraphStageLogic
         {
             private readonly LastOrDefault<TIn> _stage;
-            private readonly TaskCompletionSource<TIn> _promise = new();
+            private readonly TaskCompletionSource<TIn> _promise = TaskEx.NonBlockingTaskCompletionSource<TIn>();
             private TIn _prev;
             private bool _foundAtLeastOne;
 


### PR DESCRIPTION
## Summary

Part of the epic tracked by #8161. This PR flips default `TaskCompletionSource<T>()` to `TaskEx.NonBlockingTaskCompletionSource<T>()` for materialized-value TCS in:

- `Implementation/Sinks.cs` — `SeqStage`, `QueueSink`, `LazySink`, and also the `FirstOrDefaultStage` / `LastOrDefaultStage` public types (see note below)
- `Implementation/Sources.cs` — `Source.Queue` completion (exposed via `WatchCompletionAsync`), `LazySource`
- `Implementation/Stages/Stages.cs` — `FirstOrDefault<TIn>` and `LastOrDefault<TIn>`

### Audit correction

The original audit in #8161 listed `Sinks.cs:512 LastOrDefaultStage` and `Sinks.cs:597 FirstOrDefaultStage`. Those types are never instantiated in the repo — they're kept in the public API surface for compatibility, but `Sink.First<T>()` / `Sink.Last<T>()` / `Sink.FirstOrDefault<T>()` / `Sink.LastOrDefault<T>()` at `Dsl/Sink.cs:218-258` are actually backed by `FirstOrDefault<TIn>` / `LastOrDefault<TIn>` in `Implementation/Stages/Stages.cs`. This PR flips both — the dead-code Sinks.cs types for convention, and the live Stages.cs types to close the actual hazard.

This is one of six independent slices of the epic — all slices touch disjoint files and can be merged in any order.

## Scope

- 3 files, 9 call sites
- No public API, wire-format, or serialization changes

## Test plan

- [x] `dotnet build src/core/Akka.Streams/Akka.Streams.csproj -c Release` — 0 warnings, 0 errors
- [x] `dotnet test src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release --framework net10.0` — 1801 passed, 0 failed, 34 skipped (full suite incl. `QueueSinkSpec`, `SeqSinkSpec`, `FirstSinkSpec`, `LastSinkSpec`)