### PR TITLE
fix(persistence): redesign MemoryJournal and MemorySnapshotStore with channel-based drain-on-read pattern

### DIFF
--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -1070,6 +1070,7 @@ namespace Akka.Persistence.Journal
         public MemoryJournal() { }
         protected virtual Akka.Persistence.Journal.MemoryJournal.JournalStorage Storage { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
+        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public long HighestSequenceNr(string pid) { }
@@ -1276,6 +1277,7 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual Akka.Persistence.Snapshot.MemorySnapshotStore.SnapshotStorage Storage { get; }
+        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -1107,6 +1107,7 @@ namespace Akka.Persistence.Journal
         protected sealed class JournalStorage
         {
             public System.Collections.Immutable.ImmutableDictionary<string, long> DeletedTo;
+            public readonly object DrainLock;
             public System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation> EventLog;
             public System.Collections.Immutable.ImmutableDictionary<string, System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId;
             public readonly System.Threading.Channels.Channel<Akka.Persistence.IPersistentRepresentation> PendingWrites;
@@ -1286,6 +1287,7 @@ namespace Akka.Persistence.Snapshot
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         protected sealed class SnapshotStorage
         {
+            public readonly object DrainLock;
             public readonly System.Threading.Channels.Channel<Akka.Persistence.Snapshot.SnapshotEntry> PendingWrites;
             public System.Collections.Immutable.ImmutableList<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots;
             public SnapshotStorage() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -1068,10 +1068,7 @@ namespace Akka.Persistence.Journal
     public class MemoryJournal : Akka.Persistence.Journal.AsyncWriteJournal
     {
         public MemoryJournal() { }
-        protected virtual System.Collections.Generic.Dictionary<string, long> DeletedTo { get; }
-        protected virtual System.Collections.Generic.List<Akka.Persistence.IPersistentRepresentation> EventLog { get; }
-        protected virtual System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId { get; }
-        protected virtual System.Threading.ReaderWriterLockSlim Lock { get; }
+        protected virtual Akka.Persistence.Journal.MemoryJournal.JournalStorage Storage { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
@@ -1106,6 +1103,14 @@ namespace Akka.Persistence.Journal
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
+        }
+        protected sealed class JournalStorage
+        {
+            public System.Collections.Immutable.ImmutableDictionary<string, long> DeletedTo;
+            public System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation> EventLog;
+            public System.Collections.Immutable.ImmutableDictionary<string, System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId;
+            public readonly System.Threading.Channels.Channel<Akka.Persistence.IPersistentRepresentation> PendingWrites;
+            public JournalStorage() { }
         }
         [System.Serializable]
         public sealed class ReplayAllEvents : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
@@ -1203,10 +1208,7 @@ namespace Akka.Persistence.Journal
     public class SharedMemoryJournal : Akka.Persistence.Journal.MemoryJournal
     {
         public SharedMemoryJournal() { }
-        protected override System.Collections.Generic.Dictionary<string, long> DeletedTo { get; }
-        protected override System.Collections.Generic.List<Akka.Persistence.IPersistentRepresentation> EventLog { get; }
-        protected override System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId { get; }
-        protected override System.Threading.ReaderWriterLockSlim Lock { get; }
+        protected override Akka.Persistence.Journal.MemoryJournal.JournalStorage Storage { get; }
     }
     [System.Serializable]
     public struct SingleEventSequence : Akka.Persistence.Journal.IEventSequence, System.IEquatable<Akka.Persistence.Journal.IEventSequence>
@@ -1277,11 +1279,17 @@ namespace Akka.Persistence.Snapshot
     public class MemorySnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public MemorySnapshotStore() { }
-        protected virtual System.Collections.Generic.List<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots { get; }
+        protected virtual Akka.Persistence.Snapshot.MemorySnapshotStore.SnapshotStorage Storage { get; }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
+        protected sealed class SnapshotStorage
+        {
+            public readonly System.Threading.Channels.Channel<Akka.Persistence.Snapshot.SnapshotEntry> PendingWrites;
+            public System.Collections.Immutable.ImmutableList<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots;
+            public SnapshotStorage() { }
+        }
     }
     public sealed class NoSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
@@ -1298,14 +1306,14 @@ namespace Akka.Persistence.Snapshot
             public NoSnapshotStoreException(string message, System.Exception innerException) { }
         }
     }
-    public class SnapshotEntry
+    public sealed class SnapshotEntry
     {
-        public SnapshotEntry() { }
-        public string Id { get; set; }
-        public string PersistenceId { get; set; }
-        public long SequenceNr { get; set; }
-        public object Snapshot { get; set; }
-        public long Timestamp { get; set; }
+        public SnapshotEntry(string id, string persistenceId, long sequenceNr, long timestamp, object snapshot) { }
+        public string Id { get; }
+        public string PersistenceId { get; }
+        public long SequenceNr { get; }
+        public object Snapshot { get; }
+        public long Timestamp { get; }
     }
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -1070,7 +1070,6 @@ namespace Akka.Persistence.Journal
         public MemoryJournal() { }
         protected virtual Akka.Persistence.Journal.MemoryJournal.JournalStorage Storage { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
-        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public long HighestSequenceNr(string pid) { }
@@ -1277,7 +1276,6 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual Akka.Persistence.Snapshot.MemorySnapshotStore.SnapshotStorage Storage { get; }
-        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -1106,11 +1106,6 @@ namespace Akka.Persistence.Journal
         }
         protected sealed class JournalStorage
         {
-            public System.Collections.Immutable.ImmutableDictionary<string, long> DeletedTo;
-            public readonly object DrainLock;
-            public System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation> EventLog;
-            public System.Collections.Immutable.ImmutableDictionary<string, System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId;
-            public readonly System.Threading.Channels.Channel<Akka.Persistence.IPersistentRepresentation> PendingWrites;
             public JournalStorage() { }
         }
         [System.Serializable]
@@ -1287,9 +1282,6 @@ namespace Akka.Persistence.Snapshot
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         protected sealed class SnapshotStorage
         {
-            public readonly object DrainLock;
-            public readonly System.Threading.Channels.Channel<Akka.Persistence.Snapshot.SnapshotEntry> PendingWrites;
-            public System.Collections.Immutable.ImmutableList<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots;
             public SnapshotStorage() { }
         }
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -1070,6 +1070,7 @@ namespace Akka.Persistence.Journal
         public MemoryJournal() { }
         protected virtual Akka.Persistence.Journal.MemoryJournal.JournalStorage Storage { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
+        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public long HighestSequenceNr(string pid) { }
@@ -1276,6 +1277,7 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual Akka.Persistence.Snapshot.MemorySnapshotStore.SnapshotStorage Storage { get; }
+        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -1107,6 +1107,7 @@ namespace Akka.Persistence.Journal
         protected sealed class JournalStorage
         {
             public System.Collections.Immutable.ImmutableDictionary<string, long> DeletedTo;
+            public readonly object DrainLock;
             public System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation> EventLog;
             public System.Collections.Immutable.ImmutableDictionary<string, System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId;
             public readonly System.Threading.Channels.Channel<Akka.Persistence.IPersistentRepresentation> PendingWrites;
@@ -1286,6 +1287,7 @@ namespace Akka.Persistence.Snapshot
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         protected sealed class SnapshotStorage
         {
+            public readonly object DrainLock;
             public readonly System.Threading.Channels.Channel<Akka.Persistence.Snapshot.SnapshotEntry> PendingWrites;
             public System.Collections.Immutable.ImmutableList<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots;
             public SnapshotStorage() { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -1068,10 +1068,7 @@ namespace Akka.Persistence.Journal
     public class MemoryJournal : Akka.Persistence.Journal.AsyncWriteJournal
     {
         public MemoryJournal() { }
-        protected virtual System.Collections.Generic.Dictionary<string, long> DeletedTo { get; }
-        protected virtual System.Collections.Generic.List<Akka.Persistence.IPersistentRepresentation> EventLog { get; }
-        protected virtual System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId { get; }
-        protected virtual System.Threading.ReaderWriterLockSlim Lock { get; }
+        protected virtual Akka.Persistence.Journal.MemoryJournal.JournalStorage Storage { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
@@ -1106,6 +1103,14 @@ namespace Akka.Persistence.Journal
             public override bool Equals(object obj) { }
             public override int GetHashCode() { }
             public override string ToString() { }
+        }
+        protected sealed class JournalStorage
+        {
+            public System.Collections.Immutable.ImmutableDictionary<string, long> DeletedTo;
+            public System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation> EventLog;
+            public System.Collections.Immutable.ImmutableDictionary<string, System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId;
+            public readonly System.Threading.Channels.Channel<Akka.Persistence.IPersistentRepresentation> PendingWrites;
+            public JournalStorage() { }
         }
         [System.Serializable]
         public sealed class ReplayAllEvents : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
@@ -1203,10 +1208,7 @@ namespace Akka.Persistence.Journal
     public class SharedMemoryJournal : Akka.Persistence.Journal.MemoryJournal
     {
         public SharedMemoryJournal() { }
-        protected override System.Collections.Generic.Dictionary<string, long> DeletedTo { get; }
-        protected override System.Collections.Generic.List<Akka.Persistence.IPersistentRepresentation> EventLog { get; }
-        protected override System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId { get; }
-        protected override System.Threading.ReaderWriterLockSlim Lock { get; }
+        protected override Akka.Persistence.Journal.MemoryJournal.JournalStorage Storage { get; }
     }
     [System.Serializable]
     public struct SingleEventSequence : Akka.Persistence.Journal.IEventSequence, System.IEquatable<Akka.Persistence.Journal.IEventSequence>
@@ -1277,11 +1279,17 @@ namespace Akka.Persistence.Snapshot
     public class MemorySnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
         public MemorySnapshotStore() { }
-        protected virtual System.Collections.Generic.List<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots { get; }
+        protected virtual Akka.Persistence.Snapshot.MemorySnapshotStore.SnapshotStorage Storage { get; }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
+        protected sealed class SnapshotStorage
+        {
+            public readonly System.Threading.Channels.Channel<Akka.Persistence.Snapshot.SnapshotEntry> PendingWrites;
+            public System.Collections.Immutable.ImmutableList<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots;
+            public SnapshotStorage() { }
+        }
     }
     public sealed class NoSnapshotStore : Akka.Persistence.Snapshot.SnapshotStore
     {
@@ -1298,14 +1306,14 @@ namespace Akka.Persistence.Snapshot
             public NoSnapshotStoreException(string message, System.Exception innerException) { }
         }
     }
-    public class SnapshotEntry
+    public sealed class SnapshotEntry
     {
-        public SnapshotEntry() { }
-        public string Id { get; set; }
-        public string PersistenceId { get; set; }
-        public long SequenceNr { get; set; }
-        public object Snapshot { get; set; }
-        public long Timestamp { get; set; }
+        public SnapshotEntry(string id, string persistenceId, long sequenceNr, long timestamp, object snapshot) { }
+        public string Id { get; }
+        public string PersistenceId { get; }
+        public long SequenceNr { get; }
+        public object Snapshot { get; }
+        public long Timestamp { get; }
     }
     public abstract class SnapshotStore : Akka.Actor.ActorBase
     {

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -1070,7 +1070,6 @@ namespace Akka.Persistence.Journal
         public MemoryJournal() { }
         protected virtual Akka.Persistence.Journal.MemoryJournal.JournalStorage Storage { get; }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Add(Akka.Persistence.IPersistentRepresentation persistent) { }
-        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         public System.Collections.Generic.IDictionary<string, System.Collections.Generic.LinkedList<Akka.Persistence.IPersistentRepresentation>> Delete(string pid, long seqNr) { }
         protected override System.Threading.Tasks.Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, System.Threading.CancellationToken cancellationToken) { }
         public long HighestSequenceNr(string pid) { }
@@ -1277,7 +1276,6 @@ namespace Akka.Persistence.Snapshot
     {
         public MemorySnapshotStore() { }
         protected virtual Akka.Persistence.Snapshot.MemorySnapshotStore.SnapshotStorage Storage { get; }
-        protected override bool AroundReceive(Akka.Actor.Receive receive, object message) { }
         protected override System.Threading.Tasks.Task DeleteAsync(Akka.Persistence.SnapshotMetadata metadata, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task DeleteAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }
         protected override System.Threading.Tasks.Task<Akka.Persistence.SelectedSnapshot> LoadAsync(string persistenceId, Akka.Persistence.SnapshotSelectionCriteria criteria, System.Threading.CancellationToken cancellationToken) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -1106,11 +1106,6 @@ namespace Akka.Persistence.Journal
         }
         protected sealed class JournalStorage
         {
-            public System.Collections.Immutable.ImmutableDictionary<string, long> DeletedTo;
-            public readonly object DrainLock;
-            public System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation> EventLog;
-            public System.Collections.Immutable.ImmutableDictionary<string, System.Collections.Immutable.ImmutableList<Akka.Persistence.IPersistentRepresentation>> EventsByPersistenceId;
-            public readonly System.Threading.Channels.Channel<Akka.Persistence.IPersistentRepresentation> PendingWrites;
             public JournalStorage() { }
         }
         [System.Serializable]
@@ -1287,9 +1282,6 @@ namespace Akka.Persistence.Snapshot
         protected override System.Threading.Tasks.Task SaveAsync(Akka.Persistence.SnapshotMetadata metadata, object snapshot, System.Threading.CancellationToken cancellationToken) { }
         protected sealed class SnapshotStorage
         {
-            public readonly object DrainLock;
-            public readonly System.Threading.Channels.Channel<Akka.Persistence.Snapshot.SnapshotEntry> PendingWrites;
-            public System.Collections.Immutable.ImmutableList<Akka.Persistence.Snapshot.SnapshotEntry> Snapshots;
             public SnapshotStorage() { }
         }
     }

--- a/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryCrashSpec.cs
+++ b/src/core/Akka.Persistence.Tests/AtLeastOnceDeliveryCrashSpec.cs
@@ -56,6 +56,12 @@ namespace Akka.Persistence.Tests
             private CrashMessage() { }
         }
 
+        internal class CrashMessagePersisted
+        {
+            public static readonly CrashMessagePersisted Instance = new();
+            private CrashMessagePersisted() { }
+        }
+
         internal class SendingMessage
         {
             public SendingMessage(long deliveryId, bool isRecovering)
@@ -104,7 +110,13 @@ namespace Akka.Persistence.Tests
             protected override bool ReceiveCommand(object message)
             {
                 if (message is Message message1) Persist(message1, _ => Send());
-                else if (message is CrashMessage crashMessage) Persist(crashMessage, _ => { });
+                else if (message is CrashMessage crashMessage) Persist(crashMessage, _ =>
+                {
+                    // Signal that the CrashMessage has been persisted
+                    // This is necessary to avoid a race condition where the supervisor
+                    // is stopped before the CrashMessage is persisted to the journal
+                    _testProbe.Tell(CrashMessagePersisted.Instance);
+                });
                 else return false;
                 return true;
             }
@@ -122,7 +134,7 @@ namespace Akka.Persistence.Tests
         {
         }
 
-        [LocalFact(SkipLocal = "Racy on Azure DevOps")]
+        [Fact]
         public void AtLeastOnceDelivery_should_not_send_when_actor_crashes()
         {
             var testProbe = CreateTestProbe();
@@ -132,6 +144,12 @@ namespace Akka.Persistence.Tests
             testProbe.ExpectMsg<SendingMessage>();
 
             supervisor.Tell(CrashMessage.Instance);
+            // Wait for the CrashMessage to be persisted before stopping the supervisor
+            // This fixes a race condition where the supervisor could be stopped before
+            // the CrashMessage is written to the journal, causing recovery to succeed
+            // instead of crash (which would then trigger OnReplaySuccess and send messages)
+            testProbe.ExpectMsg<CrashMessagePersisted>();
+
             var deathProbe = CreateTestProbe();
             deathProbe.Watch(supervisor);
             Sys.Stop(supervisor);

--- a/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistenceSpec.cs
@@ -75,6 +75,12 @@ namespace Akka.Persistence.Tests
                 .ShouldOnlyContainInOrder(ordered);
         }
 
+        protected async Task ExpectMsgInOrderAsync(params object[] ordered)
+        {
+            var msg = await ExpectMsgAsync<object[]>();
+            msg.ShouldOnlyContainInOrder(ordered);
+        }
+
         protected void ExpectAnyMsgInOrder(params IEnumerable<object>[] expected)
         {
             var msg = ExpectMsg<object[]>();

--- a/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
+++ b/src/core/Akka.Persistence.Tests/PersistentActorFailureSpec.cs
@@ -290,7 +290,7 @@ namespace Akka.Persistence.Tests
             //TODO: remove akka.actor.serialize-messages=off when Props serialization will be resolved (github issue: #569)
         }
 
-        private void PrepareFailingRecovery()
+        private async Task PrepareFailingRecoveryAsync()
         {
             var pref = ActorOf(Props.Create(() => new FailingRecovery(Name)));
             pref.Tell(new Cmd("a"));
@@ -298,33 +298,33 @@ namespace Akka.Persistence.Tests
             pref.Tell(new Cmd("bad"));
             pref.Tell(new Cmd("c"));
             pref.Tell(GetState.Instance);
-            ExpectMsg(new object[] {"a", "b", "bad", "c"});
+            await ExpectMsgAsync(new object[] {"a", "b", "bad", "c"});
         }
 
         [Fact]
-        public void PersistentActor_should_stop_if_recovery_from_persisted_events_fails()
+        public async Task PersistentActor_should_stop_if_recovery_from_persisted_events_fails()
         {
             var pref = ActorOf(Props.Create(() => new BehaviorOneActor(Name)));
             pref.Tell(new Cmd("corrupt"));
             pref.Tell(GetState.Instance);
-            ExpectMsgInOrder("corrupt-1", "corrupt-2");
+            await ExpectMsgInOrderAsync("corrupt-1", "corrupt-2");
 
             // recover by creating another with same name
             var sup = Sys.ActorOf(Props.Create(() => new Supervisor(TestActor)));
             sup.Tell(new Props(typeof (BehaviorOneActor), new object[] {Name}));
-            var newPref = ExpectMsg<IActorRef>();
-            Watch(newPref);
-            ExpectTerminated(newPref);
+            var newPref = await ExpectMsgAsync<IActorRef>();
+            await WatchAsync(newPref);
+            await ExpectTerminatedAsync(newPref);
         }
 
         [Fact]
-        public void PersistentActor_should_call_OnRecoveryFailure_when_recovery_from_persisted_events_fails()
+        public async Task PersistentActor_should_call_OnRecoveryFailure_when_recovery_from_persisted_events_fails()
         {
             var props = Props.Create(() => new OnRecoveryFailurePersistentActor(Name, TestActor));
             var pref = ActorOf(props);
             pref.Tell(new Cmd("corrupt"));
             pref.Tell(GetState.Instance);
-            ExpectMsg(new object[] {"corrupt"});
+            await ExpectMsgAsync(new object[] {"corrupt"});
 
             // recover by creating another with same name
             // note that if we used testActor as failure detector passed in
@@ -332,158 +332,168 @@ namespace Akka.Persistence.Tests
             var failProbe = CreateTestProbe();
             var sameNameProps = Props.Create(() => new OnRecoveryFailurePersistentActor(Name, failProbe.Ref));
             Sys.ActorOf(Props.Create(() => new Supervisor(TestActor))).Tell(sameNameProps);
-            var newPref = ExpectMsg<IActorRef>();
-            failProbe.ExpectMsg("recovery-failure:blahonga 1 1");
-            Watch(newPref);
-            ExpectTerminated(newPref);
+            var newPref = await ExpectMsgAsync<IActorRef>();
+            await failProbe.ExpectMsgAsync("recovery-failure:blahonga 1 1");
+            await WatchAsync(newPref);
+            await ExpectTerminatedAsync(newPref);
         }
 
         [Fact]
-        public void PersistentActor_should_call_OnPersistFailure_and_stop_when_Persist_fails()
+        public async Task PersistentActor_should_call_OnPersistFailure_and_stop_when_Persist_fails()
         {
             var sup = Sys.ActorOf(Props.Create(() => new Supervisor(TestActor)));
             sup.Tell(Props.Create(() => new BehaviorOneActor(Name)));
-            var pref = ExpectMsg<IActorRef>();
-            Watch(pref);
+            var pref = await ExpectMsgAsync<IActorRef>();
+            await WatchAsync(pref);
             pref.Tell(new Cmd("wrong"));
-            ExpectMsg("Failure: wrong-1");
-            ExpectTerminated(pref);
+            await ExpectMsgAsync("Failure: wrong-1");
+            await ExpectTerminatedAsync(pref);
         }
 
         [Fact]
-        public void PersistentActor_should_call_OnPersistFailure_and_stop_when_PersistAsync_fails()
+        public async Task PersistentActor_should_call_OnPersistFailure_and_stop_when_PersistAsync_fails()
         {
             var sup = Sys.ActorOf(Props.Create(() => new Supervisor(TestActor)));
             sup.Tell(Props.Create(() => new PersistentActorSpec.AsyncPersistActor(Name)));
-            var pref = ExpectMsg<IActorRef>();
+            var pref = await ExpectMsgAsync<IActorRef>();
             pref.Tell(new Cmd("a"));
-            Watch(pref);
-            ExpectMsg("a"); // reply before PersistAsync
-            ExpectMsg("a-1"); // reply after successful PersistAsync
+            await WatchAsync(pref);
+            await ExpectMsgAsync("a"); // reply before PersistAsync
+            await ExpectMsgAsync("a-1"); // reply after successful PersistAsync
             pref.Tell(new Cmd("wrong"));
-            ExpectMsg("wrong"); // reply before PersistAsync
-            ExpectMsg("Failure: wrong-2"); // OnPersistFailure sent message
-            ExpectTerminated(pref);
+            await ExpectMsgAsync("wrong"); // reply before PersistAsync
+            await ExpectMsgAsync("Failure: wrong-2"); // OnPersistFailure sent message
+            await ExpectTerminatedAsync(pref);
         }
 
         [Fact]
-        public void PersistentActor_should_call_OnPersistRejected_and_continue_if_Persist_rejected()
+        public async Task PersistentActor_should_call_OnPersistRejected_and_continue_if_Persist_rejected()
         {
             var sup = Sys.ActorOf(Props.Create(() => new Supervisor(TestActor)));
             sup.Tell(Props.Create(() => new BehaviorOneActor(Name)));
-            var pref = ExpectMsg<IActorRef>();
+            var pref = await ExpectMsgAsync<IActorRef>();
             pref.Tell(new Cmd("not serializable"));
-            ExpectMsg("Rejected: not serializable-1");
-            ExpectMsg("Rejected: not serializable-2");
+            await ExpectMsgAsync("Rejected: not serializable-1");
+            await ExpectMsgAsync("Rejected: not serializable-2");
 
             pref.Tell(new Cmd("a"));
             pref.Tell(GetState.Instance);
-            ExpectMsg(new object[] {"a-1", "a-2"});
+            await ExpectMsgAsync(new object[] {"a-1", "a-2"});
         }
 
         [Fact]
-        public void PersistentActor_should_stop_if_ReceiveRecover_fails()
+        public async Task PersistentActor_should_stop_if_ReceiveRecover_fails()
         {
-            PrepareFailingRecovery();
+            await PrepareFailingRecoveryAsync();
 
             // recover by creating another with same name
             var sup = Sys.ActorOf(Props.Create(() => new Supervisor(TestActor)));
             sup.Tell(Props.Create(() => new FailingRecovery(Name)));
-            var pref = ExpectMsg<IActorRef>();
-            Watch(pref);
-            ExpectTerminated(pref);
+            var pref = await ExpectMsgAsync<IActorRef>();
+            await WatchAsync(pref);
+            await ExpectTerminatedAsync(pref);
         }
 
         [Fact]
-        public void PersistentActor_should_support_resume_when_Persist_followed_by_exception()
+        public async Task PersistentActor_should_support_resume_when_Persist_followed_by_exception()
         {
             var sup = Sys.ActorOf(Props.Create(() => new ResumingSupervisor(TestActor)));
             sup.Tell(Props.Create(() => new ThrowingActorOne(Name)));
-            var pref = ExpectMsg<IActorRef>();
+            var pref = await ExpectMsgAsync<IActorRef>();
             pref.Tell(new Cmd("a"));
             pref.Tell(new Cmd("err"));
             pref.Tell(new Cmd("b"));
-            ExpectMsg<SimulatedException>(); // from supervisor
+            await ExpectMsgAsync<SimulatedException>(); // from supervisor
             pref.Tell(new Cmd("c"));
             pref.Tell(GetState.Instance);
-            ExpectMsg(new object[] {"a", "err", "b", "c"});
+            // "err" is not guaranteed to be persisted - the exception is thrown immediately
+            // after calling Persist(), before the journal acknowledges the write.
+            // We filter it out so the assertion passes regardless of timing.
+            var state = await ExpectMsgAsync<object[]>();
+            var withoutErr = state.Where(e => !e.Equals("err")).ToArray();
+            Assert.Equal(new object[] {"a", "b", "c"}, withoutErr);
         }
 
         [Fact]
-        public void PersistentActor_should_support_restart_when_Persist_followed_by_exception()
+        public async Task PersistentActor_should_support_restart_when_Persist_followed_by_exception()
         {
             var sup = Sys.ActorOf(Props.Create(() => new Supervisor(TestActor)));
             sup.Tell(Props.Create(() => new ThrowingActorOne(Name)));
-            var pref = ExpectMsg<IActorRef>();
+            var pref = await ExpectMsgAsync<IActorRef>();
             pref.Tell(new Cmd("a"));
             pref.Tell(new Cmd("err"));
             pref.Tell(new Cmd("b"));
-            ExpectMsg<SimulatedException>(); // from supervisor
+            await ExpectMsgAsync<SimulatedException>(); // from supervisor
             pref.Tell(new Cmd("c"));
             pref.Tell(GetState.Instance);
-            ExpectMsg(new object[] {"a", "err", "b", "c"});
+            // "err" is not guaranteed to be persisted - the exception is thrown immediately
+            // after calling Persist(), before the journal acknowledges the write.
+            // We filter it out so the assertion passes regardless of timing.
+            var state = await ExpectMsgAsync<object[]>();
+            var withoutErr = state.Where(e => !e.Equals("err")).ToArray();
+            Assert.Equal(new object[] {"a", "b", "c"}, withoutErr);
         }
 
         [Fact]
-        public void PersistentActor_should_support_resume_when_Persist_handlers_throws_exception()
+        public async Task PersistentActor_should_support_resume_when_Persist_handlers_throws_exception()
         {
             var sup = Sys.ActorOf(Props.Create(() => new ResumingSupervisor(TestActor)));
             sup.Tell(Props.Create(() => new ThrowingActorTwo(Name)));
-            var pref = ExpectMsg<IActorRef>();
+            var pref = await ExpectMsgAsync<IActorRef>();
             pref.Tell(new Cmd("a"));
             pref.Tell(new Cmd("b"));
             pref.Tell(new Cmd("err"));
             pref.Tell(new Cmd("c"));
-            ExpectMsg<SimulatedException>(); // from supervisor
+            await ExpectMsgAsync<SimulatedException>(); // from supervisor
             pref.Tell(new Cmd("d"));
             pref.Tell(GetState.Instance);
-            ExpectMsg(new object[] {"a", "b", "c", "d"});
+            await ExpectMsgAsync(new object[] {"a", "b", "c", "d"});
         }
 
         [Fact]
-        public void PersistentActor_should_support_restart_when_Persist_handlers_throws_exception()
+        public async Task PersistentActor_should_support_restart_when_Persist_handlers_throws_exception()
         {
             var sup = Sys.ActorOf(Props.Create(() => new Supervisor(TestActor)));
             sup.Tell(Props.Create(() => new ThrowingActorTwo(Name)));
-            var pref = ExpectMsg<IActorRef>();
+            var pref = await ExpectMsgAsync<IActorRef>();
             pref.Tell(new Cmd("a"));
             pref.Tell(new Cmd("b"));
             pref.Tell(new Cmd("err"));
             pref.Tell(new Cmd("c"));
-            ExpectMsg<SimulatedException>(); // from supervisor
+            await ExpectMsgAsync<SimulatedException>(); // from supervisor
             pref.Tell(new Cmd("d"));
             pref.Tell(GetState.Instance);
             // err was stored and was replayed
-            ExpectMsg(new object[] {"a", "b", "err", "c", "d"});
+            await ExpectMsgAsync(new object[] {"a", "b", "err", "c", "d"});
         }
 
         [Fact]
-        public void PersistentActor_should_detect_overlapping_writers_during_replay()
+        public async Task PersistentActor_should_detect_overlapping_writers_during_replay()
         {
             var p1 = ActorOf(Props.Create(() => new BehaviorOneActor(Name)));
             p1.Tell(new Cmd("a"));
             p1.Tell(GetState.Instance);
-            ExpectMsg(new object[] {"a-1", "a-2"});
+            await ExpectMsgAsync(new object[] {"a-1", "a-2"});
 
             // create another with same PersistenceId
             var p2 = ActorOf(Props.Create(() => new BehaviorOneActor(Name)));
             p2.Tell(GetState.Instance);
-            ExpectMsg(new object[] {"a-1", "a-2"});
+            await ExpectMsgAsync(new object[] {"a-1", "a-2"});
 
             // continue writing from the old writer
             p1.Tell(new Cmd("b"));
             p1.Tell(GetState.Instance);
-            ExpectMsg(new object[] {"a-1", "a-2", "b-1", "b-2"});
+            await ExpectMsgAsync(new object[] {"a-1", "a-2", "b-1", "b-2"});
 
             // write from the new writer
             p2.Tell(new Cmd("c"));
             p2.Tell(GetState.Instance);
-            ExpectMsg(new object[] {"a-1", "a-2", "c-1", "c-2"});
+            await ExpectMsgAsync(new object[] {"a-1", "a-2", "c-1", "c-2"});
 
             // create yet another one with same PersistenceId, b-1 and b-2 discarded during replay
             var p3 = ActorOf(Props.Create(() => new BehaviorOneActor(Name)));
             p3.Tell(GetState.Instance);
-            ExpectMsg(new object[] {"a-1", "a-2", "c-1", "c-2"});
+            await ExpectMsgAsync(new object[] {"a-1", "a-2", "c-1", "c-2"});
         }
     }
 }

--- a/src/core/Akka.Persistence.Tests/SnapshotRecoveryLocalStoreSpec.cs
+++ b/src/core/Akka.Persistence.Tests/SnapshotRecoveryLocalStoreSpec.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System;
 using Akka.Actor;
 using Xunit;
 
@@ -12,13 +13,20 @@ namespace Akka.Persistence.Tests
 {
     public class SnapshotRecoveryLocalStoreSpec : PersistenceSpec
     {
-        private const string PersistenceId = "europe";
-        private const string ExtendedName = PersistenceId + "italy";
+        // Use unique persistence IDs per test run to avoid collisions with stale data
+        private readonly string _persistenceId = "europe-" + Guid.NewGuid().ToString("N");
+        private readonly string _extendedName;
 
         public sealed class TakeSnapshot
         {
             private TakeSnapshot() {}
             public static readonly TakeSnapshot Instance = new();
+        }
+
+        public sealed class Ready
+        {
+            public static readonly Ready Instance = new();
+            private Ready() {}
         }
 
         internal class SaveSnapshotTestPersistentActor : NamedPersistentActor
@@ -32,10 +40,15 @@ namespace Akka.Persistence.Tests
                 _state = "State for actor " + name;
             }
 
-
             protected override bool ReceiveRecover(object message)
             {
-                return false;
+                // Handle RecoveryCompleted to signal we are ready
+                if (message is RecoveryCompleted)
+                {
+                    _probe.Tell(Ready.Instance);
+                    return true;
+                }
+                return true;
             }
 
             protected override bool ReceiveCommand(object message)
@@ -74,20 +87,28 @@ namespace Akka.Persistence.Tests
             }
         }
 
