### PR TITLE
fix(io): finalize TCP transport cleanup before actor stop

### DIFF
--- a/src/core/Akka.Tests/IO/TcpConnectionBatchingSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpConnectionBatchingSpec.cs
@@ -133,6 +133,76 @@ namespace Akka.Tests.IO
             }
         }
 
+        private sealed class TrackingDisposeStream : Stream
+        {
+            private readonly Stream _inner;
+            private int _disposeCount;
+            private int _disposeAsyncCount;
+
+            public TrackingDisposeStream(Stream inner)
+            {
+                _inner = inner;
+            }
+
+            public int DisposeCount => Volatile.Read(ref _disposeCount);
+            public int DisposeAsyncCount => Volatile.Read(ref _disposeAsyncCount);
+
+            public override bool CanRead => _inner.CanRead;
+            public override bool CanSeek => _inner.CanSeek;
+            public override bool CanWrite => _inner.CanWrite;
+            public override long Length => _inner.Length;
+
+            public override long Position
+            {
+                get => _inner.Position;
+                set => _inner.Position = value;
+            }
+
+            public override void Flush() => _inner.Flush();
+
+            public override Task FlushAsync(CancellationToken cancellationToken) =>
+                _inner.FlushAsync(cancellationToken);
+
+            public override int Read(byte[] buffer, int offset, int count) =>
+                _inner.Read(buffer, offset, count);
+
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+                _inner.ReadAsync(buffer, offset, count, cancellationToken);
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+                _inner.ReadAsync(buffer, cancellationToken);
+
+            public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+
+            public override void SetLength(long value) => _inner.SetLength(value);
+
+            public override void Write(byte[] buffer, int offset, int count) =>
+                _inner.Write(buffer, offset, count);
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+                _inner.WriteAsync(buffer, offset, count, cancellationToken);
+
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
+                _inner.WriteAsync(buffer, cancellationToken);
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    Interlocked.Increment(ref _disposeCount);
+                    _inner.Dispose();
+                }
+
+                base.Dispose(disposing);
+            }
+
+            public override async ValueTask DisposeAsync()
+            {
+                Interlocked.Increment(ref _disposeAsyncCount);
+                await _inner.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
         public TcpConnectionBatchingSpec(ITestOutputHelper output)
             : base(@"akka.loglevel = DEBUG
                      akka.io.tcp.trace-logging = true", output: output)
@@ -188,6 +258,97 @@ namespace Akka.Tests.IO
             handler.Send(connection, Tcp.Abort.Instance);
             await handler.ExpectMsgAsync<Tcp.Aborted>();
             await ExpectTerminatedAsync(connection);
+        }
+
+        [Fact]
+        public async Task TcpConnection_should_finalize_transport_via_DisposeAsync_after_confirmed_close()
+        {
+            using var socketPair = await ConnectedSocketPair.CreateAsync();
+            var trackingStream = new TrackingDisposeStream(new NetworkStream(socketPair.Server, ownsSocket: false));
+            var bindHandler = CreateTestProbe();
+            var handler = CreateTestProbe();
+            var settings = TcpSettings.Create(Sys);
+
+            var connection = Sys.ActorOf(Props.Create(() => new TcpIncomingConnection(
+                settings,
+                socketPair.Server,
+                bindHandler.Ref,
+                Array.Empty<Inet.SocketOption>(),
+                false,
+                trackingStream)));
+
+            await bindHandler.ExpectMsgAsync<Tcp.Connected>();
+            bindHandler.Send(connection, new Tcp.Register(handler.Ref));
+            await WatchAsync(connection);
+
+            handler.Send(connection, Tcp.ConfirmedClose.Instance);
+            socketPair.Client.Shutdown(SocketShutdown.Send);
+
+            await handler.ExpectMsgAsync<Tcp.ConfirmedClosed>();
+            await ExpectTerminatedAsync(connection);
+
+            trackingStream.DisposeAsyncCount.Should().Be(1);
+            trackingStream.DisposeCount.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task TcpConnection_should_finalize_transport_during_graceful_close()
+        {
+            using var socketPair = await ConnectedSocketPair.CreateAsync();
+            var trackingStream = new TrackingDisposeStream(new NetworkStream(socketPair.Server, ownsSocket: false));
+            var bindHandler = CreateTestProbe();
+            var handler = CreateTestProbe();
+            var settings = TcpSettings.Create(Sys);
+
+            var connection = Sys.ActorOf(Props.Create(() => new TcpIncomingConnection(
+                settings,
+                socketPair.Server,
+                bindHandler.Ref,
+                Array.Empty<Inet.SocketOption>(),
+                false,
+                trackingStream)));
+
+            await bindHandler.ExpectMsgAsync<Tcp.Connected>();
+            bindHandler.Send(connection, new Tcp.Register(handler.Ref));
+            await WatchAsync(connection);
+
+            handler.Send(connection, Tcp.Close.Instance);
+
+            await handler.ExpectMsgAsync<Tcp.Closed>();
+            await ExpectTerminatedAsync(connection);
+
+            trackingStream.DisposeAsyncCount.Should().Be(1);
+            trackingStream.DisposeCount.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task TcpConnection_should_fall_back_to_abort_cleanup_when_stopped_unexpectedly()
+        {
+            using var socketPair = await ConnectedSocketPair.CreateAsync();
+            var trackingStream = new TrackingDisposeStream(new NetworkStream(socketPair.Server, ownsSocket: false));
+            var bindHandler = CreateTestProbe();
+            var handler = CreateTestProbe();
+            var settings = TcpSettings.Create(Sys);
+
+            var connection = Sys.ActorOf(Props.Create(() => new TcpIncomingConnection(
+                settings,
+                socketPair.Server,
+                bindHandler.Ref,
+                Array.Empty<Inet.SocketOption>(),
+                false,
+                trackingStream)));
+
+            await bindHandler.ExpectMsgAsync<Tcp.Connected>();
+            bindHandler.Send(connection, new Tcp.Register(handler.Ref));
+            await WatchAsync(connection);
+
+            handler.Send(connection, PoisonPill.Instance);
+
+            await handler.ExpectMsgAsync<Tcp.Aborted>();
+            await ExpectTerminatedAsync(connection);
+
+            trackingStream.DisposeAsyncCount.Should().Be(0);
+            trackingStream.DisposeCount.Should().BeGreaterThan(0);
         }
 
         private sealed class ConnectedSocketPair : IDisposable

--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -143,6 +143,24 @@ namespace Akka.IO
             public TransportOperationFailed(Exception cause) { Cause = cause; }
         }
 
+        /// <summary>
+        /// Self-tell: transport finalization completed successfully.
+        /// </summary>
+        private sealed class TransportFinalized : INoSerializationVerificationNeeded
+        {
+            public static readonly TransportFinalized Instance = new();
+            private TransportFinalized() { }
+        }
+
+        /// <summary>
+        /// Self-tell: transport finalization failed.
+        /// </summary>
+        private sealed class TransportFinalizeFailed : INoSerializationVerificationNeeded
+        {
+            public Exception Cause { get; }
+            public TransportFinalizeFailed(Exception cause) { Cause = cause; }
+        }
+
         private sealed class CommanderDied : INoSerializationVerificationNeeded, IDeadLetterSuppression
         {
             public static readonly CommanderDied Instance = new();
@@ -231,6 +249,13 @@ namespace Akka.IO
         // this as Tcp.ErrorClosed instead of treating it as a clean EOF.
         private bool _readPumpHasError;
         private Exception? _readPumpError;
+
+        // True once the transport has been fully cleaned up via CloseAsync or DisposeAsync.
+        // When set, PostStop skips the abort fallback because there's nothing left to tear down.
+        private bool _transportFinalized;
+
+        // True while an async finalization task is in flight (used by ConfirmedClose).
+        private bool _transportFinalizing;
         #endregion
 
         private static readonly IOException DroppingWriteBecauseClosingException =
@@ -265,11 +290,13 @@ namespace Akka.IO
 
             if (_transport != null)
             {
-                // Abort cancels the CTS, sets linger=0, closes the socket.
-                // This unblocks any pending stream.ReadAsync/WriteAsync in the pump tasks.
-                // The pump tasks will exit with OperationCanceledException or IOException.
-                try { _transport.Abort(); }
-                catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 transport may already be disposed
+                if (!_transportFinalized)
+                {
+                    // Abort is the emergency fallback for unexpected actor stops.
+                    // Clean Close / ConfirmedClose paths finalize the transport before stopping.
+                    try { _transport.Abort(); }
+                    catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 transport may already be disposed
+                }
             }
             else
             {
@@ -486,8 +513,8 @@ namespace Akka.IO
                 if (closeEvent is ConfirmedClosed)
                 {
                     if (_traceLogging)
-                        Log.Debug("Peer FIN received during ConfirmedClose - connection fully closed");
-                    DoCloseConnection(closeSender, ConfirmedClosed.Instance);
+                        Log.Debug("Peer FIN received during ConfirmedClose - waiting for transport finalization");
+                    TryFinishClose(closeSender, closeEvent);
                     return;
                 }
 
@@ -511,11 +538,14 @@ namespace Akka.IO
 
                     if (_traceLogging)
                         Log.Debug("ConfirmedClose: FIN sent, waiting for peer FIN");
+
+                    TryFinishClose(closeSender, closeEvent);
                 }
                 else
                 {
-                    // For regular Close, transport is fully closed
+                    // For regular Close, transport is fully closed and finalized.
                     _outputShutdown = true;
+                    _transportFinalized = true;
                     TryFinishClose(closeSender, closeEvent);
                 }
             });
@@ -529,6 +559,25 @@ namespace Akka.IO
             {
                 if (_traceLogging)
                     Log.Debug("I/O task failed during close: {0}", msg.Cause.Message);
+                DoCloseConnection(closeSender, closeEvent);
+            });
+            Receive<TransportFinalized>(_ =>
+            {
+                _transportFinalizing = false;
+                _transportFinalized = true;
+
+                if (_traceLogging)
+                    Log.Debug("Transport finalization completed");
+
+                DoCloseConnection(closeSender, closeEvent);
+            });
+            Receive<TransportFinalizeFailed>(msg =>
+            {
+                _transportFinalizing = false;
+
+                if (_traceLogging)
+                    Log.Debug("Transport finalization failed: {0}", msg.Cause.Message);
+
                 DoCloseConnection(closeSender, closeEvent);
             });
             SuspendResumeHandlers();
