### PR TITLE
Propose remote streams protocol pipeline

### DIFF
--- a/openspec/changes/remote-streams-protocol-pipeline/.openspec.yaml
+++ b/openspec/changes/remote-streams-protocol-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/remote-streams-protocol-pipeline/baselines.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/baselines.md
@@ -1,0 +1,61 @@
+## Baseline Environment
+
+Recorded on 2026-06-10 from `feature/remote-streams-protocol-pipeline` at `fdaac7172`.
+
+The branch contained OpenSpec notes and wire-format tests only; no production Remote codec or transport implementation was changed from the upstream `dev` baseline.
+
+## AkkaPduCodecBenchmark
+
+Command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj" -- --filter "*AkkaPduCodecBenchmark*"
+```
+
+BenchmarkDotNet reported that it could not set high process priority because of permissions. The run continued at normal priority.
+
+```text
+BenchmarkDotNet v0.15.8, Linux Ubuntu 24.04.4 LTS (Noble Numbat)
+Intel Core i9-9900K CPU 3.60GHz (Coffee Lake), 1 CPU, 8 logical and 8 physical cores
+.NET SDK 10.0.103
+  [Host]     : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
+  DefaultJob : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
+```
+
+| Method                 | Mean      | Error     | StdDev    | Gen0   | Gen1   | Allocated |
+|----------------------- |----------:|----------:|----------:|-------:|-------:|----------:|
+| WritePayloadPdu        | 768.59 ns | 15.340 ns | 29.919 ns | 0.1891 |      - |    1584 B |
+| DecodePayloadPdu       | 981.64 ns | 19.170 ns | 31.498 ns | 0.2234 |      - |    1872 B |
+| DecodePduOnly          |  90.26 ns |  1.696 ns |  3.267 ns | 0.0573 | 0.0001 |     480 B |
+| DecodeMessageOnly      | 765.24 ns | 15.228 ns | 20.844 ns | 0.1453 |      - |    1216 B |
+| DeserializePayloadOnly |  81.76 ns |  1.606 ns |  2.501 ns | 0.0200 |      - |     168 B |
+
+## RemotePingPong
+
+Command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1
+```
+
+The benchmark could not elevate process priority because of permissions and continued at normal priority.
+
+```text
+OSVersion:                         Unix 6.8.0.117
+ProcessorCount:                    8
+ClockSpeed:                        0 MHZ
+Actor Count:                       16
+Messages sent/received per client: 200000  (2e5)
+Is Server GC:                      True
+Thread count:                      36
+```
+
+| Num clients | Total msg | Msgs/sec | Total ms | Start threads | End threads |
+|------------:|----------:|---------:|---------:|--------------:|------------:|
+|           1 |   200000 |    77550 |  2579.66 |            36 |          51 |
+|           5 |  1000000 |   379076 |  2638.95 |            59 |          67 |
+|          10 |  2000000 |   617284 |  3240.89 |            75 |          75 |
+|          15 |  3000000 |   656599 |  4569.25 |            83 |          83 |
+|          20 |  4000000 |   714414 |  5599.08 |            91 |          83 |
+|          25 |  5000000 |   677415 |  7381.23 |            91 |          76 |
+|          30 |  6000000 |   667335 |  8991.56 |            84 |          62 |

--- a/openspec/changes/remote-streams-protocol-pipeline/design.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/design.md
@@ -1,0 +1,97 @@
+## Context
+
+Akka.Remote currently routes outbound user messages through `EndpointWriter`, `MessageSerializer`, `AkkaPduCodec`, `AkkaProtocolHandle`, `AssociationHandle.Write(ByteString)`, and the transport. The inbound path mirrors this through `InboundPayload(ByteString)`, `ProtocolStateActor`, `AkkaPduCodec.DecodeMessage`, and `EndpointReader` dispatch. This design was built around older byte-buffer transport boundaries and makes `ByteString` the handoff format between major layers.
+
+SerializerV2 now provides a buffer-writer and sequence-reader serialization contract. Akka.IO.Tcp was also modernized around stream and pipe primitives, and Akka.Streams already exposes the transport composition layer. Therefore the next Remote performance work should not create another raw pipe transport. It should use Akka.Streams / Akka.IO.Tcp as the transport substrate and focus on the PDU codec, protocol state machine, and serialization boundaries.
+
+The first production slice must preserve the current Remote wire format: length-framed Akka protocol PDUs, protobuf `AkkaProtocolMessage`, protobuf `AckAndEnvelopeContainer`, existing serializer ids, manifests, and payload bytes. The implementation can change C# internals aggressively, but mixed-version and persisted compatibility must not be compromised by this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Use Akka.Streams / Akka.IO.Tcp as the Remote transport substrate.
+- Preserve the existing Akka.Remote wire format in the first slice.
+- Redesign `AkkaPduCodec` around `ReadOnlySequence<byte>` input and `IBufferWriter<byte>` output.
+- Keep existing `ByteString` PDU methods as adapters during migration and tests.
+- Move Remote payload serialization toward a uniform `SerializerV2` model.
+- Use `SerializerV1Adapter` for legacy serializers instead of adding V1-specific branches throughout Remote.
+- Identify and then reduce hot-path mailbox hops in `AkkaProtocolTransport` / `ProtocolStateActor` without changing handshake, heartbeat, disassociation, quarantine, or reliable-delivery semantics.
+- Add baselines and regression benchmarks before changing the protocol pipeline.
+
+**Non-Goals:**
+
+- No new standalone `PipeTransport` implementation.
+- No MessagePack PDU envelope in the first slice.
+- No Artery implementation in this change.
+- No built-in serializer ID migration for Remote, Persistence, Delivery, or DistributedData in this change.
+- No removal of existing wire-compatible serializers or existing remoting behavior.
+- No public transport API redesign unless a compatibility adapter and migration plan are defined.
+
+## Decisions
+
+### 1. Use Akka.Streams / Akka.IO.Tcp, Not A New Pipe Transport
+
+Akka.IO.Tcp owns socket, stream, and pipe mechanics. Akka.Streams is the composition layer we should use for transport flow. A separate `PipeTransport` duplicates machinery, creates another lifecycle surface, and distracts from the actual bottlenecks in the PDU codec and protocol state machine.
+
+Alternative considered: port To11mtm's `TcpPipeTransport` directly. It is useful as a reference and showed promising throughput, but it still preserved the `AssociationHandle.Write(ByteString)` / `InboundPayload(ByteString)` boundary. That makes it an incremental transport replacement, not the deeper Remote protocol pipeline we need.
+
+### 2. Preserve Wire Format First
+
+The first slice must produce and consume the same bytes as the current Remote implementation for protobuf Akka protocol PDUs and `AckAndEnvelopeContainer`. This lets us isolate C# runtime improvements from wire-compatibility changes and keeps rolling upgrades feasible.
+
+Alternative considered: switch Remote PDU envelopes to MessagePack immediately. That would require coordinated cluster-wide opt-in, new compatibility rules, and new failure modes. It should be evaluated later after the wire-compatible pipeline is measurable.
+
+### 3. Make `AkkaPduCodec` Sequence/Writer-Oriented
+
+The current codec accepts and returns `ByteString`, which forces materialization at the codec boundary. The new primary codec shape should read from `ReadOnlySequence<byte>` and write to `IBufferWriter<byte>`. Existing `ByteString` methods can remain as adapters until callers are migrated.
+
+The wire format can remain protobuf while the implementation becomes allocation-conscious. Hand-written protobuf encode/decode for the small Remote PDU schema is acceptable if it preserves byte compatibility and materially reduces allocations.
+
+### 4. Treat Payload Serializers As `SerializerV2`
+
+Remote should use the V2 serializer abstraction as its payload boundary. Native V2 serializers can write into caller-owned buffers and read from `ReadOnlySequence<byte>`. Legacy serializers should flow through `SerializerV1Adapter`, where unavoidable byte-array copies remain localized.
+
+This keeps Remote code focused on frame ownership, serializer id, manifest, and payload boundaries rather than branching repeatedly on V1 versus V2.
+
+### 5. Redesign Protocol State Independently From Transport
+
+`AkkaProtocolTransport` and `ProtocolStateActor` own handshake, heartbeat, disassociation, quarantine, and listener registration. The initial implementation should keep behavior equivalent while making state transitions testable outside actor mailboxes. A later slice can replace the FSM actor with a stream-friendly state machine or stream stage once equivalence tests are in place.
+
+This sequencing avoids rewriting transport, codec, serializer, and protocol state all at once.
+
+### 6. Benchmarks Are Entry Criteria, Not Exit Notes
+
+Before implementation, record current baselines for RemotePingPong, `AkkaPduCodecBenchmark`, allocation counts, and known copy boundaries. Each code slice must update or add a benchmark that proves whether the change helped.
+
+## Risks / Trade-offs
+
+**Wire compatibility regressions** -> Add byte-for-byte golden tests for current PDU shapes before replacing codec internals.
+
+**Protocol semantic regressions** -> Extract state-machine tests for handshake, heartbeat timeout, disassociation reasons, quarantine, `refuseUid`, and listener registration before removing actor hops.
+
+**Pipe / stream buffer lifetime bugs** -> Do not pass borrowed pipe memory across actor boundaries without ownership. Decode synchronously inside the stream stage or copy into owned memory at explicit compatibility boundaries.
+
+**Over-scoping into Artery** -> Keep this change focused on classic Remote protocol internals and wire compatibility. Artery remains a future transport/protocol design.
+
+**Legacy serializer complexity** -> Route legacy serializers through `SerializerV1Adapter` and keep copies isolated there.
+
+**Performance ambiguity** -> Require benchmarks at each milestone and preserve baseline numbers in the change notes.
+
+## Migration Plan
+
+1. Add baselines and wire-format tests on the current implementation.
+2. Introduce sequence/writer PDU codec APIs with `ByteString` adapters and no behavior change.
+3. Integrate SerializerV2 payload serialization/deserialization in Remote behind existing wire-compatible payload fields.
+4. Add stream-oriented protocol state-machine tests while the actor FSM remains authoritative.
+5. Introduce an opt-in stream protocol pipeline that uses Akka.Streams / Akka.IO.Tcp and preserves the wire format.
+6. Run existing Remote, Cluster, and multi-node tests in both legacy and opt-in modes before considering a default switch.
+
+Rollback is config-based while the new pipeline is opt-in. The existing Remote path and serializers remain available throughout the change.
+
+## Open Questions
+
+- Should the first stream pipeline reuse `EndpointWriter` / `EndpointReader` directly, or should it introduce a smaller internal endpoint protocol facade first?
+- Which PDU shapes need golden byte fixtures before the codec refactor begins?
+- Can protocol state be extracted into a pure state machine while keeping `ProtocolStateActor` as a wrapper during migration?
+- What is the minimum benchmark improvement required before shipping the opt-in pipeline?

--- a/openspec/changes/remote-streams-protocol-pipeline/design.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/design.md
@@ -64,6 +64,59 @@ This sequencing avoids rewriting transport, codec, serializer, and protocol stat
 
 Before implementation, record current baselines for RemotePingPong, `AkkaPduCodecBenchmark`, allocation counts, and known copy boundaries. Each code slice must update or add a benchmark that proves whether the change helped.
 
+### 7. Inbound Payload Parsing Should Use A Conservative Fast Path
+
+After the stream transport emits `InboundSequencePayload`, the remaining steady-state inbound cost is generated protobuf parsing of the outer `AkkaProtocolMessage`. For ordinary user messages the outer wire shape is simple:
+
+```text
+AkkaProtocolMessage
+  field 1: payload bytes -> AckAndEnvelopeContainer bytes
+```
+
+The next inbound parsing slice should optimize only that payload-only shape and leave control messages on the generated protobuf path.
+
+Recommended first implementation:
+
+- Add an internal sequence-backed payload PDU representation for the decoded outer payload, separate from the existing `Payload(ByteString)` shape or behind an explicit `Payload` owned-sequence API.
+- In `AkkaPduProtobuffCodec.DecodePdu(ReadOnlySequence<byte>)`, attempt a fast path only when the frame starts with protobuf tag `0x0A` (`field 1`, length-delimited payload), has a valid varint length, and the payload field consumes the entire outer PDU.
+- Return a slice of the original `ReadOnlySequence<byte>` for that payload instead of calling `AkkaProtocolMessage.Parser.ParseFrom(raw)`.
+- Fall back to the generated parser for all other shapes, including control messages, unknown fields, non-canonical field ordering, both-fields-present frames, malformed fast-path candidates, or any case where instruction precedence might matter.
+- Keep the old `ByteString` decode path and golden wire fixtures authoritative for compatibility.
+
+This gives the hot path a narrow, auditable parser while avoiding a hand-written full protobuf implementation in the first pass.
+
+The expected data flow becomes:
+
+```text
+TCP frame payload
+  -> InboundSequencePayload(outer AkkaProtocolMessage bytes)
+  -> DecodePdu fast path slices field 1 payload
+  -> ProtocolStateActor forwards InboundSequencePayload(inner AckAndEnvelopeContainer bytes)
+  -> EndpointReader decodes AckAndEnvelopeContainer from ReadOnlySequence<byte>
+```
+
+The classic flow remains unchanged:
+
+```text
+InboundPayload(ByteString outer bytes)
+  -> generated AkkaProtocolMessage parser
+  -> Payload(ByteString inner bytes)
+  -> EndpointReader handles InboundPayload(ByteString)
+```
+
+`EndpointReader` should learn to handle `InboundSequencePayload` beside `InboundPayload` in both reading and not-reading states. The not-reading state must still process ACKs and ignore user messages, matching the current `InboundPayload` behavior.
+
+Ownership rule:
+
+- Today `TcpConnection.ReadPipeChunkAsync` copies pipe memory into an owned array before sending `Tcp.Received`, so sequence slices can safely cross actor boundaries in the current stream transport.
+- A future zero-copy pipe read must not pass borrowed pipe memory through `ProtocolStateActor` or `EndpointReader` unless it introduces an explicit consume/ack ownership protocol or decodes synchronously inside the stage before advancing the pipe reader.
+
+First-slice non-goals:
+
+- Do not manually parse `AkkaControlMessage` or `AkkaHandshakeInfo`; generated protobuf parsing is fine for handshake, heartbeat, and disassociate traffic.
+- Do not rewrite `AckAndEnvelopeContainer` parsing yet; `DecodeMessage(ReadOnlySequence<byte>)` can continue using the generated parser while avoiding the protocol-layer `ByteString` bridge.
+- Do not change public transport SPI or the classic DotNetty inbound `InboundPayload(ByteString)` path.
+
 ## Risks / Trade-offs
 
 **Wire compatibility regressions** -> Add byte-for-byte golden tests for current PDU shapes before replacing codec internals.

--- a/openspec/changes/remote-streams-protocol-pipeline/hot-path-map.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/hot-path-map.md
@@ -1,0 +1,34 @@
+## Wire Shape To Preserve
+
+Classic remoting currently sends length-framed TCP payloads containing an outer protobuf `AkkaProtocolMessage`. User messages are carried as `AkkaProtocolMessage.Payload`, which contains a protobuf `AckAndEnvelopeContainer`, which contains a `RemoteEnvelope`, which contains a protobuf serializer `Payload` with serializer id, manifest bytes, and user payload bytes.
+
+The first stream pipeline slice must preserve that wire shape exactly.
+
+## Outbound Hot Path
+
+| Step | Current boundary | Copy / allocation point | Compatibility note |
+|------|------------------|-------------------------|--------------------|
+| 1 | `EndpointWriter.WriteSend` receives `EndpointManager.Send` and builds the inner Remote PDU. See `src/core/Akka.Remote/Endpoint.cs:1477` and `src/core/Akka.Remote/Endpoint.cs:1494`. | Allocates remoting envelope state before handoff to the codec. | Required by current endpoint actor flow. |
+| 2 | `EndpointWriter.SerializeMessage` delegates to `MessageSerializer.Serialize`. See `src/core/Akka.Remote/Endpoint.cs:1339` and `src/core/Akka.Remote/MessageSerializer.cs:46`. | `serializer.ToBinary(message)` creates a `byte[]`; `ByteString.CopyFrom(...)` copies payload bytes into protobuf `ByteString`. See `src/core/Akka.Remote/MessageSerializer.cs:58`. | The `byte[]` is required for legacy `Serializer`; native `SerializerV2` can target `IBufferWriter<byte>`. |
+| 3 | `AkkaPduProtobuffCodec.ConstructMessage` builds `AckAndEnvelopeContainer`. See `src/core/Akka.Remote/Transport/AkkaPduCodec.cs:477`. | Generated protobuf objects are allocated; `ackAndEnvelope.ToByteString()` materializes the complete inner envelope. See `src/core/Akka.Remote/Transport/AkkaPduCodec.cs:488`. | Current `ConstructMessage` returns `ByteString`; a writer-oriented API can preserve bytes without this intermediate container. |
+| 4 | `AkkaProtocolHandle.Write` wraps the inner envelope in outer `AkkaProtocolMessage`. See `src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs:414`. | `ConstructPayload` creates `new AkkaProtocolMessage { Payload = payload }.ToByteString()`. See `src/core/Akka.Remote/Transport/AkkaPduCodec.cs:344`. | Required by current `AssociationHandle.Write(ByteString)` contract. |
+| 5 | DotNetty TCP handle writes the final payload. See `src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs:254`. | `payload.ToByteArray()` copies the outer protobuf `ByteString` before `Unpooled.WrappedBuffer(...)`. See `src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs:268`. | Transport SPI refactor target; not required by wire format. |
+| 6 | DotNetty pipeline prepends the TCP length field. See `src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs:340` and `src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs:344`. | Helios compatibility framing has an explicit combined-buffer copy path. See `src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs:651`. | Length framing must remain; copy behavior can change if bytes are equivalent. |
+
+## Inbound Hot Path
+
+| Step | Current boundary | Copy / allocation point | Compatibility note |
+|------|------------------|-------------------------|--------------------|
+| 1 | DotNetty strips the 4-byte length prefix and passes an `IByteBuffer` frame. See `src/core/Akka.Remote/Transport/DotNetty/DotNettyTransport.cs:337`. | `ByteString.CopyFrom(buf.Array, ...)` copies the full frame into immutable protobuf bytes, then wraps it in `InboundPayload`. See `src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs:73` and `src/core/Akka.Remote/Transport/DotNetty/TcpTransport.cs:74`. | Required by current `InboundPayload(ByteString)` contract. |
+| 2 | `ProtocolStateActor` decodes the outer `AkkaProtocolMessage`. See `src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs:1300` and `src/core/Akka.Remote/Transport/AkkaPduCodec.cs:322`. | `AkkaProtocolMessage.Parser.ParseFrom(raw)` materializes the outer protobuf object; ordinary payloads allocate `new Payload(pdu.Payload)`. See `src/core/Akka.Remote/Transport/AkkaPduCodec.cs:326` and `src/core/Akka.Remote/Transport/AkkaPduCodec.cs:328`. | Refactor target: parse outer tag and expose payload as a slice/sequence. |
+| 3 | Open protocol state forwards payloads to the endpoint listener. See `src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs:1002`. | Payload `ByteString`s may be queued before listener registration and replayed later. | Behavior must be preserved before replacing actor FSM hot-path handling. |
+| 4 | `EndpointReader` decodes `AckAndEnvelopeContainer`. See `src/core/Akka.Remote/Endpoint.cs:1838`, `src/core/Akka.Remote/Endpoint.cs:1969`, and `src/core/Akka.Remote/Transport/AkkaPduCodec.cs:413`. | `AckAndEnvelopeContainer.Parser.ParseFrom(raw)` materializes inner protobuf objects, ACK collections, actor refs, and remoting `Message` / `AckAndMessage` wrappers. See `src/core/Akka.Remote/Transport/AkkaPduCodec.cs:415` through `src/core/Akka.Remote/Transport/AkkaPduCodec.cs:455`. | Refactor target: decode headers and expose serialized user payload bytes as a sequence. |
+| 5 | `MessageSerializer.Deserialize` recovers the user message. See `src/core/Akka.Remote/MessageSerializer.cs:30`. | `messageProtocol.Message.ToByteArray()` copies protobuf payload bytes for serializer input; manifest bytes become a string. See `src/core/Akka.Remote/MessageSerializer.cs:34`. | Required for legacy serializers; native V2 can use `Serialization.Deserialize(ReadOnlySequence<byte>, ...)`. |
+| 6 | `EndpointReader` dispatches decoded user messages. See `src/core/Akka.Remote/Endpoint.cs:1843` through `src/core/Akka.Remote/Endpoint.cs:1855`. | Reliable-delivery buffering allocates around decoded `Message` wrappers before dispatch and ACK. | Protocol semantics must remain unchanged. |
+
+## Primary Refactor Targets
+
+- Add `AkkaPduCodec` APIs that read `ReadOnlySequence<byte>` and write to `IBufferWriter<byte>` while keeping `ByteString` adapters.
+- Keep legacy serializer copies inside `SerializerV1Adapter`; route native serializers through `SerializerV2.Serialize` and sequence-based deserialize where lifetime is safe.
+- Avoid re-wrapping inner and outer protobuf PDUs as separate `ByteString` instances when a single writer-owned frame buffer can preserve the exact bytes.
+- Avoid adapting the future stream pipeline back through `AssociationHandle.Write(ByteString)` and `InboundPayload(ByteString)` as the primary hot-path boundary, or most existing copies remain.

--- a/openspec/changes/remote-streams-protocol-pipeline/proposal.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Akka.Remote still spends too much of its hot path materializing byte buffers, routing frames through legacy transport boundaries, and running protocol state transitions through actor mailbox hops. SerializerV2 and the modernized Akka.IO.Tcp / Akka.Streams stack give us the primitives to redesign the C# internals while preserving the existing remote wire format.
+
+## What Changes
+
+- Introduce a stream-oriented Akka.Remote protocol pipeline that uses Akka.Streams / Akka.IO.Tcp as the transport substrate.
+- Preserve the existing Akka.Remote TCP framing and protobuf wire format for the first production slice.
+- Reshape the PDU codec around `ReadOnlySequence<byte>` input and `IBufferWriter<byte>` output while keeping existing `ByteString` paths as compatibility adapters during migration.
+- Move Remote payload serialization toward the `SerializerV2` contract and rely on `SerializerV1Adapter` for legacy serializers instead of adding separate V1 special cases in the Remote pipeline.
+- Revisit `AkkaProtocolTransport`, `ProtocolStateActor`, and endpoint listener registration so protocol state transitions can be expressed as stream-friendly state machines without changing remoting semantics.
+- Add baseline and regression benchmarks for the current and redesigned Remote hot paths.
+- Do not implement a new standalone PipeTransport in this change; Akka.IO.Tcp already owns the pipe and socket mechanics.
+- Do not introduce MessagePack PDU envelopes or new built-in serializer IDs in the first slice; those remain future opt-in changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `remote-protocol-pipeline`: Defines a wire-compatible, stream-oriented Akka.Remote protocol pipeline over Akka.Streams / Akka.IO.Tcp, including PDU codec shape, SerializerV2 payload boundaries, protocol state-machine behavior, and benchmark gates.
+
+### Modified Capabilities
+
+No existing OpenSpec capabilities are modified.
+
+## Impact
+
+- Affected code: `src/core/Akka.Remote`, especially `EndpointWriter`, `EndpointReader`, `MessageSerializer`, `AkkaPduCodec`, `AkkaProtocolTransport`, `ProtocolStateActor`, and Remote benchmarks.
+- Affected dependencies: no new transport dependency is expected; Akka.Remote should use existing Akka.Streams / Akka.IO.Tcp infrastructure.
+- Compatibility: existing Akka.Remote wire format and existing serializer IDs must remain readable; the first implementation slice must be opt-in until performance, compatibility, and rolling-upgrade behavior are proven.
+- Performance: expected to reduce allocations and copies in Remote message framing and payload serialization while keeping behavior equivalent to the current remoting stack.

--- a/openspec/changes/remote-streams-protocol-pipeline/protocol-state-machine-map.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/protocol-state-machine-map.md
@@ -1,0 +1,49 @@
+# Protocol State Machine Map
+
+## Current Authoritative Implementation
+
+`ProtocolStateActor` remains the authoritative implementation for classic Remote protocol transitions. The focused tests in `AkkaProtocolSpec` now pin the current behavior for handshake readiness, heartbeat handling, disassociation, quarantined UID refusal, quarantined disassociate propagation, and listener registration buffering before any stream-friendly state model replaces actor FSM hot-path handling.
+
+## Pure Transition Candidates
+
+These `ProtocolStateActor` decisions can be represented as pure state transitions if side effects are supplied by an adapter:
+
+- `Closed + HandleMsg + OutboundUnassociated`: write local `Associate`, start heartbeat, transition to `WaitHandshake + OutboundUnderlyingAssociated`, or retry if the write fails.
+- `WaitHandshake + InboundPayload(Associate) + OutboundUnderlyingAssociated`: reject matching `refuseUid` with `DisassociateInfo.Quarantined`, otherwise heartbeat the failure detector, cancel handshake timeout, and transition to `Open + AssociatedWaitHandler`.
+- `WaitHandshake + InboundPayload(Associate) + InboundUnassociated`: reply with local `Associate`, heartbeat the failure detector, start heartbeat timer, cancel handshake timeout, and transition to `Open + AssociatedWaitHandler`.
+- `WaitHandshake + InboundPayload(Disassociate)`: stop without sending a disassociate loopback and preserve the incoming `DisassociateInfo` as the failure reason.
+- `WaitHandshake + unexpected PDU`: send `DisassociateInfo.Unknown` and stop.
+- `Open + InboundPayload(Heartbeat)`: heartbeat the failure detector and stay open without notifying the listener.
+- `Open + InboundPayload(Payload) + AssociatedWaitHandler`: heartbeat the failure detector and enqueue payload bytes until a listener is registered.
+- `Open + InboundPayload(Payload) + ListenerReady`: heartbeat the failure detector and notify the listener with the unwrapped payload bytes.
+- `Open + InboundPayload(Disassociate)`: stop and preserve the incoming `DisassociateInfo` for listener notification.
+- `Open + DisassociateUnderlying`: write a disassociate PDU with the supplied reason and stop.
+- `Open + HandleListenerRegistered + AssociatedWaitHandler`: flush queued payloads FIFO and transition to `ListenerReady`.
+- `HeartbeatTimer`: if the failure detector is available, write heartbeat and stay; otherwise write `DisassociateInfo.Unknown` and stop with timeout reason.
+- `HandshakeTimer`: write `DisassociateInfo.Unknown` and stop with timeout reason while handshaking.
+
+## Side Effects To Isolate
+
+A pure model should not directly own these effects:
+
+- PDU writes: `Associate`, `Heartbeat`, `Disassociate`, and payload unwrap decisions.
+- Timer lifecycle: heartbeat timer, handshake timer, and retry timer scheduling/cancellation.
+- Failure detector calls: `HeartBeat()` and `IsAvailable` checks.
+- Listener effects: inbound association notification, handle listener registration, queued payload delivery, and final `Disassociated` notification.
+- Promise effects: outbound association completion and failure propagation.
+- Wrapped handle lifecycle: read handler installation and underlying `Disassociate` reason text.
+- Logging and transport error publication.
+
+## Listener Registration Contract
+
+The current listener contract must be preserved by any stream-oriented replacement:
+
+- A completed protocol handshake exposes an `AkkaProtocolHandle` immediately, but inbound payload delivery waits for `ReadHandlerSource` to complete.
+- Payloads received before listener registration are buffered in `AssociatedWaitHandler.Queue` and delivered FIFO once `HandleListenerRegistered` is processed.
+- Heartbeats received before listener registration update liveness but are not delivered to the listener.
+- If the association closes before listener registration, `OnTermination` attaches a continuation to the listener task and sends a single `Disassociated` notification when the listener eventually registers.
+- If the listener is already ready, disassociation is delivered immediately as `Disassociated` with the preserved `DisassociateInfo` when available.
+
+## Extraction Boundary
+
+The first safe extraction boundary is a small internal transition model that accepts the current state data, decoded PDU or control event, and a side-effect sink. `ProtocolStateActor` can then remain as the mailbox/timer/promise adapter while equivalence tests prove that the model emits the same transition and effect sequence as the current FSM.

--- a/openspec/changes/remote-streams-protocol-pipeline/specs/remote-protocol-pipeline/spec.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/specs/remote-protocol-pipeline/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Remote uses Akka.Streams TCP substrate
+
+The system SHALL use Akka.Streams and Akka.IO.Tcp as the transport substrate for the redesigned Remote protocol pipeline and SHALL NOT introduce a separate raw socket or standalone pipe transport for this change.
+
+#### Scenario: Stream substrate selected
+- **WHEN** the redesigned Remote pipeline opens a TCP association
+- **THEN** it SHALL use Akka.Streams / Akka.IO.Tcp transport infrastructure for TCP I/O
+- **AND** it SHALL keep socket and pipe ownership inside the existing Akka.IO.Tcp transport layer
+
+#### Scenario: No duplicate pipe transport
+- **WHEN** the redesigned Remote pipeline is implemented
+- **THEN** it SHALL NOT add a new transport whose primary purpose is duplicating Akka.IO.Tcp socket, stream, or pipe mechanics
+
+### Requirement: Existing Remote wire format is preserved
+
+The system SHALL preserve the current Akka.Remote wire format for the first production slice, including length framing, protobuf Akka protocol PDUs, protobuf `AckAndEnvelopeContainer`, serializer ids, manifests, and payload bytes.
+
+#### Scenario: Existing PDU bytes remain decodable
+- **WHEN** the redesigned pipeline receives bytes produced by the current Akka.Remote protobuf PDU codec
+- **THEN** it SHALL decode the same control or payload semantic value as the current implementation
+
+#### Scenario: New PDU bytes remain legacy-decodable
+- **WHEN** the redesigned pipeline emits protobuf PDU bytes in wire-compatible mode
+- **THEN** the current Akka.Remote protobuf PDU codec SHALL decode those bytes as the same control or payload semantic value
+
+#### Scenario: MessagePack PDU envelope not enabled by default
+- **WHEN** the redesigned pipeline is enabled for its first production slice
+- **THEN** it SHALL NOT require MessagePack PDU envelopes or a new PDU wire format
+
+### Requirement: PDU codec supports sequence and writer APIs
+
+The system SHALL provide a PDU codec path that reads from `ReadOnlySequence<byte>` and writes to `IBufferWriter<byte>` while preserving compatibility adapters for existing `ByteString` callers during migration.
+
+#### Scenario: Decode from sequence
+- **WHEN** the PDU codec receives a `ReadOnlySequence<byte>` containing an Akka.Remote PDU
+- **THEN** it SHALL decode the PDU without requiring callers to first materialize a `ByteString`
+
+#### Scenario: Encode to buffer writer
+- **WHEN** the PDU codec writes an Akka.Remote PDU
+- **THEN** it SHALL be able to write the encoded bytes to a caller-owned `IBufferWriter<byte>`
+
+#### Scenario: ByteString adapter remains compatible
+- **WHEN** existing Remote code calls the legacy `ByteString` PDU codec API during migration
+- **THEN** the adapter SHALL preserve existing behavior and wire output
+
+### Requirement: Remote payloads use SerializerV2 boundary
+
+The redesigned Remote payload path SHALL use `SerializerV2` as the uniform serializer abstraction and SHALL rely on `SerializerV1Adapter` for legacy serializers.
+
+#### Scenario: V2 serializer writes payload
+- **WHEN** a Remote outbound payload is handled by a native `SerializerV2`
+- **THEN** the payload path SHALL write through the V2 `IBufferWriter<byte>` serialization API where the surrounding wire format permits it
+
+#### Scenario: V2 serializer reads payload
+- **WHEN** a Remote inbound payload is handled by a native `SerializerV2`
+- **THEN** the payload path SHALL deserialize from `ReadOnlySequence<byte>` without first copying to a byte array where the surrounding wire format permits it
+
+#### Scenario: Legacy serializer uses adapter
+- **WHEN** a Remote payload is handled by a legacy V1 serializer
+- **THEN** the payload path SHALL access it through `SerializerV1Adapter`
+- **AND** unavoidable byte-array copies SHALL remain localized inside that adapter path
+
+### Requirement: Protocol state machine preserves Remote semantics
+
+The redesigned protocol pipeline SHALL preserve current Akka.Remote handshake, heartbeat, disassociation, quarantine, `refuseUid`, reliable-delivery, and listener-registration semantics.
+
+#### Scenario: Handshake semantics preserved
+- **WHEN** a redesigned association completes its handshake
+- **THEN** it SHALL expose the same local address, remote address, and remote UID semantics as the current `AkkaProtocolTransport`
+
+#### Scenario: Disassociation reason preserved
+- **WHEN** a redesigned association receives or emits a disassociation reason
+- **THEN** it SHALL surface the same `DisassociateInfo` semantics as the current protocol state actor
+
+#### Scenario: Quarantine semantics preserved
+- **WHEN** a redesigned association detects a quarantined remote UID or a refused UID
+- **THEN** it SHALL produce the same quarantine behavior expected by `EndpointManager`
+
+#### Scenario: Reliable delivery semantics preserved
+- **WHEN** a redesigned association carries ack, nack, sequence number, or pure ack frames
+- **THEN** it SHALL preserve the same reliable-delivery semantics as the current `AckAndEnvelopeContainer` path
+
+### Requirement: Benchmarks gate each pipeline milestone
+
+The system SHALL record baseline and regression benchmarks for Remote protocol pipeline changes before replacing hot-path internals.
+
+#### Scenario: Baseline captured before implementation
+- **WHEN** implementation begins
+- **THEN** current RemotePingPong and PDU codec benchmark results SHALL be captured in the change notes
+
+#### Scenario: Codec milestone benchmarked
+- **WHEN** the PDU codec API is reshaped around sequence and writer APIs
+- **THEN** the PDU codec benchmark SHALL report throughput and allocation deltas against the baseline
+
+#### Scenario: End-to-end milestone benchmarked
+- **WHEN** an opt-in redesigned Remote protocol pipeline can run end-to-end
+- **THEN** RemotePingPong SHALL report throughput and allocation deltas against the baseline

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -407,6 +407,38 @@ Validation after the inbound bridge lock fast path change:
 | `openspec validate remote-streams-protocol-pipeline --strict` | Valid |
 | `git diff --check` | Passed |
 
