### PR TITLE
Fix flaky ClusterShardingDeliveryGracefulShutdownSpec + async TestKit conversion

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Delivery/ClusterShardingDeliveryGracefulShutdownSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Delivery/ClusterShardingDeliveryGracefulShutdownSpec.cs
@@ -8,6 +8,8 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.Sharding.Delivery;
 using Akka.Configuration;
@@ -189,73 +191,81 @@ akka.reliable-delivery.sharding.consumer-controller.allow-bypass = true
         #endregion
 
         [MultiNodeFact]
-        public void ClusterShardingDeliveryGracefulShutdownSpecs()
+        public async Task ClusterShardingDeliveryGracefulShutdownSpecs()
         {
-            Cluster_sharding_must_join_cluster();
-            Cluster_sharding_must_start_some_shards_in_both_regions();
-            Cluster_sharding_must_gracefully_shutdown_the_oldest_region();
+            await Cluster_sharding_must_join_cluster();
+            await Cluster_sharding_must_start_some_shards_in_both_regions();
+            await Cluster_sharding_must_gracefully_shutdown_the_oldest_region();
         }
 
-        private void Cluster_sharding_must_join_cluster()
+        private async Task Cluster_sharding_must_join_cluster()
         {
-            StartPersistenceIfNeeded(startOn: Config.First, Config.First, Config.Second);
+            await StartPersistenceIfNeededAsync(startOn: Config.First, CancellationToken.None, Config.First, Config.Second);
 
-            Join(Config.First, Config.First);
-            Join(Config.Second, Config.First);
-            
+            await JoinAsync(Config.First, Config.First);
+            await JoinAsync(Config.Second, Config.First);
+
             // make sure all nodes are up
-            AwaitAssert(() =>
+            await AwaitAssertAsync(async () =>
             {
                 Cluster.Get(Sys).SendCurrentClusterState(TestActor);
-                ExpectMsg<ClusterEvent.CurrentClusterState>().Members.Count.Should().Be(2);
+                (await ExpectMsgAsync<ClusterEvent.CurrentClusterState>()).Members.Count.Should().Be(2);
             });
 
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 StartSharding();
+                await Task.CompletedTask;
             }, Config.First);
-            
-            RunOn(() =>
+
+            await RunOnAsync(async () =>
             {
                 StartSharding();
+                await Task.CompletedTask;
             }, Config.Second);
-            
-            EnterBarrier("sharding started");
+
+            await EnterBarrierAsync("sharding started");
         }
