### PR TITLE
fix: RejectOnType<TMessage> should use Rejection, not Failure

### DIFF
--- a/src/core/Akka.Persistence.TestKit.Tests/Actors/PersistActor.cs
+++ b/src/core/Akka.Persistence.TestKit.Tests/Actors/PersistActor.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="PersistActor.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -59,9 +59,9 @@ namespace Akka.Persistence.TestKit.Tests
 
         public class WriteMessage
         {
-            public string Data { get; }
+            public object Data { get; }
 
-            public WriteMessage(string data)
+            public WriteMessage(object data)
             {
                 Data = data;
             }

--- a/src/core/Akka.Persistence.TestKit.Tests/TestJournalSpec.cs
+++ b/src/core/Akka.Persistence.TestKit.Tests/TestJournalSpec.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="TestJournalSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -122,6 +122,34 @@ namespace Akka.Persistence.TestKit.Tests
         }
 
         [Fact]
+        public async Task when_reject_on_type_is_set_matching_type_will_be_rejected()
+        {
+            var actor = ActorOf(() => new PersistActor(_probe));
+            Watch(actor);
+            await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+            await Journal.OnWrite.RejectOnType<SpecificMessage>();
+            actor.Tell(new PersistActor.WriteMessage(new SpecificMessage()), TestActor);
+
+            await _probe.ExpectMsgAsync("rejected");
+        }
+
+        [Fact]
+        public async Task when_reject_on_type_is_set_non_matching_type_will_succeed()
+        {
+            var actor = ActorOf(() => new PersistActor(_probe));
+            Watch(actor);
+            await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+            await Journal.OnWrite.RejectOnType<SpecificMessage>();
+            actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+            await _probe.ExpectMsgAsync("ack");
+        }
+
+        private class SpecificMessage { }
+
+        [Fact]
         public async Task journal_must_reset_state_to_pass()
         {
             await WithJournalWrite(write => write.Fail(), async () =>
@@ -142,5 +170,33 @@ namespace Akka.Persistence.TestKit.Tests
             actor2.Tell(new PersistActor.WriteMessage("write"), TestActor);
             await _probe.ExpectMsgAsync("ack");
         }
+
+        [Fact]
+        public async Task when_reject_on_type_is_set_matching_type_will_be_rejected()
+        {
+            var actor = ActorOf(() => new PersistActor(_probe));
+            Watch(actor);
+            await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+            await Journal.OnWrite.RejectOnType<SpecificMessage>();
+            actor.Tell(new PersistActor.WriteMessage(new SpecificMessage()), TestActor);
+
+            await _probe.ExpectMsgAsync("rejected");
+        }
+
+        [Fact]
+        public async Task when_reject_on_type_is_set_non_matching_type_will_succeed()
+        {
+            var actor = ActorOf(() => new PersistActor(_probe));
+            Watch(actor);
+            await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+            await Journal.OnWrite.RejectOnType<SpecificMessage>();
+            actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+            await _probe.ExpectMsgAsync("ack");
+        }
+
+        private class SpecificMessage { }
     }
 }

--- a/src/core/Akka.Persistence.TestKit.Tests/TestJournalSpec.cs
+++ b/src/core/Akka.Persistence.TestKit.Tests/TestJournalSpec.cs
@@ -170,33 +170,5 @@ namespace Akka.Persistence.TestKit.Tests
             actor2.Tell(new PersistActor.WriteMessage("write"), TestActor);
             await _probe.ExpectMsgAsync("ack");
         }
-
-        [Fact]
-        public async Task when_reject_on_type_is_set_matching_type_will_be_rejected()
-        {
-            var actor = ActorOf(() => new PersistActor(_probe));
-            Watch(actor);
-            await _probe.ExpectMsgAsync<RecoveryCompleted>();
-
-            await Journal.OnWrite.RejectOnType<SpecificMessage>();
-            actor.Tell(new PersistActor.WriteMessage(new SpecificMessage()), TestActor);
-
-            await _probe.ExpectMsgAsync("rejected");
-        }
-
-        [Fact]
-        public async Task when_reject_on_type_is_set_non_matching_type_will_succeed()
-        {
-            var actor = ActorOf(() => new PersistActor(_probe));
-            Watch(actor);
-            await _probe.ExpectMsgAsync<RecoveryCompleted>();
-
-            await Journal.OnWrite.RejectOnType<SpecificMessage>();
-            actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
-
-            await _probe.ExpectMsgAsync("ack");
-        }
-
-        private class SpecificMessage { }
     }
 }

