### PR TITLE
Revert Task.Yield() from AsyncWriteJournal and SnapshotStore

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+#### 1.5.67 April 25th, 2026 ####
+
+Akka.NET v1.5.67 is a hotfix release that reverts a breaking change to the persistence plugin contract introduced in v1.5.66.
+
+**Akka.Persistence: Revert async `WriteMessagesAsync`/`SaveAsync` dispatch ([#8163](https://github.com/akkadotnet/akka.net/pull/8163))**
+
+v1.5.66 added `Task.Yield()` inside `AsyncWriteJournal.ExecuteBatch` and `SnapshotStore` to move persistence plugin `WriteMessagesAsync`/`SaveAsync` calls off the actor thread. While this improved throughput in benchmarks, it silently broke the implicit contract that persistence plugins rely on — that the synchronous preamble of these methods executes in actor context.
+
+This caused failures in plugins that:
+* Access `Self` inside `WriteMessagesAsync` (e.g. Akka.Persistence.Sql, Akka.Persistence.EventStore) — throws `NotSupportedException` off the actor thread
+* Use non-thread-safe collections for write tracking (e.g. `Dictionary<string, Task>`) — concurrent access from actor thread and thread pool causes `InvalidOperationException`
+* Send messages to subscribers after writes complete (e.g. Akka.Persistence.Redis) — accesses shared actor state off-thread
+
+This release removes the `Task.Yield()` calls and restores the original dispatch behavior. A future version may reintroduce this optimization with a more targeted approach that preserves the plugin threading contract.
+
+**If you are on v1.5.66**, upgrade to v1.5.67 immediately if you use any third-party persistence plugin.
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 1 | 3 | 17 | Aaron Stannard |
+
 #### 1.5.66 April 24th, 2026 ####
 
 Akka.NET v1.5.66 is a significant release with persistence bug fixes, major Akka.Streams improvements including OpenTelemetry trace propagation and non-blocking materialized values, and new serialization security controls.

--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -392,15 +392,7 @@ namespace Akka.Persistence.Journal
                 try
                 {
                     var writeResult =
-                        await _breaker.WithCircuitBreaker(
-                            (prepared, awj: this),
-                            async (state, ct) =>
-                            {
-                                // Ensure WriteMessagesAsync is not called in AsyncWriteJournal
-                                // actor context and so doesn't block message handling
-                                await Task.Yield();
-                                return await state.awj.WriteMessagesAsync(state.prepared, ct);
-                            }).ConfigureAwait(false);
+                        await _breaker.WithCircuitBreaker((prepared, awj: this), (state, ct) => state.awj.WriteMessagesAsync(state.prepared, ct)).ConfigureAwait(false);
 
                     ProcessResults(writeResult, atomicWriteCount, message, _resequencer, resequencerCounter, self);
                 }

--- a/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
@@ -107,14 +107,8 @@ namespace Akka.Persistence.Snapshot
                         timestamp: saveSnapshot.Metadata.Timestamp == DateTime.MinValue 
                             ? DateTime.UtcNow 
                             : saveSnapshot.Metadata.Timestamp);
-                    _breaker.WithCircuitBreaker(
-                        async (ct)  =>
-                        {
-                            // Ensure SaveAsync is not called in SnapshotStore
-                            // actor context and so doesn't block message handling
-                            await Task.Yield();
-                            await SaveAsync(metadata, saveSnapshot.Snapshot, ct);
-                        }).ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
+                    _breaker.WithCircuitBreaker(ct => SaveAsync(metadata, saveSnapshot.Snapshot, ct))
+                        .ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
                                 ? new SaveSnapshotSuccess(metadata) as ISnapshotResponse
                                 : new SaveSnapshotFailure(saveSnapshot.Metadata,
                                     t.IsFaulted


### PR DESCRIPTION
## Summary

- Reverts `Task.Yield()` additions from PR #8163 in `AsyncWriteJournal.ExecuteBatch` and `SnapshotStore.ReceiveSnapshotStore`
- Preserves the health check test improvements (`AwaitAssertAsync`, `ExpectMsgAsync`) from that same PR — those are independently correct
- Adds v1.5.67 release notes

## Why

PR #8163 added `await Task.Yield()` before calling `WriteMessagesAsync`/`SaveAsync` inside their circuit breaker lambdas to move serialization off the actor thread (~45% throughput gain in benchmarks). However, this silently broke the implicit contract that persistence plugins rely on — that the synchronous preamble of these methods executes in actor context.

**Affected plugins:**
- **Akka.Persistence.Sql** / **Akka.Persistence.EventStore** — access `Self` inside `WriteMessagesAsync` → `NotSupportedException` off actor thread; use `Dictionary<string, Task>` for write tracking → concurrent access race conditions
- **Akka.Persistence.Redis** — sends `Tell` to subscribers after writes complete → accesses shared actor state off-thread

**Irony:** The plugins that benefit most from off-thread serialization (MongoDB, Azure Table Storage — they serialize on the actor thread before any async boundary) don't access actor context at all. The plugins that break (SQL, EventStore, Redis) already do serialization off-thread in their async pipelines and gain little from the `Task.Yield()`.

A future version may reintroduce this optimization with a more targeted approach (opt-in property, Template Method pattern) that preserves the plugin threading contract.

## Test plan

- [x] `dotnet build src/core/Akka.Persistence/Akka.Persistence.csproj -c Release` — compiles
- [x] `Akka.Persistence.Tests` — 285 passed, 0 failed (net10.0)
- [x] `Akka.Persistence.TestKit.Tests` — 37 passed, 0 failed (net10.0)
- [x] Health check specs still pass (kept from #8163, not reverted)
- [ ] API approval tests — 18 pre-existing failures on net48 unrelated to this change (Verify/PublicApiGenerator tooling mismatch with .NET 10 SDK)