### PR TITLE
Add Framing/JsonFraming throughput and allocation benchmarks

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Streams/FramingBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Streams/FramingBenchmarks.cs
@@ -31,7 +31,10 @@ namespace Akka.Benchmarks.Streams
     [Config(typeof(ThroughputBenchmarkConfig))]
     public class FramingBenchmarks
     {
-        private const int MessageCount = 10_000;
+        private const int MessageCount = 100_000;
+        // 16 MB cap on framed message length. SimpleFramingProtocolDecoder adds 4 internally,
+        // so this stays well clear of int.MaxValue overflow (max + 4 ≈ 16 MB still).
+        private const int MaxFrameLength = 16 * 1024 * 1024;
 
         [Params(64, 1024)]
         public int MessageSize { get; set; }
@@ -128,7 +131,7 @@ namespace Akka.Benchmarks.Streams
             _gate = new TaskCompletionSource<NotUsed>(TaskCreationOptions.RunContinuationsAsynchronously);
             _completion = Source.FromTask(_gate.Task)
                 .ConcatMany(_ => Source.From(_rawMessages))
-                .Via(Framing.SimpleFramingProtocolEncoder(int.MaxValue))
+                .Via(Framing.SimpleFramingProtocolEncoder(MaxFrameLength))
                 .RunWith(Sink.Ignore<ByteString>(), _materializer);
         }
 
@@ -148,8 +151,8 @@ namespace Akka.Benchmarks.Streams
             _gate = new TaskCompletionSource<NotUsed>(TaskCreationOptions.RunContinuationsAsynchronously);
             _completion = Source.FromTask(_gate.Task)
                 .ConcatMany(_ => Source.From(_rawMessages))
-                .Via(Framing.SimpleFramingProtocolEncoder(int.MaxValue))
-                .Via(Framing.SimpleFramingProtocolDecoder(int.MaxValue))
+                .Via(Framing.SimpleFramingProtocolEncoder(MaxFrameLength))
+                .Via(Framing.SimpleFramingProtocolDecoder(MaxFrameLength))
                 .RunWith(Sink.Ignore<ByteString>(), _materializer);
         }
 
@@ -168,7 +171,7 @@ namespace Akka.Benchmarks.Streams
             _gate = new TaskCompletionSource<NotUsed>(TaskCreationOptions.RunContinuationsAsynchronously);
             _completion = Source.FromTask(_gate.Task)
                 .ConcatMany(_ => Source.From(_delimiterFramedChunks))
-                .Via(Framing.Delimiter(_delimiter, int.MaxValue))
+                .Via(Framing.Delimiter(_delimiter, MaxFrameLength))
                 .RunWith(Sink.Ignore<ByteString>(), _materializer);
         }
 
@@ -190,7 +193,7 @@ namespace Akka.Benchmarks.Streams
             _gate = new TaskCompletionSource<NotUsed>(TaskCreationOptions.RunContinuationsAsynchronously);
             _completion = Source.FromTask(_gate.Task)
                 .ConcatMany(_ => Source.From(_jsonChunks))
-                .Via(JsonFraming.ObjectScanner(int.MaxValue))
+                .Via(JsonFraming.ObjectScanner(MaxFrameLength))
                 .RunWith(Sink.Ignore<ByteString>(), _materializer);
         }
 

