### PR TITLE
fix: report Tcp.CommandFailed when a scheduled connect retry throws (#8195)

### DIFF
--- a/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpIntegrationSpec.cs
@@ -503,6 +503,50 @@ namespace Akka.Tests.IO
         }
 
         [Fact]
+        public async Task Should_report_CommandFailed_when_a_scheduled_connect_retry_throws()
+        {
+            // Regression test for https://github.com/akkadotnet/akka.net/issues/8195
+            //
+            // When a connect attempt fails, TcpOutgoingConnection schedules a retry. That retry
+            // used to run on the scheduler thread, so any exception it threw (e.g.
+            // PlatformNotSupportedException on Linux when reusing a socket after a failed
+            // connect) was logged and swallowed by the scheduler - the commander was never
+            // told and stayed stuck forever.
+            //
+            // This exercises the same code path deterministically and cross-platform: an
+            // IPv4-forced socket is driven down the DNS-fallback retry path and asked to
+            // retry against an IPv6 address, which throws NotSupportedException everywhere.
+            // The fix must surface that failure to the commander as Tcp.CommandFailed.
+
+            const string host = "akka-test-8195.invalid";
+
+            // Pre-seed the DNS cache so the host resolves to BOTH an IPv4 and an IPv6
+            // address, forcing TcpOutgoingConnection down its DNS-fallback retry path.
+            var cache = (SimpleDnsCache)Akka.IO.Dns.Instance.Apply(Sys).Cache;
+            cache.Put(
+                new Akka.IO.Dns.Resolved(host, new[] { IPAddress.Loopback }, new[] { IPAddress.IPv6Loopback }),
+                ttl: (long)TimeSpan.FromMinutes(10).TotalMilliseconds);
+
+            // Grab a free loopback port then release it, so the connection attempt is refused.
+            int port;
+            using (var probeSocket = new Socket(SocketType.Stream, ProtocolType.Tcp))
+            {
+                probeSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                port = ((IPEndPoint)probeSocket.LocalEndPoint).Port;
+            }
+
+            // OutgoingSocketForceIpv4 => the connection actor allocates an IPv4-only socket,
+            // so the IPv6 fallback retry throws NotSupportedException.
+            var settings = TcpSettings.Create(Sys) with { OutgoingSocketForceIpv4 = true };
+
+            var connectCommander = CreateTestProbe();
+            connectCommander.Send(Sys.Tcp(),
+                new Tcp.Connect(new DnsEndPoint(host, port)) { TcpSettings = settings });
+
+            await connectCommander.ExpectMsgAsync<Tcp.CommandFailed>(TimeSpan.FromSeconds(10));
+        }
+
+        [Fact]
         public async Task The_TCP_transport_implementation_handle_tcp_connection_actor_death_properly()
         {
             await new TestSetup(this, shouldBindServer:false).RunAsync(async _ =>

--- a/src/core/Akka/IO/TcpOutgoingConnection.cs
+++ b/src/core/Akka/IO/TcpOutgoingConnection.cs
@@ -20,8 +20,10 @@ namespace Akka.IO
     /// An actor handling the connection state machine for an outgoing connection
     /// to be established.
     /// </summary>
-    internal sealed class TcpOutgoingConnection : TcpConnection
+    internal sealed class TcpOutgoingConnection : TcpConnection, IWithTimers
     {
+        private const string RetryConnectTimerKey = "retry-connect";
+
         private readonly IActorRef _commander;
         private readonly Tcp.Connect _connect;
 
@@ -29,6 +31,19 @@ namespace Akka.IO
 
         private readonly ConnectException _finishConnectNeverReturnedTrueException =
             new("Could not establish connection because finishConnect never returned true");
+
+        public ITimerScheduler Timers { get; set; }
+
+        /// <summary>
+        /// Internal trigger used to re-attempt an outgoing connection from inside the
+        /// actor's own message loop, so connect failures are reported as <see cref="Tcp.CommandFailed"/>
+        /// instead of being swallowed by the scheduler thread.
+        /// </summary>
+        private sealed class RetryConnect
+        {
+            public static readonly RetryConnect Instance = new();
+            private RetryConnect() { }
+        }
 
         public TcpOutgoingConnection(TcpExt tcp, IActorRef commander, Tcp.Connect connect)
             : base(
@@ -210,25 +225,15 @@ namespace Akka.IO
                         // used only when we've resolved a DNS endpoint.
                         case > 0 when fallbackAddress != null:
                         {
-                            var self = Self;
                             var previousAddress = (IPEndPoint)args.RemoteEndPoint;
                             args.RemoteEndPoint = fallbackAddress;
-                            Context.System.Scheduler.Advanced.ScheduleOnce(TimeSpan.FromMilliseconds(1), () =>
-                            {
-                                if (!Socket.ConnectAsync(args))
-                                    self.Tell(IO.Tcp.SocketConnected.Instance);
-                            });
+                            ScheduleConnectRetry();
                             Become(() => Connecting(remainingFinishConnectRetries - 1, args, previousAddress));
                             break;
                         }
                         case > 0:
                         {
-                            var self = Self;
-                            Context.System.Scheduler.Advanced.ScheduleOnce(TimeSpan.FromMilliseconds(1), () =>
-                            {
-                                if (!Socket.ConnectAsync(args))
-                                    self.Tell(IO.Tcp.SocketConnected.Instance);
-                            });
+                            ScheduleConnectRetry();
                             Become(() => Connecting(remainingFinishConnectRetries - 1, args, null));
                             break;
                         }
@@ -239,6 +244,18 @@ namespace Akka.IO
                             break;
                     }
             });
+            Receive<RetryConnect>(_ =>
+            {
+                // Re-attempt the connection from within the actor's message loop so that any
+                // exception (e.g. PlatformNotSupportedException on Linux when reusing a socket
+                // after a failed connect attempt) is caught by ReportConnectFailure and reported
+                // to the commander as Tcp.CommandFailed instead of being swallowed by the scheduler.
+                ReportConnectFailure(() =>
+                {
+                    if (!Socket.ConnectAsync(args))
+                        Self.Tell(IO.Tcp.SocketConnected.Instance);
+                });
+            });
             Receive<ReceiveTimeout>(_ =>
             {
                 if (_connect.Timeout.HasValue) Context.SetReceiveTimeout(null); // Clear the timeout
@@ -246,6 +263,9 @@ namespace Akka.IO
                 Stop(new ConnectException($"Connect timeout of {_connect.Timeout} expired"));
             });
         }
