### PR TITLE
Add allow-unregistered-types setting to disable default serializer fallback

### DIFF
--- a/docs/articles/remoting/security.md
+++ b/docs/articles/remoting/security.md
@@ -796,3 +796,4 @@ Recommendations:
 
 * [Akka.Remote Configuration](xref:akka-remote-configuration)
 * [DotNetty Transport](https://github.com/Azure/DotNetty)
+* [Serialization Security](xref:serialization#serialization-security) - Disable the default serializer fallback to prevent arbitrary type deserialization (v1.5.66+)

--- a/docs/articles/serialization/serialization.md
+++ b/docs/articles/serialization/serialization.md
@@ -423,7 +423,7 @@ akka.actor.serialization-settings.hyperion.disallow-unsafe-type = false
 > This feature is turned on as default since Akka.NET v1.4.24
 
 > [!WARNING]
-> Hyperion is __NOT__ designed as a safe serializer to be used in an open network as a client-server
+> Hyperion is **NOT** designed as a safe serializer to be used in an open network as a client-server
 > communication protocol, instead it is designed to be used as a server-server communication protocol,
 > preferably inside a closed network system.
 <!-- markdownlint-enable MD028 -->

--- a/docs/articles/serialization/serialization.md
+++ b/docs/articles/serialization/serialization.md
@@ -350,7 +350,30 @@ akka {
 }
 ```
 
-## Danger of Polymorphic Serializer
+## Serialization Security
+
+### Disabling the Default Serializer Fallback
+
+> [!IMPORTANT]
+> Available in Akka.NET v1.5.66 and later.
+
+By default, Akka.NET falls back to the `System.Object` serializer (Newtonsoft.Json) when no explicit serializer binding exists for a type. This can be a security risk in applications that handle untrusted input, as it allows arbitrary types to be deserialized.
+
+For security-sensitive applications, we recommend disabling this fallback:
+
+```hocon
+akka.actor.serialization-settings.allow-unregistered-types = false
+```
+
+When disabled, `FindSerializerForType` will throw a `SerializationException` if no explicit serializer binding exists for a type. This ensures:
+
+1. **Security**: Only explicitly registered types can be serialized/deserialized
+2. **Schema safety**: Missing serializer registrations are caught at development time rather than silently falling back to JSON
+3. **Explicit contracts**: All persisted/remoted messages go through intentionally configured serializers
+
+When you enable this setting and attempt to serialize an unregistered type, you'll receive a helpful error message guiding you to either add a serialization binding or re-enable the fallback.
+
+### Danger of Polymorphic Serializer
 
 One of the danger of polymorphic serializers is the danger of unsafe object type injection into
 the serialization/de-serialization chain. This issue applies to any type of polymorphic serializer,

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -770,5 +770,58 @@ namespace Akka.Tests.Serialization
             public object MyObject { get; set; }
         }
     }
+
+    public class DisallowUnregisteredTypesSpec : AkkaSpec
+    {
+        private static readonly Config StrictConfig = ConfigurationFactory.ParseString(@"
+            akka.actor.serialization-settings.allow-unregistered-types = false
+        ");
+
+        public DisallowUnregisteredTypesSpec() : base(StrictConfig) { }
+
+        [Fact(DisplayName = "Should throw for unregistered type when fallback disabled")]
+        public void Should_throw_for_unregistered_type_when_fallback_disabled()
+        {
+            var serialization = Sys.Serialization;
+            var unregisteredType = new UnregisteredMessage("test");
+
+            var ex = Assert.Throws<SerializationException>(() =>
+                serialization.FindSerializerFor(unregisteredType));
+
+            ex.Message.Should().Contain("No serializer binding found");
+            ex.Message.Should().Contain("allow-unregistered-types");
+        }
+
+        [Fact(DisplayName = "Should still work for explicitly bound types when fallback disabled")]
+        public void Should_still_work_for_explicitly_bound_types_when_fallback_disabled()
+        {
+            var serialization = Sys.Serialization;
+            // byte[] is explicitly bound in default config
+            var serializer = serialization.FindSerializerFor(new byte[] { 1, 2, 3 });
+            serializer.Should().BeOfType<ByteArraySerializer>();
+        }
+
+        private sealed class UnregisteredMessage
+        {
+            public string Value { get; }
+            public UnregisteredMessage(string value) => Value = value;
+        }
+    }
+
+    public class AllowUnregisteredTypesSpec : AkkaSpec
+    {
+        [Fact(DisplayName = "Should use object fallback by default")]
+        public void Should_use_object_fallback_by_default()
+        {
+            var serialization = Sys.Serialization;
+            var unregisteredType = new SomeRandomType();
+
+            // Should not throw, should return json serializer
+            var serializer = serialization.FindSerializerFor(unregisteredType);
+            serializer.Should().BeOfType<NewtonSoftJsonSerializer>();
+        }
+
+        private sealed class SomeRandomType { }
+    }
 }
 

--- a/src/core/Akka.Tests/Serialization/SerializationSpec.cs
+++ b/src/core/Akka.Tests/Serialization/SerializationSpec.cs
@@ -810,6 +810,14 @@ namespace Akka.Tests.Serialization
 
     public class AllowUnregisteredTypesSpec : AkkaSpec
     {
+        [Fact(DisplayName = "Should have allow-unregistered-types enabled by default")]
+        public void Should_have_allow_unregistered_types_enabled_by_default()
+        {
+            var config = Sys.Settings.Config;
+            var allowUnregisteredTypes = config.GetBoolean("akka.actor.serialization-settings.allow-unregistered-types");
+            allowUnregisteredTypes.Should().BeTrue();
+        }
+
         [Fact(DisplayName = "Should use object fallback by default")]
         public void Should_use_object_fallback_by_default()
         {

--- a/src/core/Akka/Configuration/akka.conf
+++ b/src/core/Akka/Configuration/akka.conf
@@ -552,6 +552,15 @@ akka {
 
 	# extra settings that can be custom to a serializer implementation
   serialization-settings {
+
+      # When false, FindSerializerForType will throw SerializationException
+      # if no explicit serializer binding exists for a type, rather than
+      # falling back to the System.Object serializer.
+      #
+      # Set to false for strict serialization control where only explicitly
+      # registered types should be serializable.
+      allow-unregistered-types = true
+
       json {
         
         # Used to set whether to use stringbuilders from a pool

--- a/src/core/Akka/Serialization/Serialization.cs
+++ b/src/core/Akka/Serialization/Serialization.cs
@@ -151,6 +151,7 @@ namespace Akka.Serialization
         private readonly MinimalLogger _initializationLogger;
 
         private readonly bool _logSerializerOverrideOnStart;
+        private readonly bool _allowUnregisteredTypes;
 
         /// <summary>
         /// Serialization module. Contains methods for serialization and deserialization as well as
@@ -173,6 +174,7 @@ namespace Akka.Serialization
             var serializersConfig = system.Settings.Config.GetConfig("akka.actor.serializers").AsEnumerable().ToList();
             var serializerBindingConfig = system.Settings.Config.GetConfig("akka.actor.serialization-bindings").AsEnumerable().ToList();
             var serializerSettingsConfig = system.Settings.Config.GetConfig("akka.actor.serialization-settings");
+            _allowUnregisteredTypes = serializerSettingsConfig.GetBoolean("allow-unregistered-types", true);
 
             _serializerDetails = system.Settings.Setup.Get<SerializationSetup>()
                 .Select(x => x.CreateSerializers(system)).GetOrElse(ImmutableHashSet<SerializerDetails>.Empty);
@@ -564,12 +566,19 @@ namespace Akka.Serialization
             if (serializer == null)
                 serializer = GetSerializerByName(defaultSerializerName);
 
-            // do a final check for the "object" serializer
-            if (serializer == null)
+            // do a final check for the "object" serializer (if allowed)
+            if (serializer == null && _allowUnregisteredTypes)
                 _serializerMap.TryGetValue(_objectType, out serializer);
 
             if (serializer == null)
-                throw new SerializationException($"Serializer not found for type {objectType.Name}");
+            {
+                var message = _allowUnregisteredTypes
+                    ? $"Serializer not found for type {objectType.Name}"
+                    : $"No serializer binding found for type {objectType.Name}. " +
+                      "Configure a binding in 'akka.actor.serialization-bindings' or set " +
+                      "'akka.actor.serialization-settings.allow-unregistered-types = true' to use the default fallback.";
+                throw new SerializationException(message);
+            }
 
             AddSerializationMap(type, serializer);
             return serializer;


### PR DESCRIPTION
## Summary

Closes #8164

- Adds `akka.actor.serialization-settings.allow-unregistered-types` HOCON setting (defaults to `true` for backward compatibility)
- When set to `false`, `FindSerializerForType` throws `SerializationException` if no explicit serializer binding exists, rather than falling back to the `System.Object` serializer
- Improved error message guides users toward either adding a binding or re-enabling the fallback

## Motivation

The default `System.Object` serialization fallback creates two problems:

1. **Security risk**: Arbitrary types can be deserialized, potentially allowing untrusted type instantiation
2. **Silent failures**: Missing serializer registrations are masked rather than failing loudly at development time

## Usage

```hocon
akka.actor.serialization-settings.allow-unregistered-types = false
```

## Test plan

- [x] Added `DisallowUnregisteredTypesSpec` - verifies strict mode throws for unregistered types
- [x] Added `AllowUnregisteredTypesSpec` - verifies default behavior still uses JSON fallback
- [x] All 63 existing serialization tests pass