### PR TITLE
Akka.Streams #8161: non-blocking materialized-value TCS — non-TCP IO

### DIFF
--- a/src/core/Akka.Streams/Implementation/IO/IOSinks.cs
+++ b/src/core/Akka.Streams/Implementation/IO/IOSinks.cs
@@ -13,6 +13,7 @@ using Akka.IO;
 using Akka.Streams.Actors;
 using Akka.Streams.Implementation.Stages;
 using Akka.Streams.IO;
+using Akka.Util.Internal;
 
 namespace Akka.Streams.Implementation.IO
 {
@@ -89,7 +90,7 @@ namespace Akka.Streams.Implementation.IO
             var mat = ActorMaterializerHelper.Downcast(context.Materializer);
             var settings = mat.EffectiveSettings(context.EffectiveAttributes);
 
-            var ioResultPromise = new TaskCompletionSource<IOResult>();
+            var ioResultPromise = TaskEx.NonBlockingTaskCompletionSource<IOResult>();
             var props = FileSubscriber.Props(_f, ioResultPromise, settings.MaxInputBufferSize, _startPosition, _fileMode, _autoFlush, _flushSignaler);
 
             var actorRef = mat.ActorOf(
@@ -158,7 +159,7 @@ namespace Akka.Streams.Implementation.IO
         {
             var mat = ActorMaterializerHelper.Downcast(context.Materializer);
             var settings = mat.EffectiveSettings(context.EffectiveAttributes);
-            var ioResultPromise = new TaskCompletionSource<IOResult>();
+            var ioResultPromise = TaskEx.NonBlockingTaskCompletionSource<IOResult>();
 
             var os = _createOutput();
             var maxInputBufferSize = context

--- a/src/core/Akka.Streams/Implementation/IO/IOSources.cs
+++ b/src/core/Akka.Streams/Implementation/IO/IOSources.cs
@@ -12,6 +12,7 @@ using Akka.IO;
 using Akka.Streams.Actors;
 using Akka.Streams.Implementation.Stages;
 using Akka.Streams.IO;
+using Akka.Util.Internal;
 using Reactive.Streams;
 
 namespace Akka.Streams.Implementation.IO
@@ -89,7 +90,7 @@ namespace Akka.Streams.Implementation.IO
             var materializer = ActorMaterializerHelper.Downcast(context.Materializer);
             var settings = materializer.EffectiveSettings(context.EffectiveAttributes);
 
-            var ioResultPromise = new TaskCompletionSource<IOResult>();
+            var ioResultPromise = TaskEx.NonBlockingTaskCompletionSource<IOResult>();
             var props = FilePublisher.Props(_f, ioResultPromise, _chunkSize, _startPosition, settings.InitialInputBufferSize, settings.MaxInputBufferSize);
             var dispatcher = context.EffectiveAttributes.GetAttribute(DefaultAttributes.IODispatcher.GetAttribute<ActorAttributes.Dispatcher>());
             var actorRef = materializer.ActorOf(context, props.WithDispatcher(dispatcher.Name));
@@ -153,7 +154,7 @@ namespace Akka.Streams.Implementation.IO
         public override IPublisher<ByteString> Create(MaterializationContext context, out Task<IOResult> task)
         {
             var materializer = ActorMaterializerHelper.Downcast(context.Materializer);
-            var ioResultPromise = new TaskCompletionSource<IOResult>();
+            var ioResultPromise = TaskEx.NonBlockingTaskCompletionSource<IOResult>();
             IPublisher<ByteString> pub;
             
             try

--- a/src/core/Akka.Streams/Implementation/IO/OutputStreamSourceStage.cs
+++ b/src/core/Akka.Streams/Implementation/IO/OutputStreamSourceStage.cs
@@ -16,6 +16,7 @@ using Akka.IO;
 using Akka.Streams.Implementation.Stages;
 using Akka.Streams.Stage;
 using Akka.Util;
+using Akka.Util.Internal;
 using static Akka.Streams.Implementation.IO.OutputStreamSourceStage;
 
 namespace Akka.Streams.Implementation.IO
@@ -217,7 +218,7 @@ namespace Akka.Streams.Implementation.IO
 
             public Task WakeUp(IAdapterToStageMessage msg)
             {
-                var p = new TaskCompletionSource<NotUsed>();
+                var p = TaskEx.NonBlockingTaskCompletionSource<NotUsed>();
                 _upstreamCallback((msg, p));
                 return p.Task;
             }


### PR DESCRIPTION
## Summary

Part of the epic tracked by #8161. This PR flips default `TaskCompletionSource<T>()` to `TaskEx.NonBlockingTaskCompletionSource<T>()` for IO-result / wake-up TCS in:

- `Implementation/IO/IOSinks.cs` — `FileSink`, `OutputStreamSink`
- `Implementation/IO/IOSources.cs` — `FileSource`, `InputStreamSource`
- `Implementation/IO/OutputStreamSourceStage.cs` — `WakeUp`

Completion for these stages happens on the stage-actor thread rather than the stream interpreter thread (the failure mode is slightly different — stalls the stage actor rather than the interpreter — but the fix is identical).

This is one of six independent slices of the epic — all slices touch disjoint files and can be merged in any order.

## Scope

- 3 files, 5 call sites
- No public API, wire-format, or serialization changes

## Test plan

- [x] `dotnet build src/core/Akka.Streams/Akka.Streams.csproj -c Release` — 0 warnings, 0 errors
- [x] `dotnet test src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release --framework net10.0` — 1801 passed, 0 failed, 34 skipped (incl. `FileSinkSpec`, `FileSourceSpec`, `OutputStreamSourceSpec`)