+
+        private void ScheduleConnectRetry()
+            => Timers.StartSingleTimer(RetryConnectTimerKey, RetryConnect.Instance, TimeSpan.FromMilliseconds(1));
     }
 
     [InternalApi]


### PR DESCRIPTION
## Summary

Fixes #8195. On Linux, a dropped TCP connection could leave the commander/user actor **permanently stuck** — it never received `Tcp.Connected` or `Tcp.CommandFailed`, and the only recovery was a process restart.

## Root cause

When a connect attempt fails, `TcpOutgoingConnection.Connecting` schedules a retry. That retry was scheduled as a **raw `Action`** via `Context.System.Scheduler.Advanced.ScheduleOnce(...)`, so it ran on the **HashedWheelTimer scheduler thread — outside the actor's message loop** — and called `Socket.ConnectAsync` directly.

When that call threw (`PlatformNotSupportedException` on Linux when reusing a socket after a failed connect attempt; `NotSupportedException` on the IPv4/IPv6 DNS-fallback path), the exception propagated into `HashedWheelTimerScheduler.Bucket.Execute`, which **logs and swallows it**. Because the exception never re-entered the actor, the existing `ReportConnectFailure` → `Stop` path never ran, so `Tcp.CommandFailed` was never delivered.

## Fix

The retry now runs **inside the actor's message loop**:

- `TcpOutgoingConnection` implements `IWithTimers` (consistent with `TcpListener` in the same module).
- The retry is scheduled as a `RetryConnect` self-message via `Timers.StartSingleTimer`.
- A `Receive<RetryConnect>` handler performs the `Socket.ConnectAsync` call wrapped in the existing `ReportConnectFailure`, so **any** exception is surfaced to the commander as `Tcp.CommandFailed` and the connection actor stops cleanly.

This also removes a latent bug: the old raw action could run `Socket.ConnectAsync` on an already-disposed socket if the actor stopped before the scheduled callback fired. With `IWithTimers`, the pending timer is canceled automatically when the actor stops.

## Testing

Added `Should_report_CommandFailed_when_a_scheduled_connect_retry_throws` to `TcpIntegrationSpec`. `PlatformNotSupportedException` is architecture-specific and does not reproduce on x64, so the test instead drives the same swallowed-exception code path deterministically and cross-platform: it pre-seeds the DNS cache so a host resolves to both IPv4 and IPv6, forces an IPv4-only socket (`OutgoingSocketForceIpv4`), and lets the IPv6 fallback retry throw `NotSupportedException` (thrown on every platform).

Verified the test **fails without the fix** (`Error while executing scheduled task ... NotSupportedException`, then a 10s timeout waiting for `CommandFailed`) and **passes with it**. The full `Akka.Tests.IO` suite passes.
