### PR TITLE
Revert Task.Yield() from AsyncWriteJournal and SnapshotStore (cherry-pick to dev)

### DIFF
--- a/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
+++ b/src/core/Akka.Persistence/Journal/AsyncWriteJournal.cs
@@ -392,15 +392,7 @@ namespace Akka.Persistence.Journal
                 try
                 {
                     var writeResult =
-                        await _breaker.WithCircuitBreaker(
-                            (prepared, awj: this),
-                            async (state, ct) =>
-                            {
-                                // Ensure WriteMessagesAsync is not called in AsyncWriteJournal
-                                // actor context and so doesn't block message handling
-                                await Task.Yield();
-                                return await state.awj.WriteMessagesAsync(state.prepared, ct);
-                            }).ConfigureAwait(false);
+                        await _breaker.WithCircuitBreaker((prepared, awj: this), (state, ct) => state.awj.WriteMessagesAsync(state.prepared, ct)).ConfigureAwait(false);
 
                     ProcessResults(writeResult, atomicWriteCount, message, _resequencer, resequencerCounter, self);
                 }

--- a/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
+++ b/src/core/Akka.Persistence/Snapshot/SnapshotStore.cs
@@ -107,14 +107,8 @@ namespace Akka.Persistence.Snapshot
                         timestamp: saveSnapshot.Metadata.Timestamp == DateTime.MinValue 
                             ? DateTime.UtcNow 
                             : saveSnapshot.Metadata.Timestamp);
-                    _breaker.WithCircuitBreaker(
-                        async (ct)  =>
-                        {
-                            // Ensure SaveAsync is not called in SnapshotStore
-                            // actor context and so doesn't block message handling
-                            await Task.Yield();
-                            await SaveAsync(metadata, saveSnapshot.Snapshot, ct);
-                        }).ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
+                    _breaker.WithCircuitBreaker(ct => SaveAsync(metadata, saveSnapshot.Snapshot, ct))
+                        .ContinueWith(t => (!t.IsFaulted && !t.IsCanceled)
                                 ? new SaveSnapshotSuccess(metadata) as ISnapshotResponse
                                 : new SaveSnapshotFailure(saveSnapshot.Metadata,
                                     t.IsFaulted


### PR DESCRIPTION
## Summary

Cherry-pick of the v1.5.67 hotfix to `dev`.

- Reverts `Task.Yield()` additions from PR #8163 in `AsyncWriteJournal.ExecuteBatch` and `SnapshotStore.ReceiveSnapshotStore`
- Preserves the health check test improvements from that same PR

See #8188 and the [v1.5.67 release notes](https://github.com/akkadotnet/akka.net/releases/tag/1.5.67) for full context on why this was reverted.

## Test plan

- [x] Verified on v1.5 branch: Akka.Persistence.Tests — 285 passed, 0 failed
- [x] Verified on v1.5 branch: Akka.Persistence.TestKit.Tests — 37 passed, 0 failed
- [ ] CI on dev branch