### PR TITLE
fix: filter link-local (APIPA) addresses from DNS resolution results

### DIFF
--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTransportLinkLocalFilterSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTransportLinkLocalFilterSpec.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using Akka.Remote.Transport.DotNetty;
@@ -15,138 +15,79 @@ namespace Akka.Remote.Tests.Transport
 {
     /// <summary>
     /// Regression test for https://github.com/akkadotnet/akka.net/issues/8178
-    /// Filters link-local (169.254.x.x) and IPv6 link-local (fe80::/10) addresses from DNS results
-    /// to prevent cluster formation failures on multi-NIC Windows hosts with APIPA addresses.
     /// </summary>
     public class DotNettyTransportLinkLocalFilterSpec
     {
-        [Fact]
-        public void FilterLinkLocalAddresses_should_remove_ipv4_link_local_addresses()
+        public static IEnumerable<object[]> FilterCases()
         {
-            var addresses = new IPAddress[]
+            // removes IPv4 link-local
+            yield return new object[]
             {
-                IPAddress.Parse("10.0.0.5"),
-                IPAddress.Parse("169.254.1.1"),
-                IPAddress.Parse("192.168.1.10")
+                new[] { "10.0.0.5", "169.254.1.1", "192.168.1.10" },
+                new[] { "10.0.0.5", "192.168.1.10" }
             };
 
-            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
-
-            filtered.Should().HaveCount(2);
-            filtered.Should().Contain(IPAddress.Parse("10.0.0.5"));
-            filtered.Should().Contain(IPAddress.Parse("192.168.1.10"));
-            filtered.Should().NotContain(IPAddress.Parse("169.254.1.1"));
-        }
-
-        [Fact]
-        public void FilterLinkLocalAddresses_should_remove_ipv6_link_local_addresses()
-        {
-            var addresses = new IPAddress[]
+            // removes IPv6 link-local
+            yield return new object[]
             {
-                IPAddress.Parse("fe80::1"),
-                IPAddress.Parse("2001:db8::1")
+                new[] { "fe80::1", "2001:db8::1" },
+                new[] { "2001:db8::1" }
             };
 
-            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
-
-            filtered.Should().HaveCount(1);
-            filtered.Should().Contain(IPAddress.Parse("2001:db8::1"));
-            filtered.Should().NotContain(IPAddress.Parse("fe80::1"));
-        }
-
-        [Fact]
-        public void FilterLinkLocalAddresses_should_keep_loopback_addresses()
-        {
-            // localhost should still resolve correctly
-            var addresses = new IPAddress[]
+            // keeps loopback addresses
+            yield return new object[]
             {
-                IPAddress.Loopback,
-                IPAddress.IPv6Loopback
+                new[] { "127.0.0.1", "::1" },
+                new[] { "127.0.0.1", "::1" }
             };
 
-            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
-
-            filtered.Should().HaveCount(2);
-            filtered.Should().Contain(IPAddress.Loopback);
-            filtered.Should().Contain(IPAddress.IPv6Loopback);
-        }
-
-        [Fact]
-        public void FilterLinkLocalAddresses_should_return_empty_when_only_link_local()
-        {
-            var addresses = new IPAddress[]
+            // returns empty when only link-local
+            yield return new object[]
             {
-                IPAddress.Parse("169.254.1.1"),
-                IPAddress.Parse("169.254.2.2")
+                new[] { "169.254.1.1", "169.254.2.2" },
+                new string[] { }
             };
 
-            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
-
-            filtered.Should().BeEmpty();
-        }
-
-        [Fact]
-        public void FilterLinkLocalAddresses_should_keep_all_normal_addresses()
-        {
-            var addresses = new IPAddress[]
+            // keeps all normal addresses
+            yield return new object[]
             {
-                IPAddress.Parse("10.0.0.5"),
-                IPAddress.Parse("172.16.0.1"),
-                IPAddress.Parse("192.168.1.10"),
-                IPAddress.Loopback,
-                IPAddress.IPv6Loopback,
-                IPAddress.Parse("2001:db8::1")
+                new[] { "10.0.0.5", "172.16.0.1", "192.168.1.10", "127.0.0.1", "::1", "2001:db8::1" },
+                new[] { "10.0.0.5", "172.16.0.1", "192.168.1.10", "127.0.0.1", "::1", "2001:db8::1" }
             };
 
-            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
-
-            filtered.Should().HaveCount(addresses.Length);
-            filtered.Should().BeEquivalentTo(addresses);
-        }
-
-        [Fact]
-        public void FilterLinkLocalAddresses_should_mixed_ipv4_and_ipv6()
-        {
-            var addresses = new IPAddress[]
+            // mixed IPv4 and IPv6 link-local
+            yield return new object[]
             {
-                IPAddress.Parse("10.0.0.5"),
-                IPAddress.Parse("169.254.1.1"),
-                IPAddress.Parse("fe80::1"),
-                IPAddress.Parse("2001:db8::1")
+                new[] { "10.0.0.5", "169.254.1.1", "fe80::1", "2001:db8::1" },
+                new[] { "10.0.0.5", "2001:db8::1" }
             };
 
-            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
-
-            filtered.Should().HaveCount(2);
-            filtered.Should().Contain(IPAddress.Parse("10.0.0.5"));
-            filtered.Should().Contain(IPAddress.Parse("2001:db8::1"));
-        }
-
-        [Fact]
-        public void FilterLinkLocalAddresses_should_handle_empty_array()
-        {
-            var addresses = Array.Empty<IPAddress>();
-
-            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
-
-            filtered.Should().BeEmpty();
-        }
-
-        [Fact]
-        public void FilterLinkLocalAddresses_should_preserve_order()
-        {
-            var addresses = new IPAddress[]
+            // empty input
+            yield return new object[]
             {
-                IPAddress.Parse("192.168.1.10"),
-                IPAddress.Parse("10.0.0.5"),
-                IPAddress.Parse("169.254.1.1")
+                new string[] { },
+                new string[] { }
             };
 
-            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
+            // preserves order
+            yield return new object[]
+            {
+                new[] { "192.168.1.10", "10.0.0.5", "169.254.1.1" },
+                new[] { "192.168.1.10", "10.0.0.5" }
+            };
+        }
 
-            filtered.Should().HaveCount(2);
-            filtered[0].Should().Be(IPAddress.Parse("192.168.1.10"));
-            filtered[1].Should().Be(IPAddress.Parse("10.0.0.5"));
+        [Theory]
+        [MemberData(nameof(FilterCases))]
+        public void FilterLinkLocalAddresses_should_return_expected_results(
+            string[] input, string[] expected)
+        {
+            var addresses = input.Select(IPAddress.Parse).ToArray();
+            var expectedAddresses = expected.Select(IPAddress.Parse).ToArray();
+
+            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses).ToArray();
+
+            filtered.Should().Equal(expectedAddresses);
         }
     }
 }

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTransportLinkLocalFilterSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTransportLinkLocalFilterSpec.cs
@@ -1,0 +1,152 @@
+//-----------------------------------------------------------------------
+// <copyright file="DotNettyTransportLinkLocalFilterSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Net;
+using Akka.Remote.Transport.DotNetty;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Remote.Tests.Transport
+{
+    /// <summary>
+    /// Regression test for https://github.com/akkadotnet/akka.net/issues/8178
+    /// Filters link-local (169.254.x.x) and IPv6 link-local (fe80::/10) addresses from DNS results
+    /// to prevent cluster formation failures on multi-NIC Windows hosts with APIPA addresses.
+    /// </summary>
+    public class DotNettyTransportLinkLocalFilterSpec
+    {
+        [Fact]
+        public void FilterLinkLocalAddresses_should_remove_ipv4_link_local_addresses()
+        {
+            var addresses = new IPAddress[]
+            {
+                IPAddress.Parse("10.0.0.5"),
+                IPAddress.Parse("169.254.1.1"),
+                IPAddress.Parse("192.168.1.10")
+            };
+
+            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
+
+            filtered.Should().HaveCount(2);
+            filtered.Should().Contain(IPAddress.Parse("10.0.0.5"));
+            filtered.Should().Contain(IPAddress.Parse("192.168.1.10"));
+            filtered.Should().NotContain(IPAddress.Parse("169.254.1.1"));
+        }
+
+        [Fact]
+        public void FilterLinkLocalAddresses_should_remove_ipv6_link_local_addresses()
+        {
+            var addresses = new IPAddress[]
+            {
+                IPAddress.Parse("fe80::1"),
+                IPAddress.Parse("2001:db8::1")
+            };
+
+            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
+
+            filtered.Should().HaveCount(1);
+            filtered.Should().Contain(IPAddress.Parse("2001:db8::1"));
+            filtered.Should().NotContain(IPAddress.Parse("fe80::1"));
+        }
+
+        [Fact]
+        public void FilterLinkLocalAddresses_should_keep_loopback_addresses()
+        {
+            // localhost should still resolve correctly
+            var addresses = new IPAddress[]
+            {
+                IPAddress.Loopback,
+                IPAddress.IPv6Loopback
+            };
+
+            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
+
+            filtered.Should().HaveCount(2);
+            filtered.Should().Contain(IPAddress.Loopback);
+            filtered.Should().Contain(IPAddress.IPv6Loopback);
+        }
+
+        [Fact]
+        public void FilterLinkLocalAddresses_should_return_empty_when_only_link_local()
+        {
+            var addresses = new IPAddress[]
+            {
+                IPAddress.Parse("169.254.1.1"),
+                IPAddress.Parse("169.254.2.2")
+            };
+
+            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
+
+            filtered.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void FilterLinkLocalAddresses_should_keep_all_normal_addresses()
+        {
+            var addresses = new IPAddress[]
+            {
+                IPAddress.Parse("10.0.0.5"),
+                IPAddress.Parse("172.16.0.1"),
+                IPAddress.Parse("192.168.1.10"),
+                IPAddress.Loopback,
+                IPAddress.IPv6Loopback,
+                IPAddress.Parse("2001:db8::1")
+            };
+
+            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
+
+            filtered.Should().HaveCount(addresses.Length);
+            filtered.Should().BeEquivalentTo(addresses);
+        }
+
+        [Fact]
+        public void FilterLinkLocalAddresses_should_mixed_ipv4_and_ipv6()
+        {
+            var addresses = new IPAddress[]
+            {
+                IPAddress.Parse("10.0.0.5"),
+                IPAddress.Parse("169.254.1.1"),
+                IPAddress.Parse("fe80::1"),
+                IPAddress.Parse("2001:db8::1")
+            };
+
+            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
+
+            filtered.Should().HaveCount(2);
+            filtered.Should().Contain(IPAddress.Parse("10.0.0.5"));
+            filtered.Should().Contain(IPAddress.Parse("2001:db8::1"));
+        }
+
+        [Fact]
+        public void FilterLinkLocalAddresses_should_handle_empty_array()
+        {
+            var addresses = Array.Empty<IPAddress>();
+
+            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
+
+            filtered.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void FilterLinkLocalAddresses_should_preserve_order()
+        {
+            var addresses = new IPAddress[]
+            {
+                IPAddress.Parse("192.168.1.10"),
+                IPAddress.Parse("10.0.0.5"),
+                IPAddress.Parse("169.254.1.1")
+            };
+
+            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses);
+
+            filtered.Should().HaveCount(2);
+            filtered[0].Should().Be(IPAddress.Parse("192.168.1.10"));
+            filtered[1].Should().Be(IPAddress.Parse("10.0.0.5"));
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -534,6 +534,10 @@ namespace Akka.Remote.Transport.DotNetty
                 Log.Debug("Filtered {0} link-local address(es) from DNS results for '{1}'",
                     resolved.AddressList.Length - filtered.Length, address.Host);
 
+            // Important detail here: if your network is relying on APIPA addresses, then this patch preserves that.
+            // If 100% of resolved DNS addresses are link-local, and therefore 100% of them get filtered out,
+            // then we use the originally resolved list instead.
+            // In scenarios where you have a mix of APIPA and routable addresses, routable addresses win.
             var selected = filtered.FirstOrDefault() ?? resolved.AddressList.LastOrDefault();
             return new IPEndPoint(selected!, address.Port);
         }
@@ -552,6 +556,10 @@ namespace Akka.Remote.Transport.DotNetty
                 Log.Debug("Filtered {0} link-local address(es) from DNS results for '{1}' with address family '{2}'",
                     matching.Length - filtered.Length, address.Host, addressFamily);
 
+            // Important detail here: if your network is relying on APIPA addresses, then this patch preserves that.
+            // If 100% of resolved DNS addresses are link-local, and therefore 100% of them get filtered out,
+            // then we use the originally resolved list instead.
+            // In scenarios where you have a mix of APIPA and routable addresses, routable addresses win.
             var found = filtered.FirstOrDefault() ?? matching.FirstOrDefault();
 
             if (found == null)

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="DotNettyTransport.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -525,20 +525,53 @@ namespace Akka.Remote.Transport.DotNetty
         {
             var resolved = await Dns.GetHostEntryAsync(address.Host).ConfigureAwait(false);
             //NOTE: for some reason while Helios takes first element from resolved address list
-            // on the DotNetty side we need to take the last one in order to be compatible
-            return new IPEndPoint(resolved.AddressList[resolved.AddressList.Length - 1], address.Port);
+            // on the DotNetty side we need to take the last one in order to be compatible.
+            // We filter link-local addresses first, but fallback to the original list if filtering 
+            // eliminates everything, preserving backward compatibility.
+            var candidates = FilterLinkLocalAddresses(resolved.AddressList);
+            var selected = candidates.FirstOrDefault() ?? resolved.AddressList.LastOrDefault();
+            return new IPEndPoint(selected!, address.Port);
         }
 
         private async Task<IPEndPoint> ResolveNameAsync(DnsEndPoint address, AddressFamily addressFamily)
         {
             var resolved = await Dns.GetHostEntryAsync(address.Host).ConfigureAwait(false);
-            var found = resolved.AddressList.LastOrDefault(a => a.AddressFamily == addressFamily);
+            var matching = resolved.AddressList.Where(a => a.AddressFamily == addressFamily).ToArray();
+            
+            // Filter out link-local addresses (169.254.0.0/16, fe80::/10) which break cluster formation 
+            // on multi-NIC hosts where APIPA addresses appear in DNS results.
+            // Fallback to unfiltered list to preserve backward compatibility if filtering eliminates all candidates.
+            var filtered = FilterLinkLocalAddresses(matching);
+            var found = filtered.FirstOrDefault() ?? matching.FirstOrDefault();
+            
             if (found == null)
             {
                 throw new KeyNotFoundException($"Couldn't resolve IP endpoint from provided DNS name '{address}' with address family of '{addressFamily}'");
             }
 
             return new IPEndPoint(found, address.Port);
+        }
+
+        /// <summary>
+        /// Filters out IPv4 link-local (169.254.0.0/16) and IPv6 link-local (fe80::/10) addresses.
+        /// These addresses are not routable and can break cluster formation on multi-NIC hosts 
+        /// where APIPA addresses appear in DNS results.
+        /// </summary>
+        internal static IPAddress[] FilterLinkLocalAddresses(IPAddress[] addresses)
+        {
+            return addresses.Where(a => !IsIPv4LinkLocal(a) && !IsIPv6LinkLocal(a)).ToArray();
+        }
+
+        private static bool IsIPv4LinkLocal(IPAddress ip)
+        {
+            if (ip.AddressFamily != AddressFamily.InterNetwork) return false;
+            var bytes = ip.GetAddressBytes();
+            return bytes[0] == 169 && bytes[1] == 254;
+        }
+
+        private static bool IsIPv6LinkLocal(IPAddress ip)
+        {
+            return ip.AddressFamily == AddressFamily.InterNetworkV6 && ip.IsIPv6LinkLocal;
         }
 
         #endregion

--- a/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
+++ b/src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs
@@ -526,10 +526,15 @@ namespace Akka.Remote.Transport.DotNetty
             var resolved = await Dns.GetHostEntryAsync(address.Host).ConfigureAwait(false);
             //NOTE: for some reason while Helios takes first element from resolved address list
             // on the DotNetty side we need to take the last one in order to be compatible.
-            // We filter link-local addresses first, but fallback to the original list if filtering 
+            // We filter link-local addresses first, but fallback to the original list if filtering
             // eliminates everything, preserving backward compatibility.
-            var candidates = FilterLinkLocalAddresses(resolved.AddressList);
-            var selected = candidates.FirstOrDefault() ?? resolved.AddressList.LastOrDefault();
+            var filtered = FilterLinkLocalAddresses(resolved.AddressList).ToArray();
+
+            if (Log.IsDebugEnabled && filtered.Length < resolved.AddressList.Length)
+                Log.Debug("Filtered {0} link-local address(es) from DNS results for '{1}'",
+                    resolved.AddressList.Length - filtered.Length, address.Host);
+
+            var selected = filtered.FirstOrDefault() ?? resolved.AddressList.LastOrDefault();
             return new IPEndPoint(selected!, address.Port);
         }
 
@@ -537,13 +542,18 @@ namespace Akka.Remote.Transport.DotNetty
         {
             var resolved = await Dns.GetHostEntryAsync(address.Host).ConfigureAwait(false);
             var matching = resolved.AddressList.Where(a => a.AddressFamily == addressFamily).ToArray();
-            
-            // Filter out link-local addresses (169.254.0.0/16, fe80::/10) which break cluster formation 
+
+            // Filter out link-local addresses (169.254.0.0/16, fe80::/10) which break cluster formation
             // on multi-NIC hosts where APIPA addresses appear in DNS results.
             // Fallback to unfiltered list to preserve backward compatibility if filtering eliminates all candidates.
-            var filtered = FilterLinkLocalAddresses(matching);
+            var filtered = FilterLinkLocalAddresses(matching).ToArray();
+
+            if (Log.IsDebugEnabled && filtered.Length < matching.Length)
+                Log.Debug("Filtered {0} link-local address(es) from DNS results for '{1}' with address family '{2}'",
+                    matching.Length - filtered.Length, address.Host, addressFamily);
+
             var found = filtered.FirstOrDefault() ?? matching.FirstOrDefault();
-            
+
             if (found == null)
             {
                 throw new KeyNotFoundException($"Couldn't resolve IP endpoint from provided DNS name '{address}' with address family of '{addressFamily}'");
@@ -554,12 +564,12 @@ namespace Akka.Remote.Transport.DotNetty
 
         /// <summary>
         /// Filters out IPv4 link-local (169.254.0.0/16) and IPv6 link-local (fe80::/10) addresses.
-        /// These addresses are not routable and can break cluster formation on multi-NIC hosts 
+        /// These addresses are not routable and can break cluster formation on multi-NIC hosts
         /// where APIPA addresses appear in DNS results.
         /// </summary>
-        internal static IPAddress[] FilterLinkLocalAddresses(IPAddress[] addresses)
+        internal static IEnumerable<IPAddress> FilterLinkLocalAddresses(IEnumerable<IPAddress> addresses)
         {
-            return addresses.Where(a => !IsIPv4LinkLocal(a) && !IsIPv6LinkLocal(a)).ToArray();
+            return addresses.Where(a => !IsIPv4LinkLocal(a) && !IsIPv6LinkLocal(a));
         }
 
         private static bool IsIPv4LinkLocal(IPAddress ip)


### PR DESCRIPTION
Closes #8178

## Changes

On Windows hosts with multiple network adapters, Dns.GetHostEntryAsync can return APIPA (169.254.x.x) addresses from DNS results when a secondary NIC fails DHCP and registers the link-local address via dynamic DNS.

Previously ResolveNameAsync unconditionally selected the last matching address in the DNS result list. When the last entry was a link-local address, the transport would bind to or attempt to connect to an unreachable address, breaking cluster formation.

This fix:
- Filters out IPv4 link-local (169.254.0.0/16) and IPv6 link-local (fe80::/10) addresses
- Falls back to the original unfiltered behavior if all candidates are filtered, preserving backward compatibility
- Switches from LastOrDefault to FirstOrDefault for the filtered list, preferring the DNS server's primary result order
- Preserves loopback addresses (localhost still works normally)

## Checklist

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Design discussion issue #8178 