+## Remote TCP Framing Micro-Optimizations
+
+Implementation summary:
+
+- Outbound frame encoding now prepends the header directly instead of routing through the generic sequence concat helper.
+- Inbound frame decoding now reads the 4-byte length directly from the first span when the header is contiguous, only copying into a stack buffer for split headers.
+- This does not change the wire format or stream topology; it removes per-frame helper work from the common case.
+
+RemotePingPong stream smoke command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+```
+
+Single smoke run, used only to check for obvious regression on the busy VM:
+
+| Num clients | Msgs/sec |
+| ---: | ---: |
+| 1 | 109470 |
+| 5 | 639387 |
+| 10 | 812348 |
+| 15 | 856409 |
+| 20 | 939629 |
+| 25 | 878735 |
+| 30 | 850100 |
+
+Validation:
+
+| Command | Result |
+| --- | --- |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release --filter "FullyQualifiedName~RemoteTcpFramingSpec|FullyQualifiedName~StreamTcpTransportInteropSpec"` | Passed: 6 |
+
 ## Rejected Queue Write Path Smoke Result
 
 Command:

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -361,6 +361,52 @@ Additional regression coverage:
 - `RemoteTcpFraming_should_reject_oversized_frames` verifies frame-size enforcement.
 - `RemoteTcpFraming_should_reject_truncated_final_frame` verifies partial EOF failure behavior.
 
+## Inbound Bridge Lock Fast Path Result
+
+Implementation summary:
+
+- `DeferredInboundBridge` now uses a volatile fast path once the `StreamAssociationHandle` has been installed.
+- `StreamAssociationHandle.Notify` now uses a volatile fast path once the read listener has been registered.
+- Pending inbound frames/events are still drained under the existing locks before the handle/listener is published, preserving ordering for startup races.
+- The established inbound path avoids two uncontended locks per frame: bridge handle lookup and handle listener lookup.
+
+RemotePingPong stream command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+```
+
+Environment summary:
+
+- OS: Unix 6.8.0.117
+- Processor count: 8
+- Server GC: true
+- Stream transport: Akka.Streams TCP with `Tcp.NoAck`, inbound single-segment copy avoidance, multi-segment outbound frame encoding, Akka.IO TCP no-ack flush batching, Remote-specific TCP frame decoding, and lock-free established inbound bridge notification
+
+| Num clients | Stream sample 1 | Stream sample 2 | Stream sample 3 | Stream median | Prior stream median | Delta vs prior |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 106440 | 102093 | 104987 | 104987 | 108050 | -2.8% |
+| 5 | 648930 | 622666 | 651466 | 648930 | 617284 | +5.1% |
+| 10 | 796496 | 715052 | 773097 | 773097 | 728333 | +6.1% |
+| 15 | 862317 | 753391 | 688706 | 753391 | 774594 | -2.7% |
+| 20 | 907030 | 821187 | 701632 | 821187 | 800962 | +2.5% |
+| 25 | 830979 | 849763 | 756659 | 830979 | 784314 | +5.9% |
+| 30 | 806994 | 861946 | 789059 | 806994 | 829647 | -2.7% |
+
+This is a small hot-path cleanup with mixed benchmark movement on a noisy VM. Treat the table as smoke data, not proof of a precise throughput win. The reason to keep the slice is structural: it removes synchronization from the steady-state inbound path while preserving behavior under focused and full test validation. A fresh DotNetty comparison sample in this pass was noisy at 1 client and logged transient disassociations, so it was not used as the gate for this micro-slice.
+
+Validation after the inbound bridge lock fast path change:
+
+| Command | Result |
+| --- | --- |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release --filter "FullyQualifiedName~RemoteTcpFramingSpec|FullyQualifiedName~StreamTcpTransportInteropSpec"` | Passed: 6 |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release --filter "FullyQualifiedName~MessageSerializerV2Spec|FullyQualifiedName~AkkaPduCodecWireFormatSpec|FullyQualifiedName~AkkaProtocolSpec|FullyQualifiedName~StreamTcpTransportInteropSpec|FullyQualifiedName~RemoteTcpFramingSpec"` | Passed: 30 |
+| `dotnet test "src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj" -c Release --filter "FullyQualifiedName~TcpSpec"` | Passed: 21, skipped: 3 |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release` | Passed: 382, skipped: 5 |
+| `dotnet test "src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj" -c Release` | Passed: 364 |
+| `openspec validate remote-streams-protocol-pipeline --strict` | Valid |
+| `git diff --check` | Passed |
+
 ## Rejected Queue Write Path Smoke Result
 
 Command:

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -236,6 +236,73 @@ Environment summary from the run:
 
 This removes the outbound payload pre-copy in `TcpStreamTransport.EncodeFrame`. The write path still copies segments into the Akka.IO TCP output pipe, but it no longer builds an intermediate contiguous `[header][payload]` array per frame.
 
+## Akka.IO TCP NoAck Flush Batching Result
+
+Implementation summary:
+
+- `TcpConnection` batches no-ack writes when the active transport is `TcpTransportConnection`.
+- A batch flushes after 32 no-ack writes, 64 KiB of no-ack payload, an immediate self-message, an acked write, or graceful/confirmed close.
+- Acked writes keep the existing write-and-flush path and also flush any no-ack writes buffered ahead of them.
+- Non-`TcpTransportConnection` implementations keep the existing write-and-flush behavior; no public `ITransportConnection` member was added.
+
+Dedicated Akka.IO TCP benchmark sanity command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj" -- --filter "*TcpOperationsBenchmarks.ClientServerCommunication*" --job Dry --join
+```
+
+The existing `TcpOperationsBenchmarks` config adds `LongRun`; passing `--job Dry` adds a dry job instead of replacing the configured long job. The run therefore executed the broader parameter matrix and timed out near the later cases after producing partial current-branch data. It was useful as a sanity check that the Akka.IO TCP workload still ran, but it is not used as the comparative gate for this slice.
+
+RemotePingPong stream command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+```
+
+RemotePingPong DotNetty command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1
+```
+
+Environment summary:
+
+- OS: Unix 6.8.0.117
+- Processor count: 8
+- Server GC: true
+- Stream transport: Akka.Streams TCP with `Tcp.NoAck`, inbound single-segment copy avoidance, multi-segment outbound frame encoding, and Akka.IO TCP no-ack flush batching
+
+Sequential stream samples were used. Two accidentally parallel stream samples were discarded because they interfered with each other.
+
+| Num clients | Stream sample 1 | Stream sample 2 | Stream sample 3 | Stream median | DotNetty sample | Delta vs DotNetty |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 110254 | 108226 | 114091 | 110254 | 75302 | +46.4% |
+| 5 | 630518 | 583091 | 629723 | 629723 | 396983 | +58.6% |
+| 10 | 729395 | 688469 | 706215 | 706215 | 559441 | +26.2% |
+| 15 | 796602 | 754148 | 744787 | 754148 | 603865 | +24.9% |
+| 20 | 814996 | 795704 | 792394 | 795704 | 620733 | +28.2% |
+| 25 | 807494 | 801925 | 777243 | 801925 | 634438 | +26.4% |
+| 30 | 839161 | 841161 | 772400 | 839161 | 679041 | +23.6% |
+
+The current stream medians are generally at or above the previous multi-segment outbound-frame smoke range while preserving the stream transport's lead over DotNetty. One sequential stream run logged a transient `EndpointDisassociatedException` during the benchmark but completed; focused stream remoting tests and the full Remote suite passed afterward.
+
+Validation after the Akka.IO TCP no-ack flush batching change:
+
+| Command | Result |
+| --- | --- |
+| `dotnet test "src/core/Akka.Tests/Akka.Tests.csproj" -c Release --filter "FullyQualifiedName~TcpConnectionBatchingSpec"` | Passed: 2 |
+| `dotnet test "src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj" -c Release --filter "FullyQualifiedName~TcpSpec"` | Passed: 21, skipped: 3 |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release --filter "FullyQualifiedName~MessageSerializerV2Spec|FullyQualifiedName~AkkaPduCodecWireFormatSpec|FullyQualifiedName~AkkaProtocolSpec|FullyQualifiedName~StreamTcpTransportInteropSpec"` | Passed: 26 |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release` | Passed: 378, skipped: 5 |
+| `dotnet test "src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj" -c Release` | Passed: 364 |
+| `openspec validate remote-streams-protocol-pipeline --strict` | Valid |
+| `git diff --check` | Passed |
+
+Additional regression coverage:
+
+- `TcpConnection_should_batch_no_ack_writes_before_flushing` verifies several no-ack writes are flushed to the stream as one batch.
+- `Outgoing_TCP_stream_must_flush_small_no_ack_batch_when_upstream_completes` verifies a small no-ack batch below the threshold is still delivered when upstream completes.
+
 ## Rejected Queue Write Path Smoke Result
 
 Command:

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -507,6 +507,76 @@ Environment summary:
 
 Stream samples stayed in the recent range after the sequence-backed inbound PDU decode change, so this slice does not show an obvious regression. DotNetty sample 2 logged transient disassociations at higher client counts and sample 3 logged one shutdown-time send error, but both runs completed. Treat this as VM smoke data rather than a formal benchmark.
 
+## Payload-Only Outer PDU Fast Parser
+
+Implementation summary:
+
+- Added `SequencePayload`, an internal PDU representation that preserves the decoded outer payload as a `ReadOnlySequence<byte>`.
+- `AkkaPduProtobuffCodec.DecodePdu(ReadOnlySequence<byte>)` now fast-paths only canonical payload-only `AkkaProtocolMessage` frames that start with protobuf tag `0x0A`, contain a valid payload length, and consume the full outer PDU.
+- `DecodePdu(ByteString)` still uses the generated protobuf parser so classic callers keep receiving `Payload(ByteString)`.
+- Control PDUs, unknown fields, non-canonical field ordering, both-fields-present frames, and malformed fast-path candidates fall back to generated protobuf parsing.
+- `ProtocolStateActor` forwards decoded `SequencePayload` values as `InboundSequencePayload` to the registered endpoint listener, including listener-ready and pre-listener buffered cases.
+- `EndpointReader` now handles `InboundSequencePayload` in both reading and not-reading states, preserving ACK forwarding, reliable-delivery buffering, and user-message dispatch behavior.
+- Inner `AckAndEnvelopeContainer` parsing still uses the generated protobuf parser. A hand-rolled inner parser was evaluated and rejected before this slice was finalized.
+
+Validation after the payload-only outer PDU fast parser:
+
+| Command | Result |
+| --- | --- |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release --framework net10.0 --filter "FullyQualifiedName~EndpointReaderSpec|FullyQualifiedName~MessageSerializerV2Spec|FullyQualifiedName~AkkaPduCodecWireFormatSpec|FullyQualifiedName~AkkaProtocolSpec|FullyQualifiedName~StreamTcpTransportInteropSpec|FullyQualifiedName~RemoteTcpFramingSpec" --no-restore` | Passed: 46 |
+| `dotnet test "src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj" -c Release --framework net10.0 --filter "FullyQualifiedName~TcpSpec" --no-restore` | Passed: 21, skipped: 3 |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release --framework net10.0 --no-restore` | Passed: 398, skipped: 5 |
+| `dotnet test "src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj" -c Release --framework net10.0 --no-restore` | Passed: 364 |
+
+RemotePingPong stream smoke after the payload-only outer PDU fast parser:
+
+| Num clients | Total messages | Msgs/sec | Total ms | Start threads | End threads |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 200000 | 116823 | 1712.24 | 27 | 30 |
+| 5 | 1000000 | 564972 | 1770.70 | 30 | 36 |
+| 10 | 2000000 | 768936 | 2601.71 | 39 | 50 |
+| 15 | 3000000 | 772400 | 3884.10 | 50 | 50 |
+| 20 | 4000000 | 846741 | 4724.27 | 50 | 50 |
+| 25 | 5000000 | 831118 | 6016.38 | 50 | 50 |
+| 30 | 6000000 | 839396 | 7148.40 | 48 | 48 |
+
+## Rejected Inner Envelope Parser
+
+Experiment summary:
+
+- A hand-rolled `AckAndEnvelopeContainer` parser was prototyped for `DecodeMessage(ReadOnlySequence<byte>)`.
+- The parser recognized the common ack/envelope/recipient/payload/sender/sequence-number shape and fell back to generated protobuf parsing for unsupported or malformed shapes.
+- The prototype still had to materialize the existing generated `SerializedMessage` payload, manifest bytes, actor path strings, and Remote wrapper objects to preserve current downstream behavior.
+
+Dry `AkkaPduCodecBenchmark` command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/Akka.Benchmarks/Akka.Benchmarks.csproj" -- --filter "*AkkaPduCodecBenchmark.DecodeMessageOnly*" --job Dry --join
+```
+
+Dry benchmark result from the prototype:
+
+| Method | Mean | Allocated |
+| --- | ---: | ---: |
+| `DecodeMessageOnly` | 4.971 us | 752 B |
+| `DecodeMessageOnlyFromSequence` | 4.656 us | 752 B |
+
+The dry run is directional only, but it showed the important result: allocations stayed unchanged at `752 B/op`. The small sequence-path delta was not enough to justify a large custom protobuf parser.
+
+RemotePingPong stream smoke from the prototype:
+
+| Num clients | Total messages | Msgs/sec | Total ms | Start threads | End threads |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 200000 | 105153 | 1902.71 | 26 | 49 |
+| 5 | 1000000 | 620348 | 1612.80 | 49 | 54 |
+| 10 | 2000000 | 715308 | 2796.45 | 54 | 54 |
+| 15 | 3000000 | 784109 | 3826.01 | 54 | 54 |
+| 20 | 4000000 | 816827 | 4897.45 | 53 | 53 |
+| 25 | 5000000 | 833612 | 5998.19 | 52 | 51 |
+| 30 | 6000000 | 886133 | 6771.20 | 50 | 48 |
+
+The smoke result stayed inside the recent noisy stream range and did not identify a clear end-to-end improvement. Runtime diagnostics instead showed `EndpointReader|InboundSequencePayload` mailbox wait dominating while receive execution and TCP/framing stages remained cheap. The prototype was removed; the next meaningful optimization should reduce endpoint actor mailbox turns, for example by batching inbound payloads into one endpoint turn or removing an established-state actor hop.
+
 ## Rejected Queue Write Path Smoke Result
 
 Command:
@@ -539,4 +609,4 @@ This experiment was reverted. One in-flight async queue offer per `EndpointWrite
 
 The spike does not yet remove the inbound `ProtocolStateActor` mailbox hop. The future BidiFlow-style protocol replacement should handle the protocol events documented in `protocol-state-machine-map.md` and present the same `AkkaProtocolHandle` / `InboundAssociation` / `InboundPayload` / `Disassociated` behavior to existing remoting actors.
 
-The spike now integrates sequence-backed PDU decode into the established stream inbound path. It does not yet replace outbound PDU construction, inner protobuf `bytes payload` materialization, or the final `InboundPayload(ByteString)` contract consumed by `EndpointReader`, so the old protocol actor can remain authoritative.
+The spike now integrates sequence-backed PDU decode into the established stream inbound path through `EndpointReader`. It does not yet replace outbound PDU construction or inner `AckAndEnvelopeContainer` generated protobuf parsing, so the old protocol actor can remain authoritative.

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -115,6 +115,36 @@ Environment summary from the run:
 
 This removes one stage-actor message per outbound TCP write. Current Akka.IO TCP enqueues writes into a pipe and sends the write ack immediately, so the old `WriteAck` roundtrip did not represent socket-flush backpressure. This optimization improves the stream RemotePingPong hot path while keeping stream TCP functional tests passing.
 
+## Inbound Single-Segment Copy Smoke Result
+
+Command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+```
+
+Environment summary from the run:
+
+- OS: Unix 6.8.0.117
+- Processor count: 8
+- Server GC: true
+- Transport: Akka.Streams TCP
+- Write inlet: `Source.ActorRef`
+- TCP stream stage: `Tcp.NoAck` write path
+- Inbound bridge: single-segment `ReadOnlySequence<byte>` uses `ByteString.CopyFrom(payload.FirstSpan)` instead of `payload.ToArray()`
+
+| Num clients | Total messages | Msgs/sec | Total ms | Start threads | End threads |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 200000 | 101575 | 1969.44 | 27 | 48 |
+| 5 | 1000000 | 586855 | 1704.86 | 48 | 52 |
+| 10 | 2000000 | 674764 | 2964.74 | 52 | 52 |
+| 15 | 3000000 | 747199 | 4015.93 | 51 | 51 |
+| 20 | 4000000 | 746130 | 5361.32 | 51 | 51 |
+| 25 | 5000000 | 754262 | 6629.54 | 51 | 51 |
+| 30 | 6000000 | 776097 | 7731.59 | 51 | 51 |
+
+This removes an avoidable intermediate array allocation/copy for the common inbound frame shape emitted by the stream framing stage.
+
 ## Rejected Queue Write Path Smoke Result
 
 Command:

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -58,6 +58,62 @@ Environment summary from the run:
 
 This is a smoke result, not a final benchmark. The stream transport still uses the existing `AkkaProtocolTransport` / `ProtocolStateActor` wrapper and bridges framed payloads through `ByteString`.
 
+## Source.ActorRef Revert Confirmation
+
+Command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+```
+
+Environment summary from the run:
+
+- OS: Unix 6.8.0.117
+- Processor count: 8
+- Server GC: true
+- Transport: Akka.Streams TCP
+- Write inlet: `Source.ActorRef`
+
+| Num clients | Total messages | Msgs/sec | Total ms | Start threads | End threads |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 200000 | 89326 | 2239.59 | 25 | 45 |
+| 5 | 1000000 | 541126 | 1848.32 | 45 | 50 |
+| 10 | 2000000 | 590145 | 3389.45 | 50 | 50 |
+| 15 | 3000000 | 460759 | 6511.61 | 48 | 49 |
+| 20 | 4000000 | 625000 | 6400.36 | 47 | 47 |
+| 25 | 5000000 | 617742 | 8094.51 | 47 | 44 |
+| 30 | 6000000 | 618366 | 9703.65 | 44 | 44 |
+
+This restores the faster fire-and-forget stream inlet after the `Source.Queue` experiment below.
+
+## Rejected Queue Write Path Smoke Result
+
+Command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+```
+
+Environment summary from the run:
+
+- OS: Unix 6.8.0.117
+- Processor count: 8
+- Server GC: true
+- Transport: Akka.Streams TCP
+- Rejected write inlet: `Source.Queue` plus internal async association write seam
+
+| Num clients | Total messages | Msgs/sec | Total ms | Start threads | End threads |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 200000 | 64999 | 3077.24 | 27 | 47 |
+| 5 | 1000000 | 271887 | 3678.56 | 47 | 51 |
+| 10 | 2000000 | 284415 | 7032.90 | 51 | 49 |
+| 15 | 3000000 | 303921 | 9871.47 | 46 | 43 |
+| 20 | 4000000 | 310126 | 12898.89 | 43 | 42 |
+| 25 | 5000000 | 308757 | 16194.15 | 42 | 41 |
+| 30 | 6000000 | 295698 | 20291.62 | 41 | 41 |
+
+This experiment was reverted. One in-flight async queue offer per `EndpointWriter` adds an actor-turn and task-completion cost per payload, reducing throughput from the previous `Source.ActorRef` stream spike. The next performance slice should keep the faster fire-and-forget write inlet or move the protocol/write pump into a purpose-built stream stage or bounded writer pump without per-message `Source.Queue.OfferAsync` acknowledgements on the endpoint hot path.
+
 ## Deferred Work
 
 The spike does not yet remove the inbound `ProtocolStateActor` mailbox hop. The future BidiFlow-style protocol replacement should handle the protocol events documented in `protocol-state-machine-map.md` and present the same `AkkaProtocolHandle` / `InboundAssociation` / `InboundPayload` / `Disassociated` behavior to existing remoting actors.

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -439,6 +439,45 @@ Validation:
 | --- | --- |
 | `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release --filter "FullyQualifiedName~RemoteTcpFramingSpec|FullyQualifiedName~StreamTcpTransportInteropSpec"` | Passed: 6 |
 
+## Sequence-Backed Inbound PDU Decode
+
+Implementation summary:
+
+- Added an internal `InboundSequencePayload` event for transports that can expose encoded Akka protocol PDUs as `ReadOnlySequence<byte>`.
+- `ProtocolStateActor` now decodes `InboundPayload` and `InboundSequencePayload` through the same handshake, heartbeat, disassociation, and open-payload branches.
+- The established `TcpStreamTransport` inbound path now notifies the protocol actor with `InboundSequencePayload`, avoiding the prior transport-frame-to-`ByteString` materialization before PDU decode.
+- Startup race buffering remains conservative: frames received before the `StreamAssociationHandle` exists are still copied into `ByteString` and replayed through the classic path.
+- The user payload event exposed after protocol unwrap remains `InboundPayload(ByteString)`; this slice only removes the outer Remote PDU materialization in the established stream inbound path.
+
+RemotePingPong stream smoke command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+```
+
+Single smoke run on the busy VM:
+
+| Num clients | Msgs/sec |
+| ---: | ---: |
+| 1 | 105486 |
+| 5 | 674764 |
+| 10 | 730995 |
+| 15 | 771209 |
+| 20 | 779272 |
+| 25 | 823181 |
+| 30 | 846741 |
+
+Validation:
+
+| Command | Result |
+| --- | --- |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release --filter "FullyQualifiedName~MessageSerializerV2Spec|FullyQualifiedName~AkkaPduCodecWireFormatSpec|FullyQualifiedName~AkkaProtocolSpec|FullyQualifiedName~StreamTcpTransportInteropSpec|FullyQualifiedName~RemoteTcpFramingSpec"` | Passed: 35 |
+| `dotnet test "src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj" -c Release --filter "FullyQualifiedName~TcpSpec"` | Passed: 21, skipped: 3 |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release` | Passed: 387, skipped: 5 |
+| `dotnet test "src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj" -c Release` | Passed: 364 |
+| `openspec validate remote-streams-protocol-pipeline --strict` | Valid |
+| `git diff --check` | Passed |
+
 ## Rejected Queue Write Path Smoke Result
 
 Command:
@@ -471,4 +510,4 @@ This experiment was reverted. One in-flight async queue offer per `EndpointWrite
 
 The spike does not yet remove the inbound `ProtocolStateActor` mailbox hop. The future BidiFlow-style protocol replacement should handle the protocol events documented in `protocol-state-machine-map.md` and present the same `AkkaProtocolHandle` / `InboundAssociation` / `InboundPayload` / `Disassociated` behavior to existing remoting actors.
 
-The spike also does not yet integrate the sequence/writer PDU codec into stream framing. Frames are currently bridged through `ByteString` at the classic transport boundary so the old protocol actor can remain authoritative.
+The spike now integrates sequence-backed PDU decode into the established stream inbound path. It does not yet replace outbound PDU construction, inner protobuf `bytes payload` materialization, or the final `InboundPayload(ByteString)` contract consumed by `EndpointReader`, so the old protocol actor can remain authoritative.

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -145,6 +145,66 @@ Environment summary from the run:
 
 This removes an avoidable intermediate array allocation/copy for the common inbound frame shape emitted by the stream framing stage.
 
+## Repeat Median Comparison
+
+Commands:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1
+```
+
+Each transport was run 3 times on the same branch and machine. The table reports median `Msgs/sec`.
+
+| Num clients | Stream median | DotNetty median | Delta |
+| ---: | ---: | ---: | ---: |
+| 1 | 98961 | 77370 | +27.9% |
+| 5 | 566573 | 371886 | +52.4% |
+| 10 | 655738 | 521921 | +25.6% |
+| 15 | 696056 | 562009 | +23.9% |
+| 20 | 690013 | 577284 | +19.5% |
+| 25 | 721397 | 594319 | +21.4% |
+| 30 | 740833 | 617031 | +20.1% |
+
+Stream sample `Msgs/sec` values:
+
+| Num clients | Sample 1 | Sample 2 | Sample 3 |
+| ---: | ---: | ---: | ---: |
+| 1 | 102146 | 97944 | 98961 |
+| 5 | 597015 | 566573 | 535046 |
+| 10 | 593648 | 669345 | 655738 |
+| 15 | 696056 | 679348 | 722022 |
+| 20 | 626665 | 702371 | 690013 |
+| 25 | 721397 | 749738 | 717979 |
+| 30 | 740833 | 781352 | 727009 |
+
+DotNetty sample `Msgs/sec` values:
+
+| Num clients | Sample 1 | Sample 2 | Sample 3 |
+| ---: | ---: | ---: | ---: |
+| 1 | 77370 | 72860 | 79555 |
+| 5 | 392004 | 361272 | 371886 |
+| 10 | 521921 | 508389 | 525211 |
+| 15 | 576148 | 562009 | 551572 |
+| 20 | 577284 | 572738 | 584283 |
+| 25 | 610278 | 584796 | 594319 |
+| 30 | 617031 | 618876 | 597372 |
+
+## Validation
+
+Validation run after the TCP stage no-ack and inbound single-segment copy changes:
+
+| Command | Result |
+| --- | --- |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release` | Passed: 378, skipped: 5 |
+| `dotnet test "src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj" -c Release --filter "FullyQualifiedName~TcpSpec"` | Passed: 20, skipped: 3 |
+| `dotnet test "src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj" -c Release` | Passed: 364 |
+| `openspec validate remote-streams-protocol-pipeline --strict` | Valid |
+
+Additional TCP stream regression coverage:
+
+- `Outgoing_TCP_stream_must_not_drop_writes_when_remote_reads_slowly` delays server-side reads while the client writes 2048 64-byte chunks, then verifies exact byte-for-byte delivery.
+
 ## Rejected Queue Write Path Smoke Result
 
 Command:

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -86,6 +86,35 @@ Environment summary from the run:
 
 This restores the faster fire-and-forget stream inlet after the `Source.Queue` experiment below.
 
+## TCP Stage NoAck Smoke Result
+
+Command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+```
+
+Environment summary from the run:
+
+- OS: Unix 6.8.0.117
+- Processor count: 8
+- Server GC: true
+- Transport: Akka.Streams TCP
+- Write inlet: `Source.ActorRef`
+- TCP stream stage: writes use `Tcp.NoAck` and pull the next upstream element immediately after enqueueing to Akka.IO TCP
+
+| Num clients | Total messages | Msgs/sec | Total ms | Start threads | End threads |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 200000 | 96433 | 2074.60 | 27 | 32 |
+| 5 | 1000000 | 558972 | 1789.18 | 32 | 36 |
+| 10 | 2000000 | 655953 | 3049.72 | 36 | 50 |
+| 15 | 3000000 | 663424 | 4522.44 | 50 | 51 |
+| 20 | 4000000 | 636639 | 6283.79 | 51 | 51 |
+| 25 | 5000000 | 660241 | 7573.99 | 51 | 50 |
+| 30 | 6000000 | 738735 | 8122.63 | 50 | 50 |
+
+This removes one stage-actor message per outbound TCP write. Current Akka.IO TCP enqueues writes into a pipe and sends the write ack immediately, so the old `WriteAck` roundtrip did not represent socket-flush backpressure. This optimization improves the stream RemotePingPong hot path while keeping stream TCP functional tests passing.
+
 ## Rejected Queue Write Path Smoke Result
 
 Command:

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -478,6 +478,35 @@ Validation:
 | `openspec validate remote-streams-protocol-pipeline --strict` | Valid |
 | `git diff --check` | Passed |
 
+Current-commit 3-run comparison after the sequence-backed inbound PDU decode change:
+
+Commands:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1
+```
+
+Environment summary:
+
+- OS: Unix 6.8.0.117
+- Processor count: 8
+- Server GC: true
+- Process priority elevation failed with `Permission denied`; runs used normal priority.
+- Compared commit: `5aed5a8d7 Avoid inbound stream PDU materialization`
+
+| Num clients | Stream sample 1 | Stream sample 2 | Stream sample 3 | Stream median | DotNetty sample 1 | DotNetty sample 2 | DotNetty sample 3 | DotNetty median | Delta vs DotNetty |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 112045 | 127714 | 110804 | 112045 | 81005 | 83543 | 79083 | 81005 | +38.3% |
+| 5 | 643087 | 490437 | 695895 | 643087 | 336701 | 353983 | 328408 | 336701 | +91.0% |
+| 10 | 742391 | 738008 | 759014 | 742391 | 560853 | 531350 | 546150 | 546150 | +35.9% |
+| 15 | 764526 | 787195 | 821918 | 787195 | 622407 | 584454 | 587545 | 587545 | +34.0% |
+| 20 | 838223 | 793494 | 806777 | 806777 | 641129 | 618717 | 607626 | 618717 | +30.4% |
+| 25 | 826857 | 811162 | 824675 | 824675 | 659283 | 633233 | 627511 | 633233 | +30.2% |
+| 30 | 833681 | 857879 | 834029 | 834029 | 675448 | 657607 | 654808 | 657607 | +26.8% |
+
+Stream samples stayed in the recent range after the sequence-backed inbound PDU decode change, so this slice does not show an obvious regression. DotNetty sample 2 logged transient disassociations at higher client counts and sample 3 logged one shutdown-time send error, but both runs completed. Treat this as VM smoke data rather than a formal benchmark.
+
 ## Rejected Queue Write Path Smoke Result
 
 Command:

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -205,6 +205,37 @@ Additional TCP stream regression coverage:
 
 - `Outgoing_TCP_stream_must_not_drop_writes_when_remote_reads_slowly` delays server-side reads while the client writes 2048 64-byte chunks, then verifies exact byte-for-byte delivery.
 