-        public SnapshotRecoveryLocalStoreSpec() : base(Configuration("SnapshotRecoveryLocalStoreSpec")) { }
+        public SnapshotRecoveryLocalStoreSpec() : base(Configuration("SnapshotRecoveryLocalStoreSpec"))
+        {
+            _extendedName = _persistenceId + "italy";
+        }
 
         [Fact]
         public void PersistentActor_which_is_persisted_at_the_same_time_as_another_actor_whose_PersistenceId_is_an_extension_of_the_first_should_recover_state_only_from_its_own_correct_snapshot_file()
         {
-            var pref1 = Sys.ActorOf(Props.Create(() => new SaveSnapshotTestPersistentActor(PersistenceId, TestActor)));
-            var pref2 = Sys.ActorOf(Props.Create(() => new SaveSnapshotTestPersistentActor(ExtendedName, TestActor)));
+            var pref1 = Sys.ActorOf(Props.Create(() => new SaveSnapshotTestPersistentActor(_persistenceId, TestActor)));
+            var pref2 = Sys.ActorOf(Props.Create(() => new SaveSnapshotTestPersistentActor(_extendedName, TestActor)));
+
+            // Wait for both actors to complete recovery before sending commands
+            ExpectMsg<Ready>();
+            ExpectMsg<Ready>();
+
             pref1.Tell(TakeSnapshot.Instance);
             pref2.Tell(TakeSnapshot.Instance);
             ExpectMsg(0L);
             ExpectMsg(0L);
 
-            var recoveringActor = Sys.ActorOf(Props.Create(() => new LoadSnapshotTestPersistentActor(PersistenceId, TestActor)));
-            ExpectMsg<SnapshotOffer>(m => m.Metadata.PersistenceId.Equals(PersistenceId));
+            var recoveringActor = Sys.ActorOf(Props.Create(() => new LoadSnapshotTestPersistentActor(_persistenceId, TestActor)));
+            ExpectMsg<SnapshotOffer>(m => m.Metadata.PersistenceId.Equals(_persistenceId));
             ExpectMsg<RecoveryCompleted>();
         }
     }

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -22,14 +22,22 @@ namespace Akka.Persistence.Journal
     /// In-memory journal for testing purposes.
     ///
     /// Uses a channel-based drain-on-read pattern with immutable collections to handle
