### PR TITLE
fix: implement IAsyncLifetime on Akka.TestKit.Xunit (v3) to stop ActorSystem leaks (#8191)

### DIFF
--- a/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/BugFixSpec.cs
+++ b/src/contrib/dependencyinjection/Akka.DependencyInjection.Tests/BugFixSpec.cs
@@ -19,7 +19,7 @@ using static FluentAssertions.FluentActions;
 
 namespace Akka.DependencyInjection.Tests
 {
-    public class BugFixSpec: AkkaSpec, IAsyncLifetime
+    public class BugFixSpec: AkkaSpec
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly AkkaService _akkaService;
@@ -59,8 +59,9 @@ namespace Akka.DependencyInjection.Tests
         }
         
         
-        public async ValueTask InitializeAsync()
+        public override async ValueTask InitializeAsync()
         {
+            await base.InitializeAsync();
             await _akkaService.StartAsync(default);
             InitializeLogger(_akkaService.ActorSystem);
         }
@@ -72,11 +73,6 @@ namespace Akka.DependencyInjection.Tests
             base.AfterAll();
         }
 
-        public ValueTask DisposeAsync()
-        {
-            return new ValueTask(Task.CompletedTask);
-        }
-        
         internal class AkkaService : IHostedService
         {
             public ActorSystem ActorSystem { get; private set; }

--- a/src/contrib/testkits/Akka.TestKit.Xunit.Tests/Bugfix8144Spec.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit.Tests/Bugfix8144Spec.cs
@@ -17,15 +17,12 @@ namespace Akka.TestKit.Tests;
 /// Verifies that implicit sender (TestActor) is preserved across async boundaries.
 /// Regression test for https://github.com/akkadotnet/akka.net/issues/8144
 /// </summary>
-public class Bugfix8144Spec: Xunit.TestKit, IAsyncLifetime
+public class Bugfix8144Spec: Xunit.TestKit
 {
-    public ValueTask DisposeAsync()
+    public override async ValueTask InitializeAsync()
     {
-        return new ValueTask(Task.CompletedTask);
-    }
+        await base.InitializeAsync();
 
-    public async ValueTask InitializeAsync()
-    {
         // Any await here can cause a thread switch, which previously
         // lost the [ThreadStatic] InternalCurrentActorCellKeeper.Current
         await Task.Delay(TimeSpan.FromMilliseconds(100));

--- a/src/contrib/testkits/Akka.TestKit.Xunit.Tests/Bugfix8191Spec.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit.Tests/Bugfix8191Spec.cs
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------
+//  <copyright file="Bugfix8191Spec.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Akka.TestKit.Xunit.Tests;
+
+/// <summary>
+/// Regression tests for https://github.com/akkadotnet/akka.net/issues/8191
+///
+/// xUnit v3 tears a test class instance down via <see cref="IAsyncDisposable.DisposeAsync"/>
+/// in preference to <see cref="IDisposable.Dispose"/> whenever the type implements both.
+/// <see cref="TestKit"/> must therefore drive its dispose chain — and shut the
+/// <c>ActorSystem</c> down — from <c>DisposeAsync</c>, and a derived <c>DisposeAsync</c>
+/// override must be able to chain to <c>base.DisposeAsync()</c>. Before the fix the
+/// <c>ActorSystem</c> was silently leaked once a derived spec implemented
+/// <c>IAsyncLifetime</c>.
+/// </summary>
+public class Bugfix8191Spec
+{
+    private sealed class TrackingTestKit : TestKit
+    {
+        public bool AfterAllRan { get; private set; }
+
+        protected override void AfterAll()
+        {
+            AfterAllRan = true;
+            base.AfterAll();
+        }
+    }
+
+    private sealed class AsyncTeardownTestKit : TestKit
+    {
+        public bool DisposeAsyncOverrideRan { get; private set; }
+
+        public override async ValueTask DisposeAsync()
+        {
+            DisposeAsyncOverrideRan = true;
+            await base.DisposeAsync();
+        }
+    }
+
+    [Fact(DisplayName = "TestKit.DisposeAsync should run the dispose chain and shut down the ActorSystem")]
+    public async Task Should_run_dispose_chain_and_shut_down_system_When_disposed_via_DisposeAsync()
+    {
+        var testKit = new TrackingTestKit();
+        var system = testKit.Sys;
+
+        // Exercise the exact path xUnit v3 uses to tear down a test class instance.
+        await ((IAsyncDisposable)testKit).DisposeAsync();
+
+        Assert.True(testKit.AfterAllRan, "AfterAll() should run as part of the DisposeAsync chain");
+        Assert.True(system.WhenTerminated.IsCompleted, "the ActorSystem should be shut down");
+    }
+
+    [Fact(DisplayName = "A derived DisposeAsync override chaining to base should shut down the ActorSystem")]
+    public async Task Should_shut_down_system_When_derived_DisposeAsync_chains_to_base()
+    {
+        var testKit = new AsyncTeardownTestKit();
+        var system = testKit.Sys;
+
+        await ((IAsyncDisposable)testKit).DisposeAsync();
+
+        Assert.True(testKit.DisposeAsyncOverrideRan, "the derived DisposeAsync override should run");
+        Assert.True(system.WhenTerminated.IsCompleted, "base.DisposeAsync() should shut the ActorSystem down");
+    }
+}

--- a/src/contrib/testkits/Akka.TestKit.Xunit.Tests/ParallelAmbientContextSpec.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit.Tests/ParallelAmbientContextSpec.cs
@@ -20,14 +20,12 @@ namespace Akka.TestKit.Xunit.Tests;
 // This project provides its own xunit.runner.json with parallel collections
 // enabled so CI and local runs exercise the reported failure mode by default.
 
-public abstract class ParallelAmbientContextSpecBase : TestKit, IAsyncLifetime
+public abstract class ParallelAmbientContextSpecBase : TestKit
 {
     // Forces the post-ctor continuation onto a different SC worker — the
     // thread pollution only manifests when the body thread differs from the
     // ctor thread.
-    public async ValueTask InitializeAsync() => await Task.Yield();
-
-    public ValueTask DisposeAsync() => default;
+    public override async ValueTask InitializeAsync() => await Task.Yield();
 
     [Fact]
     public async Task Implicit_sender_should_resolve_to_own_TestActor()
@@ -67,11 +65,9 @@ public class ParallelAmbientContextSpec16 : ParallelAmbientContextSpecBase { }
 // Current must be null both at body entry (pre-await prefix) and across any
 // await continuations resumed on a reused worker thread that a sibling's
 // Before hook may have pinned with a non-null cell.
-public abstract class ParallelNoImplicitSenderSpecBase : TestKit, IAsyncLifetime, INoImplicitSender
+public abstract class ParallelNoImplicitSenderSpecBase : TestKit, INoImplicitSender
 {
-    public async ValueTask InitializeAsync() => await Task.Yield();
-
-    public ValueTask DisposeAsync() => default;
+    public override async ValueTask InitializeAsync() => await Task.Yield();
 
     [Fact]
     public async Task Current_should_be_null_both_pre_and_post_await()

--- a/src/contrib/testkits/Akka.TestKit.Xunit/TestKit.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/TestKit.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Actor.Internal;
 using Akka.Actor.Setup;
@@ -22,7 +23,7 @@ namespace Akka.TestKit.Xunit;
 /// as its testing framework.
 /// </summary>
 [AkkaCleanAmbientContext]
-public class TestKit : TestKitBase, IDisposable
+public class TestKit : TestKitBase, IDisposable, IAsyncLifetime
 {
     private class PrefixedOutput : ITestOutputHelper
     {
@@ -250,6 +251,14 @@ public class TestKit : TestKitBase, IDisposable
     }
 
     /// <summary>
+    /// xUnit lifecycle hook, invoked once before the test method runs. The default
+    /// implementation does nothing. Override to perform asynchronous test setup, and
+    /// call <c>await base.InitializeAsync()</c> from your override.
+    /// </summary>
+    public virtual ValueTask InitializeAsync()
+        => default;
+
+    /// <summary>
     /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
     /// </summary>
     /// <param name="disposing">
@@ -278,5 +287,23 @@ public class TestKit : TestKitBase, IDisposable
     public void Dispose()
     {
         Dispose(true);
+    }
+
+    /// <summary>
+    /// xUnit lifecycle hook, invoked once after the test method completes. The default
+    /// implementation drives the synchronous dispose chain
+    /// (<see cref="Dispose(bool)"/> -&gt; <see cref="AfterAll"/> -&gt; actor system shutdown).
+    /// <para>
+    /// Override this for asynchronous teardown, and always call <c>await base.DisposeAsync()</c>
+    /// from your override. xUnit v3 invokes <see cref="System.IAsyncDisposable.DisposeAsync"/> in
+    /// preference to <see cref="IDisposable.Dispose"/> for any type that implements both
+    /// interfaces, so an override that does not chain to the base will skip shutdown and leak
+    /// the <see cref="ActorSystem"/>.
+    /// </para>
+    /// </summary>
+    public virtual ValueTask DisposeAsync()
+    {
+        Dispose(true);
+        return default;
     }
 }

--- a/src/contrib/testkits/Akka.TestKit.Xunit/TestKit.cs
+++ b/src/contrib/testkits/Akka.TestKit.Xunit/TestKit.cs
@@ -85,6 +85,7 @@ public class TestKit : TestKitBase, IDisposable, IAsyncLifetime
 
     private bool _disposed;
     private bool _disposing;
+    private bool _disposingAsync;
         
     /// <summary>
     /// <para>
@@ -279,7 +280,10 @@ public class TestKit : TestKitBase, IDisposable, IAsyncLifetime
         }
         finally
         {
-            Shutdown();
+            // DisposeAsync() terminates the ActorSystem asynchronously and sets this flag,
+            // so we don't also block here with a synchronous Shutdown().
+            if (!_disposingAsync)
+                Shutdown();
             _disposed = true;
         }
     }
@@ -291,8 +295,9 @@ public class TestKit : TestKitBase, IDisposable, IAsyncLifetime
 
     /// <summary>
     /// xUnit lifecycle hook, invoked once after the test method completes. The default
-    /// implementation drives the synchronous dispose chain
-    /// (<see cref="Dispose(bool)"/> -&gt; <see cref="AfterAll"/> -&gt; actor system shutdown).
+    /// implementation runs the synchronous dispose chain (<see cref="Dispose(bool)"/> and
+    /// therefore <see cref="AfterAll"/>) and then asynchronously terminates the
+    /// <see cref="ActorSystem"/>, without blocking the calling thread.
     /// <para>
     /// Override this for asynchronous teardown, and always call <c>await base.DisposeAsync()</c>
     /// from your override. xUnit v3 invokes <see cref="System.IAsyncDisposable.DisposeAsync"/> in
@@ -301,9 +306,23 @@ public class TestKit : TestKitBase, IDisposable, IAsyncLifetime
     /// the <see cref="ActorSystem"/>.
     /// </para>
     /// </summary>
-    public virtual ValueTask DisposeAsync()
+    public virtual async ValueTask DisposeAsync()
     {
-        Dispose(true);
-        return default;
+        if (_disposing || _disposed)
+            return;
+
+        // Run the synchronous dispose chain — AfterAll() plus any overridden Dispose(bool) —
+        // but suppress its blocking Shutdown() call; the ActorSystem is terminated
+        // asynchronously below instead. The finally guarantees shutdown still runs even if
+        // AfterAll() throws, matching the synchronous Dispose() behavior.
+        _disposingAsync = true;
+        try
+        {
+            Dispose(true);
+        }
+        finally
+        {
+            await ShutdownAsync();
+        }
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
@@ -405,17 +405,17 @@ namespace Akka.TestKit
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, params T[] messages) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__158<T>))]
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__160<T>))]
         public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__161<T>))]
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__163<T>))]
         public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(params Akka.TestKit.PredicateInfo[] predicates) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, params Akka.TestKit.PredicateInfo[] predicates) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__168))]
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__170))]
         public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__171))]
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__173))]
         public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public T ExpectMsgAnyOf<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask<T> ExpectMsgAnyOfAsync<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