@@ -551,14 +600,35 @@ namespace Akka.IO
         {
             if (closeEvent is ConfirmedClosed)
             {
-                // For ConfirmedClose, we need to wait for peer FIN (StreamEof).
-                // The StreamEof handler calls DoCloseConnection directly.
+                // For ConfirmedClose, wait until our FIN has been sent and the peer's FIN has arrived.
+                // Once both sides are closed, finalize the transport asynchronously before stopping.
+                if (_outputShutdown && _peerClosed)
+                    StartTransportFinalization();
+
                 return;
             }
 
             // For regular Close: once read pump has completed and output is shutdown
             if (_outputShutdown && _readPumpCompleted)
                 DoCloseConnection(closeSender, closeEvent);
+        }
+
+        private void StartTransportFinalization()
+        {
+            if (_transport is null || _transportFinalized || _transportFinalizing)
+                return;
+
+            _transportFinalizing = true;
+            _transport.DisposeAsync().AsTask().ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                    return (object)new TransportFinalizeFailed(t.Exception!.InnerException ?? t.Exception);
+
+                if (t.IsCanceled)
+                    return (object)new TransportFinalizeFailed(new TaskCanceledException("Transport finalization was canceled"));
+
+                return TransportFinalized.Instance;
+            }, TaskContinuationOptions.ExecuteSynchronously).PipeTo(Self);
         }
 
         private void SuspendResumeHandlers()

