### PR TITLE
Update RELEASE_NOTES.md for 1.5.68 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.60</VersionPrefix>
+    <VersionPrefix>1.5.68</VersionPrefix>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>https://getakka.net/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -54,33 +54,27 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Akka.NET v1.5.59 is a maintenance release with critical bug fixes and new features for observability.
+    <PackageReleaseNotes>Akka.NET v1.5.68 is a maintenance release with bug fixes for Akka.IO TCP connection handling, Akka.Streams stream materialized task faults, and Akka.TestKit xUnit 3 parallel context management.
 
-**Critical Bug Fixes**
+**Akka.IO Bug Fixes**
 
-* [Fix MergeSeen to filter Seen against current Members](https://github.com/akkadotnet/akka.net/pull/8011) - Fixes [issue #8009](https://github.com/akkadotnet/akka.net/issues/8009). Resolves a cluster gossip serialization failure that could occur with the error "Unknown address in cluster message" when the `Seen` table contained addresses of members that had already left the cluster.
+* [Fix: report `Tcp.CommandFailed` when a scheduled connect retry throws](https://github.com/akkadotnet/akka.net/pull/8214) - Fixes [#8195](https://github.com/akkadotnet/akka.net/issues/8195): On Linux, a dropped TCP connection could permanently stall the user actor — it never received `Tcp.Connected` or `Tcp.CommandFailed` because a `PlatformNotSupportedException` thrown during a scheduled connect retry was swallowed by the `HashedWheelTimerScheduler`. The retry is now scheduled as a `RetryConnect` self-message via `IWithTimers`, ensuring any exception is surfaced to the commander as `Tcp.CommandFailed` and the connection actor stops cleanly. The pending timer is also canceled automatically when the actor stops, removing a latent use-after-dispose bug.
 
-**Bug Fixes**
+**Akka.Streams Bug Fixes**
 
-* [Fix logger initialization continuation race in LoggingBus](https://github.com/akkadotnet/akka.net/pull/8006) - Fixes a race condition during logger initialization that could cause logging failures during actor system startup.
-* [Fix Inbox.AwaitResult throwing AggregateException instead of TimeoutException](https://github.com/akkadotnet/akka.net/pull/8005) - `Inbox.AwaitResult` now correctly throws `TimeoutException` when a timeout occurs, rather than wrapping it in an `AggregateException`.
-* [Fix DeferAsync async handler nesting bug in CommandAsync](https://github.com/akkadotnet/akka.net/pull/7999) - Fixes [issue #7998](https://github.com/akkadotnet/akka.net/issues/7998). Resolves an issue where `DeferAsync` with an async handler would throw "RunTask calls cannot be nested" when called from `CommandAsync`.
-* [Fix AwaitAssertAsync logic causing premature timeout](https://github.com/akkadotnet/akka.net/pull/7986) - Fixes `AwaitAssertAsync` in Akka.TestKit to correctly wait for the full timeout duration before failing assertions.
+* [Fix: observe discarded stream task faults](https://github.com/akkadotnet/akka.net/pull/8212) - Fixes [#8209](https://github.com/akkadotnet/akka.net/issues/8209) and [#8210](https://github.com/akkadotnet/akka.net/issues/8210): `IgnoreSink`, `QueueSource`, and `LazySink` now observe their internal materialized `Task` faults, preventing them from surfacing later as `UnobservedTaskException` events on the thread pool.
 
-**New Features**
+**Akka.TestKit Bug Fixes**
 
-* [Add ActivityContext capture to LogEvent for trace correlation](https://github.com/akkadotnet/akka.net/pull/7995) - Log events now automatically capture the current `System.Diagnostics.ActivityContext` when created, enabling correlation between Akka.NET logs and distributed traces in observability platforms like OpenTelemetry, Application Insights, and Jaeger.
-* [Add BroadcastHub startAfterNrOfConsumers parameter](https://github.com/akkadotnet/akka.net/pull/8018) - Fixes [issue #8017](https://github.com/akkadotnet/akka.net/issues/8017). Port from Apache Pekko - adds a `startAfterNrOfConsumers` parameter to `BroadcastHub.Sink&lt;T&gt;()` that delays broadcasting until the specified number of consumers have subscribed:
-  ```csharp
-  // Wait for 3 consumers before starting to broadcast
-  var sink = BroadcastHub.Sink&lt;int&gt;(startAfterNrOfConsumers: 3, bufferSize: 256);
-  ```
+* [Fix: wrap outer `SynchronizationContext` in `ActorCellKeepingSynchronizationContext`](https://github.com/akkadotnet/akka.net/pull/8182) - `ActorCellKeepingSynchronizationContext` now accepts an optional inner `SynchronizationContext` and delegates scheduling to it while wrapping callbacks with the cell-pinning window. This prevents test hangs in downstream consumers such as `Akka.Hosting.TestKit` whose async `IHost` lifecycle depends on xUnit v3's `MaxConcurrencySyncContext` scheduling.
 
-**Improvements**
+1 contributor since release 1.5.67
 
-* [CoordinatedShutdown: clearly log the reason why we're exiting](https://github.com/akkadotnet/akka.net/pull/7988) - `CoordinatedShutdown` now logs the specific reason for shutdown at INFO level, making it easier to diagnose why an actor system terminated.
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 3 | 476 | 119 | Aaron Stannard |
 
-To see the full set of changes in Akka.NET v1.5.59, [click here](https://github.com/akkadotnet/akka.net/milestone/142?closed=1).</PackageReleaseNotes>
+To see the full set of changes in Akka.NET v1.5.68, [click here](https://github.com/akkadotnet/akka.net/milestone/151?closed=1).</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup Label="Analyzers" Condition="'$(MSBuildProjectName)' != 'Akka'">
     <PackageReference Include="Akka.Analyzers" Version="$(AkkaAnalyzerVersion)" PrivateAssets="all" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,27 @@
+#### 1.5.68 May 17th, 2026 ####
+
+Akka.NET v1.5.68 is a maintenance release with bug fixes for Akka.IO TCP connection handling, Akka.Streams stream materialized task faults, and Akka.TestKit xUnit 3 parallel context management.
+
+**Akka.IO Bug Fixes**
+
+* [Fix: report `Tcp.CommandFailed` when a scheduled connect retry throws](https://github.com/akkadotnet/akka.net/pull/8214) - Fixes [#8195](https://github.com/akkadotnet/akka.net/issues/8195): On Linux, a dropped TCP connection could permanently stall the user actor — it never received `Tcp.Connected` or `Tcp.CommandFailed` because a `PlatformNotSupportedException` thrown during a scheduled connect retry was swallowed by the `HashedWheelTimerScheduler`. The retry is now scheduled as a `RetryConnect` self-message via `IWithTimers`, ensuring any exception is surfaced to the commander as `Tcp.CommandFailed` and the connection actor stops cleanly. The pending timer is also canceled automatically when the actor stops, removing a latent use-after-dispose bug.
+
+**Akka.Streams Bug Fixes**
+
+* [Fix: observe discarded stream task faults](https://github.com/akkadotnet/akka.net/pull/8212) - Fixes [#8209](https://github.com/akkadotnet/akka.net/issues/8209) and [#8210](https://github.com/akkadotnet/akka.net/issues/8210): `IgnoreSink`, `QueueSource`, and `LazySink` now observe their internal materialized `Task` faults, preventing them from surfacing later as `UnobservedTaskException` events on the thread pool.
+
+**Akka.TestKit Bug Fixes**
+
+* [Fix: wrap outer `SynchronizationContext` in `ActorCellKeepingSynchronizationContext`](https://github.com/akkadotnet/akka.net/pull/8182) - `ActorCellKeepingSynchronizationContext` now accepts an optional inner `SynchronizationContext` and delegates scheduling to it while wrapping callbacks with the cell-pinning window. This prevents test hangs in downstream consumers such as `Akka.Hosting.TestKit` whose async `IHost` lifecycle depends on xUnit v3's `MaxConcurrencySyncContext` scheduling.
+
+1 contributor since release 1.5.67
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 3 | 476 | 119 | Aaron Stannard |
+
+To see the full set of changes in Akka.NET v1.5.68, [click here](https://github.com/akkadotnet/akka.net/milestone/151?closed=1).
+
 #### 1.5.67 April 25th, 2026 ####
 
 Akka.NET v1.5.67 is a hotfix release that reverts a breaking change to the persistence plugin contract introduced in v1.5.66.


### PR DESCRIPTION
## Summary

- Updates `RELEASE_NOTES.md` with the 1.5.68 release section (3 bug fixes since 1.5.67)
- Updates `Directory.Build.props` `VersionPrefix` to `1.5.68` and `PackageReleaseNotes` via `build.ps1`

## Changes included in 1.5.68

**Akka.IO**
- Fix: report `Tcp.CommandFailed` when a scheduled connect retry throws ([#8214](https://github.com/akkadotnet/akka.net/pull/8214)) — fixes permanent stall of user actor on Linux when a `PlatformNotSupportedException` is swallowed by the scheduler during a TCP connect retry ([#8195](https://github.com/akkadotnet/akka.net/issues/8195))

**Akka.Streams**
- Fix: observe discarded stream task faults ([#8212](https://github.com/akkadotnet/akka.net/pull/8212)) — `IgnoreSink`, `QueueSource`, and `LazySink` now observe internal materialized task faults so they don't surface as `UnobservedTaskException` ([#8209](https://github.com/akkadotnet/akka.net/issues/8209), [#8210](https://github.com/akkadotnet/akka.net/issues/8210))

**Akka.TestKit**
- Fix: wrap outer `SynchronizationContext` in `ActorCellKeepingSynchronizationContext` ([#8182](https://github.com/akkadotnet/akka.net/pull/8182)) — prevents test hangs in downstream consumers such as `Akka.Hosting.TestKit` under xUnit v3 parallel execution

## Test plan

- [ ] Verify CI passes
- [ ] Confirm `Directory.Build.props` `VersionPrefix` is `1.5.68`