--- a/src/benchmark/Akka.Benchmarks/Streams/FramingBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Streams/FramingBenchmarks.cs
@@ -1,0 +1,204 @@
+//-----------------------------------------------------------------------
+// <copyright file="FramingBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.IO;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Streams
+{
+    /// <summary>
+    /// Throughput and allocation benchmarks for <see cref="Framing"/> and <see cref="JsonFraming"/>
+    /// stages. Each benchmark materializes its graph in <see cref="IterationSetup"/> and parks it
+    /// on a deferred source (<see cref="Source.FromTask{T}"/> waiting on a
+    /// <see cref="TaskCompletionSource{T}"/>) so all materializer overhead — actor spawning,
+    /// stage fusing, dispatcher attachment — is excluded from the measurement window. The
+    /// benchmark method does only two things: trip the gate and await drain. With
+    /// <c>OperationsPerInvoke = MessageCount</c>, the two fixed hops (gate signal + sink-complete)
+    /// dilute to noise and the reported <c>Allocated</c> column is bytes-per-framed-message.
+    /// </summary>
+    [Config(typeof(ThroughputBenchmarkConfig))]
+    public class FramingBenchmarks
+    {
+        private const int MessageCount = 10_000;
+
+        [Params(64, 1024)]
+        public int MessageSize { get; set; }
+
+        private ActorSystem _system;
+        private ActorMaterializer _materializer;
+
+        // Reused across all iterations; rebuilt in GlobalSetup whenever MessageSize changes.
+        private ByteString[] _rawMessages;
+        private ByteString[] _delimiterFramedChunks;
+        private ByteString[] _jsonChunks;
+        private ByteString _delimiter;
+
+        // Per-iteration state — fresh graph + gate per measurement.
+        private TaskCompletionSource<NotUsed> _gate;
+        private Task _completion;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _system = ActorSystem.Create("framing-bench", "akka.log-dead-letters = off");
+            _materializer = _system.Materializer();
+
+            // Random payload bytes give realistic compression-resistant data without
+            // accidentally hitting any common-prefix optimization in the framing scan.
+            var rng = new Random(42);
+            _rawMessages = new ByteString[MessageCount];
+            for (var i = 0; i < MessageCount; i++)
+            {
+                var bytes = new byte[MessageSize];
+                rng.NextBytes(bytes);
+                _rawMessages[i] = ByteString.FromBytes(bytes);
+            }
+
+            // Delimiter input: one message per chunk, terminated by '\n'. We avoid '\n' inside
+            // the random payload by reserving byte 0x00 as the terminator instead.
+            _delimiter = ByteString.FromBytes(new byte[] { 0x00 });
+            _delimiterFramedChunks = new ByteString[MessageCount];
+            for (var i = 0; i < MessageCount; i++)
+            {
+                // Replace any 0x00 in the payload to keep frames well-formed.
+                var bytes = _rawMessages[i].ToArray();
+                for (var j = 0; j < bytes.Length; j++)
+                    if (bytes[j] == 0x00) bytes[j] = 0xFF;
+                _delimiterFramedChunks[i] = ByteString.FromBytes(bytes) + _delimiter;
+            }
+
+            // JSON input: a stream of small objects split into chunks that *cross* object
+            // boundaries, forcing the multi-Offer path inside JsonObjectParser. With chunk size
+            // smaller than the object size, every Offer past the first one concatenates into
+            // a non-empty buffer — which is exactly the path the migration optimized.
+            BuildJsonChunks();
+        }
+
+        private void BuildJsonChunks()
+        {
+            // Build MessageCount JSON objects of ~MessageSize bytes each, concatenated with no
+            // separator (the parser handles whitespace / commas itself). Split the resulting
+            // stream into fixed-size chunks; chunk_size deliberately smaller than object_size
+            // so every chunk straddles at least one object boundary.
+            var sb = new StringBuilder(MessageSize * MessageCount + 1024);
+            // {"data":"<filler>"}  — pad filler so total ≈ MessageSize bytes.
+            var fillerLength = Math.Max(1, MessageSize - "{\"data\":\"\"}".Length);
+            var filler = new string('x', fillerLength);
+            for (var i = 0; i < MessageCount; i++)
+            {
+                sb.Append("{\"data\":\"").Append(filler).Append("\"}");
+            }
+            var allBytes = Encoding.UTF8.GetBytes(sb.ToString());
+
+            // Chunk size = MessageSize / 3 → typically straddles object boundaries.
+            var chunkSize = Math.Max(16, MessageSize / 3);
+            var chunks = new System.Collections.Generic.List<ByteString>(allBytes.Length / chunkSize + 1);
+            for (var pos = 0; pos < allBytes.Length; pos += chunkSize)
+            {
+                var len = Math.Min(chunkSize, allBytes.Length - pos);
+                chunks.Add(ByteString.FromBytes(allBytes, pos, len));
+            }
+            _jsonChunks = chunks.ToArray();
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            _materializer?.Dispose();
+            _system?.Dispose();
+        }
+
+        // ----- LengthField encode -----
+
+        [IterationSetup(Target = nameof(LengthField_Encode))]
+        public void SetupLengthFieldEncode()
+        {
+            _gate = new TaskCompletionSource<NotUsed>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _completion = Source.FromTask(_gate.Task)
+                .ConcatMany(_ => Source.From(_rawMessages))
+                .Via(Framing.SimpleFramingProtocolEncoder(int.MaxValue))
+                .RunWith(Sink.Ignore<ByteString>(), _materializer);
+        }
+
+        [Benchmark(OperationsPerInvoke = MessageCount)]
+        public Task LengthField_Encode()
+        {
+            _gate.SetResult(NotUsed.Instance);
+            return _completion;
+        }
+
+        // ----- LengthField decode -----
+        // Pre-encode the messages so the benchmark window only times the decode side.
+
+        [IterationSetup(Target = nameof(LengthField_Decode))]
+        public void SetupLengthFieldDecode()
+        {
+            _gate = new TaskCompletionSource<NotUsed>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _completion = Source.FromTask(_gate.Task)
+                .ConcatMany(_ => Source.From(_rawMessages))
+                .Via(Framing.SimpleFramingProtocolEncoder(int.MaxValue))
+                .Via(Framing.SimpleFramingProtocolDecoder(int.MaxValue))
+                .RunWith(Sink.Ignore<ByteString>(), _materializer);
+        }
+
+        [Benchmark(OperationsPerInvoke = MessageCount)]
+        public Task LengthField_Decode()
+        {
+            _gate.SetResult(NotUsed.Instance);
+            return _completion;
+        }
+
+        // ----- Delimiter decode -----
+
+        [IterationSetup(Target = nameof(Delimiter_Decode))]
+        public void SetupDelimiterDecode()
+        {
+            _gate = new TaskCompletionSource<NotUsed>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _completion = Source.FromTask(_gate.Task)
+                .ConcatMany(_ => Source.From(_delimiterFramedChunks))
+                .Via(Framing.Delimiter(_delimiter, int.MaxValue))
+                .RunWith(Sink.Ignore<ByteString>(), _materializer);
+        }
+
+        [Benchmark(OperationsPerInvoke = MessageCount)]
+        public Task Delimiter_Decode()
+        {
+            _gate.SetResult(NotUsed.Instance);
+            return _completion;
+        }
+
+        // ----- JSON multi-chunk -----
+        // Drives JsonFraming.ObjectScanner with chunks that straddle object boundaries, so
+        // most Offers concatenate into a non-empty buffer. OperationsPerInvoke is the number
+        // of complete JSON objects emitted (= MessageCount), not the number of input chunks.
+
+        [IterationSetup(Target = nameof(JsonFraming_MultiChunk))]
+        public void SetupJsonFramingMultiChunk()
+        {
+            _gate = new TaskCompletionSource<NotUsed>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _completion = Source.FromTask(_gate.Task)
+                .ConcatMany(_ => Source.From(_jsonChunks))
+                .Via(JsonFraming.ObjectScanner(int.MaxValue))
+                .RunWith(Sink.Ignore<ByteString>(), _materializer);
+        }
+
+        [Benchmark(OperationsPerInvoke = MessageCount)]
+        public Task JsonFraming_MultiChunk()
+        {
+            _gate.SetResult(NotUsed.Instance);
+            return _completion;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `FramingBenchmarks` class to `Akka.Benchmarks` that measures throughput and per-frame allocation overhead for the four hot paths in the framing system:

- `LengthField_Encode` — `Framing.SimpleFramingProtocolEncoder` (4-byte big-endian length prefix + payload)
- `LengthField_Decode` — encode→decode round-trip through `SimpleFramingProtocol`
- `Delimiter_Decode` — `Framing.Delimiter` over a stream of single-message-per-chunk inputs
- `JsonFraming_MultiChunk` — `JsonFraming.ObjectScanner` with chunks deliberately sized to straddle object boundaries (so most `Offer` calls into `JsonObjectParser` concatenate into a non-empty buffer)

## Why this PR

The framing stages have always been suspected of being allocation-heavy on the per-message path (the `parsedFrame.ToArray()` / `_buffer.ToArray()` defensive compactions, the encoder's `Concat` byte[] allocation, and the JSON parser's merge byte[] in non-empty `Offer`). There is no BenchmarkDotNet coverage of the framing paths today, so any change in this area has to be evaluated against indirect signal (the TCP echo benchmark, the NBench `JsonFramingBenchmark`).

This adds direct, comparable BDN numbers — the same harness shape used by `TcpOperationsBenchmarks` / `StreamThroughputBenchmarks` — so future framing changes can be measured cleanly.

## Benchmark design

The benchmark uses a **deferred-source** pattern so all materializer overhead sits outside the measurement window:

```csharp
[IterationSetup(Target = nameof(LengthField_Encode))]
public void Setup() {
    _gate = new TaskCompletionSource<NotUsed>(TaskCreationOptions.RunContinuationsAsynchronously);
    _completion = Source.FromTask(_gate.Task)
        .ConcatMany(_ => Source.From(_rawMessages))
        .Via(Framing.SimpleFramingProtocolEncoder(int.MaxValue))
        .RunWith(Sink.Ignore<ByteString>(), _materializer);
}

[Benchmark(OperationsPerInvoke = MessageCount)]
public Task LengthField_Encode() {
    _gate.SetResult(NotUsed.Instance);
    return _completion;
}
```

The graph materializes during `IterationSetup` — actors spawn, stages fuse, the dispatcher attaches, the sink subscribes — and parks waiting on the TCS. The benchmark method only trips the gate and awaits drain. With `OperationsPerInvoke = 10000`, the two fixed hops (gate-signal + sink-complete) amortize to noise and the reported `Allocated` column reads as **bytes-per-framed-message**.

For `JsonFraming_MultiChunk`, input chunks are sized at `MessageSize / 3` so every chunk crosses at least one object boundary. This exercises the multi-Offer concatenation path inside `JsonObjectParser` rather than the empty-buffer fast path.

## Parameters

- `MessageSize` ∈ `{64, 1024}` bytes
- `MessageCount` fixed at 10,000

8 cells total. Wall-clock under `Job.Default` (BDN's chosen warmup/iterations) is well under 10 minutes on a modern machine.

## Test plan

- [ ] Smoke run with `--job dry` confirms the benchmark executes end-to-end on `dev` (already verified locally)
- [ ] Full run with default job to capture baseline numbers
- [ ] Numbers can then be compared against framing-related changes on feature branches

## Notes

Ports the same `FramingBenchmarks.cs` will need to be backported (with `ByteString` → `ReadOnlyMemory<byte>` / `ReadOnlySequence<byte>` adaptations) to feature branches that change the underlying byte-buffer type. The benchmark structure stays identical; only the type name changes.