### PR TITLE
Experiment: remoting outbound write-loop spike

### DIFF
--- a/openspec/IMPLEMENTATION_ORDER.md
+++ b/openspec/IMPLEMENTATION_ORDER.md
@@ -96,13 +96,14 @@ Captured on `dev` branch (commit 467cbb510), .NET 10.0, Release, ServerGC, Linux
 **OpenSpec change**: `openspec/changes/streams-tcp-transport/`
 **Tasks file**: `openspec/changes/streams-tcp-transport/tasks.md`
 
-**What it does**: First prove the integrated outbound write loop with a bounded spike. Then replace DotNetty with Akka.Streams TCP transport, lower serialization into the transport-owned outbound path, and delete DotNetty entirely.
+**What it does**: First prove the integrated outbound write loop with a bounded spike. Then redesign the production remoting outbound path around a transport-owned writer loop, preserve the current remoting wire format, replace DotNetty with Akka.Streams TCP transport, and take any needed C# API breaks in service of performance.
 
 **Completion criteria**:
 - The bounded spike shows a meaningful win for the integrated outbound write loop over the current split path
+- The first production redesign preserves the current remoting wire format while constructing outbound frames in one pass
 - StreamsTcpTransport implements the revised transport abstraction
 - FrameBufferWriter enables single-buffer outbound frame construction
-- Production protocol encoding strategy is chosen based on spike results
+- Source-compatible C# transport API preservation does not block the redesign
 - All `akka.remote.dot-netty.tcp.*` HOCON config works unchanged
 - DotNetty directory and NuGet deps deleted
 - Two ActorSystems communicate via new transport
@@ -120,7 +121,7 @@ Captured on `dev` branch (commit 467cbb510), .NET 10.0, Release, ServerGC, Linux
 **OpenSpec change**: `openspec/changes/transport-performance/`
 **Tasks file**: `openspec/changes/transport-performance/tasks.md`
 
-**What it does**: Run RemotePingPong, validate the full transport against the DotNetty baseline, and tune flush batching and other optimizations.
+**What it does**: Run RemotePingPong against the first wire-compatible redesigned transport, validate it against the DotNetty baseline, and tune flush batching and other optimizations before any compatibility follow-up work.
 
 **Completion criteria**:
 - RemotePingPong on new transport exceeds 680K msgs/sec peak

--- a/openspec/IMPLEMENTATION_ORDER.md
+++ b/openspec/IMPLEMENTATION_ORDER.md
@@ -54,7 +54,7 @@ Captured on `dev` branch (commit 467cbb510), .NET 10.0, Release, ServerGC, Linux
 
 **What it does**: Add SerializerV2 base class, SerializerV1Adapter, MessagePackSerializer, modify Serialization.cs infrastructure, mechanical port of simple internal Protobuf serializers.
 
-**Note**: This was originally planned as parallel with Milestone 1 but is sequenced after it to avoid merge conflicts in Serialization.cs and MessageSerializer.cs. The ByteString removal in Milestone 1 also affects serializer code paths.
+**Note**: This milestone now produces the serializer foundation only. Full remoting integration is intentionally held behind the outbound write-loop spike in Milestone 4.
 
 **Completion criteria**:
 - SerializerV2, SerializerV1Adapter exist in `src/core/Akka/Serialization/`
@@ -96,12 +96,13 @@ Captured on `dev` branch (commit 467cbb510), .NET 10.0, Release, ServerGC, Linux
 **OpenSpec change**: `openspec/changes/streams-tcp-transport/`
 **Tasks file**: `openspec/changes/streams-tcp-transport/tasks.md`
 
-**What it does**: Replace DotNetty with Akka.Streams TCP transport. FrameBufferWriter for integrated framing + serialization. Binary PDU codec. Delete DotNetty entirely.
+**What it does**: First prove the integrated outbound write loop with a bounded spike. Then replace DotNetty with Akka.Streams TCP transport, lower serialization into the transport-owned outbound path, and delete DotNetty entirely.
 
 **Completion criteria**:
-- StreamsTcpTransport implements Transport abstraction
-- FrameBufferWriter enables single-buffer frame construction
-- BinaryPduCodec replaces Protobuf AkkaPduCodec
+- The bounded spike shows a meaningful win for the integrated outbound write loop over the current split path
+- StreamsTcpTransport implements the revised transport abstraction
+- FrameBufferWriter enables single-buffer outbound frame construction
+- Production protocol encoding strategy is chosen based on spike results
 - All `akka.remote.dot-netty.tcp.*` HOCON config works unchanged
 - DotNetty directory and NuGet deps deleted
 - Two ActorSystems communicate via new transport
@@ -119,7 +120,7 @@ Captured on `dev` branch (commit 467cbb510), .NET 10.0, Release, ServerGC, Linux
 **OpenSpec change**: `openspec/changes/transport-performance/`
 **Tasks file**: `openspec/changes/transport-performance/tasks.md`
 
-**What it does**: Run RemotePingPong, implement flush batching and optimizations, exceed DotNetty baseline.
+**What it does**: Run RemotePingPong, validate the full transport against the DotNetty baseline, and tune flush batching and other optimizations.
 
 **Completion criteria**:
 - RemotePingPong on new transport exceeds 680K msgs/sec peak