@@ -470,9 +470,9 @@ namespace Akka.TestKit
         public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.TimeSpan max, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__217))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__219))]
+        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__221))]
         public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, System.TimeSpan max, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public object ReceiveOne(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask<object> ReceiveOneAsync(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
@@ -480,19 +480,21 @@ namespace Akka.TestKit
         public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__208<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__210<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__212<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__214<T>))]
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__216<T>))]
         public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         protected System.TimeSpan RemainingOr(System.TimeSpan duration) { }
         public System.TimeSpan RemainingOrDilated(System.Nullable<System.TimeSpan> duration) { }
         public void SetAutoPilot(Akka.TestKit.AutoPilot pilot) { }
         public virtual void Shutdown(System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
         protected virtual void Shutdown(Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
+        public virtual System.Threading.Tasks.Task ShutdownAsync(System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
+        protected virtual System.Threading.Tasks.Task ShutdownAsync(Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
         public bool TryPeekOne(out Akka.TestKit.MessageEnvelope envelope, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken) { }
         [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
                 "success",

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.Net.verified.txt
@@ -405,17 +405,17 @@ namespace Akka.TestKit
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, params T[] messages) { }
         public System.Collections.Generic.IReadOnlyCollection<T> ExpectMsgAllOf<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__158<T>))]
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__160<T>))]
         public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__161<T>))]
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfAsync>d__163<T>))]
         public System.Collections.Generic.IAsyncEnumerable<T> ExpectMsgAllOfAsync<T>(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<T> messages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(params Akka.TestKit.PredicateInfo[] predicates) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, params Akka.TestKit.PredicateInfo[] predicates) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ExpectMsgAllOfMatchingPredicates(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, System.Threading.CancellationToken cancellationToken) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__168))]
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__170))]
         public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__171))]
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ExpectMsgAllOfMatchingPredicatesAsync>d__173))]
         public System.Collections.Generic.IAsyncEnumerable<object> ExpectMsgAllOfMatchingPredicatesAsync(System.TimeSpan max, System.Collections.Generic.IReadOnlyCollection<Akka.TestKit.PredicateInfo> predicates, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public T ExpectMsgAnyOf<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask<T> ExpectMsgAnyOfAsync<T>(System.Collections.Generic.IEnumerable<T> messages, System.Threading.CancellationToken cancellationToken = null) { }
@@ -470,9 +470,9 @@ namespace Akka.TestKit
         public System.Threading.Tasks.ValueTask<object> PeekOneAsync(System.Threading.CancellationToken cancellationToken) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyCollection<object> ReceiveN(int numberOfMessages, System.TimeSpan max, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__217))]