+## Multi-Segment Outbound Frame Smoke Result
+
+Command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+```
+
+Environment summary from the run:
+
+- OS: Unix 6.8.0.117
+- Processor count: 8
+- Server GC: true
+- Transport: Akka.Streams TCP
+- Write inlet: `Source.ActorRef`
+- TCP stream stage: `Tcp.NoAck` write path
+- Inbound bridge: single-segment `ReadOnlySequence<byte>` avoids intermediate `ToArray()`
+- Outbound frame encoder: emits a multi-segment `[4-byte length] + [payload]` `ReadOnlySequence<byte>` instead of allocating and copying `[length + payload]`
+
+| Num clients | Sample 1 msgs/sec | Sample 2 msgs/sec |
+| ---: | ---: | ---: |
+| 1 | 105319 | 119761 |
+| 5 | 597015 | 572410 |
+| 10 | 704226 | 724901 |
+| 15 | 764916 | 731708 |
+| 20 | 784776 | 772350 |
+| 25 | 799106 | 783945 |
+| 30 | 798616 | 846024 |
+
+This removes the outbound payload pre-copy in `TcpStreamTransport.EncodeFrame`. The write path still copies segments into the Akka.IO TCP output pipe, but it no longer builds an intermediate contiguous `[header][payload]` array per frame.
+
 ## Rejected Queue Write Path Smoke Result
 
 Command:

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -1,0 +1,36 @@
+# Stream TCP Pipeline Spike
+
+## Scope
+
+The first stream transport spike adds an opt-in TCP transport class backed by Akka.Streams TCP and the existing Akka.IO.Tcp substrate:
+
+- Transport class: `Akka.Remote.Transport.Streams.TcpStreamTransport, Akka.Remote`
+- Opt-in shape: override `akka.remote.dot-netty.tcp.transport-class` while keeping `akka.remote.enabled-transports = ["akka.remote.dot-netty.tcp"]`
+- Public scheme remains `akka.tcp` because the raw transport scheme remains `tcp` and the existing `AkkaProtocolTransport` wrapper still augments it.
+
+This proves a stream-backed TCP substrate can interoperate with classic DotNetty using the same length-framed Akka.Remote PDU bytes.
+
+## Current Boundary
+
+This spike intentionally keeps the existing classic protocol wrapper in place:
+
+- `EndpointWriter` still serializes actor messages and writes payload bytes.
+- `EndpointReader` still deserializes unwrapped payload bytes and dispatches messages.
+- `AkkaProtocolTransport` / `ProtocolStateActor` still own handshake, heartbeat, `refuseUid`, disassociation, and listener buffering semantics.
+- `TcpStreamTransport` owns only socket I/O, DotNetty-compatible length framing, and the raw `AssociationHandle` bridge.
+
+## Compatibility Test
+
+`StreamTcpTransportInteropSpec` validates:
+
+- Classic DotNetty node sends to stream TCP node.
+- Stream TCP node sends to classic DotNetty node.
+- Stream TCP node shuts down and restarts on the same address.
+- Classic DotNetty node reconnects to the restarted stream TCP node.
+- Stream TCP node can still send back to the classic DotNetty node after restart.
+
+## Deferred Work
+
+The spike does not yet remove the inbound `ProtocolStateActor` mailbox hop. The future BidiFlow-style protocol replacement should handle the protocol events documented in `protocol-state-machine-map.md` and present the same `AkkaProtocolHandle` / `InboundAssociation` / `InboundPayload` / `Disassociated` behavior to existing remoting actors.
+
+The spike also does not yet integrate the sequence/writer PDU codec into stream framing. Frames are currently bridged through `ByteString` at the classic transport boundary so the old protocol actor can remain authoritative.

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -303,6 +303,64 @@ Additional regression coverage:
 - `TcpConnection_should_batch_no_ack_writes_before_flushing` verifies several no-ack writes are flushed to the stream as one batch.
 - `Outgoing_TCP_stream_must_flush_small_no_ack_batch_when_upstream_completes` verifies a small no-ack batch below the threshold is still delivered when upstream completes.
 
+## Remote TCP Framing Stage Result
+
+Implementation summary:
+
+- Added `RemoteTcpFraming` for DotNetty-compatible 4-byte Remote TCP length framing.
+- Inbound stream path now uses a Remote-specific decoder that emits payload slices directly instead of generic `Framing.LengthField(...).Select(frame => frame.Slice(4))`.
+- Outbound stream path now encodes frames before telling the `Source.ActorRef`, removing the outbound stream `Select(EncodeFrame)` stage.
+- The wire format remains `[4-byte payload length][payload bytes]` using the configured DotNetty byte order.
+
+RemotePingPong stream command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+```
+
+RemotePingPong DotNetty command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1
+```
+
+Environment summary:
+
+- OS: Unix 6.8.0.117
+- Processor count: 8
+- Server GC: true
+- Stream transport: Akka.Streams TCP with `Tcp.NoAck`, inbound single-segment copy avoidance, multi-segment outbound frame encoding, Akka.IO TCP no-ack flush batching, and Remote-specific TCP frame decoding
+
+| Num clients | Stream sample 1 | Stream sample 2 | Stream sample 3 | Stream median | DotNetty sample | Delta vs DotNetty |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 101369 | 108050 | 122474 | 108050 | 75586 | +43.0% |
+| 5 | 617284 | 623831 | 541712 | 617284 | 358552 | +72.2% |
+| 10 | 728333 | 740467 | 711238 | 728333 | 548697 | +32.7% |
+| 15 | 774594 | 755288 | 774794 | 774594 | 574713 | +34.8% |
+| 20 | 805640 | 769972 | 800962 | 800962 | 624415 | +28.3% |
+| 25 | 784314 | 804247 | 774234 | 784314 | 649858 | +20.7% |
+| 30 | 829647 | 815883 | 838106 | 829647 | 657247 | +26.2% |
+
+Compared with the prior no-ack batching slice, this change is mostly neutral to modestly positive: 10, 15, 20, and 25 client medians improved, 1, 5, and 30 client medians moved down but stayed within the recent stream smoke range. The main value is removing generic framing and map stages from the stream transport while preserving the stream transport's end-to-end lead over DotNetty.
+
+Validation after the Remote TCP framing stage change:
+
+| Command | Result |
+| --- | --- |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release --filter "FullyQualifiedName~RemoteTcpFramingSpec|FullyQualifiedName~StreamTcpTransportInteropSpec"` | Passed: 6 |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release --filter "FullyQualifiedName~MessageSerializerV2Spec|FullyQualifiedName~AkkaPduCodecWireFormatSpec|FullyQualifiedName~AkkaProtocolSpec|FullyQualifiedName~StreamTcpTransportInteropSpec|FullyQualifiedName~RemoteTcpFramingSpec"` | Passed: 30 |
+| `dotnet test "src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj" -c Release --filter "FullyQualifiedName~TcpSpec"` | Passed: 21, skipped: 3 |
+| `dotnet test "src/core/Akka.Tests/Akka.Tests.csproj" -c Release --filter "FullyQualifiedName~TcpConnectionBatchingSpec"` | Passed: 2 |
+| `dotnet test "src/core/Akka.Remote.Tests/Akka.Remote.Tests.csproj" -c Release` | Passed: 382, skipped: 5 |
+| `dotnet test "src/core/Akka.Cluster.Tests/Akka.Cluster.Tests.csproj" -c Release` | Passed: 364 |
+
+Additional regression coverage:
+
+- `RemoteTcpFraming_should_decode_multiple_big_endian_frames_from_one_chunk` verifies multiple payload frames, including empty payloads, from one upstream chunk.
+- `RemoteTcpFraming_should_decode_little_endian_frames_split_across_chunks` verifies split header/payload reassembly and byte-order handling.
+- `RemoteTcpFraming_should_reject_oversized_frames` verifies frame-size enforcement.
+- `RemoteTcpFraming_should_reject_truncated_final_frame` verifies partial EOF failure behavior.
+
 ## Rejected Queue Write Path Smoke Result
 
 Command:

--- a/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/stream-pipeline-spike.md
@@ -7,6 +7,7 @@ The first stream transport spike adds an opt-in TCP transport class backed by Ak
 - Transport class: `Akka.Remote.Transport.Streams.TcpStreamTransport, Akka.Remote`
 - Opt-in shape: override `akka.remote.dot-netty.tcp.transport-class` while keeping `akka.remote.enabled-transports = ["akka.remote.dot-netty.tcp"]`
 - Public scheme remains `akka.tcp` because the raw transport scheme remains `tcp` and the existing `AkkaProtocolTransport` wrapper still augments it.
+- Stream write inlet buffering is controlled by `akka.remote.dot-netty.tcp.stream-write-buffer-size` and defaults to `65536` elements for this spike.
 
 This proves a stream-backed TCP substrate can interoperate with classic DotNetty using the same length-framed Akka.Remote PDU bytes.
 
@@ -28,6 +29,34 @@ This spike intentionally keeps the existing classic protocol wrapper in place:
 - Stream TCP node shuts down and restarts on the same address.
 - Classic DotNetty node reconnects to the restarted stream TCP node.
 - Stream TCP node can still send back to the classic DotNetty node after restart.
+- Stream TCP nodes can exchange messages with each other in both directions.
+
+## RemotePingPong Smoke Result
+
+Command:
+
+```bash
+dotnet run -c Release --project "src/benchmark/RemotePingPong/RemotePingPong.csproj" -- 1 stream
+```
+
+Environment summary from the run:
+
+- OS: Unix 6.8.0.117
+- Processor count: 8
+- Server GC: true
+- Transport: Akka.Streams TCP
+
+| Num clients | Total messages | Msgs/sec | Total ms | Start threads | End threads |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 200000 | 85361 | 2343.11 | 26 | 50 |
+| 5 | 1000000 | 360621 | 2773.77 | 50 | 54 |
+| 10 | 2000000 | 406092 | 4925.38 | 54 | 54 |
+| 15 | 3000000 | 489158 | 6133.34 | 53 | 52 |
+| 20 | 4000000 | 522194 | 7660.26 | 47 | 45 |
+| 25 | 5000000 | 631712 | 7915.40 | 45 | 45 |
+| 30 | 6000000 | 623377 | 9625.28 | 43 | 43 |
+
+This is a smoke result, not a final benchmark. The stream transport still uses the existing `AkkaProtocolTransport` / `ProtocolStateActor` wrapper and bridges framed payloads through `ByteString`.
 
 ## Deferred Work
 

--- a/openspec/changes/remote-streams-protocol-pipeline/tasks.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/tasks.md
@@ -47,10 +47,11 @@
 - [ ] 6.4 Integrate the sequence/writer PDU codec into the stream pipeline.
 - [ ] 6.5 Integrate the SerializerV2 payload boundary into the stream pipeline.
 - [ ] 6.6 Preserve `EndpointWriter`, `EndpointReader`, and reliable-delivery semantics or document any required internal facade.
-- [ ] 6.7 Add a conservative payload-only outer `AkkaProtocolMessage` fast parser over `ReadOnlySequence<byte>`.
-- [ ] 6.8 Fall back to generated protobuf parsing for control PDUs, unknown fields, non-canonical field ordering, and malformed fast-path candidates.
-- [ ] 6.9 Forward sequence-backed payload PDUs from `ProtocolStateActor` to `EndpointReader` without materializing `InboundPayload(ByteString)` on the established stream inbound path.
-- [ ] 6.10 Teach `EndpointReader` to handle `InboundSequencePayload` in both reading and not-reading states while preserving ACK and reliable-delivery behavior.
+- [x] 6.7 Add a conservative payload-only outer `AkkaProtocolMessage` fast parser over `ReadOnlySequence<byte>`.
+- [x] 6.8 Fall back to generated protobuf parsing for control PDUs, unknown fields, non-canonical field ordering, and malformed fast-path candidates.
+- [x] 6.9 Forward sequence-backed payload PDUs from `ProtocolStateActor` to `EndpointReader` without materializing `InboundPayload(ByteString)` on the established stream inbound path.
+- [x] 6.10 Teach `EndpointReader` to handle `InboundSequencePayload` in both reading and not-reading states while preserving ACK and reliable-delivery behavior.
+- [x] 6.11 Evaluate and reject a hand-rolled inner `AckAndEnvelopeContainer` parser after measurements showed no allocation reduction and no clear end-to-end throughput win.
 
 ## 7. Validation And Performance Gates
 
@@ -58,7 +59,7 @@
 - [x] 7.2 Run relevant `Akka.Cluster.Tests` or multi-node smoke tests in legacy mode.
 - [ ] 7.3 Run relevant `Akka.Cluster.Tests` or multi-node smoke tests in the opt-in stream pipeline mode when available.
 - [x] 7.4 Rerun `RemotePingPong` after each implementation milestone and record result deltas.
-- [ ] 7.5 Rerun `AkkaPduCodecBenchmark` after codec milestones and record allocation deltas.
+- [x] 7.5 Rerun `AkkaPduCodecBenchmark` after codec milestones and record allocation deltas.
 - [x] 7.6 Stop before defaulting the stream pipeline on until benchmarks and compatibility tests justify the change.
 
 ## 8. Documentation And Review

--- a/openspec/changes/remote-streams-protocol-pipeline/tasks.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/tasks.md
@@ -24,26 +24,26 @@
 
 ## 4. SerializerV2 Remote Payload Boundary
 
-- [ ] 4.1 Update Remote payload serialization design so `MessageSerializer` resolves a `SerializerV2` for outbound payloads.
-- [ ] 4.2 Route legacy serializers through `SerializerV1Adapter` rather than adding V1-specific branches in Remote code.
-- [ ] 4.3 Write native V2 payload bytes through `SerializerV2.Serialize` where the current protobuf payload field requires bytes.
-- [ ] 4.4 Read native V2 payload bytes through `Serialization.Deserialize(ReadOnlySequence<byte>, int, string)` where the payload sequence lifetime is valid.
-- [ ] 4.5 Preserve serializer id, manifest, and payload byte semantics for old and new payload serializers.
-- [ ] 4.6 Add tests for V2 payloads and V1-adapted payloads through the Remote message serializer path.
+- [x] 4.1 Update Remote payload serialization design so `MessageSerializer` resolves a `SerializerV2` for outbound payloads.
+- [x] 4.2 Route legacy serializers through `SerializerV1Adapter` rather than adding V1-specific branches in Remote code.
+- [x] 4.3 Write native V2 payload bytes through `SerializerV2.Serialize` where the current protobuf payload field requires bytes.
+- [x] 4.4 Read native V2 payload bytes through `Serialization.Deserialize(ReadOnlySequence<byte>, int, string)` where the payload sequence lifetime is valid.
+- [x] 4.5 Preserve serializer id, manifest, and payload byte semantics for old and new payload serializers.
+- [x] 4.6 Add tests for V2 payloads and V1-adapted payloads through the Remote message serializer path.
 
 ## 5. Protocol State Machine Isolation
 
-- [ ] 5.1 Extract protocol transition scenarios from `ProtocolStateActor` into focused tests for handshake, heartbeat, disassociation, quarantine, `refuseUid`, and listener registration.
-- [ ] 5.2 Identify which `ProtocolStateActor` behavior can be represented as a pure state machine while preserving public remoting behavior.
+- [x] 5.1 Extract protocol transition scenarios from `ProtocolStateActor` into focused tests for handshake, heartbeat, disassociation, quarantine, `refuseUid`, and listener registration.
+- [x] 5.2 Identify which `ProtocolStateActor` behavior can be represented as a pure state machine while preserving public remoting behavior.
 - [ ] 5.3 Add an internal state-machine model or facade that can be exercised without a live actor mailbox.
 - [ ] 5.4 Keep `ProtocolStateActor` authoritative until the extracted model passes equivalence tests.
-- [ ] 5.5 Document any required listener-registration or pre-listener buffering behavior before replacing actor FSM hot-path handling.
+- [x] 5.5 Document any required listener-registration or pre-listener buffering behavior before replacing actor FSM hot-path handling.
 
 ## 6. Stream Protocol Pipeline Spike
 
-- [ ] 6.1 Prototype an opt-in Remote protocol pipeline over Akka.Streams / Akka.IO.Tcp without adding a new raw pipe transport.
-- [ ] 6.2 Use existing Remote protobuf wire format in the opt-in stream pipeline.
-- [ ] 6.3 Ensure stream framing preserves the same length-framed PDU semantics expected by existing Remote tests.
+- [x] 6.1 Prototype an opt-in Remote protocol pipeline over Akka.Streams / Akka.IO.Tcp without adding a new raw pipe transport.
+- [x] 6.2 Use existing Remote protobuf wire format in the opt-in stream pipeline.
+- [x] 6.3 Ensure stream framing preserves the same length-framed PDU semantics expected by existing Remote tests.
 - [ ] 6.4 Integrate the sequence/writer PDU codec into the stream pipeline.
 - [ ] 6.5 Integrate the SerializerV2 payload boundary into the stream pipeline.
 - [ ] 6.6 Preserve `EndpointWriter`, `EndpointReader`, and reliable-delivery semantics or document any required internal facade.

--- a/openspec/changes/remote-streams-protocol-pipeline/tasks.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/tasks.md
@@ -50,12 +50,12 @@
 
 ## 7. Validation And Performance Gates
 
-- [ ] 7.1 Run focused `Akka.Remote.Tests` covering `AkkaProtocolSpec`, codec tests, and endpoint send/receive behavior.
+- [x] 7.1 Run focused `Akka.Remote.Tests` covering `AkkaProtocolSpec`, codec tests, and endpoint send/receive behavior.
 - [ ] 7.2 Run relevant `Akka.Cluster.Tests` or multi-node smoke tests in legacy mode.
 - [ ] 7.3 Run relevant `Akka.Cluster.Tests` or multi-node smoke tests in the opt-in stream pipeline mode when available.
-- [ ] 7.4 Rerun `RemotePingPong` after each implementation milestone and record result deltas.
+- [x] 7.4 Rerun `RemotePingPong` after each implementation milestone and record result deltas.
 - [ ] 7.5 Rerun `AkkaPduCodecBenchmark` after codec milestones and record allocation deltas.
-- [ ] 7.6 Stop before defaulting the stream pipeline on until benchmarks and compatibility tests justify the change.
+- [x] 7.6 Stop before defaulting the stream pipeline on until benchmarks and compatibility tests justify the change.
 
 ## 8. Documentation And Review
 

--- a/openspec/changes/remote-streams-protocol-pipeline/tasks.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/tasks.md
@@ -2,8 +2,8 @@
 
 - [x] 1.1 Run current `RemotePingPong` baseline on `dev` and record throughput results in this change.
 - [x] 1.2 Run current `AkkaPduCodecBenchmark` baseline and record throughput/allocation results in this change.
-- [ ] 1.3 Map outbound copy/allocation boundaries from `EndpointWriter` through `MessageSerializer`, `AkkaPduCodec`, `AkkaProtocolHandle`, and the transport boundary.
-- [ ] 1.4 Map inbound copy/allocation boundaries from transport frame receipt through `InboundPayload`, `ProtocolStateActor`, `AkkaPduCodec.DecodeMessage`, and `EndpointReader` dispatch.
+- [x] 1.3 Map outbound copy/allocation boundaries from `EndpointWriter` through `MessageSerializer`, `AkkaPduCodec`, `AkkaProtocolHandle`, and the transport boundary.
+- [x] 1.4 Map inbound copy/allocation boundaries from transport frame receipt through `InboundPayload`, `ProtocolStateActor`, `AkkaPduCodec.DecodeMessage`, and `EndpointReader` dispatch.
 - [x] 1.5 Add or update benchmark documentation with baseline commands, environment, and result tables.
 
 ## 2. Wire-Compatibility Fixtures

--- a/openspec/changes/remote-streams-protocol-pipeline/tasks.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/tasks.md
@@ -1,0 +1,65 @@
+## 1. Baseline And Hot-Path Mapping
+
+- [ ] 1.1 Run current `RemotePingPong` baseline on `dev` and record throughput results in this change.
+- [ ] 1.2 Run current `AkkaPduCodecBenchmark` baseline and record throughput/allocation results in this change.
+- [ ] 1.3 Map outbound copy/allocation boundaries from `EndpointWriter` through `MessageSerializer`, `AkkaPduCodec`, `AkkaProtocolHandle`, and the transport boundary.
+- [ ] 1.4 Map inbound copy/allocation boundaries from transport frame receipt through `InboundPayload`, `ProtocolStateActor`, `AkkaPduCodec.DecodeMessage`, and `EndpointReader` dispatch.
+- [ ] 1.5 Add or update benchmark documentation with baseline commands, environment, and result tables.
+
+## 2. Wire-Compatibility Fixtures
+
+- [ ] 2.1 Add golden byte fixtures for `Associate`, `Heartbeat`, and each `DisassociateInfo` control PDU.
+- [ ] 2.2 Add golden byte fixtures for payload PDU wrapping an `AckAndEnvelopeContainer`.
+- [ ] 2.3 Add golden byte fixtures for pure ack, ack plus message, and sequenced reliable-delivery message envelopes.
+- [ ] 2.4 Verify existing `AkkaPduProtobuffCodec` decodes all golden fixtures.
+- [ ] 2.5 Verify existing `AkkaPduProtobuffCodec` emits byte-compatible output for the supported golden fixture shapes.
+
+## 3. Sequence/Writer PDU Codec Shape
+
+- [ ] 3.1 Introduce internal PDU decode APIs that accept `ReadOnlySequence<byte>` without requiring caller-side `ByteString` materialization.
+- [ ] 3.2 Introduce internal PDU encode APIs that write to caller-owned `IBufferWriter<byte>`.
+- [ ] 3.3 Keep existing `ByteString` PDU APIs as adapters over the new internal codec path.
+- [ ] 3.4 Preserve current protobuf wire output for control PDUs and payload PDUs.
+- [ ] 3.5 Update `AkkaPduCodecBenchmark` to compare legacy adapter calls and sequence/writer calls.
+
+## 4. SerializerV2 Remote Payload Boundary
+
+- [ ] 4.1 Update Remote payload serialization design so `MessageSerializer` resolves a `SerializerV2` for outbound payloads.
+- [ ] 4.2 Route legacy serializers through `SerializerV1Adapter` rather than adding V1-specific branches in Remote code.
+- [ ] 4.3 Write native V2 payload bytes through `SerializerV2.Serialize` where the current protobuf payload field requires bytes.
+- [ ] 4.4 Read native V2 payload bytes through `Serialization.Deserialize(ReadOnlySequence<byte>, int, string)` where the payload sequence lifetime is valid.
+- [ ] 4.5 Preserve serializer id, manifest, and payload byte semantics for old and new payload serializers.
+- [ ] 4.6 Add tests for V2 payloads and V1-adapted payloads through the Remote message serializer path.
+
+## 5. Protocol State Machine Isolation
+
+- [ ] 5.1 Extract protocol transition scenarios from `ProtocolStateActor` into focused tests for handshake, heartbeat, disassociation, quarantine, `refuseUid`, and listener registration.
+- [ ] 5.2 Identify which `ProtocolStateActor` behavior can be represented as a pure state machine while preserving public remoting behavior.
+- [ ] 5.3 Add an internal state-machine model or facade that can be exercised without a live actor mailbox.
+- [ ] 5.4 Keep `ProtocolStateActor` authoritative until the extracted model passes equivalence tests.
+- [ ] 5.5 Document any required listener-registration or pre-listener buffering behavior before replacing actor FSM hot-path handling.
+
+## 6. Stream Protocol Pipeline Spike
+
+- [ ] 6.1 Prototype an opt-in Remote protocol pipeline over Akka.Streams / Akka.IO.Tcp without adding a new raw pipe transport.
+- [ ] 6.2 Use existing Remote protobuf wire format in the opt-in stream pipeline.
+- [ ] 6.3 Ensure stream framing preserves the same length-framed PDU semantics expected by existing Remote tests.
+- [ ] 6.4 Integrate the sequence/writer PDU codec into the stream pipeline.
+- [ ] 6.5 Integrate the SerializerV2 payload boundary into the stream pipeline.
+- [ ] 6.6 Preserve `EndpointWriter`, `EndpointReader`, and reliable-delivery semantics or document any required internal facade.
+
+## 7. Validation And Performance Gates
+
+- [ ] 7.1 Run focused `Akka.Remote.Tests` covering `AkkaProtocolSpec`, codec tests, and endpoint send/receive behavior.
+- [ ] 7.2 Run relevant `Akka.Cluster.Tests` or multi-node smoke tests in legacy mode.
+- [ ] 7.3 Run relevant `Akka.Cluster.Tests` or multi-node smoke tests in the opt-in stream pipeline mode when available.
+- [ ] 7.4 Rerun `RemotePingPong` after each implementation milestone and record result deltas.
+- [ ] 7.5 Rerun `AkkaPduCodecBenchmark` after codec milestones and record allocation deltas.
+- [ ] 7.6 Stop before defaulting the stream pipeline on until benchmarks and compatibility tests justify the change.
+
+## 8. Documentation And Review
+
+- [ ] 8.1 Update OpenSpec notes with baseline and final benchmark tables.
+- [ ] 8.2 Document rollout behavior, opt-in configuration, and rollback path.
+- [ ] 8.3 Document why Akka.Streams / Akka.IO.Tcp is the substrate and why no standalone PipeTransport is added.
+- [ ] 8.4 Review public or internal API changes for compatibility before opening a PR.

--- a/openspec/changes/remote-streams-protocol-pipeline/tasks.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/tasks.md
@@ -8,11 +8,11 @@
 
 ## 2. Wire-Compatibility Fixtures
 
-- [ ] 2.1 Add golden byte fixtures for `Associate`, `Heartbeat`, and each `DisassociateInfo` control PDU.
-- [ ] 2.2 Add golden byte fixtures for payload PDU wrapping an `AckAndEnvelopeContainer`.
-- [ ] 2.3 Add golden byte fixtures for pure ack, ack plus message, and sequenced reliable-delivery message envelopes.
-- [ ] 2.4 Verify existing `AkkaPduProtobuffCodec` decodes all golden fixtures.
-- [ ] 2.5 Verify existing `AkkaPduProtobuffCodec` emits byte-compatible output for the supported golden fixture shapes.
+- [x] 2.1 Add golden byte fixtures for `Associate`, `Heartbeat`, and each `DisassociateInfo` control PDU.
+- [x] 2.2 Add golden byte fixtures for payload PDU wrapping an `AckAndEnvelopeContainer`.
+- [x] 2.3 Add golden byte fixtures for pure ack, ack plus message, and sequenced reliable-delivery message envelopes.
+- [x] 2.4 Verify existing `AkkaPduProtobuffCodec` decodes all golden fixtures.
+- [x] 2.5 Verify existing `AkkaPduProtobuffCodec` emits byte-compatible output for the supported golden fixture shapes.
 
 ## 3. Sequence/Writer PDU Codec Shape
 

--- a/openspec/changes/remote-streams-protocol-pipeline/tasks.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/tasks.md
@@ -51,7 +51,7 @@
 ## 7. Validation And Performance Gates
 
 - [x] 7.1 Run focused `Akka.Remote.Tests` covering `AkkaProtocolSpec`, codec tests, and endpoint send/receive behavior.
-- [ ] 7.2 Run relevant `Akka.Cluster.Tests` or multi-node smoke tests in legacy mode.
+- [x] 7.2 Run relevant `Akka.Cluster.Tests` or multi-node smoke tests in legacy mode.
 - [ ] 7.3 Run relevant `Akka.Cluster.Tests` or multi-node smoke tests in the opt-in stream pipeline mode when available.
 - [x] 7.4 Rerun `RemotePingPong` after each implementation milestone and record result deltas.
 - [ ] 7.5 Rerun `AkkaPduCodecBenchmark` after codec milestones and record allocation deltas.
@@ -59,7 +59,7 @@
 
 ## 8. Documentation And Review
 
-- [ ] 8.1 Update OpenSpec notes with baseline and final benchmark tables.
+- [x] 8.1 Update OpenSpec notes with baseline and final benchmark tables.
 - [ ] 8.2 Document rollout behavior, opt-in configuration, and rollback path.
 - [ ] 8.3 Document why Akka.Streams / Akka.IO.Tcp is the substrate and why no standalone PipeTransport is added.
 - [ ] 8.4 Review public or internal API changes for compatibility before opening a PR.

--- a/openspec/changes/remote-streams-protocol-pipeline/tasks.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/tasks.md
@@ -16,11 +16,11 @@
 
 ## 3. Sequence/Writer PDU Codec Shape
 
-- [ ] 3.1 Introduce internal PDU decode APIs that accept `ReadOnlySequence<byte>` without requiring caller-side `ByteString` materialization.
-- [ ] 3.2 Introduce internal PDU encode APIs that write to caller-owned `IBufferWriter<byte>`.
-- [ ] 3.3 Keep existing `ByteString` PDU APIs as adapters over the new internal codec path.
-- [ ] 3.4 Preserve current protobuf wire output for control PDUs and payload PDUs.
-- [ ] 3.5 Update `AkkaPduCodecBenchmark` to compare legacy adapter calls and sequence/writer calls.
+- [x] 3.1 Introduce internal PDU decode APIs that accept `ReadOnlySequence<byte>` without requiring caller-side `ByteString` materialization.
+- [x] 3.2 Introduce internal PDU encode APIs that write to caller-owned `IBufferWriter<byte>`.
+- [x] 3.3 Keep existing `ByteString` PDU APIs as adapters over the new internal codec path.
+- [x] 3.4 Preserve current protobuf wire output for control PDUs and payload PDUs.
+- [x] 3.5 Update `AkkaPduCodecBenchmark` to compare legacy adapter calls and sequence/writer calls.
 
 ## 4. SerializerV2 Remote Payload Boundary
 

--- a/openspec/changes/remote-streams-protocol-pipeline/tasks.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/tasks.md
@@ -47,6 +47,10 @@
 - [ ] 6.4 Integrate the sequence/writer PDU codec into the stream pipeline.
 - [ ] 6.5 Integrate the SerializerV2 payload boundary into the stream pipeline.
 - [ ] 6.6 Preserve `EndpointWriter`, `EndpointReader`, and reliable-delivery semantics or document any required internal facade.
+- [ ] 6.7 Add a conservative payload-only outer `AkkaProtocolMessage` fast parser over `ReadOnlySequence<byte>`.
+- [ ] 6.8 Fall back to generated protobuf parsing for control PDUs, unknown fields, non-canonical field ordering, and malformed fast-path candidates.
+- [ ] 6.9 Forward sequence-backed payload PDUs from `ProtocolStateActor` to `EndpointReader` without materializing `InboundPayload(ByteString)` on the established stream inbound path.
+- [ ] 6.10 Teach `EndpointReader` to handle `InboundSequencePayload` in both reading and not-reading states while preserving ACK and reliable-delivery behavior.
 
 ## 7. Validation And Performance Gates
 

--- a/openspec/changes/remote-streams-protocol-pipeline/tasks.md
+++ b/openspec/changes/remote-streams-protocol-pipeline/tasks.md
@@ -1,10 +1,10 @@
 ## 1. Baseline And Hot-Path Mapping
 
-- [ ] 1.1 Run current `RemotePingPong` baseline on `dev` and record throughput results in this change.
-- [ ] 1.2 Run current `AkkaPduCodecBenchmark` baseline and record throughput/allocation results in this change.
+- [x] 1.1 Run current `RemotePingPong` baseline on `dev` and record throughput results in this change.
+- [x] 1.2 Run current `AkkaPduCodecBenchmark` baseline and record throughput/allocation results in this change.
 - [ ] 1.3 Map outbound copy/allocation boundaries from `EndpointWriter` through `MessageSerializer`, `AkkaPduCodec`, `AkkaProtocolHandle`, and the transport boundary.
 - [ ] 1.4 Map inbound copy/allocation boundaries from transport frame receipt through `InboundPayload`, `ProtocolStateActor`, `AkkaPduCodec.DecodeMessage`, and `EndpointReader` dispatch.
-- [ ] 1.5 Add or update benchmark documentation with baseline commands, environment, and result tables.
+- [x] 1.5 Add or update benchmark documentation with baseline commands, environment, and result tables.
 
 ## 2. Wire-Compatibility Fixtures
 

--- a/src/benchmark/Akka.Benchmarks/Remoting/AkkaPduCodecBenchmark.cs
+++ b/src/benchmark/Akka.Benchmarks/Remoting/AkkaPduCodecBenchmark.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Buffers;
 using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -53,8 +54,12 @@ namespace Akka.Benchmarks.Remoting
         private readonly Ack _lastAck = new(-1);
 
         private ByteString _fullDecode;
+        private ReadOnlySequence<byte> _fullDecodeSequence;
         private ByteString _pduDecoded;
+        private ReadOnlySequence<byte> _pduDecodedSequence;
         private Akka.Remote.Serialization.Proto.Msg.Payload _payloadDecoded;
+        private ArrayBufferWriter<byte> _messageWriter;
+        private ArrayBufferWriter<byte> _payloadWriter;
 
         [GlobalSetup]
         public async Task Setup()
@@ -83,8 +88,12 @@ namespace Akka.Benchmarks.Remoting
             _recvCodec = new AkkaPduProtobuffCodec(_sys1);
             _sendCodec = new AkkaPduProtobuffCodec(_sys2);
             _fullDecode = CreatePayloadPdu();
+            _fullDecodeSequence = new ReadOnlySequence<byte>(_fullDecode.Memory);
             _pduDecoded = ((Payload)_recvCodec.DecodePdu(_fullDecode)).Bytes;
+            _pduDecodedSequence = new ReadOnlySequence<byte>(_pduDecoded.Memory);
             _payloadDecoded = _recvCodec.DecodeMessage(_pduDecoded, _rarp, _addr1).MessageOption.SerializedMessage;
+            _messageWriter = new ArrayBufferWriter<byte>(_pduDecoded.Length);
+            _payloadWriter = new ArrayBufferWriter<byte>(_fullDecode.Length);
         }
 
         [GlobalCleanup]
@@ -144,6 +153,26 @@ namespace Akka.Benchmarks.Remoting
             }
         }
 
+        [Benchmark(OperationsPerInvoke = Operations)]
+        public void WriteMessagePduToBufferWriter()
+        {
+            for (var i = 0; i < Operations; i++)
+            {
+                _messageWriter.Clear();
+                CreateMessagePdu(_messageWriter);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Operations)]
+        public void WritePayloadPduToBufferWriter()
+        {
+            for (var i = 0; i < Operations; i++)
+            {
+                _payloadWriter.Clear();
+                CreatePayloadPdu(_payloadWriter);
+            }
+        }
+
         /// <summary>
         /// Simulates the read-side of the wire
         /// </summary>
@@ -162,6 +191,20 @@ namespace Akka.Benchmarks.Remoting
         }
 
         [Benchmark(OperationsPerInvoke = Operations)]
+        public void DecodePayloadPduFromSequence()
+        {
+            for (var i = 0; i < Operations; i++)
+            {
+                var pdu = _recvCodec.DecodePdu(_fullDecodeSequence);
+                if (pdu is Payload p)
+                {
+                    var msg = _recvCodec.DecodeMessage(new ReadOnlySequence<byte>(p.Bytes.Memory), _rarp, _addr1);
+                    var deserialize = MessageSerializer.Deserialize(_sys1, msg.MessageOption.SerializedMessage);
+                }
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Operations)]
         public void DecodePduOnly()
         {
             for (var i = 0; i < Operations; i++)
@@ -171,11 +214,29 @@ namespace Akka.Benchmarks.Remoting
         }
 
         [Benchmark(OperationsPerInvoke = Operations)]
+        public void DecodePduOnlyFromSequence()
+        {
+            for (var i = 0; i < Operations; i++)
+            {
+                var pdu = _recvCodec.DecodePdu(_fullDecodeSequence);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Operations)]
         public void DecodeMessageOnly()
         {
             for (var i = 0; i < Operations; i++)
             {
                 var msg = _recvCodec.DecodeMessage(_pduDecoded, _rarp, _addr1);
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = Operations)]
+        public void DecodeMessageOnlyFromSequence()
+        {
+            for (var i = 0; i < Operations; i++)
+            {
+                var msg = _recvCodec.DecodeMessage(_pduDecodedSequence, _rarp, _addr1);
             }
         }
 
@@ -190,8 +251,24 @@ namespace Akka.Benchmarks.Remoting
 
         private ByteString CreatePayloadPdu()
         {
-            return _sendCodec.ConstructPayload(_sendCodec.ConstructMessage(_remoteReceiveRef.LocalAddressToUse, _remoteReceiveRef,
-                MessageSerializer.Serialize(_sys2, _addr2Info, _message), _senderActorRef, null, _lastAck));
+            return _sendCodec.ConstructPayload(CreateMessagePdu());
+        }
+
+        private void CreatePayloadPdu(IBufferWriter<byte> writer)
+        {
+            _sendCodec.ConstructPayload(CreateMessagePdu(), writer);
+        }
+
+        private ByteString CreateMessagePdu()
+        {
+            return _sendCodec.ConstructMessage(_remoteReceiveRef.LocalAddressToUse, _remoteReceiveRef,
+                MessageSerializer.Serialize(_sys2, _addr2Info, _message), _senderActorRef, null, _lastAck);
+        }
+
+        private void CreateMessagePdu(IBufferWriter<byte> writer)
+        {
+            _sendCodec.ConstructMessage(_remoteReceiveRef.LocalAddressToUse, _remoteReceiveRef,
+                MessageSerializer.Serialize(_sys2, _addr2Info, _message), writer, _senderActorRef, null, _lastAck);
         }
     }
 }

--- a/src/benchmark/RemotePingPong/Program.cs
+++ b/src/benchmark/RemotePingPong/Program.cs
@@ -41,7 +41,7 @@ namespace RemotePingPong
 #endif
         }
 
-        public static Config CreateActorSystemConfig(string actorSystemName, string ipOrHostname, int port)
+        public static Config CreateActorSystemConfig(string actorSystemName, string ipOrHostname, int port, bool useStreamTransport = false)
         {
             var baseConfig = ConfigurationFactory.ParseString(@"
             akka {
@@ -61,11 +61,19 @@ namespace RemotePingPong
               }
             }");
 
+            var streamTransportConfig = useStreamTransport
+                ? ConfigurationFactory.ParseString(@"
+                    akka.remote.dot-netty.tcp {
+                        transport-class = ""Akka.Remote.Transport.Streams.TcpStreamTransport, Akka.Remote""
+                        stream-write-buffer-size = 65536
+                    }")
+                : ConfigurationFactory.Empty;
+
             var bindingConfig =
                 ConfigurationFactory.ParseString(@"akka.remote.dot-netty.tcp.hostname = """ + ipOrHostname + @"""")
                     .WithFallback(ConfigurationFactory.ParseString(@"akka.remote.dot-netty.tcp.port = " + port));
 
-            return bindingConfig.WithFallback(baseConfig);
+            return streamTransportConfig.WithFallback(bindingConfig).WithFallback(baseConfig);
         }
 
         private static async Task Main(params string[] args)
@@ -83,12 +91,14 @@ namespace RemotePingPong
                 timesToRun = 1u;
             }
 
-            await Start(timesToRun);
+            var useStreamTransport = args.Any(arg => string.Equals(arg, "stream", StringComparison.OrdinalIgnoreCase)
+                                                     || string.Equals(arg, "--stream-transport", StringComparison.OrdinalIgnoreCase));
+            await Start(timesToRun, useStreamTransport);
         }
 
         private static bool _firstRun = true;
 
-        private static void PrintSysInfo(){
+        private static void PrintSysInfo(bool useStreamTransport){
             var processorCount = Environment.ProcessorCount;
             if (processorCount == 0)
             {
@@ -104,6 +114,7 @@ namespace RemotePingPong
             Console.WriteLine("Messages sent/received per client: {0}  ({0:0e0})", repeat*2);
             Console.WriteLine("Is Server GC:                      {0}", GCSettings.IsServerGC);
             Console.WriteLine("Thread count:                      {0}", Process.GetCurrentProcess().Threads.Count);
+            Console.WriteLine("Transport:                         {0}", useStreamTransport ? "Akka.Streams TCP" : "DotNetty TCP");
             Console.WriteLine();
 
             //Print tables
@@ -114,7 +125,7 @@ namespace RemotePingPong
 
         const long repeat = 100000L;
 
-        private static async Task Start(uint timesToRun)
+        private static async Task Start(uint timesToRun, bool useStreamTransport)
         {         
             for (var i = 0; i < timesToRun; i++)
             {
@@ -122,7 +133,7 @@ namespace RemotePingPong
                 var bestThroughput = 0L;
                 foreach (var throughput in GetClientSettings())
                 {
-                    var result1 = await Benchmark(throughput, repeat, bestThroughput, redCount);
+                    var result1 = await Benchmark(throughput, repeat, bestThroughput, redCount, useStreamTransport);
                     bestThroughput = result1.Item2;
                     redCount = result1.Item3;
                 }
@@ -148,12 +159,12 @@ namespace RemotePingPong
             return numberOfClients * numberOfRepeats * 2;
         }
 
-        private static async Task<(bool, long, int)> Benchmark(int numberOfClients, long numberOfRepeats, long bestThroughput, int redCount)
+        private static async Task<(bool, long, int)> Benchmark(int numberOfClients, long numberOfRepeats, long bestThroughput, int redCount, bool useStreamTransport)
         {
             var totalMessagesReceived = GetTotalMessagesReceived(numberOfClients, numberOfRepeats);
-            var system1 = ActorSystem.Create("SystemA", CreateActorSystemConfig("SystemA", "127.0.0.1", 0));
+            var system1 = ActorSystem.Create("SystemA", CreateActorSystemConfig("SystemA", "127.0.0.1", 0, useStreamTransport));
 
-            var system2 = ActorSystem.Create("SystemB", CreateActorSystemConfig("SystemB", "127.0.0.1", 0));
+            var system2 = ActorSystem.Create("SystemB", CreateActorSystemConfig("SystemB", "127.0.0.1", 0, useStreamTransport));
 
             List<Task<long>> tasks = new List<Task<long>>();
             List<IActorRef> receivers = new List<IActorRef>();
@@ -191,7 +202,7 @@ namespace RemotePingPong
             // now that the dispatchers in both ActorSystems are started, we want to measure thread count and other system
             // metrics here - but only the very first benchmark
             if(_firstRun){
-                PrintSysInfo();
+                PrintSysInfo(useStreamTransport);
             }
 
             var startThreads = Process.GetCurrentProcess().Threads.Count;

--- a/src/core/Akka.Remote.Tests/EndpointReaderSpec.cs
+++ b/src/core/Akka.Remote.Tests/EndpointReaderSpec.cs
@@ -1,0 +1,164 @@
+//-----------------------------------------------------------------------
+// <copyright file="EndpointReaderSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Remote.Transport;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using Google.Protobuf;
+using Xunit;
+using SerializedMessage = Akka.Remote.Serialization.Proto.Msg.Payload;
+
+namespace Akka.Remote.Tests
+{
+    public class EndpointReaderSpec : AkkaSpec
+    {
+        private static readonly Address LocalAddress = new("akka.tcp", "EndpointReaderSpec", "127.0.0.1", 2551);
+        private static readonly Address RemoteAddress = new("akka.tcp", "EndpointReaderSpecRemote", "127.0.0.1", 2552);
+
+        private readonly AkkaPduProtobuffCodec _codec;
+
+        public EndpointReaderSpec(ITestOutputHelper output)
+            : base(ConfigurationFactory.ParseString("akka.actor.provider = remote"), output)
+        {
+            _codec = new AkkaPduProtobuffCodec(Sys);
+        }
+
+        [Fact(DisplayName = "EndpointReader should decode sequence payload while reading")]
+        public async Task EndpointReader_should_decode_sequence_payload_while_reading()
+        {
+            var (reader, dispatchProbe, ackProbe) = CreateReader();
+            var expectedAck = Ack();
+            var expectedMessage = SerializedPayload();
+
+            reader.Tell(new InboundSequencePayload(new ReadOnlySequence<byte>(
+                _codec.ConstructMessage(LocalAddress, CreateFixedActorRef("recipient"), expectedMessage, ackOption: expectedAck).Memory)));
+
+            var ack = await ackProbe.ExpectMsgAsync<Ack>();
+            AssertAck(expectedAck, ack);
+
+            var dispatched = await dispatchProbe.ExpectMsgAsync<Dispatched>();
+            Assert.Equal(expectedMessage, dispatched.Message);
+        }
+
+        [Fact(DisplayName = "EndpointReader should decode sequence ACKs while not reading")]
+        public async Task EndpointReader_should_decode_sequence_acks_while_not_reading()
+        {
+            var (reader, dispatchProbe, ackProbe) = CreateReader();
+            var expectedAck = Ack();
+
+            reader.Tell(new EndpointWriter.StopReading(TestActor, TestActor));
+            await ExpectMsgAsync<EndpointWriter.StoppedReading>();
+
+            reader.Tell(new InboundSequencePayload(new ReadOnlySequence<byte>(
+                _codec.ConstructMessage(LocalAddress, CreateFixedActorRef("recipient"), SerializedPayload(), ackOption: expectedAck).Memory)));
+
+            var ack = await ackProbe.ExpectMsgAsync<Ack>();
+            AssertAck(expectedAck, ack);
+            await dispatchProbe.ExpectNoMsgAsync(RemainingOrDefault);
+        }
+
+        private (IActorRef Reader, TestProbe DispatchProbe, TestProbe AckProbe) CreateReader()
+        {
+            var dispatchProbe = CreateTestProbe();
+            var ackProbe = CreateTestProbe();
+            var transport = new AkkaProtocolTransport(
+                new TestTransport(LocalAddress, new AssociationRegistry()),
+                Sys,
+                new AkkaProtocolSettings(Sys.Settings.Config),
+                _codec);
+
+            var reader = Sys.ActorOf(EndpointReader.ReaderProps(
+                LocalAddress,
+                RemoteAddress,
+                transport,
+                RARP.For(Sys).Provider.RemoteSettings,
+                _codec,
+                new ProbeInboundMessageDispatcher(dispatchProbe.Ref),
+                inbound: false,
+                uid: 1,
+                receiveBuffers: new ConcurrentDictionary<EndpointManager.Link, EndpointManager.ResendState>(),
+                reliableDeliverySupervisor: ackProbe.Ref));
+
+            return (reader, dispatchProbe, ackProbe);
+        }
+
+        private IActorRef CreateFixedActorRef(string name)
+        {
+            return new FixedActorRef(
+                new RootActorPath(LocalAddress) / "user" / name,
+                Sys.AsInstanceOf<ExtendedActorSystem>().Provider);
+        }
+
+        private static SerializedMessage SerializedPayload()
+        {
+            return new SerializedMessage
+            {
+                SerializerId = 123,
+                MessageManifest = ByteString.CopyFromUtf8("manifest-a"),
+                Message = ByteString.CopyFrom(1, 2, 3, 4)
+            };
+        }
+
+        private static Ack Ack()
+        {
+            return new Ack(new SeqNo(10), new[] { new SeqNo(11), new SeqNo(12) });
+        }
+
+        private static void AssertAck(Ack expected, Ack actual)
+        {
+            Assert.Equal(expected.CumulativeAck, actual.CumulativeAck);
+            Assert.Equal(expected.Nacks.ToArray(), actual.Nacks.ToArray());
+        }
+
+        private sealed class ProbeInboundMessageDispatcher : IInboundMessageDispatcher
+        {
+            private readonly IActorRef _probe;
+
+            public ProbeInboundMessageDispatcher(IActorRef probe)
+            {
+                _probe = probe;
+            }
+
+            public void Dispatch(IInternalActorRef recipient, Address recipientAddress, SerializedMessage message,
+                IActorRef senderOption = null!)
+            {
+                _probe.Tell(new Dispatched(message));
+            }
+        }
+
+        private sealed class Dispatched
+        {
+            public Dispatched(SerializedMessage message)
+            {
+                Message = message;
+            }
+
+            public SerializedMessage Message { get; }
+        }
+
+        private sealed class FixedActorRef : MinimalActorRef
+        {
+            public FixedActorRef(ActorPath path, IActorRefProvider provider)
+            {
+                Path = path;
+                Provider = provider;
+            }
+
+            public override ActorPath Path { get; }
+
+            public override IActorRefProvider Provider { get; }
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/Serialization/MessageSerializerV2Spec.cs
+++ b/src/core/Akka.Remote.Tests/Serialization/MessageSerializerV2Spec.cs
@@ -24,9 +24,11 @@ namespace Akka.Remote.Tests.Serialization
             akka.actor {{
                 serializers {{
                     native-v2 = ""{typeof(NativeV2Serializer).AssemblyQualifiedName}""
+                    legacy-v1 = ""{typeof(LegacyV1Serializer).AssemblyQualifiedName}""
                 }}
                 serialization-bindings {{
                     ""{typeof(NativeV2Message).AssemblyQualifiedName}"" = native-v2
+                    ""{typeof(LegacyV1Message).AssemblyQualifiedName}"" = legacy-v1
                 }}
             }}");
 
@@ -45,6 +47,22 @@ namespace Akka.Remote.Tests.Serialization
 
             serialized.SerializerId.Should().Be(NativeV2Serializer.SerializerId);
             serialized.MessageManifest.ToStringUtf8().Should().Be(NativeV2Serializer.NativeManifest);
+            serialized.Message.ToByteArray().Should().Equal(Encoding.UTF8.GetBytes(message.Value));
+            MessageSerializer.Deserialize((ExtendedActorSystem)Sys, serialized).Should().Be(message);
+        }
+
+        [Fact]
+        public void Classic_MessageSerializer_should_roundtrip_v1_adapted_payloads()
+        {
+            var message = new LegacyV1Message("classic remoting v1");
+            var address = new Address("akka.tcp", "Sys", "localhost", 2551);
+            var info = new Information(address, Sys);
+
+            Sys.Serialization.FindSerializerV2For(message).Should().BeOfType<SerializerV1Adapter>();
+            var serialized = MessageSerializer.Serialize((ExtendedActorSystem)Sys, info, message);
+
+            serialized.SerializerId.Should().Be(LegacyV1Serializer.SerializerId);
+            serialized.MessageManifest.ToStringUtf8().Should().Be(LegacyV1Serializer.LegacyManifest);
             serialized.Message.ToByteArray().Should().Equal(Encoding.UTF8.GetBytes(message.Value));
             MessageSerializer.Deserialize((ExtendedActorSystem)Sys, serialized).Should().Be(message);
         }
@@ -143,6 +161,61 @@ namespace Akka.Remote.Tests.Serialization
                 if (manifest != NativeManifest)
                     throw new SerializationException($"Unknown manifest [{manifest}]");
                 return new NativeV2Message(Encoding.UTF8.GetString(bytes.ToArray()));
+            }
+        }
+
+        public sealed class LegacyV1Message: IEquatable<LegacyV1Message>
+        {
+            public LegacyV1Message(string value)
+            {
+                Value = value;
+            }
+
+            public string Value { get; }
+
+            public bool Equals(LegacyV1Message other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return Value == other.Value;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                return obj.GetType() == GetType() && Equals((LegacyV1Message)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return Value.GetHashCode();
+            }
+        }
+
+        public sealed class LegacyV1Serializer: SerializerWithStringManifest
+        {
+            public const int SerializerId = 77126;
+            public const string LegacyManifest = "legacy-v1-message";
+
+            public LegacyV1Serializer(ExtendedActorSystem system) : base(system)
+            {
+            }
+
+            public override int Identifier => SerializerId;
+
+            public override string Manifest(object o) => LegacyManifest;
+
+            public override byte[] ToBinary(object obj)
+            {
+                return Encoding.UTF8.GetBytes(((LegacyV1Message)obj).Value);
+            }
+
+            public override object FromBinary(byte[] bytes, string manifest)
+            {
+                if (manifest != LegacyManifest)
+                    throw new SerializationException($"Unknown manifest [{manifest}]");
+                return new LegacyV1Message(Encoding.UTF8.GetString(bytes));
             }
         }
     }

--- a/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecWireFormatSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecWireFormatSpec.cs
@@ -98,8 +98,38 @@ namespace Akka.Remote.Tests.Transport
             AssertBytes(PayloadHex, _codec.ConstructPayload(payloadBytes));
             AssertWriterBytes(PayloadHex, writer => _codec.ConstructPayload(payloadBytes, writer));
 
-            var decodedPayload = Assert.IsType<Payload>(_codec.DecodePdu(FromHexSequence(PayloadHex)));
+            var decodedPayload = Assert.IsType<Payload>(_codec.DecodePdu(FromHex(PayloadHex)));
             Assert.Equal(payloadBytes, decodedPayload.Bytes);
+
+            var decodedSequencePayload = Assert.IsType<SequencePayload>(_codec.DecodePdu(FromHexSequence(PayloadHex)));
+            AssertSequenceBytes(payloadBytes, decodedSequencePayload.Bytes);
+        }
+
+        [Fact(DisplayName = "AkkaPduProtobuffCodec should fast-path canonical sequence payload PDUs")]
+        public void AkkaPduProtobuffCodec_should_fast_path_canonical_sequence_payload_pdus()
+        {
+            var decodedPayload = Assert.IsType<SequencePayload>(_codec.DecodePdu(SplitSequence(0x0A, 0x03, 0xAA, 0xBB, 0xCC)));
+
+            AssertSequenceBytes(ByteString.CopyFrom(0xAA, 0xBB, 0xCC), decodedPayload.Bytes);
+        }
+
+        [Theory(DisplayName = "AkkaPduProtobuffCodec should fall back from sequence fast path when needed")]
+        [InlineData(HeartbeatHex, typeof(Heartbeat))]
+        [InlineData("18010A03AABBCC", typeof(Payload))]
+        [InlineData("0A03AABBCC1801", typeof(Payload))]
+        [InlineData("120208030A03AABBCC", typeof(Heartbeat))]
+        [InlineData("0A03AABBCC12020803", typeof(Heartbeat))]
+        public void AkkaPduProtobuffCodec_should_fall_back_from_sequence_fast_path_when_needed(string hex, Type expectedPduType)
+        {
+            var decoded = _codec.DecodePdu(FromHexSequence(hex));
+
+            Assert.Equal(expectedPduType, decoded.GetType());
+        }
+
+        [Fact(DisplayName = "AkkaPduProtobuffCodec should reject malformed sequence payload fast path candidates")]
+        public void AkkaPduProtobuffCodec_should_reject_malformed_sequence_payload_fast_path_candidates()
+        {
+            Assert.Throws<PduCodecException>(() => _codec.DecodePdu(FromHexSequence("0A80")));
         }
 
         [Fact(DisplayName = "AkkaPduProtobuffCodec should preserve payload-wrapped envelope wire format")]
@@ -151,6 +181,26 @@ namespace Akka.Remote.Tests.Transport
                 Ack()));
 
             var decoded = _codec.DecodeMessage(FromHexSequence(AckAndMessageHex), RemoteProvider, LocalAddress);
+            AssertAck(decoded.AckOption);
+            AssertMessage(decoded.MessageOption, reliableDeliveryEnabled: true);
+            Assert.Equal(new SeqNo(42), decoded.MessageOption!.Seq);
+        }
+
+        [Fact(DisplayName = "AkkaPduProtobuffCodec should decode reliable delivery envelope from split sequence")]
+        public void AkkaPduProtobuffCodec_should_decode_reliable_delivery_envelope_from_split_sequence()
+        {
+            var decoded = _codec.DecodeMessage(SplitSequence(Convert.FromHexString(AckAndMessageHex)), RemoteProvider, LocalAddress);
+
+            AssertAck(decoded.AckOption);
+            AssertMessage(decoded.MessageOption, reliableDeliveryEnabled: true);
+            Assert.Equal(new SeqNo(42), decoded.MessageOption!.Seq);
+        }
+
+        [Fact(DisplayName = "AkkaPduProtobuffCodec should decode envelopes with unknown fields")]
+        public void AkkaPduProtobuffCodec_should_decode_envelopes_with_unknown_fields()
+        {
+            var decoded = _codec.DecodeMessage(FromHexSequence(AckAndMessageHex + "1801"), RemoteProvider, LocalAddress);
+
             AssertAck(decoded.AckOption);
             AssertMessage(decoded.MessageOption, reliableDeliveryEnabled: true);
             Assert.Equal(new SeqNo(42), decoded.MessageOption!.Seq);
@@ -237,6 +287,23 @@ namespace Akka.Remote.Tests.Transport
             return new ReadOnlySequence<byte>(Convert.FromHexString(hex));
         }
 
+        private static ReadOnlySequence<byte> SplitSequence(params byte[] bytes)
+        {
+            var first = new SequenceSegment(new[] { bytes[0] });
+            var current = first;
+            for (var i = 1; i < bytes.Length; i++)
+            {
+                current = current.Append(new[] { bytes[i] });
+            }
+
+            return new ReadOnlySequence<byte>(first, 0, current, current.Memory.Length);
+        }
+
+        private static void AssertSequenceBytes(ByteString expected, ReadOnlySequence<byte> actual)
+        {
+            Assert.Equal(expected, ByteString.CopyFrom(actual.ToArray()));
+        }
+
         private static void AssertBytes(string expectedHex, ByteString actual)
         {
             Assert.Equal(expectedHex, Convert.ToHexString(actual.ToByteArray()));
@@ -260,6 +327,24 @@ namespace Akka.Remote.Tests.Transport
             public override ActorPath Path { get; }
 
             public override IActorRefProvider Provider { get; }
+        }
+
+        private sealed class SequenceSegment : ReadOnlySequenceSegment<byte>
+        {
+            public SequenceSegment(ReadOnlyMemory<byte> memory)
+            {
+                Memory = memory;
+            }
+
+            public SequenceSegment Append(ReadOnlyMemory<byte> memory)
+            {
+                var segment = new SequenceSegment(memory)
+                {
+                    RunningIndex = RunningIndex + Memory.Length
+                };
+                Next = segment;
+                return segment;
+            }
         }
     }
 }

--- a/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecWireFormatSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecWireFormatSpec.cs
@@ -1,0 +1,230 @@
+//-----------------------------------------------------------------------
+// <copyright file="AkkaPduCodecWireFormatSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Remote.Transport;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using Google.Protobuf;
+using Xunit;
+using SerializedMessage = Akka.Remote.Serialization.Proto.Msg.Payload;
+
+namespace Akka.Remote.Tests.Transport
+{
+    public class AkkaPduCodecWireFormatSpec : AkkaSpec
+    {
+        private const string AssociateHex =
+            "1239080112350A2A0A1057697265436F6D70617452656D6F746512093132372E302E302E3218F813" +
+            "2208616B6B612E746370111100000000000000";
+
+        private const string HeartbeatHex = "12020803";
+        private const string DisassociateUnknownHex = "12020802";
+        private const string DisassociateShutdownHex = "12020804";
+        private const string DisassociateQuarantinedHex = "12020805";
+        private const string PayloadHex = "0A03AABBCC";
+
+        private const string PayloadWrappingAckAndMessageHex =
+            "0AAA010A1B090A0000000000000012100B000000000000000C00000000000000128A010A350A33616B6B" +
+            "612E7463703A2F2F57697265436F6D706174403132372E302E302E313A323535312F757365722F726563" +
+            "697069656E7412140A0401020304107B1A0A6D616E69666573742D6122320A30616B6B612E7463703A2F" +
+            "2F57697265436F6D706174403132372E302E302E313A323535312F757365722F73656E646572292A0000" +
+            "0000000000";
+
+        private const string PureAckHex = "0A1B090A0000000000000012100B000000000000000C00000000000000";
+
+        private const string AckAndMessageHex =
+            "0A1B090A0000000000000012100B000000000000000C00000000000000128A010A350A33616B6B612E746370" +
+            "3A2F2F57697265436F6D706174403132372E302E302E313A323535312F757365722F726563697069656E74" +
+            "12140A0401020304107B1A0A6D616E69666573742D6122320A30616B6B612E7463703A2F2F5769726543" +
+            "6F6D706174403132372E302E302E313A323535312F757365722F73656E646572292A00000000000000";
+
+        private const string UnsequencedMessageHex =
+            "128A010A350A33616B6B612E7463703A2F2F57697265436F6D706174403132372E302E302E313A323535" +
+            "312F757365722F726563697069656E7412140A0401020304107B1A0A6D616E69666573742D6122320A30" +
+            "616B6B612E7463703A2F2F57697265436F6D706174403132372E302E302E313A323535312F757365722F" +
+            "73656E64657229FFFFFFFFFFFFFFFF";
+
+        private static readonly Address LocalAddress = new("akka.tcp", "WireCompat", "127.0.0.1", 2551);
+        private static readonly Address RemoteAddress = new("akka.tcp", "WireCompatRemote", "127.0.0.2", 2552);
+
+        private readonly AkkaPduProtobuffCodec _codec;
+
+        public AkkaPduCodecWireFormatSpec(ITestOutputHelper output)
+            : base(ConfigurationFactory.ParseString("akka.actor.provider = remote"), output)
+        {
+            _codec = new AkkaPduProtobuffCodec(Sys);
+        }
+
+        [Fact(DisplayName = "AkkaPduProtobuffCodec should preserve control PDU wire format")]
+        public void AkkaPduProtobuffCodec_should_preserve_control_pdu_wire_format()
+        {
+            AssertBytes(AssociateHex, _codec.ConstructAssociate(new HandshakeInfo(RemoteAddress, 17)));
+            AssertBytes(HeartbeatHex, _codec.ConstructHeartbeat());
+            AssertBytes(DisassociateUnknownHex, _codec.ConstructDisassociate(DisassociateInfo.Unknown));
+            AssertBytes(DisassociateShutdownHex, _codec.ConstructDisassociate(DisassociateInfo.Shutdown));
+            AssertBytes(DisassociateQuarantinedHex, _codec.ConstructDisassociate(DisassociateInfo.Quarantined));
+
+            var associate = Assert.IsType<Associate>(_codec.DecodePdu(FromHex(AssociateHex)));
+            Assert.Equal(RemoteAddress, associate.Info.Origin);
+            Assert.Equal(17, associate.Info.Uid);
+
+            Assert.IsType<Heartbeat>(_codec.DecodePdu(FromHex(HeartbeatHex)));
+
+            AssertDisassociate(DisassociateUnknownHex, DisassociateInfo.Unknown);
+            AssertDisassociate(DisassociateShutdownHex, DisassociateInfo.Shutdown);
+            AssertDisassociate(DisassociateQuarantinedHex, DisassociateInfo.Quarantined);
+        }
+
+        [Fact(DisplayName = "AkkaPduProtobuffCodec should preserve payload PDU wire format")]
+        public void AkkaPduProtobuffCodec_should_preserve_payload_pdu_wire_format()
+        {
+            var payloadBytes = ByteString.CopyFrom(0xAA, 0xBB, 0xCC);
+
+            AssertBytes(PayloadHex, _codec.ConstructPayload(payloadBytes));
+
+            var decodedPayload = Assert.IsType<Payload>(_codec.DecodePdu(FromHex(PayloadHex)));
+            Assert.Equal(payloadBytes, decodedPayload.Bytes);
+        }
+
+        [Fact(DisplayName = "AkkaPduProtobuffCodec should preserve payload-wrapped envelope wire format")]
+        public void AkkaPduProtobuffCodec_should_preserve_payload_wrapped_envelope_wire_format()
+        {
+            var envelope = _codec.ConstructMessage(
+                LocalAddress,
+                CreateFixedActorRef("recipient"),
+                SerializedPayload(),
+                CreateFixedActorRef("sender"),
+                new SeqNo(42),
+                Ack());
+
+            AssertBytes(PayloadWrappingAckAndMessageHex, _codec.ConstructPayload(envelope));
+
+            var decodedPayload = Assert.IsType<Payload>(_codec.DecodePdu(FromHex(PayloadWrappingAckAndMessageHex)));
+            Assert.Equal(FromHex(AckAndMessageHex), decodedPayload.Bytes);
+        }
+
+        [Fact(DisplayName = "AkkaPduProtobuffCodec should preserve pure ACK wire format")]
+        public void AkkaPduProtobuffCodec_should_preserve_pure_ack_wire_format()
+        {
+            AssertBytes(PureAckHex, _codec.ConstructPureAck(Ack()));
+
+            var decoded = _codec.DecodeMessage(FromHex(PureAckHex), RemoteProvider, LocalAddress);
+            Assert.Null(decoded.MessageOption);
+            AssertAck(decoded.AckOption);
+        }
+
+        [Fact(DisplayName = "AkkaPduProtobuffCodec should preserve reliable delivery envelope wire format")]
+        public void AkkaPduProtobuffCodec_should_preserve_reliable_delivery_envelope_wire_format()
+        {
+            AssertBytes(AckAndMessageHex, _codec.ConstructMessage(
+                LocalAddress,
+                CreateFixedActorRef("recipient"),
+                SerializedPayload(),
+                CreateFixedActorRef("sender"),
+                new SeqNo(42),
+                Ack()));
+
+            var decoded = _codec.DecodeMessage(FromHex(AckAndMessageHex), RemoteProvider, LocalAddress);
+            AssertAck(decoded.AckOption);
+            AssertMessage(decoded.MessageOption, reliableDeliveryEnabled: true);
+            Assert.Equal(new SeqNo(42), decoded.MessageOption!.Seq);
+        }
+
+        [Fact(DisplayName = "AkkaPduProtobuffCodec should preserve unsequenced envelope wire format")]
+        public void AkkaPduProtobuffCodec_should_preserve_unsequenced_envelope_wire_format()
+        {
+            AssertBytes(UnsequencedMessageHex, _codec.ConstructMessage(
+                LocalAddress,
+                CreateFixedActorRef("recipient"),
+                SerializedPayload(),
+                CreateFixedActorRef("sender")));
+
+            var decoded = _codec.DecodeMessage(FromHex(UnsequencedMessageHex), RemoteProvider, LocalAddress);
+            Assert.Null(decoded.AckOption);
+            AssertMessage(decoded.MessageOption, reliableDeliveryEnabled: false);
+            Assert.Null(decoded.MessageOption!.Seq);
+        }
+
+        private IRemoteActorRefProvider RemoteProvider =>
+            Sys.AsInstanceOf<ExtendedActorSystem>().Provider.AsInstanceOf<IRemoteActorRefProvider>();
+
+        private IActorRef CreateFixedActorRef(string name)
+        {
+            return new FixedActorRef(
+                new RootActorPath(LocalAddress) / "user" / name,
+                Sys.AsInstanceOf<ExtendedActorSystem>().Provider);
+        }
+
+        private static SerializedMessage SerializedPayload()
+        {
+            return new SerializedMessage
+            {
+                SerializerId = 123,
+                MessageManifest = ByteString.CopyFromUtf8("manifest-a"),
+                Message = ByteString.CopyFrom(1, 2, 3, 4)
+            };
+        }
+
+        private static Ack Ack()
+        {
+            return new Ack(new SeqNo(10), new[] { new SeqNo(11), new SeqNo(12) });
+        }
+
+        private void AssertDisassociate(string hex, DisassociateInfo reason)
+        {
+            var disassociate = Assert.IsType<Disassociate>(_codec.DecodePdu(FromHex(hex)));
+            Assert.Equal(reason, disassociate.Reason);
+        }
+
+        private static void AssertAck(Ack? ack)
+        {
+            Assert.NotNull(ack);
+            Assert.Equal(new SeqNo(10), ack.CumulativeAck);
+            Assert.Equal(new[] { new SeqNo(11), new SeqNo(12) }, ack.Nacks.ToArray());
+        }
+
+        private static void AssertMessage(Message? message, bool reliableDeliveryEnabled)
+        {
+            Assert.NotNull(message);
+            Assert.Equal(LocalAddress, message.RecipientAddress);
+            Assert.Equal(reliableDeliveryEnabled, message.ReliableDeliveryEnabled);
+
+            var serializedMessage = message.SerializedMessage;
+            Assert.Equal(123, serializedMessage.SerializerId);
+            Assert.Equal(ByteString.CopyFromUtf8("manifest-a"), serializedMessage.MessageManifest);
+            Assert.Equal(ByteString.CopyFrom(1, 2, 3, 4), serializedMessage.Message);
+        }
+
+        private static ByteString FromHex(string hex)
+        {
+            return ByteString.CopyFrom(Convert.FromHexString(hex));
+        }
+
+        private static void AssertBytes(string expectedHex, ByteString actual)
+        {
+            Assert.Equal(expectedHex, Convert.ToHexString(actual.ToByteArray()));
+        }
+
+        private sealed class FixedActorRef : MinimalActorRef
+        {
+            public FixedActorRef(ActorPath path, IActorRefProvider provider)
+            {
+                Path = path;
+                Provider = provider;
+            }
+
+            public override ActorPath Path { get; }
+
+            public override IActorRefProvider Provider { get; }
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecWireFormatSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecWireFormatSpec.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using System;
+using System.Buffers;
 using System.Linq;
 using Akka.Actor;
 using Akka.Configuration;
@@ -72,8 +73,13 @@ namespace Akka.Remote.Tests.Transport
             AssertBytes(DisassociateUnknownHex, _codec.ConstructDisassociate(DisassociateInfo.Unknown));
             AssertBytes(DisassociateShutdownHex, _codec.ConstructDisassociate(DisassociateInfo.Shutdown));
             AssertBytes(DisassociateQuarantinedHex, _codec.ConstructDisassociate(DisassociateInfo.Quarantined));
+            AssertWriterBytes(AssociateHex, writer => _codec.ConstructAssociate(new HandshakeInfo(RemoteAddress, 17), writer));
+            AssertWriterBytes(HeartbeatHex, writer => _codec.ConstructHeartbeat(writer));
+            AssertWriterBytes(DisassociateUnknownHex, writer => _codec.ConstructDisassociate(DisassociateInfo.Unknown, writer));
+            AssertWriterBytes(DisassociateShutdownHex, writer => _codec.ConstructDisassociate(DisassociateInfo.Shutdown, writer));
+            AssertWriterBytes(DisassociateQuarantinedHex, writer => _codec.ConstructDisassociate(DisassociateInfo.Quarantined, writer));
 
-            var associate = Assert.IsType<Associate>(_codec.DecodePdu(FromHex(AssociateHex)));
+            var associate = Assert.IsType<Associate>(_codec.DecodePdu(FromHexSequence(AssociateHex)));
             Assert.Equal(RemoteAddress, associate.Info.Origin);
             Assert.Equal(17, associate.Info.Uid);
 
@@ -90,8 +96,9 @@ namespace Akka.Remote.Tests.Transport
             var payloadBytes = ByteString.CopyFrom(0xAA, 0xBB, 0xCC);
 
             AssertBytes(PayloadHex, _codec.ConstructPayload(payloadBytes));
+            AssertWriterBytes(PayloadHex, writer => _codec.ConstructPayload(payloadBytes, writer));
 
-            var decodedPayload = Assert.IsType<Payload>(_codec.DecodePdu(FromHex(PayloadHex)));
+            var decodedPayload = Assert.IsType<Payload>(_codec.DecodePdu(FromHexSequence(PayloadHex)));
             Assert.Equal(payloadBytes, decodedPayload.Bytes);
         }
 
@@ -107,6 +114,7 @@ namespace Akka.Remote.Tests.Transport
                 Ack());
 
             AssertBytes(PayloadWrappingAckAndMessageHex, _codec.ConstructPayload(envelope));
+            AssertWriterBytes(PayloadWrappingAckAndMessageHex, writer => _codec.ConstructPayload(envelope, writer));
 
             var decodedPayload = Assert.IsType<Payload>(_codec.DecodePdu(FromHex(PayloadWrappingAckAndMessageHex)));
             Assert.Equal(FromHex(AckAndMessageHex), decodedPayload.Bytes);
@@ -116,8 +124,9 @@ namespace Akka.Remote.Tests.Transport
         public void AkkaPduProtobuffCodec_should_preserve_pure_ack_wire_format()
         {
             AssertBytes(PureAckHex, _codec.ConstructPureAck(Ack()));
+            AssertWriterBytes(PureAckHex, writer => _codec.ConstructPureAck(Ack(), writer));
 
-            var decoded = _codec.DecodeMessage(FromHex(PureAckHex), RemoteProvider, LocalAddress);
+            var decoded = _codec.DecodeMessage(FromHexSequence(PureAckHex), RemoteProvider, LocalAddress);
             Assert.Null(decoded.MessageOption);
             AssertAck(decoded.AckOption);
         }
@@ -132,8 +141,16 @@ namespace Akka.Remote.Tests.Transport
                 CreateFixedActorRef("sender"),
                 new SeqNo(42),
                 Ack()));
+            AssertWriterBytes(AckAndMessageHex, writer => _codec.ConstructMessage(
+                LocalAddress,
+                CreateFixedActorRef("recipient"),
+                SerializedPayload(),
+                writer,
+                CreateFixedActorRef("sender"),
+                new SeqNo(42),
+                Ack()));
 
-            var decoded = _codec.DecodeMessage(FromHex(AckAndMessageHex), RemoteProvider, LocalAddress);
+            var decoded = _codec.DecodeMessage(FromHexSequence(AckAndMessageHex), RemoteProvider, LocalAddress);
             AssertAck(decoded.AckOption);
             AssertMessage(decoded.MessageOption, reliableDeliveryEnabled: true);
             Assert.Equal(new SeqNo(42), decoded.MessageOption!.Seq);
@@ -147,8 +164,14 @@ namespace Akka.Remote.Tests.Transport
                 CreateFixedActorRef("recipient"),
                 SerializedPayload(),
                 CreateFixedActorRef("sender")));
+            AssertWriterBytes(UnsequencedMessageHex, writer => _codec.ConstructMessage(
+                LocalAddress,
+                CreateFixedActorRef("recipient"),
+                SerializedPayload(),
+                writer,
+                CreateFixedActorRef("sender")));
 
-            var decoded = _codec.DecodeMessage(FromHex(UnsequencedMessageHex), RemoteProvider, LocalAddress);
+            var decoded = _codec.DecodeMessage(FromHexSequence(UnsequencedMessageHex), RemoteProvider, LocalAddress);
             Assert.Null(decoded.AckOption);
             AssertMessage(decoded.MessageOption, reliableDeliveryEnabled: false);
             Assert.Null(decoded.MessageOption!.Seq);
@@ -209,9 +232,21 @@ namespace Akka.Remote.Tests.Transport
             return ByteString.CopyFrom(Convert.FromHexString(hex));
         }
 
+        private static ReadOnlySequence<byte> FromHexSequence(string hex)
+        {
+            return new ReadOnlySequence<byte>(Convert.FromHexString(hex));
+        }
+
         private static void AssertBytes(string expectedHex, ByteString actual)
         {
             Assert.Equal(expectedHex, Convert.ToHexString(actual.ToByteArray()));
+        }
+
+        private static void AssertWriterBytes(string expectedHex, Action<IBufferWriter<byte>> write)
+        {
+            var writer = new ArrayBufferWriter<byte>();
+            write(writer);
+            Assert.Equal(expectedHex, Convert.ToHexString(writer.WrittenSpan));
         }
 
         private sealed class FixedActorRef : MinimalActorRef

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
@@ -116,10 +116,13 @@ namespace Akka.Remote.Tests.Transport
             
             private volatile bool _called;
             public override bool IsMonitoring => _called;
+            private int _heartbeatCount;
+            public int HeartbeatCount => Volatile.Read(ref _heartbeatCount);
 
             public override void HeartBeat()
             {
                 _called = true;
+                Interlocked.Increment(ref _heartbeatCount);
             }
         }
 
@@ -249,6 +252,80 @@ namespace Akka.Remote.Tests.Transport
                 default:
                     throw new Exception("Did not receive expected AkkaProtocolHandle from handshake");
             }
+        }
+
+        [Fact]
+        public async Task ProtocolStateActor_must_refuse_outbound_handshake_when_remote_uid_matches_refuseUid()
+        {
+            var collaborators = GetCollaborators();
+            collaborators.Transport.AssociateBehavior.PushConstant(collaborators.Handle);
+
+            var statusPromise = new TaskCompletionSource<AssociationHandle>();
+            var reader = Sys.ActorOf(ProtocolStateActor.OutboundProps(
+                handshakeInfo: new HandshakeInfo(_localAddress, 42),
+                remoteAddress: _remoteAddress,
+                statusCompletionSource: statusPromise,
+                transport: collaborators.Transport,
+                settings: new AkkaProtocolSettings(_config),
+                codec: _codec,
+                failureDetector: collaborators.FailureDetector,
+                refuseUid: 33));
+
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
+
+            reader.Tell(TestAssociate(33), TestActor);
+
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsDisassociate(collaborators.Registry, DisassociateInfo.Quarantined)), DefaultTimeout);
+            await Awaiting(() => statusPromise.Task.WithTimeout(DefaultTimeout))
+                .Should().ThrowAsync<AkkaProtocolException>()
+                .WithMessage("*quarantined*");
+        }
+
+        [Fact]
+        public async Task ProtocolStateActor_must_update_failure_detector_when_heartbeat_received()
+        {
+            var (collaborators, reader, wrappedHandle) = await OpenOutboundAssociation(TestActor);
+            var heartbeatCount = collaborators.FailureDetector.HeartbeatCount;
+
+            reader.Tell(_testHeartbeat, TestActor);
+
+            await AwaitConditionAsync(() => Task.FromResult(collaborators.FailureDetector.HeartbeatCount > heartbeatCount), DefaultTimeout);
+            await ExpectNoMsgAsync(Dilated(TimeSpan.FromMilliseconds(100)));
+            wrappedHandle.HandshakeInfo.Uid.Should().Be(33);
+        }
+
+        [Fact]
+        public async Task ProtocolStateActor_must_buffer_payload_until_listener_registration_then_flush()
+        {
+            var (_, reader, wrappedHandle) = await OpenOutboundAssociation();
+
+            reader.Tell(_testPayload, TestActor);
+            await ExpectNoMsgAsync(Dilated(TimeSpan.FromMilliseconds(100)));
+
+            wrappedHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
+
+            await ExpectMsgAsync<InboundPayload>(inbound =>
+            {
+                Assert.Equal(_testEnvelope, inbound.Payload);
+            }, hint: "expected queued InboundPayload after listener registration");
+        }
+
+        [Fact]
+        public async Task ProtocolStateActor_must_propagate_quarantined_disassociate_to_registered_listener()
+        {
+            var (_, reader, _) = await OpenOutboundAssociation(TestActor);
+
+            reader.Tell(TestDisassociate(DisassociateInfo.Quarantined), TestActor);
+
+            await ExpectMsgOfAsync("expected Disassociated(DisassociateInfo.Quarantined)", o =>
+            {
+                var disassociated = o.AsInstanceOf<Disassociated>();
+
+                Assert.NotNull(disassociated);
+                Assert.Equal(DisassociateInfo.Quarantined, disassociated.Info);
+
+                return disassociated;
+            });
         }
 
         [Fact]
@@ -504,6 +581,34 @@ namespace Akka.Remote.Tests.Transport
 
         #region Internal helper methods
 
+        private async Task<(Collaborators Collaborators, IActorRef StateActor, AkkaProtocolHandle ProtocolHandle)> OpenOutboundAssociation(IActorRef listener = null)
+        {
+            var collaborators = GetCollaborators();
+            collaborators.Transport.AssociateBehavior.PushConstant(collaborators.Handle);
+
+            var statusPromise = new TaskCompletionSource<AssociationHandle>();
+            var stateActor = Sys.ActorOf(ProtocolStateActor.OutboundProps(
+                handshakeInfo: new HandshakeInfo(_localAddress, 42),
+                remoteAddress: _remoteAddress,
+                statusCompletionSource: statusPromise,
+                transport: collaborators.Transport,
+                settings: new AkkaProtocolSettings(_config),
+                codec: _codec,
+                failureDetector: collaborators.FailureDetector));
+
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
+
+            stateActor.Tell(TestAssociate(33), TestActor);
+
+            var association = await statusPromise.Task.WithTimeout(3.Seconds());
+            var protocolHandle = Assert.IsType<AkkaProtocolHandle>(association);
+
+            if (listener != null)
+                protocolHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(listener));
+
+            return (collaborators, stateActor, protocolHandle);
+        }
+
         private bool LastActivityIsHeartbeat(AssociationRegistry associationRegistry)
         {
             if (associationRegistry.LogSnapshot().Count == 0) return false;
@@ -530,12 +635,18 @@ namespace Akka.Remote.Tests.Transport
 
         private bool LastActivityIsDisassociate(AssociationRegistry associationRegistry)
         {
-            if (associationRegistry.LogSnapshot().Count == 0) return false;
-            if (!(associationRegistry.LogSnapshot().Last() is WriteAttempt attempt)) return false;
-            if (!attempt.Sender.Equals(_localAddress) || !attempt.Recipient.Equals(_remoteAddress)) return false;
+            return LastActivityIsDisassociate(associationRegistry, null);
+        }
+
+        private bool LastActivityIsDisassociate(AssociationRegistry associationRegistry, DisassociateInfo? reason)
+        {
+            var attempt = associationRegistry.LogSnapshot()
+                .OfType<WriteAttempt>()
+                .LastOrDefault(x => x.Sender.Equals(_localAddress) && x.Recipient.Equals(_remoteAddress));
+            if (attempt == null) return false;
             return _codec.DecodePdu(attempt.Payload) switch
             {
-                Disassociate _ => true,
+                Disassociate d => !reason.HasValue || d.Reason == reason.Value,
                 _ => false
             };
         }
@@ -543,4 +654,3 @@ namespace Akka.Remote.Tests.Transport
         #endregion
     }
 }
-

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Buffers;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,8 +44,12 @@ namespace Akka.Remote.Tests.Transport
 
         private readonly IHandleEvent _testHeartbeat;
         private readonly IHandleEvent _testPayload;
+        private readonly IHandleEvent _testSequenceHeartbeat;
+        private readonly IHandleEvent _testSequencePayload;
         private IHandleEvent TestDisassociate(DisassociateInfo info) => new InboundPayload(_codec.ConstructDisassociate(info));
         private IHandleEvent TestAssociate(int uid) => new InboundPayload(_codec.ConstructAssociate(new HandshakeInfo(_remoteAkkaAddress, uid)));
+        private IHandleEvent TestSequenceDisassociate(DisassociateInfo info) => TestSequencePayload(_codec.ConstructDisassociate(info));
+        private IHandleEvent TestSequenceAssociate(int uid) => TestSequencePayload(_codec.ConstructAssociate(new HandshakeInfo(_remoteAkkaAddress, uid)));
         private TimeSpan DefaultTimeout => Dilated(TestKitSettings.DefaultTimeout);
 
         public AkkaProtocolSpec(ITestOutputHelper helper)
@@ -56,6 +61,8 @@ namespace Akka.Remote.Tests.Transport
 
             _testHeartbeat = new InboundPayload(_codec.ConstructHeartbeat());
             _testPayload = new InboundPayload(_testMsgPdu);
+            _testSequenceHeartbeat = TestSequencePayload(_codec.ConstructHeartbeat());
+            _testSequencePayload = TestSequencePayload(_testMsgPdu);
 
             _config = ConfigurationFactory.ParseString(
                 @"akka{
@@ -188,6 +195,43 @@ namespace Akka.Remote.Tests.Transport
         }
 
         [Fact]
+        public async Task ProtocolStateActor_must_in_inbound_mode_accept_sequence_payload_after_Associate_PDU_received()
+        {
+            var collaborators = GetCollaborators();
+            var reader = Sys.ActorOf(ProtocolStateActor.InboundProps(
+                handshakeInfo: new HandshakeInfo(_localAddress, 42),
+                wrappedHandle: collaborators.Handle,
+                associationEventListener: new ActorAssociationEventListener(TestActor),
+                settings: new AkkaProtocolSettings(_config),
+                codec: _codec,
+                failureDetector: collaborators.FailureDetector));
+
+            reader.Tell(TestSequenceAssociate(33), TestActor);
+
+            await AwaitConditionAsync(() => Task.FromResult(collaborators.FailureDetector.IsMonitoring), DefaultTimeout);
+
+            var wrappedHandle = await ExpectMsgOfAsync(DefaultTimeout, "expected InboundAssociation", o =>
+            {
+                var inbound = o.AsInstanceOf<InboundAssociation>();
+                if (inbound == null) return null;
+                var association = (AkkaProtocolHandle)inbound.Association;
+                Assert.Equal(33, association.HandshakeInfo.Uid);
+                return association;
+            });
+            Assert.NotNull(wrappedHandle);
+
+            wrappedHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
+
+            await AwaitConditionAsync(() => Task.FromResult(LastActivityIsHeartbeat(collaborators.Registry)), DefaultTimeout);
+
+            reader.Tell(_testSequencePayload, TestActor);
+            await ExpectMsgAsync<InboundPayload>(inbound =>
+            {
+                Assert.Equal(_testEnvelope, inbound.Payload);
+            }, hint: "expected InboundPayload");
+        }
+
+        [Fact]
         public async Task ProtocolStateActor_must_in_inbound_mode_disassociate_when_an_unexpected_message_arrives_instead_of_Associate()
         {
             var collaborators = GetCollaborators();
@@ -255,6 +299,16 @@ namespace Akka.Remote.Tests.Transport
         }
 
         [Fact]
+        public async Task ProtocolStateActor_must_in_outbound_mode_finish_handshake_from_sequence_associate()
+        {
+            var (_, _, wrappedHandle) = await OpenOutboundAssociation(associateFactory: TestSequenceAssociate);
+
+            wrappedHandle.HandshakeInfo.Uid.Should().Be(33);
+            wrappedHandle.RemoteAddress.Should().Be(_remoteAkkaAddress);
+            wrappedHandle.LocalAddress.Should().Be(_localAkkaAddress);
+        }
+
+        [Fact]
         public async Task ProtocolStateActor_must_refuse_outbound_handshake_when_remote_uid_matches_refuseUid()
         {
             var collaborators = GetCollaborators();
@@ -295,6 +349,19 @@ namespace Akka.Remote.Tests.Transport
         }
 
         [Fact]
+        public async Task ProtocolStateActor_must_update_failure_detector_when_sequence_heartbeat_received()
+        {
+            var (collaborators, reader, wrappedHandle) = await OpenOutboundAssociation(TestActor);
+            var heartbeatCount = collaborators.FailureDetector.HeartbeatCount;
+
+            reader.Tell(_testSequenceHeartbeat, TestActor);
+
+            await AwaitConditionAsync(() => Task.FromResult(collaborators.FailureDetector.HeartbeatCount > heartbeatCount), DefaultTimeout);
+            await ExpectNoMsgAsync(Dilated(TimeSpan.FromMilliseconds(100)));
+            wrappedHandle.HandshakeInfo.Uid.Should().Be(33);
+        }
+
+        [Fact]
         public async Task ProtocolStateActor_must_buffer_payload_until_listener_registration_then_flush()
         {
             var (_, reader, wrappedHandle) = await OpenOutboundAssociation();
@@ -311,11 +378,45 @@ namespace Akka.Remote.Tests.Transport
         }
 
         [Fact]
+        public async Task ProtocolStateActor_must_buffer_sequence_payload_until_listener_registration_then_flush()
+        {
+            var (_, reader, wrappedHandle) = await OpenOutboundAssociation();
+
+            reader.Tell(_testSequencePayload, TestActor);
+            await ExpectNoMsgAsync(Dilated(TimeSpan.FromMilliseconds(100)));
+
+            wrappedHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
+
+            await ExpectMsgAsync<InboundPayload>(inbound =>
+            {
+                Assert.Equal(_testEnvelope, inbound.Payload);
+            }, hint: "expected queued InboundPayload after listener registration");
+        }
+
+        [Fact]
         public async Task ProtocolStateActor_must_propagate_quarantined_disassociate_to_registered_listener()
         {
             var (_, reader, _) = await OpenOutboundAssociation(TestActor);
 
             reader.Tell(TestDisassociate(DisassociateInfo.Quarantined), TestActor);
+
+            await ExpectMsgOfAsync("expected Disassociated(DisassociateInfo.Quarantined)", o =>
+            {
+                var disassociated = o.AsInstanceOf<Disassociated>();
+
+                Assert.NotNull(disassociated);
+                Assert.Equal(DisassociateInfo.Quarantined, disassociated.Info);
+
+                return disassociated;
+            });
+        }
+
+        [Fact]
+        public async Task ProtocolStateActor_must_propagate_sequence_quarantined_disassociate_to_registered_listener()
+        {
+            var (_, reader, _) = await OpenOutboundAssociation(TestActor);
+
+            reader.Tell(TestSequenceDisassociate(DisassociateInfo.Quarantined), TestActor);
 
             await ExpectMsgOfAsync("expected Disassociated(DisassociateInfo.Quarantined)", o =>
             {
@@ -581,10 +682,18 @@ namespace Akka.Remote.Tests.Transport
 
         #region Internal helper methods
 
-        private async Task<(Collaborators Collaborators, IActorRef StateActor, AkkaProtocolHandle ProtocolHandle)> OpenOutboundAssociation(IActorRef listener = null)
+        private static IHandleEvent TestSequencePayload(ByteString payload)
+        {
+            return new InboundSequencePayload(new ReadOnlySequence<byte>(payload.Memory));
+        }
+
+        private async Task<(Collaborators Collaborators, IActorRef StateActor, AkkaProtocolHandle ProtocolHandle)> OpenOutboundAssociation(
+            IActorRef listener = null,
+            Func<int, IHandleEvent> associateFactory = null)
         {
             var collaborators = GetCollaborators();
             collaborators.Transport.AssociateBehavior.PushConstant(collaborators.Handle);
+            associateFactory ??= TestAssociate;
 
             var statusPromise = new TaskCompletionSource<AssociationHandle>();
             var stateActor = Sys.ActorOf(ProtocolStateActor.OutboundProps(
@@ -598,7 +707,7 @@ namespace Akka.Remote.Tests.Transport
 
             await AwaitConditionAsync(() => Task.FromResult(LastActivityIsAssociate(collaborators.Registry, 42)), DefaultTimeout);
 
-            stateActor.Tell(TestAssociate(33), TestActor);
+            stateActor.Tell(associateFactory(33), TestActor);
 
             var association = await statusPromise.Task.WithTimeout(3.Seconds());
             var protocolHandle = Assert.IsType<AkkaProtocolHandle>(association);

--- a/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaProtocolSpec.cs
@@ -225,10 +225,8 @@ namespace Akka.Remote.Tests.Transport
             await AwaitConditionAsync(() => Task.FromResult(LastActivityIsHeartbeat(collaborators.Registry)), DefaultTimeout);
 
             reader.Tell(_testSequencePayload, TestActor);
-            await ExpectMsgAsync<InboundPayload>(inbound =>
-            {
-                Assert.Equal(_testEnvelope, inbound.Payload);
-            }, hint: "expected InboundPayload");
+            await ExpectMsgAsync<InboundSequencePayload>(inbound => AssertSequencePayload(_testEnvelope, inbound),
+                hint: "expected InboundSequencePayload");
         }
 
         [Fact]
@@ -387,10 +385,8 @@ namespace Akka.Remote.Tests.Transport
 
             wrappedHandle.ReadHandlerSource.SetResult(new ActorHandleEventListener(TestActor));
 
-            await ExpectMsgAsync<InboundPayload>(inbound =>
-            {
-                Assert.Equal(_testEnvelope, inbound.Payload);
-            }, hint: "expected queued InboundPayload after listener registration");
+            await ExpectMsgAsync<InboundSequencePayload>(inbound => AssertSequencePayload(_testEnvelope, inbound),
+                hint: "expected queued InboundSequencePayload after listener registration");
         }
 
         [Fact]
@@ -685,6 +681,11 @@ namespace Akka.Remote.Tests.Transport
         private static IHandleEvent TestSequencePayload(ByteString payload)
         {
             return new InboundSequencePayload(new ReadOnlySequence<byte>(payload.Memory));
+        }
+
+        private static void AssertSequencePayload(ByteString expected, InboundSequencePayload actual)
+        {
+            Assert.Equal(expected, ByteString.CopyFrom(actual.Payload.ToArray()));
         }
 
         private async Task<(Collaborators Collaborators, IActorRef StateActor, AkkaProtocolHandle ProtocolHandle)> OpenOutboundAssociation(

--- a/src/core/Akka.Remote.Tests/Transport/RemoteTcpFramingSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/RemoteTcpFramingSpec.cs
@@ -1,0 +1,140 @@
+//-----------------------------------------------------------------------
+// <copyright file="RemoteTcpFramingSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Remote.Transport.Streams;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Akka.TestKit;
+using FluentAssertions;
+using Xunit;
+using DotNettyByteOrder = DotNetty.Buffers.ByteOrder;
+
+namespace Akka.Remote.Tests.Transport
+{
+    public class RemoteTcpFramingSpec : AkkaSpec
+    {
+        private readonly ActorMaterializer _materializer;
+
+        public RemoteTcpFramingSpec(ITestOutputHelper output)
+            : base(ActorMaterializer.DefaultConfig(), output)
+        {
+            _materializer = Sys.Materializer();
+        }
+
+        [Fact]
+        public async Task RemoteTcpFraming_should_decode_multiple_big_endian_frames_from_one_chunk()
+        {
+            var payload1 = new byte[] { 1, 2, 3 };
+            var payload2 = Array.Empty<byte>();
+            var payload3 = new byte[] { 4, 5, 6, 7 };
+            var chunk = Combine(
+                Encode(payload1, DotNettyByteOrder.BigEndian),
+                Encode(payload2, DotNettyByteOrder.BigEndian),
+                Encode(payload3, DotNettyByteOrder.BigEndian));
+
+            var decoded = await Decode(new[] { new ReadOnlySequence<byte>(chunk) }, DotNettyByteOrder.BigEndian);
+
+            decoded.Should().HaveCount(3);
+            decoded[0].ToArray().Should().Equal(payload1);
+            decoded[1].ToArray().Should().BeEmpty();
+            decoded[2].ToArray().Should().Equal(payload3);
+        }
+
+        [Fact]
+        public async Task RemoteTcpFraming_should_decode_little_endian_frames_split_across_chunks()
+        {
+            var payload = new byte[] { 11, 12, 13, 14, 15, 16, 17, 18 };
+            var frame = Encode(payload, DotNettyByteOrder.LittleEndian);
+
+            var decoded = await Decode(Split(frame, 1, 2, 4), DotNettyByteOrder.LittleEndian);
+
+            decoded.Should().ContainSingle();
+            decoded[0].ToArray().Should().Equal(payload);
+        }
+
+        [Fact]
+        public async Task RemoteTcpFraming_should_reject_oversized_frames()
+        {
+            var header = new byte[4];
+            BinaryPrimitives.WriteInt32BigEndian(header, 5);
+
+            Func<Task> decode = async () => await Decode(new[] { new ReadOnlySequence<byte>(header) }, DotNettyByteOrder.BigEndian, maxFrameSize: 4);
+
+            await decode.Should()
+                .ThrowAsync<Framing.FramingException>()
+                .WithMessage("Maximum allowed remote frame size is 4 but decoded frame header reported size 5");
+        }
+
+        [Fact]
+        public async Task RemoteTcpFraming_should_reject_truncated_final_frame()
+        {
+            var frame = Encode(new byte[] { 1, 2, 3, 4 }, DotNettyByteOrder.BigEndian);
+            var truncated = frame.AsMemory(0, frame.Length - 1);
+
+            Func<Task> decode = async () => await Decode(new[] { new ReadOnlySequence<byte>(truncated) }, DotNettyByteOrder.BigEndian);
+
+            await decode.Should()
+                .ThrowAsync<Framing.FramingException>()
+                .WithMessage("Stream finished but there was a truncated final remote frame in the buffer");
+        }
+
+        private async Task<IReadOnlyList<ReadOnlySequence<byte>>> Decode(
+            IEnumerable<ReadOnlySequence<byte>> chunks,
+            DotNettyByteOrder byteOrder,
+            int maxFrameSize = 1024)
+        {
+            return await Source.From(chunks)
+                .Via(RemoteTcpFraming.Decoder(maxFrameSize, byteOrder))
+                .RunWith(Sink.Seq<ReadOnlySequence<byte>>(), _materializer)
+                .WaitAsync(TimeSpan.FromSeconds(3));
+        }
+
+        private static byte[] Encode(byte[] payload, DotNettyByteOrder byteOrder)
+        {
+            return RemoteTcpFraming.Encode(new ReadOnlySequence<byte>(payload), 1024, byteOrder).ToArray();
+        }
+
+        private static ReadOnlySequence<byte>[] Split(byte[] bytes, params int[] prefixLengths)
+        {
+            var chunks = new List<ReadOnlySequence<byte>>(prefixLengths.Length + 1);
+            var offset = 0;
+
+            foreach (var length in prefixLengths)
+            {
+                chunks.Add(new ReadOnlySequence<byte>(bytes.AsMemory(offset, length)));
+                offset += length;
+            }
+
+            if (offset < bytes.Length)
+                chunks.Add(new ReadOnlySequence<byte>(bytes.AsMemory(offset)));
+
+            return chunks.ToArray();
+        }
+
+        private static byte[] Combine(params byte[][] arrays)
+        {
+            var length = 0;
+            foreach (var array in arrays)
+                length += array.Length;
+
+            var combined = new byte[length];
+            var offset = 0;
+            foreach (var array in arrays)
+            {
+                array.CopyTo(combined.AsSpan(offset));
+                offset += array.Length;
+            }
+
+            return combined;
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/Transport/StreamTcpTransportInteropSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/StreamTcpTransportInteropSpec.cs
@@ -42,8 +42,8 @@ namespace Akka.Remote.Tests.Transport
                 var classicAddress = RARP.For(classic).Provider.DefaultAddress;
                 var streamAddress = RARP.For(stream).Provider.DefaultAddress;
 
-                await AssertRemoteEcho(classic, streamAddress, "classic-to-stream-1");
-                await AssertRemoteEcho(stream, classicAddress, "stream-to-classic-1");
+                await AssertRemoteEcho(classic, streamAddress, "classic-to-stream-1", TimeSpan.FromSeconds(15));
+                await AssertRemoteEcho(stream, classicAddress, "stream-to-classic-1", TimeSpan.FromSeconds(15));
 
                 Shutdown(stream, TimeSpan.FromSeconds(10));
                 stream = null;

--- a/src/core/Akka.Remote.Tests/Transport/StreamTcpTransportInteropSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/StreamTcpTransportInteropSpec.cs
@@ -1,0 +1,140 @@
+//-----------------------------------------------------------------------
+// <copyright file="StreamTcpTransportInteropSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.TestKit;
+using Akka.TestKit.Extensions;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Remote.Tests.Transport
+{
+    public class StreamTcpTransportInteropSpec : AkkaSpec
+    {
+        public StreamTcpTransportInteropSpec(ITestOutputHelper output) : base(ConfigurationFactory.Empty, output)
+        {
+        }
+
+        [Fact]
+        public async Task StreamTcpTransport_should_interoperate_with_classic_DotNetty_and_reconnect_after_stream_node_restart()
+        {
+            var streamPort = GetFreeTcpPort();
+            ActorSystem classic = null;
+            ActorSystem stream = null;
+
+            try
+            {
+                classic = ActorSystem.Create("classic-sys", ClassicConfig(0));
+                InitializeLogger(classic);
+                classic.ActorOf(Props.Create<Echo>(), "echo");
+
+                stream = StartStreamSystem(streamPort);
+
+                var classicAddress = RARP.For(classic).Provider.DefaultAddress;
+                var streamAddress = RARP.For(stream).Provider.DefaultAddress;
+
+                await AssertRemoteEcho(classic, streamAddress, "classic-to-stream-1");
+                await AssertRemoteEcho(stream, classicAddress, "stream-to-classic-1");
+
+                Shutdown(stream, TimeSpan.FromSeconds(10));
+                stream = null;
+
+                stream = StartStreamSystem(streamPort);
+                var restartedStreamAddress = RARP.For(stream).Provider.DefaultAddress;
+                restartedStreamAddress.Should().Be(streamAddress);
+
+                await AssertRemoteEcho(classic, restartedStreamAddress, "classic-to-stream-2", TimeSpan.FromSeconds(15));
+                await AssertRemoteEcho(stream, classicAddress, "stream-to-classic-2", TimeSpan.FromSeconds(15));
+            }
+            finally
+            {
+                if (stream != null)
+                    Shutdown(stream);
+                if (classic != null)
+                    Shutdown(classic);
+            }
+        }
+
+        private ActorSystem StartStreamSystem(int port)
+        {
+            var system = ActorSystem.Create("stream-sys", StreamConfig(port));
+            InitializeLogger(system);
+            system.ActorOf(Props.Create<Echo>(), "echo");
+            return system;
+        }
+
+        private async Task AssertRemoteEcho(ActorSystem sendingSystem, Address remoteAddress, string payload, TimeSpan? timeout = null)
+        {
+            var max = timeout ?? TimeSpan.FromSeconds(5);
+            await AwaitAssertAsync(async () =>
+            {
+                var probe = CreateTestProbe(sendingSystem);
+                var echo = sendingSystem.ActorSelection(new RootActorPath(remoteAddress) / "user" / "echo");
+                echo.Tell(payload, probe.Ref);
+                var response = await probe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(2));
+                response.Should().Be($"echo:{payload}");
+            }, max);
+        }
+
+        private static Config ClassicConfig(int port)
+        {
+            return ConfigurationFactory.ParseString($@"
+                akka.actor.provider = remote
+                akka.remote.retry-gate-closed-for = 1s
+                akka.remote.log-remote-lifecycle-events = off
+                akka.remote.enabled-transports = [""akka.remote.dot-netty.tcp""]
+                akka.remote.dot-netty.tcp {{
+                    hostname = localhost
+                    port = {port}
+                }}
+                akka.test.single-expect-default = 3s");
+        }
+
+        private static Config StreamConfig(int port)
+        {
+            return ConfigurationFactory.ParseString($@"
+                akka.actor.provider = remote
+                akka.remote.retry-gate-closed-for = 1s
+                akka.remote.log-remote-lifecycle-events = off
+                akka.remote.enabled-transports = [""akka.remote.dot-netty.tcp""]
+                akka.remote.dot-netty.tcp {{
+                    transport-class = ""Akka.Remote.Transport.Streams.TcpStreamTransport, Akka.Remote""
+                    hostname = localhost
+                    port = {port}
+                    tcp-reuse-addr = on
+                }}
+                akka.test.single-expect-default = 3s");
+        }
+
+        private static int GetFreeTcpPort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            try
+            {
+                return ((IPEndPoint)listener.LocalEndpoint).Port;
+            }
+            finally
+            {
+                listener.Stop();
+            }
+        }
+
+        private sealed class Echo : ReceiveActor
+        {
+            public Echo()
+            {
+                Receive<string>(message => Sender.Tell($"echo:{message}"));
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/Transport/StreamTcpTransportInteropSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/StreamTcpTransportInteropSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
@@ -89,6 +90,47 @@ namespace Akka.Remote.Tests.Transport
             }
         }
 
+        [Fact]
+        public async Task StreamTcpTransport_should_terminate_remote_deployments_without_waiting_for_actor_system_timeout()
+        {
+            ActorSystem streamA = null;
+            ActorSystem streamB = null;
+
+            try
+            {
+                streamA = ActorSystem.Create("stream-remote-deploy-a", StreamRemoteDeploymentShutdownConfig(0));
+                InitializeLogger(streamA);
+                streamB = ActorSystem.Create("stream-remote-deploy-b", StreamRemoteDeploymentShutdownConfig(0));
+                InitializeLogger(streamB);
+
+                var remoteAddress = RARP.For(streamB).Provider.DefaultAddress;
+                var echo = streamA.ActorOf(
+                    Props.Create<Echo>().WithDeploy(new Deploy(new RemoteScope(remoteAddress))),
+                    "echo");
+                var probe = CreateTestProbe(streamA);
+                echo.Tell("remote-deploy", probe.Ref);
+                var response = await probe.ExpectMsgAsync<string>(TimeSpan.FromSeconds(5));
+                response.Should().Be("echo:remote-deploy");
+
+                var shutdown = Stopwatch.StartNew();
+                await Task.WhenAll(streamA.Terminate(), streamB.Terminate());
+                shutdown.Stop();
+                streamA.WhenTerminated.IsCompleted.Should().BeTrue();
+                streamB.WhenTerminated.IsCompleted.Should().BeTrue();
+
+                shutdown.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(3));
+                streamA = null;
+                streamB = null;
+            }
+            finally
+            {
+                if (streamB != null)
+                    Shutdown(streamB, TimeSpan.FromSeconds(3));
+                if (streamA != null)
+                    Shutdown(streamA, TimeSpan.FromSeconds(3));
+            }
+        }
+
         private ActorSystem StartStreamSystem(string systemName, int port)
         {
             var system = ActorSystem.Create(systemName, StreamConfig(port));
@@ -138,6 +180,13 @@ namespace Akka.Remote.Tests.Transport
                     tcp-reuse-addr = on
                 }}
                 akka.test.single-expect-default = 3s");
+        }
+
+        private static Config StreamRemoteDeploymentShutdownConfig(int port)
+        {
+            return ConfigurationFactory.ParseString(@"
+                akka.coordinated-shutdown.phases.actor-system-terminate.timeout = 1s")
+                .WithFallback(StreamConfig(port));
         }
 
         private static int GetFreeTcpPort()

--- a/src/core/Akka.Remote.Tests/Transport/StreamTcpTransportInteropSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/StreamTcpTransportInteropSpec.cs
@@ -37,7 +37,7 @@ namespace Akka.Remote.Tests.Transport
                 InitializeLogger(classic);
                 classic.ActorOf(Props.Create<Echo>(), "echo");
 
-                stream = StartStreamSystem(streamPort);
+                stream = StartStreamSystem("stream-sys", streamPort);
 
                 var classicAddress = RARP.For(classic).Provider.DefaultAddress;
                 var streamAddress = RARP.For(stream).Provider.DefaultAddress;
@@ -48,7 +48,7 @@ namespace Akka.Remote.Tests.Transport
                 Shutdown(stream, TimeSpan.FromSeconds(10));
                 stream = null;
 
-                stream = StartStreamSystem(streamPort);
+                stream = StartStreamSystem("stream-sys", streamPort);
                 var restartedStreamAddress = RARP.For(stream).Provider.DefaultAddress;
                 restartedStreamAddress.Should().Be(streamAddress);
 
@@ -64,9 +64,34 @@ namespace Akka.Remote.Tests.Transport
             }
         }
 
-        private ActorSystem StartStreamSystem(int port)
+        [Fact]
+        public async Task StreamTcpTransport_should_support_stream_to_stream_remote_messaging()
         {
-            var system = ActorSystem.Create("stream-sys", StreamConfig(port));
+            ActorSystem streamA = null;
+            ActorSystem streamB = null;
+
+            try
+            {
+                streamA = StartStreamSystem("stream-a", GetFreeTcpPort());
+                streamB = StartStreamSystem("stream-b", GetFreeTcpPort());
+                var addressA = RARP.For(streamA).Provider.DefaultAddress;
+                var addressB = RARP.For(streamB).Provider.DefaultAddress;
+
+                await AssertRemoteEcho(streamA, addressB, "stream-a-to-stream-b");
+                await AssertRemoteEcho(streamB, addressA, "stream-b-to-stream-a");
+            }
+            finally
+            {
+                if (streamB != null)
+                    Shutdown(streamB);
+                if (streamA != null)
+                    Shutdown(streamA);
+            }
+        }
+
+        private ActorSystem StartStreamSystem(string systemName, int port)
+        {
+            var system = ActorSystem.Create(systemName, StreamConfig(port));
             InitializeLogger(system);
             system.ActorOf(Props.Create<Echo>(), "echo");
             return system;

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -8,6 +8,7 @@
     <ItemGroup>
         <EmbeddedResource Include="Configuration\Remote.conf" />
         <ProjectReference Include="..\Akka\Akka.csproj" />
+        <ProjectReference Include="..\Akka.Streams\Akka.Streams.csproj" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="DotNetty.Handlers" Version="0.7.6" />

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 #pragma warning disable AK1004
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -1823,45 +1824,8 @@ namespace Akka.Remote
 
         private void Reading()
         {
-           
-            Receive<InboundPayload>(inbound =>
-            {
-                var payload = inbound.Payload;
-                if (payload.Length > Transport.MaximumPayloadBytes)
-                {
-                    var reason = new OversizedPayloadException(
-                        $"Discarding oversized payload received: max allowed size {Transport.MaximumPayloadBytes} bytes, actual size {payload.Length} bytes.");
-                    _log.Error(reason, "Transient error while reading from association (association remains live)");
-                }
-                else
-                {
-                    var ackAndMessage = TryDecodeMessageAndAck(payload);
-                    if (ackAndMessage.AckOption != null && _reliableDeliverySupervisor != null)
-                        _reliableDeliverySupervisor.Tell(ackAndMessage.AckOption);
-                    if (ackAndMessage.MessageOption != null)
-                    {
-                        if (ackAndMessage.MessageOption.ReliableDeliveryEnabled)
-                        {
-                            _ackedReceiveBuffer = _ackedReceiveBuffer.Receive(ackAndMessage.MessageOption);
-                            DeliverAndAck();
-                        }
-                        else
-                        {
-                            try
-                            {
-                                _msgDispatch.Dispatch(ackAndMessage.MessageOption.Recipient,
-                                    ackAndMessage.MessageOption.RecipientAddress,
-                                    ackAndMessage.MessageOption.SerializedMessage,
-                                    ackAndMessage.MessageOption.SenderOptional);
-                            }
-                            catch (Exception e)
-                            {
-                                LogTransientSerializationError(ackAndMessage.MessageOption, e);
-                            }
-                        }
-                    }
-                }
-            });
+            Receive<InboundPayload>(inbound => HandleInboundPayload(inbound.Payload));
+            Receive<InboundSequencePayload>(inbound => HandleInboundPayload(inbound.Payload));
             Receive<Disassociated>(disassociated => HandleDisassociated(disassociated.Info));
             Receive<EndpointWriter.StopReading>(stop =>
             {
@@ -1888,6 +1852,12 @@ namespace Akka.Remote
             Receive<Disassociated>(disassociated => HandleDisassociated(disassociated.Info));
             Receive<EndpointWriter.StopReading>(stop => stop.ReplyTo.Tell(new EndpointWriter.StoppedReading(stop.Writer)));
             Receive<InboundPayload>(payload =>
+            {
+                var ackAndMessage = TryDecodeMessageAndAck(payload.Payload);
+                if (ackAndMessage.AckOption != null && _reliableDeliverySupervisor != null)
+                    _reliableDeliverySupervisor.Tell(ackAndMessage.AckOption);
+            });
+            Receive<InboundSequencePayload>(payload =>
             {
                 var ackAndMessage = TryDecodeMessageAndAck(payload.Payload);
                 if (ackAndMessage.AckOption != null && _reliableDeliverySupervisor != null)
@@ -1966,7 +1936,78 @@ namespace Akka.Remote
             deliverable.Deliverables.ForEach(msg => _msgDispatch.Dispatch(msg.Recipient, msg.RecipientAddress, msg.SerializedMessage, msg.SenderOptional));
         }
 
+        private void HandleInboundPayload(ByteString payload)
+        {
+            if (payload.Length > Transport.MaximumPayloadBytes)
+            {
+                LogOversizedPayload(payload.Length);
+            }
+            else
+            {
+                HandleDecodedMessage(TryDecodeMessageAndAck(payload));
+            }
+        }
+
+        private void HandleInboundPayload(ReadOnlySequence<byte> payload)
+        {
+            if (payload.Length > Transport.MaximumPayloadBytes)
+            {
+                LogOversizedPayload(payload.Length);
+            }
+            else
+            {
+                HandleDecodedMessage(TryDecodeMessageAndAck(payload));
+            }
+        }
+
+        private void LogOversizedPayload(long payloadLength)
+        {
+            var reason = new OversizedPayloadException(
+                $"Discarding oversized payload received: max allowed size {Transport.MaximumPayloadBytes} bytes, actual size {payloadLength} bytes.");
+            _log.Error(reason, "Transient error while reading from association (association remains live)");
+        }
+
+        private void HandleDecodedMessage(AckAndMessage ackAndMessage)
+        {
+            if (ackAndMessage.AckOption != null && _reliableDeliverySupervisor != null)
+                _reliableDeliverySupervisor.Tell(ackAndMessage.AckOption);
+            if (ackAndMessage.MessageOption != null)
+            {
+                if (ackAndMessage.MessageOption.ReliableDeliveryEnabled)
+                {
+                    _ackedReceiveBuffer = _ackedReceiveBuffer.Receive(ackAndMessage.MessageOption);
+                    DeliverAndAck();
+                }
+                else
+                {
+                    try
+                    {
+                        _msgDispatch.Dispatch(ackAndMessage.MessageOption.Recipient,
+                            ackAndMessage.MessageOption.RecipientAddress,
+                            ackAndMessage.MessageOption.SerializedMessage,
+                            ackAndMessage.MessageOption.SenderOptional);
+                    }
+                    catch (Exception e)
+                    {
+                        LogTransientSerializationError(ackAndMessage.MessageOption, e);
+                    }
+                }
+            }
+        }
+
         private AckAndMessage TryDecodeMessageAndAck(ByteString pdu)
+        {
+            try
+            {
+                return _codec.DecodeMessage(pdu, _provider, LocalAddress);
+            }
+            catch (Exception ex)
+            {
+                throw new EndpointException("Error while decoding incoming Akka PDU", ex);
+            }
+        }
+
+        private AckAndMessage TryDecodeMessageAndAck(ReadOnlySequence<byte> pdu)
         {
             try
             {

--- a/src/core/Akka.Remote/MessageSerializer.cs
+++ b/src/core/Akka.Remote/MessageSerializer.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Buffers;
 using Akka.Actor;
 using Akka.Serialization;
 using Akka.Util;
@@ -30,10 +31,11 @@ namespace Akka.Remote
         public static object Deserialize(ExtendedActorSystem system,
             SerializedMessage messageProtocol)
         {
+            var manifest = !messageProtocol.MessageManifest.IsEmpty ? messageProtocol.MessageManifest.ToStringUtf8() : null;
             return system.Serialization.Deserialize(
-                messageProtocol.Message.ToByteArray(),
+                new ReadOnlySequence<byte>(messageProtocol.Message.Memory),
                 messageProtocol.SerializerId,
-                !messageProtocol.MessageManifest.IsEmpty ? messageProtocol.MessageManifest.ToStringUtf8() : null);
+                manifest);
         }
 
         /// <summary>
@@ -46,16 +48,18 @@ namespace Akka.Remote
         public static SerializedMessage Serialize(ExtendedActorSystem system, Information transportInformation,
             object message)
         {
-            var serializer = system.Serialization.FindSerializerFor(message);
-
             var oldInfo = Akka.Serialization.Serialization.CurrentTransportInformation;
             try
             {
                 Akka.Serialization.Serialization.CurrentTransportInformation = transportInformation;
 
+                var serializer = system.Serialization.FindSerializerV2For(message);
+                var writer = CreateWriter(serializer, message);
+                serializer.Serialize(message, writer);
+
                 var serializedMsg = new SerializedMessage
                 {
-                    Message = ByteString.CopyFrom(serializer.ToBinary(message)),
+                    Message = ByteString.CopyFrom(writer.WrittenSpan),
                     SerializerId = serializer.Identifier
                 };
 
@@ -71,6 +75,14 @@ namespace Akka.Remote
             {
                 Akka.Serialization.Serialization.CurrentTransportInformation = oldInfo;
             }
+        }
+
+        private static ArrayBufferWriter<byte> CreateWriter(SerializerV2 serializer, object message)
+        {
+            var sizeHint = serializer.SizeHint(message);
+            return sizeHint > 0
+                ? new ArrayBufferWriter<byte>(sizeHint)
+                : new ArrayBufferWriter<byte>();
         }
     }
 }

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -275,6 +275,12 @@ namespace Akka.Remote
             Transport.Start();
             _remoteWatcher = CreateRemoteWatcher(system);
             _remoteDeploymentWatcher = CreateRemoteDeploymentWatcher(system);
+            CoordinatedShutdown.Get(system).AddTask(
+                CoordinatedShutdown.PhaseBeforeActorSystemTerminate,
+                "flush-remote-deployments",
+                () => _remoteDeploymentWatcher.Ask<Done>(
+                    RemoteDeploymentWatcher.FlushRemoteDeployments.Instance,
+                    RemoteSettings.ShutdownTimeout));
         }
 
         /// <summary>
@@ -806,4 +812,3 @@ namespace Akka.Remote
         }
     }
 }
-

--- a/src/core/Akka.Remote/RemoteDeploymentWatcher.cs
+++ b/src/core/Akka.Remote/RemoteDeploymentWatcher.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using Akka.Actor;
 using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
@@ -43,6 +44,38 @@ namespace Akka.Remote
                     _supervisors.Remove(t.ActorRef);
                 }
             });
+
+            Receive<RemotingShutdownEvent>(_ => NotifyRemoteDeploymentsTerminated());
+            Receive<FlushRemoteDeployments>(_ =>
+            {
+                NotifyRemoteDeploymentsTerminated();
+                Sender.Tell(Done.Instance);
+            });
+        }
+
+        protected override void PreStart()
+        {
+            Context.System.EventStream.Subscribe(Self, typeof(RemotingShutdownEvent));
+        }
+
+        protected override void PostStop()
+        {
+            Context.System.EventStream.Unsubscribe(Self);
+        }
+
+        private void NotifyRemoteDeploymentsTerminated()
+        {
+            // Local shutdown cannot wait for remote DeathWatch round-trips; release local supervisors first.
+            foreach (var deployment in _supervisors.ToArray())
+            {
+                deployment.Value.SendSystemMessage(new DeathWatchNotification(
+                    deployment.Key,
+                    existenceConfirmed: true,
+                    addressTerminated: true));
+                Context.Unwatch(deployment.Key);
+            }
+
+            _supervisors.Clear();
         }
 
         /// <summary>
@@ -69,6 +102,15 @@ namespace Akka.Remote
             /// TBD
             /// </summary>
             public IInternalActorRef Supervisor { get; private set; }
+        }
+
+        internal sealed class FlushRemoteDeployments
+        {
+            public static readonly FlushRemoteDeployments Instance = new();
+
+            private FlushRemoteDeployments()
+            {
+            }
         }
     }
 }

--- a/src/core/Akka.Remote/Serialization/WrappedPayloadSupport.cs
+++ b/src/core/Akka.Remote/Serialization/WrappedPayloadSupport.cs
@@ -5,7 +5,9 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using System.Buffers;
 using Akka.Actor;
+using Akka.Serialization;
 using Google.Protobuf;
 
 namespace Akka.Remote.Serialization
@@ -25,9 +27,11 @@ namespace Akka.Remote.Serialization
                 return new Proto.Msg.Payload();
 
             var payloadProto = new Proto.Msg.Payload();
-            var serializer = _system.Serialization.FindSerializerFor(payload);
+            var serializer = _system.Serialization.FindSerializerV2For(payload);
+            var writer = CreateWriter(serializer, payload);
+            serializer.Serialize(payload, writer);
 
-            payloadProto.Message = ByteString.CopyFrom(serializer.ToBinary(payload));
+            payloadProto.Message = ByteString.CopyFrom(writer.WrittenSpan);
             payloadProto.SerializerId = serializer.Identifier;
 
             // get manifest
@@ -47,9 +51,17 @@ namespace Akka.Remote.Serialization
                 : string.Empty;
 
             return _system.Serialization.Deserialize(
-                payload.Message.ToByteArray(),
+                new ReadOnlySequence<byte>(payload.Message.Memory),
                 payload.SerializerId,
                 manifest);
+        }
+
+        private static ArrayBufferWriter<byte> CreateWriter(SerializerV2 serializer, object payload)
+        {
+            var sizeHint = serializer.SizeHint(payload);
+            return sizeHint > 0
+                ? new ArrayBufferWriter<byte>(sizeHint)
+                : new ArrayBufferWriter<byte>();
         }
     }
 }

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Buffers;
 using System.Linq;
 using Akka.Actor;
 using Google.Protobuf;
@@ -219,7 +220,18 @@ namespace Akka.Remote.Transport
         /// </summary>
         /// <param name="raw">Encoded raw byte representation of an Akka PDU</param>
         /// <returns>Class representation of a PDU.</returns>
-        public abstract IAkkaPdu DecodePdu(ByteString raw);
+        public virtual IAkkaPdu DecodePdu(ByteString raw)
+        {
+            return DecodePdu(new ReadOnlySequence<byte>(raw.Memory));
+        }
+
+        /// <summary>
+        /// Return an <see cref="IAkkaPdu"/> instance that represents a PDU contained in the raw
+        /// <see cref="ReadOnlySequence{T}"/>.
+        /// </summary>
+        /// <param name="raw">Encoded raw byte representation of an Akka PDU</param>
+        /// <returns>Class representation of a PDU.</returns>
+        public abstract IAkkaPdu DecodePdu(ReadOnlySequence<byte> raw);
 
         /// <summary>
         /// Takes an <see cref="IAkkaPdu"/> representation of an Akka PDU and returns its encoded form
@@ -249,27 +261,66 @@ namespace Akka.Remote.Transport
         /// </summary>
         /// <param name="payload">TBD</param>
         /// <returns>TBD</returns>
-        public abstract ByteString ConstructPayload(ByteString payload);
+        public virtual ByteString ConstructPayload(ByteString payload)
+        {
+            return ConstructByteString(writer => ConstructPayload(payload, writer), payload.Length + 8);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="payload">TBD</param>
+        /// <param name="writer">TBD</param>
+        public abstract void ConstructPayload(ByteString payload, IBufferWriter<byte> writer);
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="info">TBD</param>
         /// <returns>TBD</returns>
-        public abstract ByteString ConstructAssociate(HandshakeInfo info);
+        public virtual ByteString ConstructAssociate(HandshakeInfo info)
+        {
+            return ConstructByteString(writer => ConstructAssociate(info, writer));
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="info">TBD</param>
+        /// <param name="writer">TBD</param>
+        public abstract void ConstructAssociate(HandshakeInfo info, IBufferWriter<byte> writer);
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="reason">TBD</param>
         /// <returns>TBD</returns>
-        public abstract ByteString ConstructDisassociate(DisassociateInfo reason);
+        public virtual ByteString ConstructDisassociate(DisassociateInfo reason)
+        {
+            return ConstructByteString(writer => ConstructDisassociate(reason, writer));
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="reason">TBD</param>
+        /// <param name="writer">TBD</param>
+        public abstract void ConstructDisassociate(DisassociateInfo reason, IBufferWriter<byte> writer);
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <returns>TBD</returns>
-        public abstract ByteString ConstructHeartbeat();
+        public virtual ByteString ConstructHeartbeat()
+        {
+            return ConstructByteString(ConstructHeartbeat);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="writer">TBD</param>
+        public abstract void ConstructHeartbeat(IBufferWriter<byte> writer);
 
         /// <summary>
         /// TBD
@@ -278,7 +329,19 @@ namespace Akka.Remote.Transport
         /// <param name="provider">TBD</param>
         /// <param name="localAddress">TBD</param>
         /// <returns>TBD</returns>
-        public abstract AckAndMessage DecodeMessage(ByteString raw, IRemoteActorRefProvider provider, Address localAddress);
+        public virtual AckAndMessage DecodeMessage(ByteString raw, IRemoteActorRefProvider provider, Address localAddress)
+        {
+            return DecodeMessage(new ReadOnlySequence<byte>(raw.Memory), provider, localAddress);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="raw">TBD</param>
+        /// <param name="provider">TBD</param>
+        /// <param name="localAddress">TBD</param>
+        /// <returns>TBD</returns>
+        public abstract AckAndMessage DecodeMessage(ReadOnlySequence<byte> raw, IRemoteActorRefProvider provider, Address localAddress);
 
         /// <summary>
         /// TBD
@@ -290,15 +353,50 @@ namespace Akka.Remote.Transport
         /// <param name="seqOption">TBD</param>
         /// <param name="ackOption">TBD</param>
         /// <returns>TBD</returns>
-        public abstract ByteString ConstructMessage(Address localAddress, IActorRef recipient,
-            SerializedMessage serializedMessage, IActorRef senderOption = null, SeqNo? seqOption = null, Ack ackOption = null);
+        public virtual ByteString ConstructMessage(Address localAddress, IActorRef recipient,
+            SerializedMessage serializedMessage, IActorRef senderOption = null, SeqNo? seqOption = null, Ack ackOption = null)
+        {
+            return ConstructByteString(writer => ConstructMessage(localAddress, recipient, serializedMessage, writer, senderOption, seqOption, ackOption));
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="localAddress">TBD</param>
+        /// <param name="recipient">TBD</param>
+        /// <param name="serializedMessage">TBD</param>
+        /// <param name="writer">TBD</param>
+        /// <param name="senderOption">TBD</param>
+        /// <param name="seqOption">TBD</param>
+        /// <param name="ackOption">TBD</param>
+        public abstract void ConstructMessage(Address localAddress, IActorRef recipient, SerializedMessage serializedMessage,
+            IBufferWriter<byte> writer, IActorRef senderOption = null, SeqNo? seqOption = null, Ack ackOption = null);
 
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="ack">TBD</param>
         /// <returns>TBD</returns>
-        public abstract ByteString ConstructPureAck(Ack ack);
+        public virtual ByteString ConstructPureAck(Ack ack)
+        {
+            return ConstructByteString(writer => ConstructPureAck(ack, writer));
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="ack">TBD</param>
+        /// <param name="writer">TBD</param>
+        public abstract void ConstructPureAck(Ack ack, IBufferWriter<byte> writer);
+
+        private static ByteString ConstructByteString(Action<IBufferWriter<byte>> write, int initialCapacity = 0)
+        {
+            var writer = initialCapacity > 0
+                ? new ArrayBufferWriter<byte>(initialCapacity)
+                : new ArrayBufferWriter<byte>();
+            write(writer);
+            return ByteString.CopyFrom(writer.WrittenSpan);
+        }
     }
 
     /// <summary>
@@ -319,7 +417,7 @@ namespace Akka.Remote.Transport
         /// </ul>
         /// </exception>
         /// <returns>TBD</returns>
-        public override IAkkaPdu DecodePdu(ByteString raw)
+        public override IAkkaPdu DecodePdu(ReadOnlySequence<byte> raw)
         {
             try
             {
@@ -341,7 +439,17 @@ namespace Akka.Remote.Transport
         /// <returns>TBD</returns>
         public override ByteString ConstructPayload(ByteString payload)
         {
-            return new AkkaProtocolMessage() { Payload = payload }.ToByteString();
+            return CreatePayloadPdu(payload).ToByteString();
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="payload">TBD</param>
+        /// <param name="writer">TBD</param>
+        public override void ConstructPayload(ByteString payload, IBufferWriter<byte> writer)
+        {
+            CreatePayloadPdu(payload).WriteTo(writer);
         }
 
         /// <summary>
@@ -366,6 +474,25 @@ namespace Akka.Remote.Transport
         /// <summary>
         /// TBD
         /// </summary>
+        /// <param name="info">TBD</param>
+        /// <param name="writer">TBD</param>
+        /// <exception cref="ArgumentException">
+        /// This exception is thrown when the specified <paramref name="info"/> contains an invalid address.
+        /// </exception>
+        public override void ConstructAssociate(HandshakeInfo info, IBufferWriter<byte> writer)
+        {
+            var handshakeInfo = new AkkaHandshakeInfo()
+            {
+                Origin = SerializeAddress(info.Origin),
+                Uid = (ulong)info.Uid
+            };
+
+            ConstructControlMessagePdu(CommandType.Associate, handshakeInfo, writer);
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
         /// <param name="reason">TBD</param>
         /// <returns>TBD</returns>
         public override ByteString ConstructDisassociate(DisassociateInfo reason)
@@ -379,6 +506,28 @@ namespace Akka.Remote.Transport
                 case DisassociateInfo.Unknown:
                 default:
                     return DISASSOCIATE;
+            }
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="reason">TBD</param>
+        /// <param name="writer">TBD</param>
+        public override void ConstructDisassociate(DisassociateInfo reason, IBufferWriter<byte> writer)
+        {
+            switch (reason)
+            {
+                case DisassociateInfo.Quarantined:
+                    ConstructControlMessagePdu(CommandType.DisassociateQuarantined, null, writer);
+                    break;
+                case DisassociateInfo.Shutdown:
+                    ConstructControlMessagePdu(CommandType.DisassociateShuttingDown, null, writer);
+                    break;
+                case DisassociateInfo.Unknown:
+                default:
+                    ConstructControlMessagePdu(CommandType.Disassociate, null, writer);
+                    break;
             }
         }
 
@@ -399,6 +548,17 @@ namespace Akka.Remote.Transport
         }
 
         /// <summary>
+        /// Creates a new Heartbeat message instance.
+        /// </summary>
+        /// <param name="writer">The writer receiving the heartbeat message.</param>
+        public override void ConstructHeartbeat(IBufferWriter<byte> writer)
+        {
+            var span = writer.GetSpan(HeartbeatPdu.Length);
+            HeartbeatPdu.Span.CopyTo(span);
+            writer.Advance(HeartbeatPdu.Length);
+        }
+
+        /// <summary>
         /// Indicated RemoteEnvelope.Seq is not defined (order is irrelevant)
         /// </summary>
         private const ulong SeqUndefined = ulong.MaxValue;
@@ -410,7 +570,7 @@ namespace Akka.Remote.Transport
         /// <param name="provider">TBD</param>
         /// <param name="localAddress">TBD</param>
         /// <returns>TBD</returns>
-        public override AckAndMessage DecodeMessage(ByteString raw, IRemoteActorRefProvider provider, Address localAddress)
+        public override AckAndMessage DecodeMessage(ReadOnlySequence<byte> raw, IRemoteActorRefProvider provider, Address localAddress)
         {
             var ackAndEnvelope = AckAndEnvelopeContainer.Parser.ParseFrom(raw);
 
@@ -464,6 +624,31 @@ namespace Akka.Remote.Transport
             return acki;
         }
 
+        private static AkkaProtocolMessage CreatePayloadPdu(ByteString payload)
+        {
+            return new AkkaProtocolMessage() { Payload = payload };
+        }
+
+        private AckAndEnvelopeContainer CreateAckAndEnvelope(Address localAddress, IActorRef recipient,
+            SerializedMessage serializedMessage, IActorRef senderOption = null, SeqNo? seqOption = null,
+            Ack ackOption = null)
+        {
+            var ackAndEnvelope = new AckAndEnvelopeContainer();
+            var envelope = new RemoteEnvelope() { Recipient = SerializeActorRef(recipient.Path.Address, recipient) };
+            if (senderOption != null && senderOption.Path != null) { envelope.Sender = SerializeActorRef(localAddress, senderOption); }
+            if (seqOption is { } seq) { envelope.Seq = (ulong)seq.RawValue; } else envelope.Seq = SeqUndefined;
+            if (ackOption != null) { ackAndEnvelope.Ack = AckBuilder(ackOption); }
+            envelope.Message = serializedMessage;
+            ackAndEnvelope.Envelope = envelope;
+
+            return ackAndEnvelope;
+        }
+
+        private AckAndEnvelopeContainer CreatePureAck(Ack ack)
+        {
+            return new AckAndEnvelopeContainer() { Ack = AckBuilder(ack) };
+        }
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -477,15 +662,23 @@ namespace Akka.Remote.Transport
         public override ByteString ConstructMessage(Address localAddress, IActorRef recipient, SerializedMessage serializedMessage,
             IActorRef senderOption = null, SeqNo? seqOption = null, Ack ackOption = null)
         {
-            var ackAndEnvelope = new AckAndEnvelopeContainer();
-            var envelope = new RemoteEnvelope() { Recipient = SerializeActorRef(recipient.Path.Address, recipient) };
-            if (senderOption != null && senderOption.Path != null) { envelope.Sender = SerializeActorRef(localAddress, senderOption); }
-            if (seqOption is { } seq) { envelope.Seq = (ulong)seq.RawValue; } else envelope.Seq = SeqUndefined;
-            if (ackOption != null) { ackAndEnvelope.Ack = AckBuilder(ackOption); }
-            envelope.Message = serializedMessage;
-            ackAndEnvelope.Envelope = envelope;
+            return CreateAckAndEnvelope(localAddress, recipient, serializedMessage, senderOption, seqOption, ackOption).ToByteString();
+        }
 
-            return ackAndEnvelope.ToByteString();
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="localAddress">TBD</param>
+        /// <param name="recipient">TBD</param>
+        /// <param name="serializedMessage">TBD</param>
+        /// <param name="writer">TBD</param>
+        /// <param name="senderOption">TBD</param>
+        /// <param name="seqOption">TBD</param>
+        /// <param name="ackOption">TBD</param>
+        public override void ConstructMessage(Address localAddress, IActorRef recipient, SerializedMessage serializedMessage,
+            IBufferWriter<byte> writer, IActorRef senderOption = null, SeqNo? seqOption = null, Ack ackOption = null)
+        {
+            CreateAckAndEnvelope(localAddress, recipient, serializedMessage, senderOption, seqOption, ackOption).WriteTo(writer);
         }
 
         /// <summary>
@@ -495,7 +688,17 @@ namespace Akka.Remote.Transport
         /// <returns>TBD</returns>
         public override ByteString ConstructPureAck(Ack ack)
         {
-            return new AckAndEnvelopeContainer() { Ack = AckBuilder(ack) }.ToByteString();
+            return CreatePureAck(ack).ToByteString();
+        }
+
+        /// <summary>
+        /// TBD
+        /// </summary>
+        /// <param name="ack">TBD</param>
+        /// <param name="writer">TBD</param>
+        public override void ConstructPureAck(Ack ack, IBufferWriter<byte> writer)
+        {
+            CreatePureAck(ack).WriteTo(writer);
         }
 
 #region Internal methods
@@ -542,13 +745,23 @@ namespace Akka.Remote.Transport
 
         private static ByteString ConstructControlMessagePdu(CommandType code, AkkaHandshakeInfo handshakeInfo = null)
         {
+            return CreateControlMessagePdu(code, handshakeInfo).ToByteString();
+        }
+
+        private static void ConstructControlMessagePdu(CommandType code, AkkaHandshakeInfo handshakeInfo, IBufferWriter<byte> writer)
+        {
+            CreateControlMessagePdu(code, handshakeInfo).WriteTo(writer);
+        }
+
+        private static AkkaProtocolMessage CreateControlMessagePdu(CommandType code, AkkaHandshakeInfo handshakeInfo = null)
+        {
             var controlMessage = new AkkaControlMessage() { CommandType = code };
             if (handshakeInfo != null)
             {
                 controlMessage.HandshakeInfo = handshakeInfo;
             }
 
-            return new AkkaProtocolMessage() { Instruction = controlMessage }.ToByteString();
+            return new AkkaProtocolMessage() { Instruction = controlMessage };
         }
 
         private static Address DecodeAddress(AddressData origin)

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -116,6 +116,20 @@ namespace Akka.Remote.Transport
     }
 
     /// <summary>
+    /// INTERNAL API.
+    /// Represents an ordinary payload PDU whose bytes are backed by an owned sequence.
+    /// </summary>
+    internal sealed class SequencePayload : IAkkaPdu
+    {
+        public SequencePayload(ReadOnlySequence<byte> bytes)
+        {
+            Bytes = bytes;
+        }
+
+        public ReadOnlySequence<byte> Bytes { get; }
+    }
+
+    /// <summary>
     /// TBD
     /// </summary>
     internal sealed class Message : IAkkaPdu, IHasSequenceNumber
@@ -245,6 +259,8 @@ namespace Akka.Remote.Transport
             {
                 case Payload p:
                     return ConstructPayload(p.Bytes);
+                case SequencePayload p:
+                    return ConstructPayload(ToByteString(p.Bytes));
                 case Heartbeat h:
                     return ConstructHeartbeat();
                 case Associate a:
@@ -397,6 +413,13 @@ namespace Akka.Remote.Transport
             write(writer);
             return ByteString.CopyFrom(writer.WrittenSpan);
         }
+
+        private static ByteString ToByteString(ReadOnlySequence<byte> bytes)
+        {
+            return bytes.IsSingleSegment
+                ? ByteString.CopyFrom(bytes.FirstSpan)
+                : ByteString.CopyFrom(bytes.ToArray());
+        }
     }
 
     /// <summary>
@@ -404,6 +427,8 @@ namespace Akka.Remote.Transport
     /// </summary>
     internal sealed class AkkaPduProtobuffCodec : AkkaPduCodec
     {
+        private const byte PayloadFieldTag = 0x0A;
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -421,15 +446,87 @@ namespace Akka.Remote.Transport
         {
             try
             {
+                if (TryDecodePayloadPdu(raw, out var payload))
+                    return payload;
+
                 var pdu = AkkaProtocolMessage.Parser.ParseFrom(raw);
-                if (pdu.Instruction != null) return DecodeControlPdu(pdu.Instruction);
-                else if (!pdu.Payload.IsEmpty) return new Payload(pdu.Payload); // TODO HasPayload
-                else throw new PduCodecException("Error decoding Akka PDU: Neither message nor control message were contained");
+                return DecodePdu(pdu);
             }
             catch (InvalidProtocolBufferException ex)
             {
                 throw new PduCodecException("Decoding PDU failed", ex);
             }
+        }
+
+        public override IAkkaPdu DecodePdu(ByteString raw)
+        {
+            try
+            {
+                var pdu = AkkaProtocolMessage.Parser.ParseFrom(raw);
+                return DecodePdu(pdu);
+            }
+            catch (InvalidProtocolBufferException ex)
+            {
+                throw new PduCodecException("Decoding PDU failed", ex);
+            }
+        }
+
+        private IAkkaPdu DecodePdu(AkkaProtocolMessage pdu)
+        {
+            if (pdu.Instruction != null) return DecodeControlPdu(pdu.Instruction);
+            else if (!pdu.Payload.IsEmpty) return new Payload(pdu.Payload); // TODO HasPayload
+            else throw new PduCodecException("Error decoding Akka PDU: Neither message nor control message were contained");
+        }
+
+        private static bool TryDecodePayloadPdu(ReadOnlySequence<byte> raw, out SequencePayload payload)
+        {
+            payload = null;
+
+            var reader = new SequenceReader<byte>(raw);
+            if (!reader.TryRead(out var tag) || tag != PayloadFieldTag)
+                return false;
+
+            if (!TryReadVarint32(ref reader, out var payloadLength) || payloadLength <= 0)
+                return false;
+
+            if (reader.Remaining != payloadLength)
+                return false;
+
+            payload = new SequencePayload(raw.Slice(reader.Position, payloadLength));
+            return true;
+        }
+
+        private static bool TryReadVarint32(ref SequenceReader<byte> reader, out int value)
+        {
+            long result = 0;
+            var shift = 0;
+
+            while (shift < 35)
+            {
+                if (!reader.TryRead(out var b))
+                {
+                    value = 0;
+                    return false;
+                }
+
+                result |= (long)(b & 0x7F) << shift;
+                if ((b & 0x80) == 0)
+                {
+                    if (result > int.MaxValue)
+                    {
+                        value = 0;
+                        return false;
+                    }
+
+                    value = (int)result;
+                    return true;
+                }
+
+                shift += 7;
+            }
+
+            value = 0;
+            return false;
         }
 
         /// <summary>
@@ -573,7 +670,6 @@ namespace Akka.Remote.Transport
         public override AckAndMessage DecodeMessage(ReadOnlySequence<byte> raw, IRemoteActorRefProvider provider, Address localAddress)
         {
             var ackAndEnvelope = AckAndEnvelopeContainer.Parser.ParseFrom(raw);
-
             Ack ackOption = null;
 
             if (ackAndEnvelope.Ack != null)

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -637,7 +637,7 @@ namespace Akka.Remote.Transport
         /// <param name="handlerListener">TBD</param>
         /// <param name="wrappedHandle">TBD</param>
         /// <param name="queue">TBD</param>
-        public AssociatedWaitHandler(Task<IHandleEventListener> handlerListener, AssociationHandle wrappedHandle, Queue<ByteString> queue)
+        public AssociatedWaitHandler(Task<IHandleEventListener> handlerListener, AssociationHandle wrappedHandle, Queue<IHandleEvent> queue)
         {
             Queue = queue;
             WrappedHandle = wrappedHandle;
@@ -657,7 +657,7 @@ namespace Akka.Remote.Transport
         /// <summary>
         /// TBD
         /// </summary>
-        public Queue<ByteString> Queue { get; private set; }
+        public Queue<IHandleEvent> Queue { get; private set; }
     }
 
     /// <summary>
@@ -920,7 +920,7 @@ namespace Akka.Remote.Transport
                                                     new AssociatedWaitHandler(
                                                         NotifyOutboundHandler(wrappedHandle, handshakeInfo,
                                                             statusCompletionSource), wrappedHandle,
-                                                        new Queue<ByteString>()));
+                                                        new Queue<IHandleEvent>()));
                                     }
                                 case Disassociate d:
                                     //After receiving Disassociate we MUST NOT send back a Disassociate (loop)
@@ -963,7 +963,7 @@ namespace Akka.Remote.Transport
                                     return GoTo(AssociationState.Open).Using(
                                         new AssociatedWaitHandler(
                                             NotifyInboundHandler(wrappedHandle, a.Info, associationHandler),
-                                            wrappedHandle, new Queue<ByteString>()));
+                                            wrappedHandle, new Queue<IHandleEvent>()));
 
                                 // Got a stray message -- explicitly reset the association (force remote endpoint to reassociate)
                                 default:
@@ -1013,22 +1013,11 @@ namespace Akka.Remote.Transport
                                 case Payload p:
                                     // use incoming ordinary message as alive sign
                                     _failureDetector.HeartBeat();
-                                    switch (@event.StateData)
-                                    {
-                                        case AssociatedWaitHandler awh:
-                                            var nQueue = new Queue<ByteString>(awh.Queue);
-                                            nQueue.Enqueue(p.Bytes);
-                                            return
-                                                Stay()
-                                                    .Using(new AssociatedWaitHandler(awh.HandlerListener, awh.WrappedHandle,
-                                                        nQueue));
-                                        case ListenerReady lr:
-                                            lr.Listener.Notify(new InboundPayload(p.Bytes));
-                                            return Stay();
-                                        default:
-                                            throw new AkkaProtocolException(
-                                                $"Unhandled message in state Open(InboundPayload) with type [{@event.FsmEvent?.GetType()}]");
-                                    }
+                                    return HandlePayload(new InboundPayload(p.Bytes), @event.StateData, @event.FsmEvent);
+                                case SequencePayload p:
+                                    // use incoming ordinary message as alive sign
+                                    _failureDetector.HeartBeat();
+                                    return HandlePayload(new InboundSequencePayload(p.Bytes), @event.StateData, @event.FsmEvent);
                                 default:
                                     return Stay();
                             }
@@ -1063,7 +1052,7 @@ namespace Akka.Remote.Transport
                     case HandleListenerRegistered hlr when @event.StateData is AssociatedWaitHandler awh:
                         foreach (var p in awh.Queue)
                         {
-                            hlr.Listener.Notify(new InboundPayload(p));
+                            hlr.Listener.Notify(p);
                         }
 
                         return Stay().Using(new ListenerReady(hlr.Listener, awh.WrappedHandle));
@@ -1306,6 +1295,23 @@ namespace Akka.Remote.Transport
                 InboundSequencePayload p => DecodePdu(p.Payload),
                 _ => throw new AkkaProtocolException($"Expected inbound payload event, received [{ev.GetType()}]")
             };
+        }
+
+        private State<AssociationState, ProtocolStateData> HandlePayload(IHandleEvent payload, ProtocolStateData stateData, object fsmEvent)
+        {
+            switch (stateData)
+            {
+                case AssociatedWaitHandler awh:
+                    var nQueue = new Queue<IHandleEvent>(awh.Queue);
+                    nQueue.Enqueue(payload);
+                    return Stay().Using(new AssociatedWaitHandler(awh.HandlerListener, awh.WrappedHandle, nQueue));
+                case ListenerReady lr:
+                    lr.Listener.Notify(payload);
+                    return Stay();
+                default:
+                    throw new AkkaProtocolException(
+                        $"Unhandled message in state Open(InboundPayload) with type [{fsmEvent?.GetType()}]");
+            }
         }
 
         private IAkkaPdu DecodePdu(ByteString pdu)

--- a/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
+++ b/src/core/Akka.Remote/Transport/AkkaProtocolTransport.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -891,9 +892,9 @@ namespace Akka.Remote.Transport
                 {
                     case Disassociated d:
                         return Stop(new Failure(d.Info));
-                    case InboundPayload p when @event.StateData is OutboundUnderlyingAssociated ola:
+                    case InboundPayload or InboundSequencePayload when @event.StateData is OutboundUnderlyingAssociated ola:
                         {
-                            var pdu = DecodePdu(p.Payload);
+                            var pdu = DecodePdu((IHandleEvent)@event.FsmEvent);
                             /*
                              * This state is used for OutboundProtocolState actors when they receive
                              * a reply back from the inbound end of the association.
@@ -938,9 +939,9 @@ namespace Akka.Remote.Transport
                         return HandleTimers(oua.WrappedHandle);
 
                     // Events for inbound associations
-                    case InboundPayload p when @event.StateData is InboundUnassociated iu:
+                    case InboundPayload or InboundSequencePayload when @event.StateData is InboundUnassociated iu:
                         {
-                            var pdu = DecodePdu(p.Payload);
+                            var pdu = DecodePdu((IHandleEvent)@event.FsmEvent);
                             /*
                              * This state is used by inbound protocol state actors
                              * when they receive an association attempt from the
@@ -999,9 +1000,9 @@ namespace Akka.Remote.Transport
                 {
                     case Disassociated d:
                         return Stop(new Failure(d.Info));
-                    case InboundPayload ip:
+                    case InboundPayload or InboundSequencePayload:
                         {
-                            var pdu = DecodePdu(ip.Payload);
+                            var pdu = DecodePdu((IHandleEvent)@event.FsmEvent);
                             switch (pdu)
                             {
                                 case Disassociate d:
@@ -1297,7 +1298,29 @@ namespace Akka.Remote.Transport
             return readHandlerPromise.Task;
         }
 
+        private IAkkaPdu DecodePdu(IHandleEvent ev)
+        {
+            return ev switch
+            {
+                InboundPayload p => DecodePdu(p.Payload),
+                InboundSequencePayload p => DecodePdu(p.Payload),
+                _ => throw new AkkaProtocolException($"Expected inbound payload event, received [{ev.GetType()}]")
+            };
+        }
+
         private IAkkaPdu DecodePdu(ByteString pdu)
+        {
+            try
+            {
+                return _codec.DecodePdu(pdu);
+            }
+            catch (Exception ex)
+            {
+                throw new AkkaProtocolException($"Error while decoding incoming Akka PDU of length {pdu.Length}", ex);
+            }
+        }
+
+        private IAkkaPdu DecodePdu(ReadOnlySequence<byte> pdu)
         {
             try
             {
@@ -1410,4 +1433,3 @@ namespace Akka.Remote.Transport
         #endregion
     }
 }
-

--- a/src/core/Akka.Remote/Transport/Streams/RemoteTcpFraming.cs
+++ b/src/core/Akka.Remote/Transport/Streams/RemoteTcpFraming.cs
@@ -79,9 +79,15 @@ namespace Akka.Remote.Transport.Streams
 
         private static ReadOnlySequence<byte> PrependHeader(byte[] header, ReadOnlySequence<byte> payload)
         {
-            return payload.IsEmpty
-                ? new ReadOnlySequence<byte>(header)
-                : Concat(new ReadOnlySequence<byte>(header), payload);
+            if (payload.IsEmpty)
+                return new ReadOnlySequence<byte>(header);
+
+            var head = new SequenceSegment(header);
+            var tail = head;
+            foreach (var memory in payload)
+                tail = tail.Append(memory);
+
+            return new ReadOnlySequence<byte>(head, 0, tail, tail.Memory.Length);
         }
 
         private sealed class RemoteTcpFrameDecoder : GraphStage<FlowShape<ReadOnlySequence<byte>, ReadOnlySequence<byte>>>
@@ -148,11 +154,10 @@ namespace Akka.Remote.Transport.Streams
                             return;
                         }
 
-                        Span<byte> header = stackalloc byte[FrameHeaderBytes];
-                        _buffer.Slice(0, FrameHeaderBytes).CopyTo(header);
-                        var payloadSize = _stage._byteOrder == DotNettyByteOrder.LittleEndian
-                            ? BinaryPrimitives.ReadInt32LittleEndian(header)
-                            : BinaryPrimitives.ReadInt32BigEndian(header);
+                        var firstSpan = _buffer.FirstSpan;
+                        var payloadSize = firstSpan.Length >= FrameHeaderBytes
+                            ? DecodeFrameSize(firstSpan.Slice(0, FrameHeaderBytes), _stage._byteOrder)
+                            : DecodeSplitFrameSize(_buffer, _stage._byteOrder);
 
                         if (payloadSize < 0)
                         {
@@ -192,6 +197,20 @@ namespace Akka.Remote.Transport.Streams
                         FailStage(new Framing.FramingException("Stream finished but there was a truncated final remote frame in the buffer"));
                     else
                         Pull(_stage._in);
+                }
+
+                private static int DecodeSplitFrameSize(ReadOnlySequence<byte> buffer, DotNettyByteOrder byteOrder)
+                {
+                    Span<byte> header = stackalloc byte[FrameHeaderBytes];
+                    buffer.Slice(0, FrameHeaderBytes).CopyTo(header);
+                    return DecodeFrameSize(header, byteOrder);
+                }
+
+                private static int DecodeFrameSize(ReadOnlySpan<byte> header, DotNettyByteOrder byteOrder)
+                {
+                    return byteOrder == DotNettyByteOrder.LittleEndian
+                        ? BinaryPrimitives.ReadInt32LittleEndian(header)
+                        : BinaryPrimitives.ReadInt32BigEndian(header);
                 }
             }
         }

--- a/src/core/Akka.Remote/Transport/Streams/RemoteTcpFraming.cs
+++ b/src/core/Akka.Remote/Transport/Streams/RemoteTcpFraming.cs
@@ -1,0 +1,217 @@
+//-----------------------------------------------------------------------
+// <copyright file="RemoteTcpFraming.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Akka.Streams.Stage;
+using DotNettyByteOrder = DotNetty.Buffers.ByteOrder;
+
+namespace Akka.Remote.Transport.Streams
+{
+    /// <summary>
+    /// INTERNAL API.
+    /// DotNetty-compatible Remote TCP length framing for the stream transport.
+    /// Frames are encoded as a 4-byte payload length followed by payload bytes.
+    /// </summary>
+    internal static class RemoteTcpFraming
+    {
+        private const int FrameHeaderBytes = 4;
+
+        public static Flow<ReadOnlySequence<byte>, ReadOnlySequence<byte>, NotUsed> Decoder(
+            int maxFrameSize,
+            DotNettyByteOrder byteOrder)
+        {
+            return Flow.Create<ReadOnlySequence<byte>>()
+                .Via(new RemoteTcpFrameDecoder(maxFrameSize, byteOrder))
+                .Named("RemoteTcpFrameDecoder");
+        }
+
+        public static ReadOnlySequence<byte> Encode(
+            ReadOnlySequence<byte> payload,
+            int maxFrameSize,
+            DotNettyByteOrder byteOrder)
+        {
+            if (payload.Length > maxFrameSize)
+                throw new Framing.FramingException($"Remote frame size [{payload.Length}] exceeds maximum frame size [{maxFrameSize}]");
+
+            var header = new byte[FrameHeaderBytes];
+            if (byteOrder == DotNettyByteOrder.LittleEndian)
+                BinaryPrimitives.WriteInt32LittleEndian(header, (int)payload.Length);
+            else
+                BinaryPrimitives.WriteInt32BigEndian(header, (int)payload.Length);
+
+            return PrependHeader(header, payload);
+        }
+
+        private static ReadOnlySequence<byte> Concat(ReadOnlySequence<byte> first, ReadOnlySequence<byte> second)
+        {
+            if (first.IsEmpty) return second;
+            if (second.IsEmpty) return first;
+
+            SequenceSegment? head = null;
+            SequenceSegment? tail = null;
+
+            foreach (var memory in first)
+            {
+                if (head is null)
+                {
+                    head = new SequenceSegment(memory);
+                    tail = head;
+                }
+                else
+                {
+                    tail = tail!.Append(memory);
+                }
+            }
+
+            foreach (var memory in second)
+                tail = tail!.Append(memory);
+
+            return new ReadOnlySequence<byte>(head!, 0, tail!, tail!.Memory.Length);
+        }
+
+        private static ReadOnlySequence<byte> PrependHeader(byte[] header, ReadOnlySequence<byte> payload)
+        {
+            return payload.IsEmpty
+                ? new ReadOnlySequence<byte>(header)
+                : Concat(new ReadOnlySequence<byte>(header), payload);
+        }
+
+        private sealed class RemoteTcpFrameDecoder : GraphStage<FlowShape<ReadOnlySequence<byte>, ReadOnlySequence<byte>>>
+        {
+            private readonly int _maxFrameSize;
+            private readonly DotNettyByteOrder _byteOrder;
+            private readonly Inlet<ReadOnlySequence<byte>> _in = new("RemoteTcpFrameDecoder.in");
+            private readonly Outlet<ReadOnlySequence<byte>> _out = new("RemoteTcpFrameDecoder.out");
+
+            public RemoteTcpFrameDecoder(int maxFrameSize, DotNettyByteOrder byteOrder)
+            {
+                _maxFrameSize = maxFrameSize;
+                _byteOrder = byteOrder;
+                Shape = new FlowShape<ReadOnlySequence<byte>, ReadOnlySequence<byte>>(_in, _out);
+            }
+
+            public override FlowShape<ReadOnlySequence<byte>, ReadOnlySequence<byte>> Shape { get; }
+
+            protected override Attributes InitialAttributes { get; } = Attributes.CreateName("RemoteTcpFrameDecoder");
+
+            protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes)
+            {
+                return new Logic(this);
+            }
+
+            private sealed class Logic : InAndOutGraphStageLogic
+            {
+                private readonly RemoteTcpFrameDecoder _stage;
+                private ReadOnlySequence<byte> _buffer = ReadOnlySequence<byte>.Empty;
+                private int? _payloadSize;
+
+                public Logic(RemoteTcpFrameDecoder stage) : base(stage.Shape)
+                {
+                    _stage = stage;
+                    SetHandlers(stage._in, stage._out, this);
+                }
+
+                public override void OnPush()
+                {
+                    _buffer = Concat(_buffer, Grab(_stage._in));
+                    TryPushFrame();
+                }
+
+                public override void OnPull()
+                {
+                    TryPushFrame();
+                }
+
+                public override void OnUpstreamFinish()
+                {
+                    if (_buffer.IsEmpty)
+                        CompleteStage();
+                    else if (IsAvailable(_stage._out))
+                        TryPushFrame();
+                }
+
+                private void TryPushFrame()
+                {
+                    if (_payloadSize is null)
+                    {
+                        if (_buffer.Length < FrameHeaderBytes)
+                        {
+                            TryPull();
+                            return;
+                        }
+
+                        Span<byte> header = stackalloc byte[FrameHeaderBytes];
+                        _buffer.Slice(0, FrameHeaderBytes).CopyTo(header);
+                        var payloadSize = _stage._byteOrder == DotNettyByteOrder.LittleEndian
+                            ? BinaryPrimitives.ReadInt32LittleEndian(header)
+                            : BinaryPrimitives.ReadInt32BigEndian(header);
+
+                        if (payloadSize < 0)
+                        {
+                            FailStage(new Framing.FramingException($"Decoded frame header reported negative size {payloadSize}"));
+                            return;
+                        }
+
+                        if (payloadSize > _stage._maxFrameSize)
+                        {
+                            FailStage(new Framing.FramingException(
+                                $"Maximum allowed remote frame size is {_stage._maxFrameSize} but decoded frame header reported size {payloadSize}"));
+                            return;
+                        }
+
+                        _payloadSize = payloadSize;
+                    }
+
+                    var frameSize = FrameHeaderBytes + _payloadSize.Value;
+                    if (_buffer.Length < frameSize)
+                    {
+                        TryPull();
+                        return;
+                    }
+
+                    var payload = _buffer.Slice(FrameHeaderBytes, _payloadSize.Value);
+                    _buffer = _buffer.Slice(frameSize);
+                    _payloadSize = null;
+                    Push(_stage._out, payload);
+
+                    if (_buffer.IsEmpty && IsClosed(_stage._in))
+                        CompleteStage();
+                }
+
+                private void TryPull()
+                {
+                    if (IsClosed(_stage._in))
+                        FailStage(new Framing.FramingException("Stream finished but there was a truncated final remote frame in the buffer"));
+                    else
+                        Pull(_stage._in);
+                }
+            }
+        }
+
+        private sealed class SequenceSegment : ReadOnlySequenceSegment<byte>
+        {
+            public SequenceSegment(ReadOnlyMemory<byte> memory)
+            {
+                Memory = memory;
+            }
+
+            public SequenceSegment Append(ReadOnlyMemory<byte> memory)
+            {
+                var next = new SequenceSegment(memory)
+                {
+                    RunningIndex = RunningIndex + Memory.Length
+                };
+                Next = next;
+                return next;
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
@@ -213,13 +213,26 @@ namespace Akka.Remote.Transport.Streams
             if (payload.Length > Settings.MaxFrameSize)
                 throw new Framing.FramingException($"Remote frame size [{payload.Length}] exceeds maximum frame size [{Settings.MaxFrameSize}]");
 
-            var buffer = new byte[FrameHeaderBytes + (int)payload.Length];
+            var header = new byte[FrameHeaderBytes];
             if (Settings.ByteOrder == DotNettyByteOrder.LittleEndian)
-                BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan(0, FrameHeaderBytes), (int)payload.Length);
+                BinaryPrimitives.WriteInt32LittleEndian(header, (int)payload.Length);
             else
-                BinaryPrimitives.WriteInt32BigEndian(buffer.AsSpan(0, FrameHeaderBytes), (int)payload.Length);
-            payload.CopyTo(buffer.AsSpan(FrameHeaderBytes));
-            return new ReadOnlySequence<byte>(buffer);
+                BinaryPrimitives.WriteInt32BigEndian(header, (int)payload.Length);
+
+            return PrependHeader(header, payload);
+        }
+
+        private static ReadOnlySequence<byte> PrependHeader(byte[] header, ReadOnlySequence<byte> payload)
+        {
+            if (payload.IsEmpty)
+                return new ReadOnlySequence<byte>(header);
+
+            var head = new FrameSegment(header);
+            var tail = head;
+            foreach (var segment in payload)
+                tail = tail.Append(segment);
+
+            return new ReadOnlySequence<byte>(head, 0, tail, tail.Memory.Length);
         }
 
         private static AkkaByteOrder ToAkkaByteOrder(DotNettyByteOrder byteOrder)
@@ -249,6 +262,24 @@ namespace Akka.Remote.Transport.Streams
             return payload.IsSingleSegment
                 ? ByteString.CopyFrom(payload.FirstSpan)
                 : ByteString.CopyFrom(payload.ToArray());
+        }
+
+        private sealed class FrameSegment : ReadOnlySequenceSegment<byte>
+        {
+            public FrameSegment(ReadOnlyMemory<byte> memory)
+            {
+                Memory = memory;
+            }
+
+            public FrameSegment Append(ReadOnlyMemory<byte> memory)
+            {
+                var next = new FrameSegment(memory)
+                {
+                    RunningIndex = RunningIndex + Memory.Length
+                };
+                Next = next;
+                return next;
+            }
         }
 
         private sealed class DeferredInboundBridge

--- a/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
@@ -244,6 +244,13 @@ namespace Akka.Remote.Transport.Streams
             _connections.TryRemove(handle, out _);
         }
 
+        private static ByteString ToByteString(ReadOnlySequence<byte> payload)
+        {
+            return payload.IsSingleSegment
+                ? ByteString.CopyFrom(payload.FirstSpan)
+                : ByteString.CopyFrom(payload.ToArray());
+        }
+
         private sealed class DeferredInboundBridge
         {
             private readonly object _gate = new();
@@ -252,7 +259,7 @@ namespace Akka.Remote.Transport.Streams
 
             public void NotifyInbound(ReadOnlySequence<byte> payload)
             {
-                var bytes = ByteString.CopyFrom(payload.ToArray());
+                var bytes = ToByteString(payload);
                 lock (_gate)
                 {
                     if (_handle != null)
@@ -333,7 +340,7 @@ namespace Akka.Remote.Transport.Streams
 
             public void NotifyInbound(ReadOnlySequence<byte> payload)
             {
-                Notify(new InboundPayload(ByteString.CopyFrom(payload.ToArray())));
+                Notify(new InboundPayload(ToByteString(payload)));
             }
 
             public void NotifyInbound(ByteString payload)

--- a/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
@@ -10,6 +10,7 @@ using System.Buffers;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -235,12 +236,20 @@ namespace Akka.Remote.Transport.Streams
 
             public void NotifyInbound(ReadOnlySequence<byte> payload)
             {
+                var handle = Volatile.Read(ref _handle);
+                if (handle != null)
+                {
+                    handle.NotifyInbound(payload);
+                    return;
+                }
+
                 var bytes = ToByteString(payload);
                 lock (_gate)
                 {
-                    if (_handle != null)
+                    handle = _handle;
+                    if (handle != null)
                     {
-                        _handle.NotifyInbound(bytes);
+                        handle.NotifyInbound(bytes);
                     }
                     else
                     {
@@ -253,9 +262,10 @@ namespace Akka.Remote.Transport.Streams
             {
                 lock (_gate)
                 {
-                    _handle = handle;
                     while (_pending.Count > 0)
-                        _handle.NotifyInbound(_pending.Dequeue());
+                        handle.NotifyInbound(_pending.Dequeue());
+
+                    Volatile.Write(ref _handle, handle);
                 }
             }
         }
@@ -292,9 +302,11 @@ namespace Akka.Remote.Transport.Streams
 
                     lock (_gate)
                     {
-                        _listener = task.Result;
+                        var listener = task.Result;
                         while (_pending.Count > 0)
-                            _listener.Notify(_pending.Dequeue());
+                            listener.Notify(_pending.Dequeue());
+
+                        Volatile.Write(ref _listener, listener);
                     }
                 }, TaskContinuationOptions.ExecuteSynchronously);
             }
@@ -354,11 +366,19 @@ namespace Akka.Remote.Transport.Streams
 
             private void Notify(IHandleEvent ev)
             {
+                var listener = Volatile.Read(ref _listener);
+                if (listener != null)
+                {
+                    listener.Notify(ev);
+                    return;
+                }
+
                 lock (_gate)
                 {
-                    if (_listener != null)
+                    listener = _listener;
+                    if (listener != null)
                     {
-                        _listener.Notify(ev);
+                        listener.Notify(ev);
                     }
                     else
                     {

--- a/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
@@ -1,0 +1,327 @@
+//-----------------------------------------------------------------------
+// <copyright file="TcpStreamTransport.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote.Transport.DotNetty;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Akka.Util.Internal;
+using Google.Protobuf;
+using AkkaByteOrder = Akka.Util.ByteOrder;
+using DotNettyByteOrder = DotNetty.Buffers.ByteOrder;
+using StreamTcp = Akka.Streams.Dsl.Tcp;
+
+namespace Akka.Remote.Transport.Streams
+{
+    /// <summary>
+    /// INTERNAL API.
+    /// Experimental TCP transport backed by Akka.Streams TCP while preserving the classic Remote
+    /// length-frame format consumed by <see cref="AkkaProtocolTransport" />.
+    /// </summary>
+    internal sealed class TcpStreamTransport : Transport
+    {
+        private const int FrameHeaderBytes = 4;
+
+        private readonly TaskCompletionSource<IAssociationEventListener> _associationListenerPromise = new();
+        private readonly ConcurrentDictionary<StreamAssociationHandle, StreamAssociationHandle> _connections = new();
+        private readonly ILoggingAdapter _log;
+        private readonly ActorMaterializer _materializer;
+
+        private StreamTcp.ServerBinding? _binding;
+        private volatile bool _shutdown;
+
+        public TcpStreamTransport(ActorSystem system, Config config)
+        {
+            System = system;
+            Config = config;
+            Settings = DotNettyTransportSettings.Create(config);
+            if (Settings.EnableSsl)
+                throw new NotSupportedException("TcpStreamTransport does not support SSL yet.");
+            if (Settings.BackwardsCompatibilityModeEnabled)
+                throw new NotSupportedException("TcpStreamTransport does not support Helios backwards-compatible framing.");
+
+            SchemeIdentifier = Settings.TransportMode.ToString().ToLowerInvariant();
+            _log = Logging.GetLogger(system, GetType());
+            _materializer = ActorMaterializer.Create(system);
+        }
+
+        public DotNettyTransportSettings Settings { get; }
+
+        public override long MaximumPayloadBytes => Settings.MaxFrameSize;
+
+        public override bool IsResponsibleFor(Address remote) => true;
+
+        public override async Task<(Address, TaskCompletionSource<IAssociationEventListener>)> Listen()
+        {
+            try
+            {
+                var binding = await System.TcpStream()
+                    .Bind(Settings.Hostname, Settings.Port, Settings.Backlog, halfClose: false)
+                    .ToMaterialized(Sink.ForEach<StreamTcp.IncomingConnection>(HandleIncomingConnection), Keep.Left)
+                    .Run(_materializer)
+                    .ConfigureAwait(false);
+
+                _binding = binding;
+                var localEndpoint = (IPEndPoint)binding.LocalAddress;
+                var address = DotNettyTransport.MapSocketToAddress(
+                    localEndpoint,
+                    SchemeIdentifier,
+                    System.Name,
+                    Settings.PublicHostname,
+                    Settings.PublicPort);
+
+                return (address ?? throw new ConfigurationException($"Unknown local address type [{binding.LocalAddress}]"), _associationListenerPromise);
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Failed to bind stream TCP transport to [{0}:{1}]", Settings.Hostname, Settings.Port);
+                await Shutdown().ConfigureAwait(false);
+                throw;
+            }
+        }
+
+        public override async Task<AssociationHandle> Associate(Address remoteAddress)
+        {
+            if (_binding == null)
+                throw new InvalidAssociationException("Transport is not bound or not open");
+
+            var remoteEndpoint = DotNettyTransport.AddressToSocketAddress(remoteAddress);
+            StreamAssociationHandle handle = null;
+
+            var sink = DecodeFrames().ToMaterialized(Sink.ForEach<ReadOnlySequence<byte>>(frame => handle?.NotifyInbound(frame)), Keep.Right);
+            var source = CreateOutboundSource();
+            var tcpFlow = System.TcpStream().OutgoingConnection(
+                remoteEndpoint,
+                connectionTimeout: Settings.ConnectTimeout,
+                halfClose: false);
+
+            var ((writer, connectionTask), inboundDone) = source
+                .ViaMaterialized(tcpFlow, Keep.Both)
+                .ToMaterialized(sink, Keep.Both)
+                .Run(_materializer);
+
+            try
+            {
+                var connection = await connectionTask.ConfigureAwait(false);
+                var localAddress = DotNettyTransport.MapSocketToAddress(
+                    (IPEndPoint)connection.LocalAddress,
+                    SchemeIdentifier,
+                    System.Name,
+                    Settings.Hostname);
+                handle = new StreamAssociationHandle(
+                    localAddress ?? throw new ConfigurationException($"Unknown local address type [{connection.LocalAddress}]"),
+                    remoteAddress,
+                    writer,
+                    RemoveConnection,
+                    _log);
+                TrackConnection(handle, inboundDone);
+                return handle;
+            }
+            catch (Exception ex)
+            {
+                writer.Tell(new Status.Failure(ex));
+                throw;
+            }
+        }
+
+        public override async Task<bool> Shutdown()
+        {
+            _shutdown = true;
+
+            foreach (var handle in _connections.Keys.ToArray())
+#pragma warning disable CS0618 // Intentionally implementing classic transport shutdown contract.
+                handle.Disassociate();
+#pragma warning restore CS0618
+
+            if (_binding.HasValue)
+                await _binding.Value.Unbind().ConfigureAwait(false);
+
+            _materializer.Shutdown();
+            return true;
+        }
+
+        private void HandleIncomingConnection(StreamTcp.IncomingConnection connection)
+        {
+            _associationListenerPromise.Task.ContinueWith(listenerTask =>
+            {
+                if (listenerTask.IsFaulted || listenerTask.IsCanceled || _shutdown)
+                    return;
+
+                StreamAssociationHandle handle = null;
+                var sink = DecodeFrames().ToMaterialized(Sink.ForEach<ReadOnlySequence<byte>>(frame => handle?.NotifyInbound(frame)), Keep.Right);
+                var source = CreateOutboundSource();
+                var flow = Flow.FromSinkAndSource(sink, source, Keep.Both);
+                var (inboundDone, writer) = connection.HandleWith(flow, _materializer);
+
+                var localAddress = DotNettyTransport.MapSocketToAddress(
+                    (IPEndPoint)connection.LocalAddress,
+                    SchemeIdentifier,
+                    System.Name,
+                    Settings.Hostname);
+                var remoteAddress = DotNettyTransport.MapSocketToAddress(
+                    (IPEndPoint)connection.RemoteAddress,
+                    SchemeIdentifier,
+                    System.Name);
+
+                if (localAddress == null || remoteAddress == null)
+                {
+                    writer.Tell(new Status.Success(NotUsed.Instance));
+                    return;
+                }
+
+                handle = new StreamAssociationHandle(localAddress, remoteAddress, writer, RemoveConnection, _log);
+                TrackConnection(handle, inboundDone);
+                listenerTask.Result.Notify(new InboundAssociation(handle));
+            }, TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        private Source<ReadOnlySequence<byte>, IActorRef> CreateOutboundSource()
+        {
+            return Source.ActorRef<ReadOnlySequence<byte>>(128, OverflowStrategy.Fail)
+                .Select(EncodeFrame);
+        }
+
+        private Flow<ReadOnlySequence<byte>, ReadOnlySequence<byte>, NotUsed> DecodeFrames()
+        {
+            return Framing.LengthField(FrameHeaderBytes, Settings.MaxFrameSize + FrameHeaderBytes, 0, ToAkkaByteOrder(Settings.ByteOrder))
+                .Select(frame => frame.Slice(FrameHeaderBytes));
+        }
+
+        private ReadOnlySequence<byte> EncodeFrame(ReadOnlySequence<byte> payload)
+        {
+            if (payload.Length > Settings.MaxFrameSize)
+                throw new Framing.FramingException($"Remote frame size [{payload.Length}] exceeds maximum frame size [{Settings.MaxFrameSize}]");
+
+            var buffer = new byte[FrameHeaderBytes + (int)payload.Length];
+            if (Settings.ByteOrder == DotNettyByteOrder.LittleEndian)
+                BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan(0, FrameHeaderBytes), (int)payload.Length);
+            else
+                BinaryPrimitives.WriteInt32BigEndian(buffer.AsSpan(0, FrameHeaderBytes), (int)payload.Length);
+            payload.CopyTo(buffer.AsSpan(FrameHeaderBytes));
+            return new ReadOnlySequence<byte>(buffer);
+        }
+
+        private static AkkaByteOrder ToAkkaByteOrder(DotNettyByteOrder byteOrder)
+        {
+            return byteOrder == DotNettyByteOrder.LittleEndian ? AkkaByteOrder.LittleEndian : AkkaByteOrder.BigEndian;
+        }
+
+        private void TrackConnection(StreamAssociationHandle handle, Task<Done> inboundDone)
+        {
+            _connections.TryAdd(handle, handle);
+            inboundDone.ContinueWith(task =>
+            {
+                RemoveConnection(handle);
+                if (task.IsFaulted)
+                    handle.NotifyError(task.Exception?.GetBaseException() ?? task.Exception, "Stream TCP connection failed");
+                handle.NotifyDisassociated(DisassociateInfo.Unknown);
+            }, TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        private void RemoveConnection(StreamAssociationHandle handle)
+        {
+            _connections.TryRemove(handle, out _);
+        }
+
+        private sealed class StreamAssociationHandle : AssociationHandle
+        {
+            private readonly Action<StreamAssociationHandle> _remove;
+            private readonly ILoggingAdapter _log;
+            private readonly object _gate = new();
+            private readonly System.Collections.Generic.Queue<IHandleEvent> _pending = new();
+            private volatile bool _closed;
+            private IHandleEventListener _listener;
+
+            public StreamAssociationHandle(
+                Address localAddress,
+                Address remoteAddress,
+                IActorRef writer,
+                Action<StreamAssociationHandle> remove,
+                ILoggingAdapter log) : base(localAddress, remoteAddress)
+            {
+                Writer = writer;
+                _remove = remove;
+                _log = log;
+                ReadHandlerSource.Task.ContinueWith(task =>
+                {
+                    if (task.IsFaulted || task.IsCanceled)
+                        return;
+
+                    lock (_gate)
+                    {
+                        _listener = task.Result;
+                        while (_pending.Count > 0)
+                            _listener.Notify(_pending.Dequeue());
+                    }
+                }, TaskContinuationOptions.ExecuteSynchronously);
+            }
+
+            public IActorRef Writer { get; }
+
+            public override bool Write(ByteString payload)
+            {
+                if (_closed)
+                    return false;
+
+                Writer.Tell(new ReadOnlySequence<byte>(payload.Memory));
+                return true;
+            }
+
+            public override void Disassociate()
+            {
+                if (_closed)
+                    return;
+
+                _closed = true;
+                Writer.Tell(new Status.Success(NotUsed.Instance));
+                _remove(this);
+            }
+
+            public void NotifyInbound(ReadOnlySequence<byte> payload)
+            {
+                Notify(new InboundPayload(ByteString.CopyFrom(payload.ToArray())));
+            }
+
+            public void NotifyDisassociated(DisassociateInfo info)
+            {
+                _closed = true;
+                Notify(new Disassociated(info));
+            }
+
+            public void NotifyError(Exception cause, string message)
+            {
+                if (cause != null)
+                    _log.Debug(cause, "{0} between local [{1}] and remote [{2}]", message, LocalAddress, RemoteAddress);
+                Notify(new UnderlyingTransportError(cause, message));
+            }
+
+            private void Notify(IHandleEvent ev)
+            {
+                lock (_gate)
+                {
+                    if (_listener != null)
+                    {
+                        _listener.Notify(ev);
+                    }
+                    else
+                    {
+                        _pending.Enqueue(ev);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
@@ -343,7 +343,7 @@ namespace Akka.Remote.Transport.Streams
 
             public void NotifyInbound(ReadOnlySequence<byte> payload)
             {
-                Notify(new InboundPayload(ToByteString(payload)));
+                Notify(new InboundSequencePayload(payload));
             }
 
             public void NotifyInbound(ByteString payload)

--- a/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
@@ -39,6 +39,7 @@ namespace Akka.Remote.Transport.Streams
         private readonly ConcurrentDictionary<StreamAssociationHandle, StreamAssociationHandle> _connections = new();
         private readonly ILoggingAdapter _log;
         private readonly ActorMaterializer _materializer;
+        private readonly int _writeBufferSize;
 
         private StreamTcp.ServerBinding? _binding;
         private volatile bool _shutdown;
@@ -56,6 +57,9 @@ namespace Akka.Remote.Transport.Streams
             SchemeIdentifier = Settings.TransportMode.ToString().ToLowerInvariant();
             _log = Logging.GetLogger(system, GetType());
             _materializer = ActorMaterializer.Create(system);
+            _writeBufferSize = Math.Max(1, config.HasPath("stream-write-buffer-size")
+                ? config.GetInt("stream-write-buffer-size")
+                : 65536);
         }
 
         public DotNettyTransportSettings Settings { get; }
@@ -100,8 +104,9 @@ namespace Akka.Remote.Transport.Streams
 
             var remoteEndpoint = DotNettyTransport.AddressToSocketAddress(remoteAddress);
             StreamAssociationHandle handle = null;
+            var inboundBridge = new DeferredInboundBridge();
 
-            var sink = DecodeFrames().ToMaterialized(Sink.ForEach<ReadOnlySequence<byte>>(frame => handle?.NotifyInbound(frame)), Keep.Right);
+            var sink = DecodeFrames().ToMaterialized(Sink.ForEach<ReadOnlySequence<byte>>(inboundBridge.NotifyInbound), Keep.Right);
             var source = CreateOutboundSource();
             var tcpFlow = System.TcpStream().OutgoingConnection(
                 remoteEndpoint,
@@ -128,6 +133,7 @@ namespace Akka.Remote.Transport.Streams
                     RemoveConnection,
                     _log);
                 TrackConnection(handle, inboundDone);
+                inboundBridge.SetHandle(handle);
                 return handle;
             }
             catch (Exception ex)
@@ -161,7 +167,8 @@ namespace Akka.Remote.Transport.Streams
                     return;
 
                 StreamAssociationHandle handle = null;
-                var sink = DecodeFrames().ToMaterialized(Sink.ForEach<ReadOnlySequence<byte>>(frame => handle?.NotifyInbound(frame)), Keep.Right);
+                var inboundBridge = new DeferredInboundBridge();
+                var sink = DecodeFrames().ToMaterialized(Sink.ForEach<ReadOnlySequence<byte>>(inboundBridge.NotifyInbound), Keep.Right);
                 var source = CreateOutboundSource();
                 var flow = Flow.FromSinkAndSource(sink, source, Keep.Both);
                 var (inboundDone, writer) = connection.HandleWith(flow, _materializer);
@@ -184,13 +191,14 @@ namespace Akka.Remote.Transport.Streams
 
                 handle = new StreamAssociationHandle(localAddress, remoteAddress, writer, RemoveConnection, _log);
                 TrackConnection(handle, inboundDone);
+                inboundBridge.SetHandle(handle);
                 listenerTask.Result.Notify(new InboundAssociation(handle));
             }, TaskContinuationOptions.ExecuteSynchronously);
         }
 
         private Source<ReadOnlySequence<byte>, IActorRef> CreateOutboundSource()
         {
-            return Source.ActorRef<ReadOnlySequence<byte>>(128, OverflowStrategy.Fail)
+            return Source.ActorRef<ReadOnlySequence<byte>>(_writeBufferSize, OverflowStrategy.Fail)
                 .Select(EncodeFrame);
         }
 
@@ -234,6 +242,39 @@ namespace Akka.Remote.Transport.Streams
         private void RemoveConnection(StreamAssociationHandle handle)
         {
             _connections.TryRemove(handle, out _);
+        }
+
+        private sealed class DeferredInboundBridge
+        {
+            private readonly object _gate = new();
+            private readonly System.Collections.Generic.Queue<ByteString> _pending = new();
+            private StreamAssociationHandle _handle;
+
+            public void NotifyInbound(ReadOnlySequence<byte> payload)
+            {
+                var bytes = ByteString.CopyFrom(payload.ToArray());
+                lock (_gate)
+                {
+                    if (_handle != null)
+                    {
+                        _handle.NotifyInbound(bytes);
+                    }
+                    else
+                    {
+                        _pending.Enqueue(bytes);
+                    }
+                }
+            }
+
+            public void SetHandle(StreamAssociationHandle handle)
+            {
+                lock (_gate)
+                {
+                    _handle = handle;
+                    while (_pending.Count > 0)
+                        _handle.NotifyInbound(_pending.Dequeue());
+                }
+            }
         }
 
         private sealed class StreamAssociationHandle : AssociationHandle
@@ -293,6 +334,11 @@ namespace Akka.Remote.Transport.Streams
             public void NotifyInbound(ReadOnlySequence<byte> payload)
             {
                 Notify(new InboundPayload(ByteString.CopyFrom(payload.ToArray())));
+            }
+
+            public void NotifyInbound(ByteString payload)
+            {
+                Notify(new InboundPayload(payload));
             }
 
             public void NotifyDisassociated(DisassociateInfo info)

--- a/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
+++ b/src/core/Akka.Remote/Transport/Streams/TcpStreamTransport.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Buffers;
-using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Net;
@@ -18,9 +17,7 @@ using Akka.Event;
 using Akka.Remote.Transport.DotNetty;
 using Akka.Streams;
 using Akka.Streams.Dsl;
-using Akka.Util.Internal;
 using Google.Protobuf;
-using AkkaByteOrder = Akka.Util.ByteOrder;
 using DotNettyByteOrder = DotNetty.Buffers.ByteOrder;
 using StreamTcp = Akka.Streams.Dsl.Tcp;
 
@@ -33,8 +30,6 @@ namespace Akka.Remote.Transport.Streams
     /// </summary>
     internal sealed class TcpStreamTransport : Transport
     {
-        private const int FrameHeaderBytes = 4;
-
         private readonly TaskCompletionSource<IAssociationEventListener> _associationListenerPromise = new();
         private readonly ConcurrentDictionary<StreamAssociationHandle, StreamAssociationHandle> _connections = new();
         private readonly ILoggingAdapter _log;
@@ -130,6 +125,8 @@ namespace Akka.Remote.Transport.Streams
                     localAddress ?? throw new ConfigurationException($"Unknown local address type [{connection.LocalAddress}]"),
                     remoteAddress,
                     writer,
+                    Settings.MaxFrameSize,
+                    Settings.ByteOrder,
                     RemoveConnection,
                     _log);
                 TrackConnection(handle, inboundDone);
@@ -189,7 +186,7 @@ namespace Akka.Remote.Transport.Streams
                     return;
                 }
 
-                handle = new StreamAssociationHandle(localAddress, remoteAddress, writer, RemoveConnection, _log);
+                handle = new StreamAssociationHandle(localAddress, remoteAddress, writer, Settings.MaxFrameSize, Settings.ByteOrder, RemoveConnection, _log);
                 TrackConnection(handle, inboundDone);
                 inboundBridge.SetHandle(handle);
                 listenerTask.Result.Notify(new InboundAssociation(handle));
@@ -198,46 +195,12 @@ namespace Akka.Remote.Transport.Streams
 
         private Source<ReadOnlySequence<byte>, IActorRef> CreateOutboundSource()
         {
-            return Source.ActorRef<ReadOnlySequence<byte>>(_writeBufferSize, OverflowStrategy.Fail)
-                .Select(EncodeFrame);
+            return Source.ActorRef<ReadOnlySequence<byte>>(_writeBufferSize, OverflowStrategy.Fail);
         }
 
         private Flow<ReadOnlySequence<byte>, ReadOnlySequence<byte>, NotUsed> DecodeFrames()
         {
-            return Framing.LengthField(FrameHeaderBytes, Settings.MaxFrameSize + FrameHeaderBytes, 0, ToAkkaByteOrder(Settings.ByteOrder))
-                .Select(frame => frame.Slice(FrameHeaderBytes));
-        }
-
-        private ReadOnlySequence<byte> EncodeFrame(ReadOnlySequence<byte> payload)
-        {
-            if (payload.Length > Settings.MaxFrameSize)
-                throw new Framing.FramingException($"Remote frame size [{payload.Length}] exceeds maximum frame size [{Settings.MaxFrameSize}]");
-
-            var header = new byte[FrameHeaderBytes];
-            if (Settings.ByteOrder == DotNettyByteOrder.LittleEndian)
-                BinaryPrimitives.WriteInt32LittleEndian(header, (int)payload.Length);
-            else
-                BinaryPrimitives.WriteInt32BigEndian(header, (int)payload.Length);
-
-            return PrependHeader(header, payload);
-        }
-
-        private static ReadOnlySequence<byte> PrependHeader(byte[] header, ReadOnlySequence<byte> payload)
-        {
-            if (payload.IsEmpty)
-                return new ReadOnlySequence<byte>(header);
-
-            var head = new FrameSegment(header);
-            var tail = head;
-            foreach (var segment in payload)
-                tail = tail.Append(segment);
-
-            return new ReadOnlySequence<byte>(head, 0, tail, tail.Memory.Length);
-        }
-
-        private static AkkaByteOrder ToAkkaByteOrder(DotNettyByteOrder byteOrder)
-        {
-            return byteOrder == DotNettyByteOrder.LittleEndian ? AkkaByteOrder.LittleEndian : AkkaByteOrder.BigEndian;
+            return RemoteTcpFraming.Decoder(Settings.MaxFrameSize, Settings.ByteOrder);
         }
 
         private void TrackConnection(StreamAssociationHandle handle, Task<Done> inboundDone)
@@ -262,24 +225,6 @@ namespace Akka.Remote.Transport.Streams
             return payload.IsSingleSegment
                 ? ByteString.CopyFrom(payload.FirstSpan)
                 : ByteString.CopyFrom(payload.ToArray());
-        }
-
-        private sealed class FrameSegment : ReadOnlySequenceSegment<byte>
-        {
-            public FrameSegment(ReadOnlyMemory<byte> memory)
-            {
-                Memory = memory;
-            }
-
-            public FrameSegment Append(ReadOnlyMemory<byte> memory)
-            {
-                var next = new FrameSegment(memory)
-                {
-                    RunningIndex = RunningIndex + Memory.Length
-                };
-                Next = next;
-                return next;
-            }
         }
 
         private sealed class DeferredInboundBridge
@@ -319,6 +264,8 @@ namespace Akka.Remote.Transport.Streams
         {
             private readonly Action<StreamAssociationHandle> _remove;
             private readonly ILoggingAdapter _log;
+            private readonly int _maxFrameSize;
+            private readonly DotNettyByteOrder _byteOrder;
             private readonly object _gate = new();
             private readonly System.Collections.Generic.Queue<IHandleEvent> _pending = new();
             private volatile bool _closed;
@@ -328,10 +275,14 @@ namespace Akka.Remote.Transport.Streams
                 Address localAddress,
                 Address remoteAddress,
                 IActorRef writer,
+                int maxFrameSize,
+                DotNettyByteOrder byteOrder,
                 Action<StreamAssociationHandle> remove,
                 ILoggingAdapter log) : base(localAddress, remoteAddress)
             {
                 Writer = writer;
+                _maxFrameSize = maxFrameSize;
+                _byteOrder = byteOrder;
                 _remove = remove;
                 _log = log;
                 ReadHandlerSource.Task.ContinueWith(task =>
@@ -355,7 +306,16 @@ namespace Akka.Remote.Transport.Streams
                 if (_closed)
                     return false;
 
-                Writer.Tell(new ReadOnlySequence<byte>(payload.Memory));
+                try
+                {
+                    Writer.Tell(RemoteTcpFraming.Encode(new ReadOnlySequence<byte>(payload.Memory), _maxFrameSize, _byteOrder));
+                }
+                catch (Exception ex)
+                {
+                    Writer.Tell(new Status.Failure(ex));
+                    return false;
+                }
+
                 return true;
             }
 

--- a/src/core/Akka.Remote/Transport/Transport.cs
+++ b/src/core/Akka.Remote/Transport/Transport.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Buffers;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -138,6 +139,25 @@ namespace Akka.Remote.Transport
         public override string ToString()
         {
             return $"InboundPayload(size = {Payload.Length} bytes)";
+        }
+    }
+
+    /// <summary>
+    /// Message sent to the internal Akka protocol listener when the underlying transport can expose
+    /// the encoded PDU as a <see cref="ReadOnlySequence{T}"/> without first materializing a <see cref="ByteString"/>.
+    /// </summary>
+    internal sealed class InboundSequencePayload : IHandleEvent
+    {
+        public InboundSequencePayload(ReadOnlySequence<byte> payload)
+        {
+            Payload = payload;
+        }
+
+        public ReadOnlySequence<byte> Payload { get; }
+
+        public override string ToString()
+        {
+            return $"InboundSequencePayload(size = {Payload.Length} bytes)";
         }
     }
 
@@ -429,4 +449,3 @@ namespace Akka.Remote.Transport
         }
     }
 }
-

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -95,6 +95,43 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
+        public async Task Outgoing_TCP_stream_must_not_drop_writes_when_remote_reads_slowly()
+        {
+            await this.AssertAllStagesStoppedAsync(async () =>
+            {
+                const int messageCount = 2048;
+                const int payloadSize = 64;
+                var totalBytes = messageCount * payloadSize;
+                var expected = new byte[totalBytes];
+                var testInput = new List<ReadOnlySequence<byte>>(messageCount);
+
+                for (var i = 0; i < messageCount; i++)
+                {
+                    var payload = new byte[payloadSize];
+                    Array.Fill(payload, (byte)(i & 0xff));
+                    payload.CopyTo(expected, i * payloadSize);
+                    testInput.Add(new ReadOnlySequence<byte>(payload));
+                }
+
+                var server = await new Server(this).InitializeAsync();
+                Source.From(testInput)
+                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
+                    .To(Sink.Ignore<ReadOnlySequence<byte>>())
+                    .Run(Materializer);
+
+                var serverConnection = await server.WaitAcceptAsync();
+
+                // Do not resume server-side reads until the client has had time to enqueue writes.
+                await Task.Delay(250);
+
+                serverConnection.Read(totalBytes);
+                var received = await serverConnection.WaitReadAsync();
+                received.ToArray().Should().Equal(expected);
+                server.Close();
+            }, Materializer);
+        }
+
+        [Fact]
         public async Task Outgoing_TCP_stream_must_be_able_to_read_a_sequence_of_ByteStrings()
         {
             var server = await new Server(this).InitializeAsync();

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -132,6 +132,32 @@ namespace Akka.Streams.Tests.IO
         }
 
         [Fact]
+        public async Task Outgoing_TCP_stream_must_flush_small_no_ack_batch_when_upstream_completes()
+        {
+            await this.AssertAllStagesStoppedAsync(async () =>
+            {
+                var testInput = new[]
+                {
+                    new ReadOnlySequence<byte>(new byte[] { 1 }),
+                    new ReadOnlySequence<byte>(new byte[] { 2 }),
+                    new ReadOnlySequence<byte>(new byte[] { 3 })
+                };
+                var expectedOutput = new ReadOnlySequence<byte>(new byte[] { 1, 2, 3 });
+
+                var server = await new Server(this).InitializeAsync();
+                Source.From(testInput)
+                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
+                    .To(Sink.Ignore<ReadOnlySequence<byte>>())
+                    .Run(Materializer);
+
+                var serverConnection = await server.WaitAcceptAsync();
+                serverConnection.Read(3);
+                (await serverConnection.WaitReadAsync()).ToArray().SequenceEqual(expectedOutput.ToArray()).Should().BeTrue();
+                server.Close();
+            }, Materializer);
+        }
+
+        [Fact]
         public async Task Outgoing_TCP_stream_must_be_able_to_read_a_sequence_of_ByteStrings()
         {
             var server = await new Server(this).InitializeAsync();

--- a/src/core/Akka.Streams/Implementation/IO/TcpStages.cs
+++ b/src/core/Akka.Streams/Implementation/IO/TcpStages.cs
@@ -323,17 +323,6 @@ namespace Akka.Streams.Implementation.IO
     /// </summary>
     internal static class TcpConnectionStage
     {
-        private class WriteAck : Tcp.Event
-        {
-            public static readonly WriteAck Instance = new();
-
-            private WriteAck()
-            {
-
-            }
-
-        }
-
         /// <summary>
         /// TBD
         /// </summary>
@@ -468,7 +457,8 @@ namespace Akka.Streams.Implementation.IO
                     {
                         var elem = Grab(_bytesIn);
                         ReactiveStreamsCompliance.RequireNonNullElement(elem);
-                        _connection.Tell(Tcp.Write.Create(elem, WriteAck.Instance), StageActor.Ref);
+                        _connection.Tell(Tcp.Write.Create(elem), StageActor.Ref);
+                        if (!IsClosed(_bytesIn)) Pull(_bytesIn);
                     },
                     onUpstreamFinish: () =>
                     {
@@ -574,11 +564,6 @@ namespace Akka.Streams.Implementation.IO
                     case Tcp.Received received:
                         Push(_bytesOut, received.Data);
                         break;
-                    case WriteAck:
-                    {
-                        if (!IsClosed(_bytesIn)) Pull(_bytesIn);
-                        break;
-                    }
                     case Terminated:
                         FailStage(new StreamTcpException("The connection actor has terminated. Stopping now."));
                         break;

--- a/src/core/Akka.Tests/IO/TcpConnectionBatchingSpec.cs
+++ b/src/core/Akka.Tests/IO/TcpConnectionBatchingSpec.cs
@@ -190,6 +190,42 @@ namespace Akka.Tests.IO
             await ExpectTerminatedAsync(connection);
         }
 
+        [Fact]
+        public async Task TcpConnection_should_batch_no_ack_writes_before_flushing()
+        {
+            using var socketPair = await ConnectedSocketPair.CreateAsync();
+            await using var stream = new BlockingWriteStream();
+            var bindHandler = CreateTestProbe();
+            var handler = CreateTestProbe();
+            var settings = TcpSettings.Create(Sys);
+
+            var connection = Sys.ActorOf(Props.Create(() => new TcpIncomingConnection(
+                settings,
+                socketPair.Server,
+                bindHandler.Ref,
+                Array.Empty<Inet.SocketOption>(),
+                false,
+                stream)));
+
+            await bindHandler.ExpectMsgAsync<Tcp.Connected>();
+            bindHandler.Send(connection, new Tcp.Register(handler.Ref));
+
+            var writes = new Tcp.WriteCommand[8];
+            for (var i = 0; i < writes.Length; i++)
+                writes[i] = Tcp.Write.Create(new byte[32].AsMemory());
+
+            handler.Send(connection, Tcp.WriteCommand.Create(writes));
+
+            await stream.FirstWriteStarted.WaitAsync(TimeSpan.FromSeconds(3));
+            stream.WriteSizes.Should().Equal(256);
+            stream.ReleaseFirstWrite();
+
+            await WatchAsync(connection);
+            handler.Send(connection, Tcp.Abort.Instance);
+            await handler.ExpectMsgAsync<Tcp.Aborted>();
+            await ExpectTerminatedAsync(connection);
+        }
+
         private sealed class ConnectedSocketPair : IDisposable
         {
             private ConnectedSocketPair(Socket client, Socket server)

--- a/src/core/Akka/IO/TcpConnection.cs
+++ b/src/core/Akka/IO/TcpConnection.cs
@@ -143,6 +143,12 @@ namespace Akka.IO
             public TransportOperationFailed(Exception cause) { Cause = cause; }
         }
 
+        private sealed class FlushPendingWrites : INoSerializationVerificationNeeded
+        {
+            public static readonly FlushPendingWrites Instance = new();
+            private FlushPendingWrites() { }
+        }
+
         private sealed class CommanderDied : INoSerializationVerificationNeeded, IDeadLetterSuppression
         {
             public static readonly CommanderDied Instance = new();
@@ -168,6 +174,9 @@ namespace Akka.IO
         private const int ShutdownNone = 0;
         private const int ShutdownInitiated = 1;
 
+        private const int NoAckWriteFlushThreshold = 32;
+        private const int NoAckByteFlushThreshold = 64 * 1024;
+
         #endregion
 
         protected readonly TcpSettings Settings;
@@ -180,6 +189,10 @@ namespace Akka.IO
 
         // Transport connection — owns pipes, pump loops, stream
         private ITransportConnection? _transport;
+
+        // TCP transport supports non-flushing writes; other transport implementations
+        // keep the existing write-and-flush behavior.
+        private TcpTransportConnection? _batchingTransport;
 
         // CTS for pipe read cancellation
         private CancellationTokenSource? _cts;
@@ -199,6 +212,10 @@ namespace Akka.IO
         private int _pendingRegistrationBytes;
 
         private readonly Queue<WriteCommand> _pendingRegistrationWrites = new();
+
+        private int _unflushedWriteCount;
+        private long _unflushedBytes;
+        private bool _writeFlushScheduled;
 
         #region Connection state flags
         // Transient flags that survive a Become(...) and together describe where this
@@ -336,6 +353,7 @@ namespace Akka.IO
         protected void StartTransport(ITransportConnection transport)
         {
             _transport = transport;
+            _batchingTransport = transport as TcpTransportConnection;
             _cts = new CancellationTokenSource();
 
             // Monitor the read pump for completion/errors
@@ -423,6 +441,7 @@ namespace Akka.IO
         private void OpenBehaviour()
         {
             Receive<Tcp.WriteCommand>(HandleWrite);
+            Receive<FlushPendingWrites>(_ => FlushPendingWritesNow());
             Receive<CloseCommand>(c => HandleClose(Sender, c.Event));
             Receive<ReadPumpFailed>(msg => HandleReadPumpFailed(msg));
             Receive<ReadPumpCompleted>(_ => HandleReadPumpCompleted());
@@ -442,6 +461,7 @@ namespace Akka.IO
         {
             // Peer closed their write side, but we can still write
             Receive<Tcp.WriteCommand>(HandleWrite);
+            Receive<FlushPendingWrites>(_ => FlushPendingWritesNow());
             Receive<CloseCommand>(c => HandleClose(Sender, c.Event));
             Receive<ReadPumpFailed>(msg => HandleReadPumpFailed(msg));
             Receive<ReadPumpCompleted>(_ => HandleReadPumpCompleted());
@@ -468,6 +488,7 @@ namespace Akka.IO
             {
                 Sender.Tell(w.FailureMessage.WithCause(DroppingWriteBecauseClosingException));
             });
+            Receive<FlushPendingWrites>(_ => FlushPendingWritesNow());
             Receive<Abort>(c => HandleClose(Sender, c.Event));
             Receive<ReadPumpFailed>(msg =>
             {
@@ -875,16 +896,67 @@ namespace Akka.IO
             // Handle empty writes immediately
             if (byteCount == 0)
             {
+                if (write.WantsAck)
+                    FlushPendingWritesNow();
+
                 if (write.WantsAck) sender.Tell(write.Ack);
                 return;
             }
 
-            // Write directly to transport — pipe handles buffering and batching.
-            // The pipe absorbs writes into its internal buffer (memcpy, not syscall).
-            // The write pump flushes the buffer to the socket asynchronously.
-            _transport!.WriteAsync(write.Data, _cts!.Token);
+            if (write.WantsAck)
+            {
+                // Acked writes preserve the existing write-and-flush path. This also
+                // flushes any no-ack writes buffered ahead of this write.
+                _transport!.WriteAsync(write.Data, _cts!.Token);
+                ResetPendingWriteFlush();
+                sender.Tell(write.Ack);
+                return;
+            }
 
-            if (write.WantsAck) sender.Tell(write.Ack);
+            // No-ack writes are the hot path for Streams TCP. Buffer a small burst
+            // before flushing the pipe so the write pump wakes up once per batch.
+            if (_batchingTransport is null)
+            {
+                _transport!.WriteAsync(write.Data, _cts!.Token);
+                return;
+            }
+
+            _batchingTransport.WriteUnflushed(write.Data);
+            _unflushedWriteCount++;
+            _unflushedBytes += byteCount;
+
+            if (_unflushedWriteCount >= NoAckWriteFlushThreshold || _unflushedBytes >= NoAckByteFlushThreshold)
+                FlushPendingWritesNow();
+            else
+                SchedulePendingWriteFlush();
+        }
+
+        private void SchedulePendingWriteFlush()
+        {
+            if (_writeFlushScheduled)
+                return;
+
+            _writeFlushScheduled = true;
+            Self.Tell(FlushPendingWrites.Instance);
+        }
+
+        private void FlushPendingWritesNow()
+        {
+            if (_unflushedWriteCount == 0)
+            {
+                _writeFlushScheduled = false;
+                return;
+            }
+
+            _transport!.FlushAsync(_cts!.Token);
+            ResetPendingWriteFlush();
+        }
+
+        private void ResetPendingWriteFlush()
+        {
+            _unflushedWriteCount = 0;
+            _unflushedBytes = 0;
+            _writeFlushScheduled = false;
         }
 
         /* ================================================================= */
@@ -931,6 +1003,7 @@ namespace Akka.IO
         private void HandleGracefulClose(IActorRef closeSender, ConnectionClosed closeEvent)
         {
             _closingGracefully = true;
+            FlushPendingWritesNow();
 
             // Ask the transport to close (flushes writes, closes connection)
             if (_transport != null)
@@ -971,6 +1044,7 @@ namespace Akka.IO
         private void HandleConfirmedClose(IActorRef closeSender)
         {
             _closingGracefully = true;
+            FlushPendingWritesNow();
 
             // Ask the transport to shutdown (flush writes, send FIN, keep reading)
             if (_transport != null)

--- a/src/core/Akka/IO/TcpTransportConnection.cs
+++ b/src/core/Akka/IO/TcpTransportConnection.cs
@@ -79,22 +79,30 @@ namespace Akka.IO
         private bool _hasReadError;
         private Exception? _readError;
 
-        public ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        internal void WriteUnflushed(ReadOnlyMemory<byte> data)
         {
-            var writer = _outputPipe.Writer;
-            writer.Write(data.Span);
-            return writer.FlushAsync(ct);
+            _outputPipe.Writer.Write(data.Span);
         }
 
-        public ValueTask<FlushResult> WriteAsync(ReadOnlySequence<byte> data, CancellationToken ct = default)
+        internal void WriteUnflushed(ReadOnlySequence<byte> data)
         {
             var writer = _outputPipe.Writer;
             foreach (var segment in data)
             {
                 writer.Write(segment.Span);
             }
+        }
 
-            return writer.FlushAsync(ct);
+        public ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        {
+            WriteUnflushed(data);
+            return FlushAsync(ct);
+        }
+
+        public ValueTask<FlushResult> WriteAsync(ReadOnlySequence<byte> data, CancellationToken ct = default)
+        {
+            WriteUnflushed(data);
+            return FlushAsync(ct);
         }
 
         public ValueTask<FlushResult> FlushAsync(CancellationToken ct = default)


### PR DESCRIPTION
## Summary
- add OpenSpec proposal for a wire-compatible Remote protocol pipeline over Akka.Streams / Akka.IO.Tcp
- define requirements for sequence/writer PDU codec APIs, SerializerV2 payload boundaries, protocol-state preservation, and benchmark gates
- add implementation tasks for baseline measurement, wire-format fixtures, codec reshaping, SerializerV2 integration, and stream pipeline validation

## Validation
- openspec validate remote-streams-protocol-pipeline --strict
- git diff --check