### PR TITLE
fix: forward-port discarded stream task fault observation

### DIFF
--- a/src/core/Akka.Streams.Tests/Dsl/FlowWatchTerminationSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FlowWatchTerminationSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
@@ -25,6 +26,28 @@ namespace Akka.Streams.Tests.Dsl
         {
             var settings = ActorMaterializerSettings.Create(Sys);
             Materializer = ActorMaterializer.Create(Sys, settings);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private async Task RunIssue8209ReproAsync(string boomMessage)
+        {
+            var killSwitch = KillSwitches.Shared("issue-8209");
+            var watchTask = Source.Repeat(1)
+                .Via(killSwitch.Flow<int>())
+                .WatchTermination((_, done) => done)
+                .ToMaterialized(Sink.ForEach<int>(_ => { }), Keep.Left)
+                .Run(Materializer);
+
+            killSwitch.Abort(new InvalidOperationException(boomMessage));
+
+            var completedTask = await Task.WhenAny(watchTask, Task.Delay(TimeSpan.FromSeconds(3)));
+            completedTask.Should().BeSameAs(watchTask, "the watched termination task should complete promptly after abort");
+
+            watchTask.IsFaulted.Should().BeTrue();
+            watchTask.Exception.Should().NotBeNull();
+            watchTask.Exception!.Flatten().InnerExceptions
+                .OfType<InvalidOperationException>()
+                .Should().ContainSingle(e => e.Message == boomMessage);
         }
 
         [Fact]
@@ -142,6 +165,54 @@ namespace Akka.Streams.Tests.Dsl
 
             Action a = () => task.Wait(TimeSpan.FromSeconds(3));
             a.Should().Throw<AbruptTerminationException>();
+        }
+
+        [Fact]
+        public async Task A_WatchTermination_with_discarded_Sink_ForEach_must_not_trigger_UnobservedTaskException()
+        {
+            await this.AssertAllStagesStoppedAsync(async () =>
+            {
+                const string boomMessage = "issue-8209-boom";
+                var unobserved = new TaskCompletionSource<AggregateException>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, args) =>
+                {
+                    try
+                    {
+                        if (args.Exception.Flatten().InnerExceptions
+                            .OfType<InvalidOperationException>()
+                            .Any(ex => ex.Message == boomMessage))
+                        {
+                            unobserved.TrySetResult(args.Exception);
+                        }
+                    }
+                    finally
+                    {
+                        args.SetObserved();
+                    }
+                };
+
+                TaskScheduler.UnobservedTaskException += handler;
+                try
+                {
+                    await RunIssue8209ReproAsync(boomMessage);
+
+                    for (var i = 0; i < 20 && !unobserved.Task.IsCompleted; i++)
+                    {
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+                        GC.Collect();
+                        await Task.Delay(100);
+                    }
+
+                    unobserved.Task.IsCompleted.Should().BeFalse(
+                        "observing WatchTermination should not leave Sink.ForEach's discarded completion task unobserved");
+                }
+                finally
+                {
+                    TaskScheduler.UnobservedTaskException -= handler;
+                }
+            }, Materializer);
         }
     }
 }

--- a/src/core/Akka.Streams.Tests/Dsl/FutureFlattenSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/FutureFlattenSourceSpec.cs
@@ -8,6 +8,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Stage;
@@ -269,6 +271,41 @@ namespace Akka.Streams.Tests.Dsl
                 // wait until the underlying tasks are completed
                 await AssertThrowsAsync(() => outerSinkMat, FailingMatGraphStage.Exception).WaitAsync(3.Seconds());
                 await AssertThrowsAsync(() => innerSourceMat, FailingMatGraphStage.Exception).WaitAsync(3.Seconds());
