### PR TITLE
Pipe Transport Yolo for Reference

### DIFF
--- a/src/benchmark/RemotePingPong/Program.cs
+++ b/src/benchmark/RemotePingPong/Program.cs
@@ -41,31 +41,96 @@ namespace RemotePingPong
 #endif
         }
 
-        public static Config CreateActorSystemConfig(string actorSystemName, string ipOrHostname, int port)
+        /// <summary>
+        /// Selects which Akka.Remote transport driver + PDU codec to use for the benchmark run.
+        /// </summary>
+        internal enum TransportMode
         {
+            /// <summary>Legacy DotNetty TCP transport with protobuf codec (the historical baseline).</summary>
+            DotNetty,
+
+            /// <summary>System.IO.Pipelines TCP transport with protobuf codec (wire-compatible).</summary>
+            PipeProtobuf,
+
+            /// <summary>System.IO.Pipelines TCP transport with MessagePack codec (fastest, cluster-wide opt-in).</summary>
+            PipeMsgPack,
+        }
+
+        /// <summary>
+        /// Parses a transport mode string from the command line.
+        /// Valid values (case-insensitive): "dotnetty", "pipe", "pipe-protobuf", "pipe-msgpack", "messagepack".
+        /// Defaults to <see cref="TransportMode.DotNetty"/> when the string is empty / unrecognised.
+        /// </summary>
+        private static TransportMode ParseTransportMode(string? arg)
+        {
+            return (arg ?? "").ToLowerInvariant() switch
+            {
+                "pipe" or "pipe-protobuf" or "pipelines" => TransportMode.PipeProtobuf,
+                "pipe-msgpack" or "messagepack" or "msgpack" => TransportMode.PipeMsgPack,
+                _ => TransportMode.DotNetty,
+            };
+        }
+
+        private static string TransportLabel(TransportMode mode) => mode switch
+        {
+            TransportMode.PipeProtobuf => "Pipe/TCP + Protobuf",
+            TransportMode.PipeMsgPack  => "Pipe/TCP + MessagePack",
+            _                          => "DotNetty/TCP + Protobuf",
+        };
+
+        public static Config CreateActorSystemConfig(
+            string actorSystemName,
+            string ipOrHostname,
+            int port,
+            TransportMode mode = TransportMode.DotNetty)
+        {
+            // ── Base config shared by all modes ──────────────────────────────
             var baseConfig = ConfigurationFactory.ParseString(@"
             akka {
               actor.provider = remote
               loglevel = ERROR
               suppress-json-serializer-warning = on
               log-dead-letters = off
-
               remote {
                 log-remote-lifecycle-events = off
-
-                dot-netty.tcp {
-                    port = 0
-                    hostname = ""localhost""
-                }
-                
               }
             }");
 
-            var bindingConfig =
-                ConfigurationFactory.ParseString(@"akka.remote.dot-netty.tcp.hostname = """ + ipOrHostname + @"""")
-                    .WithFallback(ConfigurationFactory.ParseString(@"akka.remote.dot-netty.tcp.port = " + port));
+            // ── Transport-specific overrides ─────────────────────────────────
+            Config transportConfig = mode switch
+            {
+                TransportMode.PipeProtobuf => ConfigurationFactory.ParseString($@"
+                    akka.remote {{
+                        enabled-transports = [""akka.remote.pipe.tcp""]
+                        pipe.tcp {{
+                            hostname = ""{ipOrHostname}""
+                            port     = {port}
+                            envelope = protobuf
+                        }}
+                    }}"),
 
-            return bindingConfig.WithFallback(baseConfig);
+                TransportMode.PipeMsgPack => ConfigurationFactory.ParseString($@"
+                    akka.remote {{
+                        enabled-transports = [""akka.remote.pipe.tcp""]
+                        pipe.tcp {{
+                            hostname = ""{ipOrHostname}""
+                            port     = {port}
+                            envelope = messagepack
+                        }}
+                    }}"),
+
+                // Default: DotNetty
+                _ => ConfigurationFactory.ParseString($@"
+                    akka.remote {{
+                        enabled-transports = [""akka.remote.dot-netty.tcp""]
+                        dot-netty.tcp {{
+                            hostname = ""{ipOrHostname}""
+                            port     = {port}
+                        }}
+                    }}"),
+            };
+
+            return transportConfig.WithFallback(baseConfig);
         }
 
         private static async Task Main(params string[] args)
@@ -76,19 +141,32 @@ namespace RemotePingPong
             }
             catch (Exception ex)
             {
-                await Console.Error.WriteLineAsync($"Attempted to elevate process priority, but failed due to {ex.Message} - carrying on at normal process priority.");
-            }
-            if (args.Length == 0 || !uint.TryParse(args[0], out var timesToRun))
-            {
-                timesToRun = 1u;
+                await Console.Error.WriteLineAsync(
+                    $"Attempted to elevate process priority, but failed due to {ex.Message} - carrying on at normal process priority.");
             }
 
-            await Start(timesToRun);
+            // ── Parse args ────────────────────────────────────────────────────
+            // Usage: RemotePingPong [timesToRun] [transport]
+            // transport: dotnetty | pipe | pipe-msgpack
+            uint timesToRun = 1;
+            var  transportMode = TransportMode.DotNetty;
+
+            if (args.Length >= 1 && !uint.TryParse(args[0], out timesToRun))
+                timesToRun = 1;
+            if (args.Length >= 2)
+                transportMode = ParseTransportMode(args[1]);
+
+            Console.ForegroundColor = ConsoleColor.Cyan;
+            Console.WriteLine($"Transport mode: {TransportLabel(transportMode)}");
+            Console.ResetColor();
+
+            await Start(timesToRun, transportMode);
         }
 
         private static bool _firstRun = true;
 
-        private static void PrintSysInfo(){
+        private static void PrintSysInfo(TransportMode mode)
+        {
             var processorCount = Environment.ProcessorCount;
             if (processorCount == 0)
             {
@@ -97,16 +175,15 @@ namespace RemotePingPong
                 return;
             }
 
+            Console.WriteLine("Transport:                         {0}", TransportLabel(mode));
             Console.WriteLine("OSVersion:                         {0}", Environment.OSVersion);
             Console.WriteLine("ProcessorCount:                    {0}", processorCount);
             Console.WriteLine("ClockSpeed:                        {0} MHZ", CpuSpeed());
             Console.WriteLine("Actor Count:                       {0}", processorCount * 2);
-            Console.WriteLine("Messages sent/received per client: {0}  ({0:0e0})", repeat*2);
+            Console.WriteLine("Messages sent/received per client: {0}  ({0:0e0})", repeat * 2);
             Console.WriteLine("Is Server GC:                      {0}", GCSettings.IsServerGC);
             Console.WriteLine("Thread count:                      {0}", Process.GetCurrentProcess().Threads.Count);
             Console.WriteLine();
-
-            //Print tables
             Console.WriteLine("Num clients, Total [msg], Msgs/sec, Total [ms], Start Threads, End Threads");
 
             _firstRun = false;
@@ -114,15 +191,15 @@ namespace RemotePingPong
 
         const long repeat = 100000L;
 
-        private static async Task Start(uint timesToRun)
-        {         
+        private static async Task Start(uint timesToRun, TransportMode mode)
+        {
             for (var i = 0; i < timesToRun; i++)
             {
                 var redCount = 0;
                 var bestThroughput = 0L;
                 foreach (var throughput in GetClientSettings())
                 {
-                    var result1 = await Benchmark(throughput, repeat, bestThroughput, redCount);
+                    var result1 = await Benchmark(throughput, repeat, bestThroughput, redCount, mode);
                     bestThroughput = result1.Item2;
                     redCount = result1.Item3;
                 }
@@ -148,12 +225,16 @@ namespace RemotePingPong
             return numberOfClients * numberOfRepeats * 2;
         }
 
-        private static async Task<(bool, long, int)> Benchmark(int numberOfClients, long numberOfRepeats, long bestThroughput, int redCount)
+        private static async Task<(bool, long, int)> Benchmark(
+            int numberOfClients,
+            long numberOfRepeats,
+            long bestThroughput,
+            int redCount,
+            TransportMode mode)
         {
             var totalMessagesReceived = GetTotalMessagesReceived(numberOfClients, numberOfRepeats);
-            var system1 = ActorSystem.Create("SystemA", CreateActorSystemConfig("SystemA", "127.0.0.1", 0));
-
-            var system2 = ActorSystem.Create("SystemB", CreateActorSystemConfig("SystemB", "127.0.0.1", 0));
+            var system1 = ActorSystem.Create("SystemA", CreateActorSystemConfig("SystemA", "127.0.0.1", 0, mode));
+            var system2 = ActorSystem.Create("SystemB", CreateActorSystemConfig("SystemB", "127.0.0.1", 0, mode));
 
             List<Task<long>> tasks = new List<Task<long>>();
             List<IActorRef> receivers = new List<IActorRef>();
@@ -185,13 +266,13 @@ namespace RemotePingPong
             var testReady = (bool)rsp;
             if (!testReady)
             {
-                throw new Exception("Received report that 1 or more remote actor is unable to begin the test. Aborting run.");
+                throw new Exception(
+                    "Received report that 1 or more remote actor is unable to begin the test. Aborting run.");
             }
 
-            // now that the dispatchers in both ActorSystems are started, we want to measure thread count and other system
-            // metrics here - but only the very first benchmark
-            if(_firstRun){
-                PrintSysInfo();
+            if (_firstRun)
+            {
+                PrintSysInfo(mode);
             }
 
             var startThreads = Process.GetCurrentProcess().Threads.Count;
@@ -199,20 +280,21 @@ namespace RemotePingPong
             var sw = Stopwatch.StartNew();
             receivers.ForEach(c =>
             {
-                for (var i = 0; i < 50; i++) // prime the pump so EndpointWriters can take advantage of their batching model
+                for (var i = 0; i < 50; i++) // prime the pump
                     c.Tell("hit");
             });
-            var waiting = Task.WhenAll(tasks);
-            await Task.WhenAll(waiting);
+            await Task.WhenAll(tasks);
             sw.Stop();
-            
+
             var endThreads = Process.GetCurrentProcess().Threads.Count;
 
-            // force clean termination
             await Task.WhenAll(new[] { system1.Terminate(), system2.Terminate() });
 
             var elapsedMilliseconds = sw.ElapsedMilliseconds;
-            long throughput = elapsedMilliseconds == 0 ? -1 : (long)Math.Ceiling((double)totalMessagesReceived / elapsedMilliseconds * 1000);
+            long throughput = elapsedMilliseconds == 0
+                ? -1
+                : (long)Math.Ceiling((double)totalMessagesReceived / elapsedMilliseconds * 1000);
+
             var foregroundColor = Console.ForegroundColor;
             if (throughput >= bestThroughput)
             {
@@ -227,7 +309,15 @@ namespace RemotePingPong
             }
 
             Console.ForegroundColor = foregroundColor;
-            Console.WriteLine("{0,10},{1,8},{2,10},{3,11}, {4,13}, {5,15}", numberOfClients, totalMessagesReceived, throughput, sw.Elapsed.TotalMilliseconds.ToString("F2", CultureInfo.InvariantCulture), startThreads, endThreads);
+            Console.WriteLine(
+                "{0,10},{1,8},{2,10},{3,11}, {4,13}, {5,15}",
+                numberOfClients,
+                totalMessagesReceived,
+                throughput,
+                sw.Elapsed.TotalMilliseconds.ToString("F2", CultureInfo.InvariantCulture),
+                startThreads,
+                endThreads);
+
             return (redCount <= 3, bestThroughput, redCount);
         }
 

--- a/src/core/Akka.Remote.Tests/Transport/AkkaPduMessagePackCodecSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaPduMessagePackCodecSpec.cs
@@ -1,0 +1,298 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AkkaPduMessagePackCodecSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Remote.Transport;
+using Akka.Remote.Transport.Pipelines;
+using Akka.Remote.Transport.Pipelines.MessagePack;
+using Akka.TestKit;
+using FluentAssertions;
+using Google.Protobuf;
+using Xunit;
+using Xunit.v3;
+using SerializedMessage = Akka.Remote.Serialization.Proto.Msg.Payload;
+
+namespace Akka.Remote.Tests.Transport
+{
+    /// <summary>
+    /// Unit tests for <see cref="AkkaPduMessagePackCodec"/>.
+    ///
+    /// Tests encode/decode round-trips for every PDU type:
+    /// <list type="bullet">
+    ///   <item>Protocol level: Heartbeat, Associate, Disassociate (all three variants), Payload</item>
+    ///   <item>Message level: ConstructMessage round-trip, ConstructPureAck round-trip,
+    ///     ConstructMessage with no seq/ack, ConstructPureAck with nacks</item>
+    ///   <item>Config: PipeTransportSettings.CreateCodec returns the correct codec type</item>
+    /// </list>
+    ///
+    /// <!-- CopilotNotes: Tests use AkkaSpec (inherits TestKit) but only need Sys for the
+    ///      codec constructor (ActorPathThreadLocalCache). No real networking is used here. -->
+    /// </summary>
+    public class AkkaPduMessagePackCodecSpec : AkkaSpec
+    {
+        private static readonly Config BaseConfig = ConfigurationFactory.ParseString(@"
+            akka {
+                actor.provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+                remote.pipe.tcp {
+                    port     = 0
+                    hostname = ""127.0.0.1""
+                }
+            }");
+
+        private readonly AkkaPduMessagePackCodec _codec;
+
+        public AkkaPduMessagePackCodecSpec(ITestOutputHelper output)
+            : base(BaseConfig, output)
+        {
+            _codec = new AkkaPduMessagePackCodec(Sys);
+        }
+
+        // ── Protocol-level: Heartbeat ───────────────────────────────────────────
+
+        [Fact(DisplayName = "MessagePack codec: Heartbeat encodes and decodes to Heartbeat")]
+        public void Heartbeat_Should_RoundTrip()
+        {
+            var bytes = _codec.ConstructHeartbeat();
+            bytes.Should().NotBeNull();
+            bytes.IsEmpty.Should().BeFalse();
+
+            var pdu = _codec.DecodePdu(bytes);
+            pdu.Should().BeOfType<Heartbeat>();
+        }
+
+        // ── Protocol-level: Associate ───────────────────────────────────────────
+
+        [Fact(DisplayName = "MessagePack codec: Associate encodes and decodes preserving origin and uid")]
+        public void Associate_Should_RoundTrip_With_Origin_And_Uid()
+        {
+            var origin  = new Address("akka.tcp", "TestSystem", "127.0.0.1", 7355);
+            var info    = new HandshakeInfo(origin, uid: 42);
+            var bytes   = _codec.ConstructAssociate(info);
+
+            bytes.Should().NotBeNull();
+            bytes.IsEmpty.Should().BeFalse();
+
+            var pdu = _codec.DecodePdu(bytes) as Associate;
+            pdu.Should().NotBeNull();
+            pdu!.Info.Origin.Should().Be(origin);
+            pdu.Info.Uid.Should().Be(42);
+        }
+
+        // ── Protocol-level: Disassociate variants ──────────────────────────────
+
+        [Fact(DisplayName = "MessagePack codec: Disassociate(Unknown) encodes and decodes correctly")]
+        public void Disassociate_Unknown_Should_RoundTrip()
+        {
+            var bytes = _codec.ConstructDisassociate(DisassociateInfo.Unknown);
+            var pdu   = _codec.DecodePdu(bytes) as Disassociate;
+
+            pdu.Should().NotBeNull();
+            pdu!.Reason.Should().Be(DisassociateInfo.Unknown);
+        }
+
+        [Fact(DisplayName = "MessagePack codec: Disassociate(Quarantined) encodes and decodes correctly")]
+        public void Disassociate_Quarantined_Should_RoundTrip()
+        {
+            var bytes = _codec.ConstructDisassociate(DisassociateInfo.Quarantined);
+            var pdu   = _codec.DecodePdu(bytes) as Disassociate;
+
+            pdu.Should().NotBeNull();
+            pdu!.Reason.Should().Be(DisassociateInfo.Quarantined);
+        }
+
+        [Fact(DisplayName = "MessagePack codec: Disassociate(Shutdown) encodes and decodes correctly")]
+        public void Disassociate_Shutdown_Should_RoundTrip()
+        {
+            var bytes = _codec.ConstructDisassociate(DisassociateInfo.Shutdown);
+            var pdu   = _codec.DecodePdu(bytes) as Disassociate;
+
+            pdu.Should().NotBeNull();
+            pdu!.Reason.Should().Be(DisassociateInfo.Shutdown);
+        }
+
+        // ── Protocol-level: Payload wrapper ────────────────────────────────────
+
+        [Fact(DisplayName = "MessagePack codec: ConstructPayload preserves inner bytes through DecodePdu")]
+        public void Payload_Should_RoundTrip_Via_DecodePdu()
+        {
+            var innerBytes = ByteString.CopyFromUtf8("hello-msgpack-world");
+            var bytes      = _codec.ConstructPayload(innerBytes);
+
+            var pdu = _codec.DecodePdu(bytes) as Payload;
+            pdu.Should().NotBeNull();
+            pdu!.Bytes.ToStringUtf8().Should().Be("hello-msgpack-world");
+        }
+
+        // ── Message-level: ConstructMessage round-trip ─────────────────────────
+
+        [Fact(DisplayName = "MessagePack codec: ConstructMessage + DecodeMessage round-trips payload, seq, and ack")]
+        public void ConstructMessage_Should_RoundTrip_Full_Envelope()
+        {
+            // Build a minimal serialized payload (mirrors what EndpointWriter does).
+            var serialized = new SerializedMessage
+            {
+                Message         = ByteString.CopyFromUtf8("the-message"),
+                SerializerId    = 42,
+                MessageManifest = ByteString.CopyFromUtf8("SomeCls")
+            };
+
+            var recipient    = Sys.ActorOf(Props.Empty);
+            var localAddress = new Address("akka.tcp", Sys.Name, "127.0.0.1", 7355);
+            var seqNo        = new SeqNo(7);
+            var ack          = new Ack(new SeqNo(6), new[] { new SeqNo(3), new SeqNo(4) });
+
+            // Encode via ConstructMessage (same path as EndpointWriter)
+            var bytes = _codec.ConstructMessage(
+                localAddress, recipient, serialized,
+                senderOption: null,
+                seqOption:    seqNo,
+                ackOption:    ack);
+
+            // DecodeMessage reconstructs the full AckAndMessage
+            var provider = (IRemoteActorRefProvider)((ExtendedActorSystem)Sys).Provider;
+            var result   = _codec.DecodeMessage(bytes, provider, localAddress);
+
+            // ── ACK half ──────────────────────────────────────────────────────────
+            result.AckOption.Should().NotBeNull();
+            result.AckOption!.CumulativeAck.RawValue.Should().Be(6);
+            result.AckOption.Nacks.Select(n => n.RawValue)
+                .Should().BeEquivalentTo(new long[] { 3, 4 });
+
+            // ── Message half ──────────────────────────────────────────────────────
+            result.MessageOption.Should().NotBeNull();
+            result.MessageOption!.SerializedMessage.Message.ToStringUtf8()
+                .Should().Be("the-message");
+            result.MessageOption.SerializedMessage.SerializerId.Should().Be(42);
+            result.MessageOption.SerializedMessage.MessageManifest.ToStringUtf8()
+                .Should().Be("SomeCls");
+            result.MessageOption.Seq.Should().NotBeNull();
+            result.MessageOption.Seq!.Value.RawValue.Should().Be(7);
+        }
+
+        [Fact(DisplayName = "MessagePack codec: ConstructMessage without seq/ack produces no seq and no ack")]
+        public void ConstructMessage_Without_Seq_Or_Ack_Should_Produce_Empty_Envelope()
+        {
+            var serialized = new SerializedMessage
+            {
+                Message      = ByteString.CopyFromUtf8("bare-msg"),
+                SerializerId = 1
+            };
+
+            var recipient    = Sys.ActorOf(Props.Empty);
+            var localAddress = new Address("akka.tcp", Sys.Name, "127.0.0.1", 7355);
+
+            var bytes = _codec.ConstructMessage(localAddress, recipient, serialized);
+
+            var provider = (IRemoteActorRefProvider)((ExtendedActorSystem)Sys).Provider;
+            var result   = _codec.DecodeMessage(bytes, provider, localAddress);
+
+            result.AckOption.Should().BeNull();
+            result.MessageOption.Should().NotBeNull();
+            result.MessageOption!.Seq.Should().BeNull(); // no sequence number
+        }
+
+        // ── Message-level: ConstructPureAck ────────────────────────────────────
+
+        [Fact(DisplayName = "MessagePack codec: ConstructPureAck + DecodeMessage round-trips ACK only")]
+        public void ConstructPureAck_Should_RoundTrip()
+        {
+            var ack = new Ack(new SeqNo(100), new[] { new SeqNo(97), new SeqNo(98) });
+            var bytes = _codec.ConstructPureAck(ack);
+
+            var localAddress = new Address("akka.tcp", Sys.Name, "127.0.0.1", 7355);
+            var provider     = (IRemoteActorRefProvider)((ExtendedActorSystem)Sys).Provider;
+            var result       = _codec.DecodeMessage(bytes, provider, localAddress);
+
+            result.MessageOption.Should().BeNull();
+            result.AckOption.Should().NotBeNull();
+            result.AckOption!.CumulativeAck.RawValue.Should().Be(100);
+            result.AckOption.Nacks.Select(n => n.RawValue)
+                .Should().BeEquivalentTo(new long[] { 97, 98 });
+        }
+
+        // ── Config factory ──────────────────────────────────────────────────────
+
+        [Fact(DisplayName = "MessagePack codec: PipeTransportSettings.CreateCodec returns MessagePack codec when envelope=messagepack")]
+        public void CreateCodec_With_MessagePack_Envelope_Should_Return_MessagePack_Codec()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+                akka.remote {
+                    enabled-transports = [""akka.remote.pipe.tcp""]
+                    pipe.tcp {
+                        port     = 0
+                        hostname = ""127.0.0.1""
+                        envelope = messagepack
+                    }
+                }
+            ").WithFallback(Sys.Settings.Config).GetConfig("akka.remote");
+
+            var codec = PipeTransportSettings.CreateCodec(config, Sys);
+            codec.Should().BeOfType<AkkaPduMessagePackCodec>();
+        }
+
+        [Fact(DisplayName = "MessagePack codec: PipeTransportSettings.CreateCodec returns Protobuf codec when envelope=protobuf")]
+        public void CreateCodec_With_Protobuf_Envelope_Should_Return_Protobuf_Codec()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+                akka.remote {
+                    enabled-transports = [""akka.remote.pipe.tcp""]
+                    pipe.tcp {
+                        port     = 0
+                        hostname = ""127.0.0.1""
+                        envelope = protobuf
+                    }
+                }
+            ").WithFallback(Sys.Settings.Config).GetConfig("akka.remote");
+
+            var codec = PipeTransportSettings.CreateCodec(config, Sys);
+            codec.Should().BeOfType<AkkaPduProtobuffCodec>();
+        }
+
+        [Fact(DisplayName = "MessagePack codec: PipeTransportSettings.CreateCodec defaults to Protobuf when no pipe transport")]
+        public void CreateCodec_Without_Pipe_Transport_Should_Default_To_Protobuf()
+        {
+            var config = ConfigurationFactory.ParseString(@"
+                akka.remote {
+                    enabled-transports = [""akka.remote.dot-netty.tcp""]
+                }
+            ").WithFallback(Sys.Settings.Config).GetConfig("akka.remote");
+
+            var codec = PipeTransportSettings.CreateCodec(config, Sys);
+            codec.Should().BeOfType<AkkaPduProtobuffCodec>();
+        }
+
+        // ── Codec produces shorter frames than protobuf ─────────────────────────
+
+        [Fact(DisplayName = "MessagePack codec: Heartbeat frame is smaller than or equal to protobuf equivalent")]
+        public void MessagePack_Heartbeat_Frame_Should_Be_Compact()
+        {
+            var mpBytes  = _codec.ConstructHeartbeat();
+            var pbCodec  = new AkkaPduProtobuffCodec(Sys);
+            var pbBytes  = pbCodec.ConstructHeartbeat();
+
+            // MessagePack has no varint + field-id overhead for empty messages
+            // so the frame should be at most as large as protobuf.
+            mpBytes.Length.Should().BeLessOrEqualTo(pbBytes.Length * 2,
+                because: "MessagePack should be compact for control frames");
+        }
+
+        [Fact(DisplayName = "MessagePack codec: Invalid bytes throw PduCodecException")]
+        public void DecodePdu_With_Garbage_Bytes_Should_Throw_PduCodecException()
+        {
+            var garbage = ByteString.CopyFrom(new byte[] { 0xFF, 0x00, 0xAB, 0xCD });
+            Action act  = () => _codec.DecodePdu(garbage);
+            act.Should().Throw<PduCodecException>();
+        }
+    }
+}
+
+

--- a/src/core/Akka.Remote.Tests/Transport/TcpPipeTransportSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/TcpPipeTransportSpec.cs
@@ -1,0 +1,516 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TcpPipeTransportSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Remote.Transport;
+using Akka.Remote.Transport.Pipelines;
+using Akka.TestKit;
+using FluentAssertions;
+using Google.Protobuf;
+using Xunit;
+using Xunit.v3;
+
+namespace Akka.Remote.Tests.Transport
+{
+    /// <summary>
+    /// Integration tests for <see cref="TcpPipeTransport"/>.
+    ///
+    /// Each test creates real TCP sockets on 127.0.0.1 with port=0 (OS-assigned)
+    /// to keep tests fast, deterministic, and independent of each other.
+    ///
+    /// <!-- CopilotNotes: The pattern mirrors DotNettyTransportShutdownSpec:
+    ///      - Create two TcpPipeTransport instances sharing a config with port=0.
+    ///      - Call Listen() on both, complete their association-listener promises.
+    ///      - Drive the returned AssociationHandles directly (no AkkaProtocol layer)
+    ///        so we test only the transport's wire behaviour.
+    ///      - Always call Shutdown() in a finally block to free the sockets. -->
+    /// </summary>
+    public class TcpPipeTransportSpec : AkkaSpec
+    {
+        // ── HOCON ──────────────────────────────────────────────────────────────
+        private static readonly Config TestConfig = ConfigurationFactory.ParseString(@"
+            akka {
+                loglevel = DEBUG
+                actor.provider = ""Akka.Remote.RemoteActorRefProvider, Akka.Remote""
+                remote {
+                    pipe.tcp {
+                        port     = 0
+                        hostname = ""127.0.0.1""
+                    }
+                }
+            }");
+
+        // ── Helpers ────────────────────────────────────────────────────────────
+
+        /// <summary>Create a fresh transport using the test config.</summary>
+        private TcpPipeTransport NewTransport() =>
+            new(Sys, Sys.Settings.Config.GetConfig("akka.remote.pipe.tcp"));
+
+        // ── Constructor ────────────────────────────────────────────────────────
+
+        public TcpPipeTransportSpec(ITestOutputHelper output)
+            : base(TestConfig, output) { }
+
+        // ── Tests ──────────────────────────────────────────────────────────────
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Bind_And_Return_Address_When_Listen_Called")]
+        public async Task TcpPipeTransport_Should_Bind_And_Return_Address_When_Listen_Called()
+        {
+            var t1 = NewTransport();
+            try
+            {
+                var (addr, listenerPromise) = await t1.Listen();
+
+                addr.Should().NotBeNull();
+                addr.Host.Should().Be("127.0.0.1");
+                addr.Port.Should().BeGreaterThan(0);
+                addr.Protocol.Should().Be("tcp");
+                listenerPromise.Should().NotBeNull();
+            }
+            finally
+            {
+                await t1.Shutdown();
+            }
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Associate_Outbound_And_Deliver_InboundAssociation")]
+        public async Task TcpPipeTransport_Should_Associate_Outbound_And_Deliver_InboundAssociation()
+        {
+            var t1 = NewTransport();
+            var t2 = NewTransport();
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                var (addr1, lp1) = await t1.Listen();
+                lp1.SetResult(new ActorAssociationEventListener(p1));
+
+                var (addr2, lp2) = await t2.Listen();
+                lp2.SetResult(new ActorAssociationEventListener(p2));
+
+                // Outbound: t1 ──► t2
+                var outboundHandle = await t1.Associate(addr2);
+                outboundHandle.Should().NotBeNull();
+                outboundHandle.RemoteAddress.Should().Be(addr2);
+
+                // t2 should receive InboundAssociation from t1
+                var inbound = await p2.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromSeconds(5));
+                inbound.Association.Should().NotBeNull();
+                inbound.Association.RemoteAddress.Host.Should().Be("127.0.0.1");
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Deliver_Payload_From_Outbound_To_Inbound")]
+        public async Task TcpPipeTransport_Should_Deliver_Payload_From_Outbound_To_Inbound()
+        {
+            var t1 = NewTransport();
+            var t2 = NewTransport();
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                var (addr1, lp1) = await t1.Listen();
+                lp1.SetResult(new ActorAssociationEventListener(p1));
+
+                var (addr2, lp2) = await t2.Listen();
+                lp2.SetResult(new ActorAssociationEventListener(p2));
+
+                // Establish association
+                var outHandle = await t1.Associate(addr2);
+                var inbound   = await p2.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromSeconds(5));
+                var inHandle  = inbound.Association;
+
+                // Register listeners so reads are routed to the probes
+                outHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                inHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                // Send a payload t1 ──► t2
+                var payload = ByteString.CopyFromUtf8("Hello from Ami-chan!");
+                var wrote   = outHandle.Write(payload);
+                wrote.Should().BeTrue();
+
+                // t2's probe should receive the InboundPayload
+                var received = await p2.ExpectMsgAsync<InboundPayload>(TimeSpan.FromSeconds(5));
+                received.Payload.ToStringUtf8().Should().Be("Hello from Ami-chan!");
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Deliver_Payload_From_Inbound_To_Outbound")]
+        public async Task TcpPipeTransport_Should_Deliver_Payload_From_Inbound_To_Outbound()
+        {
+            var t1 = NewTransport();
+            var t2 = NewTransport();
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                var (addr1, lp1) = await t1.Listen();
+                lp1.SetResult(new ActorAssociationEventListener(p1));
+
+                var (addr2, lp2) = await t2.Listen();
+                lp2.SetResult(new ActorAssociationEventListener(p2));
+
+                var outHandle = await t1.Associate(addr2);
+                var inbound   = await p2.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromSeconds(5));
+                var inHandle  = inbound.Association;
+
+                outHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                inHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                // Send the OTHER direction: t2 ──► t1
+                var payload = ByteString.CopyFromUtf8("Reply from t2 uwu~");
+                inHandle.Write(payload);
+
+                var received = await p1.ExpectMsgAsync<InboundPayload>(TimeSpan.FromSeconds(5));
+                received.Payload.ToStringUtf8().Should().Be("Reply from t2 uwu~");
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Send_Multiple_Payloads_In_Order")]
+        public async Task TcpPipeTransport_Should_Send_Multiple_Payloads_In_Order()
+        {
+            var t1 = NewTransport();
+            var t2 = NewTransport();
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                var (_, lp1) = await t1.Listen();
+                lp1.SetResult(new ActorAssociationEventListener(p1));
+
+                var (addr2, lp2) = await t2.Listen();
+                lp2.SetResult(new ActorAssociationEventListener(p2));
+
+                var outHandle = await t1.Associate(addr2);
+                var inbound   = await p2.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromSeconds(5));
+                var inHandle  = inbound.Association;
+
+                outHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                inHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                // Write 5 messages back-to-back to exercise write coalescing
+                // CopilotNotes: This exercises the ArrayBufferWriter batch-drain path in
+                // PipeConnection.WriteLoopAsync — all 5 writes may land in a single TCP segment.
+                const int MessageCount = 5;
+                for (var i = 0; i < MessageCount; i++)
+                    outHandle.Write(ByteString.CopyFromUtf8($"msg-{i}"));
+
+                // All 5 must arrive in order at t2
+                for (var i = 0; i < MessageCount; i++)
+                {
+                    var msg = await p2.ExpectMsgAsync<InboundPayload>(TimeSpan.FromSeconds(5));
+                    msg.Payload.ToStringUtf8().Should().Be($"msg-{i}");
+                }
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Notify_Disassociated_When_Outbound_Calls_Disassociate")]
+        public async Task TcpPipeTransport_Should_Notify_Disassociated_When_Outbound_Calls_Disassociate()
+        {
+            var t1 = NewTransport();
+            var t2 = NewTransport();
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                var (_, lp1) = await t1.Listen();
+                lp1.SetResult(new ActorAssociationEventListener(p1));
+
+                var (addr2, lp2) = await t2.Listen();
+                lp2.SetResult(new ActorAssociationEventListener(p2));
+
+                var outHandle = await t1.Associate(addr2);
+                var inbound   = await p2.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromSeconds(5));
+                var inHandle  = inbound.Association;
+
+                outHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                inHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                // Outbound side initiates disassociation
+                outHandle.Disassociate("test disassociation", Log);
+
+                // t2 (inbound) should receive the Disassociated notification
+                var disassociated = await p2.ExpectMsgAsync<Disassociated>(TimeSpan.FromSeconds(5));
+                disassociated.Should().NotBeNull();
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Notify_Disassociated_When_Inbound_Calls_Disassociate")]
+        public async Task TcpPipeTransport_Should_Notify_Disassociated_When_Inbound_Calls_Disassociate()
+        {
+            var t1 = NewTransport();
+            var t2 = NewTransport();
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                var (_, lp1) = await t1.Listen();
+                lp1.SetResult(new ActorAssociationEventListener(p1));
+
+                var (addr2, lp2) = await t2.Listen();
+                lp2.SetResult(new ActorAssociationEventListener(p2));
+
+                var outHandle = await t1.Associate(addr2);
+                var inbound   = await p2.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromSeconds(5));
+                var inHandle  = inbound.Association;
+
+                outHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                inHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                // Inbound side initiates disassociation
+                inHandle.Disassociate("inbound test", Log);
+
+                // t1 (outbound) must receive a Disassociated event
+                var disassociated = await p1.ExpectMsgAsync<Disassociated>(TimeSpan.FromSeconds(5));
+                disassociated.Should().NotBeNull();
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Notify_Disassociated_On_Remote_Shutdown")]
+        public async Task TcpPipeTransport_Should_Notify_Disassociated_On_Remote_Shutdown()
+        {
+            var t1 = NewTransport();
+            var t2 = NewTransport();
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                var (_, lp1) = await t1.Listen();
+                lp1.SetResult(new ActorAssociationEventListener(p1));
+
+                var (addr2, lp2) = await t2.Listen();
+                lp2.SetResult(new ActorAssociationEventListener(p2));
+
+                var outHandle = await t1.Associate(addr2);
+                var inbound   = await p2.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromSeconds(5));
+                var inHandle  = inbound.Association;
+
+                outHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                inHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                // Shut down t2 entirely — t1 should detect the connection is gone
+                await t2.Shutdown();
+
+                // t1 should receive Disassociated because t2's socket was closed
+                await p1.ExpectMsgAsync<Disassociated>(TimeSpan.FromSeconds(10));
+            }
+            finally
+            {
+                await t1.Shutdown();
+                // t2 already shut down, second call is safe
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Throw_InvalidAssociationException_For_Refused_Connection")]
+        public async Task TcpPipeTransport_Should_Throw_InvalidAssociationException_For_Refused_Connection()
+        {
+            var t1 = NewTransport();
+            try
+            {
+                var (addr1, lp1) = await t1.Listen();
+                lp1.SetResult(new ActorAssociationEventListener(CreateTestProbe()));
+
+                // Obtain a guaranteed-free port by binding briefly then releasing.
+                // CopilotNotes: The brief race window (bind→close→connect) is acceptable in
+                // tests because the OS won't immediately reassign a just-released ephemeral port.
+                int deadPort;
+                using (var tmp = new System.Net.Sockets.Socket(
+                           System.Net.Sockets.AddressFamily.InterNetwork,
+                           System.Net.Sockets.SocketType.Stream,
+                           System.Net.Sockets.ProtocolType.Tcp))
+                {
+                    tmp.Bind(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 0));
+                    deadPort = ((System.Net.IPEndPoint)tmp.LocalEndPoint!).Port;
+                } // Socket closed here — nothing is listening on deadPort
+
+                var deadAddress = addr1.WithPort(deadPort);
+
+                await Assert.ThrowsAsync<InvalidAssociationException>(
+                    () => t1.Associate(deadAddress));
+            }
+            finally
+            {
+                await t1.Shutdown();
+            }
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Cleanly_Shutdown_Without_Active_Connections")]
+        public async Task TcpPipeTransport_Should_Cleanly_Shutdown_Without_Active_Connections()
+        {
+            var t1 = NewTransport();
+
+            await t1.Listen();
+
+            // Shutdown with no active connections should succeed immediately
+            var result = await t1.Shutdown().WaitAsync(TimeSpan.FromSeconds(5));
+            result.Should().BeTrue();
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Return_False_For_Write_After_Disassociate")]
+        public async Task TcpPipeTransport_Should_Return_False_For_Write_After_Disassociate()
+        {
+            var t1 = NewTransport();
+            var t2 = NewTransport();
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                var (_, lp1) = await t1.Listen();
+                lp1.SetResult(new ActorAssociationEventListener(p1));
+
+                var (addr2, lp2) = await t2.Listen();
+                lp2.SetResult(new ActorAssociationEventListener(p2));
+
+                var outHandle = await t1.Associate(addr2);
+                var inbound   = await p2.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromSeconds(5));
+
+                outHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                inbound.Association.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                // Disassociate then immediately try to write — should return false
+                outHandle.Disassociate("test", Log);
+
+                // Give the close a moment to propagate
+                await Task.Delay(100);
+
+                var writeResult = outHandle.Write(ByteString.CopyFromUtf8("should be dropped"));
+                writeResult.Should().BeFalse("because the handle is already disassociated");
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Send_And_Receive_Large_Payload")]
+        public async Task TcpPipeTransport_Should_Send_And_Receive_Large_Payload()
+        {
+            var t1 = NewTransport();
+            var t2 = NewTransport();
+            try
+            {
+                var p1 = CreateTestProbe();
+                var p2 = CreateTestProbe();
+
+                var (_, lp1) = await t1.Listen();
+                lp1.SetResult(new ActorAssociationEventListener(p1));
+
+                var (addr2, lp2) = await t2.Listen();
+                lp2.SetResult(new ActorAssociationEventListener(p2));
+
+                var outHandle = await t1.Associate(addr2);
+                var inbound   = await p2.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromSeconds(5));
+                var inHandle  = inbound.Association;
+
+                outHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p1));
+                inHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(p2));
+
+                // 64 KB payload — exercises multi-segment PipeReader reads
+                var largeBytes = new byte[64 * 1024];
+                new Random(42).NextBytes(largeBytes);
+                var payload = ByteString.CopyFrom(largeBytes);
+
+                outHandle.Write(payload);
+
+                var received = await p2.ExpectMsgAsync<InboundPayload>(TimeSpan.FromSeconds(10));
+                received.Payload.ToByteArray().Should().Equal(largeBytes);
+            }
+            finally
+            {
+                await t1.Shutdown();
+                await t2.Shutdown();
+            }
+        }
+
+        [Fact(DisplayName = "TcpPipeTransport_Should_Handle_Concurrent_Associates")]
+        public async Task TcpPipeTransport_Should_Handle_Concurrent_Associates()
+        {
+            // Spin up 5 client transports all connecting to one server transport concurrently.
+            const int ClientCount = 5;
+            var server = NewTransport();
+            var clients = Enumerable.Range(0, ClientCount).Select(_ => NewTransport()).ToArray();
+            try
+            {
+                var serverProbe = CreateTestProbe();
+                var (serverAddr, serverLp) = await server.Listen();
+                serverLp.SetResult(new ActorAssociationEventListener(serverProbe));
+
+                // Bind all clients
+                var clientListens = await Task.WhenAll(clients.Select(c => c.Listen()));
+                foreach (var (_, lp) in clientListens)
+                    lp.SetResult(new ActorAssociationEventListener(CreateTestProbe()));
+
+                // Connect all clients concurrently
+                var connectTasks = clients.Select(c => c.Associate(serverAddr)).ToArray();
+                var handles = await Task.WhenAll(connectTasks);
+
+                // Server should receive one InboundAssociation per client
+                for (var i = 0; i < ClientCount; i++)
+                    await serverProbe.ExpectMsgAsync<InboundAssociation>(TimeSpan.FromSeconds(5));
+
+                handles.Should().HaveCount(ClientCount);
+                handles.Should().OnlyContain(h => h != null);
+            }
+            finally
+            {
+                await server.Shutdown();
+                await Task.WhenAll(clients.Select(c => c.Shutdown()));
+            }
+        }
+    }
+}
+
+
+
+
+
+

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -16,6 +16,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="MessagePack" Version="3.1.4" />
     </ItemGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -585,6 +585,95 @@ akka {
       transport-protocol = udp
     }
 
+    ### Default configuration for the System.IO.Pipelines-based TCP transport (Phase 1)
+    ### Activate with: akka.remote.enabled-transports = ["akka.remote.pipe.tcp"]
+
+    pipe.tcp {
+      # The class implementing the Transport SPI.
+      transport-class = "Akka.Remote.Transport.Pipelines.TcpPipeTransport,Akka.Remote"
+
+      # Transport adapters applied on top of this driver (e.g. gremlin, trttl).
+      applied-adapters = []
+
+      # The default remote server port. Use 0 for a random available port.
+      # This port must be unique per actor system on the same machine.
+      port = 2552
+
+      # Public-facing port alias (for NAT / Docker / load-balancer scenarios).
+      # Leave at 0 to advertise the actual bound port.
+      public-port = 0
+
+      # Hostname or IP address to bind to.
+      # Leave empty to bind to all interfaces (0.0.0.0).
+      hostname = ""
+
+      # Public-facing hostname advertised in Akka.Remote addresses.
+      # Useful when the process is behind NAT or runs inside Docker.
+      public-hostname = ""
+
+      # Prefer IPv6 when resolving hostnames via DNS.
+      dns-use-ipv6 = false
+
+      # Enable TLS/SSL on this transport.
+      # Certificate and validation settings are read from the 'ssl' sub-block below.
+      enable-ssl = false
+
+      # Timeout for outbound TCP connect attempts.
+      connection-timeout = 15 s
+
+      # Maximum allowed payload size per frame (header not counted).
+      # Must be at least 32000 bytes.
+      maximum-frame-size = 128000b
+
+      # Socket SO_SNDBUF size in bytes.
+      send-buffer-size = 256000b
+
+      # Socket SO_RCVBUF size in bytes.
+      receive-buffer-size = 256000b
+
+      # Server listen backlog (passed to Socket.Listen).
+      backlog = 4096
+
+      # Enable TCP keepalive probes.
+      tcp-keepalive = on
+
+      # Disable Nagle's algorithm (TCP_NODELAY). Recommended for low-latency actor messaging.
+      tcp-nodelay = on
+
+      # Bounded capacity of the per-connection outbound write channel.
+      # When full, AssociationHandle.Write returns false (same as DotNetty water-mark behaviour).
+      write-channel-capacity = 1024
+
+      # SSL settings — structure mirrors akka.remote.dot-netty.tcp.ssl.
+      ssl {
+        certificate {
+          # Path to the PKCS#12 (.pfx / .p12) certificate file.
+          path = ""
+          # Certificate file password.
+          password = ""
+          # Key storage flags. Available: default-key-set | exportable | machine-key-set |
+          #   persist-key-set | user-key-set | user-protected
+          # flags = ["default-key-set"]
+
+          # Use a certificate store thumbprint instead of a file.
+          use-thumbprint-over-file = false
+          thumbprint = ""
+          store-name = ""
+          # Valid options: local-machine | current-user
+          store-location = "current-user"
+        }
+
+        # Set to true to skip certificate chain validation (dev/test only!).
+        suppress-validation = false
+
+        # Require mutual TLS: both client and server present certificates.
+        require-mutual-authentication = true
+
+        # Validate that the remote certificate CN/SAN matches the target hostname.
+        validate-certificate-hostname = false
+      }
+    }
+
     ### Default configuration for the failure injector transport adapter
 
     gremlin {

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -644,6 +644,13 @@ akka {
       # When full, AssociationHandle.Write returns false (same as DotNetty water-mark behaviour).
       write-channel-capacity = 1024
 
+      # PDU envelope codec for the AkkaProtocol wire layer.
+      # Allowed values: "protobuf" (default, wire-compatible with DotNetty) or "messagepack".
+      # IMPORTANT: The entire cluster must use the same codec. Mixing codecs across nodes
+      # will cause PduCodecException on decode. Only switch to "messagepack" when every node
+      # in the cluster is running the Pipelines transport with this setting.
+      envelope = protobuf
+
       # SSL settings — structure mirrors akka.remote.dot-netty.tcp.ssl.
       ssl {
         certificate {

--- a/src/core/Akka.Remote/EndpointManager.cs
+++ b/src/core/Akka.Remote/EndpointManager.cs
@@ -17,6 +17,7 @@ using Akka.Dispatch;
 using Akka.Remote.Transport.DotNetty;
 using Akka.Event;
 using Akka.Remote.Transport;
+using Akka.Remote.Transport.Pipelines;
 using Akka.Util.Internal;
 
 namespace Akka.Remote
@@ -1073,7 +1074,11 @@ namespace Akka.Remote
                         //Apply AkkaProtocolTransport wrapper to the end of the chain
                         //The chain at this point:
                         // AkkaProtocolTransport <-- Adapter <-- .. <-- Adapter <-- Driver
-                        transports.Add(new AkkaProtocolTransport(wrappedTransport, Context.System, new AkkaProtocolSettings(_conf), new AkkaPduProtobuffCodec(Context.System)));
+                        // CopilotNotes: CreateCodec checks whether the pipe transport is enabled
+                        // + configured for MessagePack, and returns the correct codec. Falls back
+                        // to AkkaPduProtobuffCodec for all other transports.
+                        var pduCodec = PipeTransportSettings.CreateCodec(_conf, Context.System);
+                        transports.Add(new AkkaProtocolTransport(wrappedTransport, Context.System, new AkkaProtocolSettings(_conf), pduCodec));
                     }
 
                     // Collect all transports, listen addresses, and listener promises in one Task
@@ -1148,7 +1153,7 @@ namespace Akka.Remote
                     Context.ActorOf(RARP.For(Context.System)
                     .ConfigureDispatcher(
                         ReliableDeliverySupervisor.ReliableDeliverySupervisorProps(handleOption, localAddress,
-                            remoteAddress, refuseUid, transport, endpointSettings, new AkkaPduProtobuffCodec(Context.System),
+                            remoteAddress, refuseUid, transport, endpointSettings, PipeTransportSettings.CreateCodec(_conf, Context.System),
                             _receiveBuffers, endpointSettings.Dispatcher)
                             .WithDeploy(Deploy.Local)),
                         $"reliableEndpointWriter-{AddressUrlEncoder.Encode(remoteAddress)}-{_endpointId.Next()}");
@@ -1159,7 +1164,7 @@ namespace Akka.Remote
                     Context.ActorOf(RARP.For(Context.System)
                     .ConfigureDispatcher(
                         EndpointWriter.EndpointWriterProps(handleOption, localAddress, remoteAddress, refuseUid,
-                            transport, endpointSettings, new AkkaPduProtobuffCodec(Context.System), _receiveBuffers,
+                            transport, endpointSettings, PipeTransportSettings.CreateCodec(_conf, Context.System), _receiveBuffers,
                             reliableDeliverySupervisor: null)
                             .WithDeploy(Deploy.Local)),
                         $"endpointWriter-{AddressUrlEncoder.Encode(remoteAddress)}-{_endpointId.Next()}");

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -140,7 +140,11 @@ namespace Akka.Remote.Transport
         {
             get
             {
-                return _managerProps ??= Props.Create(() => new AkkaProtocolManager(WrappedTransport, Settings))
+                // CopilotNotes: Capture Codec here so the lambda closes over the
+                // already-resolved value rather than the property getter. Codec is
+                // immutable after construction so this is safe.
+                var codec = Codec;
+                return _managerProps ??= Props.Create(() => new AkkaProtocolManager(WrappedTransport, Settings, codec))
                     .WithDeploy(Deploy.Local);
             }
         }
@@ -191,15 +195,24 @@ namespace Akka.Remote.Transport
         /// </summary>
         /// <param name="wrappedTransport">TBD</param>
         /// <param name="settings">TBD</param>
-        public AkkaProtocolManager(Transport wrappedTransport, AkkaProtocolSettings settings)
+        /// <param name="codec">
+        /// The PDU codec to use for all <see cref="ProtocolStateActor"/> instances created
+        /// by this manager.  Defaults to <see cref="AkkaPduProtobuffCodec"/> when null.
+        /// </param>
+        public AkkaProtocolManager(Transport wrappedTransport, AkkaProtocolSettings settings, AkkaPduCodec? codec = null)
         {
             _wrappedTransport = wrappedTransport;
             _settings = settings;
+            // CopilotNotes: codec may be null when AkkaProtocolManager is created in tests
+            // that don't pass a codec explicitly; fall back to the protobuf codec in that case.
+            _codec = codec ?? new AkkaPduProtobuffCodec(Context.System);
         }
 
         private readonly Transport _wrappedTransport;
-
         private readonly AkkaProtocolSettings _settings;
+        // CopilotNotes: Stored here so both inbound and outbound ProtocolStateActors use
+        // the same codec instance rather than each creating their own protobuf instance.
+        private AkkaPduCodec _codec;
 
         /// <summary>
         /// The <see cref="AkkaProtocolTransport"/> does not handle recovery of associations, this task is implemented
@@ -236,7 +249,7 @@ namespace Akka.Remote.Transport
                         handle,
                         stateActorAssociationListener,
                         stateActorSettings,
-                        new AkkaPduProtobuffCodec(Context.System),
+                        _codec,
                         failureDetector)), ActorNameFor(handle.RemoteAddress));
                     break;
                 case AssociateUnderlying au:
@@ -274,7 +287,7 @@ namespace Akka.Remote.Transport
                 statusPromise,
                 stateActorWrappedTransport,
                 stateActorSettings,
-                new AkkaPduProtobuffCodec(Context.System), failureDetector, refuseUid)),
+                _codec, failureDetector, refuseUid)),
                 ActorNameFor(remoteAddress));
         }
 

--- a/src/core/Akka.Remote/Transport/Pipelines/AkkaPduMessagePackCodec.cs
+++ b/src/core/Akka.Remote/Transport/Pipelines/AkkaPduMessagePackCodec.cs
@@ -228,7 +228,7 @@ namespace Akka.Remote.Transport.Pipelines
                     var serializedMessage = new SerializedMessage
                     {
                         Message         = env.Message.Message is { Length: > 0 }
-                            ? ByteString.CopyFrom(env.Message.Message)
+                            ? ByteString.CopyFrom(env.Message.Message.Value.Span)
                             : ByteString.Empty,
                         SerializerId    = env.Message.SerializerId,
                         MessageManifest = env.Message.Manifest is { Length: > 0 }

--- a/src/core/Akka.Remote/Transport/Pipelines/AkkaPduMessagePackCodec.cs
+++ b/src/core/Akka.Remote/Transport/Pipelines/AkkaPduMessagePackCodec.cs
@@ -1,0 +1,333 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="AkkaPduMessagePackCodec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Linq;
+using Akka.Actor;
+using Akka.Remote.Transport.Pipelines.MessagePack;
+using Google.Protobuf;
+using MP = global::MessagePack;
+using SerializedMessage = Akka.Remote.Serialization.Proto.Msg.Payload;
+
+namespace Akka.Remote.Transport.Pipelines
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// MessagePack-based implementation of <see cref="AkkaPduCodec"/> that mirrors
+    /// the <c>AkkaProtocolMessage</c> / <c>AckAndEnvelopeContainer</c> protobuf schema
+    /// using source-generated (or dynamically emitted) MessagePack formatters.
+    ///
+    /// <para>
+    /// This codec is <b>cluster-wide opt-in</b>: enable it only when every node in the
+    /// cluster is running the pipelines transport with
+    /// <c>akka.remote.pipe.tcp.envelope = messagepack</c>.  Mixed-codec clusters will
+    /// produce <see cref="PduCodecException"/> on decode.
+    /// </para>
+    ///
+    /// <para>
+    /// Wire format summary:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <b>Protocol frame</b> — a MessagePack-serialized <see cref="MpProtocolFrame"/>
+    ///     with a 1-byte <c>Tag</c> discriminant, optional <c>Payload</c> bytes, and
+    ///     optional <c>HandshakeInfo</c>.  Mirrors <c>AkkaProtocolMessage</c>.
+    ///   </item>
+    ///   <item>
+    ///     <b>Message envelope</b> — a MessagePack-serialized <see cref="MpAckAndEnvelope"/>
+    ///     containing optional <see cref="MpAck"/> and <see cref="MpRemoteEnvelope"/>.
+    ///     Mirrors <c>AckAndEnvelopeContainer</c>.
+    ///   </item>
+    /// </list>
+    /// </para>
+    ///
+    /// <!-- CopilotNotes: The codec intentionally avoids ByteString allocations for the
+    ///      static control messages (heartbeat, disassociate) by caching their serialised
+    ///      bytes as static readonly fields computed once in the static constructor. -->
+    /// </summary>
+    internal sealed class AkkaPduMessagePackCodec : AkkaPduCodec
+    {
+        // ── Static cache for allocation-free control messages ─────────────────
+
+        // CopilotNotes: These are safe as static bytes because no ActorSystem state is
+        // encoded in heartbeat/disassociate frames — same reasoning as HeartbeatPdu in
+        // AkkaPduProtobuffCodec.
+        private static readonly byte[] s_heartbeatBytes;
+        private static readonly byte[] s_disassociateBytes;
+        private static readonly byte[] s_disassociateQuarantinedBytes;
+        private static readonly byte[] s_disassociateShuttingDownBytes;
+
+        static AkkaPduMessagePackCodec()
+        {
+            s_heartbeatBytes               = SerializeFrame(new MpProtocolFrame { Tag = ProtocolTag.Heartbeat });
+            s_disassociateBytes            = SerializeFrame(new MpProtocolFrame { Tag = ProtocolTag.Disassociate });
+            s_disassociateQuarantinedBytes = SerializeFrame(new MpProtocolFrame { Tag = ProtocolTag.DisassociateQuarantined });
+            s_disassociateShuttingDownBytes= SerializeFrame(new MpProtocolFrame { Tag = ProtocolTag.DisassociateShuttingDown });
+        }
+
+        // ── Constructor ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Creates a new instance of <see cref="AkkaPduMessagePackCodec"/>.
+        /// </summary>
+        /// <param name="system">The hosting actor system (for path caching).</param>
+        public AkkaPduMessagePackCodec(ActorSystem system) : base(system) { }
+
+        // ── Protocol-level encode / decode ─────────────────────────────────────
+
+        /// <inheritdoc/>
+        /// <summary>
+        /// Decodes a MessagePack-serialized <see cref="MpProtocolFrame"/> from <paramref name="raw"/>
+        /// and returns the corresponding <see cref="IAkkaPdu"/> variant.
+        /// </summary>
+        /// <exception cref="PduCodecException">
+        /// Thrown when the bytes cannot be deserialized or the tag is unrecognised.
+        /// </exception>
+        public override IAkkaPdu DecodePdu(ByteString raw)
+        {
+            try
+            {
+                var frame = MP.MessagePackSerializer.Deserialize<MpProtocolFrame>(raw.ToByteArray());
+                return frame.Tag switch
+                {
+                    ProtocolTag.Payload =>
+                        new Payload(frame.Payload is { Length: > 0 }
+                            ? ByteString.CopyFrom(frame.Payload)
+                            : ByteString.Empty),
+
+                    ProtocolTag.Heartbeat => new Heartbeat(),
+
+                    ProtocolTag.Associate => DecodeAssociate(frame),
+
+                    ProtocolTag.Disassociate            => new Disassociate(DisassociateInfo.Unknown),
+                    ProtocolTag.DisassociateQuarantined => new Disassociate(DisassociateInfo.Quarantined),
+                    ProtocolTag.DisassociateShuttingDown=> new Disassociate(DisassociateInfo.Shutdown),
+
+                    _ => throw new PduCodecException(
+                        $"Unknown MessagePack protocol tag: {frame.Tag}. " +
+                        "Ensure all cluster nodes use the same envelope codec.")
+                };
+            }
+            catch (MP.MessagePackSerializationException ex)
+            {
+                throw new PduCodecException("Failed to deserialize MessagePack protocol frame.", ex);
+            }
+        }
+
+        /// <inheritdoc/>
+        /// <summary>
+        /// Wraps <paramref name="payload"/> (the serialized <c>AckAndEnvelopeContainer</c> bytes)
+        /// in an <see cref="MpProtocolFrame"/> with <see cref="ProtocolTag.Payload"/>.
+        /// </summary>
+        public override ByteString ConstructPayload(ByteString payload)
+        {
+            var frame = new MpProtocolFrame
+            {
+                Tag     = ProtocolTag.Payload,
+                Payload = payload.ToByteArray()
+            };
+            return ByteString.CopyFrom(SerializeFrame(frame));
+        }
+
+        /// <inheritdoc/>
+        public override ByteString ConstructAssociate(HandshakeInfo info)
+        {
+            if (string.IsNullOrEmpty(info.Origin.Host) || !info.Origin.Port.HasValue)
+                throw new ArgumentException(
+                    $"HandshakeInfo origin {info.Origin} is missing host or port.", nameof(info));
+
+            var frame = new MpProtocolFrame
+            {
+                Tag = ProtocolTag.Associate,
+                HandshakeInfo = new MpHandshakeInfo
+                {
+                    Protocol = info.Origin.Protocol,
+                    System   = info.Origin.System,
+                    Hostname = info.Origin.Host!,
+                    Port     = info.Origin.Port!.Value,
+                    Uid      = info.Uid // int → long widening
+                }
+            };
+            return ByteString.CopyFrom(SerializeFrame(frame));
+        }
+
+        /// <inheritdoc/>
+        public override ByteString ConstructDisassociate(DisassociateInfo reason)
+        {
+            var bytes = reason switch
+            {
+                DisassociateInfo.Quarantined => s_disassociateQuarantinedBytes,
+                DisassociateInfo.Shutdown    => s_disassociateShuttingDownBytes,
+                _                            => s_disassociateBytes
+            };
+            // CopilotNotes: CopyFrom required because ByteString must own the backing array.
+            return ByteString.CopyFrom(bytes);
+        }
+
+        /// <inheritdoc/>
+        public override ByteString ConstructHeartbeat() =>
+            ByteString.CopyFrom(s_heartbeatBytes);
+
+        // ── Message-level encode / decode ──────────────────────────────────────
+
+        /// <inheritdoc/>
+        /// <summary>
+        /// Deserializes a MessagePack <see cref="MpAckAndEnvelope"/> and reconstructs an
+        /// <see cref="AckAndMessage"/>, bridging into the protobuf-based upper-layer types
+        /// (<see cref="SerializedMessage"/> etc.) so <c>EndpointWriter</c> / <c>EndpointReader</c>
+        /// remain unchanged.
+        /// </summary>
+        public override AckAndMessage DecodeMessage(
+            ByteString raw,
+            IRemoteActorRefProvider provider,
+            Address localAddress)
+        {
+            try
+            {
+                var msg = MP.MessagePackSerializer.Deserialize<MpAckAndEnvelope>(raw.Memory);
+
+                // ── ACK half ──────────────────────────────────────────────────
+                Ack? ackOption = null;
+                if (msg.Ack is { } mpAck)
+                {
+                    ackOption = new Ack(
+                        new SeqNo(mpAck.CumulativeAck),
+                        mpAck.Nacks?.Select(n => new SeqNo(n)) ?? Enumerable.Empty<SeqNo>());
+                }
+
+                // ── Message half ──────────────────────────────────────────────
+                Message? messageOption = null;
+                if (msg.Envelope is { } env)
+                {
+                    var recipient = provider.ResolveActorRefWithLocalAddress(
+                        env.RecipientPath, localAddress);
+
+                    // CopilotNotes: Mirrors the ActorPathCache pattern in AkkaPduProtobuffCodec
+                    // so we hit the same thread-local path-parse cache.
+                    var recipientAddress = ActorPathCache.Cache
+                        .GetOrCompute(env.RecipientPath).Address;
+
+                    IActorRef? senderOption = null;
+                    if (!string.IsNullOrEmpty(env.SenderPath))
+                        senderOption = provider.ResolveActorRefWithLocalAddress(
+                            env.SenderPath, localAddress);
+
+                    SeqNo? seqOption = null;
+                    if (env.Seq != MpRemoteEnvelope.SeqUndefined)
+                    {
+                        unchecked { seqOption = new SeqNo((long)env.Seq); }
+                    }
+
+                    // Reconstruct the protobuf Payload (SerializedMessage) from the MessagePack fields.
+                    var serializedMessage = new SerializedMessage
+                    {
+                        Message         = env.Message.Message is { Length: > 0 }
+                            ? ByteString.CopyFrom(env.Message.Message)
+                            : ByteString.Empty,
+                        SerializerId    = env.Message.SerializerId,
+                        MessageManifest = env.Message.Manifest is { Length: > 0 }
+                            ? ByteString.CopyFrom(env.Message.Manifest)
+                            : ByteString.Empty
+                    };
+
+                    messageOption = new Message(
+                        recipient, recipientAddress, serializedMessage,
+                        senderOption, seqOption);
+                }
+
+                return new AckAndMessage(ackOption, messageOption);
+            }
+            catch (MP.MessagePackSerializationException ex)
+            {
+                throw new PduCodecException(
+                    "Failed to deserialize MessagePack AckAndEnvelope.", ex);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override ByteString ConstructMessage(
+            Address localAddress,
+            IActorRef recipient,
+            SerializedMessage serializedMessage,
+            IActorRef? senderOption       = null,
+            SeqNo? seqOption              = null,
+            Ack? ackOption                = null)
+        {
+            var env = new MpRemoteEnvelope
+            {
+                RecipientPath = SerializeActorRef(recipient.Path.Address, recipient),
+                Message       = BuildMpPayload(serializedMessage),
+                Seq           = seqOption.HasValue
+                    ? (ulong)seqOption.Value.RawValue
+                    : MpRemoteEnvelope.SeqUndefined
+            };
+
+            if (senderOption?.Path is not null)
+                env.SenderPath = SerializeActorRef(localAddress, senderOption);
+
+            var container = new MpAckAndEnvelope
+            {
+                Envelope = env,
+                Ack      = ackOption is not null ? BuildMpAck(ackOption) : null
+            };
+
+            return ByteString.CopyFrom(
+                MP.MessagePackSerializer.Serialize(container));
+        }
+
+        /// <inheritdoc/>
+        public override ByteString ConstructPureAck(Ack ack)
+        {
+            var container = new MpAckAndEnvelope { Ack = BuildMpAck(ack) };
+            return ByteString.CopyFrom(
+                MP.MessagePackSerializer.Serialize(container));
+        }
+
+        // ── Private helpers ────────────────────────────────────────────────────
+
+        private static byte[] SerializeFrame(MpProtocolFrame frame) =>
+            MP.MessagePackSerializer.Serialize(frame);
+
+        private static Associate DecodeAssociate(MpProtocolFrame frame)
+        {
+            if (frame.HandshakeInfo is not { } hi)
+                throw new PduCodecException(
+                    "Associate MessagePack frame is missing HandshakeInfo.");
+
+            var origin = new Address(hi.Protocol, hi.System, hi.Hostname, hi.Port);
+            return new Associate(new HandshakeInfo(origin, (int)hi.Uid));
+        }
+
+        private static MpAck BuildMpAck(Ack ack) =>
+            new()
+            {
+                CumulativeAck = ack.CumulativeAck.RawValue,
+                Nacks         = ack.Nacks.Select(n => n.RawValue).ToArray()
+            };
+
+        private static MpPayload BuildMpPayload(SerializedMessage msg) =>
+            new()
+            {
+                Message      = msg.Message.IsEmpty      ? null : msg.Message.ToByteArray(),
+                SerializerId = msg.SerializerId,
+                Manifest     = msg.MessageManifest.IsEmpty ? null : msg.MessageManifest.ToByteArray()
+            };
+
+        /// <summary>
+        /// Returns the serialized actor ref path as a string.
+        /// Uses the full canonical format when the actor has a remote address,
+        /// or appends <paramref name="defaultAddress"/> for local actors.
+        /// </summary>
+        private static string SerializeActorRef(Address defaultAddress, IActorRef actorRef) =>
+            !string.IsNullOrEmpty(actorRef.Path.Address.Host)
+                ? actorRef.Path.ToSerializationFormat()
+                : actorRef.Path.ToSerializationFormatWithAddress(defaultAddress);
+    }
+}
+

--- a/src/core/Akka.Remote/Transport/Pipelines/MessagePack/MpProtocol.cs
+++ b/src/core/Akka.Remote/Transport/Pipelines/MessagePack/MpProtocol.cs
@@ -1,0 +1,181 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="MpProtocol.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using global::MessagePack;
+
+namespace Akka.Remote.Transport.Pipelines.MessagePack
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Tag constants for <see cref="MpProtocolFrame.Tag"/>, mirroring the
+    /// <c>CommandType</c> enum in <c>WireFormats.proto</c>.
+    /// </summary>
+    internal static class ProtocolTag
+    {
+        // CopilotNotes: These map 1:1 to the protobuf CommandType enum values so the
+        // semantics are identical regardless of which codec is used on each hop.
+        
+        /// <summary>A raw payload frame (wraps serialized <c>AckAndEnvelopeContainer</c> bytes).</summary>
+        public const byte Payload = 0;
+        /// <summary>Heartbeat — no additional payload.</summary>
+        public const byte Heartbeat = 1;
+        /// <summary>Associate handshake — <see cref="MpProtocolFrame.HandshakeInfo"/> must be populated.</summary>
+        public const byte Associate = 2;
+        /// <summary>Disassociate (unknown reason).</summary>
+        public const byte Disassociate = 3;
+        /// <summary>Disassociate: remote quarantined this node.</summary>
+        public const byte DisassociateQuarantined = 4;
+        /// <summary>Disassociate: remote is shutting down.</summary>
+        public const byte DisassociateShuttingDown = 5;
+    }
+
+    // ── Protocol-level outer envelope ────────────────────────────────────────
+    // Mirrors AkkaProtocolMessage { payload | instruction } + AkkaControlMessage + AkkaHandshakeInfo.
+    // We flatten into a single tagged struct to avoid an extra allocation for the control path.
+
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Outer protocol-level frame, equivalent to the protobuf <c>AkkaProtocolMessage</c>
+    /// union. Uses a single <see cref="Tag"/> discriminant instead of a protobuf
+    /// <c>oneof</c> field selection.
+    ///
+    /// <!-- CopilotNotes: Keeping this a single flat type avoids the union-boxing overhead
+    ///      of MessagePack's [Union] attribute approach. The Tag byte is in Key(0) so
+    ///      reading it costs only 1 byte before we decide what else to deserialize.
+    ///      AllowPrivate = true is required because the type is internal and the
+    ///      source generator needs access to non-public members. -->
+    /// </summary>
+    [MessagePackObject(AllowPrivate = true)]
+    internal sealed class MpProtocolFrame
+    {
+        /// <summary>One of the <see cref="ProtocolTag"/> constants.</summary>
+        [Key(0)] public byte Tag { get; set; }
+
+        /// <summary>Serialized inner <see cref="MpAckAndEnvelope"/> bytes. Non-null when <see cref="Tag"/> == <see cref="ProtocolTag.Payload"/>.</summary>
+        [Key(1)] public byte[]? Payload { get; set; }
+
+        /// <summary>Handshake origin info. Non-null when <see cref="Tag"/> == <see cref="ProtocolTag.Associate"/>.</summary>
+        [Key(2)] public MpHandshakeInfo? HandshakeInfo { get; set; }
+    }
+
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Mirror of <c>AkkaHandshakeInfo { origin: AddressData, uid: fixed64 }</c>.
+    /// The <c>AddressData</c> fields are inlined to reduce nested allocations.
+    /// </summary>
+    [MessagePackObject(AllowPrivate = true)]
+    internal sealed class MpHandshakeInfo
+    {
+        /// <summary>Akka address protocol string, e.g. <c>"akka.tcp"</c>.</summary>
+        [Key(0)] public string Protocol { get; set; } = "";
+
+        /// <summary>Actor system name.</summary>
+        [Key(1)] public string System { get; set; } = "";
+
+        /// <summary>Hostname or IP address string.</summary>
+        [Key(2)] public string Hostname { get; set; } = "";
+
+        /// <summary>TCP port number.</summary>
+        [Key(3)] public int Port { get; set; }
+
+        /// <summary>
+        /// System UID. Stored as <c>long</c> for MessagePack efficiency;
+        /// the value is cast from <see cref="Akka.Remote.Transport.HandshakeInfo.Uid"/>
+        /// which is <c>int</c> on the .NET side.
+        /// </summary>
+        [Key(4)] public long Uid { get; set; }
+    }
+
+    // ── Application-level message envelope ───────────────────────────────────
+    // Mirrors AckAndEnvelopeContainer { ack, envelope } + RemoteEnvelope + AcknowledgementInfo.
+
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Mirror of <c>AckAndEnvelopeContainer { ack, envelope }</c>.
+    /// Both fields are optional; a pure-ack has no <see cref="Envelope"/> and a
+    /// heartbeat-payload frame has no <see cref="Ack"/>.
+    /// </summary>
+    [MessagePackObject(AllowPrivate = true)]
+    internal sealed class MpAckAndEnvelope
+    {
+        [Key(0)] public MpAck? Ack { get; set; }
+        [Key(1)] public MpRemoteEnvelope? Envelope { get; set; }
+    }
+
+    /// <summary>
+    /// INTERNAL API. Mirror of <c>AcknowledgementInfo { cumulativeAck, nacks }</c>.
+    /// </summary>
+    [MessagePackObject(AllowPrivate = true)]
+    internal sealed class MpAck
+    {
+        /// <summary>Mirrors <c>cumulativeAck: fixed64</c>; stored as <c>long</c> (same bit pattern).</summary>
+        [Key(0)] public long CumulativeAck { get; set; }
+
+        /// <summary>Selective-NAK sequence numbers; may be null for a pure cumulative ACK.</summary>
+        [Key(1)] public long[]? Nacks { get; set; }
+    }
+
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Mirror of <c>RemoteEnvelope { recipient, message, sender, seq }</c>.
+    /// ActorRef paths are stored as strings (same as <c>ActorRefData.path</c>).
+    /// </summary>
+    [MessagePackObject(AllowPrivate = true)]
+    internal sealed class MpRemoteEnvelope
+    {
+        /// <summary>Full serialized path of the recipient actor ref (mirrors <c>ActorRefData.path</c>).</summary>
+        [Key(0)] public string RecipientPath { get; set; } = "";
+
+        /// <summary>The serialized message payload (mirrors <c>Payload</c> protobuf).</summary>
+        [Key(1)] public MpPayload Message { get; set; } = new();
+
+        /// <summary>Full serialized path of the sender. Null / empty when no sender is provided.</summary>
+        [Key(2)] public string? SenderPath { get; set; }
+
+        /// <summary>
+        /// Reliable-delivery sequence number. <c>ulong.MaxValue</c> (= <see cref="SeqUndefined"/>)
+        /// means no sequence number is assigned, matching the protobuf convention.
+        /// </summary>
+        [Key(3)] public ulong Seq { get; set; } = SeqUndefined;
+
+        /// <summary>Sentinel value meaning "no sequence number" — mirrors <c>ulong.MaxValue</c> in the protobuf codec.</summary>
+        public const ulong SeqUndefined = ulong.MaxValue;
+    }
+
+    /// <summary>
+    /// INTERNAL API. Mirror of the <c>Payload</c> protobuf message.
+    /// </summary>
+    [MessagePackObject(AllowPrivate = true)]
+    internal sealed class MpPayload
+    {
+        /// <summary>The opaque serialized actor message bytes.</summary>
+        [Key(0)] public byte[]? Message { get; set; }
+
+        /// <summary>Akka serializer ID (matches <c>Payload.serializerId</c>).</summary>
+        [Key(1)] public int SerializerId { get; set; }
+
+        /// <summary>
+        /// Optional type manifest bytes (matches <c>Payload.messageManifest</c>).
+        /// Null is used instead of an empty array to save 1 byte on the wire.
+        /// </summary>
+        [Key(2)] public byte[]? Manifest { get; set; }
+    }
+}
+
+
+
+
+
+
+

--- a/src/core/Akka.Remote/Transport/Pipelines/MessagePack/MpProtocol.cs
+++ b/src/core/Akka.Remote/Transport/Pipelines/MessagePack/MpProtocol.cs
@@ -7,6 +7,7 @@
 
 #nullable enable
 
+using System;
 using global::MessagePack;
 
 namespace Akka.Remote.Transport.Pipelines.MessagePack
@@ -160,7 +161,7 @@ namespace Akka.Remote.Transport.Pipelines.MessagePack
     internal sealed class MpPayload
     {
         /// <summary>The opaque serialized actor message bytes.</summary>
-        [Key(0)] public byte[]? Message { get; set; }
+        [Key(0)] public ReadOnlyMemory<byte>? Message { get; set; }
 
         /// <summary>Akka serializer ID (matches <c>Payload.serializerId</c>).</summary>
         [Key(1)] public int SerializerId { get; set; }

--- a/src/core/Akka.Remote/Transport/Pipelines/PipeAssociationHandle.cs
+++ b/src/core/Akka.Remote/Transport/Pipelines/PipeAssociationHandle.cs
@@ -1,0 +1,81 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PipeAssociationHandle.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System.Threading;
+using Akka.Actor;
+using Google.Protobuf;
+
+namespace Akka.Remote.Transport.Pipelines
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// <see cref="AssociationHandle"/> implementation for <see cref="TcpPipeTransport"/>.
+    ///
+    /// <para>
+    /// <see cref="Write"/> enqueues the payload onto the per-connection bounded
+    /// <see cref="System.Threading.Channels.Channel{T}"/> write queue and returns
+    /// <c>false</c> when the channel is at capacity (matching DotNetty water-mark semantics).
+    /// </para>
+    /// <para>
+    /// <see cref="Disassociate()"/> signals the owning <see cref="PipeConnection"/> to
+    /// cancel its read/write loops and close the socket.
+    /// </para>
+    ///
+    /// <!-- CopilotNotes: The circular reference between PipeAssociationHandle and PipeConnection is
+    ///      intentional — they are tightly coupled by design. Connection is set via the internal
+    ///      setter immediately after construction, before Start() is called, so there is no null risk
+    ///      in practice. The Interlocked guard on _disassociated prevents double-close. -->
+    /// </summary>
+    internal sealed class PipeAssociationHandle : AssociationHandle
+    {
+        // CAS guard: 0 = open, 1 = disassociated
+        private int _disassociated;
+
+        /// <summary>
+        /// Back-reference to the owning connection. Set by <see cref="PipeConnection"/> constructor.
+        /// </summary>
+        internal PipeConnection? Connection { get; set; }
+
+        /// <summary>
+        /// Initializes a new <see cref="PipeAssociationHandle"/>.
+        /// </summary>
+        public PipeAssociationHandle(Address localAddress, Address remoteAddress)
+            : base(localAddress, remoteAddress)
+        {
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Thread-safe. Returns <c>false</c> if the channel is full
+        /// or the association has already been disassociated.
+        /// A return value of <c>false</c> means the write was dropped
+        /// (guaranteed-no-duplication semantics per the <see cref="AssociationHandle"/> contract).
+        /// </remarks>
+        public override bool Write(ByteString payload)
+        {
+            if (Connection is null || Volatile.Read(ref _disassociated) == 1)
+                return false;
+
+            return Connection.TryEnqueueWrite(payload);
+        }
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Safe to call multiple times; only the first call takes effect.
+        /// </remarks>
+#pragma warning disable CS0672 // override of obsolete member — suppressed globally via Directory.Build.props NoWarn
+        public override void Disassociate()
+#pragma warning restore CS0672
+        {
+            if (Interlocked.CompareExchange(ref _disassociated, 1, 0) == 0)
+                Connection?.BeginDisassociate();
+        }
+    }
+}
+

--- a/src/core/Akka.Remote/Transport/Pipelines/PipeConnection.cs
+++ b/src/core/Akka.Remote/Transport/Pipelines/PipeConnection.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipelines;
 using System.Net.Sockets;
@@ -245,36 +246,80 @@ namespace Akka.Remote.Transport.Pipelines
 
         // ── Write loop ─────────────────────────────────────────────────────────
 
+        /// <summary>
+        /// Asynchronous write loop that drains <see cref="_writeChannel"/> and sends
+        /// coalesced length-prefixed frames to the underlying stream.
+        ///
+        /// <para>
+        /// <b>Double-buffer ping-pong optimisation 🏓</b>: two <see cref="ArrayBufferWriter{T}"/>
+        /// slots are pre-allocated and alternated each cycle.  While the OS/kernel is
+        /// transmitting the <em>previous</em> batch (in-flight <see cref="Task"/>), the CPU
+        /// simultaneously drains new messages from the channel into the <em>other</em> buffer.
+        /// The in-flight task is only awaited immediately before we would start the next
+        /// <see cref="Stream.WriteAsync(ReadOnlyMemory{byte},CancellationToken)"/> call, giving
+        /// maximum overlap between user-space batching and kernel I/O.
+        /// </para>
+        ///
+        /// <!-- CopilotNotes: ValueTask is NOT safe to store and re-await; .AsTask() boxes once
+        ///      but lets us hold the Task across loop iterations.  The swap (activeIdx ^= 1)
+        ///      is only performed when a write is actually started so we never clear a buffer
+        ///      that is still live inside an in-flight WriteAsync. -->
+        /// </summary>
         private async Task WriteLoopAsync(CancellationToken ct)
         {
-            // Reusable batch buffer — avoids per-batch heap allocations.
-            var batchBuffer = new ArrayBufferWriter<byte>(initialCapacity: 8192);
+            // Two buffers — one fills while the other is in-flight to the stream. ✨
+            var buffers = new ArrayBufferWriter<byte>[]
+            {
+                new(initialCapacity: 8192),
+                new(initialCapacity: 8192),
+            };
+            var activeIdx   = 0;
+            Task? inflightWrite = null;
 
             try
             {
                 while (await _writeChannel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
                 {
-                    batchBuffer.Clear();
+                    var active = buffers[activeIdx];
+                    active.Clear();
 
-                    // Drain ALL currently available payloads into a single batch write.
+                    // Drain ALL currently available payloads into the active buffer.
                     // This is the write-coalescing step: one StreamWriter.WriteAsync per batch
                     // instead of one per message.
                     while (_writeChannel.Reader.TryRead(out var payload))
                     {
                         // CopilotNotes: GetSpan returns at least 'count' bytes. We write the
                         // 4-byte LE length header then the payload bytes back-to-back.
-                        BinaryPrimitives.WriteInt32LittleEndian(batchBuffer.GetSpan(FrameHeaderSize), payload.Length);
-                        batchBuffer.Advance(FrameHeaderSize);
+                        BinaryPrimitives.WriteInt32LittleEndian(active.GetSpan(FrameHeaderSize), payload.Length);
+                        active.Advance(FrameHeaderSize);
 
-                        payload.AsSpan().CopyTo(batchBuffer.GetSpan(payload.Length));
-                        batchBuffer.Advance(payload.Length);
+                        payload.AsSpan().CopyTo(active.GetSpan(payload.Length));
+                        active.Advance(payload.Length);
                     }
 
-                    if (batchBuffer.WrittenCount > 0)
-                        await _stream.WriteAsync(batchBuffer.WrittenMemory, ct).ConfigureAwait(false);
-                    // No explicit Flush needed: NetworkStream.WriteAsync flushes immediately.
-                    // SslStream also flushes per WriteAsync call.
+                    if (active.WrittenCount > 0)
+                    {
+                        // Await the PREVIOUS write before launching the next one.
+                        // At this point inflightWrite owns the OTHER buffer slot, so once it
+                        // completes that slot is idle and can be safely cleared next cycle.
+                        // No explicit Flush needed: NetworkStream.WriteAsync flushes immediately.
+                        // SslStream also flushes per WriteAsync call.
+                        if (inflightWrite != null)
+                            await inflightWrite.ConfigureAwait(false);
+
+                        // Kick off the write for the freshly-filled buffer without awaiting it
+                        // yet — this is the key: kernel I/O runs concurrently with the next batch fill.
+                        inflightWrite = _stream.WriteAsync(active.WrittenMemory, ct).AsTask();
+
+                        // Swap: next iteration fills the slot that was just awaited (now idle).
+                        activeIdx ^= 1;
+                    }
                 }
+
+                // Channel drained — await the final in-flight write so we don't close
+                // the stream while bytes are still being flushed to the OS. 🌸
+                if (inflightWrite != null)
+                    await inflightWrite.ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/src/core/Akka.Remote/Transport/Pipelines/PipeConnection.cs
+++ b/src/core/Akka.Remote/Transport/Pipelines/PipeConnection.cs
@@ -1,0 +1,357 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PipeConnection.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.IO;
+using System.IO.Pipelines;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Akka.Event;
+using Google.Protobuf;
+
+namespace Akka.Remote.Transport.Pipelines
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Represents a single TCP association managed by <see cref="TcpPipeTransport"/>.
+    ///
+    /// <para>
+    /// Owns two async loops running concurrently via <see cref="Start"/>:
+    /// <list type="bullet">
+    ///   <item><see cref="ReadLoopAsync"/> — reads length-prefixed frames from a
+    ///     <see cref="PipeReader"/>-wrapped stream and delivers them to the registered
+    ///     <see cref="IHandleEventListener"/>.</item>
+    ///   <item><see cref="WriteLoopAsync"/> — drains a bounded
+    ///     <see cref="Channel{T}"/> and writes coalesced length-prefixed frames to the stream.</item>
+    /// </list>
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Frame format (little-endian, matching Akka.Remote's DotNetty default):</b>
+    /// <code>
+    /// ┌──────────────────────────┬───────────────────────────┐
+    /// │  length : int32 (4 B LE) │  payload : byte[length]   │
+    /// └──────────────────────────┴───────────────────────────┘
+    /// </code>
+    /// </para>
+    ///
+    /// <!-- CopilotNotes: Little-endian framing matches akka.remote.dot-netty.tcp byte-order = "little-endian".
+    ///      This makes rolling upgrades from DotNetty to PipeTransport wire-compatible when both use
+    ///      the protobuf AkkaProtocol codec. Phase 2 can negotiate a frame-tag format for further gains. -->
+    /// </summary>
+    internal sealed class PipeConnection : IDisposable
+    {
+        // ── Frame constants ─────────────────────────────────────────────────────
+        private const int FrameHeaderSize = 4; // 4-byte LE int32 length prefix
+
+        // ── Core infrastructure ────────────────────────────────────────────────
+        private readonly Socket _socket;
+        private readonly Stream _stream; // NetworkStream or SslStream
+        private readonly PipeReader _reader;
+        private readonly Channel<byte[]> _writeChannel;
+        private readonly CancellationTokenSource _cts;
+        private readonly ILoggingAdapter _log;
+        private readonly TcpPipeTransport _transport;
+
+        // Listener is set asynchronously once ReadHandlerSource.Task completes.
+        // CopilotNotes: Declared volatile so the write loop's TryEnqueueWrite has a cheap
+        // fast-exit path without taking a lock. The read loop awaits the handler source
+        // task before processing any frames, so the pre-listener buffer below is a
+        // belt-and-suspenders safety net for the inbound path only.
+        private volatile IHandleEventListener? _listener;
+
+        // Closed gate: 0 = open, 1 = closed. Used in BeginDisassociate / DisassociateQuiet.
+        private int _closed;
+
+        // ── Public API ─────────────────────────────────────────────────────────
+
+        /// <summary>The <see cref="AssociationHandle"/> exposed to the upper transport layers.</summary>
+        public PipeAssociationHandle Handle { get; }
+
+        // ── Constructor ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Constructs a <see cref="PipeConnection"/> over an already-connected (and optionally TLS-wrapped) stream.
+        /// Call <see cref="Start"/> after construction to start the read/write loops.
+        /// </summary>
+        /// <param name="socket">The underlying socket. Owned by this connection; closed on <see cref="Dispose"/>.</param>
+        /// <param name="stream">The <see cref="NetworkStream"/> or <see cref="System.Net.Security.SslStream"/> to use.</param>
+        /// <param name="handle">The pre-constructed association handle. Its <see cref="PipeAssociationHandle.Connection"/> is wired here.</param>
+        /// <param name="transport">Parent transport (used for connection-set bookkeeping).</param>
+        /// <param name="log">Logger.</param>
+        /// <param name="writeChannelCapacity">Bounded capacity of the outbound write channel.</param>
+        internal PipeConnection(
+            Socket socket,
+            Stream stream,
+            PipeAssociationHandle handle,
+            TcpPipeTransport transport,
+            ILoggingAdapter log,
+            int writeChannelCapacity)
+        {
+            _socket    = socket;
+            _stream    = stream;
+            _reader    = PipeReader.Create(stream, new StreamPipeReaderOptions(leaveOpen: true));
+            _writeChannel = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(writeChannelCapacity)
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                // CopilotNotes: DropWrite means a full channel returns false from TryWrite,
+                // which maps to the AssociationHandle.Write contract: "false = dropped, no duplicate".
+                FullMode = BoundedChannelFullMode.DropWrite
+            });
+            _cts       = new CancellationTokenSource();
+            _log       = log;
+            _transport = transport;
+            Handle     = handle;
+
+            // Wire circular reference: handle -> connection
+            handle.Connection = this;
+        }
+
+        // ── Lifecycle ──────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Starts the read and write loops as background <see cref="Task"/>s.
+        /// Must be called exactly once after construction.
+        /// </summary>
+        public void Start()
+        {
+            // Register listener callback: when ProtocolStateActor (or equivalent) completes
+            // ReadHandlerSource, store the listener reference so the read loop can deliver frames.
+            Handle.ReadHandlerSource.Task.ContinueWith(
+                t => { _listener = t.Result; },
+                TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnRanToCompletion);
+
+            // Fire-and-forget — exceptions are caught and logged inside each loop.
+            _ = ReadLoopAsync(_cts.Token);
+            _ = WriteLoopAsync(_cts.Token);
+        }
+
+        /// <summary>
+        /// Enqueue a payload for writing. Thread-safe. Returns <c>false</c> if the
+        /// channel is at capacity (write dropped) or the connection is closing.
+        /// </summary>
+        public bool TryEnqueueWrite(ByteString payload)
+        {
+            if (Volatile.Read(ref _closed) == 1)
+                return false;
+
+            // ToByteArray() copies — Phase 2 can eliminate this via IBufferWriter writer.
+            return _writeChannel.Writer.TryWrite(payload.ToByteArray());
+        }
+
+        /// <summary>
+        /// Begin graceful disassociation: drain any pending writes then close.
+        /// Safe to call multiple times concurrently.
+        /// </summary>
+        public void BeginDisassociate()
+        {
+            if (Interlocked.CompareExchange(ref _closed, 1, 0) == 0)
+            {
+                // Signal writer channel that no more items will be enqueued.
+                _writeChannel.Writer.TryComplete();
+                // Cancel both read + write loops.
+                _cts.Cancel();
+            }
+        }
+
+        /// <summary>
+        /// Quiet close used during transport-level shutdown — does NOT notify the listener
+        /// (the actor system is shutting down anyway).
+        /// </summary>
+        public void DisassociateQuiet()
+        {
+            if (Interlocked.CompareExchange(ref _closed, 1, 0) == 0)
+            {
+                _writeChannel.Writer.TryComplete();
+                _cts.Cancel();
+                CloseSocket();
+            }
+        }
+
+        // ── Read loop ──────────────────────────────────────────────────────────
+
+        private async Task ReadLoopAsync(CancellationToken ct)
+        {
+            try
+            {
+                // Wait for the upper layer (ProtocolStateActor) to register itself as the
+                // IHandleEventListener before we start processing frames.
+                // CopilotNotes: WaitAsync is .NET 6+ and returns a faulted task if ct is cancelled,
+                // which is caught below. On net10.0 this is in-box.
+                var listener = await Handle.ReadHandlerSource.Task
+                    .WaitAsync(ct)
+                    .ConfigureAwait(false);
+                _listener = listener;
+
+                while (!ct.IsCancellationRequested)
+                {
+                    var result = await _reader.ReadAsync(ct).ConfigureAwait(false);
+                    var buffer = result.Buffer;
+
+                    while (TryParseFrame(ref buffer, out var frame))
+                    {
+                        // CopilotNotes: ByteString.CopyFrom allocates per frame (the frame bytes are
+                        // already in a pooled PipeReader buffer). Phase 2 can avoid the copy by
+                        // teaching IHandleEventListener about ReadOnlySequence<byte> directly.
+                        var bytes = frame.IsSingleSegment
+                            ? ByteString.CopyFrom(frame.FirstSpan)
+                            : ByteString.CopyFrom(frame.ToArray());
+
+                        listener.Notify(new InboundPayload(bytes));
+                    }
+
+                    _reader.AdvanceTo(buffer.Start, buffer.End);
+
+                    if (result.IsCompleted || result.IsCanceled)
+                        break;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Normal shutdown — no-op.
+            }
+            catch (Exception ex) when (IsConnectionReset(ex))
+            {
+                _log.Info("Pipe transport: connection reset by remote [{0}]", Handle.RemoteAddress);
+            }
+            catch (EndOfStreamException)
+            {
+                _log.Debug("Pipe transport: remote [{0}] closed the connection.", Handle.RemoteAddress);
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Pipe transport: read loop error on connection [{0}]", Handle.RemoteAddress);
+            }
+            finally
+            {
+                await _reader.CompleteAsync().ConfigureAwait(false);
+                NotifyDisassociated();
+                CloseSocket();
+                _transport.RemoveConnection(this);
+            }
+        }
+
+        // ── Write loop ─────────────────────────────────────────────────────────
+
+        private async Task WriteLoopAsync(CancellationToken ct)
+        {
+            // Reusable batch buffer — avoids per-batch heap allocations.
+            var batchBuffer = new ArrayBufferWriter<byte>(initialCapacity: 8192);
+
+            try
+            {
+                while (await _writeChannel.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
+                {
+                    batchBuffer.Clear();
+
+                    // Drain ALL currently available payloads into a single batch write.
+                    // This is the write-coalescing step: one StreamWriter.WriteAsync per batch
+                    // instead of one per message.
+                    while (_writeChannel.Reader.TryRead(out var payload))
+                    {
+                        // CopilotNotes: GetSpan returns at least 'count' bytes. We write the
+                        // 4-byte LE length header then the payload bytes back-to-back.
+                        BinaryPrimitives.WriteInt32LittleEndian(batchBuffer.GetSpan(FrameHeaderSize), payload.Length);
+                        batchBuffer.Advance(FrameHeaderSize);
+
+                        payload.AsSpan().CopyTo(batchBuffer.GetSpan(payload.Length));
+                        batchBuffer.Advance(payload.Length);
+                    }
+
+                    if (batchBuffer.WrittenCount > 0)
+                        await _stream.WriteAsync(batchBuffer.WrittenMemory, ct).ConfigureAwait(false);
+                    // No explicit Flush needed: NetworkStream.WriteAsync flushes immediately.
+                    // SslStream also flushes per WriteAsync call.
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Normal shutdown — no-op.
+            }
+            catch (Exception ex) when (IsConnectionReset(ex))
+            {
+                _log.Info("Pipe transport: write connection reset on [{0}]", Handle.RemoteAddress);
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Pipe transport: write loop error on connection [{0}]", Handle.RemoteAddress);
+            }
+        }
+
+        // ── Frame parsing ──────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Tries to parse one complete frame from <paramref name="buffer"/>.
+        /// On success, advances <paramref name="buffer"/> past the consumed header + payload.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryParseFrame(ref ReadOnlySequence<byte> buffer, out ReadOnlySequence<byte> frame)
+        {
+            if (buffer.Length < FrameHeaderSize)
+            {
+                frame = default;
+                return false;
+            }
+
+            Span<byte> header = stackalloc byte[FrameHeaderSize];
+            buffer.Slice(0, FrameHeaderSize).CopyTo(header);
+            var payloadLength = BinaryPrimitives.ReadInt32LittleEndian(header);
+
+            // Guard against corrupt / malicious frames.
+            if (payloadLength < 0 || buffer.Length < FrameHeaderSize + (long)payloadLength)
+            {
+                frame = default;
+                return false;
+            }
+
+            frame  = buffer.Slice(FrameHeaderSize, payloadLength);
+            buffer = buffer.Slice(FrameHeaderSize + payloadLength);
+            return true;
+        }
+
+        // ── Helpers ────────────────────────────────────────────────────────────
+
+        private void NotifyDisassociated()
+        {
+            // Only notify if the listener is already wired — if not, the connection died
+            // before the upper layer could register, which is a non-fatal edge case.
+            _listener?.Notify(new Disassociated(DisassociateInfo.Unknown));
+        }
+
+        private void CloseSocket()
+        {
+            try { _socket.Shutdown(SocketShutdown.Both); } catch (Exception) { /* Socket may already be closed */ }
+            try { _socket.Close();  } catch (Exception) { /* Best-effort */ }
+            try { _stream.Dispose(); } catch (Exception) { /* Best-effort */ }
+        }
+
+        private static bool IsConnectionReset(Exception ex) =>
+            ex is SocketException { SocketErrorCode: SocketError.ConnectionReset
+                                                   or SocketError.ConnectionAborted
+                                                   or SocketError.OperationAborted }
+            || (ex is IOException ioEx && ioEx.InnerException is SocketException);
+
+        // ── IDisposable ────────────────────────────────────────────────────────
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            BeginDisassociate();
+            _cts.Dispose();
+        }
+    }
+}
+
+

--- a/src/core/Akka.Remote/Transport/Pipelines/PipeTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/Pipelines/PipeTransportSettings.cs
@@ -1,0 +1,157 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="PipeTransportSettings.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Net;
+using Akka.Configuration;
+using Akka.Remote.Transport.DotNetty; // SslSettings lives here; same assembly so internal access is fine
+
+namespace Akka.Remote.Transport.Pipelines
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Configuration for <see cref="TcpPipeTransport"/>, parsed from the
+    /// <c>akka.remote.pipe.tcp</c> HOCON block.
+    ///
+    /// <!-- CopilotNotes: Sealed class (not record) so per-property XML docs work cleanly in C# 12.
+    ///      The factory method pattern mirrors DotNettyTransportSettings.Create(). -->
+    /// </summary>
+    internal sealed class PipeTransportSettings
+    {
+        // ── Minimum frame size guard mirrors the DotNetty transport constraint ─
+        private const int MinFrameSize = 32_000;
+
+        // ── Properties ─────────────────────────────────────────────────────────
+
+        /// <summary>The hostname or IP address to bind to (empty → 0.0.0.0).</summary>
+        public string Hostname { get; }
+
+        /// <summary>Public-facing hostname advertised via Akka addresses (e.g. for NAT / Docker).</summary>
+        public string PublicHostname { get; }
+
+        /// <summary>TCP port to listen on. 0 = random.</summary>
+        public int Port { get; }
+
+        /// <summary>Public port to advertise (<c>null</c> = use <see cref="Port"/>).</summary>
+        public int? PublicPort { get; }
+
+        /// <summary>Enable TLS/SSL on this transport.</summary>
+        public bool EnableSsl { get; }
+
+        /// <summary>Timeout for outbound TCP connect attempts.</summary>
+        public TimeSpan ConnectTimeout { get; }
+
+        /// <summary>Maximum allowed frame payload size in bytes. Must be ≥ 32 000.</summary>
+        public int MaxFrameSize { get; }
+
+        /// <summary>Socket <c>SO_SNDBUF</c> in bytes.</summary>
+        public int SendBufferSize { get; }
+
+        /// <summary>Socket <c>SO_RCVBUF</c> in bytes.</summary>
+        public int ReceiveBufferSize { get; }
+
+        /// <summary>Server listen backlog (passed to <c>Socket.Listen</c>).</summary>
+        public int Backlog { get; }
+
+        /// <summary>Enable TCP keepalive probes.</summary>
+        public bool TcpKeepAlive { get; }
+
+        /// <summary>Disable Nagle's algorithm (<c>TCP_NODELAY</c>) for lower latency.</summary>
+        public bool TcpNoDelay { get; }
+
+        /// <summary>Prefer IPv6 when resolving hostnames via DNS.</summary>
+        public bool DnsUseIpv6 { get; }
+
+        /// <summary>
+        /// Bounded capacity of the per-connection outbound write channel.
+        /// When full, <see cref="AssociationHandle.Write"/> returns <c>false</c>
+        /// (matching DotNetty water-mark semantics: write was dropped, no duplicate).
+        /// </summary>
+        public int WriteChannelCapacity { get; }
+
+        /// <summary>SSL/TLS settings. Only meaningful when <see cref="EnableSsl"/> is <c>true</c>.</summary>
+        public SslSettings Ssl { get; }
+
+        // ── Constructor ────────────────────────────────────────────────────────
+
+        private PipeTransportSettings(
+            string hostname, string publicHostname, int port, int? publicPort,
+            bool enableSsl, TimeSpan connectTimeout, int maxFrameSize,
+            int sendBufferSize, int receiveBufferSize, int backlog,
+            bool tcpKeepAlive, bool tcpNoDelay, bool dnsUseIpv6,
+            int writeChannelCapacity, SslSettings ssl)
+        {
+            Hostname             = hostname;
+            PublicHostname       = publicHostname;
+            Port                 = port;
+            PublicPort           = publicPort;
+            EnableSsl            = enableSsl;
+            ConnectTimeout       = connectTimeout;
+            MaxFrameSize         = maxFrameSize;
+            SendBufferSize       = sendBufferSize;
+            ReceiveBufferSize    = receiveBufferSize;
+            Backlog              = backlog;
+            TcpKeepAlive         = tcpKeepAlive;
+            TcpNoDelay           = tcpNoDelay;
+            DnsUseIpv6           = dnsUseIpv6;
+            WriteChannelCapacity = writeChannelCapacity;
+            Ssl                  = ssl;
+        }
+
+        // ── Factory ────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Parse settings from the provided <paramref name="config"/> block
+        /// (expected to be the resolved <c>akka.remote.pipe.tcp</c> sub-config).
+        /// </summary>
+        /// <exception cref="ConfigurationException">
+        /// Thrown when the config block is null or empty, or <c>maximum-frame-size</c>
+        /// is below the minimum.
+        /// </exception>
+        public static PipeTransportSettings Create(Config config)
+        {
+            if (config.IsNullOrEmpty())
+                throw ConfigurationException.NullOrEmptyConfig<PipeTransportSettings>("akka.remote.pipe.tcp");
+
+            var host = config.GetString("hostname", "");
+            if (string.IsNullOrWhiteSpace(host))
+                host = IPAddress.Any.ToString();
+
+            var publicHost = config.GetString("public-hostname", "");
+            var enableSsl  = config.GetBoolean("enable-ssl");
+            var publicPort = config.GetInt("public-port");
+            var maxFrame   = (int)(config.GetByteSize("maximum-frame-size", null) ?? 128_000L);
+
+            if (maxFrame < MinFrameSize)
+                throw new ArgumentException(
+                    $"akka.remote.pipe.tcp.maximum-frame-size must be at least {MinFrameSize} bytes",
+                    nameof(maxFrame));
+
+            return new PipeTransportSettings(
+                hostname:            host,
+                publicHostname:      !string.IsNullOrEmpty(publicHost) ? publicHost : host,
+                port:                config.GetInt("port", 2552),
+                publicPort:          publicPort > 0 ? publicPort : null,
+                enableSsl:           enableSsl,
+                connectTimeout:      config.GetTimeSpan("connection-timeout", TimeSpan.FromSeconds(15)),
+                maxFrameSize:        maxFrame,
+                sendBufferSize:      (int)(config.GetByteSize("send-buffer-size",    null) ?? 256_000L),
+                receiveBufferSize:   (int)(config.GetByteSize("receive-buffer-size", null) ?? 256_000L),
+                backlog:             config.GetInt("backlog", 4096),
+                tcpKeepAlive:        config.GetBoolean("tcp-keepalive", true),
+                tcpNoDelay:          config.GetBoolean("tcp-nodelay",   true),
+                dnsUseIpv6:          config.GetBoolean("dns-use-ipv6",  false),
+                writeChannelCapacity: config.GetInt("write-channel-capacity", 1024),
+                ssl: enableSsl
+                    ? SslSettings.Create(config.GetConfig("ssl"))
+                    : SslSettings.Empty
+            );
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/Pipelines/PipeTransportSettings.cs
+++ b/src/core/Akka.Remote/Transport/Pipelines/PipeTransportSettings.cs
@@ -7,12 +7,37 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Net;
+using Akka.Actor;
 using Akka.Configuration;
 using Akka.Remote.Transport.DotNetty; // SslSettings lives here; same assembly so internal access is fine
 
 namespace Akka.Remote.Transport.Pipelines
 {
+    /// <summary>
+    /// Selects which PDU envelope codec the Pipelines transport uses for
+    /// the <c>AkkaProtocol</c> wire layer.
+    ///
+    /// <!-- CopilotNotes: Only switch to MessagePack when every node in the cluster
+    ///      is running the PipeTransport with this setting — mixed clusters will throw
+    ///      PduCodecException when trying to decode the incorrect wire format. -->
+    /// </summary>
+    internal enum EnvelopeCodecKind
+    {
+        /// <summary>
+        /// Default — the same protobuf-based <c>AkkaPduProtobuffCodec</c> used by DotNetty.
+        /// Wire-compatible with all existing Akka.Remote nodes.
+        /// </summary>
+        Protobuf,
+
+        /// <summary>
+        /// Opt-in — source-generated MessagePack codec.  Smaller frames, lower GC pressure,
+        /// but <b>not</b> wire-compatible with protobuf nodes.
+        /// </summary>
+        MessagePack
+    }
+
     /// <summary>
     /// INTERNAL API.
     ///
@@ -78,6 +103,13 @@ namespace Akka.Remote.Transport.Pipelines
         /// <summary>SSL/TLS settings. Only meaningful when <see cref="EnableSsl"/> is <c>true</c>.</summary>
         public SslSettings Ssl { get; }
 
+        /// <summary>
+        /// Selects which PDU codec is used for the AkkaProtocol wire layer.
+        /// Defaults to <see cref="EnvelopeCodecKind.Protobuf"/> for wire-compatibility
+        /// with DotNetty nodes.
+        /// </summary>
+        public EnvelopeCodecKind EnvelopeCodec { get; }
+
         // ── Constructor ────────────────────────────────────────────────────────
 
         private PipeTransportSettings(
@@ -85,7 +117,8 @@ namespace Akka.Remote.Transport.Pipelines
             bool enableSsl, TimeSpan connectTimeout, int maxFrameSize,
             int sendBufferSize, int receiveBufferSize, int backlog,
             bool tcpKeepAlive, bool tcpNoDelay, bool dnsUseIpv6,
-            int writeChannelCapacity, SslSettings ssl)
+            int writeChannelCapacity, SslSettings ssl,
+            EnvelopeCodecKind envelopeCodec)
         {
             Hostname             = hostname;
             PublicHostname       = publicHostname;
@@ -102,6 +135,7 @@ namespace Akka.Remote.Transport.Pipelines
             DnsUseIpv6           = dnsUseIpv6;
             WriteChannelCapacity = writeChannelCapacity;
             Ssl                  = ssl;
+            EnvelopeCodec        = envelopeCodec;
         }
 
         // ── Factory ────────────────────────────────────────────────────────────
@@ -133,6 +167,11 @@ namespace Akka.Remote.Transport.Pipelines
                     $"akka.remote.pipe.tcp.maximum-frame-size must be at least {MinFrameSize} bytes",
                     nameof(maxFrame));
 
+            var envelopeStr = config.GetString("envelope", "protobuf");
+            var envelopeCodec = string.Equals(envelopeStr, "messagepack", StringComparison.OrdinalIgnoreCase)
+                ? EnvelopeCodecKind.MessagePack
+                : EnvelopeCodecKind.Protobuf;
+
             return new PipeTransportSettings(
                 hostname:            host,
                 publicHostname:      !string.IsNullOrEmpty(publicHost) ? publicHost : host,
@@ -150,8 +189,48 @@ namespace Akka.Remote.Transport.Pipelines
                 writeChannelCapacity: config.GetInt("write-channel-capacity", 1024),
                 ssl: enableSsl
                     ? SslSettings.Create(config.GetConfig("ssl"))
-                    : SslSettings.Empty
+                    : SslSettings.Empty,
+                envelopeCodec: envelopeCodec
             );
+        }
+
+        /// <summary>
+        /// Creates the <see cref="AkkaPduCodec"/> appropriate for the current
+        /// <paramref name="remoteConfig"/> (<c>akka.remote</c> block).
+        ///
+        /// <para>
+        /// When <c>akka.remote.pipe.tcp</c> is in <c>enabled-transports</c> and its
+        /// <c>envelope</c> key is <c>"messagepack"</c>, returns an
+        /// <see cref="AkkaPduMessagePackCodec"/>; otherwise returns the default
+        /// <see cref="AkkaPduProtobuffCodec"/>.
+        /// </para>
+        ///
+        /// <!-- CopilotNotes: Called from EndpointManager and AkkaProtocolManager to
+        ///      ensure the same codec is used consistently for both the protocol-level
+        ///      (handshake/heartbeat/disassociate) and message-level (AckAndEnvelope) frames. -->
+        /// </summary>
+        /// <param name="remoteConfig">The resolved <c>akka.remote</c> config block.</param>
+        /// <param name="system">The hosting actor system.</param>
+        /// <returns>The most appropriate <see cref="AkkaPduCodec"/> instance.</returns>
+        public static AkkaPduCodec CreateCodec(Config remoteConfig, ActorSystem system)
+        {
+            IList<string>? enabledTransports = null;
+            try { enabledTransports = remoteConfig.GetStringList("enabled-transports"); }
+            catch (Exception) { /* config key absent — fall back to protobuf */ }
+
+            if (enabledTransports != null
+                && enabledTransports.Contains("akka.remote.pipe.tcp"))
+            {
+                var pipeConfig = remoteConfig.GetConfig("pipe.tcp");
+                if (!pipeConfig.IsNullOrEmpty())
+                {
+                    var envelope = pipeConfig.GetString("envelope", "protobuf");
+                    if (string.Equals(envelope, "messagepack", StringComparison.OrdinalIgnoreCase))
+                        return new AkkaPduMessagePackCodec(system);
+                }
+            }
+
+            return new AkkaPduProtobuffCodec(system);
         }
     }
 }

--- a/src/core/Akka.Remote/Transport/Pipelines/TcpPipeTransport.cs
+++ b/src/core/Akka.Remote/Transport/Pipelines/TcpPipeTransport.cs
@@ -1,0 +1,476 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TcpPipeTransport.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote.Transport.DotNetty;
+using Akka.Util;
+
+namespace Akka.Remote.Transport.Pipelines
+{
+    /// <summary>
+    /// A <see cref="Transport"/> implementation backed by <see cref="System.IO.Pipelines"/>
+    /// and raw BCL sockets — no DotNetty dependency on the hot path.
+    ///
+    /// <para>
+    /// Activate by adding <c>akka.remote.pipe.tcp</c> to <c>akka.remote.enabled-transports</c>:
+    /// <code>
+    /// akka.remote.enabled-transports = ["akka.remote.pipe.tcp"]
+    /// </code>
+    /// </para>
+    ///
+    /// <para>
+    /// Phase 1 design: this class implements the existing <see cref="Transport"/> SPI so
+    /// every actor layer above it (<c>EndpointManager</c>, <c>AkkaProtocolTransport</c>,
+    /// <c>ProtocolStateActor</c>) is unchanged.  See
+    /// <c>akka-remote-transport-redux.md</c> for the full design rationale.
+    /// </para>
+    ///
+    /// <!-- CopilotNotes: Public because the Remoting startup code reflects on the type
+    ///      name stored in HOCON transport-class. The class must be constructible with
+    ///      (ActorSystem, Config) — the same convention as TcpTransport. -->
+    /// </summary>
+    public sealed class TcpPipeTransport : Transport
+    {
+        // ── Fields ─────────────────────────────────────────────────────────────
+        private readonly PipeTransportSettings _settings;
+        private readonly ILoggingAdapter _log;
+
+        // Server socket; set during Listen().
+        private Socket? _serverSocket;
+
+        // Resolved local Akka address; set during Listen().
+        private Address? _localAddress;
+
+        // Completed with the IAssociationEventListener when the upper layer is ready.
+        private readonly TaskCompletionSource<IAssociationEventListener> _associationListenerPromise = new();
+
+        // Cancellation source for the accept loop and all connections.
+        private readonly CancellationTokenSource _shutdownCts = new();
+
+        // Thread-safe set of active connections — used for graceful shutdown.
+        private readonly ConcurrentSet<PipeConnection> _connections = new();
+
+        // ── Constructor ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Constructor called by the Akka.Remote transport loader (via reflection).
+        /// Signature must be <c>(ActorSystem system, Config config)</c>.
+        /// </summary>
+        /// <param name="system">The hosting actor system.</param>
+        /// <param name="config">
+        /// The resolved <c>akka.remote.pipe.tcp</c> config block.
+        /// </param>
+        public TcpPipeTransport(ActorSystem system, Config config)
+        {
+            System             = system;
+            Config             = config;
+            _settings          = PipeTransportSettings.Create(config);
+            _log               = Logging.GetLogger(system, this);
+            SchemeIdentifier   = (_settings.EnableSsl ? "ssl." : string.Empty) + "tcp";
+            MaximumPayloadBytes = _settings.MaxFrameSize;
+        }
+
+        // ── Transport contract ─────────────────────────────────────────────────
+
+        /// <inheritdoc/>
+        public override string SchemeIdentifier { get; protected set; }
+
+        /// <inheritdoc/>
+        public override long MaximumPayloadBytes { get; protected set; }
+
+        /// <inheritdoc/>
+        public override bool IsResponsibleFor(Address remote) => true;
+
+        /// <inheritdoc/>
+        /// <summary>
+        /// Binds the server socket and schedules the accept loop to start once the
+        /// <see cref="IAssociationEventListener"/> is registered.
+        /// </summary>
+        public override async Task<(Address, TaskCompletionSource<IAssociationEventListener>)> Listen()
+        {
+            if (_settings.EnableSsl)
+                _settings.Ssl.ValidateCertificate(); // fail fast on bad cert
+
+            var listenEndPoint = await ResolveEndpointAsync(_settings.Hostname, _settings.Port)
+                .ConfigureAwait(false);
+
+            _serverSocket = CreateServerSocket();
+            _serverSocket.Bind(listenEndPoint);
+            _serverSocket.Listen(_settings.Backlog);
+
+            var localEp = (IPEndPoint)_serverSocket.LocalEndPoint!;
+            _localAddress = DotNettyTransport.MapSocketToAddress(
+                localEp,
+                schemeIdentifier: SchemeIdentifier,
+                systemName:       System.Name,
+                hostName:         _settings.PublicHostname,
+                publicPort:       _settings.PublicPort);
+
+            if (_localAddress is null)
+                throw new InvalidOperationException(
+                    $"Could not map local endpoint [{localEp}] to an Akka.Remote Address.");
+
+            // Defer accept loop until the upper layer has registered an IAssociationEventListener.
+            // This mirrors DotNetty's AutoRead=false-until-ready behaviour.
+            _ = _associationListenerPromise.Task.ContinueWith(
+                _ => AcceptLoopAsync(_shutdownCts.Token),
+                TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
+
+            _log.Info("Pipe transport listening on [{0}]", _localAddress);
+            return (_localAddress, _associationListenerPromise);
+        }
+
+        /// <inheritdoc/>
+        /// <summary>
+        /// Resolves the remote <paramref name="remoteAddress"/>, connects a socket,
+        /// and returns a <see cref="PipeAssociationHandle"/> backed by a started
+        /// <see cref="PipeConnection"/>.
+        /// </summary>
+        public override async Task<AssociationHandle> Associate(Address remoteAddress)
+        {
+            if (_localAddress is null)
+                throw new InvalidOperationException(
+                    "Transport has not been started. Call Listen() before Associate().");
+
+            var remoteEp = await ResolveEndpointAsync(remoteAddress.Host!, remoteAddress.Port!.Value)
+                .ConfigureAwait(false);
+
+            var socket = CreateClientSocket();
+            try
+            {
+                using var connectCts = new CancellationTokenSource(_settings.ConnectTimeout);
+                await socket.ConnectAsync(remoteEp, connectCts.Token).ConfigureAwait(false);
+
+                var stream = await BuildStreamAsync(socket, remoteAddress.Host!, isServer: false, connectCts.Token)
+                    .ConfigureAwait(false);
+
+                var handle = new PipeAssociationHandle(_localAddress!, remoteAddress);
+                var conn   = new PipeConnection(
+                    socket, stream, handle, this, _log, _settings.WriteChannelCapacity);
+
+                _connections.TryAdd(conn);
+                conn.Start();
+
+                _log.Debug("Pipe transport: outbound connection established to [{0}]", remoteAddress);
+                return handle;
+            }
+            catch (InvalidAssociationException)
+            {
+                // Already the right type — rethrow without wrapping.
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                socket.Dispose();
+                throw new InvalidAssociationException(
+                    $"Connection to [{remoteAddress}] timed out after {_settings.ConnectTimeout}.");
+            }
+            catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionRefused)
+            {
+                socket.Dispose();
+                throw new InvalidAssociationException(
+                    $"Connection refused by [{remoteAddress}].", ex);
+            }
+            catch (Exception ex)
+            {
+                // CopilotNotes: Wrap ALL connection-setup failures as InvalidAssociationException so
+                // EndpointManager's gating logic works correctly — mirrors how DotNetty's
+                // HandleConnectException wraps everything in InvalidAssociationException.
+                socket.Dispose();
+                throw new InvalidAssociationException(
+                    $"Failed to associate with [{remoteAddress}]: {ex.Message}", ex);
+            }
+        }
+
+        /// <inheritdoc/>
+        public override async Task<bool> Shutdown()
+        {
+            _log.Debug("Pipe transport: shutting down.");
+            _shutdownCts.Cancel();
+
+            // Quietly close all active connections (no Disassociated events — system is going away).
+            foreach (var conn in _connections)
+                conn.DisassociateQuiet();
+            _connections.Clear();
+
+            try { _serverSocket?.Close(); } catch { /* Best-effort */ }
+
+            await Task.CompletedTask.ConfigureAwait(false);
+            return true;
+        }
+
+        // ── Internal API used by PipeConnection ────────────────────────────────
+
+        /// <summary>
+        /// Removes a closed connection from the tracking set.
+        /// Called from <see cref="PipeConnection"/> after its read loop exits.
+        /// </summary>
+        internal void RemoveConnection(PipeConnection connection)
+        {
+            _connections.TryRemove(connection);
+        }
+
+        // ── Accept loop ────────────────────────────────────────────────────────
+
+        private async Task AcceptLoopAsync(CancellationToken ct)
+        {
+            // The listener promise is already completed at this point (ContinueWith guard).
+            var listener = _associationListenerPromise.Task.Result;
+
+            _log.Debug("Pipe transport: accept loop started.");
+
+            while (!ct.IsCancellationRequested)
+            {
+                Socket clientSocket;
+                try
+                {
+                    clientSocket = await _serverSocket!.AcceptAsync(ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break; // Normal shutdown
+                }
+                catch (Exception ex)
+                {
+                    if (!ct.IsCancellationRequested)
+                        _log.Warning("Pipe transport: accept loop error [{0}]", ex.Message);
+                    break;
+                }
+
+                // Handle each inbound connection independently — never block the accept loop.
+                _ = HandleInboundAsync(clientSocket, listener, ct);
+            }
+
+            _log.Debug("Pipe transport: accept loop stopped.");
+        }
+
+        private async Task HandleInboundAsync(
+            Socket clientSocket,
+            IAssociationEventListener listener,
+            CancellationToken ct = default)
+        {
+            try
+            {
+                var remoteEp = (IPEndPoint)clientSocket.RemoteEndPoint!;
+
+                // CopilotNotes: MapSocketToAddress is a static helper on DotNettyTransport.
+                // Since we're in the same assembly we can call it here directly.
+                // In a future standalone Akka.Remote.Transport.Pipelines project this would
+                // need to be copied or the helper promoted to a shared utility class.
+                var remoteAddress = DotNettyTransport.MapSocketToAddress(
+                    remoteEp,
+                    schemeIdentifier: SchemeIdentifier,
+                    systemName:       System.Name);
+
+                if (remoteAddress is null)
+                {
+                    _log.Warning(
+                        "Pipe transport: could not map remote endpoint [{0}] to an Akka Address. Dropping.",
+                        remoteEp);
+                    clientSocket.Dispose();
+                    return;
+                }
+
+                var host   = remoteEp.Address.ToString();
+                var stream = await BuildStreamAsync(clientSocket, host, isServer: true, ct).ConfigureAwait(false);
+
+                var handle = new PipeAssociationHandle(_localAddress!, remoteAddress);
+                var conn   = new PipeConnection(
+                    clientSocket, stream, handle, this, _log, _settings.WriteChannelCapacity);
+
+                _connections.TryAdd(conn);
+                conn.Start();
+
+                listener.Notify(new InboundAssociation(handle));
+                _log.Debug("Pipe transport: inbound connection from [{0}]", remoteAddress);
+            }
+            catch (Exception ex)
+            {
+                _log.Warning(ex, "Pipe transport: error setting up inbound connection from [{0}]",
+                    clientSocket.RemoteEndPoint);
+                clientSocket.Dispose();
+            }
+        }
+
+        // ── TLS helper ─────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Returns a plain <see cref="System.Net.Sockets.NetworkStream"/> when TLS is disabled,
+        /// or a fully authenticated <see cref="SslStream"/> when enabled.
+        /// </summary>
+        private async Task<System.IO.Stream> BuildStreamAsync(
+            Socket socket,
+            string host,
+            bool isServer,
+            CancellationToken ct = default)
+        {
+            var networkStream = new NetworkStream(socket, ownsSocket: false);
+            if (!_settings.EnableSsl)
+                return networkStream;
+
+            var ssl = new SslStream(networkStream, leaveInnerStreamOpen: false);
+            try
+            {
+                if (isServer)
+                {
+                    await ssl.AuthenticateAsServerAsync(new SslServerAuthenticationOptions
+                    {
+                        ServerCertificate              = _settings.Ssl.Certificate,
+                        ClientCertificateRequired      = _settings.Ssl.RequireMutualAuthentication,
+                        RemoteCertificateValidationCallback = BuildValidationCallback(host),
+                    }, ct).ConfigureAwait(false);
+                }
+                else
+                {
+                    await ssl.AuthenticateAsClientAsync(new SslClientAuthenticationOptions
+                    {
+                        TargetHost         = host,
+                        ClientCertificates = _settings.Ssl.Certificate is not null
+                            ? new X509CertificateCollection { _settings.Ssl.Certificate }
+                            : null,
+                        RemoteCertificateValidationCallback = BuildValidationCallback(host),
+                    }, ct).ConfigureAwait(false);
+                }
+            }
+            catch (AuthenticationException ex)
+            {
+                await ssl.DisposeAsync().ConfigureAwait(false);
+                throw new InvalidAssociationException(
+                    $"TLS handshake with [{host}] failed: {ex.Message}", ex);
+            }
+
+            return ssl;
+        }
+
+        /// <summary>
+        /// Builds a <see cref="RemoteCertificateValidationCallback"/> from the current SSL settings.
+        /// Honours <see cref="DotNetty.SslSettings.SuppressValidation"/> and
+        /// <see cref="DotNetty.SslSettings.CustomValidator"/>.
+        /// </summary>
+        private RemoteCertificateValidationCallback BuildValidationCallback(string host)
+        {
+            var ssl = _settings.Ssl;
+
+            if (ssl.SuppressValidation)
+                return (_, _, _, _) => true;
+
+            return (_, cert, chain, errors) =>
+            {
+                if (ssl.CustomValidator is not null)
+                {
+#if NET10_0_OR_GREATER
+                    var cert2 = cert as X509Certificate2
+                                ?? (cert is not null
+                                    ? X509CertificateLoader.LoadCertificate(cert.GetRawCertData())
+                                    : null);
+#else
+                    var cert2 = cert as X509Certificate2
+                                ?? (cert is not null ? new X509Certificate2(cert) : null);
+#endif
+                    return ssl.CustomValidator(cert2, chain, host, errors, _log);
+                }
+
+                if (errors == SslPolicyErrors.None)
+                    return true;
+
+                _log.Warning("Pipe transport: TLS cert validation failed for [{0}]: {1}", host, errors);
+                return false;
+            };
+        }
+
+        // ── Socket factory helpers ─────────────────────────────────────────────
+
+        private Socket CreateServerSocket()
+        {
+            var family = _settings.DnsUseIpv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork;
+            var socket = new Socket(family, SocketType.Stream, ProtocolType.Tcp);
+            socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            ApplyCommonSocketOptions(socket);
+            return socket;
+        }
+
+        private Socket CreateClientSocket()
+        {
+            var family = _settings.DnsUseIpv6 ? AddressFamily.InterNetworkV6 : AddressFamily.InterNetwork;
+            var socket = new Socket(family, SocketType.Stream, ProtocolType.Tcp);
+            ApplyCommonSocketOptions(socket);
+            return socket;
+        }
+
+        private void ApplyCommonSocketOptions(Socket socket)
+        {
+            if (_settings.TcpNoDelay)
+                socket.NoDelay = true;
+
+            if (_settings.TcpKeepAlive)
+                socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+
+            if (_settings.ReceiveBufferSize > 0)
+                socket.ReceiveBufferSize = _settings.ReceiveBufferSize;
+
+            if (_settings.SendBufferSize > 0)
+                socket.SendBufferSize = _settings.SendBufferSize;
+        }
+
+        // ── DNS resolution ─────────────────────────────────────────────────────
+
+        private async Task<IPEndPoint> ResolveEndpointAsync(string hostname, int port)
+        {
+            // Bind-all shortcut
+            if (string.IsNullOrWhiteSpace(hostname)
+                || hostname == IPAddress.Any.ToString()
+                || hostname == IPAddress.IPv6Any.ToString())
+            {
+                return new IPEndPoint(IPAddress.Any, port);
+            }
+
+            // Already an IP address
+            if (IPAddress.TryParse(hostname, out var ip))
+                return new IPEndPoint(ip, port);
+
+            // DNS resolution
+            var addresses = await Dns.GetHostAddressesAsync(hostname).ConfigureAwait(false);
+
+            // Filter link-local (APIPA) addresses to avoid connecting to unreachable NICs.
+            var filtered = DotNettyTransport.FilterLinkLocalAddresses(addresses).ToArray();
+            var candidates = filtered.Length > 0 ? filtered : addresses;
+
+            var preferredFamily = _settings.DnsUseIpv6
+                ? AddressFamily.InterNetworkV6
+                : AddressFamily.InterNetwork;
+
+            var found = Array.Find(candidates, a => a.AddressFamily == preferredFamily)
+                        ?? candidates.FirstOrDefault();
+
+            if (found is null)
+                throw new InvalidOperationException(
+                    $"Could not resolve hostname [{hostname}] to any IP address.");
+
+            return new IPEndPoint(found, port);
+        }
+    }
+}
+
+
+
+
+
+
+
+

--- a/src/core/Akka.Remote/akka-remote-akka-protocol-redux.md
+++ b/src/core/Akka.Remote/akka-remote-akka-protocol-redux.md
@@ -1,0 +1,412 @@
+﻿# Akka.Remote AkkaProtocol Redux (Phase 2)
+
+> Companion to [akka-remote-transport-redux.md](./akka-remote-transport-redux.md).
+> That doc covers Phase 1 — replacing the DotNetty wire transport with a
+> `System.IO.Pipelines`-based implementation while leaving the
+> `AkkaProtocolTransport` / `ProtocolStateActor` layer untouched. **This** doc
+> covers Phase 2 — collapsing that FSM-actor layer into the new transport.
+
+---
+
+## What `AkkaProtocolTransport` Does Today
+
+`AkkaProtocolTransport` is a logical `Transport` that wraps the physical
+DotNetty `Transport` and adds three things on top of every association:
+
+1. **A handshake** carrying a `HandshakeInfo { Origin: Address, Uid: int }`
+   so that both sides learn each other's logical address and incarnation UID
+   before any user payload flows.
+2. **Heartbeats and a Phi-Accrual failure detector** so a silent peer is
+   torn down even if the underlying socket is still nominally open.
+3. **Disassociation semantics with a reason** (`Unknown`, `Shutdown`,
+   `Quarantined`) wired to quarantine and `RefuseUid` handling in
+   `EndpointManager`.
+
+It implements all of this with a per-association FSM actor.
+
+### The actor cast
+
+| Type | Role |
+|---|---|
+| `AkkaProtocolTransport` | `ActorTransportAdapter` facade. `Associate(remote, refuseUid)` sends an `AssociateUnderlyingRefuseUid` to the manager. |
+| `AkkaProtocolManager` | `ActorTransportAdapterManager`. On `InboundAssociation` or `AssociateUnderlying[RefuseUid]` it spawns one `ProtocolStateActor` per association, supervised `Directive.Stop`. |
+| `ProtocolStateActor` | `FSM<AssociationState, ProtocolStateData>` — the actual protocol state machine. One per association. |
+| `AkkaProtocolHandle` | `AbstractTransportAdapterHandle` returned to `EndpointWriter` / `EndpointReader`. `Write(payload)` calls `Codec.ConstructPayload` and forwards to the wrapped handle. `Disassociate(info)` is just `StateActor.Tell(new DisassociateUnderlying(info))`. |
+| `AkkaPduCodec` (impl `AkkaPduProtobuffCodec`) | Protobuf encode/decode of `AkkaProtocolMessage` (control vs. payload) and `AckAndEnvelopeContainer` (seq/ack envelope). |
+
+### The FSM
+
+States are `AssociationState.Closed`, `WaitHandshake`, `Open`. Per-state data
+classes (`OutboundUnassociated`, `OutboundUnderlyingAssociated`,
+`InboundUnassociated`, `AssociatedWaitHandler`, `ListenerReady`) carry the
+wrapped handle, the `TaskCompletionSource<AssociationHandle>` for the
+caller, and a buffer queue for payloads that arrive before the upper-layer
+listener has been wired in.
+
+Outbound flow:
+
+1. `Closed` + `HandleMsg` → call `SendAssociate`, start heartbeat timer,
+   transition to `WaitHandshake`.
+2. `WaitHandshake` + inbound `Associate` PDU → check `_refuseUid`; if it
+   matches, `SendDisassociate(Quarantined)` and `Stop(ForbiddenUidReason)`;
+   otherwise `_failureDetector.HeartBeat()`, cancel `HandshakeTimer`,
+   transition to `Open` with an `AssociatedWaitHandler` that holds a
+   queue plus a `Task<IHandleEventListener>` for the upper layer's
+   read handler.
+
+Inbound flow:
+
+1. Starts in `WaitHandshake` with `InboundUnassociated`.
+2. On the first inbound `Associate` PDU → `SendAssociate` (implicit ACK),
+   start heartbeat timer, transition to `Open` and notify the
+   `IAssociationEventListener` with a fresh `AkkaProtocolHandle`.
+
+Common to both:
+
+- `HeartbeatTimer` fires every `TransportHeartBeatInterval`. If the
+  failure detector still says `IsAvailable`, send a `Heartbeat` PDU.
+  Otherwise `SendDisassociate(Unknown)` and `Stop` with a
+  `TimeoutReason`.
+- `HandshakeTimer` fires once after `HandshakeTimeout`; if we are not
+  yet in `Open`, send disassociate and stop.
+- `Disassociated` from below → `Stop(Failure(d.Info))`.
+- `OnTermination` fans the failure out to the
+  `TaskCompletionSource<AssociationHandle>` (if outbound and not yet
+  resolved), to the upper-layer listener via `Disassociated`, and
+  finally to `WrappedHandle.Disassociate(reason, log)`.
+
+### The two-phase listener registration
+
+The `EndpointWriter` / `EndpointReader` cannot consume frames until they
+are constructed, but the FSM may already be receiving payloads while it
+waits. `ProtocolStateActor` solves this with a
+`TaskCompletionSource<IHandleEventListener>` (`AkkaProtocolHandle.ReadHandlerSource`)
+plus an internal `HandleListenerRegistered` message:
+
+1. Promote to `Open` carrying an `AssociatedWaitHandler` whose `Queue`
+   buffers `Payload` PDUs.
+2. Upper layer eventually completes `ReadHandlerSource`; that
+   continuation pipes a `HandleListenerRegistered` back into the FSM.
+3. FSM drains the queue into the listener and transitions data state to
+   `ListenerReady`.
+
+### Wire format
+
+`AkkaPduProtobuffCodec` produces three shapes wrapped in
+`AkkaProtocolMessage` (a oneof of `Instruction` vs. `Payload`):
+
+- `AkkaControlMessage { CommandType: Associate, HandshakeInfo }`
+- `AkkaControlMessage { CommandType: Disassociate | DisassociateShuttingDown | DisassociateQuarantined }`
+- `AkkaControlMessage { CommandType: Heartbeat }` — cached as a single
+  static `ByteString` (`HeartbeatPdu`).
+- A non-empty `Payload` field whose bytes are themselves an
+  `AckAndEnvelopeContainer` (built by `EndpointWriter` via
+  `ConstructMessage` / `ConstructPureAck`).
+
+---
+
+## Sources of Overhead
+
+| # | Cost | Where it shows up |
+|---|---|---|
+| 1 | **One actor per association**, one mailbox hop per inbound frame and one per outbound frame | `ProtocolStateActor` receives every `InboundPayload`, decodes the PDU, then calls `Listener.Notify`. Outbound `Disassociate` and `Heartbeat` are also Tells. |
+| 2 | **FSM allocations** on every event | `Event<T>`, `State<S,D>`, `FSMBase.Reason`, plus rebuilt data records. `Open + Payload` allocates a fresh `Queue<ByteString>` every frame while waiting for the listener (`new Queue<ByteString>(awh.Queue)`). |
+| 3 | **Two-phase listener handshake** | `ReadHandlerSource` is a `TaskCompletionSource`, `ListenForListenerRegistration` adds a `ContinueWith` + `PipeTo(Self)`, the FSM then walks the queue. Adds at least one scheduler hop per association. |
+| 4 | **Scheduler-driven heartbeats** | `SetTimer("heartbeat-timer", new HeartbeatTimer(), interval, repeat: true)` per association. With N associations that is N independent scheduler entries and N mailbox enqueues per tick. |
+| 5 | **Failure detector behind an actor** | `_failureDetector.HeartBeat()` and `IsAvailable` are called from message handlers, so every signal pays the mailbox cost above. |
+| 6 | **Codec is interface-dispatched and reflective** | `_codec.DecodePdu(...)` returns `IAkkaPdu`, then a `switch` dispatches; the underlying `AkkaProtocolMessage.Parser.ParseFrom` is protobuf-reflective and allocates regardless of whether the frame is a 0-byte heartbeat or a 64 KB payload. |
+| 7 | **Disassociate path Tells** | `AkkaProtocolHandle.Disassociate(info)` is `StateActor.Tell(new DisassociateUnderlying(info))` — even a graceful shutdown costs another mailbox round-trip. |
+
+---
+
+## Stack: Today vs. Phase 2
+
+```mermaid
+graph TD
+    subgraph Today["Phase 1 — FSM actor per association"]
+        EM1[EndpointManager] --> EW1[EndpointWriter / Reader]
+        EW1 --> APH1[AkkaProtocolHandle]
+        APH1 --> PSA[ProtocolStateActor &#40;FSM&#41;]
+        PSA --> Codec1[AkkaPduProtobuffCodec]
+        PSA --> FD1[PhiAccrualFailureDetector]
+        PSA --> Sched1[ActorSystem Scheduler<br/>HeartbeatTimer / HandshakeTimer]
+        PSA --> WH1[Wrapped AssociationHandle]
+        WH1 --> Pipe1[PipeConnection read/write loops]
+    end
+
+    subgraph Phase2["Phase 2 — inline state machine on the read loop"]
+        EM2[EndpointManager] --> EW2[EndpointWriter / Reader]
+        EW2 --> APH2[AkkaProtocolHandle &#40;facade&#41;]
+        APH2 --> Conn[PipeConnection]
+        Conn --> SM[InlineProtocolState<br/>&#40;struct + enum switch&#41;]
+        Conn --> Codec2[AkkaPduProtobuffCodec<br/>or MessagePack]
+        SM --> FD2[PhiAccrualFailureDetector<br/>&#40;called from read loop&#41;]
+        SM --> Tick[Shared PeriodicTimer<br/>per transport]
+    end
+```
+
+Net effect: the `ProtocolStateActor` box and its mailbox disappear; the
+state machine runs as a plain method called from inside the connection's
+`PipeReader` loop. `AkkaProtocolHandle` survives as a thin facade so the
+upper layers see the same `AssociationHandle` SPI.
+
+---
+
+## Inline Handshake (no FSM actor)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Sock as Socket / SslStream
+    participant Reader as PipeConnection.ReadLoop
+    participant SM as InlineProtocolState
+    participant FD as PhiAccrualFailureDetector
+    participant EM as EndpointManager
+    participant EW as EndpointWriter
+
+    Note over SM: state = WaitHandshake (inbound)
+    Sock->>Reader: bytes
+    Reader->>Reader: parse length-prefixed frame
+    Reader->>SM: OnFrame(tag=Associate, payload)
+    SM->>SM: decode HandshakeInfo
+    SM->>FD: HeartBeat()
+    SM->>SM: write reply Associate via Channel<Frame>
+    SM->>SM: state = Open
+    SM->>EM: InboundAssociation(AkkaProtocolHandle facade)
+    EM->>EW: spawn EndpointWriter / Reader
+    EW->>SM: SetListener(IHandleEventListener)
+    Note over Reader,SM: From now on, every payload frame is<br/>delivered directly to the listener<br/>with no mailbox hop.
+    Sock->>Reader: bytes
+    Reader->>SM: OnFrame(tag=Payload, payload)
+    SM->>FD: HeartBeat()
+    SM->>EW: listener.Notify(InboundPayload)
+```
+
+Key differences vs. today:
+
+- The FSM lives on the read loop; there is **no `Tell`** between
+  decoding a frame and notifying the listener.
+- The `AkkaProtocolHandle` facade is created and surfaced to
+  `EndpointManager` only **after** the handshake completes, so
+  `EndpointWriter` never sees a half-open association and the
+  `AssociatedWaitHandler` queue / `HandleListenerRegistered` dance is
+  gone.
+- A handful of frames that arrive in the (sub-microsecond) window
+  between `Open` and `SetListener` are buffered in a tiny
+  `ArrayBuffer<ReadOnlySequence<byte>>` on the connection rather than
+  allocated as fresh `Queue<ByteString>` instances per frame.
+
+---
+
+## Frame-Tag Fast Path
+
+Today every inbound frame is parsed as `AkkaProtocolMessage` before we
+know whether it is control or payload. Phase 2 prefixes each frame with
+a single byte tag that mirrors the existing `CommandType` plus
+`Payload`:
+
+```
++--------+--------+----+----+----+----+========================+
+| len32 (BE)      | tg | <body bytes>                          |
++--------+--------+----+----+----+----+========================+
+
+tg = 1 Associate    body = AkkaHandshakeInfo (protobuf or msgpack)
+tg = 2 Disassociate body = 1 byte DisassociateInfo enum
+tg = 3 Heartbeat    body = empty
+tg = 4 Payload      body = AckAndEnvelopeContainer bytes
+```
+
+Heartbeats are a fixed 5-byte frame and never enter the protobuf
+parser. `Payload` frames are forwarded to the upper-layer listener as
+the same `AckAndEnvelopeContainer` bytes today's code expects, so
+`EndpointReader` is unchanged.
+
+**Wire compatibility**: a `pipe.tcp` node configured with
+`envelope = protobuf` and `inline-protocol = off` produces and consumes
+the legacy `AkkaProtocolMessage`-wrapped bytes. The tagged frame layout
+above only kicks in when both peers negotiate
+`inline-protocol = on` (Phase 2). See the migration section.
+
+---
+
+## FSM Actor vs. Inline State Machine
+
+| Concern | `ProtocolStateActor` (today) | Inline state machine (Phase 2) |
+|---|---|---|
+| Threading model | Akka mailbox + dispatcher | The connection's `PipeReader` `async` loop |
+| Per-frame cost | Decode → `Tell` → mailbox dequeue → `Notify` | Decode → direct method call to `IHandleEventListener` |
+| State representation | `FSM<AssociationState, ProtocolStateData>` + 5 data classes | `enum InlineState { WaitHandshake, Open, Closed }` + a `struct InlineProtocolState` field on the connection |
+| State transition allocs | `Event<T>`, `State<S,D>`, new data record per change | Field assignment; zero allocation on the steady-state path |
+| Heartbeat timer | One `SetTimer` per association on the system scheduler | One `PeriodicTimer` per transport, fans out to active connections |
+| Handshake timer | `SetTimer(HandshakeTimerKey, …)` per association | `Stopwatch.GetTimestamp()` checked from the heartbeat tick |
+| Failure detector | `_failureDetector.HeartBeat()` from message handler | Same call, made directly on the read loop after every frame |
+| Listener wiring | `TaskCompletionSource<IHandleEventListener>` + `HandleListenerRegistered` | Single `Volatile.Write` to a `_listener` field, with a tiny pre-listener buffer |
+| Outbound `Disassociate` | `StateActor.Tell(DisassociateUnderlying)` | Direct enqueue on the connection's `Channel<Frame>` |
+| Quarantine / `RefuseUid` | Compared in `WaitHandshake` after decoding `Associate` | Same comparison, same `Disassociate(Quarantined)` reply, same `ForbiddenUidReason` raised to `EndpointManager` |
+| Debuggability | Akka FSM event log, supervised under `AkkaProtocolManager` | Inline log statements + structured trace; FSM event log goes away |
+
+---
+
+## Thread-Safety: Outbound vs. Inbound
+
+The inline state machine is touched from two sides:
+
+- **Inbound (read loop):** decodes frames, advances state, calls
+  `_failureDetector.HeartBeat()`, hands payloads to the listener.
+- **Outbound (`AkkaProtocolHandle.Write` from `EndpointWriter`):** must
+  check that the handshake is complete and enqueue a Payload frame.
+
+Two viable designs:
+
+1. **Funnel outbound through the same `Channel<Frame>` already used by
+   the writer loop.** State checks happen inside the writer loop, which
+   is single-threaded by construction. `EndpointWriter` only ever
+   `TryWrite`s; the channel handles backpressure.
+2. **Lock-free state load.** `InlineProtocolState.Phase` is an
+   `int` field; outbound `Write` does an `Volatile.Read` and refuses if
+   not `Open`. Frames still go through the writer channel but
+   `Disassociate` can be enqueued from any thread.
+
+Recommend **(1)** as the default — it preserves a single ownership rule
+("the writer loop owns outbound state") and matches how
+`Channel<Frame>` is already used in the Phase 1 transport.
+
+---
+
+## Failure Detector Without an Actor
+
+`PhiAccrualFailureDetector` already has its own `Clock` abstraction and
+holds its sample state in private fields. The only Akka coupling is
+through `FailureDetectorRegistry.LoadFailureDetector(...)`, which calls
+the `(Config, EventStream)` constructor.
+
+Phase 2 keeps the same construction path inside `PipeTransport` setup
+(`FailureDetectorRegistry` / `Context.LoadFailureDetector` equivalents
+called once at transport startup), then invokes
+`heartbeat()` / `IsAvailable` directly from the read loop and the
+shared heartbeat tick — no behavioural change, just no mailbox between
+the call sites and the detector.
+
+---
+
+## Surfacing Errors Without Re-introducing a Mailbox Hop
+
+Hot-path frames (Payload, Heartbeat) bypass the `EndpointManager` entirely
+and go straight to the existing `IHandleEventListener`. Errors and
+lifecycle events still need to reach `EndpointManager`:
+
+- **Disassociation (any reason)** — one-shot `IActorRef.Tell` of a
+  `Disassociated(info)` to the listener actor, exactly as today.
+- **Quarantine / `RefuseUid` failures during handshake** — the inline
+  state machine fails the outbound
+  `TaskCompletionSource<AssociationHandle>` with the same
+  `AkkaProtocolException` text the FSM produces today (so log scraping
+  and tests stay valid), then closes the connection.
+- **Underlying transport errors** — published to the system event
+  stream the same way `PublishError` does today.
+
+The cost is at most one `Tell` per association lifetime, not per frame.
+
+---
+
+## Migration Strategy
+
+Phase 2 is **opt-in** for at least one minor release.
+
+- **HOCON switch**: `akka.remote.pipe.tcp.inline-protocol = off`
+  default in the first release that ships it. When `off`, the new
+  `PipeTransport` continues to wrap `AkkaProtocolTransport` exactly
+  like Phase 1; the inline state machine is not constructed.
+- When `on`, `PipeTransport` constructs the inline state machine
+  directly and **does not register `AkkaProtocolTransport`** in the
+  adapter chain. The `AkkaProtocolHandle` facade is created by the
+  inline implementation so `EndpointManager`, `EndpointWriter`,
+  `EndpointReader`, and `ReliableDeliverySupervisor` see no API change.
+- **Wire compatibility** is preserved when the protobuf codec is
+  selected and `inline-protocol = off`. With `inline-protocol = on`
+  both peers must agree (it changes the framing tag); this is gated
+  the same way the MessagePack envelope is gated in Phase 1.
+
+### Behaviours that MUST be preserved exactly
+
+- Quarantine: receiving `DisassociateQuarantined` from a remote with
+  a known UID still triggers the same `AkkaProtocolException` text
+  (`"The remote system has quarantined this system…"`) so
+  `EndpointManager`'s quarantine bookkeeping is unchanged.
+- `RefuseUid`: outbound association where the remote's `Associate.Uid`
+  matches the supplied refuseUid still results in
+  `SendDisassociate(Quarantined)` followed by an
+  `AkkaProtocolException` carrying the `ForbiddenUidReason` text.
+- Handshake timeout: `AkkaProtocolException` text and
+  `TimeoutException` propagation to the
+  `TaskCompletionSource<AssociationHandle>` are byte-for-byte identical.
+- Disassociate-with-reason logging: the `DisassociationReason(reason)`
+  strings emitted today by `ProtocolStateActor.OnTermination` must
+  appear in the same log messages.
+
+### Behaviour change that needs a release note
+
+- The Akka FSM event log for `ProtocolStateActor` (visible if you
+  enable `akka.actor.debug.fsm = on`) goes away when
+  `inline-protocol = on`. There is no equivalent FSM trace; the inline
+  implementation logs the same transitions at `Debug` instead.
+
+### Test plan
+
+- Re-run `AkkaProtocolSpec` and `AkkaProtocolStressTest` (under
+  `src/core/Akka.Remote.Tests/Transport/`) twice in CI: once against
+  the FSM implementation, once with `inline-protocol = on`. Both must
+  pass unchanged.
+- Re-run the existing remoting integration tests
+  (`Akka.Remote.Tests` + `Akka.Cluster.Tests`) under both modes.
+- Add a focused unit suite for the inline state machine that
+  exercises every transition the FSM does today
+  (`Closed → WaitHandshake`, `WaitHandshake → Open`,
+  `Open → Closed` via `Disassociate(*)`, both handshake and heartbeat
+  timeouts, refuseUid path).
+- Wire-format snapshot test: capture every PDU bytes produced by
+  `AkkaPduProtobuffCodec` today and assert the inline implementation
+  produces the same bytes when `envelope = protobuf` and
+  `inline-protocol = off`.
+
+---
+
+## Risks & Open Questions
+
+1. **Handshake-state visibility on outbound writes.** Recommend
+   funnelling all outbound frames through the per-connection
+   `Channel<Frame>`; do we need a non-blocking "try, else drop"
+   variant for `Heartbeat` to avoid HOL-blocking under user-payload
+   pressure?
+2. **Pre-listener buffering bound.** Today's `AssociatedWaitHandler.Queue`
+   is unbounded (`Queue<ByteString>`). The inline implementation should
+   bound it (e.g. 32 frames) and trip a hard disassociation if exceeded —
+   strictly safer, but a behaviour change worth flagging in the release
+   note.
+3. **`PhiAccrualFailureDetector` clock source.** Currently uses Akka's
+   `Clock` abstraction. Inline use from the read loop means we should
+   verify the default `Clock` implementation is lock-free; if it is
+   not, swap to a `Stopwatch.GetTimestamp()`-backed clock at
+   construction.
+4. **Removing `AkkaProtocolTransport` registration when
+   `inline-protocol = on`.** The current `Remoting` startup wraps every
+   loaded transport with `AkkaProtocolTransport` automatically. Phase 2
+   needs a clean way for `PipeTransport` to opt out of that wrap
+   without breaking the loader contract for other transports.
+5. **Diagnostics.** Some operators rely on the FSM event log to debug
+   association problems. We should ship a structured replacement
+   (e.g. `Akka.Remote.InlineProtocol.Trace` event source) before
+   defaulting `inline-protocol` to `on`.
+
+---
+
+## Out of Scope
+
+- Replacing `EndpointWriter` / `ReliableDeliverySupervisor` (Artery-style
+  outbound stream) — separate proposal.
+- Changing the wire envelope (`AckAndEnvelopeContainer`) — covered by
+  the Phase 1 doc's MessagePack discussion.
+- Removing `AkkaProtocolTransport` for transports other than the new
+  `PipeTransport`. The DotNetty transport keeps the FSM until it is
+  retired.
+

--- a/src/core/Akka.Remote/akka-remote-transport-redux.md
+++ b/src/core/Akka.Remote/akka-remote-transport-redux.md
@@ -378,4 +378,32 @@ require no changes other than the transport-class path.
 | `tcp-nodelay` | `on` | Disable Nagle's algorithm |
 | `dns-use-ipv6` | `false` | Prefer IPv6 in DNS resolution |
 | `write-channel-capacity` | `1024` | Outbound write-channel bound |
+| `envelope` | `protobuf` | PDU envelope codec: `"protobuf"` (wire-compat default) or `"messagepack"` (cluster-wide opt-in, better perf) |
+
+### Enabling MessagePack envelopes (cluster-wide opt-in)
+
+> ⚠️ **Every node in the cluster must use the same codec.** Mixed-codec clusters
+> will throw `PduCodecException` on decode.  Roll out in a coordinated cluster
+> restart, not a rolling upgrade.
+
+```hocon
+akka.remote.pipe.tcp {
+  hostname = "0.0.0.0"
+  port     = 2552
+  envelope = messagepack   # switch from protobuf to MessagePack
+}
+```
+
+The MessagePack codec (`AkkaPduMessagePackCodec`) mirrors the
+`AkkaProtocolMessage` / `AckAndEnvelopeContainer` protobuf schema using the
+[MessagePack-CSharp](https://github.com/MessagePack-CSharp/MessagePack-CSharp)
+v3 library already bundled in `Akka.Remote`.  It produces smaller frames
+and lower GC pressure because:
+
+- Control messages (heartbeat, disassociate) are pre-serialised into static
+  `byte[]` fields — **no per-call allocation**.
+- Actor-ref paths are stored as plain strings (same data, no protobuf
+  `ActorRefData` wrapper struct).
+- `MpPayload` fields that are empty are serialised as MessagePack `nil` instead
+  of an empty `bytes` field, saving a few bytes per message.
 

--- a/src/core/Akka.Remote/akka-remote-transport-redux.md
+++ b/src/core/Akka.Remote/akka-remote-transport-redux.md
@@ -1,0 +1,381 @@
+# Akka.Remote.Transport Redux
+
+We want to replace the current DotNetty transport with a new one.
+
+we want to consider both TCP and TLS.
+We want to be able to compare performance between the old and new transports.
+
+We should consider modern Dotnet designs using System.IO.Pipelines such as exampled by [Nats.Net v2](https://github.com/nats-io/nats.net)
+and [Akka.Streams](https://github.com/akkadotnet/akka.net/tree/dev/src/Akka.Streams).
+
+We should also consider the possibility of this new transport using MessagePack rather than Protobuf for envelopes.
+
+---
+
+## Current Architecture
+
+Akka.Remote today is a layered stack of actors sitting on top of an abstract
+`Transport` SPI, with the only production implementation being the DotNetty
+TCP/TLS transport.
+
+```mermaid
+graph TD
+    subgraph User["User Code"]
+        URef[RemoteActorRef.Tell]
+    end
+
+    subgraph Provider["Provider Layer"]
+        RARP[RemoteActorRefProvider]
+        RT[Remoting]
+    end
+
+    subgraph EndpointActors["Endpoint Actor Layer (per remote address)"]
+        EM[EndpointManager]
+        RDS[ReliableDeliverySupervisor]
+        EW[EndpointWriter]
+        ER[EndpointReader]
+    end
+
+    subgraph Protocol["Akka Protocol Layer (FSM per association)"]
+        APM[AkkaProtocolManager]
+        PSA[ProtocolStateActor &#40;FSM&#41;]
+        APH[AkkaProtocolHandle]
+        Codec[AkkaPduCodec &#40;protobuf&#41;]
+    end
+
+    subgraph TransportSPI["Transport SPI"]
+        T[Transport &#40;abstract&#41;<br/>Listen / Associate]
+        AH[AssociationHandle]
+        HEL[IHandleEventListener]
+        AEL[IAssociationEventListener]
+    end
+
+    subgraph DotNetty["DotNetty Implementation"]
+        DNT[DotNettyTransport]
+        TCP[TcpTransport]
+        TH[TcpServerHandler / TcpClientHandler]
+        TAH[TcpAssociationHandle]
+        BW[BatchWriter]
+        SSL[DotNettySslSetup &#40;TlsHandler&#41;]
+    end
+
+    Sock[(Socket / Wire)]
+
+    URef --> RARP --> RT --> EM
+    EM --> RDS --> EW
+    EM --> ER
+    EW --> APH
+    ER --> APH
+    APH --> PSA
+    PSA --> APM
+    APH --> Codec
+    APM --> T
+    APH --> AH
+    AH --> HEL
+    T --> AEL
+    T --> DNT
+    DNT --> TCP
+    TCP --> TH
+    TH --> TAH
+    TAH --> BW
+    TCP -. optional .-> SSL
+    BW --> Sock
+    SSL --> Sock
+```
+
+### Outbound Message Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant App as RemoteActorRef
+    participant EW as EndpointWriter
+    participant MS as MessageSerializer
+    participant PC as AkkaPduCodec
+    participant APH as AkkaProtocolHandle
+    participant TAH as TcpAssociationHandle
+    participant Ch as DotNetty IChannel
+    participant Wire
+
+    App->>EW: Tell(message)
+    EW->>MS: Serialize(message) -> SerializedMessage (protobuf)
+    EW->>PC: ConstructMessage(seq, ack, payload)
+    PC-->>EW: AckAndEnvelopeContainer bytes
+    EW->>APH: Write(ByteString)
+    APH->>TAH: Write(ByteString)
+    TAH->>Ch: WriteAsync(IByteBuffer) [LengthFieldPrepender]
+    Ch->>Wire: length-prefixed frame
+```
+
+The inbound path is the mirror image: `TcpHandlers.ChannelRead` copies the
+incoming `IByteBuffer` into a Google `ByteString`, raises `InboundPayload` on
+the `IHandleEventListener`, the `ProtocolStateActor` decodes it via
+`AkkaPduCodec`, and an `AckAndMessage` is forwarded to the `EndpointReader`,
+which dispatches to the local `IInternalActorRef`.
+
+### Pain Points Motivating a Rewrite
+
+- **DotNetty is effectively unmaintained** and increasingly painful on modern
+  .NET (TFM churn, trimming/AOT hostility, allocation-heavy buffers).
+- **Per-read allocations** &mdash; `TcpHandlers.ChannelRead` calls
+  `ByteString.CopyFrom` for every inbound frame, defeating any pooling Netty
+  does upstream.
+- **Protobuf reflection** in the hot path for `AckAndEnvelopeContainer` adds
+  CPU + GC pressure that source-generated codecs avoid.
+- **Actor-per-association FSM overhead** &mdash; `ProtocolStateActor` adds a
+  mailbox hop on every inbound and outbound frame.
+- **No `System.IO.Pipelines` backpressure** &mdash; flow control today is
+  emulated via `BatchWriter` + DotNetty water-marks rather than the BCL's
+  pipe primitives.
+- **TLS via DotNetty `TlsHandler`** instead of the BCL `SslStream`, which
+  diverges from the rest of the .NET ecosystem.
+
+---
+
+## Proposed Architecture
+
+The new transport drops in at the existing `Transport` SPI, so Phase 1 leaves
+every actor above it (`EndpointManager`, `EndpointWriter`/`Reader`,
+`AkkaProtocolHandle`, `ProtocolStateActor`) untouched. This keeps quarantine,
+handshake, and reliable-delivery semantics identical and lets us A/B the wire
+implementation only.
+
+```mermaid
+graph TD
+    subgraph Unchanged["Unchanged Upper Layers"]
+        EM[EndpointManager]
+        EW[EndpointWriter / EndpointReader]
+        APH[AkkaProtocolHandle / ProtocolStateActor]
+    end
+
+    subgraph NewTransport["New PipeTransport &#40;Transport SPI&#41;"]
+        PT[PipeTransport]
+        Listener[Socket Accept Loop]
+        Conn[PipeConnection &#40;per association&#41;]
+        Reader[Read Loop<br/>PipeReader + SequenceReader]
+        Writer[Write Loop<br/>Channel&lt;Frame&gt; + PipeWriter]
+        PAH[PipeAssociationHandle]
+        Frame[FrameCodec &#40;length-prefixed&#41;]
+    end
+
+    subgraph Codec["Pluggable Envelope Codec"]
+        PB[Protobuf AkkaPduCodec<br/>&#40;wire-compat default&#41;]
+        MP[MessagePack Codec<br/>&#40;opt-in&#41;]
+    end
+
+    subgraph BCL[".NET BCL"]
+        Sock[(Socket)]
+        Ssl[SslStream &#40;TLS&#41;]
+        Pipe[System.IO.Pipelines]
+    end
+
+    EM --> EW --> APH --> PT
+    PT --> Listener --> Conn
+    PT --> Conn
+    Conn --> Reader
+    Conn --> Writer
+    Reader --> Frame --> PAH --> APH
+    APH --> PAH --> Writer
+    Writer --> Frame
+    Frame --> PB
+    Frame -. opt-in .-> MP
+    Reader --> Pipe
+    Writer --> Pipe
+    Pipe --> Sock
+    Pipe -. TLS .-> Ssl --> Sock
+```
+
+### Key Design Choices
+
+- **`SocketConnection` + `PipeReader`/`PipeWriter`** modeled on Nats.Net v2's
+  `NatsConnection` / `CommandWriter` and Akka.Streams' `TcpStage`. Reads parse
+  frames directly off `ReadOnlySequence<byte>` &mdash; zero copy until the
+  envelope codec needs a contiguous span.
+- **Length-prefixed framing** identical to today's
+  `LengthFieldBasedFrameDecoder` layout (4-byte BE length + payload), so a
+  Pipelines node and a DotNetty node remain wire-compatible when both use the
+  protobuf codec.
+- **Write coalescing** via a bounded `Channel<Frame>` feeding a single writer
+  loop that flushes the `PipeWriter` once per drained batch &mdash; same idea
+  as `BatchWriter` but expressed in BCL primitives.
+- **TLS via `SslStream`**, wrapped over the raw `Socket` before the pipe is
+  built. Cert loading reuses the existing HOCON keys from `DotNettySslSetup`.
+- **MessagePack envelope (opt-in)** &mdash; a `MessagePackPduCodec` mirrors
+  the `AckAndMessage` shape (handshake, heartbeat, disassociate, payload with
+  seq/ack) using source-generated formatters. Gated behind
+  `akka.remote.pipe.tcp.envelope = messagepack` and only safe when the
+  entire cluster is on the new codec.
+
+### Phase 2 (Future)
+
+Once Phase 1 is proven, collapse the `ProtocolStateActor` FSM into the
+transport itself (handshake/heartbeat handled inline on the read loop) to
+remove a mailbox hop per frame. This is explicitly **out of scope** for the
+initial PR &mdash; see the companion doc
+[akka-remote-akka-protocol-redux.md](./akka-remote-akka-protocol-redux.md)
+for the detailed Phase 2 design.
+
+---
+
+## Comparison
+
+| Concern             | Current (DotNetty)                              | Proposed (Pipelines)                              |
+|---------------------|-------------------------------------------------|---------------------------------------------------|
+| Dependency          | `DotNetty.*` (unmaintained)                     | BCL `System.IO.Pipelines` only                    |
+| Buffers             | `IByteBuffer` &rarr; `ByteString.CopyFrom`      | Pooled `ReadOnlySequence<byte>`, zero-copy reads  |
+| Async model         | Netty event-loop threads                        | `async`/`await` reader+writer loops per conn      |
+| Framing             | `LengthFieldBasedFrameDecoder/Prepender`        | Hand-rolled `SequenceReader<byte>` (same layout)  |
+| TLS                 | DotNetty `TlsHandler`                           | `SslStream` over `Socket`                         |
+| Envelope (default)  | Protobuf reflection (`AckAndEnvelopeContainer`) | Same protobuf bytes (compat)                      |
+| Envelope (opt-in)   | n/a                                             | Source-gen MessagePack                            |
+| Write batching      | `BatchWriter` + Netty water-marks               | `Channel<Frame>` + `PipeWriter` flush coalescing  |
+| SPI surface         | `Transport` / `AssociationHandle`               | **Unchanged** &mdash; same SPI, new impl          |
+
+---
+
+## Migration / Compatibility
+
+- **Wire compatibility** is preserved when the MessagePack codec is **off**.
+  The new transport produces and consumes the exact same length-prefixed
+  `AkkaProtocolMessage` / `AckAndEnvelopeContainer` bytes as DotNetty, so a
+  Pipelines node can join an otherwise-DotNetty cluster.
+- **HOCON switch:** ship both transports in `Akka.Remote` and let users opt
+  in via `akka.remote.enabled-transports = ["akka.remote.pipe.tcp"]`. Default
+  stays on `dot-netty.tcp` for at least one minor release.
+- **MessagePack envelope is cluster-wide opt-in** and breaks compat with
+  older nodes &mdash; gated, documented, off by default.
+- **TLS configuration keys are reused** (cert path, password, validation
+  flags) so existing deployments only change the transport class name.
+- **Quarantine, handshake, reliable delivery** are unchanged because we
+  reuse `ProtocolStateActor` and `EndpointManager` verbatim in Phase 1.
+
+---
+
+## Benchmarking Plan
+
+Goal: prove the new transport is &ge; DotNetty on every axis before flipping
+the default.
+
+- **Harnesses**
+  - Reuse `src/benchmark/RemotePingPong` for end-to-end throughput.
+  - Reuse `src/core/Akka.Remote.Tests.Performance` NBench specs as a smoke
+    gate in CI.
+  - Add a new BenchmarkDotNet project comparing the two transports head-to-head
+    with `MemoryDiagnoser` enabled.
+- **Matrix**
+  - Concurrent associations: 1, 8, 64
+  - Payload sizes: 64 B, 1 KB, 64 KB
+  - TLS: off / on
+  - Envelope: protobuf / MessagePack (new transport only)
+- **Metrics**
+  - Throughput (msgs/sec, MB/sec)
+  - Latency p50 / p99 / p999
+  - Allocations per message, Gen0/1/2 collections
+  - CPU% at saturation
+- **Backpressure spec**
+  - New `RemoteSurgeBenchmark` with a deliberately slow consumer to validate
+    `PipeWriter` backpressure vs DotNetty water-marks &mdash; assert no
+    unbounded queue growth.
+- **Baseline first:** capture DotNetty numbers on `dev` and check them in
+  alongside the new benchmark project so regressions are obvious in PRs.
+
+---
+
+## Out of Scope (for now)
+
+- UDP / Aeron-style transports
+- Full Artery parity
+- Cluster sharding / DData changes
+- Removing `ProtocolStateActor` (deferred to Phase 2)
+
+---
+
+## Switching from DotNetty to the Pipelines Transport
+
+### Minimal opt-in (plain TCP, port 2553)
+
+```hocon
+akka {
+  remote {
+    # Replace the DotNetty driver with the Pipelines driver.
+    enabled-transports = ["akka.remote.pipe.tcp"]
+
+    pipe.tcp {
+      hostname = "127.0.0.1"   # or your public IP / hostname
+      port     = 2553
+    }
+  }
+}
+```
+
+> **Tip:** Set `port = 0` to let the OS pick a random available port —
+> useful in tests and when running multiple nodes on one machine.
+
+### Keeping DotNetty as a fallback during a rolling upgrade
+
+Ship the new transport on new nodes while old nodes still use DotNetty.
+Add **both** transports and let Akka.Remote negotiate the best match:
+
+```hocon
+akka.remote {
+  # New nodes listen on both transports.
+  # Old DotNetty-only nodes will still connect via dot-netty.tcp.
+  enabled-transports = ["akka.remote.pipe.tcp", "akka.remote.dot-netty.tcp"]
+
+  pipe.tcp {
+    hostname = "0.0.0.0"
+    port     = 2552           # same port — each transport binds a separate socket
+  }
+
+  dot-netty.tcp {
+    hostname = "0.0.0.0"
+    port     = 2553
+  }
+}
+```
+
+### With TLS
+
+```hocon
+akka.remote.pipe.tcp {
+  hostname   = "0.0.0.0"
+  port       = 2552
+  enable-ssl = on
+
+  ssl {
+    certificate {
+      path     = "/etc/akka/node.pfx"
+      password = "secret"
+    }
+    suppress-validation          = off
+    require-mutual-authentication = on
+    validate-certificate-hostname = off
+  }
+}
+```
+
+Certificate loading supports both a file path (`.pfx` / `.p12`) and a
+Windows certificate-store thumbprint — identical settings to the
+`akka.remote.dot-netty.tcp.ssl` block so existing cert deployments
+require no changes other than the transport-class path.
+
+### Full reference for `akka.remote.pipe.tcp`
+
+| Key | Default | Notes |
+|---|---|---|
+| `transport-class` | `Akka.Remote.Transport.Pipelines.TcpPipeTransport,Akka.Remote` | Loaded by reflection |
+| `hostname` | `""` (→ `0.0.0.0`) | Bind address |
+| `public-hostname` | same as `hostname` | Address advertised to peers |
+| `port` | `2552` | Use `0` for random |
+| `public-port` | `0` (→ same as `port`) | Advertised port (NAT / Docker) |
+| `enable-ssl` | `false` | Enable TLS |
+| `connection-timeout` | `15 s` | Outbound TCP connect timeout |
+| `maximum-frame-size` | `128000b` | Max payload bytes (≥ 32 000) |
+| `send-buffer-size` | `256000b` | `SO_SNDBUF` |
+| `receive-buffer-size` | `256000b` | `SO_RCVBUF` |
+| `backlog` | `4096` | `Socket.Listen` backlog |
+| `tcp-keepalive` | `on` | OS-level keepalive probes |
+| `tcp-nodelay` | `on` | Disable Nagle's algorithm |
+| `dns-use-ipv6` | `false` | Prefer IPv6 in DNS resolution |
+| `write-channel-capacity` | `1024` | Outbound write-channel bound |
+

--- a/src/core/Akka.Streams/Dsl/FlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/FlowOperations.cs
@@ -1155,7 +1155,7 @@ namespace Akka.Streams.Dsl
 
         ///  <summary>
         /// Allows a faster upstream to progress independently of a slower subscriber by aggregating elements into batches
-        /// until the subscriber is ready to accept them.For example a batch step might concatenate <c>ReadOnlyMemory&lt;byte&gt;</c>
+        /// until the subscriber is ready to accept them.For example a batch step might concatenate <see cref="ByteString"/>
         /// elements up to the allowed max limit if the upstream publisher is faster.
         ///
         /// This element only rolls up elements if the upstream is faster, but if the downstream is faster it will not
@@ -1844,7 +1844,7 @@ namespace Akka.Streams.Dsl
         /// Sends elements downstream with speed limited to <paramref name="cost"/>/<paramref name="per"/>`. Cost is
         /// calculating for each element individually by calling <paramref name="calculateCost"/> function.
         /// This combinator works for streams when elements have different cost(length).
-        /// Streams of <c>ReadOnlyMemory&lt;byte&gt;</c> for example.
+        /// Streams of <see cref="ByteString"/> for example.
         /// 
         /// Throttle implements the token bucket model. There is a bucket with a given token capacity (burst size or maximumBurst).
         /// Tokens drops into the bucket at a given rate and can be spared for later use up to bucket capacity

--- a/src/core/Akka.Streams/Dsl/SourceOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SourceOperations.cs
@@ -1048,7 +1048,7 @@ namespace Akka.Streams.Dsl
 
         ///  <summary>
         /// Allows a faster upstream to progress independently of a slower subscriber by aggregating elements into batches
-        /// until the subscriber is ready to accept them.For example a batch step might concatenate <c>ReadOnlyMemory&lt;byte&gt;</c>
+        /// until the subscriber is ready to accept them.For example a batch step might concatenate <see cref="ByteString"/>
         /// elements up to the allowed max limit if the upstream publisher is faster.
         ///
         /// This element only rolls up elements if the upstream is faster, but if the downstream is faster it will not
@@ -1639,7 +1639,7 @@ namespace Akka.Streams.Dsl
         /// Sends elements downstream with speed limited to <paramref name="cost"/>/<paramref name="per"/>`. Cost is
         /// calculating for each element individually by calling <paramref name="calculateCost"/> function.
         /// This combinator works for streams when elements have different cost(length).
-        /// Streams of <c>ReadOnlyMemory&lt;byte&gt;</c> for example.
+        /// Streams of <see cref="ByteString"/> for example.
         /// 
         /// Throttle implements the token bucket model. There is a bucket with a given token capacity (burst size or maximumBurst).
         /// Tokens drops into the bucket at a given rate and can be spared for later use up to bucket capacity

--- a/src/core/Akka.Streams/Dsl/SubFlowOperations.cs
+++ b/src/core/Akka.Streams/Dsl/SubFlowOperations.cs
@@ -1133,7 +1133,7 @@ namespace Akka.Streams.Dsl
 
         ///  <summary>
         /// Allows a faster upstream to progress independently of a slower subscriber by aggregating elements into batches
-        /// until the subscriber is ready to accept them.For example a batch step might concatenate <c>ReadOnlyMemory&lt;byte&gt;</c>
+        /// until the subscriber is ready to accept them.For example a batch step might concatenate <see cref="ByteString"/>
         /// elements up to the allowed max limit if the upstream publisher is faster.
         ///
         /// This element only rolls up elements if the upstream is faster, but if the downstream is faster it will not
@@ -1510,7 +1510,7 @@ namespace Akka.Streams.Dsl
         /// Sends elements downstream with speed limited to <paramref name="cost"/>/<paramref name="per"/>`. Cost is
         /// calculating for each element individually by calling <paramref name="calculateCost"/> function.
         /// This combinator works for streams when elements have different cost(length).
-        /// Streams of <c>ReadOnlyMemory&lt;byte&gt;</c> for example.
+        /// Streams of <see cref="ByteString"/> for example.
         /// 
         /// Throttle implements the token bucket model. There is a bucket with a given token capacity (burst size or maximumBurst).
         /// Tokens drops into the bucket at a given rate and can be spared for later use up to bucket capacity


### PR DESCRIPTION
## Changes

Just a Draft PR of a Transport that uses `System.IO.Pipelines` instead of DotNetty.

Theoretically, it supports SSL.

Based on remotePingPong, it seems to have a decent-ish (>10%) improvement on throughput.

There's also some minor hackery here around having messagepack as an opt-in-only wire format, There's an earlier commit without that, but it doesn't have the optimization for multi-buffering writes....

## Checklist
N/A for now - This is a draft PR because code golf sounded fun.

Note: This was made with me and Ami-Chan (FWIW, whatever's in the instruction file for this repo kept the personality leakage to test files, and even then mostly just as test data... but also this is mostly for reference anyway.)