-        
-        private void Cluster_sharding_must_start_some_shards_in_both_regions()
+
+        private async Task Cluster_sharding_must_start_some_shards_in_both_regions()
         {
-            RunOn(() =>
+            await RunOnAsync(async () =>
             {
                 var producer = CreateProducer("p-1");
-                Within(TimeSpan.FromSeconds(30), () =>
+                // Serial Tell/ExpectMsg loop. Cold-shard allocation on the very first entity
+                // (coordinator journal write + cross-node remote delivery + consumer start +
+                // remote probe reply) can realistically take 2-3 s on CI. The outer 30 s
+                // Within caps the aggregate budget; the per-iteration budget just has to be
+                // wide enough that a single cold round trip never trips it.
+                await WithinAsync(TimeSpan.FromSeconds(30), async () =>
                 {
-                    var regionAddresses = Enumerable.Range(1, 20).Select(n =>
+                    var regionAddresses = ImmutableHashSet<Address>.Empty.ToBuilder();
+                    foreach (var n in Enumerable.Range(1, 20))
                     {
                         producer.Tell(n, TestActor);
-                        ExpectMsg(n, TimeSpan.FromSeconds(1));
-                        return LastSender.Path.Address;
-                    }).ToImmutableHashSet();
+                        await ExpectMsgAsync(n, TimeSpan.FromSeconds(10));
+                        regionAddresses.Add(LastSender.Path.Address);
+                    }
 
                     regionAddresses.Count.Should().Be(2);
                 });
             }, Config.First);
-            
-            EnterBarrier("after-2");
+
+            await EnterBarrierAsync("after-2");
         }
 
-        private void Cluster_sharding_must_gracefully_shutdown_the_oldest_region()
+        private async Task Cluster_sharding_must_gracefully_shutdown_the_oldest_region()
         {
-            Within(TimeSpan.FromSeconds(30), () =>
+            await WithinAsync(TimeSpan.FromSeconds(30), async () =>
             {
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
                     IActorRef coordinator = null;
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(async () =>
                     {
-                        coordinator = Sys
+                        coordinator = await Sys
                           .ActorSelection($"/system/sharding/{TypeName}Coordinator/singleton/coordinator")
-                          .ResolveOne(RemainingOrDefault).Result;
+                          .ResolveOne(RemainingOrDefault);
                     });
                     var terminationProbe = CreateTestProbe();
                     var region = ClusterSharding.Get(Sys).ShardRegion(TypeName);
@@ -265,27 +275,27 @@ akka.reliable-delivery.sharding.consumer-controller.allow-bypass = true
                     Cluster.Leave(GetAddress(Config.First));
 
                     // region first
-                    terminationProbe.ExpectMsg<TerminationOrderActor.RegionTerminated>();
-                    terminationProbe.ExpectMsg<TerminationOrderActor.CoordinatorTerminated>();
+                    await terminationProbe.ExpectMsgAsync<TerminationOrderActor.RegionTerminated>();
+                    await terminationProbe.ExpectMsgAsync<TerminationOrderActor.CoordinatorTerminated>();
                 }, Config.First);
 
-                EnterBarrier("terminated");
+                await EnterBarrierAsync("terminated");
 
-                RunOn(() =>
+                await RunOnAsync(async () =>
                 {
                     var producer = CreateProducer("p-2");
-                    AwaitAssert(() =>
+                    await AwaitAssertAsync(async () =>
                     {
                         var maxCount = 20;
-                        foreach(var n in Enumerable.Range(1, maxCount))
+                        foreach (var n in Enumerable.Range(1, maxCount))
                         {
                             producer.Tell(n, TestActor);
                         }
-                        var responses = ReceiveN(maxCount, TimeSpan.FromSeconds(2));
+                        var responses = await ReceiveNAsync(maxCount, TimeSpan.FromSeconds(10)).ToListAsync();
                         responses.Count.Should().Be(20);
                     });
                 }, Config.Second);
-                EnterBarrier("done-o");
+                await EnterBarrierAsync("done-o");
             });
         }
     }


### PR DESCRIPTION
## Problem

`PersistentClusterShardingDeliveryGracefulShutdownSpec.ClusterShardingDeliveryGracefulShutdownSpecs` failed on Node 1 \[first\] in PR #8160's MNTR run (Azure DevOps build 126149) with `Timeout 00:00:01 while waiting for a message of type System.Int32`, in the first iteration of the `Enumerable.Range(1, 20).Select(n => { producer.Tell(n); ExpectMsg(n, 1s); ... })` loop at `ClusterShardingDeliveryGracefulShutdownSpec.cs:236`.

Root cause (not a regression from #8160 — diagnosed by reading the per-node logs and confirming `Akka.Cluster.Sharding.Delivery` has zero `using Akka.Streams` reach):

Cold-shard first-touch on the Persistence variant requires, in series:

| Step | Observed on the failing run |
|---|---|
| Local Tell + producer-controller handshake | ~70 ms |
| Coordinator journal write + `ShardHomeAllocated` | ~530 ms |
| Cross-node remote delivery + consumer start + confirm | ~240 ms |
| Consumer ack → remote probe Tell → Node 1 dequeue | never completed in the remaining ~130 ms |

The spec budgeted 1 second for that entire chain. With ~870 ms consumed before the reply even started back, iteration `n=1` had effectively zero race margin on a Windows CI VM. The sibling test method in the same file (line 284, `Cluster_sharding_must_gracefully_shutdown_the_oldest_region`) was already hardened against this exact pattern in #7218 — the first method was missed.

## Fix

1. Widen the per-iteration `ExpectMsg` budget to 10 s. The outer `Within(TimeSpan.FromSeconds(30))` still caps the aggregate.
2. Preserve `LastSender.Path.Address` correctness by keeping a per-message Tell/ExpectMsg loop rather than batching into `ReceiveN` (which would only expose the last envelope's sender).
3. Convert the entire spec to the async TestKit surface — `RunOnAsync`, `EnterBarrierAsync`, `WithinAsync`, `AwaitAssertAsync`, `ExpectMsgAsync`, `ReceiveNAsync` — eliminating the sync-over-async `.GetAwaiter().GetResult()` internal calls that the sync variants route through.

## Verification

- `dotnet build` on `Akka.Cluster.Sharding.Tests.MultiNode`: 0 warnings, 0 errors.
- `dotnet test --filter 'FullyQualifiedName~ClusterShardingDeliveryGracefulShutdownSpec'` run 5 times back-to-back on net8.0 locally: 4/4 nodes (Persistence + DData × first + second) pass every run, ~33 s total per run.
- Node 1 (the previously racy one) consistently completes all three test methods in 16–17 s, well inside the 30 s `Within` ceiling.

## Scope

Test-only change. No production code touched. This is a follow-up to the single-node flake observed on #8160; the PR itself is unaffected and unrelated in causal terms.