### PR TITLE
Akka.Streams #8161: non-blocking TCS — benign cleanup (KillSwitch, Source.Never)

### DIFF
--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -21,6 +21,7 @@ using Akka.Streams.Implementation.Stages;
 using Akka.Streams.Util;
 using Akka.Util;
 using Akka.Util.Extensions;
+using Akka.Util.Internal;
 using Reactive.Streams;
 // ReSharper disable UnusedMember.Global
 
@@ -704,7 +705,7 @@ namespace Akka.Streams.Dsl
         /// </summary>
         /// <typeparam name="T">TBD</typeparam>
         /// <returns>TBD</returns>
-        public static Source<T, NotUsed> Never<T>() => FromTask(new TaskCompletionSource<T>().Task).WithAttributes(DefaultAttributes.NeverSource);
+        public static Source<T, NotUsed> Never<T>() => FromTask(TaskEx.NonBlockingTaskCompletionSource<T>().Task).WithAttributes(DefaultAttributes.NeverSource);
 
         /// <summary>
         /// Streams the elements of the given future source once it successfully completes.

--- a/src/core/Akka.Streams/KillSwitch.cs
+++ b/src/core/Akka.Streams/KillSwitch.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams.Stage;
+using Akka.Util.Internal;
 
 namespace Akka.Streams
 {
@@ -222,7 +223,7 @@ namespace Akka.Streams
             public override ILogicAndMaterializedValue<UniqueKillSwitch> CreateLogicAndMaterializedValue(
                 Attributes inheritedAttributes)
             {
-                var promise = new TaskCompletionSource<NotUsed>();
+                var promise = TaskEx.NonBlockingTaskCompletionSource<NotUsed>();
                 var killSwitch = new UniqueKillSwitch(promise);
                 return new LogicAndMaterializedValue<UniqueKillSwitch>(new Logic(promise.Task, this), killSwitch);
             }
@@ -288,7 +289,7 @@ namespace Akka.Streams
                 
             public override ILogicAndMaterializedValue<UniqueKillSwitch> CreateLogicAndMaterializedValue(Attributes inheritedAttributes)
             {
-                var promise = new TaskCompletionSource<NotUsed>();
+                var promise = TaskEx.NonBlockingTaskCompletionSource<NotUsed>();
                 var killSwitch = new UniqueKillSwitch(promise);
                 var logic = new Logic(promise.Task, this);
 
@@ -442,7 +443,7 @@ namespace Akka.Streams
 
         #endregion
 
-        private readonly TaskCompletionSource<NotUsed> _shutdownPromise = new();
+        private readonly TaskCompletionSource<NotUsed> _shutdownPromise = TaskEx.NonBlockingTaskCompletionSource<NotUsed>();
         private readonly string _name;
 
         /// <summary>


### PR DESCRIPTION
## Summary

Part of the epic tracked by #8161. This PR flips default `TaskCompletionSource<T>()` to `TaskEx.NonBlockingTaskCompletionSource<T>()` in the remaining Akka.Streams call sites audited as **benign** for the interpreter-inlining hazard:

- `KillSwitch.cs` — `UniqueKillSwitchStage<T>` / `UniqueBidiKillSwitchStage<T1,T2>` promises (L225/L291) and `SharedKillSwitch._shutdownPromise` (L445). These tasks are consumed internally by `KillableGraphStageLogic` via `ContinueWith`-wrapped async callbacks, not exposed as materialized values to user code.
- `Dsl/Source.cs` — `Source.Never<T>()` allocates a TCS purely to obtain a never-completing `Task`; `SetResult` is never called.

These sites are safe with or without the flip, but flipping them is cheap consistency cleanup so the whole Akka.Streams module converges on `TaskEx.NonBlockingTaskCompletionSource<T>()` and future contributors don't accidentally copy the old pattern. Zero behavioural change.

This is one of six independent slices of the epic — all slices touch disjoint files and can be merged in any order. Can land first or last with near-zero risk, reviewer preference.

## Scope

- 2 files, 4 call sites
- No public API, wire-format, or serialization changes
- No behavioural change

## Test plan

- [x] `dotnet build src/core/Akka.Streams/Akka.Streams.csproj -c Release` — 0 warnings, 0 errors
- [x] `dotnet test src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release --framework net10.0` — 1801 passed, 0 failed, 34 skipped