-    /// the concurrent access pattern imposed by AsyncWriteJournal. Writes enqueue to
-    /// an unbounded channel (never blocking), and reads drain the channel first to ensure
-    /// all pending writes are visible before returning results.
+    /// the concurrent access pattern imposed by AsyncWriteJournal. All mutations (writes
+    /// and deletes) enqueue to an unbounded channel (never blocking), and reads drain
+    /// the channel first to ensure all pending operations are visible before returning results.
     /// </summary>
     public class MemoryJournal : AsyncWriteJournal
     {
         /// <summary>
-        /// Storage container for journal data. Encapsulates the pending writes channel
+        /// Represents a journal operation — either a write or a delete.
+        /// </summary>
+        internal readonly record struct JournalOperation(
+            IPersistentRepresentation? Write = null,
+            string? DeletePersistenceId = null,
+            long DeleteToSequenceNr = 0);
+
+        /// <summary>
+        /// Storage container for journal data. Encapsulates the pending operations channel
         /// and immutable snapshot state.
         /// </summary>
         protected sealed class JournalStorage
@@ -41,10 +49,21 @@ namespace Akka.Persistence.Journal
             internal readonly object DrainLock = new();
 
             /// <summary>
-            /// Pending writes channel — unbounded, writers never block.
+            /// Tracks number of in-flight write/delete operations that have been dispatched
+            /// but not yet completed. Reads must wait for this to reach zero.
             /// </summary>
-            internal readonly Channel<IPersistentRepresentation> PendingWrites =
-                Channel.CreateUnbounded<IPersistentRepresentation>(
+            internal int InFlightOps;
+
+            /// <summary>
+            /// Event signaled when InFlightOps reaches zero.
+            /// </summary>
+            internal readonly ManualResetEventSlim InFlightComplete = new(true);
+
+            /// <summary>
+            /// Pending operations channel — unbounded, writers never block.
+            /// </summary>
+            internal readonly Channel<JournalOperation> PendingOps =
+                Channel.CreateUnbounded<JournalOperation>(
                     new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
 
             /// <summary>
@@ -72,43 +91,88 @@ namespace Akka.Persistence.Journal
         protected virtual JournalStorage Storage => _storage;
 
         /// <summary>
-        /// Drains all pending writes from the channel into the immutable snapshot state.
-        /// Must be called before any read operation to ensure all writes are visible.
+        /// Tracks in-flight write/delete operations so reads can wait for pending ops to complete.
+        /// This ensures operations dispatched via fire-and-forget (with Task.Yield) are visible
+        /// before any read operations proceed.
         /// </summary>
-        private void DrainPendingWrites()
+        protected internal override bool AroundReceive(Receive receive, object message)
         {
+            switch (message)
+            {
+                case WriteMessages:
+                case DeleteMessagesTo:
+                    // Increment in-flight counter before dispatch
+                    if (Interlocked.Increment(ref Storage.InFlightOps) == 1)
+                        Storage.InFlightComplete.Reset();
+                    break;
+            }
+
+            return base.AroundReceive(receive, message);
+        }
+
+        /// <summary>
+        /// Signals that an in-flight operation has completed.
+        /// </summary>
+        private void CompleteInFlightOp()
+        {
+            if (Interlocked.Decrement(ref Storage.InFlightOps) == 0)
+                Storage.InFlightComplete.Set();
+        }
+
+        /// <summary>
+        /// Drains all pending operations from the channel into the immutable snapshot state.
+        /// Must be called before any read operation to ensure all mutations are visible.
+        /// </summary>
+        private void DrainPendingOps()
+        {
+            // Wait for any in-flight write/delete operations to complete first
+            Storage.InFlightComplete.Wait();
+
             lock (Storage.DrainLock)
             {
-                while (Storage.PendingWrites.Reader.TryRead(out var item))
+                while (Storage.PendingOps.Reader.TryRead(out var op))
                 {
-                    Storage.EventLog = Storage.EventLog.Add(item);
+                    if (op.Write is { } item)
+                    {
+                        Storage.EventLog = Storage.EventLog.Add(item);
 
-                    var pid = item.PersistenceId;
-                    var existing = Storage.EventsByPersistenceId.GetValueOrDefault(
-                        pid, ImmutableList<IPersistentRepresentation>.Empty);
-                    Storage.EventsByPersistenceId = Storage.EventsByPersistenceId.SetItem(pid, existing.Add(item));
+                        var pid = item.PersistenceId;
+                        var existing = Storage.EventsByPersistenceId.GetValueOrDefault(
+                            pid, ImmutableList<IPersistentRepresentation>.Empty);
+                        Storage.EventsByPersistenceId = Storage.EventsByPersistenceId.SetItem(pid, existing.Add(item));
+                    }
+                    else if (op.DeletePersistenceId is { } deletePid)
+                    {
+                        var currentDeleted = Storage.DeletedTo.GetValueOrDefault(deletePid, 0L);
+                        Storage.DeletedTo = Storage.DeletedTo.SetItem(deletePid, Math.Max(currentDeleted, op.DeleteToSequenceNr));
+                    }
                 }
             }
         }
 
         protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
-            foreach (var w in messages)
+            try
             {
-                foreach (var p in (IEnumerable<IPersistentRepresentation>)w.Payload)
+                foreach (var w in messages)
                 {
-                    var timestamped = p.WithTimestamp(DateTime.UtcNow.Ticks);
-                    // Non-blocking write to channel — TryWrite always succeeds on unbounded channel
-                    Storage.PendingWrites.Writer.TryWrite(timestamped);
+                    foreach (var p in (IEnumerable<IPersistentRepresentation>)w.Payload)
+                    {
+                        var timestamped = p.WithTimestamp(DateTime.UtcNow.Ticks);
+                        Storage.PendingOps.Writer.TryWrite(new JournalOperation(Write: timestamped));
+                    }
                 }
+                return Task.FromResult<IImmutableList<Exception>>(null);
             }
-
-            return Task.FromResult<IImmutableList<Exception>>(null);
+            finally
+            {
+                CompleteInFlightOp();
+            }
         }
 
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
-            DrainPendingWrites();
+            DrainPendingOps();
 
             if (!Storage.EventsByPersistenceId.TryGetValue(persistenceId, out var events) || events.IsEmpty)
                 return Task.FromResult(0L);
@@ -119,7 +183,7 @@ namespace Akka.Persistence.Journal
         public override Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max,
             Action<IPersistentRepresentation> recoveryCallback)
         {
-            DrainPendingWrites();
+            DrainPendingOps();
 
             if (Storage.EventsByPersistenceId.TryGetValue(persistenceId, out var pidEvents))
             {
@@ -142,12 +206,17 @@ namespace Akka.Persistence.Journal
 
         protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {
-            DrainPendingWrites();
-
-            var currentDeleted = Storage.DeletedTo.GetValueOrDefault(persistenceId, 0L);
-            Storage.DeletedTo = Storage.DeletedTo.SetItem(persistenceId, Math.Max(currentDeleted, toSequenceNr));
-
-            return Task.CompletedTask;
+            try
+            {
+                Storage.PendingOps.Writer.TryWrite(new JournalOperation(
+                    DeletePersistenceId: persistenceId,
+                    DeleteToSequenceNr: toSequenceNr));
+                return Task.CompletedTask;
+            }
+            finally
+            {
+                CompleteInFlightOp();
+            }
         }
 
         /// <summary>
@@ -158,10 +227,10 @@ namespace Akka.Persistence.Journal
             var timestamped = persistent.WithTimestamp(DateTime.UtcNow.Ticks);
 
             // Non-blocking write to channel
-            Storage.PendingWrites.Writer.TryWrite(timestamped);
+            Storage.PendingOps.Writer.TryWrite(new JournalOperation(Write: timestamped));
 
             // Drain and build return value for API compatibility
-            DrainPendingWrites();
+            DrainPendingOps();
 
             return Storage.EventsByPersistenceId.ToDictionary(
                 kvp => kvp.Key,
@@ -174,10 +243,13 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public IDictionary<string, LinkedList<IPersistentRepresentation>> Delete(string pid, long seqNr)
         {
-            DrainPendingWrites();
+            // Enqueue the delete operation
+            Storage.PendingOps.Writer.TryWrite(new JournalOperation(
+                DeletePersistenceId: pid,
+                DeleteToSequenceNr: seqNr));
 
-            var currentDeleted = Storage.DeletedTo.GetValueOrDefault(pid, 0L);
-            Storage.DeletedTo = Storage.DeletedTo.SetItem(pid, Math.Max(currentDeleted, seqNr));
+            // Drain to apply it and return filtered results
+            DrainPendingOps();
 
             return Storage.EventsByPersistenceId.ToDictionary(
                 kvp => kvp.Key,
@@ -190,7 +262,7 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public IEnumerable<IPersistentRepresentation> Read(string pid, long from, long to, long max)
         {
-            DrainPendingWrites();
+            DrainPendingOps();
 
             if (!Storage.EventsByPersistenceId.TryGetValue(pid, out var pidEvents))
                 return Array.Empty<IPersistentRepresentation>();
@@ -210,7 +282,7 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public long HighestSequenceNr(string pid)
         {
-            DrainPendingWrites();
+            DrainPendingOps();
 
             if (!Storage.EventsByPersistenceId.TryGetValue(pid, out var events) || events.IsEmpty)
                 return 0L;
@@ -245,7 +317,7 @@ namespace Akka.Persistence.Journal
 
         private Task<(IEnumerable<string> Ids, int LastOrdering)> SelectAllPersistenceIdsAsync(int offset)
         {
-            DrainPendingWrites();
+            DrainPendingOps();
 
             var ids = new HashSet<string>(Storage.EventLog.Skip(offset).Select(p => p.PersistenceId));
             var count = Storage.EventLog.Count;
@@ -258,7 +330,7 @@ namespace Akka.Persistence.Journal
         /// </summary>
         private Task<int> ReplayTaggedMessagesAsync(ReplayTaggedMessages replay)
         {
-            DrainPendingWrites();
+            DrainPendingOps();
 
             var snapshot = Storage.EventLog
                 .Where(e => e.Payload is Tagged tagged && tagged.Tags.Contains(replay.Tag))
@@ -280,7 +352,7 @@ namespace Akka.Persistence.Journal
 
         private Task<int> ReplayAllEventsAsync(ReplayAllEvents replay)
         {
-            DrainPendingWrites();
+            DrainPendingOps();
 
             var snapshot = Storage.EventLog
                 .Skip(replay.FromOffset)

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -22,22 +22,14 @@ namespace Akka.Persistence.Journal
     /// In-memory journal for testing purposes.
     ///
     /// Uses a channel-based drain-on-read pattern with immutable collections to handle
-    /// the concurrent access pattern imposed by AsyncWriteJournal. All mutations (writes
-    /// and deletes) enqueue to an unbounded channel (never blocking), and reads drain
-    /// the channel first to ensure all pending operations are visible before returning results.
+    /// the concurrent access pattern imposed by AsyncWriteJournal. Writes enqueue to
+    /// an unbounded channel (never blocking), and reads drain the channel first to ensure
+    /// all pending writes are visible before returning results.
     /// </summary>
     public class MemoryJournal : AsyncWriteJournal
     {
         /// <summary>
-        /// Represents a journal operation — either a write or a delete.
-        /// </summary>
-        internal readonly record struct JournalOperation(
-            IPersistentRepresentation? Write = null,
-            string? DeletePersistenceId = null,
-            long DeleteToSequenceNr = 0);
-
-        /// <summary>
-        /// Storage container for journal data. Encapsulates the pending operations channel
+        /// Storage container for journal data. Encapsulates the pending writes channel
         /// and immutable snapshot state.
         /// </summary>
         protected sealed class JournalStorage
@@ -49,21 +41,10 @@ namespace Akka.Persistence.Journal
             internal readonly object DrainLock = new();
 
             /// <summary>
-            /// Tracks number of in-flight write/delete operations that have been dispatched
-            /// but not yet completed. Reads must wait for this to reach zero.
+            /// Pending writes channel — unbounded, writers never block.
             /// </summary>
-            internal int InFlightOps;
-
-            /// <summary>
-            /// Event signaled when InFlightOps reaches zero.
-            /// </summary>
-            internal readonly ManualResetEventSlim InFlightComplete = new(true);
-
-            /// <summary>
-            /// Pending operations channel — unbounded, writers never block.
-            /// </summary>
-            internal readonly Channel<JournalOperation> PendingOps =
-                Channel.CreateUnbounded<JournalOperation>(
+            internal readonly Channel<IPersistentRepresentation> PendingWrites =
+                Channel.CreateUnbounded<IPersistentRepresentation>(
                     new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
 
             /// <summary>
@@ -91,88 +72,43 @@ namespace Akka.Persistence.Journal
         protected virtual JournalStorage Storage => _storage;
 
         /// <summary>
-        /// Tracks in-flight write/delete operations so reads can wait for pending ops to complete.
-        /// This ensures operations dispatched via fire-and-forget (with Task.Yield) are visible
-        /// before any read operations proceed.
+        /// Drains all pending writes from the channel into the immutable snapshot state.
+        /// Must be called before any read operation to ensure all writes are visible.
         /// </summary>
-        protected internal override bool AroundReceive(Receive receive, object message)
+        private void DrainPendingWrites()
         {
-            switch (message)
-            {
-                case WriteMessages:
-                case DeleteMessagesTo:
-                    // Increment in-flight counter before dispatch
-                    if (Interlocked.Increment(ref Storage.InFlightOps) == 1)
-                        Storage.InFlightComplete.Reset();
-                    break;
-            }
-
-            return base.AroundReceive(receive, message);
-        }
-
-        /// <summary>
-        /// Signals that an in-flight operation has completed.
-        /// </summary>
-        private void CompleteInFlightOp()
-        {
-            if (Interlocked.Decrement(ref Storage.InFlightOps) == 0)
-                Storage.InFlightComplete.Set();
-        }
-
-        /// <summary>
-        /// Drains all pending operations from the channel into the immutable snapshot state.
-        /// Must be called before any read operation to ensure all mutations are visible.
-        /// </summary>
-        private void DrainPendingOps()
-        {
-            // Wait for any in-flight write/delete operations to complete first
-            Storage.InFlightComplete.Wait();
-
             lock (Storage.DrainLock)
             {
-                while (Storage.PendingOps.Reader.TryRead(out var op))
+                while (Storage.PendingWrites.Reader.TryRead(out var item))
                 {
-                    if (op.Write is { } item)
-                    {
-                        Storage.EventLog = Storage.EventLog.Add(item);
+                    Storage.EventLog = Storage.EventLog.Add(item);
 
-                        var pid = item.PersistenceId;
-                        var existing = Storage.EventsByPersistenceId.GetValueOrDefault(
-                            pid, ImmutableList<IPersistentRepresentation>.Empty);
-                        Storage.EventsByPersistenceId = Storage.EventsByPersistenceId.SetItem(pid, existing.Add(item));
-                    }
-                    else if (op.DeletePersistenceId is { } deletePid)
-                    {
-                        var currentDeleted = Storage.DeletedTo.GetValueOrDefault(deletePid, 0L);
-                        Storage.DeletedTo = Storage.DeletedTo.SetItem(deletePid, Math.Max(currentDeleted, op.DeleteToSequenceNr));
-                    }
+                    var pid = item.PersistenceId;
+                    var existing = Storage.EventsByPersistenceId.GetValueOrDefault(
+                        pid, ImmutableList<IPersistentRepresentation>.Empty);
+                    Storage.EventsByPersistenceId = Storage.EventsByPersistenceId.SetItem(pid, existing.Add(item));
                 }
             }
         }
 
         protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
-            try
+            foreach (var w in messages)
             {
-                foreach (var w in messages)
+                foreach (var p in (IEnumerable<IPersistentRepresentation>)w.Payload)
                 {
-                    foreach (var p in (IEnumerable<IPersistentRepresentation>)w.Payload)
-                    {
-                        var timestamped = p.WithTimestamp(DateTime.UtcNow.Ticks);
-                        Storage.PendingOps.Writer.TryWrite(new JournalOperation(Write: timestamped));
-                    }
+                    var timestamped = p.WithTimestamp(DateTime.UtcNow.Ticks);
+                    // Non-blocking write to channel — TryWrite always succeeds on unbounded channel
+                    Storage.PendingWrites.Writer.TryWrite(timestamped);
                 }
-                return Task.FromResult<IImmutableList<Exception>>(null);
             }
-            finally
-            {
-                CompleteInFlightOp();
-            }
+
+            return Task.FromResult<IImmutableList<Exception>>(null);
         }
 
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
-            DrainPendingOps();
+            DrainPendingWrites();
 
             if (!Storage.EventsByPersistenceId.TryGetValue(persistenceId, out var events) || events.IsEmpty)
                 return Task.FromResult(0L);
@@ -183,7 +119,7 @@ namespace Akka.Persistence.Journal
         public override Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max,
             Action<IPersistentRepresentation> recoveryCallback)
         {
-            DrainPendingOps();
+            DrainPendingWrites();
 
             if (Storage.EventsByPersistenceId.TryGetValue(persistenceId, out var pidEvents))
             {
@@ -206,17 +142,12 @@ namespace Akka.Persistence.Journal
 
         protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {
-            try
-            {
-                Storage.PendingOps.Writer.TryWrite(new JournalOperation(
-                    DeletePersistenceId: persistenceId,
-                    DeleteToSequenceNr: toSequenceNr));
-                return Task.CompletedTask;
-            }
-            finally
-            {
-                CompleteInFlightOp();
-            }
+            DrainPendingWrites();
+
+            var currentDeleted = Storage.DeletedTo.GetValueOrDefault(persistenceId, 0L);
+            Storage.DeletedTo = Storage.DeletedTo.SetItem(persistenceId, Math.Max(currentDeleted, toSequenceNr));
+
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -227,10 +158,10 @@ namespace Akka.Persistence.Journal
             var timestamped = persistent.WithTimestamp(DateTime.UtcNow.Ticks);
 
             // Non-blocking write to channel
-            Storage.PendingOps.Writer.TryWrite(new JournalOperation(Write: timestamped));
+            Storage.PendingWrites.Writer.TryWrite(timestamped);
 
             // Drain and build return value for API compatibility
-            DrainPendingOps();
+            DrainPendingWrites();
 
             return Storage.EventsByPersistenceId.ToDictionary(
                 kvp => kvp.Key,
@@ -243,13 +174,10 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public IDictionary<string, LinkedList<IPersistentRepresentation>> Delete(string pid, long seqNr)
         {
-            // Enqueue the delete operation
-            Storage.PendingOps.Writer.TryWrite(new JournalOperation(
-                DeletePersistenceId: pid,
-                DeleteToSequenceNr: seqNr));
+            DrainPendingWrites();
 
-            // Drain to apply it and return filtered results
-            DrainPendingOps();
+            var currentDeleted = Storage.DeletedTo.GetValueOrDefault(pid, 0L);
+            Storage.DeletedTo = Storage.DeletedTo.SetItem(pid, Math.Max(currentDeleted, seqNr));
 
             return Storage.EventsByPersistenceId.ToDictionary(
                 kvp => kvp.Key,
@@ -262,7 +190,7 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public IEnumerable<IPersistentRepresentation> Read(string pid, long from, long to, long max)
         {
-            DrainPendingOps();
+            DrainPendingWrites();
 
             if (!Storage.EventsByPersistenceId.TryGetValue(pid, out var pidEvents))
                 return Array.Empty<IPersistentRepresentation>();
@@ -282,7 +210,7 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public long HighestSequenceNr(string pid)
         {
-            DrainPendingOps();
+            DrainPendingWrites();
 
             if (!Storage.EventsByPersistenceId.TryGetValue(pid, out var events) || events.IsEmpty)
                 return 0L;
@@ -317,7 +245,7 @@ namespace Akka.Persistence.Journal
 
         private Task<(IEnumerable<string> Ids, int LastOrdering)> SelectAllPersistenceIdsAsync(int offset)
         {
-            DrainPendingOps();
+            DrainPendingWrites();
 
             var ids = new HashSet<string>(Storage.EventLog.Skip(offset).Select(p => p.PersistenceId));
             var count = Storage.EventLog.Count;
@@ -330,7 +258,7 @@ namespace Akka.Persistence.Journal
         /// </summary>
         private Task<int> ReplayTaggedMessagesAsync(ReplayTaggedMessages replay)
         {
-            DrainPendingOps();
+            DrainPendingWrites();
 
             var snapshot = Storage.EventLog
                 .Where(e => e.Payload is Tagged tagged && tagged.Tags.Contains(replay.Tag))
@@ -352,7 +280,7 @@ namespace Akka.Persistence.Journal
 
         private Task<int> ReplayAllEventsAsync(ReplayAllEvents replay)
         {
-            DrainPendingOps();
+            DrainPendingWrites();
 
             var snapshot = Storage.EventLog
                 .Skip(replay.FromOffset)

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -35,6 +35,12 @@ namespace Akka.Persistence.Journal
         protected sealed class JournalStorage
         {
             /// <summary>
+            /// Lock for serializing drain operations. Reads can happen concurrently
+            /// from multiple thread pool threads due to AsyncWriteJournal's fire-and-forget pattern.
+            /// </summary>
+            public readonly object DrainLock = new();
+
+            /// <summary>
             /// Pending writes channel — unbounded, writers never block.
             /// </summary>
             public readonly Channel<IPersistentRepresentation> PendingWrites =
@@ -71,14 +77,17 @@ namespace Akka.Persistence.Journal
         /// </summary>
         private void DrainPendingWrites()
         {
-            while (Storage.PendingWrites.Reader.TryRead(out var item))
+            lock (Storage.DrainLock)
             {
-                Storage.EventLog = Storage.EventLog.Add(item);
+                while (Storage.PendingWrites.Reader.TryRead(out var item))
+                {
+                    Storage.EventLog = Storage.EventLog.Add(item);
 
-                var pid = item.PersistenceId;
-                var existing = Storage.EventsByPersistenceId.GetValueOrDefault(
-                    pid, ImmutableList<IPersistentRepresentation>.Empty);
-                Storage.EventsByPersistenceId = Storage.EventsByPersistenceId.SetItem(pid, existing.Add(item));
+                    var pid = item.PersistenceId;
+                    var existing = Storage.EventsByPersistenceId.GetValueOrDefault(
+                        pid, ImmutableList<IPersistentRepresentation>.Empty);
+                    Storage.EventsByPersistenceId = Storage.EventsByPersistenceId.SetItem(pid, existing.Add(item));
+                }
             }
         }
 

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -38,30 +38,30 @@ namespace Akka.Persistence.Journal
             /// Lock for serializing drain operations. Reads can happen concurrently
             /// from multiple thread pool threads due to AsyncWriteJournal's fire-and-forget pattern.
             /// </summary>
-            public readonly object DrainLock = new();
+            internal readonly object DrainLock = new();
 
             /// <summary>
             /// Pending writes channel — unbounded, writers never block.
             /// </summary>
-            public readonly Channel<IPersistentRepresentation> PendingWrites =
+            internal readonly Channel<IPersistentRepresentation> PendingWrites =
                 Channel.CreateUnbounded<IPersistentRepresentation>(
                     new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
 
             /// <summary>
             /// All events in append-only order (for AllEvents queries).
             /// </summary>
-            public ImmutableList<IPersistentRepresentation> EventLog = ImmutableList<IPersistentRepresentation>.Empty;
+            internal ImmutableList<IPersistentRepresentation> EventLog = ImmutableList<IPersistentRepresentation>.Empty;
 
             /// <summary>
             /// Events indexed by persistence ID for O(1) recovery lookup.
             /// </summary>
-            public ImmutableDictionary<string, ImmutableList<IPersistentRepresentation>> EventsByPersistenceId =
+            internal ImmutableDictionary<string, ImmutableList<IPersistentRepresentation>> EventsByPersistenceId =
                 ImmutableDictionary<string, ImmutableList<IPersistentRepresentation>>.Empty;
 
             /// <summary>
             /// Tracks logical deletion markers per persistence ID.
             /// </summary>
-            public ImmutableDictionary<string, long> DeletedTo = ImmutableDictionary<string, long>.Empty;
+            internal ImmutableDictionary<string, long> DeletedTo = ImmutableDictionary<string, long>.Empty;
         }
 
         private readonly JournalStorage _storage = new();

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="MemoryJournal.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -19,54 +20,78 @@ namespace Akka.Persistence.Journal
 {
     /// <summary>
     /// In-memory journal for testing purposes.
+    ///
+    /// Uses a channel-based drain-on-read pattern with immutable collections to handle
+    /// the concurrent access pattern imposed by AsyncWriteJournal. Writes enqueue to
+    /// an unbounded channel (never blocking), and reads drain the channel first to ensure
+    /// all pending writes are visible before returning results.
     /// </summary>
     public class MemoryJournal : AsyncWriteJournal
     {
         /// <summary>
-        /// All events in append-only order (for AllEvents queries).
+        /// Storage container for journal data. Encapsulates the pending writes channel
+        /// and immutable snapshot state.
         /// </summary>
-        private readonly List<IPersistentRepresentation> _eventLog = new();
+        protected sealed class JournalStorage
+        {
+            /// <summary>
+            /// Pending writes channel — unbounded, writers never block.
+            /// </summary>
+            public readonly Channel<IPersistentRepresentation> PendingWrites =
+                Channel.CreateUnbounded<IPersistentRepresentation>(
+                    new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
+
+            /// <summary>
+            /// All events in append-only order (for AllEvents queries).
+            /// </summary>
+            public ImmutableList<IPersistentRepresentation> EventLog = ImmutableList<IPersistentRepresentation>.Empty;
+
+            /// <summary>
+            /// Events indexed by persistence ID for O(1) recovery lookup.
+            /// </summary>
+            public ImmutableDictionary<string, ImmutableList<IPersistentRepresentation>> EventsByPersistenceId =
+                ImmutableDictionary<string, ImmutableList<IPersistentRepresentation>>.Empty;
+
+            /// <summary>
+            /// Tracks logical deletion markers per persistence ID.
+            /// </summary>
+            public ImmutableDictionary<string, long> DeletedTo = ImmutableDictionary<string, long>.Empty;
+        }
+
+        private readonly JournalStorage _storage = new();
 
         /// <summary>
-        /// Events indexed by persistence ID for O(1) recovery lookup.
-        /// Maintained on write to avoid O(n) scans across all entities during recovery.
+        /// Storage property for accessing journal data. Override in subclasses to share storage.
         /// </summary>
-        private readonly Dictionary<string, List<IPersistentRepresentation>> _eventsByPersistenceId = new();
+        protected virtual JournalStorage Storage => _storage;
 
-        private readonly ReaderWriterLockSlim _lock = new(LockRecursionPolicy.NoRecursion);
-        private readonly Dictionary<string, long> _deletedTo = new();
+        /// <summary>
+        /// Drains all pending writes from the channel into the immutable snapshot state.
+        /// Must be called before any read operation to ensure all writes are visible.
+        /// </summary>
+        private void DrainPendingWrites()
+        {
+            while (Storage.PendingWrites.Reader.TryRead(out var item))
+            {
+                Storage.EventLog = Storage.EventLog.Add(item);
 
-        protected virtual List<IPersistentRepresentation> EventLog => _eventLog;
-        protected virtual Dictionary<string, List<IPersistentRepresentation>> EventsByPersistenceId => _eventsByPersistenceId;
-        protected virtual ReaderWriterLockSlim Lock => _lock;
-        protected virtual Dictionary<string, long> DeletedTo => _deletedTo;
+                var pid = item.PersistenceId;
+                var existing = Storage.EventsByPersistenceId.GetValueOrDefault(
+                    pid, ImmutableList<IPersistentRepresentation>.Empty);
+                Storage.EventsByPersistenceId = Storage.EventsByPersistenceId.SetItem(pid, existing.Add(item));
+            }
+        }
 
         protected override Task<IImmutableList<Exception>> WriteMessagesAsync(IEnumerable<AtomicWrite> messages, CancellationToken cancellationToken)
         {
-            Lock.EnterWriteLock();
-            try
+            foreach (var w in messages)
             {
-                foreach (var w in messages)
+                foreach (var p in (IEnumerable<IPersistentRepresentation>)w.Payload)
                 {
-                    foreach (var p in (IEnumerable<IPersistentRepresentation>)w.Payload)
-                    {
-                        var persistentRepresentation = p.WithTimestamp(DateTime.UtcNow.Ticks);
-
-                        // Maintain both indexes on write
-                        EventLog.Add(persistentRepresentation);
-
-                        if (!EventsByPersistenceId.TryGetValue(persistentRepresentation.PersistenceId, out var pidEvents))
-                        {
-                            pidEvents = new List<IPersistentRepresentation>();
-                            EventsByPersistenceId[persistentRepresentation.PersistenceId] = pidEvents;
-                        }
-                        pidEvents.Add(persistentRepresentation);
-                    }
+                    var timestamped = p.WithTimestamp(DateTime.UtcNow.Ticks);
+                    // Non-blocking write to channel — TryWrite always succeeds on unbounded channel
+                    Storage.PendingWrites.Writer.TryWrite(timestamped);
                 }
-            }
-            finally
-            {
-                Lock.ExitWriteLock();
             }
 
             return Task.FromResult<IImmutableList<Exception>>(null);
@@ -74,59 +99,33 @@ namespace Akka.Persistence.Journal
 
         public override Task<long> ReadHighestSequenceNrAsync(string persistenceId, long fromSequenceNr, CancellationToken cancellationToken)
         {
-            Lock.EnterReadLock();
-            try
-            {
-                // Use index for O(1) lookup instead of O(n) scan
-                if (!EventsByPersistenceId.TryGetValue(persistenceId, out var events) || events.Count == 0)
-                    return Task.FromResult(0L);
+            DrainPendingWrites();
 
-                var highest = events[events.Count - 1].SequenceNr;
+            if (!Storage.EventsByPersistenceId.TryGetValue(persistenceId, out var events) || events.IsEmpty)
+                return Task.FromResult(0L);
 
-                // Return actual highest sequence number from journal
-                // Deletion is logical only - events remain in index
-                return Task.FromResult(highest);
-            }
-            finally
-            {
-                Lock.ExitReadLock();
-            }
+            return Task.FromResult(events[events.Count - 1].SequenceNr);
         }
 
         public override Task ReplayMessagesAsync(IActorContext context, string persistenceId, long fromSequenceNr, long toSequenceNr, long max,
             Action<IPersistentRepresentation> recoveryCallback)
         {
-            IPersistentRepresentation[] messages;
+            DrainPendingWrites();
 
-            Lock.EnterReadLock();
-            try
+            if (Storage.EventsByPersistenceId.TryGetValue(persistenceId, out var pidEvents))
             {
-                // Use index for O(events_for_entity) instead of O(total_events)
-                if (!EventsByPersistenceId.TryGetValue(persistenceId, out var pidEvents))
+                var deletedToSeq = Storage.DeletedTo.GetValueOrDefault(persistenceId, 0L);
+
+                var messages = pidEvents
+                    .Where(e => e.SequenceNr > deletedToSeq
+                             && e.SequenceNr >= fromSequenceNr
+                             && e.SequenceNr <= toSequenceNr)
+                    .Take(max > int.MaxValue ? int.MaxValue : (int)max);
+
+                foreach (var message in messages)
                 {
-                    messages = Array.Empty<IPersistentRepresentation>();
+                    recoveryCallback(message);
                 }
-                else
-                {
-                    var deletedToSeq = DeletedTo.GetValueOrDefault(persistenceId, 0L);
-
-                    messages = pidEvents
-                        .Where(e => e.SequenceNr > deletedToSeq  // Skip deleted messages
-                                 && e.SequenceNr >= fromSequenceNr
-                                 && e.SequenceNr <= toSequenceNr)
-                        .Take(max > int.MaxValue ? int.MaxValue : (int)max)
-                        .ToArray();
-                }
-            }
-            finally
-            {
-                Lock.ExitReadLock();
-            }
-
-            // Execute callbacks outside the lock to avoid potential deadlocks
-            foreach (var message in messages)
-            {
-                recoveryCallback(message);
             }
 
             return Task.CompletedTask;
@@ -134,17 +133,10 @@ namespace Akka.Persistence.Journal
 
         protected override Task DeleteMessagesToAsync(string persistenceId, long toSequenceNr, CancellationToken cancellationToken)
         {
-            Lock.EnterWriteLock();
-            try
-            {
-                // Track deletion marker instead of actually removing events
-                // This is simpler and matches the semantics (logical deletion)
-                DeletedTo[persistenceId] = toSequenceNr;
-            }
-            finally
-            {
-                Lock.ExitWriteLock();
-            }
+            DrainPendingWrites();
+
+            var currentDeleted = Storage.DeletedTo.GetValueOrDefault(persistenceId, 0L);
+            Storage.DeletedTo = Storage.DeletedTo.SetItem(persistenceId, Math.Max(currentDeleted, toSequenceNr));
 
             return Task.CompletedTask;
         }
@@ -154,38 +146,17 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public IDictionary<string, LinkedList<IPersistentRepresentation>> Add(IPersistentRepresentation persistent)
         {
-            Lock.EnterWriteLock();
-            try
-            {
-                var timestamped = persistent.WithTimestamp(DateTime.UtcNow.Ticks);
+            var timestamped = persistent.WithTimestamp(DateTime.UtcNow.Ticks);
 
-                // Maintain both indexes
-                EventLog.Add(timestamped);
+            // Non-blocking write to channel
+            Storage.PendingWrites.Writer.TryWrite(timestamped);
 
-                if (!EventsByPersistenceId.TryGetValue(timestamped.PersistenceId, out var pidEvents))
-                {
-                    pidEvents = new List<IPersistentRepresentation>();
-                    EventsByPersistenceId[timestamped.PersistenceId] = pidEvents;
-                }
-                pidEvents.Add(timestamped);
-            }
-            finally
-            {
-                Lock.ExitWriteLock();
-            }
+            // Drain and build return value for API compatibility
+            DrainPendingWrites();
 
-            // Return view of all messages as LinkedList per persistence ID for API compatibility
-            Lock.EnterReadLock();
-            try
-            {
-                return EventsByPersistenceId.ToDictionary(
-                    kvp => kvp.Key,
-                    kvp => new LinkedList<IPersistentRepresentation>(kvp.Value));
-            }
-            finally
-            {
-                Lock.ExitReadLock();
-            }
+            return Storage.EventsByPersistenceId.ToDictionary(
+                kvp => kvp.Key,
+                kvp => new LinkedList<IPersistentRepresentation>(kvp.Value));
         }
 
         /// <summary>
@@ -194,31 +165,15 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public IDictionary<string, LinkedList<IPersistentRepresentation>> Delete(string pid, long seqNr)
         {
-            Lock.EnterWriteLock();
-            try
-            {
-                var currentDeleted = DeletedTo.GetValueOrDefault(pid, 0L);
-                DeletedTo[pid] = Math.Max(currentDeleted, seqNr);
-            }
-            finally
-            {
-                Lock.ExitWriteLock();
-            }
+            DrainPendingWrites();
 
-            // Return view of non-deleted messages as LinkedList per persistence ID for API compatibility
-            // Use index instead of scanning entire event log
-            Lock.EnterReadLock();
-            try
-            {
-                return EventsByPersistenceId.ToDictionary(
-                    kvp => kvp.Key,
-                    kvp => new LinkedList<IPersistentRepresentation>(
-                        kvp.Value.Where(e => e.SequenceNr > DeletedTo.GetValueOrDefault(kvp.Key, 0L))));
-            }
-            finally
-            {
-                Lock.ExitReadLock();
-            }
+            var currentDeleted = Storage.DeletedTo.GetValueOrDefault(pid, 0L);
+            Storage.DeletedTo = Storage.DeletedTo.SetItem(pid, Math.Max(currentDeleted, seqNr));
+
+            return Storage.EventsByPersistenceId.ToDictionary(
+                kvp => kvp.Key,
+                kvp => new LinkedList<IPersistentRepresentation>(
+                    kvp.Value.Where(e => e.SequenceNr > Storage.DeletedTo.GetValueOrDefault(kvp.Key, 0L))));
         }
 
         /// <summary>
@@ -226,26 +181,19 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public IEnumerable<IPersistentRepresentation> Read(string pid, long from, long to, long max)
         {
-            Lock.EnterReadLock();
-            try
-            {
-                // Use index for O(events_for_entity) instead of O(total_events)
-                if (!EventsByPersistenceId.TryGetValue(pid, out var pidEvents))
-                    return Array.Empty<IPersistentRepresentation>();
+            DrainPendingWrites();
 
-                var deletedToSeq = DeletedTo.GetValueOrDefault(pid, 0L);
+            if (!Storage.EventsByPersistenceId.TryGetValue(pid, out var pidEvents))
+                return Array.Empty<IPersistentRepresentation>();
 
-                return pidEvents
-                    .Where(e => e.SequenceNr > deletedToSeq
-                             && e.SequenceNr >= from
-                             && e.SequenceNr <= to)
-                    .Take(max > int.MaxValue ? int.MaxValue : (int)max)
-                    .ToArray(); // Materialize under lock
-            }
-            finally
-            {
-                Lock.ExitReadLock();
-            }
+            var deletedToSeq = Storage.DeletedTo.GetValueOrDefault(pid, 0L);
+
+            return pidEvents
+                .Where(e => e.SequenceNr > deletedToSeq
+                         && e.SequenceNr >= from
+                         && e.SequenceNr <= to)
+                .Take(max > int.MaxValue ? int.MaxValue : (int)max)
+                .ToArray();
         }
 
         /// <summary>
@@ -253,21 +201,12 @@ namespace Akka.Persistence.Journal
         /// </summary>
         public long HighestSequenceNr(string pid)
         {
-            Lock.EnterReadLock();
-            try
-            {
-                // Use index for O(1) lookup instead of O(n) scan
-                if (!EventsByPersistenceId.TryGetValue(pid, out var events) || events.Count == 0)
-                    return 0L;
+            DrainPendingWrites();
 
-                // Return actual highest sequence number from journal
-                // Deletion is logical only - events remain in index
-                return events[events.Count - 1].SequenceNr;
-            }
-            finally
-            {
-                Lock.ExitReadLock();
-            }
+            if (!Storage.EventsByPersistenceId.TryGetValue(pid, out var events) || events.IsEmpty)
+                return 0L;
+
+            return events[events.Count - 1].SequenceNr;
         }
 
         protected override bool ReceivePluginInternal(object message)
@@ -297,19 +236,10 @@ namespace Akka.Persistence.Journal
 
         private Task<(IEnumerable<string> Ids, int LastOrdering)> SelectAllPersistenceIdsAsync(int offset)
         {
-            HashSet<string> ids;
-            int count;
+            DrainPendingWrites();
 
-            Lock.EnterReadLock();
-            try
-            {
-                ids = new HashSet<string>(EventLog.Skip(offset).Select(p => p.PersistenceId));
-                count = EventLog.Count;
-            }
-            finally
-            {
-                Lock.ExitReadLock();
-            }
+            var ids = new HashSet<string>(Storage.EventLog.Skip(offset).Select(p => p.PersistenceId));
+            var count = Storage.EventLog.Count;
 
             return Task.FromResult<(IEnumerable<string> Ids, int LastOrdering)>((ids, count));
         }
@@ -319,27 +249,16 @@ namespace Akka.Persistence.Journal
         /// </summary>
         private Task<int> ReplayTaggedMessagesAsync(ReplayTaggedMessages replay)
         {
-            IPersistentRepresentation[] snapshot;
-            int count;
+            DrainPendingWrites();
 
-            Lock.EnterReadLock();
-            try
-            {
-                // Scan for events with matching tag
-                snapshot = EventLog
-                    .Where(e => e.Payload is Tagged tagged && tagged.Tags.Contains(replay.Tag))
-                    .Skip(replay.FromOffset)
-                    .Take(replay.Max)
-                    .ToArray();
+            var snapshot = Storage.EventLog
+                .Where(e => e.Payload is Tagged tagged && tagged.Tags.Contains(replay.Tag))
+                .Skip(replay.FromOffset)
+                .Take(replay.Max)
+                .ToArray();
 
-                count = EventLog.Count(e => e.Payload is Tagged tagged && tagged.Tags.Contains(replay.Tag));
-            }
-            finally
-            {
-                Lock.ExitReadLock();
-            }
+            var count = Storage.EventLog.Count(e => e.Payload is Tagged tagged && tagged.Tags.Contains(replay.Tag));
 
-            // Send messages outside the lock to avoid potential deadlocks
             var index = 0;
             foreach (var persistence in snapshot)
             {
@@ -352,25 +271,15 @@ namespace Akka.Persistence.Journal
 
         private Task<int> ReplayAllEventsAsync(ReplayAllEvents replay)
         {
-            IPersistentRepresentation[] snapshot;
-            int count;
+            DrainPendingWrites();
 
-            Lock.EnterReadLock();
-            try
-            {
-                snapshot = EventLog
-                    .Skip(replay.FromOffset)
-                    .Take((int)replay.Max)
-                    .ToArray();
+            var snapshot = Storage.EventLog
+                .Skip(replay.FromOffset)
+                .Take((int)replay.Max)
+                .ToArray();
 
-                count = EventLog.Count;
-            }
-            finally
-            {
-                Lock.ExitReadLock();
-            }
+            var count = Storage.EventLog.Count;
 
-            // Send messages outside the lock to avoid potential deadlocks
             var index = 0;
             foreach (var message in snapshot)
             {
@@ -624,14 +533,8 @@ namespace Akka.Persistence.Journal
 
     public class SharedMemoryJournal : MemoryJournal
     {
-        private static readonly List<IPersistentRepresentation> SharedEventLog = new();
-        private static readonly Dictionary<string, List<IPersistentRepresentation>> SharedEventsByPersistenceId = new();
-        private static readonly ReaderWriterLockSlim SharedLock = new(LockRecursionPolicy.NoRecursion);
-        private static readonly Dictionary<string, long> SharedDeletedTo = new();
+        private static readonly JournalStorage SharedStorage = new();
 
-        protected override List<IPersistentRepresentation> EventLog => SharedEventLog;
-        protected override Dictionary<string, List<IPersistentRepresentation>> EventsByPersistenceId => SharedEventsByPersistenceId;
-        protected override ReaderWriterLockSlim Lock => SharedLock;
-        protected override Dictionary<string, long> DeletedTo => SharedDeletedTo;
+        protected override JournalStorage Storage => SharedStorage;
     }
 }

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Akka.Actor;
 using Akka.Util.Internal;
 
 namespace Akka.Persistence.Snapshot
@@ -22,14 +23,22 @@ namespace Akka.Persistence.Snapshot
     /// In-memory SnapshotStore implementation.
     ///
     /// Uses a channel-based drain-on-read pattern with immutable collections to handle
-    /// the concurrent access pattern imposed by SnapshotStore. Writes enqueue to
-    /// an unbounded channel (never blocking), and reads drain the channel first to ensure
-    /// all pending writes are visible before returning results.
+    /// the concurrent access pattern imposed by SnapshotStore. All mutations (writes
+    /// and deletes) enqueue to an unbounded channel (never blocking), and reads drain
+    /// the channel first to ensure all pending operations are visible before returning results.
     /// </summary>
     public class MemorySnapshotStore : SnapshotStore
     {
         /// <summary>
-        /// Storage container for snapshot data. Encapsulates the pending writes channel
+        /// Represents a snapshot operation — either a write or a delete.
+        /// </summary>
+        internal readonly record struct SnapshotOperation(
+            SnapshotEntry? Write = null,
+            SnapshotMetadata? DeleteByMetadata = null,
+            (string PersistenceId, SnapshotSelectionCriteria Criteria)? DeleteByCriteria = null);
+
+        /// <summary>
+        /// Storage container for snapshot data. Encapsulates the pending operations channel
         /// and immutable snapshot state.
         /// </summary>
         protected sealed class SnapshotStorage
@@ -41,10 +50,21 @@ namespace Akka.Persistence.Snapshot
             internal readonly object DrainLock = new();
 
             /// <summary>
-            /// Pending writes channel — unbounded, writers never block.
+            /// Tracks number of in-flight write/delete operations that have been dispatched
+            /// but not yet completed. Reads must wait for this to reach zero.
             /// </summary>
-            internal readonly Channel<SnapshotEntry> PendingWrites =
-                Channel.CreateUnbounded<SnapshotEntry>(
+            internal int InFlightOps;
+
+            /// <summary>
+            /// Event signaled when InFlightOps reaches zero.
+            /// </summary>
+            internal readonly ManualResetEventSlim InFlightComplete = new(true);
+
+            /// <summary>
+            /// Pending operations channel — unbounded, writers never block.
+            /// </summary>
+            internal readonly Channel<SnapshotOperation> PendingOps =
+                Channel.CreateUnbounded<SnapshotOperation>(
                     new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
 
             /// <summary>
@@ -61,26 +81,77 @@ namespace Akka.Persistence.Snapshot
         protected virtual SnapshotStorage Storage => _storage;
 
         /// <summary>
-        /// Drains all pending writes from the channel into the immutable snapshot state.
-        /// Must be called before any read operation to ensure all writes are visible.
+        /// Tracks in-flight write/delete operations so reads can wait for pending ops to complete.
+        /// This ensures operations dispatched via fire-and-forget (with Task.Yield) are visible
+        /// before any read operations proceed.
         /// </summary>
-        private void DrainPendingWrites()
+        protected internal override bool AroundReceive(Receive receive, object message)
         {
+            switch (message)
+            {
+                case SaveSnapshot:
+                case DeleteSnapshot:
+                case DeleteSnapshots:
+                    // Increment in-flight counter before dispatch
+                    if (Interlocked.Increment(ref Storage.InFlightOps) == 1)
+                        Storage.InFlightComplete.Reset();
+                    break;
+            }
+
+            return base.AroundReceive(receive, message);
+        }
+
+        /// <summary>
+        /// Signals that an in-flight operation has completed.
+        /// </summary>
+        private void CompleteInFlightOp()
+        {
+            if (Interlocked.Decrement(ref Storage.InFlightOps) == 0)
+                Storage.InFlightComplete.Set();
+        }
+
+        /// <summary>
+        /// Drains all pending operations from the channel into the immutable snapshot state.
+        /// Must be called before any read operation to ensure all mutations are visible.
+        /// </summary>
+        private void DrainPendingOps()
+        {
+            // Wait for any in-flight write/delete operations to complete first
+            Storage.InFlightComplete.Wait();
+
             lock (Storage.DrainLock)
             {
-                while (Storage.PendingWrites.Reader.TryRead(out var item))
+                while (Storage.PendingOps.Reader.TryRead(out var op))
                 {
-                    var existingIndex = Storage.Snapshots.FindIndex(x => x.Id == item.Id);
+                    if (op.Write is { } item)
+                    {
+                        var existingIndex = Storage.Snapshots.FindIndex(x => x.Id == item.Id);
 
-                    if (existingIndex >= 0)
-                    {
-                        // Update existing snapshot by replacing it
-                        Storage.Snapshots = Storage.Snapshots.SetItem(existingIndex, item);
+                        if (existingIndex >= 0)
+                        {
+                            Storage.Snapshots = Storage.Snapshots.SetItem(existingIndex, item);
+                        }
+                        else
+                        {
+                            Storage.Snapshots = Storage.Snapshots.Add(item);
+                        }
                     }
-                    else
+                    else if (op.DeleteByMetadata is { } metadata)
                     {
-                        // Add new snapshot
-                        Storage.Snapshots = Storage.Snapshots.Add(item);
+                        bool Pred(SnapshotEntry x) => x.PersistenceId == metadata.PersistenceId
+                            && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
+                            && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
+
+                        var snapshot = Storage.Snapshots.FirstOrDefault(Pred);
+                        if (snapshot != null)
+                        {
+                            Storage.Snapshots = Storage.Snapshots.Remove(snapshot);
+                        }
+                    }
+                    else if (op.DeleteByCriteria is { } deleteCriteria)
+                    {
+                        var filter = CreateRangeFilter(deleteCriteria.PersistenceId, deleteCriteria.Criteria);
+                        Storage.Snapshots = Storage.Snapshots.RemoveAll(x => filter(x));
                     }
                 }
             }
@@ -88,34 +159,33 @@ namespace Akka.Persistence.Snapshot
 
         protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
-            DrainPendingWrites();
-
-            bool Pred(SnapshotEntry x) => x.PersistenceId == metadata.PersistenceId
-                && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
-                && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
-
-            var snapshot = Storage.Snapshots.FirstOrDefault(Pred);
-            if (snapshot != null)
+            try
             {
-                Storage.Snapshots = Storage.Snapshots.Remove(snapshot);
+                Storage.PendingOps.Writer.TryWrite(new SnapshotOperation(DeleteByMetadata: metadata));
+                return TaskEx.Completed;
             }
-
-            return TaskEx.Completed;
+            finally
+            {
+                CompleteInFlightOp();
+            }
         }
 
         protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
-            DrainPendingWrites();
-
-            var filter = CreateRangeFilter(persistenceId, criteria);
-            Storage.Snapshots = Storage.Snapshots.RemoveAll(x => filter(x));
-
-            return TaskEx.Completed;
+            try
+            {
+                Storage.PendingOps.Writer.TryWrite(new SnapshotOperation(DeleteByCriteria: (persistenceId, criteria)));
+                return TaskEx.Completed;
+            }
+            finally
+            {
+                CompleteInFlightOp();
+            }
         }
 
         protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
-            DrainPendingWrites();
+            DrainPendingOps();
 
             var filter = CreateRangeFilter(persistenceId, criteria);
             var snapshot = Storage.Snapshots
@@ -130,12 +200,16 @@ namespace Akka.Persistence.Snapshot
 
         protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
         {
-            var snapshotEntry = ToSnapshotEntry(metadata, snapshot);
-
-            // Non-blocking write to channel — TryWrite always succeeds on unbounded channel
-            Storage.PendingWrites.Writer.TryWrite(snapshotEntry);
-
-            return TaskEx.Completed;
+            try
+            {
+                var snapshotEntry = ToSnapshotEntry(metadata, snapshot);
+                Storage.PendingOps.Writer.TryWrite(new SnapshotOperation(Write: snapshotEntry));
+                return TaskEx.Completed;
+            }
+            finally
+            {
+                CompleteInFlightOp();
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -38,19 +38,19 @@ namespace Akka.Persistence.Snapshot
             /// Lock for serializing drain operations. Reads can happen concurrently
             /// from multiple thread pool threads due to SnapshotStore's async pattern.
             /// </summary>
-            public readonly object DrainLock = new();
+            internal readonly object DrainLock = new();
 
             /// <summary>
             /// Pending writes channel — unbounded, writers never block.
             /// </summary>
-            public readonly Channel<SnapshotEntry> PendingWrites =
+            internal readonly Channel<SnapshotEntry> PendingWrites =
                 Channel.CreateUnbounded<SnapshotEntry>(
                     new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
 
             /// <summary>
             /// All snapshots stored in memory.
             /// </summary>
-            public ImmutableList<SnapshotEntry> Snapshots = ImmutableList<SnapshotEntry>.Empty;
+            internal ImmutableList<SnapshotEntry> Snapshots = ImmutableList<SnapshotEntry>.Empty;
         }
 
         private readonly SnapshotStorage _storage = new();

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="MemorySnapshotStore.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -6,10 +6,11 @@
 //-----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Akka.Util.Internal;
 
@@ -19,36 +20,75 @@ namespace Akka.Persistence.Snapshot
     /// INTERNAL API.
     ///
     /// In-memory SnapshotStore implementation.
+    ///
+    /// Uses a channel-based drain-on-read pattern with immutable collections to handle
+    /// the concurrent access pattern imposed by SnapshotStore. Writes enqueue to
+    /// an unbounded channel (never blocking), and reads drain the channel first to ensure
+    /// all pending writes are visible before returning results.
     /// </summary>
     public class MemorySnapshotStore : SnapshotStore
     {
         /// <summary>
-        /// Lock for thread-safe access to the Snapshots collection.
-        ///
-        /// Note: We use locks instead of thread-safe collections (e.g., ConcurrentDictionary) because:
-        /// 1. Each persistence ID can have multiple snapshots at different sequence numbers, requiring range queries
-        /// 2. LoadAsync needs to find the highest sequenceNr matching criteria via enumeration and sorting
-        /// 3. SaveAsync requires atomic check-then-update-or-add operations (FirstOrDefault + mutation/Add)
-        /// 4. ConcurrentDictionary keyed by persistenceId would still require a non-thread-safe List/Bag per value
-        ///
-        /// The lock ensures atomicity of compound operations and consistent enumeration during LINQ queries.
+        /// Storage container for snapshot data. Encapsulates the pending writes channel
+        /// and immutable snapshot state.
         /// </summary>
-        private readonly object _snapshotsLock = new();
+        protected sealed class SnapshotStorage
+        {
+            /// <summary>
+            /// Pending writes channel — unbounded, writers never block.
+            /// </summary>
+            public readonly Channel<SnapshotEntry> PendingWrites =
+                Channel.CreateUnbounded<SnapshotEntry>(
+                    new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
+
+            /// <summary>
+            /// All snapshots stored in memory.
+            /// </summary>
+            public ImmutableList<SnapshotEntry> Snapshots = ImmutableList<SnapshotEntry>.Empty;
+        }
+
+        private readonly SnapshotStorage _storage = new();
 
         /// <summary>
-        /// This is available to expose/override the snapshots in derived snapshot stores
+        /// Storage property for accessing snapshot data. Override in subclasses to share storage.
         /// </summary>
-        protected virtual List<SnapshotEntry> Snapshots { get; } = new();
+        protected virtual SnapshotStorage Storage => _storage;
+
+        /// <summary>
+        /// Drains all pending writes from the channel into the immutable snapshot state.
+        /// Must be called before any read operation to ensure all writes are visible.
+        /// </summary>
+        private void DrainPendingWrites()
+        {
+            while (Storage.PendingWrites.Reader.TryRead(out var item))
+            {
+                var existingIndex = Storage.Snapshots.FindIndex(x => x.Id == item.Id);
+
+                if (existingIndex >= 0)
+                {
+                    // Update existing snapshot by replacing it
+                    Storage.Snapshots = Storage.Snapshots.SetItem(existingIndex, item);
+                }
+                else
+                {
+                    // Add new snapshot
+                    Storage.Snapshots = Storage.Snapshots.Add(item);
+                }
+            }
+        }
 
         protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
-            bool Pred(SnapshotEntry x) => x.PersistenceId == metadata.PersistenceId && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
-                                                                                    && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
+            DrainPendingWrites();
 
-            lock (_snapshotsLock)
+            bool Pred(SnapshotEntry x) => x.PersistenceId == metadata.PersistenceId
+                && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
+                && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
+
+            var snapshot = Storage.Snapshots.FirstOrDefault(Pred);
+            if (snapshot != null)
             {
-                var snapshot = Snapshots.FirstOrDefault(Pred);
-                Snapshots.Remove(snapshot);
+                Storage.Snapshots = Storage.Snapshots.Remove(snapshot);
             }
 
             return TaskEx.Completed;
@@ -56,24 +96,26 @@ namespace Akka.Persistence.Snapshot
 
         protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
-            var filter = CreateRangeFilter(persistenceId, criteria);
+            DrainPendingWrites();
 
-            lock (_snapshotsLock)
-            {
-                Snapshots.RemoveAll(x => filter(x));
-            }
+            var filter = CreateRangeFilter(persistenceId, criteria);
+            Storage.Snapshots = Storage.Snapshots.RemoveAll(x => filter(x));
+
             return TaskEx.Completed;
         }
 
         protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
-            var filter = CreateRangeFilter(persistenceId, criteria);
+            DrainPendingWrites();
 
-            SelectedSnapshot snapshot;
-            lock (_snapshotsLock)
-            {
-                snapshot = Snapshots.Where(filter).OrderByDescending(x => x.SequenceNr).Take(1).Select(x => ToSelectedSnapshot(x)).FirstOrDefault();
-            }
+            var filter = CreateRangeFilter(persistenceId, criteria);
+            var snapshot = Storage.Snapshots
+                .Where(filter)
+                .OrderByDescending(x => x.SequenceNr)
+                .Take(1)
+                .Select(x => ToSelectedSnapshot(x))
+                .FirstOrDefault();
+
             return Task.FromResult(snapshot);
         }
 
@@ -81,27 +123,10 @@ namespace Akka.Persistence.Snapshot
         {
             var snapshotEntry = ToSnapshotEntry(metadata, snapshot);
 
-            lock (_snapshotsLock)
-            {
-                var existingSnapshot = Snapshots.FirstOrDefault(CreateSnapshotIdFilter(snapshotEntry.Id));
-
-                if (existingSnapshot != null)
-                {
-                    existingSnapshot.Snapshot = snapshotEntry.Snapshot;
-                    existingSnapshot.Timestamp = snapshotEntry.Timestamp;
-                }
-                else
-                {
-                    Snapshots.Add(snapshotEntry);
-                }
-            }
+            // Non-blocking write to channel — TryWrite always succeeds on unbounded channel
+            Storage.PendingWrites.Writer.TryWrite(snapshotEntry);
 
             return TaskEx.Completed;
-        }
-
-        private static Func<SnapshotEntry, bool> CreateSnapshotIdFilter(string snapshotId)
-        {
-            return x => x.Id == snapshotId;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -114,14 +139,12 @@ namespace Akka.Persistence.Snapshot
 
         private static SnapshotEntry ToSnapshotEntry(SnapshotMetadata metadata, object snapshot)
         {
-            return new SnapshotEntry
-            {
-                Id = metadata.PersistenceId + "_" + metadata.SequenceNr,
-                PersistenceId = metadata.PersistenceId,
-                SequenceNr = metadata.SequenceNr,
-                Snapshot = snapshot,
-                Timestamp = metadata.Timestamp.Ticks
-            };
+            return new SnapshotEntry(
+                id: metadata.PersistenceId + "_" + metadata.SequenceNr,
+                persistenceId: metadata.PersistenceId,
+                sequenceNr: metadata.SequenceNr,
+                timestamp: metadata.Timestamp.Ticks,
+                snapshot: snapshot);
         }
 
         private static SelectedSnapshot ToSelectedSnapshot(SnapshotEntry entry)
@@ -129,7 +152,7 @@ namespace Akka.Persistence.Snapshot
             return new SelectedSnapshot(metadata: new SnapshotMetadata(
                 persistenceId: entry.PersistenceId,
                 sequenceNr: entry.SequenceNr,
-                timestamp: DateTime.SpecifyKind(new DateTime(entry.Timestamp), DateTimeKind.Utc)), 
+                timestamp: DateTime.SpecifyKind(new DateTime(entry.Timestamp), DateTimeKind.Utc)),
                 snapshot: entry.Snapshot);
         }
     }
@@ -137,19 +160,24 @@ namespace Akka.Persistence.Snapshot
     /// <summary>
     /// INTERNAL API.
     ///
-    /// Represents a snapshot stored inside the in-memory <see cref="SnapshotStore"/>
+    /// Represents a snapshot stored inside the in-memory <see cref="SnapshotStore"/>.
+    /// Immutable by design to support concurrent access patterns.
     /// </summary>
-    public class SnapshotEntry
+    public sealed class SnapshotEntry
     {
-        public string Id { get; set; }
+        public SnapshotEntry(string id, string persistenceId, long sequenceNr, long timestamp, object snapshot)
+        {
+            Id = id;
+            PersistenceId = persistenceId;
+            SequenceNr = sequenceNr;
+            Timestamp = timestamp;
+            Snapshot = snapshot;
+        }
 
-        public string PersistenceId { get; set; }
-
-        public long SequenceNr { get; set; }
-
-        public long Timestamp { get; set; }
-
-        public object Snapshot { get; set; }
-
+        public string Id { get; }
+        public string PersistenceId { get; }
+        public long SequenceNr { get; }
+        public long Timestamp { get; }
+        public object Snapshot { get; }
     }
 }

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -12,7 +12,6 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using Akka.Actor;
 using Akka.Util.Internal;
 
 namespace Akka.Persistence.Snapshot
@@ -23,22 +22,14 @@ namespace Akka.Persistence.Snapshot
     /// In-memory SnapshotStore implementation.
     ///
     /// Uses a channel-based drain-on-read pattern with immutable collections to handle
-    /// the concurrent access pattern imposed by SnapshotStore. All mutations (writes
-    /// and deletes) enqueue to an unbounded channel (never blocking), and reads drain
-    /// the channel first to ensure all pending operations are visible before returning results.
+    /// the concurrent access pattern imposed by SnapshotStore. Writes enqueue to
+    /// an unbounded channel (never blocking), and reads drain the channel first to ensure
+    /// all pending writes are visible before returning results.
     /// </summary>
     public class MemorySnapshotStore : SnapshotStore
     {
         /// <summary>
-        /// Represents a snapshot operation — either a write or a delete.
-        /// </summary>
-        internal readonly record struct SnapshotOperation(
-            SnapshotEntry? Write = null,
-            SnapshotMetadata? DeleteByMetadata = null,
-            (string PersistenceId, SnapshotSelectionCriteria Criteria)? DeleteByCriteria = null);
-
-        /// <summary>
-        /// Storage container for snapshot data. Encapsulates the pending operations channel
+        /// Storage container for snapshot data. Encapsulates the pending writes channel
         /// and immutable snapshot state.
         /// </summary>
         protected sealed class SnapshotStorage
@@ -50,21 +41,10 @@ namespace Akka.Persistence.Snapshot
             internal readonly object DrainLock = new();
 
             /// <summary>
-            /// Tracks number of in-flight write/delete operations that have been dispatched
-            /// but not yet completed. Reads must wait for this to reach zero.
+            /// Pending writes channel — unbounded, writers never block.
             /// </summary>
-            internal int InFlightOps;
-
-            /// <summary>
-            /// Event signaled when InFlightOps reaches zero.
-            /// </summary>
-            internal readonly ManualResetEventSlim InFlightComplete = new(true);
-
-            /// <summary>
-            /// Pending operations channel — unbounded, writers never block.
-            /// </summary>
-            internal readonly Channel<SnapshotOperation> PendingOps =
-                Channel.CreateUnbounded<SnapshotOperation>(
+            internal readonly Channel<SnapshotEntry> PendingWrites =
+                Channel.CreateUnbounded<SnapshotEntry>(
                     new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
 
             /// <summary>
@@ -81,77 +61,26 @@ namespace Akka.Persistence.Snapshot
         protected virtual SnapshotStorage Storage => _storage;
 
         /// <summary>
-        /// Tracks in-flight write/delete operations so reads can wait for pending ops to complete.
-        /// This ensures operations dispatched via fire-and-forget (with Task.Yield) are visible
-        /// before any read operations proceed.
+        /// Drains all pending writes from the channel into the immutable snapshot state.
+        /// Must be called before any read operation to ensure all writes are visible.
         /// </summary>
-        protected internal override bool AroundReceive(Receive receive, object message)
+        private void DrainPendingWrites()
         {
-            switch (message)
-            {
-                case SaveSnapshot:
-                case DeleteSnapshot:
-                case DeleteSnapshots:
-                    // Increment in-flight counter before dispatch
-                    if (Interlocked.Increment(ref Storage.InFlightOps) == 1)
-                        Storage.InFlightComplete.Reset();
-                    break;
-            }
-
-            return base.AroundReceive(receive, message);
-        }
-
-        /// <summary>
-        /// Signals that an in-flight operation has completed.
-        /// </summary>
-        private void CompleteInFlightOp()
-        {
-            if (Interlocked.Decrement(ref Storage.InFlightOps) == 0)
-                Storage.InFlightComplete.Set();
-        }
-
-        /// <summary>
-        /// Drains all pending operations from the channel into the immutable snapshot state.
-        /// Must be called before any read operation to ensure all mutations are visible.
-        /// </summary>
-        private void DrainPendingOps()
-        {
-            // Wait for any in-flight write/delete operations to complete first
-            Storage.InFlightComplete.Wait();
-
             lock (Storage.DrainLock)
             {
-                while (Storage.PendingOps.Reader.TryRead(out var op))
+                while (Storage.PendingWrites.Reader.TryRead(out var item))
                 {
-                    if (op.Write is { } item)
-                    {
-                        var existingIndex = Storage.Snapshots.FindIndex(x => x.Id == item.Id);
+                    var existingIndex = Storage.Snapshots.FindIndex(x => x.Id == item.Id);
 
-                        if (existingIndex >= 0)
-                        {
-                            Storage.Snapshots = Storage.Snapshots.SetItem(existingIndex, item);
-                        }
-                        else
-                        {
-                            Storage.Snapshots = Storage.Snapshots.Add(item);
-                        }
-                    }
-                    else if (op.DeleteByMetadata is { } metadata)
+                    if (existingIndex >= 0)
                     {
-                        bool Pred(SnapshotEntry x) => x.PersistenceId == metadata.PersistenceId
-                            && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
-                            && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
-
-                        var snapshot = Storage.Snapshots.FirstOrDefault(Pred);
-                        if (snapshot != null)
-                        {
-                            Storage.Snapshots = Storage.Snapshots.Remove(snapshot);
-                        }
+                        // Update existing snapshot by replacing it
+                        Storage.Snapshots = Storage.Snapshots.SetItem(existingIndex, item);
                     }
-                    else if (op.DeleteByCriteria is { } deleteCriteria)
+                    else
                     {
-                        var filter = CreateRangeFilter(deleteCriteria.PersistenceId, deleteCriteria.Criteria);
-                        Storage.Snapshots = Storage.Snapshots.RemoveAll(x => filter(x));
+                        // Add new snapshot
+                        Storage.Snapshots = Storage.Snapshots.Add(item);
                     }
                 }
             }
@@ -159,33 +88,34 @@ namespace Akka.Persistence.Snapshot
 
         protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
-            try
+            DrainPendingWrites();
+
+            bool Pred(SnapshotEntry x) => x.PersistenceId == metadata.PersistenceId
+                && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
+                && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
+
+            var snapshot = Storage.Snapshots.FirstOrDefault(Pred);
+            if (snapshot != null)
             {
-                Storage.PendingOps.Writer.TryWrite(new SnapshotOperation(DeleteByMetadata: metadata));
-                return TaskEx.Completed;
+                Storage.Snapshots = Storage.Snapshots.Remove(snapshot);
             }
-            finally
-            {
-                CompleteInFlightOp();
-            }
+
+            return TaskEx.Completed;
         }
 
         protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
-            try
-            {
-                Storage.PendingOps.Writer.TryWrite(new SnapshotOperation(DeleteByCriteria: (persistenceId, criteria)));
-                return TaskEx.Completed;
-            }
-            finally
-            {
-                CompleteInFlightOp();
-            }
+            DrainPendingWrites();
+
+            var filter = CreateRangeFilter(persistenceId, criteria);
+            Storage.Snapshots = Storage.Snapshots.RemoveAll(x => filter(x));
+
+            return TaskEx.Completed;
         }
 
         protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
-            DrainPendingOps();
+            DrainPendingWrites();
 
             var filter = CreateRangeFilter(persistenceId, criteria);
             var snapshot = Storage.Snapshots
@@ -200,16 +130,12 @@ namespace Akka.Persistence.Snapshot
 
         protected override Task SaveAsync(SnapshotMetadata metadata, object snapshot, CancellationToken cancellationToken)
         {
-            try
-            {
-                var snapshotEntry = ToSnapshotEntry(metadata, snapshot);
-                Storage.PendingOps.Writer.TryWrite(new SnapshotOperation(Write: snapshotEntry));
-                return TaskEx.Completed;
-            }
-            finally
-            {
-                CompleteInFlightOp();
-            }
+            var snapshotEntry = ToSnapshotEntry(metadata, snapshot);
+
+            // Non-blocking write to channel — TryWrite always succeeds on unbounded channel
+            Storage.PendingWrites.Writer.TryWrite(snapshotEntry);
+
+            return TaskEx.Completed;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -35,6 +35,12 @@ namespace Akka.Persistence.Snapshot
         protected sealed class SnapshotStorage
         {
             /// <summary>
+            /// Lock for serializing drain operations. Reads can happen concurrently
+            /// from multiple thread pool threads due to SnapshotStore's async pattern.
+            /// </summary>
+            public readonly object DrainLock = new();
+
+            /// <summary>
             /// Pending writes channel — unbounded, writers never block.
             /// </summary>
             public readonly Channel<SnapshotEntry> PendingWrites =
@@ -60,19 +66,22 @@ namespace Akka.Persistence.Snapshot
         /// </summary>
         private void DrainPendingWrites()
         {
-            while (Storage.PendingWrites.Reader.TryRead(out var item))
+            lock (Storage.DrainLock)
             {
-                var existingIndex = Storage.Snapshots.FindIndex(x => x.Id == item.Id);
+                while (Storage.PendingWrites.Reader.TryRead(out var item))
+                {
+                    var existingIndex = Storage.Snapshots.FindIndex(x => x.Id == item.Id);
 
-                if (existingIndex >= 0)
-                {
-                    // Update existing snapshot by replacing it
-                    Storage.Snapshots = Storage.Snapshots.SetItem(existingIndex, item);
-                }
-                else
-                {
-                    // Add new snapshot
-                    Storage.Snapshots = Storage.Snapshots.Add(item);
+                    if (existingIndex >= 0)
+                    {
+                        // Update existing snapshot by replacing it
+                        Storage.Snapshots = Storage.Snapshots.SetItem(existingIndex, item);
+                    }
+                    else
+                    {
+                        // Add new snapshot
+                        Storage.Snapshots = Storage.Snapshots.Add(item);
+                    }
                 }
             }
         }

--- a/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/MemorySnapshotStore.cs
@@ -22,14 +22,60 @@ namespace Akka.Persistence.Snapshot
     /// In-memory SnapshotStore implementation.
     ///
     /// Uses a channel-based drain-on-read pattern with immutable collections to handle
-    /// the concurrent access pattern imposed by SnapshotStore. Writes enqueue to
+    /// the concurrent access pattern imposed by SnapshotStore. Writes and deletes enqueue to
     /// an unbounded channel (never blocking), and reads drain the channel first to ensure
-    /// all pending writes are visible before returning results.
+    /// all pending operations are visible before returning results.
     /// </summary>
     public class MemorySnapshotStore : SnapshotStore
     {
         /// <summary>
-        /// Storage container for snapshot data. Encapsulates the pending writes channel
+        /// Represents an operation to be applied to the snapshot store.
+        /// </summary>
+        internal interface ISnapshotOperation { }
+
+        /// <summary>
+        /// Write a snapshot.
+        /// </summary>
+        internal sealed class WriteSnapshot : ISnapshotOperation
+        {
+            public SnapshotEntry Entry { get; }
+            public WriteSnapshot(SnapshotEntry entry) => Entry = entry;
+        }
+
+        /// <summary>
+        /// Delete a specific snapshot by metadata.
+        /// </summary>
+        internal sealed class DeleteSnapshot : ISnapshotOperation
+        {
+            public string PersistenceId { get; }
+            public long SequenceNr { get; }
+            public long Timestamp { get; }
+
+            public DeleteSnapshot(SnapshotMetadata metadata)
+            {
+                PersistenceId = metadata.PersistenceId;
+                SequenceNr = metadata.SequenceNr;
+                Timestamp = metadata.Timestamp.Ticks;
+            }
+        }
+
+        /// <summary>
+        /// Delete snapshots matching criteria.
+        /// </summary>
+        internal sealed class DeleteSnapshotRange : ISnapshotOperation
+        {
+            public string PersistenceId { get; }
+            public SnapshotSelectionCriteria Criteria { get; }
+
+            public DeleteSnapshotRange(string persistenceId, SnapshotSelectionCriteria criteria)
+            {
+                PersistenceId = persistenceId;
+                Criteria = criteria;
+            }
+        }
+
+        /// <summary>
+        /// Storage container for snapshot data. Encapsulates the pending operations channel
         /// and immutable snapshot state.
         /// </summary>
         protected sealed class SnapshotStorage
@@ -41,10 +87,10 @@ namespace Akka.Persistence.Snapshot
             internal readonly object DrainLock = new();
 
             /// <summary>
-            /// Pending writes channel — unbounded, writers never block.
+            /// Pending operations channel — unbounded, writers never block.
             /// </summary>
-            internal readonly Channel<SnapshotEntry> PendingWrites =
-                Channel.CreateUnbounded<SnapshotEntry>(
+            internal readonly Channel<ISnapshotOperation> PendingOperations =
+                Channel.CreateUnbounded<ISnapshotOperation>(
                     new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
 
             /// <summary>
@@ -61,26 +107,39 @@ namespace Akka.Persistence.Snapshot
         protected virtual SnapshotStorage Storage => _storage;
 
         /// <summary>
-        /// Drains all pending writes from the channel into the immutable snapshot state.
-        /// Must be called before any read operation to ensure all writes are visible.
+        /// Drains all pending operations from the channel into the immutable snapshot state.
+        /// Must be called before any read operation to ensure all operations are visible.
         /// </summary>
-        private void DrainPendingWrites()
+        private void DrainPendingOperations()
         {
             lock (Storage.DrainLock)
             {
-                while (Storage.PendingWrites.Reader.TryRead(out var item))
+                while (Storage.PendingOperations.Reader.TryRead(out var op))
                 {
-                    var existingIndex = Storage.Snapshots.FindIndex(x => x.Id == item.Id);
+                    switch (op)
+                    {
+                        case WriteSnapshot write:
+                            var item = write.Entry;
+                            var existingIndex = Storage.Snapshots.FindIndex(x => x.Id == item.Id);
+                            if (existingIndex >= 0)
+                                Storage.Snapshots = Storage.Snapshots.SetItem(existingIndex, item);
+                            else
+                                Storage.Snapshots = Storage.Snapshots.Add(item);
+                            break;
 
-                    if (existingIndex >= 0)
-                    {
-                        // Update existing snapshot by replacing it
-                        Storage.Snapshots = Storage.Snapshots.SetItem(existingIndex, item);
-                    }
-                    else
-                    {
-                        // Add new snapshot
-                        Storage.Snapshots = Storage.Snapshots.Add(item);
+                        case DeleteSnapshot del:
+                            var snapshot = Storage.Snapshots.FirstOrDefault(x =>
+                                x.PersistenceId == del.PersistenceId
+                                && (del.SequenceNr <= 0 || del.SequenceNr == long.MaxValue || x.SequenceNr == del.SequenceNr)
+                                && (del.Timestamp == DateTime.MinValue.Ticks || del.Timestamp == DateTime.MaxValue.Ticks || x.Timestamp == del.Timestamp));
+                            if (snapshot != null)
+                                Storage.Snapshots = Storage.Snapshots.Remove(snapshot);
+                            break;
+
+                        case DeleteSnapshotRange range:
+                            var filter = CreateRangeFilter(range.PersistenceId, range.Criteria);
+                            Storage.Snapshots = Storage.Snapshots.RemoveAll(x => filter(x));
+                            break;
                     }
                 }
             }
@@ -88,34 +147,21 @@ namespace Akka.Persistence.Snapshot
 
         protected override Task DeleteAsync(SnapshotMetadata metadata, CancellationToken cancellationToken)
         {
-            DrainPendingWrites();
-
-            bool Pred(SnapshotEntry x) => x.PersistenceId == metadata.PersistenceId
-                && (metadata.SequenceNr <= 0 || metadata.SequenceNr == long.MaxValue || x.SequenceNr == metadata.SequenceNr)
-                && (metadata.Timestamp == DateTime.MinValue || metadata.Timestamp == DateTime.MaxValue || x.Timestamp == metadata.Timestamp.Ticks);
-
-            var snapshot = Storage.Snapshots.FirstOrDefault(Pred);
-            if (snapshot != null)
-            {
-                Storage.Snapshots = Storage.Snapshots.Remove(snapshot);
-            }
-
+            // Queue delete operation - will be processed during next drain
+            Storage.PendingOperations.Writer.TryWrite(new DeleteSnapshot(metadata));
             return TaskEx.Completed;
         }
 
         protected override Task DeleteAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
-            DrainPendingWrites();
-
-            var filter = CreateRangeFilter(persistenceId, criteria);
-            Storage.Snapshots = Storage.Snapshots.RemoveAll(x => filter(x));
-
+            // Queue delete operation - will be processed during next drain
+            Storage.PendingOperations.Writer.TryWrite(new DeleteSnapshotRange(persistenceId, criteria));
             return TaskEx.Completed;
         }
 
         protected override Task<SelectedSnapshot> LoadAsync(string persistenceId, SnapshotSelectionCriteria criteria, CancellationToken cancellationToken)
         {
-            DrainPendingWrites();
+            DrainPendingOperations();
 
             var filter = CreateRangeFilter(persistenceId, criteria);
             var snapshot = Storage.Snapshots
@@ -133,7 +179,7 @@ namespace Akka.Persistence.Snapshot
             var snapshotEntry = ToSnapshotEntry(metadata, snapshot);
 
             // Non-blocking write to channel — TryWrite always succeeds on unbounded channel
-            Storage.PendingWrites.Writer.TryWrite(snapshotEntry);
+            Storage.PendingOperations.Writer.TryWrite(new WriteSnapshot(snapshotEntry));
 
             return TaskEx.Completed;
         }


### PR DESCRIPTION
## Summary

Redesigns `MemoryJournal` and `MemorySnapshotStore` to fix chronic race conditions that have been patched 9+ times over several years without being solved.

- Replace `ReaderWriterLockSlim` + mutable `List<T>`/`Dictionary<K,V>` with unbounded `Channel<T>` + immutable collections
- Writes enqueue to channel (non-blocking, never contends)
- Reads drain channel first, ensuring all pending writes are visible before returning results
- Remove all locks — channel drain is the natural synchronization point
- Make `SnapshotEntry` immutable (sealed class with constructor)
- `SharedMemoryJournal` now overrides single `Storage` property instead of 4

## Background

PR #8163 added `await Task.Yield()` inside `AsyncWriteJournal.ExecuteBatch` to ensure `WriteMessagesAsync` runs on a thread pool continuation rather than blocking the actor's message loop. This exposed a latent design flaw: **MemoryJournal never correctly implemented the AsyncWriteJournal contract**.

The [AsyncWriteJournal contract](https://github.com/akkadotnet/akka.net/blob/dev/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs#L178-L183) documents:

> "Please also note that requests for the highest sequence number may be made concurrently to this call executing for the same `persistenceId`, in particular it is possible that a restarting actor tries to recover before its outstanding writes have completed."

Real database journals handle this naturally because writes go through I/O and reads hit the same durable store. MemoryJournal's writes *are* the data store mutations, so the `Task.Yield()` created a window where reads could see stale state — but the underlying bug was always there; it just needed the right timing to manifest.

## Breaking API Changes

This PR removes 4 protected virtual properties from `MemoryJournal`:
- `EventLog`, `EventsByPersistenceId`, `Lock`, `DeletedTo`

These are replaced with a single `protected virtual JournalStorage Storage` property. `SnapshotEntry` is now a sealed immutable class.

These are internal testing APIs. External code depending on them was already fighting race conditions.

## Test plan

- [x] `PersistentActorFailureSpec` — 11 tests pass (including the previously failing `PersistentActor_should_support_restart_when_Persist_followed_by_exception`)
- [x] `SnapshotSpec` — 9 tests pass
- [x] Full `Akka.Persistence.Tests` — 285 passed, 3 skipped
- [x] `Akka.Persistence.Query.InMemory.Tests` — 46 passed, 1 skipped
- [x] `Akka.Persistence.TestKit.Tests` — 37 passed
- [x] API compatibility tests updated