--- a/src/core/Akka/IO/TcpTransportConnection.cs
+++ b/src/core/Akka/IO/TcpTransportConnection.cs
@@ -200,7 +200,8 @@ namespace Akka.IO
             }
             catch (ObjectDisposedException)
             {
-                // slopwatch-ignore: SW003 CTS may already be disposed during shutdown races
+                // The CTS was already disposed by another shutdown path.
+                return;
             }
         }
 
@@ -215,7 +216,8 @@ namespace Akka.IO
             }
             catch (InvalidOperationException)
             {
-                // slopwatch-ignore: SW003 pipe may already be completed by another shutdown path
+                // Another shutdown path already completed the writer.
+                return;
             }
         }
 
@@ -230,7 +232,8 @@ namespace Akka.IO
             }
             catch (InvalidOperationException)
             {
-                // slopwatch-ignore: SW003 pipe may already be completed by another shutdown path
+                // Another shutdown path already completed the writer.
+                return;
             }
         }
 
@@ -258,7 +261,8 @@ namespace Akka.IO
             }
             catch (ObjectDisposedException)
             {
-                // slopwatch-ignore: SW003 stream may already be disposed by another shutdown path
+                // Another shutdown path already disposed the stream.
+                return;
             }
         }
 
@@ -273,7 +277,8 @@ namespace Akka.IO
             }
             catch (ObjectDisposedException)
             {
-                // slopwatch-ignore: SW003 stream may already be disposed by another shutdown path
+                // Another shutdown path already disposed the stream.
+                return;
             }
         }
 