+            }, _materializer);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private async Task RunTaskFlattenSourceUnobservedReproAsync()
+        {
+            var sourcePromise = new TaskCompletionSource<Source<int, string>>();
+            var probe = this.CreateSubscriberProbe<int>();
+
+            var sourceMatVal = Source.FromTaskSource(sourcePromise.Task)
+                .ToMaterialized(Sink.FromSubscriber(probe), Keep.Left)
+                .Run(_materializer);
+
+            await probe.AsyncBuilder()
+                .EnsureSubscription()
+                .Request(1)
+                .Cancel()
+                .ExecuteAsync();
+
+            await Task.Delay(100);
+            sourcePromise.SetResult(Underlying);
+
+            var task = AssertThrowsAsync<StreamDetachedException>(() => sourceMatVal);
+            await task.WaitAsync(3.Seconds());
+        }
+
+        [Fact]
+        public async Task TaskSource_with_discarded_inner_materialized_task_must_not_trigger_UnobservedTaskException()
+        {
+            await this.AssertAllStagesStoppedAsync(async () =>
+            {
+                await UnobservedTaskExceptionAssertions.ShouldNotRaiseAsync(
+                    RunTaskFlattenSourceUnobservedReproAsync,
+                    aggregate => aggregate.InnerExceptions.Any(e => e is StreamDetachedException),
+                    "discarding FromTaskSource's hidden inner materialized task should not leave a faulted task unobserved");
             }, _materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/LazyFlowSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LazyFlowSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.TestKit;
@@ -213,6 +214,30 @@ namespace Akka.Streams.Tests.Dsl
 
                 result.Should().Throw<TestException>().WithMessage(msg);
                 return Task.CompletedTask;
+            }, Materializer);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private TestSubscriber.Probe<int> RunLazyFlowUnobservedReproAsync() =>
+            Source.Single(1)
+                .ViaMaterialized(Flow.LazyInitAsync<int, int, NotUsed>(() => Task.FromException<Flow<int, int, NotUsed>>(Ex)), Keep.Left)
+                .RunWith(this.SinkProbe<int>(), Materializer);
+
+        [Fact]
+        public async Task A_LazyFlow_with_discarded_materialized_task_must_not_trigger_UnobservedTaskException()
+        {
+            await this.AssertAllStagesStoppedAsync(async () =>
+            {
+                await UnobservedTaskExceptionAssertions.ShouldNotRaiseAsync(
+                    () =>
+                    {
+                        var probe = RunLazyFlowUnobservedReproAsync();
+                        var error = probe.Request(1).ExpectError().As<AggregateException>();
+                        error.Flatten().InnerExceptions.Should().ContainSingle(e => ReferenceEquals(e, Ex));
+                        return Task.CompletedTask;
+                    },
+                    aggregate => aggregate.InnerExceptions.Any(e => ReferenceEquals(e, Ex)),
+                    "discarding LazyFlow's materialized task should not leave a hidden faulted task unobserved");
             }, Materializer);
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/LazySinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/LazySinkSpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Akka.Streams.Dsl;
 using Akka.Streams.Stage;
@@ -208,6 +209,30 @@ namespace Akka.Streams.Tests.Dsl
                 task.Exception.ShouldNotBe(null);
                 task.Exception.Flatten().InnerException.Should().BeEquivalentTo(matFail);
                 return Task.CompletedTask;
+            }, Materializer);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private Task RunLazySinkUnobservedReproAsync()
+        {
+            Source.Single(1)
+                .ToMaterialized(
+                    Sink.LazyInitAsync<int, TestSubscriber.Probe<int>>(() => Task.FromException<Sink<int, TestSubscriber.Probe<int>>>(Ex)),
+                    Keep.Left)
+                .Run(Materializer);
+
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task A_LazySink_with_discarded_materialized_task_must_not_trigger_UnobservedTaskException()
+        {
+            await this.AssertAllStagesStoppedAsync(async () =>
+            {
+                await UnobservedTaskExceptionAssertions.ShouldNotRaiseAsync(
+                    RunLazySinkUnobservedReproAsync,
+                    aggregate => aggregate.InnerExceptions.Any(e => ReferenceEquals(e, Ex)),
+                    "discarding LazySink's materialized task should not leave a hidden faulted task unobserved");
             }, Materializer);
         }
 

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
@@ -6,6 +6,10 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Reflection;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Pattern;
@@ -23,12 +27,57 @@ namespace Akka.Streams.Tests.Dsl
 {
     public class QueueSourceSpec : AkkaSpec
     {
+        private sealed class QueueCompletionRefs
+        {
+            public QueueCompletionRefs(WeakReference queue, WeakReference completionTask)
+            {
+                Queue = queue;
+                CompletionTask = completionTask;
+            }
+
+            public WeakReference Queue { get; }
+
+            public WeakReference CompletionTask { get; }
+        }
+
+        private static readonly FieldInfo QueueCompletionField = typeof(QueueSource<int>.Materialized)
+            .GetField("_completion", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
         private readonly ActorMaterializer _materializer;
         private readonly TimeSpan _pause = TimeSpan.FromMilliseconds(300);
 
         public QueueSourceSpec(ITestOutputHelper output) : base(output)
         {
             _materializer = Sys.Materializer();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private async Task<IReadOnlyList<QueueCompletionRefs>> CreateIssue8210FaultedCompletionTaskRefsAsync(int count)
+        {
+            var refs = new List<QueueCompletionRefs>(count);
+
+            for (var i = 0; i < count; i++)
+            {
+                var tempMat = ActorMaterializer.Create(Sys, ActorMaterializerSettings.Create(Sys));
+                var queue = (QueueSource<int>.Materialized)Source.Queue<int>(1, OverflowStrategy.Fail)
+                    .To(Sink.Ignore<int>())
+                    .Run(tempMat);
+                var completion = (TaskCompletionSource<object>)QueueCompletionField.GetValue(queue)!;
+                var completionTask = completion.Task;
+
+                refs.Add(new QueueCompletionRefs(new WeakReference(queue), new WeakReference(completionTask)));
+
+                await Task.Delay(50);
+                tempMat.Shutdown();
+
+                for (var attempt = 0; attempt < 30 && !completionTask.IsCompleted; attempt++)
+                    await Task.Delay(10);
+
+                completionTask.IsFaulted.Should().BeTrue(
+                    "QueueSource should fault its internal completion task when the stage is abruptly stopped");
+            }
+
+            return refs;
         }
 
         private static void AssertSuccess(Task<IQueueOfferResult> task)
@@ -287,6 +336,52 @@ namespace Akka.Streams.Tests.Dsl
                 tempMap.Shutdown();
                 await ExpectMsgAsync<Status.Failure>();
             }, _materializer);
+        }
+
+        [Fact]
+        public async Task QueueSource_should_not_trigger_UnobservedTaskException_when_completion_is_not_watched_and_materializer_is_shut_down()
+        {
+            var unobserved = new TaskCompletionSource<AggregateException>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, args) =>
+            {
+                try
+                {
+                    if (args.Exception.Flatten().InnerExceptions.OfType<StreamDetachedException>().Any())
+                        unobserved.TrySetResult(args.Exception);
+                }
+                finally
+                {
+                    args.SetObserved();
+                }
+            };
+
+            TaskScheduler.UnobservedTaskException += handler;
+            try
+            {
+                var refs = await this.AssertAllStagesStoppedAsync(() => CreateIssue8210FaultedCompletionTaskRefsAsync(10), _materializer);
+
+                for (var i = 0; i < 30 && !unobserved.Task.IsCompleted && refs.Any(r => r.Queue.IsAlive || r.CompletionTask.IsAlive); i++)
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                    await Task.Delay(100);
+                }
+
+                refs.Count(r => !r.Queue.IsAlive).Should().BeGreaterThan(0,
+                    "the discarded Source.Queue materialized values should become collectible during the repro");
+
+                refs.Count(r => !r.CompletionTask.IsAlive).Should().BeGreaterThan(0,
+                    "the unwatched completion tasks should become collectible during the repro");
+
+                unobserved.Task.IsCompleted.Should().BeFalse(
+                    "discarding Source.Queue completion should not leave an internal faulted task unobserved during abrupt shutdown");
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= handler;
+            }
         }
 
         [Fact]

