### PR TITLE
Fix multi-node adapter output race

### DIFF
--- a/.incrementalist/testsOnlyNetFx.json
+++ b/.incrementalist/testsOnlyNetFx.json
@@ -9,6 +9,7 @@
   "skip": [
     "**/.Tests.MultiNode.csproj",
     "**/Akka.MultiNode.TestAdapter.Tests.csproj",
+    "**/Akka.MultiNode.TestAdapter.Xunit2.Tests.csproj",
     "src/examples/**"
   ],
   "target": [

--- a/src/core/Akka.MultiNode.TestAdapter.Xunit2/Internal/MultiNodeTestRunner.cs
+++ b/src/core/Akka.MultiNode.TestAdapter.Xunit2/Internal/MultiNodeTestRunner.cs
@@ -93,7 +93,17 @@ namespace Akka.MultiNode.TestAdapter.Internal
         private MultiNodeTestCase TestCase => _test.TestCase;
 
         private readonly StringBuilder _outputBuilder = new StringBuilder();
-        private string Output => _outputBuilder.ToString();
+        private readonly object _outputLock = new object();
+        private string Output
+        {
+            get
+            {
+                lock (_outputLock)
+                {
+                    return _outputBuilder.ToString();
+                }
+            }
+        }
 
         private readonly List<string> _exceptionType = new List<string>();
         private readonly List<string> _exceptionMessage = new List<string>();
@@ -217,7 +227,10 @@ namespace Akka.MultiNode.TestAdapter.Internal
                 if (eventArgs?.Data != null)
                 {
                     var data = eventArgs.Data;
-                    _outputBuilder.AppendLine(data);
+                    lock (_outputLock)
+                    {
+                        _outputBuilder.AppendLine(data);
+                    }
                     _messageBus.QueueMessage(new TestOutput(_test, data + Environment.NewLine));
                     _timelineCollector.Tell(new TimelineLogCollectorActor.LogMessage(nodeInfo, data));
 

--- a/src/core/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestRunner.cs
+++ b/src/core/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestRunner.cs
@@ -61,7 +61,17 @@ namespace Akka.MultiNode.TestAdapter.Internal
         private MultiNodeTestCase TestCase => _test.TestCase;
 
         private readonly StringBuilder _outputBuilder = new StringBuilder();
-        private string Output => _outputBuilder.ToString();
+        private readonly object _outputLock = new object();
+        private string Output
+        {
+            get
+            {
+                lock (_outputLock)
+                {
+                    return _outputBuilder.ToString();
+                }
+            }
+        }
 
         private readonly List<string> _exceptionType = new List<string>();
         private readonly List<string> _exceptionMessage = new List<string>();
@@ -256,7 +266,10 @@ namespace Akka.MultiNode.TestAdapter.Internal
                 if (eventArgs?.Data != null)
                 {
                     var data = eventArgs.Data;
-                    _outputBuilder.AppendLine(data);
+                    lock (_outputLock)
+                    {
+                        _outputBuilder.AppendLine(data);
+                    }
                     _messageBus.QueueMessage(new TestOutput
                     {
                         AssemblyUniqueID = _ids.AssemblyUniqueID,


### PR DESCRIPTION
## Bug
Windows multi-node CI could fail during test cleanup even when the underlying tests all passed.

In the failing case that prompted this PR, the TRX reported:
- `136` tests passed
- `0` tests failed
- xUnit still emitted `[Test Method Cleanup Failure (ClusterSharding_specs)] System.AggregateException`
- the inner exception came from `System.Text.StringBuilder.ToString()` inside `Akka.MultiNode.TestAdapter.Internal.MultiNodeTestRunner.get_Output()`

Closes #8179.

## Cause
Each `MultiNodeTestRunner` accumulates child process output in a shared `StringBuilder`.

That buffer was being written from async process output callbacks:
- `OutputDataReceived`
- `ErrorDataReceived`

At the same time, the runner was reading the same buffer via `Output => _outputBuilder.ToString()` while publishing `TestPassed` / `TestFailed` / `TestFinished` messages and writing node logs.

Because those reads and writes were unsynchronized, the adapter could race with its own stdout/stderr handlers during shutdown and crash while reporting results.

## Fix
Synchronize access to the shared output buffer in both adapter implementations by locking:
- appends performed by the process output handlers
- snapshots taken through `Output`

Files changed:
- `src/core/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestRunner.cs`
- `src/core/Akka.MultiNode.TestAdapter.Xunit2/Internal/MultiNodeTestRunner.cs`

## Verification
- `dotnet test src/core/Akka.MultiNode.TestAdapter.Tests/Akka.MultiNode.TestAdapter.Tests.csproj -c Release`
- `dotnet test src/core/Akka.MultiNode.TestAdapter.Xunit2.Tests/Akka.MultiNode.TestAdapter.Xunit2.Tests.csproj -c Release`
- `dotnet test src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/Akka.Cluster.Sharding.Tests.MultiNode.csproj -c Release --framework net10.0 --filter DisplayName~Cluster_sharding_with_single_shard_per_entity_specs`