--- a/src/core/Akka/IO/TcpTransportConnection.cs
+++ b/src/core/Akka/IO/TcpTransportConnection.cs
@@ -28,6 +28,13 @@ namespace Akka.IO
         private readonly Pipe _inputPipe;
         private readonly Pipe _outputPipe;
         private readonly CancellationTokenSource _cts = new();
+        private Task? _disposeTask;
+        private int _transportCancellationRequested;
+        private int _outputWriterCompleted;
+        private int _sendShutdownApplied;
+        private int _streamDisposed;
+        private int _socketClosed;
+        private int _ctsDisposed;
 
         /// <summary>
         /// Creates a transport connection from an already-connected socket.
@@ -105,80 +112,192 @@ namespace Akka.IO
         public async Task ShutdownAsync()
         {
             // Complete the output pipe — write pump will drain and exit
-            await _outputPipe.Writer.CompleteAsync().ConfigureAwait(false);
+            await CompleteOutputWriterAsync().ConfigureAwait(false);
 
             // Wait for write pump to finish flushing
             await WriteCompleted.ConfigureAwait(false);
 
             // Half-close the socket (send FIN).
             // SocketException is expected if the peer already reset the connection.
-            try
-            {
-                _socket.Shutdown(SocketShutdown.Send);
-            }
-            catch (SocketException) { } // slopwatch-ignore: SW003 socket may already be closed by peer or abort
+            TryShutdownSend();
         }
 
         public async Task CloseAsync()
         {
             // Complete the output pipe — write pump will drain and exit
-            await _outputPipe.Writer.CompleteAsync().ConfigureAwait(false);
+            await CompleteOutputWriterAsync().ConfigureAwait(false);
 
             // Wait for write pump to finish flushing
             await WriteCompleted.ConfigureAwait(false);
 
             // Cancel to unblock the read pump (which may be blocked on stream.ReadAsync)
-            _cts.Cancel();
+            CancelTransport();
 
             // Wait for read pump to exit — it may throw OperationCanceledException (from CTS cancel)
             // or IOException/SocketException (from stream close). Both are expected during shutdown.
             try { await ReadCompleted.ConfigureAwait(false); }
-            catch (Exception) when (_cts.IsCancellationRequested) { } // slopwatch-ignore: SW003 expected cancellation or I/O error during shutdown
+            catch (Exception) when (IsTransportCancellationRequested) { } // slopwatch-ignore: SW003 expected cancellation or I/O error during shutdown
 
-            // Close the stream and socket
-            await _stream.DisposeAsync().ConfigureAwait(false);
-            _socket.Close();
+            await DisposeAsync().ConfigureAwait(false);
         }
 
         public void Abort()
         {
             // Cancel pumps immediately
-            _cts.Cancel();
+            CancelTransport();
 
             // Complete pipes to unblock any pending reads/writes on them.
             // InvalidOperationException if already completed — safe to ignore.
-            try { _outputPipe.Writer.Complete(); } catch (InvalidOperationException) { } // slopwatch-ignore: SW003 pipe may already be completed
-            try { _inputPipe.Writer.Complete(); } catch (InvalidOperationException) { } // slopwatch-ignore: SW003 pipe may already be completed
+            TryCompleteOutputWriter();
 
             // RST the socket — SocketException/ObjectDisposedException if already closed.
-            try
-            {
-                _socket.LingerState = new LingerOption(true, 0);
-                _socket.Close();
-            }
-            catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 socket may already be disposed
-            catch (SocketException) { } // slopwatch-ignore: SW003 socket may already be closed
+            CloseSocket(abortive: true);
 
             // Dispose the stream — ObjectDisposedException if already disposed.
-            try { _stream.Dispose(); } catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 stream may already be disposed
+            DisposeStream();
         }
 
         public async ValueTask DisposeAsync()
         {
-            _cts.Cancel();
+            var disposeTask = Volatile.Read(ref _disposeTask);
+            if (disposeTask is null)
+            {
+                var created = DisposeCoreAsync();
+                disposeTask = Interlocked.CompareExchange(ref _disposeTask, created, null) ?? created;
+            }
 
-            await _outputPipe.Writer.CompleteAsync().ConfigureAwait(false);
-            await _inputPipe.Writer.CompleteAsync().ConfigureAwait(false);
+            await disposeTask.ConfigureAwait(false);
+        }
+
+        private async Task DisposeCoreAsync()
+        {
+            CancelTransport();
+
+            await CompleteOutputWriterAsync().ConfigureAwait(false);
 
             // Wait for pump tasks — they may throw OperationCanceledException or I/O errors during shutdown.
             try
             {
                 await Task.WhenAll(ReadCompleted, WriteCompleted).ConfigureAwait(false);
             }
-            catch (Exception) when (_cts.IsCancellationRequested) { } // slopwatch-ignore: SW003 expected errors during disposal
+            catch (Exception) when (IsTransportCancellationRequested) { } // slopwatch-ignore: SW003 expected errors during disposal
 
-            await _stream.DisposeAsync().ConfigureAwait(false);
-            _socket.Dispose();
+            await DisposeStreamAsync().ConfigureAwait(false);
+            CloseSocket();
+            DisposeCancellationSource();
+        }
+
+        private bool IsTransportCancellationRequested => Volatile.Read(ref _transportCancellationRequested) == 1;
+
+        private void CancelTransport()
+        {
+            if (Interlocked.Exchange(ref _transportCancellationRequested, 1) != 0)
+                return;
+
+            try
+            {
+                _cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // slopwatch-ignore: SW003 CTS may already be disposed during shutdown races
+            }
+        }
+
+        private async Task CompleteOutputWriterAsync()
+        {
+            if (Interlocked.CompareExchange(ref _outputWriterCompleted, 1, 0) != 0)
+                return;
+
+            try
+            {
+                await _outputPipe.Writer.CompleteAsync().ConfigureAwait(false);
+            }
+            catch (InvalidOperationException)
+            {
+                // slopwatch-ignore: SW003 pipe may already be completed by another shutdown path
+            }
+        }
+
+        private void TryCompleteOutputWriter()
+        {
+            if (Interlocked.CompareExchange(ref _outputWriterCompleted, 1, 0) != 0)
+                return;
+
+            try
+            {
+                _outputPipe.Writer.Complete();
+            }
+            catch (InvalidOperationException)
+            {
+                // slopwatch-ignore: SW003 pipe may already be completed by another shutdown path
+            }
+        }
+
+        private void TryShutdownSend()
+        {
+            if (Interlocked.CompareExchange(ref _sendShutdownApplied, 1, 0) != 0)
+                return;
+
+            try
+            {
+                _socket.Shutdown(SocketShutdown.Send);
+            }
+            catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 socket may already be disposed
+            catch (SocketException) { } // slopwatch-ignore: SW003 socket may already be closed by peer or abort
+        }
+
+        private async Task DisposeStreamAsync()
+        {
+            if (Interlocked.CompareExchange(ref _streamDisposed, 1, 0) != 0)
+                return;
+
+            try
+            {
+                await _stream.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                // slopwatch-ignore: SW003 stream may already be disposed by another shutdown path
+            }
+        }
+
+        private void DisposeStream()
+        {
+            if (Interlocked.CompareExchange(ref _streamDisposed, 1, 0) != 0)
+                return;
+
+            try
+            {
+                _stream.Dispose();
+            }
+            catch (ObjectDisposedException)
+            {
+                // slopwatch-ignore: SW003 stream may already be disposed by another shutdown path
+            }
+        }
+
+        private void CloseSocket(bool abortive = false)
+        {
+            if (Interlocked.CompareExchange(ref _socketClosed, 1, 0) != 0)
+                return;
+
+            try
+            {
+                if (abortive)
+                    _socket.LingerState = new LingerOption(true, 0);
+
+                _socket.Close();
+            }
+            catch (ObjectDisposedException) { } // slopwatch-ignore: SW003 socket may already be disposed
+            catch (SocketException) { } // slopwatch-ignore: SW003 socket may already be closed
+        }
+
+        private void DisposeCancellationSource()
+        {
+            if (Interlocked.CompareExchange(ref _ctsDisposed, 1, 0) != 0)
+                return;
+
             _cts.Dispose();
         }
 