--- a/src/core/Akka.Streams.Tests/Dsl/UnobservedTaskExceptionAssertions.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/UnobservedTaskExceptionAssertions.cs
@@ -1,0 +1,58 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="UnobservedTaskExceptionAssertions.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace Akka.Streams.Tests.Dsl
+{
+    internal static class UnobservedTaskExceptionAssertions
+    {
+        public static async Task ShouldNotRaiseAsync(Func<Task> repro, Func<AggregateException, bool> matches, string because, Action<AggregateException> onMatch = null)
+        {
+            var unobserved = new TaskCompletionSource<AggregateException>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, args) =>
+            {
+                try
+                {
+                    var flattened = args.Exception.Flatten();
+                    if (matches(flattened))
+                    {
+                        onMatch?.Invoke(flattened);
+                        unobserved.TrySetResult(flattened);
+                    }
+                }
+                finally
+                {
+                    args.SetObserved();
+                }
+            };
+
+            TaskScheduler.UnobservedTaskException += handler;
+            try
+            {
+                await repro();
+
+                for (var i = 0; i < 20 && !unobserved.Task.IsCompleted; i++)
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                    await Task.Delay(100);
+                }
+
+                unobserved.Task.IsCompleted.Should().BeFalse(because);
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= handler;
+            }
+        }
+    }
+}

