### PR TITLE
Fix flaky RememberEntitiesFailureSpec and DotNettySslSetupSpec tests

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesFailureSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests/RememberEntitiesFailureSpec.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Threading;
+
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Sharding.Internal;
@@ -621,36 +621,36 @@ namespace Akka.Cluster.Sharding.Tests
         }
 
         [Fact]
-        public void Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails_NoResponse()
+        public async Task Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails_NoResponse()
         {
-            Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(new NoResponse());
+            await Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(new NoResponse());
         }
 
         [Fact]
-        public void Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails_CrashStore()
+        public async Task Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails_CrashStore()
         {
-            Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(new CrashStore());
+            await Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(new CrashStore());
         }
 
         [Fact]
-        public void Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails_StopStore()
+        public async Task Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails_StopStore()
         {
-            Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(new StopStore());
+            await Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(new StopStore());
         }
 
         [Fact]
-        public void Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails_Delay_500()
+        public async Task Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails_Delay_500()
         {
-            Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(new Delay(TimeSpan.FromMilliseconds(500)));
+            await Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(new Delay(TimeSpan.FromMilliseconds(500)));
         }
 
         [Fact]
-        public void Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails_Delay_1000()
+        public async Task Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails_Delay_1000()
         {
-            Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(new Delay(TimeSpan.FromSeconds(1)));
+            await Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(new Delay(TimeSpan.FromSeconds(1)));
         }
 
-        private void Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(IFail wayToFail)
+        private async Task Remember_entities_handling_in_sharding_must_recover_on_graceful_entity_stop_when_storing_a_stop_event_fails(IFail wayToFail)
         {
             var storeProbe = CreateTestProbe();
             Sys.EventStream.Subscribe(storeProbe.Ref, typeof(ShardStoreCreated));
@@ -667,29 +667,34 @@ namespace Akka.Cluster.Sharding.Tests
 
             // trigger shard start and store creation
             sharding.Tell(new EntityEnvelope(1, "hello-1"), probe.Ref);
-            var shard1Store = storeProbe.ExpectMsg<ShardStoreCreated>().Store;
-            probe.ExpectMsg("hello-1");
+            var shard1Store = (await storeProbe.ExpectMsgAsync<ShardStoreCreated>()).Store;
+            await probe.ExpectMsgAsync("hello-1");
 
             // fail it when stopping
             shard1Store.Tell(new FakeShardStoreActor.FailUpdateEntity(wayToFail), storeProbe.Ref);
-            storeProbe.ExpectMsg<Done>();
+            await storeProbe.ExpectMsgAsync<Done>();
 
             sharding.Tell(new EntityEnvelope(1, "graceful-stop"));
 
-            if (!(wayToFail is CrashStore) && !(wayToFail is StopStore))
+            if (wayToFail is StopStore or CrashStore)
             {
-                // race, give the shard some time to see the passivation before restoring the fake shard store
-                Thread.Sleep(250);
-                shard1Store.Tell(new FakeShardStoreActor.ClearFail(), probe.Ref);
-                probe.ExpectMsg<Done>();
+                shard1Store = (await storeProbe.ExpectMsgAsync<ShardStoreCreated>()).Store;
             }
 
-            // it takes a while?
-            AwaitAssert(() =>
+            if (wayToFail is NoResponse or Delay or CrashStore)
+            {
+                shard1Store = (await storeProbe.ExpectMsgAsync<ShardStoreCreated>()).Store;
+            }
+
+            shard1Store.Tell(new FakeShardStoreActor.ClearFail(), probe.Ref);
+            await probe.ExpectMsgAsync<Done>();
+
+            // it takes a while - timeout hits and then backoff
+            await AwaitAssertAsync(async () =>
             {
                 sharding.Tell(new EntityEnvelope(1, "hello-2"), probe.Ref);
-                probe.ExpectMsg("hello-2");
-            }, TimeSpan.FromSeconds(5));
+                await probe.ExpectMsgAsync("hello-2");
+            }, TimeSpan.FromSeconds(10));
             Sys.Stop(sharding);
         }
 

--- a/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettySslSetupSpec.cs
@@ -82,8 +82,8 @@ akka {{
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromMilliseconds(500));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(200));
         }
 
         [Fact]
@@ -285,8 +285,8 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromMilliseconds(500));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(200));
 
             // Verify that CustomValidator was actually called
             Assert.True(validatorCalled, "CustomValidator should have been invoked during TLS handshake");
@@ -447,8 +447,8 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromMilliseconds(500));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(200));
         }
 
         [Fact(DisplayName = "CertificateValidation.PinnedCertificate should reject certificates with non-matching thumbprint")]
@@ -526,8 +526,8 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromMilliseconds(500));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(200));
         }
 
         [Fact(DisplayName = "CertificateValidation.ValidateSubject should reject certificates with non-matching subject")]
@@ -640,8 +640,8 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromMilliseconds(500));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(200));
         }
 
         [Fact(DisplayName = "CertificateValidation.ChainPlusThen should combine chain validation with custom logic")]
@@ -696,8 +696,8 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromMilliseconds(500));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(200));
 
             // Verify custom validation was actually called
             Assert.True(customCheckCalled, "Custom validation logic should have been invoked");
@@ -754,8 +754,8 @@ akka {
             await AwaitAssertAsync(async () =>
             {
                 Sys.ActorSelection(_echoPath).Tell("hello", probe.Ref);
-                await probe.ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
-            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(100));
+                await probe.ExpectMsgAsync("hello", TimeSpan.FromMilliseconds(500));
+            }, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(200));
 
             // Verify custom validator was called (proving it took precedence)
             Assert.True(customValidatorCalled, "CustomValidator should have been invoked, proving it takes precedence");


### PR DESCRIPTION
## Summary
- **RememberEntitiesFailureSpec graceful stop**: Replaced `Thread.Sleep(250)` + stale actor reference with event-driven `ShardStoreCreated` waiting, matching the pattern already used by the working `shardStoreStart` test. The old approach sent `ClearFail` to a potentially dead actor ref after shard restart, causing dead letters and a 3-second `ExpectMsg<Done>` timeout. Converted test methods to async throughout.
- **DotNettySslSetupSpec**: Reduced inner `ExpectMsgAsync` timeout from 3s to 500ms and retry interval from 100ms to 200ms inside `AwaitAssertAsync` loops. The 3s inner timeout consumed the 30s retry budget in ~9 attempts, leaving insufficient retries for slow TLS handshakes on loaded CI machines. Now allows ~43 retries.

## Test plan
- [x] All 5 `RememberEntitiesFailureSpec` graceful stop variants pass (NoResponse, CrashStore, StopStore, Delay_500, Delay_1000)
- [x] All 9 `PinnedCertificate` tests pass
- [x] Both projects build clean with no warnings