--- a/openspec/changes/serializer-v2/design.md
+++ b/openspec/changes/serializer-v2/design.md
@@ -14,6 +14,7 @@ A POC at github.com/Aaronontheweb/AkkaSerializationPoC (PR #42, spike/serializer
 - `Serialization.cs` uses V2 internally (auto-wraps V1 on registration)
 - `MessagePackSerializer : SerializerV2` + sealed `AkkaWriter`/`AkkaReader` in separate package
 - Mechanical port of simple internal Protobuf serializers to V2 base (same IDs, same wire format)
+- Expose the minimum serializer contract needed for the transport-owned outbound writer loop to serialize directly into its destination buffer
 - Hand-written serializers validate the API before source generator investment
 - Persistence data fully backward compatible (V1-serialized events remain readable)
 
@@ -23,6 +24,7 @@ A POC at github.com/Aaronontheweb/AkkaSerializationPoC (PR #42, spike/serializer
 - Changing persistence envelope serializers (PersistenceMessageSerializer, PersistenceSnapshotSerializer)
 - Changing the HOCON registration mechanism
 - HOCON-less or attribute-only registration (future enhancement)
+- Solving read-side pooled buffer lifetime across actor boundaries
 
 ## Decisions
 
@@ -66,7 +68,13 @@ SerializerV2 (core Akka — IBufferWriter/ReadOnlySequence, no MessagePack)
 
 **Rationale:** 22% faster deserialization from JIT devirtualization. The interface layer was YAGNI — we're committed to MessagePack for user message codegen. `AkkaWriter.RawBuffer` escape hatch preserves extensibility for advanced scenarios.
 
-### 6. Bridge methods for transport compatibility
+### 6. V2 is optimized for outbound transport integration
+
+**Decision:** `SerializerV2.Serialize(IBufferWriter<byte>, object)` is designed around a transport-owned outbound destination. The serializer writes bytes into a writer it does not own, and it does not manage pooled buffer lifetime itself.
+
+**Rationale:** The transport is the natural owner of outbound frame buffers. Keeping ownership outside the serializer avoids pushing `IMemoryOwner<byte>` or other lifetime-bearing types into the serializer API.
+
+### 7. Bridge methods for transport compatibility
 
 **Decision:** `SerializerV2` has `ToBinary(object) → byte[]` and `FromBinary(byte[], string) → object` implemented in terms of the buffer API:
 
@@ -82,7 +90,7 @@ public virtual object FromBinary(byte[] bytes, string manifest)
     => Deserialize(new ReadOnlySequence<byte>(bytes), manifest);
 ```
 
-**Rationale:** The current transport (and Spec 3's initial `FrameBufferWriter` path) can call `Serialize(IBufferWriter<byte>)` directly. The bridge is for backward compat with code that still expects `byte[]`. The bridge is virtual so it can be bypassed when direct buffer access is available.
+**Rationale:** The production transport will eventually call `Serialize(IBufferWriter<byte>)` directly once the write-loop spike validates the architecture. The bridge is for backward compat with code that still expects `byte[]`. The bridge is virtual so it can be bypassed when direct buffer access is available.
 
 ## Risks / Trade-offs
 
@@ -93,3 +101,5 @@ public virtual object FromBinary(byte[] bytes, string manifest)
 **[Internal serializer port could introduce bugs]** → Mitigated by wire format being byte-identical (same Protobuf bytes, same IDs). Existing serialization round-trip tests catch regressions.
 
 **[WrappedPayloadSupport serializers deferred]** → The 4 serializers with nested user payloads continue using V1 `FindSerializerFor()` → `ToBinary()` through the adapter. They work correctly but miss the zero-copy benefit for the inner payload. Addressed in a follow-up pass after API validation.
+
+**[Transport integration still needs proof]** → `SerializerV2` is only valuable if the transport can exploit it. Mitigated by the bounded benchmark spike in Spec 3, which is sequenced before the full transport contract rewrite.

--- a/openspec/changes/serializer-v2/proposal.md
+++ b/openspec/changes/serializer-v2/proposal.md
@@ -1,6 +1,10 @@
 ## Why
 
-Akka.NET's current serialization API (`Serializer` / `SerializerWithStringManifest`) is `byte[]`-based. Every serialization produces a `byte[]` allocation, and every deserialization requires a `byte[]` input. With the new Akka.Streams transport (Spec 3) using `IBufferWriter<byte>` for writes and `ReadOnlySequence<byte>` for reads, the serializer must speak the same language to achieve zero-copy end-to-end. The V2 API makes `SerializerV2` the new foundation — V1 serializers are adapted to it, not the reverse. A POC at github.com/Aaronontheweb/AkkaSerializationPoC (PR #42) has validated the MessagePack-based approach with 22% faster deserialization than the interface-based alternative.
+Akka.NET's current serialization API (`Serializer` / `SerializerWithStringManifest`) is `byte[]`-based. Every serialization produces a `byte[]` allocation, and every deserialization requires a `byte[]` input. That makes it impossible for the remoting transport to integrate serialization directly into its outbound framing loop.
+
+PR #8203 showed that serializer improvements are meaningful, but also that `SerializerV2` by itself is not the full win. The real architectural target is an outbound remoting path where the transport-owned writer loop can ask a serializer to write directly into a destination it already owns. `SerializerV2` is therefore a foundation for the transport redesign, not an end-state on its own.
+
+Read-side buffer pooling remains explicitly out of scope. The V2 read API exists so deserializers can consume `ReadOnlySequence<byte>` efficiently, but inbound payload bytes are still copied before they cross actor-visible lifetime boundaries.
 
 ## What Changes
 
@@ -10,6 +14,7 @@ Akka.NET's current serialization API (`Serializer` / `SerializerWithStringManife
 - **Modify `Serialization.cs`** — use `SerializerV2` as internal storage type, auto-wrap V1 serializers in `SerializerV1Adapter`, `FindSerializerFor()` returns `SerializerV2`
 - **Modify `MessageSerializer.cs`** — use V2 dispatch (call `Manifest()` directly, no `is SerializerWithStringManifest` type check)
 - **Mechanical port of simple internal Protobuf serializers** — change base class to `SerializerV2`, use `proto.WriteTo(IBufferWriter<byte>)` / `Parser.ParseFrom(ReadOnlySequence<byte>)`. Same serializer IDs, same wire format.
+- **Transport integration deferred behind a spike** — the production remoting write path will only adopt direct `Serialize(IBufferWriter<byte>, object)` once the integrated outbound pipeline has been benchmarked and selected as the transport direction
 - **Source generator deferred** — validate API with hand-written serializers first
 
 ### What does NOT change
@@ -19,6 +24,7 @@ Akka.NET's current serialization API (`Serializer` / `SerializerWithStringManife
 - HOCON serializer registration (`akka.actor.serializers`, `akka.actor.serialization-bindings`, `akka.actor.serialization-identifiers`)
 - `SerializationSetup` programmatic registration API
 - Persistence data compatibility (journals store serializerId + manifest + payload — V1 data readable forever)
+- Read-side remoting semantics: inbound bytes are not leased across actor boundaries
 
 ## Capabilities
 
@@ -32,9 +38,10 @@ Akka.NET's current serialization API (`Serializer` / `SerializerWithStringManife
 ## Impact
 
 - **Akka core** (`src/core/Akka/Serialization/`): New `SerializerV2.cs`, `SerializerV1Adapter.cs`. Modified `Serialization.cs` (internal storage type, auto-wrapping), `MessageSerializer.cs` (V2 dispatch).
-- **Akka.Remote**: `MessageSerializer.cs` simplified — calls `Manifest()` directly. In Spec 3, `EndpointWriter` uses `serializer.Serialize(FrameBufferWriter)` directly.
+- **Akka.Remote**: `MessageSerializer.cs` simplified — calls `Manifest()` directly. The production transport path may later call `serializer.Serialize(FrameBufferWriter)` directly, but that integration is intentionally sequenced after the outbound write-loop spike.
 - **New package**: `Akka.Serialization.V2` with `MessagePackSerializer`, `AkkaWriter`, `AkkaReader`, attributes.
 - **NuGet dependencies**: `MessagePack` added to `Akka.Serialization.V2` (not core Akka). `System.IO.Pipelines` / `System.Memory` already in core from Spec 1.
-- **Internal serializers**: Mechanical base class change for simple ones (same wire format). Complex ones with nested payloads via `WrappedPayloadSupport` deferred until V2 API is validated.
+- **Internal serializers**: Mechanical base class change for simple ones (same wire format). Complex ones with nested payloads via `WrappedPayloadSupport` remain deferred until the transport integration point is proven.
 - **API surface**: `FindSerializerFor()` return type changes from `Serializer` to `SerializerV2`.
+- **Benchmarks**: serializer changes are now paired with a transport-owned outbound writer spike, not judged purely in isolation.
 - **Test suites**: All existing serialization tests must pass (V1 serializers auto-wrapped transparently). New tests for V2 round-trip, adapter, and hand-written MessagePack serializers.

--- a/openspec/changes/serializer-v2/specs/serializer-v2-base/spec.md
+++ b/openspec/changes/serializer-v2/specs/serializer-v2-base/spec.md
@@ -7,6 +7,10 @@ The system SHALL provide an abstract `SerializerV2` class in core Akka with `Ser
 - **WHEN** `SerializerV2.Serialize(buffer, obj)` is called
 - **THEN** the serializer SHALL write the serialized bytes directly into the provided `IBufferWriter<byte>` without allocating an intermediate `byte[]`
 
+#### Scenario: Serializer does not own pooled buffer lifetime
+- **WHEN** `SerializerV2.Serialize(buffer, obj)` writes into a transport-owned destination
+- **THEN** the serializer SHALL treat the writer as caller-owned and SHALL NOT assume responsibility for pooled buffer disposal or lifetime
+
 #### Scenario: Deserialize from ReadOnlySequence
 - **WHEN** `SerializerV2.Deserialize(buffer, manifest)` is called with a `ReadOnlySequence<byte>`
 - **THEN** the serializer SHALL read from the sequence and return the deserialized object
@@ -63,6 +67,13 @@ The `MessageSerializer` in Akka.Remote SHALL use V2 serializer dispatch, calling
 #### Scenario: Serialize with manifest
 - **WHEN** `MessageSerializer.Serialize(system, transportInfo, message)` is called
 - **THEN** it SHALL call `serializer.Manifest(message)` directly (all V2 serializers have manifests) and include it in the wire message
+
+### Requirement: SerializerV2 is a transport foundation, not proof by itself
+The system SHALL use `SerializerV2` as the enabling API for the outbound remoting transport loop, but the production remoting write path SHALL only adopt it after the integrated writer path has been benchmarked.
+
+#### Scenario: Transport integration sequenced after spike
+- **WHEN** the remoting transport is updated to use direct `Serialize(IBufferWriter<byte>, object)` calls
+- **THEN** that change SHALL be justified by benchmark evidence from the integrated outbound write-loop spike
 
 ### Requirement: Internal Protobuf serializers ported to V2
 Simple internal Protobuf serializers SHALL extend `SerializerV2` directly, using `proto.WriteTo(IBufferWriter<byte>)` and `Parser.ParseFrom(ReadOnlySequence<byte>)`. Wire format and serializer IDs SHALL remain unchanged.

--- a/openspec/changes/serializer-v2/tasks.md
+++ b/openspec/changes/serializer-v2/tasks.md
@@ -11,6 +11,12 @@
 - [ ] 1.9 Unit tests: `SerializerV1Adapter` round-trip with built-in serializers
 - [ ] 1.10 Verify all existing serialization tests pass (V1 auto-wrapped transparently)
 
+## 1A. Transport integration checkpoint
+
+- [ ] 1A.1 Verify the benchmark spike can lower serialization into a transport-owned outbound writer loop without requiring serializers to own pooled buffers
+- [ ] 1A.2 Use the spike results to confirm `SerializerV2.Serialize(...)` returns the information needed by outer framing and protocol writers
+- [ ] 1A.3 Do not wire `SerializerV2` into the production remoting path until the spike confirms the contract is worth the transport break
+
 ## 2. Akka.Serialization.V2 Package
 
 - [ ] 2.1 Create `src/core/Akka.Serialization.V2/` project, target `netstandard2.1;net6.0`, reference `Akka` + `MessagePack`
@@ -46,3 +52,4 @@
 - [ ] 5.2 Verify all Akka.Remote tests pass (V1 serializers auto-wrapped)
 - [ ] 5.3 Verify all Akka.Persistence tests pass (V1 data readable)
 - [ ] 5.4 Run `dotnet test -c Release src/core/Akka.API.Tests` — update API approval baselines for `FindSerializerFor` return type change
+- [ ] 5.5 Correlate serializer benchmark results with the outbound write-loop spike before taking on the full remoting integration

--- a/openspec/changes/streams-tcp-transport/design.md
+++ b/openspec/changes/streams-tcp-transport/design.md
@@ -1,37 +1,59 @@
 ## Context
 
-Akka.Remote's transport layer is pluggable via the abstract `Transport` class (`src/core/Akka.Remote/Transport/Transport.cs`). The current concrete implementation is `DotNettyTransport` which uses DotNetty's channel pipeline for framing, TLS, and socket I/O. Above the transport sits `AkkaProtocolTransport` — an adapter that handles the Akka protocol handshake (Associate/Disassociate), heartbeats, and association state management. `AkkaProtocolTransport` doesn't change.
+Akka.Remote's transport layer is pluggable via the abstract `Transport` class (`src/core/Akka.Remote/Transport/Transport.cs`). The current concrete implementation is `DotNettyTransport`, which uses DotNetty's channel pipeline for framing, TLS, and socket I/O. Above the transport sits `AkkaProtocolTransport`, an adapter that handles the Akka protocol handshake (Associate/Disassociate), heartbeats, and association state management.
 
-The transport API:
-- `Listen()` → binds a server socket, returns address + listener
-- `Associate(remoteAddress)` → connects to remote, returns `AssociationHandle`
-- `AssociationHandle.Write(ReadOnlyMemory<byte>)` → send framed data (after Spec 1, payload is `ReadOnlyMemory<byte>`)
-- `AssociationHandle.ReadHandlerSource` → listener receives `InboundPayload` events
+The current outbound hot path is split across multiple stages:
 
-With Specs 1+2, Akka.IO TCP now uses `Stream` + `Pipe` + `IStreamProvider` (with optional TLS). Akka.Streams TCP (`Tcp.Bind()`, `Tcp.OutgoingConnection()`) wraps Akka.IO TCP actors in a `Flow<ReadOnlyMemory<byte>, ReadOnlyMemory<byte>>`. The new transport builds on this.
+- `EndpointWriter.WriteSend()` serializes the user message into a `SerializedMessage`
+- `AkkaPduCodec.ConstructMessage()` builds the remote envelope bytes
+- `AkkaProtocolHandle.Write()` wraps that again in `AkkaProtocolMessage`
+- the concrete transport turns the resulting `ByteString` back into transport bytes
+
+That split is the main architectural bottleneck exposed by PR #8203. The abstraction overhead itself is small; the real cost is that serialization, protocol framing, and transport framing march along separate allocation-heavy paths.
+
+With Specs 1+2, Akka.IO TCP now uses `Stream` + `Pipe` + `IStreamProvider` (with optional TLS). That gives the transport a place to own a pooled outbound writer and build the entire frame in one loop. The new transport should exploit that directly.
 
 ## Goals / Non-Goals
 
 **Goals:**
 - Implement `StreamsTcpTransport : Transport` using Akka.Streams TCP
-- Integrated framing + serialization via `FrameBufferWriter : IBufferWriter<byte>` (single buffer, zero intermediate copies)
-- Replace Protobuf PDU encoding with simple binary encoding directly to `IBufferWriter<byte>`
+- Integrated outbound framing + serialization via `FrameBufferWriter : IBufferWriter<byte>` (single buffer, no intermediate payload copies on the write side)
+- Collapse the outbound path so the transport-owned write loop receives a send-shaped work item, writes protocol metadata, serializes the payload into the same writer, and emits one contiguous frame
 - All existing `akka.remote.dot-netty.tcp.*` HOCON configuration works unchanged
 - All non-DotNetty-specific Akka.Remote specs pass
 - Remove DotNetty dependency entirely
 
 **Non-Goals:**
-- Changing the `AkkaProtocolTransport` adapter (handshake, heartbeat, association management)
-- Changing the `Endpoint` / `EndpointWriter` / `EndpointReader` actor hierarchy
+- Preserving `AssociationHandle.Write(ByteString)` purely for compatibility if it blocks the integrated write path
+- Read-side pooled buffer leasing across actor boundaries
+- Changing the actor-visible `Endpoint` / `EndpointWriter` / `EndpointReader` behavior more than necessary to lower serialization into the write loop
 - UDP transport (separate, later)
 - QUIC transport (future, different spec)
 - Optimizing flush batching (Spec 5 — Performance)
 
 ## Decisions
 
-### 1. FrameBufferWriter for integrated framing + serialization
+### 1. Transport-owned outbound writer loop
 
-**Decision:** Create `FrameBufferWriter : IBufferWriter<byte>` that wraps a pooled `byte[]` with a start offset. The write path reserves 4 bytes for the length header, writes PDU metadata + serialized payload via `IBufferWriter<byte>`, then backfills the length. One buffer, one syscall.
+**Decision:** The new transport lowers serialization and framing into a single outbound write loop owned by the remoting transport. The queue item crossing into that loop is send-shaped work, not prebuilt bytes.
+
+```
+Write path:
+  EndpointWriter / transport state dequeues Send-shaped work
+    → rent transport-owned frame buffer
+    → reserve outer framing bytes
+    → write protocol / envelope metadata
+    → serializer writes payload directly into same writer
+    → backfill lengths
+    → flush completed frame to transport
+    → return buffer to pool
+```
+
+**Rationale:** This is the smallest design that actually removes the current split between serialization and transport framing. It also keeps buffer lifetime simple: the outbound transport loop owns the pool and returns buffers after the write completes.
+
+### 2. FrameBufferWriter for integrated outbound framing + serialization
+
+**Decision:** Create `FrameBufferWriter : IBufferWriter<byte>` that wraps a pooled `byte[]` with a start offset. The write path reserves space for the outer frame header, writes protocol metadata + serialized payload via `IBufferWriter<byte>`, then backfills the length.
 
 ```
 Write path:
@@ -43,30 +65,19 @@ Write path:
     → stream.WriteAsync()
 ```
 
-**Rationale:** The length header is always exactly 4 bytes. Reserve them upfront, write the rest, backfill. No need for a separate framing stage (which would require an extra copy). The serializer's `IBufferWriter<byte>` contract flows end-to-end from serialization through framing to the socket.
+**Rationale:** The length header is always exactly 4 bytes. Reserve it upfront, write the rest, backfill. No separate framing stage is needed. The buffer exists only inside the outbound loop, which avoids having to pass `IMemoryOwner<byte>` or other ownership wrappers through the actor protocol.
 
 **Alternative considered:** Separate Akka.Streams framing stage. Rejected for the transport — adds an unnecessary element copy between stages. The general-purpose `Framing.LengthField()` stage remains available for user-facing Streams TCP.
 
-### 2. Binary PDU encoding (replaces Protobuf AkkaPduCodec)
+### 3. PDU encoding strategy remains open until the spike lands
 
-**Decision:** Replace the Protobuf `SerializedMessage` / `AkkaProtocolMessage` envelope with simple binary encoding written directly to `IBufferWriter<byte>`.
+**Decision:** The production transport will keep the outer socket frame length prefix, but the inner protocol encoding remains an implementation choice until the spike proves the integrated writer path. The initial spike should validate the design against the current Protobuf-based remote envelope and protocol wrapper before a binary PDU replacement is committed.
 
-```
-PDU format (written to IBufferWriter):
-  [4 bytes] total frame length (little-endian int32)
-  [1 byte]  PDU type (0x01 = payload, 0x02 = associate, 0x03 = disassociate, 0x04 = heartbeat)
-  --- for payload PDU type ---
-  [4 bytes] serializerId (little-endian int32)
-  [2 bytes] manifest length (little-endian uint16)
-  [N bytes] manifest (UTF8)
-  [M bytes] serialized payload (remaining bytes = frame length - header)
-```
+**Rationale:** PR #8203 showed that the primary problem is the split pipeline, not just Protobuf. A spike that collapses the write path while keeping current wire semantics gives us a cleaner measurement of architectural benefit before taking on a wire-format rewrite.
 
-**Rationale:** The Protobuf PDU encoding allocates intermediate `byte[]` arrays and Protobuf `ByteString` wrappers. Direct binary encoding to `IBufferWriter<byte>` eliminates these allocations. The PDU format is simple enough that Protobuf's schema evolution isn't needed — it's a fixed internal protocol, not a public API.
+**Follow-up:** If the integrated writer path is successful, a later production step can still replace `AkkaPduProtobuffCodec` with a simpler binary format if the numbers justify the compatibility break.
 
-**Wire compatibility note:** This changes the PDU encoding format. A v1.6 node CANNOT talk to a v1.5 node. This is acceptable for a major version. The outer framing (4-byte length prefix) is preserved.
-
-### 3. StreamsTcpTransport implements Transport abstraction
+### 4. StreamsTcpTransport implements Transport abstraction
 
 **Decision:** New `StreamsTcpTransport : Transport` that uses Akka.Streams TCP for both server-side listening and client-side association.
 
@@ -77,11 +88,11 @@ Server path (`Listen`):
 
 Client path (`Associate`):
 - `Tcp.OutgoingConnection(remoteAddress)` → materialize → `StreamsAssociationHandle`
-- `Write(ReadOnlyMemory<byte>)` queues data for the materialized flow
+- the association write path accepts already-framed transport bytes only as an implementation detail; the preferred production path is that framing happens before this boundary inside the outbound loop
 
 **Rationale:** Reuses the Akka.Streams TCP infrastructure (which, after Spec 1, uses `Stream` + `Pipe` + `IStreamProvider`). Backpressure propagates naturally through Streams demand signaling.
 
-### 4. Configuration key preservation
+### 5. Configuration key preservation
 
 **Decision:** Parse all existing `akka.remote.dot-netty.tcp.*` HOCON keys into `StreamsTcpTransportSettings`. The config section name stays the same. Only the transport class reference changes.
 
@@ -97,33 +108,37 @@ Keys preserved:
 - `connection-timeout`
 - `batching.*` (flush batching settings — Spec 5 optimization)
 
-### 5. Remove DotNetty dependency
+### 6. Remove DotNetty dependency
 
 **Decision:** Delete `src/core/Akka.Remote/Transport/DotNetty/` entirely. Remove all DotNetty NuGet packages from `Akka.Remote.csproj`.
 
 **Rationale:** Clean break. No adapter layer or backward compat shim for DotNetty. The new transport is the only transport. DotNetty-specific programmatic APIs (`DotNettyTransportSettings`, `DotNettySslSetup`) are replaced by their equivalents.
 
-### 6. Read path: Pipe → length-delimited frame parsing → deserialize
+### 7. Read path remains copy-based above the transport boundary
 
-**Decision:** The read side uses the Pipe from Spec 1. `ReadOnlySequence<byte>` from `PipeReader` is parsed for length-delimited frames. Each complete frame's payload `ReadOnlySequence<byte>` is sliced and passed directly to `serializer.Deserialize()`.
+**Decision:** The read side uses the Pipe from Spec 1, but pooled buffer ownership stops before actor-visible lifetime begins. Transport and framing layers may parse from `ReadOnlySequence<byte>` while data is still in scope, but payload bytes are copied before they become inbound actor messages or stateful protocol queues.
 
 ```
 Read path:
   stream.ReadAsync() → Pipe.Writer
   Pipe.Reader.ReadAsync() → ReadOnlySequence<byte>
     → read 4-byte length → check if enough bytes for full frame
-    → if yes: slice payload → parse PDU header → serializer.Deserialize(payloadSlice)
+    → if yes: parse frame while bytes are live
+    → copy before crossing actor-visible lifetime boundaries
+    → deserialize / dispatch as ordinary inbound remoting data
     → if no: AdvanceTo(consumed, examined) → wait for more data
 ```
 
-**Rationale:** `ReadOnlySequence<byte>` is what `PipeReader` returns and what `serializer.Deserialize()` takes. The frame parser just reads the length, checks bounds, and slices. Zero copy from Pipe buffer to serializer. The only copy is the one in the Akka.IO TCP actor (required for unbounded message lifetime — decided in Spec 1).
+**Rationale:** Read-side zero-copy across actor boundaries would require explicit lifetime / release semantics and effectively a mini-GC for inbound messages. That is not a good trade-off for this milestone. Outbound pooling captures most of the practical gain with much less risk.
 
 ## Risks / Trade-offs
 
-**[Breaking wire compatibility with v1.5]** → The binary PDU encoding is incompatible with the Protobuf PDU used in v1.5. This is a major version break. Mixed-version clusters are not supported during upgrade. All nodes must be upgraded together. Document clearly in release notes.
+**[Transport abstraction changes]** → The existing `AssociationHandle.Write(ByteString)` boundary is not a good fit for a transport-owned pooled write path. This is an intentional 1.6 breaking change. The spike must prove enough benefit to justify it.
 
 **[Akka.Remote now depends on Akka.Streams]** → Currently `Akka.Remote` depends on `Akka` core only (plus DotNetty). The new transport adds a dependency on `Akka.Streams`. This is a new transitive dependency for all remoting users. Acceptable since Streams is a core module, not an external package.
 
 **[Flush batching needs tuning]** → DotNetty's `FlushConsolidationHandler` batches flushes for throughput. The new transport needs equivalent batching (consolidate multiple writes before calling `stream.FlushAsync()`). Deferred to Spec 5 (Performance) for benchmarking-driven optimization.
 
 **[FrameBufferWriter growth on SizeHint underestimate]** → If `serializer.SizeHint()` underestimates, `FrameBufferWriter` rents a larger array from `ArrayPool` and copies. This is a fallback path — `SizeHint` should be accurate for most messages. Benchmark to ensure the growth path doesn't regress.
+
+**[Read-side pooling intentionally excluded]** → Some peak read-side gains are left on the table. This is acceptable because the actor-lifetime semantics make pooled inbound buffers disproportionately risky.

--- a/openspec/changes/streams-tcp-transport/design.md
+++ b/openspec/changes/streams-tcp-transport/design.md
@@ -19,12 +19,14 @@ With Specs 1+2, Akka.IO TCP now uses `Stream` + `Pipe` + `IStreamProvider` (with
 - Implement `StreamsTcpTransport : Transport` using Akka.Streams TCP
 - Integrated outbound framing + serialization via `FrameBufferWriter : IBufferWriter<byte>` (single buffer, no intermediate payload copies on the write side)
 - Collapse the outbound path so the transport-owned write loop receives a send-shaped work item, writes protocol metadata, serializes the payload into the same writer, and emits one contiguous frame
+- Preserve the current remoting wire format in the first production redesign
 - All existing `akka.remote.dot-netty.tcp.*` HOCON configuration works unchanged
 - All non-DotNetty-specific Akka.Remote specs pass
 - Remove DotNetty dependency entirely
 
 **Non-Goals:**
 - Preserving `AssociationHandle.Write(ByteString)` purely for compatibility if it blocks the integrated write path
+- Preserving source-compatible C# transport or setup APIs if they block the faster design
 - Read-side pooled buffer leasing across actor boundaries
 - Changing the actor-visible `Endpoint` / `EndpointWriter` / `EndpointReader` behavior more than necessary to lower serialization into the write loop
 - UDP transport (separate, later)
@@ -69,15 +71,21 @@ Write path:
 
 **Alternative considered:** Separate Akka.Streams framing stage. Rejected for the transport — adds an unnecessary element copy between stages. The general-purpose `Framing.LengthField()` stage remains available for user-facing Streams TCP.
 
-### 3. PDU encoding strategy remains open until the spike lands
+### 3. First production redesign preserves the current wire format
 
-**Decision:** The production transport will keep the outer socket frame length prefix, but the inner protocol encoding remains an implementation choice until the spike proves the integrated writer path. The initial spike should validate the design against the current Protobuf-based remote envelope and protocol wrapper before a binary PDU replacement is committed.
+**Decision:** The first production redesign keeps the current remoting wire format end-to-end, including the existing protocol wrapper and envelope semantics, while rewriting the outbound path to construct that wire format in one pass.
 
-**Rationale:** PR #8203 showed that the primary problem is the split pipeline, not just Protobuf. A spike that collapses the write path while keeping current wire semantics gives us a cleaner measurement of architectural benefit before taking on a wire-format rewrite.
+**Rationale:** PR #8203 showed that the primary problem is the split pipeline, not just Protobuf. Keeping the wire format stable isolates the performance value of the new outbound regime and gets us to a production redesign faster.
 
-**Follow-up:** If the integrated writer path is successful, a later production step can still replace `AkkaPduProtobuffCodec` with a simpler binary format if the numbers justify the compatibility break.
+**Follow-up:** If the integrated writer path is successful and further gains are still available, a later change can revisit the wire format separately.
 
-### 4. StreamsTcpTransport implements Transport abstraction
+### 4. Performance-first API breaks are acceptable
+
+**Decision:** If the current C# transport, association, or setup APIs block the integrated outbound path, they should be changed instead of wrapped in compatibility shims on the hot path.
+
+**Rationale:** The priority for Akka.NET 1.6 is to prove the new regime is faster. Preserving source compatibility in the performance-critical path would obscure that result and slow down the redesign.
+
+### 5. StreamsTcpTransport implements Transport abstraction
 
 **Decision:** New `StreamsTcpTransport : Transport` that uses Akka.Streams TCP for both server-side listening and client-side association.
 
@@ -92,7 +100,7 @@ Client path (`Associate`):
 
 **Rationale:** Reuses the Akka.Streams TCP infrastructure (which, after Spec 1, uses `Stream` + `Pipe` + `IStreamProvider`). Backpressure propagates naturally through Streams demand signaling.
 
-### 5. Configuration key preservation
+### 6. Configuration key preservation
 
 **Decision:** Parse all existing `akka.remote.dot-netty.tcp.*` HOCON keys into `StreamsTcpTransportSettings`. The config section name stays the same. Only the transport class reference changes.
 
@@ -108,13 +116,13 @@ Keys preserved:
 - `connection-timeout`
 - `batching.*` (flush batching settings — Spec 5 optimization)
 
-### 6. Remove DotNetty dependency
+### 7. Remove DotNetty dependency
 
 **Decision:** Delete `src/core/Akka.Remote/Transport/DotNetty/` entirely. Remove all DotNetty NuGet packages from `Akka.Remote.csproj`.
 
 **Rationale:** Clean break. No adapter layer or backward compat shim for DotNetty. The new transport is the only transport. DotNetty-specific programmatic APIs (`DotNettyTransportSettings`, `DotNettySslSetup`) are replaced by their equivalents.
 
-### 7. Read path remains copy-based above the transport boundary
+### 8. Read path remains copy-based above the transport boundary
 
 **Decision:** The read side uses the Pipe from Spec 1, but pooled buffer ownership stops before actor-visible lifetime begins. Transport and framing layers may parse from `ReadOnlySequence<byte>` while data is still in scope, but payload bytes are copied before they become inbound actor messages or stateful protocol queues.
 
@@ -131,9 +139,18 @@ Read path:
 
 **Rationale:** Read-side zero-copy across actor boundaries would require explicit lifetime / release semantics and effectively a mini-GC for inbound messages. That is not a good trade-off for this milestone. Outbound pooling captures most of the practical gain with much less risk.
 
+### Phased delivery path
+
+- Phase 1: keep the benchmark-only spike as the proof that the integrated outbound regime is directionally better.
+- Phase 2: land a production outbound writer path that emits the current remoting wire format from send-shaped work items and takes any required C# API breaks.
+- Phase 3: swap the DotNetty transport backend for `StreamsTcpTransport` on the same wire format.
+- Phase 4: run `RemotePingPong`, tune batching and buffer thresholds, and only then decide which compatibility cleanups or additional protocol changes are worth doing.
+
 ## Risks / Trade-offs
 
-**[Transport abstraction changes]** → The existing `AssociationHandle.Write(ByteString)` boundary is not a good fit for a transport-owned pooled write path. This is an intentional 1.6 breaking change. The spike must prove enough benefit to justify it.
+**[Transport abstraction changes]** → The existing `AssociationHandle.Write(ByteString)` boundary is not a good fit for a transport-owned pooled write path. This is an intentional 1.6 breaking change. The spike already gives directional evidence that the break is worth taking.
+
+**[Wire format stays the same, so some protocol allocations may remain]** → Acceptable for the first production redesign. The goal is to remove the largest structural costs first and benchmark the result before taking on a separate wire-format rewrite.
 
 **[Akka.Remote now depends on Akka.Streams]** → Currently `Akka.Remote` depends on `Akka` core only (plus DotNetty). The new transport adds a dependency on `Akka.Streams`. This is a new transitive dependency for all remoting users. Acceptable since Streams is a core module, not an external package.
 

--- a/openspec/changes/streams-tcp-transport/proposal.md
+++ b/openspec/changes/streams-tcp-transport/proposal.md
@@ -16,14 +16,15 @@ That is where buffer pooling is practical. Read-side pooling is intentionally ou
 ## What Changes
 
 - New `StreamsTcpTransport : Transport` implementation in Akka.Remote using Akka.Streams TCP
-- **Wire-compatible outer framing**: preserve the `[4-byte length][payload]` socket framing used by the current transport
+- **Wire-compatible first production slice**: preserve the current remoting wire format end-to-end while redesigning the outbound path
 - **Config-compatible**: all `akka.remote.dot-netty.tcp.*` HOCON keys continue to work (mapped to new transport settings)
 - `AkkaProtocolTransport` remains the handshake / heartbeat / association-management layer, but the outbound write contract below it is allowed to change for performance
 - New transport-owned outbound writer loop that lowers serialization and protocol framing into a single buffer construction path
 - New pooled `FrameBufferWriter : IBufferWriter<byte>` for outbound writes only
-- Replace the current multi-stage `MessageSerializer` -> `AkkaPduCodec.ConstructMessage` -> `AkkaProtocolHandle.Write` write path with one integrated path that writes directly to the transport-owned writer
+- Replace the current multi-stage `MessageSerializer` -> `AkkaPduCodec.ConstructMessage` -> `AkkaProtocolHandle.Write` write path with one integrated path that writes the current wire format directly to the transport-owned writer
 - Remove DotNetty NuGet dependency from Akka.Remote
 - **BREAKING**: the current `AssociationHandle.Write(ByteString)` / `InboundPayload(ByteString)` assumptions are no longer design constraints for the new transport implementation
+- **BREAKING**: source-compatible C# transport/setup APIs are not a goal if they block the faster outbound regime
 - **BREAKING**: `DotNettySslSetup` replaced by `TlsSetup` (Spec 2)
 - **BREAKING**: DotNetty-specific programmatic APIs removed
 
@@ -32,7 +33,7 @@ That is where buffer pooling is practical. Read-side pooling is intentionally ou
 - `AkkaProtocolTransport` remains the layer responsible for handshake, heartbeats, acking, and association state management
 - Akka.Remote's actor-level semantics stay the same: sends are still driven by send-shaped work items and inbound payloads still become ordinary actor messages after deserialization
 - Read-side transport behavior remains copy-based before actor-visible lifetime begins
-- The outer socket framing stays length-delimited
+- The remoting wire format stays compatible in the first production redesign
 - All HOCON configuration keys (names preserved, implementation remapped)
 
 ## Capabilities
@@ -45,9 +46,9 @@ That is where buffer pooling is practical. Read-side pooling is intentionally ou
 
 ## Impact
 
-- **Akka.Remote** (`src/core/Akka.Remote/`): New transport implementation and outbound writer pipeline. Remove `Transport/DotNetty/` directory entirely. Update `EndpointWriter`, `MessageSerializer`, and transport abstractions to support transport-owned outbound buffer construction.
+- **Akka.Remote** (`src/core/Akka.Remote/`): New transport implementation and outbound writer pipeline. Remove `Transport/DotNetty/` directory entirely. Update `EndpointWriter`, `MessageSerializer`, and transport abstractions to support transport-owned outbound buffer construction while preserving the current wire format.
 - **Configuration**: All `akka.remote.dot-netty.tcp.*` keys remapped to `StreamsTcpTransportSettings`. Default transport class changes from `TcpTransport` (DotNetty) to `StreamsTcpTransport`.
 - **NuGet dependencies**: Remove `DotNetty.Transport`, `DotNetty.Codecs`, `DotNetty.Handlers`, `DotNetty.Common`, `DotNetty.Buffers`. Add dependency on `Akka.Streams` from `Akka.Remote`.
-- **Benchmarks**: Add a bounded spike that compares the current split outbound pipeline against an integrated transport-owned write loop before the full transport rewrite is attempted.
+- **Benchmarks**: Add a bounded spike that compares the current split outbound pipeline against an integrated transport-owned write loop before the full transport rewrite is attempted, then benchmark the first wire-compatible redesigned transport before any compatibility follow-up work.
 - **Test suites**: All Akka.Remote specs that don't directly reference DotNetty APIs must pass. DotNetty-specific tests removed.
 - **Downstream**: Spec 4 (SerializerV2) is now explicitly a foundation for the integrated outbound path, not a standalone end-state. Spec 5 benchmarks both the spike and the final transport.

--- a/openspec/changes/streams-tcp-transport/proposal.md
+++ b/openspec/changes/streams-tcp-transport/proposal.md
@@ -1,39 +1,53 @@
 ## Why
 
-DotNetty's `ByteBuf` is incompatible with `System.Memory`, making it a dead end for zero-copy serialization and transport. With Spec 1 delivering `System.Memory` + `Stream` + `Pipe` in Akka.IO and Spec 2 adding TLS via `IStreamProvider`, we can replace the DotNetty transport with one built on Akka.Streams TCP. This eliminates the DotNetty dependency entirely and enables end-to-end zero-copy: `IBufferWriter<byte>` flows from the serializer through framing to the socket in a single buffer with no intermediate copies.
+DotNetty's `ByteBuf` is incompatible with `System.Memory`, making it a dead end for integrated serialization and transport. Spec 1 delivered `System.Memory` + `Stream` + `Pipe` in Akka.IO and Spec 2 added TLS via `IStreamProvider`, which makes an Akka.Streams-based TCP transport viable. PR #8203 also showed that serializer improvements alone are not enough: Akka.Remote's outbound path still splits serialization, envelope construction, protocol wrapping, and transport framing into separate allocation-heavy stages.
+
+The next transport milestone therefore needs to do more than swap DotNetty for Akka.Streams. It needs to collapse the outbound write path into one transport-owned loop:
+
+- dequeue a send-shaped work item
+- reserve framing space
+- write envelope metadata
+- serialize the payload directly into the same writer
+- write the protocol wrapper and outer frame
+- flush the completed bytes to the transport
+
+That is where buffer pooling is practical. Read-side pooling is intentionally out of scope for this milestone because inbound payload bytes can outlive the transport and become actor state indefinitely.
 
 ## What Changes
 
 - New `StreamsTcpTransport : Transport` implementation in Akka.Remote using Akka.Streams TCP
-- **Wire-compatible**: same `[4-byte little-endian length][payload]` framing as DotNetty
+- **Wire-compatible outer framing**: preserve the `[4-byte length][payload]` socket framing used by the current transport
 - **Config-compatible**: all `akka.remote.dot-netty.tcp.*` HOCON keys continue to work (mapped to new transport settings)
-- **Behaviorally compatible**: `AkkaProtocolTransport` adapter layer (handshake, heartbeats, association management) sits on top unchanged
-- New `FrameBufferWriter : IBufferWriter<byte>` — lightweight wrapper over pooled `byte[]` with offset, enabling integrated framing + serialization in a single buffer write (reserve 4 bytes for length header, write PDU + payload, backfill length)
-- Replace `AkkaPduProtobuffCodec` (Protobuf-based PDU encoding) with simple binary PDU encoding directly into `IBufferWriter<byte>` (serializerId as int32, manifest as length-prefixed UTF8, payload bytes)
+- `AkkaProtocolTransport` remains the handshake / heartbeat / association-management layer, but the outbound write contract below it is allowed to change for performance
+- New transport-owned outbound writer loop that lowers serialization and protocol framing into a single buffer construction path
+- New pooled `FrameBufferWriter : IBufferWriter<byte>` for outbound writes only
+- Replace the current multi-stage `MessageSerializer` -> `AkkaPduCodec.ConstructMessage` -> `AkkaProtocolHandle.Write` write path with one integrated path that writes directly to the transport-owned writer
 - Remove DotNetty NuGet dependency from Akka.Remote
+- **BREAKING**: the current `AssociationHandle.Write(ByteString)` / `InboundPayload(ByteString)` assumptions are no longer design constraints for the new transport implementation
 - **BREAKING**: `DotNettySslSetup` replaced by `TlsSetup` (Spec 2)
 - **BREAKING**: DotNetty-specific programmatic APIs removed
 
 ### What does NOT change
 
-- `AkkaProtocolTransport` adapter layer (handshake, heartbeats, acking, association state machine)
-- The abstract `Transport` base class and `AssociationHandle` contract
-- Akka.Remote's `Endpoint` / `EndpointWriter` / `EndpointReader` actor hierarchy (though `EndpointWriter` internals change to use `IBufferWriter<byte>`)
-- Wire format on the network (same 4-byte length framing, same SerializerId + Manifest + Payload structure)
+- `AkkaProtocolTransport` remains the layer responsible for handshake, heartbeats, acking, and association state management
+- Akka.Remote's actor-level semantics stay the same: sends are still driven by send-shaped work items and inbound payloads still become ordinary actor messages after deserialization
+- Read-side transport behavior remains copy-based before actor-visible lifetime begins
+- The outer socket framing stays length-delimited
 - All HOCON configuration keys (names preserved, implementation remapped)
 
 ## Capabilities
 
 ### New Capabilities
 
-- `streams-tcp-transport`: Akka.Streams-based TCP transport replacing DotNetty. Covers the `Transport` implementation, `AssociationHandle`, integrated framing + serialization via `FrameBufferWriter`, binary PDU encoding, configuration mapping from DotNetty HOCON, and DotNetty dependency removal.
+- `streams-tcp-transport`: Akka.Streams-based TCP transport replacing DotNetty. Covers the transport implementation, integrated outbound framing + serialization via a transport-owned `FrameBufferWriter`, configuration mapping from DotNetty HOCON, and DotNetty dependency removal.
 
 ### Modified Capabilities
 
 ## Impact
 
-- **Akka.Remote** (`src/core/Akka.Remote/`): New transport implementation, `FrameBufferWriter`, binary PDU codec. Remove `Transport/DotNetty/` directory entirely. Update `MessageSerializer.cs` and `Endpoint.cs` for `IBufferWriter<byte>` write path.
+- **Akka.Remote** (`src/core/Akka.Remote/`): New transport implementation and outbound writer pipeline. Remove `Transport/DotNetty/` directory entirely. Update `EndpointWriter`, `MessageSerializer`, and transport abstractions to support transport-owned outbound buffer construction.
 - **Configuration**: All `akka.remote.dot-netty.tcp.*` keys remapped to `StreamsTcpTransportSettings`. Default transport class changes from `TcpTransport` (DotNetty) to `StreamsTcpTransport`.
 - **NuGet dependencies**: Remove `DotNetty.Transport`, `DotNetty.Codecs`, `DotNetty.Handlers`, `DotNetty.Common`, `DotNetty.Buffers`. Add dependency on `Akka.Streams` from `Akka.Remote`.
+- **Benchmarks**: Add a bounded spike that compares the current split outbound pipeline against an integrated transport-owned write loop before the full transport rewrite is attempted.
 - **Test suites**: All Akka.Remote specs that don't directly reference DotNetty APIs must pass. DotNetty-specific tests removed.
-- **Downstream**: Spec 4 (SerializerV2) `Serialize(IBufferWriter<byte>)` writes directly into `FrameBufferWriter`. Spec 5 (Performance) benchmarks this transport.
+- **Downstream**: Spec 4 (SerializerV2) is now explicitly a foundation for the integrated outbound path, not a standalone end-state. Spec 5 benchmarks both the spike and the final transport.

--- a/openspec/changes/streams-tcp-transport/specs/streams-tcp-transport/spec.md
+++ b/openspec/changes/streams-tcp-transport/specs/streams-tcp-transport/spec.md
@@ -45,20 +45,23 @@ The outbound remoting transport loop SHALL own pooled write buffers and SHALL bu
 - **WHEN** the outbound loop rents a buffer to construct a frame
 - **THEN** the transport SHALL retain ownership of that buffer until the transport write completes or fails
 
-### Requirement: Binary PDU encoding
-The system SHALL use a simple binary PDU format written directly to `IBufferWriter<byte>`, replacing the Protobuf `AkkaPduProtobuffCodec`.
+### Requirement: First production redesign preserves current wire format
+The first production remoting redesign SHALL preserve the current remoting wire format even if the internal outbound writer path and C# transport APIs change.
 
-#### Scenario: Payload PDU encoding
+#### Scenario: Payload frames remain wire-compatible
 - **WHEN** a user message is sent to a remote actor
-- **THEN** the PDU SHALL be encoded as: `[4-byte frame length][1-byte PDU type = 0x01][4-byte serializerId][2-byte manifest length][manifest UTF8 bytes][serialized payload bytes]`
+- **THEN** the integrated outbound writer SHALL emit payload bytes that are semantically equivalent to the current `AkkaPduProtobuffCodec` plus `AkkaProtocolMessage` wire format
 
-#### Scenario: Control PDU encoding (heartbeat)
-- **WHEN** a heartbeat is sent
-- **THEN** the PDU SHALL be encoded as: `[4-byte frame length][1-byte PDU type = 0x04]` (5 bytes total)
+#### Scenario: Control messages remain wire-compatible
+- **WHEN** associate, disassociate, or heartbeat messages are sent
+- **THEN** the integrated outbound writer SHALL emit the same wire-level protocol fields expected by the current remoting peer
 
-#### Scenario: Control PDU encoding (associate/disassociate)
-- **WHEN** an associate or disassociate control message is sent
-- **THEN** the PDU SHALL be encoded with the appropriate PDU type byte and protocol-specific fields
+### Requirement: Performance-first API changes allowed
+The first production redesign SHALL prioritize the faster outbound regime over source-compatible C# transport APIs.
+
+#### Scenario: Slower compatibility layer rejected on hot path
+- **WHEN** an existing C# transport or remoting write API blocks the integrated outbound path
+- **THEN** that API SHALL be changed instead of preserving a slower compatibility layer in the hot path
 
 ### Requirement: Length-delimited frame parsing on read path
 The system SHALL parse incoming data from `PipeReader` as length-delimited frames while keeping read-side pooled buffer lifetime internal to the transport.
@@ -108,9 +111,9 @@ The `Akka.Remote` project SHALL NOT reference any DotNetty NuGet packages. The `
 ### Requirement: Behavioral compatibility with existing transport
 All Akka.Remote specs that do not directly reference DotNetty library APIs SHALL pass with the new transport without modification.
 
-#### Scenario: AkkaProtocolTransport works unchanged
-- **WHEN** the `AkkaProtocolTransport` adapter is layered on top of `StreamsTcpTransport`
-- **THEN** association handshake, heartbeats, sequence numbers, ACKs, and disassociation SHALL behave identically to the DotNetty-based transport
+#### Scenario: AkkaProtocolTransport semantics preserved
+- **WHEN** the remoting protocol layer is run on top of `StreamsTcpTransport`
+- **THEN** association handshake, heartbeats, sequence numbers, ACKs, and disassociation SHALL behave identically on the wire to the DotNetty-based transport
 
 #### Scenario: EndpointWriter sends messages
 - **WHEN** `EndpointWriter` serializes a message and writes it to the transport

--- a/openspec/changes/streams-tcp-transport/specs/streams-tcp-transport/spec.md
+++ b/openspec/changes/streams-tcp-transport/specs/streams-tcp-transport/spec.md
@@ -11,9 +11,9 @@ The system SHALL provide `StreamsTcpTransport : Transport` that implements the p
 - **WHEN** `StreamsTcpTransport.Associate(remoteAddress)` is called
 - **THEN** it SHALL connect via `Tcp.OutgoingConnection()` (using `IStreamProvider` with optional TLS), materialize the connection, and return a `StreamsAssociationHandle`
 
-#### Scenario: AssociationHandle write
-- **WHEN** `StreamsAssociationHandle.Write(ReadOnlyMemory<byte>)` is called
-- **THEN** it SHALL enqueue the data for framing and transmission through the materialized Akka.Streams flow
+#### Scenario: Transport write contract modernized for outbound ownership
+- **WHEN** the new transport implementation is integrated into remoting
+- **THEN** the write contract below the remoting outbound loop SHALL support transport-owned frame construction and SHALL NOT require prebuilt `ByteString` payloads to be passed across that boundary
 
 #### Scenario: Transport shutdown
 - **WHEN** `StreamsTcpTransport.Shutdown()` is called
@@ -34,6 +34,17 @@ The system SHALL provide `FrameBufferWriter : IBufferWriter<byte>` that writes i
 - **WHEN** the frame has been written to the socket via `stream.WriteAsync()`
 - **THEN** the pooled `byte[]` SHALL be returned to `ArrayPool<byte>.Shared`
 
+### Requirement: Outbound transport loop owns buffer lifetime
+The outbound remoting transport loop SHALL own pooled write buffers and SHALL build transport frames from send-shaped work items rather than actor messages carrying pooled buffers.
+
+#### Scenario: Send-shaped work enters outbound loop
+- **WHEN** remoting has a user message ready to send
+- **THEN** the outbound loop SHALL receive a send-shaped work item containing the semantic message metadata, not a prebuilt transport payload
+
+#### Scenario: Transport owns pooled outbound buffer
+- **WHEN** the outbound loop rents a buffer to construct a frame
+- **THEN** the transport SHALL retain ownership of that buffer until the transport write completes or fails
+
 ### Requirement: Binary PDU encoding
 The system SHALL use a simple binary PDU format written directly to `IBufferWriter<byte>`, replacing the Protobuf `AkkaPduProtobuffCodec`.
 
@@ -50,11 +61,11 @@ The system SHALL use a simple binary PDU format written directly to `IBufferWrit
 - **THEN** the PDU SHALL be encoded with the appropriate PDU type byte and protocol-specific fields
 
 ### Requirement: Length-delimited frame parsing on read path
-The system SHALL parse incoming data from `PipeReader` as length-delimited frames, slicing complete frames as `ReadOnlySequence<byte>` for deserialization.
+The system SHALL parse incoming data from `PipeReader` as length-delimited frames while keeping read-side pooled buffer lifetime internal to the transport.
 
 #### Scenario: Complete frame available
 - **WHEN** `PipeReader.ReadAsync()` returns a buffer containing at least `4 + frameLength` bytes
-- **THEN** the parser SHALL read the 4-byte length, slice the payload as `ReadOnlySequence<byte>`, parse the PDU header, and pass the payload to `serializer.Deserialize()`
+- **THEN** the parser SHALL read the 4-byte length, parse the frame while bytes are live, and copy before data crosses actor-visible lifetime boundaries
 
 #### Scenario: Partial frame buffering
 - **WHEN** `PipeReader.ReadAsync()` returns a buffer with fewer bytes than the frame length indicates
@@ -63,6 +74,10 @@ The system SHALL parse incoming data from `PipeReader` as length-delimited frame
 #### Scenario: Maximum frame size enforcement
 - **WHEN** the 4-byte length header indicates a frame larger than `maximum-frame-size`
 - **THEN** the parser SHALL close the connection with an error (prevents memory exhaustion from malformed/malicious data)
+
+#### Scenario: No pooled inbound buffers across actor boundaries
+- **WHEN** inbound bytes are turned into remoting protocol events or actor messages
+- **THEN** they SHALL no longer depend on transport-owned pooled buffer lifetime
 
 ### Requirement: DotNetty HOCON configuration compatibility
 All existing `akka.remote.dot-netty.tcp.*` HOCON configuration keys SHALL continue to work without modification, mapped to the new `StreamsTcpTransportSettings`.
@@ -99,7 +114,7 @@ All Akka.Remote specs that do not directly reference DotNetty library APIs SHALL
 
 #### Scenario: EndpointWriter sends messages
 - **WHEN** `EndpointWriter` serializes a message and writes it to the transport
-- **THEN** it SHALL use the `FrameBufferWriter` path (`IBufferWriter<byte>` → single buffer → transport write)
+- **THEN** it SHALL lower serialization and protocol framing into the transport-owned outbound writer path (`Send`-shaped work → single buffer construction → transport write)
 
 #### Scenario: Two ActorSystems communicate
 - **WHEN** two ActorSystems are configured with `StreamsTcpTransport` and remoting enabled

--- a/openspec/changes/streams-tcp-transport/tasks.md
+++ b/openspec/changes/streams-tcp-transport/tasks.md
@@ -14,12 +14,12 @@
 - [ ] 2.4 Benchmark common payload shapes (`string`, `byte[]`, small and large payloads)
 - [ ] 2.5 Record whether the integrated loop is enough to justify changing the transport write contract
 
-## 3. Production PDU strategy
+## 3. Wire-compatible production integration
 
-- [ ] 3.1 Decide whether production transport keeps the current Protobuf wire semantics initially or replaces `AkkaPduProtobuffCodec` with a binary codec after the spike lands
-- [ ] 3.2 If binary PDU replacement is still justified, create `BinaryPduCodec` in `src/core/Akka.Remote/` with `WritePdu(IBufferWriter<byte>, ...)` methods for payload, associate, disassociate, heartbeat PDU types
-- [ ] 3.3 If binary PDU replacement is chosen, create `ReadPdu(ReadOnlySequence<byte>)` methods that parse PDU type and extract fields
-- [ ] 3.4 If binary PDU replacement is chosen, define PDU type constants and round-trip tests for all PDU types
+- [ ] 3.1 Lock the first production redesign to the current remoting wire format; do not introduce a new on-the-wire protocol in this milestone
+- [ ] 3.2 Implement direct writing of the current protocol wrapper and remote envelope into the transport-owned outbound writer loop
+- [ ] 3.3 Verify the integrated writer output is accepted by the current remoting decoder and interop tests
+- [ ] 3.4 Defer any alternative binary PDU format to a later change after end-to-end performance validation
 
 ## 4. StreamsTcpTransport Implementation
 
@@ -28,7 +28,7 @@
 - [ ] 4.3 Implement `Associate(remoteAddress)`: use `Tcp.OutgoingConnection()` to connect, materialize flow, return `StreamsAssociationHandle`
 - [ ] 4.4 Implement `Shutdown()`: close listener, close all active associations, complete materialized streams
 - [ ] 4.5 Implement `IsResponsibleFor(Address)`: protocol check for "tcp" / "ssl.tcp"
-- [ ] 4.6 Replace the current write boundary with a contract that supports transport-owned outbound frame construction; do not preserve `Write(ByteString)` if it blocks the integrated path
+- [ ] 4.6 Replace the current write boundary with a contract that supports transport-owned outbound frame construction; do not preserve source-compatible C# APIs if they block the integrated path
 
 ## 5. Integrated Write Path
 
@@ -73,3 +73,9 @@
 - [ ] 9.8 Test: cluster formation with multiple nodes using new transport
 - [ ] 9.9 Remove DotNetty-specific test files
 - [ ] 9.10 Run full test suite: `dotnet test -c Release`
+
+## 10. Compatibility follow-up after performance proof
+
+- [ ] 10.1 After the redesigned transport beats the baseline, audit which compatibility shims or migration helpers are actually worth adding back
+- [ ] 10.2 Decide whether any public C# transport/setup APIs need adapters or only release-note migration guidance
+- [ ] 10.3 Keep any future wire-format changes in a separate post-validation change

--- a/openspec/changes/streams-tcp-transport/tasks.md
+++ b/openspec/changes/streams-tcp-transport/tasks.md
@@ -6,63 +6,70 @@
 - [ ] 1.4 Add `Return()` method that returns the pooled `byte[]` to `ArrayPool`
 - [ ] 1.5 Unit tests for FrameBufferWriter: basic write, growth, backfill, pool return
 
-## 2. Binary PDU Codec
+## 2. Outbound write-loop spike
 
-- [ ] 2.1 Create `BinaryPduCodec` in `src/core/Akka.Remote/` with `WritePdu(IBufferWriter<byte>, ...)` methods for payload, associate, disassociate, heartbeat PDU types
-- [ ] 2.2 Create `ReadPdu(ReadOnlySequence<byte>)` methods that parse PDU type and extract fields
-- [ ] 2.3 Define PDU type constants (0x01 payload, 0x02 associate, 0x03 disassociate, 0x04 heartbeat)
-- [ ] 2.4 Implement payload PDU: serializerId (int32) + manifest (length-prefixed UTF8) + payload bytes
-- [ ] 2.5 Implement control PDUs: associate (with handshake info), disassociate (with reason), heartbeat (minimal)
-- [ ] 2.6 Unit tests: round-trip encode/decode for all PDU types, edge cases (empty manifest, large payloads, max frame size)
+- [ ] 2.1 Add a benchmark-local spike that compares the current split outbound pipeline against an integrated transport-owned writer loop
+- [ ] 2.2 Use a send-shaped work item in the spike rather than prebuilt payload bytes
+- [ ] 2.3 Keep buffer ownership internal to the outbound loop in the spike; do not pass owned buffers through actor messages
+- [ ] 2.4 Benchmark common payload shapes (`string`, `byte[]`, small and large payloads)
+- [ ] 2.5 Record whether the integrated loop is enough to justify changing the transport write contract
 
-## 3. StreamsTcpTransport Implementation
+## 3. Production PDU strategy
 
-- [ ] 3.1 Create `StreamsTcpTransport : Transport` in `src/core/Akka.Remote/Transport/Streams/`
-- [ ] 3.2 Implement `Listen()`: use `Tcp.Bind()` to create listener, materialize `Source<IncomingConnection>`, return bound address + association event listener
-- [ ] 3.3 Implement `Associate(remoteAddress)`: use `Tcp.OutgoingConnection()` to connect, materialize flow, return `StreamsAssociationHandle`
-- [ ] 3.4 Implement `Shutdown()`: close listener, close all active associations, complete materialized streams
-- [ ] 3.5 Implement `IsResponsibleFor(Address)`: protocol check for "tcp" / "ssl.tcp"
-- [ ] 3.6 Create `StreamsAssociationHandle : AssociationHandle` with `Write(ReadOnlyMemory<byte>)` that queues framed data to the materialized flow
+- [ ] 3.1 Decide whether production transport keeps the current Protobuf wire semantics initially or replaces `AkkaPduProtobuffCodec` with a binary codec after the spike lands
+- [ ] 3.2 If binary PDU replacement is still justified, create `BinaryPduCodec` in `src/core/Akka.Remote/` with `WritePdu(IBufferWriter<byte>, ...)` methods for payload, associate, disassociate, heartbeat PDU types
+- [ ] 3.3 If binary PDU replacement is chosen, create `ReadPdu(ReadOnlySequence<byte>)` methods that parse PDU type and extract fields
+- [ ] 3.4 If binary PDU replacement is chosen, define PDU type constants and round-trip tests for all PDU types
 
-## 4. Integrated Write Path
+## 4. StreamsTcpTransport Implementation
 
-- [ ] 4.1 Modify `EndpointWriter` (or create new equivalent) to use `FrameBufferWriter` for the write path
-- [ ] 4.2 Write path: rent buffer → reserve 4 bytes → `BinaryPduCodec.WritePdu(writer, ...)` → `serializer.Serialize(writer, msg)` → backfill length → `AssociationHandle.Write(frame)`
-- [ ] 4.3 Buffer lifecycle: return pooled array to `ArrayPool` after `stream.WriteAsync()` completes
+- [ ] 4.1 Create `StreamsTcpTransport : Transport` in `src/core/Akka.Remote/Transport/Streams/`
+- [ ] 4.2 Implement `Listen()`: use `Tcp.Bind()` to create listener, materialize `Source<IncomingConnection>`, return bound address + association event listener
+- [ ] 4.3 Implement `Associate(remoteAddress)`: use `Tcp.OutgoingConnection()` to connect, materialize flow, return `StreamsAssociationHandle`
+- [ ] 4.4 Implement `Shutdown()`: close listener, close all active associations, complete materialized streams
+- [ ] 4.5 Implement `IsResponsibleFor(Address)`: protocol check for "tcp" / "ssl.tcp"
+- [ ] 4.6 Replace the current write boundary with a contract that supports transport-owned outbound frame construction; do not preserve `Write(ByteString)` if it blocks the integrated path
 
-## 5. Frame Parser (Read Path)
+## 5. Integrated Write Path
 
-- [ ] 5.1 Create `FrameParser` that reads length-delimited frames from `ReadOnlySequence<byte>` (from `PipeReader`)
-- [ ] 5.2 Handle partial frames: return consumed/examined positions for `PipeReader.AdvanceTo()`
-- [ ] 5.3 Maximum frame size enforcement: reject frames exceeding `maximum-frame-size`, close connection
-- [ ] 5.4 Parse complete frame: read 4-byte length → slice payload → `BinaryPduCodec.ReadPdu()` → dispatch
-- [ ] 5.5 Unit tests: complete frames, partial frames, oversized frames, multiple frames in one read
+- [ ] 5.1 Modify `EndpointWriter` (or create new equivalent) so the outbound loop operates on send-shaped work, not prebuilt payload bytes
+- [ ] 5.2 Write path: rent buffer → reserve outer frame bytes → write protocol metadata → serialize payload directly into the same writer → backfill lengths → flush to transport
+- [ ] 5.3 Buffer lifecycle: return pooled array to `ArrayPool` after the transport write completes
+- [ ] 5.4 Keep read-side copy semantics intact; do not introduce pooled inbound buffers into actor-visible lifetime
 
-## 6. Configuration
+## 6. Frame Parser (Read Path)
 
-- [ ] 6.1 Create `StreamsTcpTransportSettings` that parses all `akka.remote.dot-netty.tcp.*` HOCON keys
-- [ ] 6.2 Map: `hostname`, `port`, `public-hostname`, `public-port`, `send-buffer-size`, `receive-buffer-size`, `maximum-frame-size`, `backlog`, `tcp-nodelay`, `tcp-keepalive`, `tcp-reuse-addr`, `connection-timeout`
-- [ ] 6.3 Map TLS settings: `enable-ssl` + `ssl.*` → `TlsSettings` (Spec 2)
-- [ ] 6.4 Update `reference.conf`: change default transport class to `StreamsTcpTransport`
-- [ ] 6.5 Preserve `batching.*` settings for Spec 5 (flush batching optimization)
+- [ ] 6.1 Create `FrameParser` that reads length-delimited frames from `ReadOnlySequence<byte>` (from `PipeReader`)
+- [ ] 6.2 Handle partial frames: return consumed/examined positions for `PipeReader.AdvanceTo()`
+- [ ] 6.3 Maximum frame size enforcement: reject frames exceeding `maximum-frame-size`, close connection
+- [ ] 6.4 Parse complete frame while bytes are live, then copy before data crosses actor-visible lifetime boundaries
+- [ ] 6.5 Unit tests: complete frames, partial frames, oversized frames, multiple frames in one read
 
-## 7. Remove DotNetty
+## 7. Configuration
 
-- [ ] 7.1 Delete `src/core/Akka.Remote/Transport/DotNetty/` directory
-- [ ] 7.2 Remove DotNetty NuGet packages from `Akka.Remote.csproj` (`DotNetty.Transport`, `DotNetty.Codecs`, `DotNetty.Handlers`, `DotNetty.Common`, `DotNetty.Buffers`)
-- [ ] 7.3 Add `Akka.Streams` project reference to `Akka.Remote.csproj`
-- [ ] 7.4 Remove `DotNettyTransportSettings`, `DotNettySslSetup`, and all DotNetty-specific types
-- [ ] 7.5 Fix all compilation errors from DotNetty removal
+- [ ] 7.1 Create `StreamsTcpTransportSettings` that parses all `akka.remote.dot-netty.tcp.*` HOCON keys
+- [ ] 7.2 Map: `hostname`, `port`, `public-hostname`, `public-port`, `send-buffer-size`, `receive-buffer-size`, `maximum-frame-size`, `backlog`, `tcp-nodelay`, `tcp-keepalive`, `tcp-reuse-addr`, `connection-timeout`
+- [ ] 7.3 Map TLS settings: `enable-ssl` + `ssl.*` → `TlsSettings` (Spec 2)
+- [ ] 7.4 Update `reference.conf`: change default transport class to `StreamsTcpTransport`
+- [ ] 7.5 Preserve `batching.*` settings for Spec 5 (flush batching optimization)
 
-## 8. Testing
+## 8. Remove DotNetty
 
-- [ ] 8.1 Verify all existing Akka.Remote specs pass (except DotNetty-specific ones)
-- [ ] 8.2 Test: two ActorSystems communicate via `StreamsTcpTransport` (basic remoting)
-- [ ] 8.3 Test: TLS remoting via `StreamsTcpTransport` + `TlsStreamProvider`
-- [ ] 8.4 Test: association handshake, heartbeat, disassociation (AkkaProtocolTransport layer)
-- [ ] 8.5 Test: large message handling (near maximum-frame-size)
-- [ ] 8.6 Test: oversized frame rejection
-- [ ] 8.7 Test: connection failure and recovery
-- [ ] 8.8 Test: cluster formation with multiple nodes using new transport
-- [ ] 8.9 Remove DotNetty-specific test files
-- [ ] 8.10 Run full test suite: `dotnet test -c Release`
+- [ ] 8.1 Delete `src/core/Akka.Remote/Transport/DotNetty/` directory
+- [ ] 8.2 Remove DotNetty NuGet packages from `Akka.Remote.csproj` (`DotNetty.Transport`, `DotNetty.Codecs`, `DotNetty.Handlers`, `DotNetty.Common`, `DotNetty.Buffers`)
+- [ ] 8.3 Add `Akka.Streams` project reference to `Akka.Remote.csproj`
+- [ ] 8.4 Remove `DotNettyTransportSettings`, `DotNettySslSetup`, and all DotNetty-specific types
+- [ ] 8.5 Fix all compilation errors from DotNetty removal
+
+## 9. Testing
+
+- [ ] 9.1 Verify all existing Akka.Remote specs pass (except DotNetty-specific ones)
+- [ ] 9.2 Test: two ActorSystems communicate via `StreamsTcpTransport` (basic remoting)
+- [ ] 9.3 Test: TLS remoting via `StreamsTcpTransport` + `TlsStreamProvider`
+- [ ] 9.4 Test: association handshake, heartbeat, disassociation (AkkaProtocolTransport layer)
+- [ ] 9.5 Test: large message handling (near maximum-frame-size)
+- [ ] 9.6 Test: oversized frame rejection
+- [ ] 9.7 Test: connection failure and recovery
+- [ ] 9.8 Test: cluster formation with multiple nodes using new transport
+- [ ] 9.9 Remove DotNetty-specific test files
+- [ ] 9.10 Run full test suite: `dotnet test -c Release`

--- a/openspec/changes/transport-performance/design.md
+++ b/openspec/changes/transport-performance/design.md
@@ -6,17 +6,18 @@ The RemotePingPong benchmark is the standard throughput measurement for Akka.NET
 
 **Goals:**
 - Establish DotNetty baseline on current `dev` branch (messages/sec, latency percentiles, allocations)
+- Benchmark the integrated outbound write-loop spike before the full transport rewrite
 - New transport MUST exceed DotNetty throughput
 - Implement flush batching (coalesce multiple writes before `stream.FlushAsync()`)
 - Tune `Pipe` backpressure thresholds for throughput
-- Tune `ArrayPool` / `MemoryPool` buffer sizing
-- Profile and optimize hot paths (allocation-free serialization, dispatch overhead)
+- Tune outbound `ArrayPool` / `MemoryPool` buffer sizing
+- Profile and optimize hot paths (allocation-free outbound serialization, dispatch overhead)
 - Continuous benchmark tracking as optimizations land
 
 **Non-Goals:**
 - QUIC transport benchmarking (future)
-- Benchmarking serialization in isolation (already validated in POC)
-- Micro-benchmarking individual components (focus on end-to-end throughput)
+- Treating serializer micro-benchmarks as sufficient proof without transport integration data
+- Read-side pooled buffer experimentation across actor boundaries
 
 ## Decisions
 
@@ -25,6 +26,23 @@ The RemotePingPong benchmark is the standard throughput measurement for Akka.NET
 **Decision:** Use the existing RemotePingPong benchmark as the single most important metric. Measure messages/second, P50/P99 latency, and allocation rate (bytes/op).
 
 **Rationale:** This is the benchmark the community knows and uses. It measures the full pipeline: serialization → framing → transport → network → transport → deframing → deserialization. End-to-end numbers are what matter.
+
+### 1A. Outbound write-loop spike as precondition benchmark
+
+**Decision:** Before the full transport rewrite lands, add a bounded benchmark that compares today's split outbound write path against an integrated transport-owned writer loop using send-shaped work items.
+
+**Rationale:** This isolates the architectural question exposed by PR #8203: is collapsing serialization and framing into one outbound loop worth the transport contract break? That should be answered before the full transport replacement takes on more moving parts.
+
+**Status:** Completed with a benchmark-only spike in `src/benchmark/Akka.Benchmarks/Remoting/IntegratedOutboundWriteLoopBenchmarks.cs`.
+
+**Current directional result:** A short BenchmarkDotNet run on .NET 10.0.7 (`--job short --warmupCount 3 --iterationCount 5`) showed the integrated loop outperforming the current split path for every tested payload shape while reducing managed allocation to `0 B` in all integrated cases. Means from that run were:
+- `StringShort`: `31.146 us`, `1904 B` -> `4.971 us`, `0 B`
+- `StringMedium`: `17.695 us`, `3408 B` -> `6.103 us`, `0 B`
+- `StringLong`: `25.512 us`, `26448 B` -> `4.972 us`, `0 B`
+- `BytesSmall`: `27.454 us`, `1672 B` -> `3.392 us`, `0 B`
+- `BytesLarge`: `36.459 us`, `83528 B` -> `6.577 us`, `0 B`
+
+**Caveat:** These results are directional only. The run used a small sample count, BenchmarkDotNet flagged short iteration times, and some cases had wide confidence intervals and outlier removal. Treat this as evidence that the integrated outbound loop is worth pursuing, not as publication-quality benchmark data.
 
 ### 2. Flush batching in write task
 
@@ -51,3 +69,5 @@ The RemotePingPong benchmark is the standard throughput measurement for Akka.NET
 **[Benchmark results are hardware-dependent]** → Run all comparisons on the same machine in the same session. Document hardware specs. Focus on relative improvement (%) rather than absolute numbers.
 
 **[Regression after optimization]** → Each optimization is a separate commit with before/after numbers. Revert if an optimization regresses other metrics.
+
+**[Spike and final transport may differ]** → The spike intentionally keeps scope narrow. Success means the architecture is promising, not that every remaining transport concern is solved. The spike should therefore be used as a gate, not as a substitute for final end-to-end benchmarks.

--- a/openspec/changes/transport-performance/design.md
+++ b/openspec/changes/transport-performance/design.md
@@ -44,6 +44,12 @@ The RemotePingPong benchmark is the standard throughput measurement for Akka.NET
 
 **Caveat:** These results are directional only. The run used a small sample count, BenchmarkDotNet flagged short iteration times, and some cases had wide confidence intervals and outlier removal. Treat this as evidence that the integrated outbound loop is worth pursuing, not as publication-quality benchmark data.
 
+### 1B. First end-to-end comparison stays on the current wire format
+
+**Decision:** The first full RemotePingPong comparison should use the redesigned transport and outbound path while preserving the current remoting wire format. Source-compatible C# API shims should not be added to the hot path before this comparison.
+
+**Rationale:** This isolates whether the new regime is actually better. If the wire-compatible redesign does not beat the baseline in its cleanest form, extra compatibility work is unlikely to improve that outcome.
+
 ### 2. Flush batching in write task
 
 **Decision:** The write-to-stream background task SHALL coalesce pending writes before calling `stream.FlushAsync()`. Instead of flushing after every `WriteAsync`, batch writes within a configurable window (e.g., flush after N writes or after a micro-delay if no more writes are pending).

--- a/openspec/changes/transport-performance/proposal.md
+++ b/openspec/changes/transport-performance/proposal.md
@@ -5,9 +5,11 @@ The Akka.NET 1.6 transport and serialization overhaul (Specs 1-4) replaces DotNe
 ## What Changes
 
 - Establish DotNetty baseline using RemotePingPong benchmark on current `dev` branch
-- Run identical benchmark on the new Akka.Streams transport (after Specs 1-4)
+- Add a bounded outbound-write-loop spike benchmark before the full transport rewrite lands
+- Use the spike results as a gate for whether the transport write contract should change before the full transport rewrite proceeds
+- Run identical end-to-end benchmark on the new Akka.Streams transport after the transport contract changes are implemented
 - New transport MUST exceed DotNetty throughput (messages/second)
-- Identify and implement optimizations: flush batching, write coalescing, Pipe tuning, buffer pool sizing, dispatch improvements
+- Identify and implement optimizations: flush batching, write coalescing, Pipe tuning, outbound buffer pool sizing, dispatch improvements
 - Continuous benchmarking as optimizations land
 
 ## Capabilities
@@ -20,7 +22,7 @@ The Akka.NET 1.6 transport and serialization overhaul (Specs 1-4) replaces DotNe
 
 ## Impact
 
-- **Benchmarks** (`src/benchmark/`): RemotePingPong benchmark with configurable transport selection
+- **Benchmarks** (`src/benchmark/`): RemotePingPong benchmark with configurable transport selection, plus a bounded spike benchmark for the integrated outbound write path
 - **Akka.Remote**: Flush batching, write coalescing, Pipe threshold tuning in `StreamsTcpTransport`
 - **Akka.IO**: Buffer pool sizing, Pipe `pauseWriterThreshold` / `resumeWriterThreshold` tuning
 - **FrameBufferWriter**: `ArrayPool` sizing, growth strategy optimization

--- a/openspec/changes/transport-performance/proposal.md
+++ b/openspec/changes/transport-performance/proposal.md
@@ -7,7 +7,7 @@ The Akka.NET 1.6 transport and serialization overhaul (Specs 1-4) replaces DotNe
 - Establish DotNetty baseline using RemotePingPong benchmark on current `dev` branch
 - Add a bounded outbound-write-loop spike benchmark before the full transport rewrite lands
 - Use the spike results as a gate for whether the transport write contract should change before the full transport rewrite proceeds
-- Run identical end-to-end benchmark on the new Akka.Streams transport after the transport contract changes are implemented
+- Run the first end-to-end benchmark on the wire-compatible Akka.Streams redesign before adding compatibility shims or alternate wire formats
 - New transport MUST exceed DotNetty throughput (messages/second)
 - Identify and implement optimizations: flush batching, write coalescing, Pipe tuning, outbound buffer pool sizing, dispatch improvements
 - Continuous benchmarking as optimizations land

--- a/openspec/changes/transport-performance/specs/transport-benchmarks/spec.md
+++ b/openspec/changes/transport-performance/specs/transport-benchmarks/spec.md
@@ -7,6 +7,17 @@ A DotNetty performance baseline SHALL be captured using the RemotePingPong bench
 - **WHEN** the RemotePingPong benchmark is run against the current DotNetty transport on reference hardware
 - **THEN** the results SHALL be recorded with hardware specs, .NET version, OS, and benchmark configuration
 
+### Requirement: Integrated outbound write-loop spike benchmarked first
+Before the full transport rewrite is completed, the system SHALL benchmark an integrated outbound write-loop spike against today's split remoting write path.
+
+#### Scenario: Spike compares split vs integrated outbound paths
+- **WHEN** the bounded spike benchmark is run
+- **THEN** it SHALL compare the current remoting write path to a transport-owned writer loop that operates on send-shaped work items and builds the outbound frame in one pass
+
+#### Scenario: Spike informs transport contract change
+- **WHEN** the spike results are reviewed
+- **THEN** they SHALL be used to decide whether the transport write contract should change to support the integrated outbound loop
+
 ### Requirement: New transport exceeds DotNetty throughput
 The Akka.Streams-based transport with SerializerV2 SHALL achieve higher messages/second than the DotNetty baseline on the RemotePingPong benchmark.
 

--- a/openspec/changes/transport-performance/specs/transport-benchmarks/spec.md
+++ b/openspec/changes/transport-performance/specs/transport-benchmarks/spec.md
@@ -18,6 +18,13 @@ Before the full transport rewrite is completed, the system SHALL benchmark an in
 - **WHEN** the spike results are reviewed
 - **THEN** they SHALL be used to decide whether the transport write contract should change to support the integrated outbound loop
 
+### Requirement: First end-to-end comparison uses wire-compatible redesign
+The first full transport comparison SHALL benchmark the redesigned outbound regime on the current remoting wire format before compatibility wrappers or alternate wire formats are considered.
+
+#### Scenario: Performance-first end-to-end comparison
+- **WHEN** the new transport is first compared to DotNetty
+- **THEN** the measured implementation SHALL use the redesigned outbound path, preserve the current wire format, and avoid hot-path compatibility shims
+
 ### Requirement: New transport exceeds DotNetty throughput
 The Akka.Streams-based transport with SerializerV2 SHALL achieve higher messages/second than the DotNetty baseline on the RemotePingPong benchmark.
 

--- a/openspec/changes/transport-performance/tasks.md
+++ b/openspec/changes/transport-performance/tasks.md
@@ -14,7 +14,7 @@
 
 ## 2. Initial Comparison
 
-- [ ] 2.1 Run RemotePingPong benchmark against new transport (after Specs 1-4 integrated)
+- [ ] 2.1 Run RemotePingPong benchmark against the first wire-compatible redesigned transport (after Specs 1-4 integrated and before compatibility follow-up work)
 - [ ] 2.2 Compare messages/second, latency, and allocation rate vs DotNetty baseline
 - [ ] 2.3 Profile with dotnet-trace or JetBrains profiler to identify hot spots
 - [ ] 2.4 Document initial comparison results

--- a/openspec/changes/transport-performance/tasks.md
+++ b/openspec/changes/transport-performance/tasks.md
@@ -5,6 +5,13 @@
 - [ ] 1.3 Document hardware specs, .NET version, OS, benchmark configuration
 - [ ] 1.4 Commit baseline results to repo for future comparison
 
+## 1A. Outbound write-loop spike
+
+- [x] 1A.1 Add a bounded benchmark that compares the current split outbound remoting write path to an integrated transport-owned writer loop
+- [x] 1A.2 Use send-shaped work items in the spike rather than prebuilt payload bytes
+- [x] 1A.3 Measure throughput / time and allocations for common payload shapes (`string`, `byte[]`, small and large payloads)
+- [x] 1A.4 Record whether the integrated loop justifies changing the transport write contract before full implementation begins
+
 ## 2. Initial Comparison
 
 - [ ] 2.1 Run RemotePingPong benchmark against new transport (after Specs 1-4 integrated)

--- a/src/benchmark/Akka.Benchmarks/Remoting/IntegratedOutboundWriteLoopBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Remoting/IntegratedOutboundWriteLoopBenchmarks.cs
@@ -1,0 +1,424 @@
+//-----------------------------------------------------------------------
+// <copyright file="IntegratedOutboundWriteLoopBenchmarks.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Buffers;
+using System.Text;
+using Akka.Actor;
+using Akka.Benchmarks.Configurations;
+using Akka.Configuration;
+using Akka.Remote;
+using Akka.Remote.Serialization;
+using Akka.Remote.Serialization.Proto.Msg;
+using Akka.Remote.Transport;
+using Akka.Serialization;
+using Akka.Util;
+using BenchmarkDotNet.Attributes;
+using Google.Protobuf;
+
+namespace Akka.Benchmarks.Remoting;
+
+[Config(typeof(MicroBenchmarkConfig))]
+public class IntegratedOutboundWriteLoopBenchmarks
+{
+    public enum PayloadKind
+    {
+        StringShort,
+        StringMedium,
+        StringLong,
+        BytesSmall,
+        BytesLarge
+    }
+
+    [Params(
+        PayloadKind.StringShort,
+        PayloadKind.StringMedium,
+        PayloadKind.StringLong,
+        PayloadKind.BytesSmall,
+        PayloadKind.BytesLarge)]
+    public PayloadKind Payload { get; set; }
+
+    private const string BenchmarkConfig = @"
+akka.actor.provider = remote
+akka.log-dead-letters = off
+akka.remote.dot-netty.tcp.port = 0
+akka.remote.dot-netty.tcp.hostname = 127.0.0.1
+akka.remote.dot-netty.tcp.public-hostname = 127.0.0.1
+akka.actor.serialization-settings.allow-unregistered-types = on";
+
+    private ActorSystem _system = null!;
+    private ExtendedActorSystem _extendedSystem = null!;
+    private AkkaPduProtobuffCodec _codec = null!;
+    private Information _transportInfo = null!;
+    private RemoteActorRef _recipient = null!;
+    private IActorRef _sender = null!;
+    private EndpointManager.Send _send = null!;
+    private BenchmarkSend _benchmarkSend;
+    private byte[] _recipientActorRefBytes = null!;
+    private byte[] _senderActorRefBytes = null!;
+    private PooledFrameWriter _writer = null!;
+    private Serializer _serializer = null!;
+    private string? _manifest;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _system = ActorSystem.Create("integrated-outbound-bench", ConfigurationFactory.ParseString(BenchmarkConfig));
+        _extendedSystem = (ExtendedActorSystem)_system;
+        _codec = new AkkaPduProtobuffCodec(_system);
+        _transportInfo = _extendedSystem.Provider.SerializationInformation;
+
+        var root = new RootActorPath(_extendedSystem.Provider.DefaultAddress) / "user" / "bench-recipient";
+        _recipient = new RemoteActorRef(RARP.For(_extendedSystem).Provider.Transport, _extendedSystem.Provider.DefaultAddress, root,
+            ActorRefs.Nobody, Props.None, Deploy.None);
+        _sender = _system.DeadLetters;
+
+        var payload = CreatePayload(Payload);
+        _send = new EndpointManager.Send(payload, _recipient, _sender, new SeqNo(1));
+        _benchmarkSend = new BenchmarkSend(payload, _recipient, _sender, new SeqNo(1));
+
+        _recipientActorRefBytes = new ActorRefData { Path = _recipient.Path.ToSerializationFormat() }.ToByteArray();
+        _senderActorRefBytes = new ActorRefData { Path = _sender.Path.ToSerializationFormatWithAddress(_extendedSystem.Provider.DefaultAddress) }.ToByteArray();
+        _writer = new PooledFrameWriter(1024);
+
+        _serializer = _extendedSystem.Serialization.FindSerializerFor(payload);
+        _manifest = _serializer switch
+        {
+            SerializerWithStringManifest withStringManifest => withStringManifest.Manifest(payload),
+            _ when _serializer.IncludeManifest => payload.GetType().TypeQualifiedName(),
+            _ => null
+        };
+
+        VerifyWireCompatibility();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _writer.Dispose();
+        _system.Terminate().Wait(TimeSpan.FromSeconds(5));
+    }
+
+    [IterationSetup]
+    public void ResetWriter()
+    {
+        _writer.Reset();
+    }
+
+    [Benchmark(Baseline = true, Description = "Current: split MessageSerializer + AkkaPduCodec + transport frame")]
+    public int CurrentSplitOutboundPath()
+    {
+        var current = BuildCurrentFrame();
+        return current.Length;
+    }
+
+    [Benchmark(Description = "Spike: integrated outbound writer loop on send-shaped work")]
+    public int IntegratedOutboundWriterLoop()
+    {
+        return BuildIntegratedFrame();
+    }
+
+    private static object CreatePayload(PayloadKind kind)
+    {
+        return kind switch
+        {
+            PayloadKind.StringShort => "hello",
+            PayloadKind.StringMedium => new string('m', 256),
+            PayloadKind.StringLong => new string('l', 4096),
+            PayloadKind.BytesSmall => CreateBytes(16),
+            PayloadKind.BytesLarge => CreateBytes(16 * 1024),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+        };
+    }
+
+    private static byte[] CreateBytes(int length)
+    {
+        var bytes = new byte[length];
+        for (var i = 0; i < bytes.Length; i++)
+            bytes[i] = (byte)i;
+        return bytes;
+    }
+
+    private byte[] BuildCurrentFrame()
+    {
+        var serialized = MessageSerializer.Serialize(_extendedSystem, _transportInfo, _send.Message);
+        var message = _codec.ConstructMessage(_send.Recipient.LocalAddressToUse, _send.Recipient, serialized,
+            _send.SenderOption, _send.Seq, ackOption: null);
+        var protocolPayload = _codec.ConstructPayload(message).ToByteArray();
+
+        var frame = new byte[sizeof(int) + protocolPayload.Length];
+        BitConverter.TryWriteBytes(frame.AsSpan(0, sizeof(int)), protocolPayload.Length);
+        protocolPayload.CopyTo(frame.AsSpan(sizeof(int)));
+        return frame;
+    }
+
+    private int BuildIntegratedFrame()
+    {
+        _writer.Reset();
+        _writer.Advance(sizeof(int));
+
+        var protocolStart = _writer.WrittenCount;
+        IntegratedProtobufWire.WriteTag(_writer, 1, IntegratedProtobufWire.WireTypeLengthDelimited);
+        var protocolPayloadLengthOffset = _writer.ReserveFixedWidthLength();
+        var protocolPayloadStart = _writer.WrittenCount;
+
+        IntegratedProtobufWire.WriteTag(_writer, 2, IntegratedProtobufWire.WireTypeLengthDelimited);
+        var envelopeLengthOffset = _writer.ReserveFixedWidthLength();
+        var envelopeStart = _writer.WrittenCount;
+
+        IntegratedProtobufWire.WriteTag(_writer, 1, IntegratedProtobufWire.WireTypeLengthDelimited);
+        IntegratedProtobufWire.WriteLengthPrefixedBytes(_writer, _recipientActorRefBytes);
+
+        IntegratedProtobufWire.WriteTag(_writer, 2, IntegratedProtobufWire.WireTypeLengthDelimited);
+        var payloadLengthOffset = _writer.ReserveFixedWidthLength();
+        var payloadStart = _writer.WrittenCount;
+
+        IntegratedProtobufWire.WriteTag(_writer, 1, IntegratedProtobufWire.WireTypeLengthDelimited);
+        var messageLengthOffset = _writer.ReserveFixedWidthLength();
+        var payloadLength = WritePayloadDirect(_benchmarkSend.Message);
+        _writer.PatchFixedWidthLength(messageLengthOffset, payloadLength);
+
+        IntegratedProtobufWire.WriteTag(_writer, 2, IntegratedProtobufWire.WireTypeVarint);
+        IntegratedProtobufWire.WriteVarint32(_writer, (uint)_serializer.Identifier);
+
+        if (!string.IsNullOrEmpty(_manifest))
+        {
+            IntegratedProtobufWire.WriteTag(_writer, 3, IntegratedProtobufWire.WireTypeLengthDelimited);
+            IntegratedProtobufWire.WriteString(_writer, _manifest);
+        }
+
+        _writer.PatchFixedWidthLength(payloadLengthOffset, _writer.WrittenCount - payloadStart);
+
+        IntegratedProtobufWire.WriteTag(_writer, 4, IntegratedProtobufWire.WireTypeLengthDelimited);
+        IntegratedProtobufWire.WriteLengthPrefixedBytes(_writer, _senderActorRefBytes);
+
+        IntegratedProtobufWire.WriteTag(_writer, 5, IntegratedProtobufWire.WireTypeFixed64);
+        IntegratedProtobufWire.WriteFixed64(_writer, (ulong)_benchmarkSend.Seq.RawValue);
+
+        _writer.PatchFixedWidthLength(envelopeLengthOffset, _writer.WrittenCount - envelopeStart);
+        _writer.PatchFixedWidthLength(protocolPayloadLengthOffset, _writer.WrittenCount - protocolPayloadStart);
+
+        _writer.PatchFrameLengthLittleEndian(_writer.WrittenCount - protocolStart);
+        return _writer.WrittenCount;
+    }
+
+    private int WritePayloadDirect(object payload)
+    {
+        switch (payload)
+        {
+            case string value:
+            {
+                var byteCount = Encoding.UTF8.GetByteCount(value);
+                var span = _writer.GetSpan(byteCount);
+                var written = Encoding.UTF8.GetBytes(value.AsSpan(), span);
+                _writer.Advance(written);
+                return written;
+            }
+            case byte[] bytes:
+                _writer.Write(bytes);
+                return bytes.Length;
+            default:
+            {
+                var serialized = _serializer.ToBinary(payload);
+                _writer.Write(serialized);
+                return serialized.Length;
+            }
+        }
+    }
+
+    private void VerifyWireCompatibility()
+    {
+        var current = BuildCurrentFrame();
+        BuildIntegratedFrame();
+
+        var currentProtocol = AkkaProtocolMessage.Parser.ParseFrom(current.AsSpan(sizeof(int)).ToArray());
+        var integratedProtocol = AkkaProtocolMessage.Parser.ParseFrom(_writer.WrittenSpan.Slice(sizeof(int)).ToArray());
+
+        var currentEnvelope = AckAndEnvelopeContainer.Parser.ParseFrom(currentProtocol.Payload);
+        var integratedEnvelope = AckAndEnvelopeContainer.Parser.ParseFrom(integratedProtocol.Payload);
+
+        if (currentEnvelope.Envelope.Recipient.Path != integratedEnvelope.Envelope.Recipient.Path)
+            throw new InvalidOperationException("Integrated write loop changed the recipient path.");
+
+        if (currentEnvelope.Envelope.Sender.Path != integratedEnvelope.Envelope.Sender.Path)
+            throw new InvalidOperationException("Integrated write loop changed the sender path.");
+
+        if (currentEnvelope.Envelope.Seq != integratedEnvelope.Envelope.Seq)
+            throw new InvalidOperationException("Integrated write loop changed the sequence number.");
+
+        if (currentEnvelope.Envelope.Message.SerializerId != integratedEnvelope.Envelope.Message.SerializerId)
+            throw new InvalidOperationException("Integrated write loop changed the serializer id.");
+
+        if (!currentEnvelope.Envelope.Message.Message.Equals(integratedEnvelope.Envelope.Message.Message))
+            throw new InvalidOperationException("Integrated write loop changed the serialized payload bytes.");
+
+        if (!currentEnvelope.Envelope.Message.MessageManifest.Equals(integratedEnvelope.Envelope.Message.MessageManifest))
+            throw new InvalidOperationException("Integrated write loop changed the payload manifest.");
+    }
+
+    private readonly record struct BenchmarkSend(object Message, RemoteActorRef Recipient, IActorRef SenderOption, SeqNo Seq);
+
+    private sealed class PooledFrameWriter : IBufferWriter<byte>, IDisposable
+    {
+        private byte[] _buffer;
+        private int _written;
+        private bool _disposed;
+
+        public PooledFrameWriter(int initialCapacity)
+        {
+            _buffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
+        }
+
+        public int WrittenCount => _written;
+        public ReadOnlySpan<byte> WrittenSpan => _buffer.AsSpan(0, _written);
+
+        public void Reset()
+        {
+            _written = 0;
+        }
+
+        public void Advance(int count)
+        {
+            _written += count;
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return _buffer.AsMemory(_written);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return _buffer.AsSpan(_written);
+        }
+
+        public int ReserveFixedWidthLength()
+        {
+            var offset = _written;
+            var span = GetSpan(IntegratedProtobufWire.FixedWidthVarintBytes);
+            span[0] = 0x80;
+            span[1] = 0x80;
+            span[2] = 0x80;
+            span[3] = 0x80;
+            span[4] = 0x00;
+            Advance(IntegratedProtobufWire.FixedWidthVarintBytes);
+            return offset;
+        }
+
+        public void PatchFixedWidthLength(int offset, int length)
+        {
+            IntegratedProtobufWire.PatchFixedWidthVarint(_buffer.AsSpan(offset, IntegratedProtobufWire.FixedWidthVarintBytes),
+                (uint)length);
+        }
+
+        public void PatchFrameLengthLittleEndian(int payloadLength)
+        {
+            BitConverter.TryWriteBytes(_buffer.AsSpan(0, sizeof(int)), payloadLength);
+        }
+
+        public void Write(ReadOnlySpan<byte> bytes)
+        {
+            var span = GetSpan(bytes.Length);
+            bytes.CopyTo(span);
+            Advance(bytes.Length);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = Array.Empty<byte>();
+            _disposed = true;
+        }
+
+        private void EnsureCapacity(int sizeHint)
+        {
+            if (sizeHint <= 0)
+                sizeHint = 1;
+
+            var required = _written + sizeHint;
+            if (required <= _buffer.Length)
+                return;
+
+            var newSize = _buffer.Length;
+            while (newSize < required)
+                newSize *= 2;
+
+            var newBuffer = ArrayPool<byte>.Shared.Rent(newSize);
+            Buffer.BlockCopy(_buffer, 0, newBuffer, 0, _written);
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = newBuffer;
+        }
+    }
+
+    private static class IntegratedProtobufWire
+    {
+        public const int FixedWidthVarintBytes = 5;
+        public const byte WireTypeVarint = 0;
+        public const byte WireTypeFixed64 = 1;
+        public const byte WireTypeLengthDelimited = 2;
+
+        public static void WriteTag(IBufferWriter<byte> writer, int fieldNumber, byte wireType)
+        {
+            WriteVarint32(writer, (uint)((fieldNumber << 3) | wireType));
+        }
+
+        public static void WriteVarint32(IBufferWriter<byte> writer, uint value)
+        {
+            var span = writer.GetSpan(FixedWidthVarintBytes);
+            var written = 0;
+
+            while (value >= 0x80)
+            {
+                span[written++] = (byte)(value | 0x80);
+                value >>= 7;
+            }
+
+            span[written++] = (byte)value;
+            writer.Advance(written);
+        }
+
+        public static void PatchFixedWidthVarint(Span<byte> span, uint value)
+        {
+            span[0] = (byte)((value & 0x7F) | 0x80);
+            span[1] = (byte)(((value >> 7) & 0x7F) | 0x80);
+            span[2] = (byte)(((value >> 14) & 0x7F) | 0x80);
+            span[3] = (byte)(((value >> 21) & 0x7F) | 0x80);
+            span[4] = (byte)((value >> 28) & 0x7F);
+        }
+
+        public static void WriteFixed64(IBufferWriter<byte> writer, ulong value)
+        {
+            var span = writer.GetSpan(sizeof(ulong));
+            BitConverter.TryWriteBytes(span, value);
+            writer.Advance(sizeof(ulong));
+        }
+
+        public static void WriteString(IBufferWriter<byte> writer, string value)
+        {
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            WriteVarint32(writer, (uint)byteCount);
+            var span = writer.GetSpan(byteCount);
+            var written = Encoding.UTF8.GetBytes(value.AsSpan(), span);
+            writer.Advance(written);
+        }
+
+        public static void WriteLengthPrefixedBytes(IBufferWriter<byte> writer, ReadOnlySpan<byte> bytes)
+        {
+            WriteVarint32(writer, (uint)bytes.Length);
+            var span = writer.GetSpan(bytes.Length);
+            bytes.CopyTo(span);
+            writer.Advance(bytes.Length);
+        }
+    }
+}

--- a/src/benchmark/RemotePingPong/Program.cs
+++ b/src/benchmark/RemotePingPong/Program.cs
@@ -52,6 +52,7 @@ namespace RemotePingPong
 
               remote {
                 log-remote-lifecycle-events = off
+                enable-direct-outbound-message-path = on
 
                 dot-netty.tcp {
                     port = 0

--- a/src/core/Akka.Remote.Tests/Transport/DirectOutboundMessagePathSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DirectOutboundMessagePathSpec.cs
@@ -1,0 +1,44 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="DirectOutboundMessagePathSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Actor;
+using Akka.Remote.Transport;
+using Akka.TestKit;
+using Google.Protobuf;
+using Xunit;
+using SerializedMessage = Akka.Remote.Serialization.Proto.Msg.Payload;
+
+namespace Akka.Remote.Tests.Transport;
+
+public class DirectOutboundMessagePathSpec : AkkaSpec
+{
+    private readonly AkkaPduProtobuffCodec _codec;
+    private readonly Address _localAddress = new("akka.test", "testsystem", "localhost", 1234);
+
+    public DirectOutboundMessagePathSpec(ITestOutputHelper output)
+        : base("akka.actor.provider = remote", output)
+    {
+        _codec = new AkkaPduProtobuffCodec(Sys);
+    }
+
+    [Fact]
+    public void Direct_message_payload_builder_should_preserve_current_wire_format_without_ack()
+    {
+        var serialized = new SerializedMessage
+        {
+            SerializerId = 17,
+            Message = ByteString.CopyFromUtf8("hello"),
+            MessageManifest = ByteString.CopyFromUtf8("System.String")
+        };
+
+        var current = _codec.ConstructPayload(_codec.ConstructMessage(_localAddress, TestActor, serialized, Sys.DeadLetters));
+        var direct = _codec.ConstructMessagePayload(_localAddress, TestActor, serialized, Sys.DeadLetters);
+
+        Assert.Equal(current, direct);
+    }
+
+}

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -165,6 +165,11 @@ akka {
     # if off then they are not logged
     log-sent-messages = off
 
+    # Spike setting: when enabled, ordinary outbound remoting messages are written
+    # directly into the current wire format instead of flowing through the full
+    # split Serialize -> ConstructMessage -> ConstructPayload path.
+    enable-direct-outbound-message-path = off
+
     # Sets the log granularity level at which Akka logs remoting events. This setting
     # can take the values OFF, ERROR, WARNING, INFO, DEBUG, or ON. For compatibility
     # reasons the setting "on" will default to "debug" level. Please note that the effective

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -1487,11 +1487,20 @@ namespace Akka.Remote
                         send.Recipient, send.Recipient.Path, send.SenderOption ?? _system.DeadLetters);
                 }
 
+                var useDirectOutboundPath = Settings.EnableDirectOutboundMessagePath
+                    && send.Message is not ISystemMessage
+                    && send.Seq is null
+                    && _lastAck is null;
+
                 ByteString pdu;
                 try
                 {
-                    pdu = _codec.ConstructMessage(send.Recipient.LocalAddressToUse, send.Recipient,
-                        SerializeMessage(send.Message), send.SenderOption, send.Seq, _lastAck);
+                    var serializedMessage = SerializeMessage(send.Message);
+                    pdu = useDirectOutboundPath
+                        ? _codec.ConstructMessagePayload(send.Recipient.LocalAddressToUse, send.Recipient,
+                            serializedMessage, send.SenderOption, send.Seq, _lastAck)
+                        : _codec.ConstructMessage(send.Recipient.LocalAddressToUse, send.Recipient,
+                            serializedMessage, send.SenderOption, send.Seq, _lastAck);
                 }
                 catch (Exception e) when (e is not SerializationException)
                 {
@@ -1514,7 +1523,9 @@ namespace Akka.Remote
                 }
                 else
                 {
-                    var ok = _handle.Write(pdu);
+                    var ok = useDirectOutboundPath
+                        ? _handle.WrappedHandle.Write(pdu)
+                        : _handle.Write(pdu);
 
                     if (ok)
                     {

--- a/src/core/Akka.Remote/RemoteSettings.cs
+++ b/src/core/Akka.Remote/RemoteSettings.cs
@@ -31,6 +31,7 @@ namespace Akka.Remote
             Config = config;
             LogReceive = config.GetBoolean("akka.remote.log-received-messages", false);
             LogSend = config.GetBoolean("akka.remote.log-sent-messages", false);
+            EnableDirectOutboundMessagePath = config.GetBoolean("akka.remote.enable-direct-outbound-message-path", false);
 
             // TODO: what is the default value if the key wasn't found?
             var bufferSizeLogKey = "akka.remote.log-buffer-size-exceeding";
@@ -111,6 +112,11 @@ namespace Akka.Remote
         /// TBD
         /// </summary>
         public bool LogReceive { get; set; }
+
+        /// <summary>
+        /// Enables the remoting spike that constructs the current outbound wire format directly for ordinary message sends.
+        /// </summary>
+        public bool EnableDirectOutboundMessagePath { get; set; }
 
         /// <summary>
         /// TBD
@@ -282,4 +288,3 @@ namespace Akka.Remote
         }
     }
 }
-

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Buffers;
 using System.Linq;
 using Akka.Actor;
 using Google.Protobuf;
@@ -299,6 +300,12 @@ namespace Akka.Remote.Transport
         /// <param name="ack">TBD</param>
         /// <returns>TBD</returns>
         public abstract ByteString ConstructPureAck(Ack ack);
+
+        public virtual ByteString ConstructMessagePayload(Address localAddress, IActorRef recipient,
+            SerializedMessage serializedMessage, IActorRef senderOption = null, SeqNo? seqOption = null, Ack ackOption = null)
+        {
+            return ConstructPayload(ConstructMessage(localAddress, recipient, serializedMessage, senderOption, seqOption, ackOption));
+        }
     }
 
     /// <summary>
@@ -498,6 +505,37 @@ namespace Akka.Remote.Transport
             return new AckAndEnvelopeContainer() { Ack = AckBuilder(ack) }.ToByteString();
         }
 
+        public override ByteString ConstructMessagePayload(Address localAddress, IActorRef recipient,
+            SerializedMessage serializedMessage, IActorRef senderOption = null, SeqNo? seqOption = null, Ack ackOption = null)
+        {
+            var ackAndEnvelope = new AckAndEnvelopeContainer();
+            var envelope = new RemoteEnvelope
+            {
+                Recipient = SerializeActorRef(recipient.Path.Address, recipient),
+                Message = serializedMessage,
+                Seq = seqOption is { } seq ? unchecked((ulong)seq.RawValue) : SeqUndefined
+            };
+
+            if (senderOption != null && senderOption.Path != null)
+                envelope.Sender = SerializeActorRef(localAddress, senderOption);
+
+            if (ackOption != null)
+                ackAndEnvelope.Ack = AckBuilder(ackOption);
+
+            ackAndEnvelope.Envelope = envelope;
+
+            var builder = new DirectPayloadPduBuilder(256);
+            try
+            {
+                builder.WriteLengthPrefixedField(1, ackAndEnvelope);
+                return ByteString.CopyFrom(builder.WrittenSpan.ToArray());
+            }
+            finally
+            {
+                builder.Dispose();
+            }
+        }
+
 #region Internal methods
         private IAkkaPdu DecodeControlPdu(AkkaControlMessage controlPdu)
         {
@@ -583,6 +621,107 @@ namespace Akka.Remote.Transport
 
         public AkkaPduProtobuffCodec(ActorSystem system) : base(system)
         {
+        }
+
+        private sealed class DirectPayloadPduBuilder : IBufferWriter<byte>, IDisposable
+        {
+            private const byte WireTypeLengthDelimited = 2;
+
+            private byte[] _buffer;
+            private int _written;
+            private bool _disposed;
+
+            public DirectPayloadPduBuilder(int initialCapacity)
+            {
+                _buffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
+            }
+
+            public ReadOnlySpan<byte> WrittenSpan => _buffer.AsSpan(0, _written);
+
+            public void WriteLengthPrefixedField(int fieldNumber, IMessage message)
+            {
+                WriteTag(fieldNumber, WireTypeLengthDelimited);
+                WriteVarint32((uint)message.CalculateSize());
+                message.WriteTo(this);
+            }
+
+            public void Advance(int count)
+            {
+                _written += count;
+            }
+
+            public Memory<byte> GetMemory(int sizeHint = 0)
+            {
+                EnsureCapacity(sizeHint);
+                return _buffer.AsMemory(_written);
+            }
+
+            public Span<byte> GetSpan(int sizeHint = 0)
+            {
+                EnsureCapacity(sizeHint);
+                return _buffer.AsSpan(_written);
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                    return;
+
+                ArrayPool<byte>.Shared.Return(_buffer);
+                _buffer = Array.Empty<byte>();
+                _disposed = true;
+            }
+
+            private void EnsureCapacity(int sizeHint)
+            {
+                if (sizeHint <= 0)
+                    sizeHint = 1;
+
+                var required = _written + sizeHint;
+                if (required <= _buffer.Length)
+                    return;
+
+                var newSize = _buffer.Length;
+                while (newSize < required)
+                    newSize *= 2;
+
+                var newBuffer = ArrayPool<byte>.Shared.Rent(newSize);
+                Buffer.BlockCopy(_buffer, 0, newBuffer, 0, _written);
+                ArrayPool<byte>.Shared.Return(_buffer);
+                _buffer = newBuffer;
+            }
+
+            private void WriteTag(int fieldNumber, byte wireType)
+            {
+                WriteVarint32((uint)((fieldNumber << 3) | wireType));
+            }
+
+            private void WriteVarint32(uint value)
+            {
+                var span = GetSpan(VarintSize(value));
+                var written = 0;
+
+                while (value >= 0x80)
+                {
+                    span[written++] = (byte)(value | 0x80);
+                    value >>= 7;
+                }
+
+                span[written++] = (byte)value;
+                Advance(written);
+            }
+
+            private static int VarintSize(uint value)
+            {
+                var bytes = 1;
+                while (value >= 0x80)
+                {
+                    value >>= 7;
+                    bytes++;
+                }
+
+                return bytes;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- update the OpenSpec sequence to make the remoting redesign performance-first, keep the current wire format in the first production slice, and treat compatibility work as follow-up
- add the integrated outbound write-loop benchmark spike and record the current directional results in the transport-performance change set
- add a default-off direct outbound remoting spike on the current transport stack that bypasses the extra outbound protocol wrap for ordinary user messages and enable it in `RemotePingPong`

## Validation
- `dotnet build src/core/Akka.Remote/Akka.Remote.csproj -c Debug`
- `dotnet build src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj -c Debug`
- `dotnet test src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj -c Debug --no-build --filter "FullyQualifiedName~DirectOutboundMessagePathSpec|FullyQualifiedName~AkkaProtocolSpec"`
- `dotnet test src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj -c Debug --no-build --filter "FullyQualifiedName~RemotingSpec"`
- `dotnet test src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj -c Debug --no-build`
- `dotnet run --project src/benchmark/RemotePingPong/RemotePingPong.csproj -c Release -- 1`

## Notes
- Draft experiment only. Do not merge.
- This PR does not implement `StreamsTcpTransport` yet.
- The current production spike preserves the wire format and runs on the existing DotNetty transport so we can isolate the outbound-path change.
- The `RemotePingPong` experiment reached roughly `691k msgs/sec`, above the previously recorded `~680k msgs/sec` baseline.