--- a/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
@@ -1051,7 +1051,11 @@ namespace Akka.Streams.Implementation.Fusing
             {
                 base.OnUpstreamFailure(e);
                 if (_completion.TrySetException(e))
+                {
+                    // See #8209: WatchTermination may keep a different materialized task and discard IgnoreSink's.
+                    // Observe the fault here so it cannot resurface later as UnobservedTaskException.
                     _ = _completion.Task.Exception;
+                }
             }
         }
 

--- a/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/GraphStages.cs
@@ -1050,7 +1050,8 @@ namespace Akka.Streams.Implementation.Fusing
             public override void OnUpstreamFailure(Exception e)
             {
                 base.OnUpstreamFailure(e);
-                _completion.TrySetException(e);
+                if (_completion.TrySetException(e))
+                    _ = _completion.Task.Exception;
             }
         }
 

--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -934,7 +934,11 @@ namespace Akka.Streams.Implementation
                             catch (Exception ex)
                             {
                                 if (_completion.TrySetException(ex))
+                                {
+                                    // Same discarded materialized-task pattern as #8209 and #8210: callers may never keep
+                                    // this Task<Option<TMat>>, so observe the fault here to avoid a later UnobservedTaskException.
                                     _ = _completion.Task.Exception;
+                                }
                                 FailStage(ex);
                             }
                         }
@@ -942,7 +946,11 @@ namespace Akka.Streams.Implementation
                     else
                     {
                         if (_completion.TrySetException(result.Exception))
+                        {
+                            // Same discarded materialized-task pattern as #8209 and #8210: callers may never keep
+                            // this Task<Option<TMat>>, so observe the fault here to avoid a later UnobservedTaskException.
                             _ = _completion.Task.Exception;
+                        }
                         FailStage(result.Exception);
                     }
                 });
@@ -955,7 +963,11 @@ namespace Akka.Streams.Implementation
                 catch (Exception ex)
                 {
                     if (_completion.TrySetException(ex))
+                    {
+                        // Same discarded materialized-task pattern as #8209 and #8210: callers may never keep
+                        // this Task<Option<TMat>>, so observe the fault here to avoid a later UnobservedTaskException.
                         _ = _completion.Task.Exception;
+                    }
                     FailStage(ex);
                 }
             }
@@ -978,7 +990,11 @@ namespace Akka.Streams.Implementation
             public override void OnUpstreamFailure(Exception ex)
             {
                 if (_completion.TrySetException(ex))
+                {
+                    // Same discarded materialized-task pattern as #8209 and #8210: callers may never keep
+                    // this Task<Option<TMat>>, so observe the fault here to avoid a later UnobservedTaskException.
                     _ = _completion.Task.Exception;
+                }
                 base.OnUpstreamFailure(ex);
             }
 

