### PR TITLE
Update Incrementalist tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": true
     },
     "incrementalist.cmd": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "commands": [
         "incrementalist"
       ],


### PR DESCRIPTION
## Summary

- Updates `incrementalist.cmd` from `1.2.0` to `1.2.1`.
- Keeps `global.json` roll-forward behavior unchanged.

## Motivation

Azure PR validation currently resolves `global.json` to .NET SDK `10.0.300`. Incrementalist `1.2.0` fails during MSBuild static graph loading under that SDK before tests run.

Observed failure from build 127778:

```text
The expression "[Microsoft.Build.Utilities.ToolLocationHelper]::GetPlatformSDKLocation(Windows, 7.0)" cannot be evaluated.
Could not load type 'Microsoft.Build.Shared.VersionUtilities'
```

## Validation

- Reproduced the Incrementalist `1.2.0` failure locally under SDK `10.0.300`.
- Verified Incrementalist `1.2.1` opens `Akka.slnx` successfully under SDK `10.0.300` using dry-run mode.
- Ran `dotnet tool restore` successfully with the updated manifest.