--- a/src/core/Akka.Persistence.TestKit/Journal/JournalWriteBehavior.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/JournalWriteBehavior.cs
@@ -31,6 +31,28 @@ namespace Akka.Persistence.TestKit
         ///     </para>
         /// </remarks>
         public Task Reject() => SetInterceptorAsync(JournalInterceptors.Rejection.Instance);
+        
+        /// <summary>
+        ///     Reject messages that fail type equality (using <see cref="object.Equals"/>).
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
+        ///         on each rejected message.
+        ///     </para>
+        ///     <para>
+        ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
+        ///         type conversion and other local problems withing journal.
+        ///     </para>
+        ///     <para>
+        ///         <list type="bullet">
+        ///             <item>If <typeparamref name="TMessage"/> is interface, journal will reject when message implements that interface.</item>
+        ///             <item>If <typeparamref name="TMessage"/> is class, journal will reject when message can be assigned to <typeparamref name="TMessage"/>.</item>
+        ///         </list>
+        ///     </para>
+        /// </remarks>
+        /// <typeparam name="TMessage"></typeparam>
+        public Task RejectOnType<TMessage>() => RejectOnType(typeof(TMessage));
 
         /// <summary>
         ///     Reject message during processing message of type <typeparamref name="TMessage"/>.

--- a/src/core/Akka.Persistence.TestKit/Journal/JournalWriteBehavior.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/JournalWriteBehavior.cs
@@ -33,28 +33,6 @@ namespace Akka.Persistence.TestKit
         public Task Reject() => SetInterceptorAsync(JournalInterceptors.Rejection.Instance);
         
         /// <summary>
-        ///     Reject messages that fail type equality (using <see cref="object.Equals"/>).
-        /// </summary>
-        /// <remarks>
-        ///     <para>
-        ///         Journal will **NOT** crash, but <see cref="Eventsourced.OnPersistRejected">UntypedPersistentActor.OnPersistRejected</see> will be called
-        ///         on each rejected message.
-        ///     </para>
-        ///     <para>
-        ///         Use this Journal behavior when it is needed to verify how well a persistent actor will handle serialization,
-        ///         type conversion and other local problems withing journal.
-        ///     </para>
-        ///     <para>
-        ///         <list type="bullet">
-        ///             <item>If <typeparamref name="TMessage"/> is interface, journal will reject when message implements that interface.</item>
-        ///             <item>If <typeparamref name="TMessage"/> is class, journal will reject when message can be assigned to <typeparamref name="TMessage"/>.</item>
-        ///         </list>
-        ///     </para>
-        /// </remarks>
-        /// <typeparam name="TMessage"></typeparam>
-        public Task RejectOnType<TMessage>() => RejectOnType(typeof(TMessage));
-
-        /// <summary>
         ///     Reject message during processing message of type <typeparamref name="TMessage"/>.
         /// </summary>
         /// <remarks>

--- a/src/core/Akka.Persistence.TestKit/Journal/JournalWriteBehavior.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/JournalWriteBehavior.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="JournalWriteBehavior.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -52,7 +52,7 @@ namespace Akka.Persistence.TestKit
         ///     </para>
         /// </remarks>
         /// <typeparam name="TMessage"></typeparam>
-        public Task RejectOnType<TMessage>() => FailOnType(typeof(TMessage));
+        public Task RejectOnType<TMessage>() => RejectOnType(typeof(TMessage));
 
         /// <summary>
         ///     Reject message during processing message of type <paramref name="messageType"/>.


### PR DESCRIPTION
## Description

Fixes a copy-paste bug in `JournalWriteBehavior.cs` where `RejectOnType<TMessage>()` was calling `FailOnType(typeof(TMessage))` instead of `RejectOnType(typeof(TMessage))`.

This caused the test journal to **fail/crash** instead of **rejecting** messages of the specified type, defeating the purpose of the `RejectOnType<T>()` API.

## Changes

- `RejectOnType<TMessage>()` now delegates to `RejectOnType(Type)` which correctly uses `JournalInterceptors.Rejection.Instance`

## Impact

This is a test kit fix only — it affects `Akka.Persistence.TestKit` which is used in unit/integration tests. No production code changes.
