### PR TITLE
backport: Merge PR #8231 — fix: RejectOnType<TMessage> should use Rejection, not Failure

### DIFF
--- a/src/core/Akka.Persistence.TestKit.Tests/Actors/PersistActor.cs
+++ b/src/core/Akka.Persistence.TestKit.Tests/Actors/PersistActor.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="PersistActor.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -59,9 +59,9 @@ namespace Akka.Persistence.TestKit.Tests
 
         public class WriteMessage
         {
-            public string Data { get; }
+            public object Data { get; }
 
-            public WriteMessage(string data)
+            public WriteMessage(object data)
             {
                 Data = data;
             }

--- a/src/core/Akka.Persistence.TestKit.Tests/TestJournalSpec.cs
+++ b/src/core/Akka.Persistence.TestKit.Tests/TestJournalSpec.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="TestJournalSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -120,6 +120,34 @@ namespace Akka.Persistence.TestKit.Tests
 
             await _probe.ExpectMsgAsync("rejected");
         }
+
+        [Fact]
+        public async Task when_reject_on_type_is_set_matching_type_will_be_rejected()
+        {
+            var actor = ActorOf(() => new PersistActor(_probe));
+            Watch(actor);
+            await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+            await Journal.OnWrite.RejectOnType<SpecificMessage>();
+            actor.Tell(new PersistActor.WriteMessage(new SpecificMessage()), TestActor);
+
+            await _probe.ExpectMsgAsync("rejected");
+        }
+
+        [Fact]
+        public async Task when_reject_on_type_is_set_non_matching_type_will_succeed()
+        {
+            var actor = ActorOf(() => new PersistActor(_probe));
+            Watch(actor);
+            await _probe.ExpectMsgAsync<RecoveryCompleted>();
+
+            await Journal.OnWrite.RejectOnType<SpecificMessage>();
+            actor.Tell(new PersistActor.WriteMessage("write"), TestActor);
+
+            await _probe.ExpectMsgAsync("ack");
+        }
+
+        private class SpecificMessage { }
 
         [Fact]
         public async Task journal_must_reset_state_to_pass()

--- a/src/core/Akka.Persistence.TestKit/Journal/JournalWriteBehavior.cs
+++ b/src/core/Akka.Persistence.TestKit/Journal/JournalWriteBehavior.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="JournalWriteBehavior.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -31,7 +31,7 @@ namespace Akka.Persistence.TestKit
         ///     </para>
         /// </remarks>
         public Task Reject() => SetInterceptorAsync(JournalInterceptors.Rejection.Instance);
-
+        
         /// <summary>
         ///     Reject message during processing message of type <typeparamref name="TMessage"/>.
         /// </summary>
@@ -52,7 +52,7 @@ namespace Akka.Persistence.TestKit
         ///     </para>
         /// </remarks>
         /// <typeparam name="TMessage"></typeparam>
-        public Task RejectOnType<TMessage>() => FailOnType(typeof(TMessage));
+        public Task RejectOnType<TMessage>() => RejectOnType(typeof(TMessage));
 
         /// <summary>
         ///     Reject message during processing message of type <paramref name="messageType"/>.


### PR DESCRIPTION
## Description

Backport of #8231 to .

Fixes the bug where  in  was incorrectly calling , causing the journal to crash instead of rejecting messages of the specified type.

-  now correctly delegates to  which uses the  interceptor
- Added regression tests covering both matching and non-matching type behavior
- Changed  from  to  to support typed message tests

## Changes
- 3 files changed, 35 insertions(+), 7 deletions(-)