--- a/src/core/Akka.Streams/Implementation/Sinks.cs
+++ b/src/core/Akka.Streams/Implementation/Sinks.cs
@@ -933,14 +933,16 @@ namespace Akka.Streams.Implementation
                             }
                             catch (Exception ex)
                             {
-                                _completion.TrySetException(ex);
+                                if (_completion.TrySetException(ex))
+                                    _ = _completion.Task.Exception;
                                 FailStage(ex);
                             }
                         }
                     }
                     else
                     {
-                        _completion.TrySetException(result.Exception);
+                        if (_completion.TrySetException(result.Exception))
+                            _ = _completion.Task.Exception;
                         FailStage(result.Exception);
                     }
                 });
@@ -952,7 +954,8 @@ namespace Akka.Streams.Implementation
                 }
                 catch (Exception ex)
                 {
-                    _completion.TrySetException(ex);
+                    if (_completion.TrySetException(ex))
+                        _ = _completion.Task.Exception;
                     FailStage(ex);
                 }
             }
@@ -974,7 +977,8 @@ namespace Akka.Streams.Implementation
 
             public override void OnUpstreamFailure(Exception ex)
             {
-                _completion.TrySetException(ex);
+                if (_completion.TrySetException(ex))
+                    _ = _completion.Task.Exception;
                 base.OnUpstreamFailure(ex);
             }
 

--- a/src/core/Akka.Streams/Implementation/Sources.cs
+++ b/src/core/Akka.Streams/Implementation/Sources.cs
@@ -174,7 +174,11 @@ namespace Akka.Streams.Implementation
             {
                 var exception = new StreamDetachedException();
                 if (_completion.TrySetException(exception))
+                {
+                    // See #8210: Source.Queue can fault this internal task even when WatchCompletionAsync() was never called.
+                    // Observe the fault here so shutdown does not leak an UnobservedTaskException.
                     _ = _completion.Task.Exception;
+                }
                 StopCallback(input =>
                 {
                     if (!(input is Offer<TOut> offer)) return;

--- a/src/core/Akka.Streams/Implementation/Sources.cs
+++ b/src/core/Akka.Streams/Implementation/Sources.cs
@@ -173,7 +173,8 @@ namespace Akka.Streams.Implementation
             public override void PostStop()
             {
                 var exception = new StreamDetachedException();
-                _completion.TrySetException(exception);
+                if (_completion.TrySetException(exception))
+                    _ = _completion.Task.Exception;
                 StopCallback(input =>
                 {
                     if (!(input is Offer<TOut> offer)) return;


### PR DESCRIPTION
## Summary
- forward-port the `v1.5` stream fixes that observe faulted internal materialized tasks in `IgnoreSink`, `QueueSource`, and `LazySink` so discarded tasks do not later surface as `UnobservedTaskException`
- forward-port the regression coverage for discarded-task scenarios in `FlowWatchTerminationSpec`, `QueueSourceSpec`, `LazySinkSpec`, `LazyFlowSpec`, and `FutureFlattenSourceSpec`
- intentionally leave out the temporary Azure/global SDK pinning changes from `v1.5`; this PR only carries the stream runtime, tests, and inline comments

## Context
- Forward-port of the changes merged into `v1.5` via #8212
- `#8209` and `#8210` were already closed by the `v1.5` PR, so this PR does not repeat closing commands

## Testing
- dotnet build src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release -p:TargetFramework=net10.0
- dotnet test src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release --framework net10.0 --no-build --filter FullyQualifiedName~Akka.Streams.Tests.Dsl.FlowWatchTerminationSpec
- dotnet test src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release --framework net10.0 --no-build --filter FullyQualifiedName~Akka.Streams.Tests.Dsl.QueueSourceSpec
- dotnet test src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release --framework net10.0 --no-build --filter FullyQualifiedName~Akka.Streams.Tests.Dsl.LazySinkSpec
- dotnet test src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release --framework net10.0 --no-build --filter FullyQualifiedName~Akka.Streams.Tests.Dsl.LazyFlowSpec
- dotnet test src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release --framework net10.0 --no-build --filter FullyQualifiedName~Akka.Streams.Tests.Dsl.FutureFlattenSourceSpec