### PR DESCRIPTION
## Summary

This is a follow-up to @to11mtm's comment on #8132 about async transport disposal in the TCP actor lifecycle:
https://github.com/akkadotnet/akka.net/pull/8132#issuecomment-4416368284

This change makes the graceful shutdown path explicit instead of relying on `PostStop()` fallback cleanup.

- finalize `ITransportConnection` asynchronously during `Tcp.Close`
- finalize `ITransportConnection` after both FINs during `Tcp.ConfirmedClose`
- keep `PostStop()` abort logic as the fallback for unexpected actor termination
- make `TcpTransportConnection` cleanup idempotent across `ShutdownAsync`, `CloseAsync`, `Abort`, and `DisposeAsync`

## Why

`TcpTransportConnection` already exposed `DisposeAsync`, but the actor lifecycle never actually used it. In practice that meant:

- graceful close paths could still fall through to abort-style cleanup in `PostStop()`
- `ConfirmedClose` did not have an explicit async finalization step after the close handshake
- the transport cleanup contract was harder to reason about across multiple shutdown paths

This PR makes the intended lifecycle explicit and keeps the emergency-stop behavior unchanged.

## Testing

- added focused `TcpConnectionBatchingSpec` coverage for:
  - graceful close uses async finalization
  - confirmed close uses async finalization after peer FIN
  - unexpected stop still falls back to abort cleanup
- `dotnet test src/core/Akka.Tests/Akka.Tests.csproj -c Release --filter \"FullyQualifiedName~TcpConnectionBatchingSpec|FullyQualifiedName~TcpIntegrationSpec\"`
- `dotnet build src/core/Akka/Akka.csproj -c Release`
- `dotnet test src/core/Akka.API.Tests/Akka.API.Tests.csproj -c Release`