-        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__219))]
+        public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveNAsync>d__221))]
         public System.Collections.Generic.IAsyncEnumerable<object> ReceiveNAsync(int numberOfMessages, System.TimeSpan max, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         public object ReceiveOne(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Threading.Tasks.ValueTask<object> ReceiveOneAsync(System.Nullable<System.TimeSpan> max = null, System.Threading.CancellationToken cancellationToken = null) { }
@@ -480,19 +480,21 @@ namespace Akka.TestKit
         public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, System.Threading.CancellationToken cancellationToken = null) { }
         public System.Collections.Generic.IReadOnlyList<T> ReceiveWhile<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, System.Threading.CancellationToken cancellationToken = null) { }
-        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__208<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__210<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__212<T>))]
-        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Nullable<System.TimeSpan> max, System.Nullable<System.TimeSpan> idle, System.Func<object, T> filter, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__214<T>))]
+        public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Func<object, T> filter, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
+        [System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Akka.TestKit.TestKitBase.<ReceiveWhileAsync>d__216<T>))]
         public System.Collections.Generic.IAsyncEnumerable<T> ReceiveWhileAsync<T>(System.Predicate<T> shouldContinue, System.Nullable<System.TimeSpan> max = null, System.Nullable<System.TimeSpan> idle = null, int msgs = 2147483647, bool shouldIgnoreOtherMessageTypes = True, [System.Runtime.CompilerServices.EnumeratorCancellationAttribute()] System.Threading.CancellationToken cancellationToken = null) { }
         protected System.TimeSpan RemainingOr(System.TimeSpan duration) { }
         public System.TimeSpan RemainingOrDilated(System.Nullable<System.TimeSpan> duration) { }
         public void SetAutoPilot(Akka.TestKit.AutoPilot pilot) { }
         public virtual void Shutdown(System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
         protected virtual void Shutdown(Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
+        public virtual System.Threading.Tasks.Task ShutdownAsync(System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
+        protected virtual System.Threading.Tasks.Task ShutdownAsync(Akka.Actor.ActorSystem system, System.Nullable<System.TimeSpan> duration = null, bool verifySystemShutdown = False) { }
         public bool TryPeekOne(out Akka.TestKit.MessageEnvelope envelope, System.Nullable<System.TimeSpan> max, System.Threading.CancellationToken cancellationToken) { }
         [return: System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
                 "success",

--- a/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/StreamRefsSpec.cs
@@ -189,7 +189,7 @@ namespace Akka.Streams.Tests
         }
     }
 
-    public class StreamRefsSpec : AkkaSpec, IAsyncLifetime
+    public class StreamRefsSpec : AkkaSpec
     {
         public static Config Config()
         {
@@ -220,18 +220,15 @@ namespace Akka.Streams.Tests
             _probe = CreateTestProbe();
         }
 
-        public async ValueTask InitializeAsync()
+        public override async ValueTask InitializeAsync()
         {
+            await base.InitializeAsync();
+
             var it = RemoteSystem.ActorOf(DataSourceActor.Props(_probe.Ref), "remoteActor");
             var remoteAddress = ((ActorSystemImpl)RemoteSystem).Provider.DefaultAddress;
             Sys.ActorSelection(it.Path.ToStringWithAddress(remoteAddress)).Tell(new Identify("hi"));
 
             _remoteActor = (await ExpectMsgAsync<ActorIdentity>(TimeSpan.FromSeconds(30))).Subject;
-        }
-
-        public ValueTask DisposeAsync()
-        {
-            return new ValueTask(Task.CompletedTask);
         }
 
         protected readonly ActorSystem RemoteSystem;

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Akka.TestKit.Tests.TestEventListenerTests
 {
-    public abstract class EventFilterTestBase : TestKit.Xunit.TestKit, IAsyncLifetime
+    public abstract class EventFilterTestBase : TestKit.Xunit.TestKit
     {
         /// <summary>
         /// Used to signal that the test was successful and that we should ensure no more messages were logged
@@ -24,22 +24,17 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         {
         }
 
-        public ValueTask InitializeAsync()
+        public override ValueTask InitializeAsync()
         {
             //We send a ForwardAllEventsTo containing message to the TestEventListenerToForwarder logger (configured as a logger above).
             //It should respond with an "OK" message when it has received the message.
             var initLoggerMessage = new ForwardAllEventsTestEventListener.ForwardAllEventsTo(TestActor);
-            
+
             SendRawLogEventMessage(initLoggerMessage);
             ExpectMsg("OK");
             //From now on we know that all messages will be forwarded to TestActor
-            
-            return new ValueTask(Task.CompletedTask);
-        }
 
-        public ValueTask DisposeAsync()
-        {
-            return new ValueTask(Task.CompletedTask);
+            return base.InitializeAsync();
         }
 
         protected abstract void SendRawLogEventMessage(object message);

--- a/src/core/Akka.TestKit/TestKitBase.cs
+++ b/src/core/Akka.TestKit/TestKitBase.cs
@@ -591,6 +591,53 @@ namespace Akka.TestKit
         }
 
         /// <summary>
+        /// Asynchronously shuts down this system. Unlike <c>Shutdown</c>, this does not block the
+        /// calling thread while waiting for the <see cref="ActorSystem"/> to terminate.
+        /// On failure debug output will be logged about the remaining actors in the system.
+        /// If verifySystemShutdown is true, then an exception will be thrown on failure.
+        /// </summary>
+        /// <param name="duration">Optional. The duration to wait for shutdown. Default is 5 seconds multiplied with the config value "akka.test.timefactor".</param>
+        /// <param name="verifySystemShutdown">if set to <c>true</c> an exception will be thrown on failure.</param>
+        /// <exception cref="TimeoutException">TBD</exception>
+        public virtual Task ShutdownAsync(
+            TimeSpan? duration = null,
+            bool verifySystemShutdown = false)
+            => ShutdownAsync(_testState.System, duration, verifySystemShutdown);
+
+        /// <summary>
+        /// Asynchronously shuts down the specified system. Unlike <c>Shutdown</c>, this does not block
+        /// the calling thread while waiting for the <see cref="ActorSystem"/> to terminate.
+        /// On failure debug output will be logged about the remaining actors in the system.
+        /// If verifySystemShutdown is true, then an exception will be thrown on failure.
+        /// </summary>
+        /// <param name="system">The system to shutdown.</param>
+        /// <param name="duration">The duration to wait for shutdown. Default is 5 seconds multiplied with the config value "akka.test.timefactor"</param>
+        /// <param name="verifySystemShutdown">if set to <c>true</c> an exception will be thrown on failure.</param>
+        /// <exception cref="TimeoutException">TBD</exception>
+        protected virtual async Task ShutdownAsync(
+            ActorSystem system,
+            TimeSpan? duration = null,
+            bool verifySystemShutdown = false)
+        {
+            system ??= _testState.System;
+
+            var durationValue = duration.GetValueOrDefault(Dilated(TimeSpan.FromSeconds(5)).Min(TimeSpan.FromSeconds(10)));
+
+            var terminateTask = system.Terminate();
+            var wasShutdownDuringWait = await Task.WhenAny(terminateTask, Task.Delay(durationValue)) == terminateTask;
+            if(!wasShutdownDuringWait)
+            {
+                // Forcefully close the ActorSystem to make sure we exit the test cleanly
+                ((ExtendedActorSystem) system).Guardian.Stop();
+
+                const string msg = "Failed to stop [{0}] within [{1}]. ActorSystem is being forcefully shut down.\n{2}";
+                if(verifySystemShutdown)
+                    throw new TimeoutException(string.Format(msg, system.Name, durationValue, ((ExtendedActorSystem) system).PrintTree()));
+                system.Log.Warning(msg, system.Name, durationValue, ((ExtendedActorSystem) system).PrintTree());
+            }
+        }
+
+        /// <summary>
         /// Spawns an actor as a child of this test actor, and returns the child's IActorRef
         /// </summary>
         /// <param name="props">Child actor props</param>


### PR DESCRIPTION
## Problem

Fixes #8191.

`Xunit.IAsyncLifetime` (xunit.v3) derives from `IAsyncDisposable`, and xUnit v3 tears a test class instance down via `IAsyncDisposable.DisposeAsync()` **in preference to** `IDisposable.Dispose()` whenever the type implements both (confirmed in `TestRunner<TContext,TTest>.DisposeTestClassInstance` and `DisposalTracker`).

The v3 `Akka.TestKit.Xunit.TestKit` implemented only `IDisposable`. As soon as a derived spec added `IAsyncLifetime` itself, xUnit called the derived `DisposeAsync()` and **skipped** `TestKit.Dispose()` entirely — so `AfterAll()` and `Shutdown()` never ran and the `ActorSystem` was silently leaked. There was also no `base.DisposeAsync()` to chain to.

Several in-repo specs were hitting this and leaking on every run: `Bugfix8144Spec`, `ParallelAmbientContextSpec*` (×24), and `EventFilterTestBase` — the last of which also meant its `AfterAll()` → `EnsureNoMoreLoggedMessages()` verification was being skipped.

## Fix

- `Akka.TestKit.Xunit.TestKit` now implements `IAsyncLifetime` with `public virtual ValueTask InitializeAsync()` and `public virtual ValueTask DisposeAsync()`. `DisposeAsync()` drives the existing `Dispose(true)` → `AfterAll()` → `Shutdown()` chain, so a derived override can safely `await base.DisposeAsync()`.
- Converted the affected in-repo specs to the `override` form (dropping the redundant `, IAsyncLifetime`). This restores `EventFilterTestBase`'s post-test verification.
- Added `Bugfix8191Spec` as a regression test exercising the exact `((IAsyncDisposable)instance).DisposeAsync()` path xUnit v3 uses.

## Compatibility

- **Binary:** non-breaking — purely additive (new interface + `public virtual` members on a non-sealed type). Existing compiled consumers keep working; `DisposeAsync()` runs the same chain `Dispose()` did.
- **Source:** can emit `CS0114` ("hides inherited member") **only** for a consumer that subclasses the v3 `Akka.TestKit.Xunit.TestKit`, added `IAsyncLifetime` themselves, and didn't use `override`/`new`. That is a *warning* (build still succeeds) unless they compile with `TreatWarningsAsErrors`. Remediation is mechanical: add `override`, drop the redundant `, IAsyncLifetime`. That set of consumers is exactly the set leaking `ActorSystem`s today.
- The xUnit2 variant (`Akka.TestKit.Xunit2`) is untouched and unaffected.

## Testing

All 10 in-repo projects that consume the v3 `Akka.TestKit.Xunit` build clean with `-warnaserror` (no `CS0114`). `Akka.TestKit.Xunit.Tests` 33/33, `Akka.TestKit.Tests` 320/320, `Akka.Discovery.Tests` 27/27.