### PR TITLE
Fix CI restore: bump MessagePack to 3.1.7 (CVE-2026-48109) and pin FSharp.Core in Akka.FSharp.Tests

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
     <ProtobufVersion>3.35.0</ProtobufVersion>
     <GrpcToolsVersion>2.81.0</GrpcToolsVersion>
     <BenchmarkDotNetVersion>0.15.8</BenchmarkDotNetVersion>
-    <MessagePackVersion>3.1.4</MessagePackVersion>
+    <MessagePackVersion>3.1.7</MessagePackVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.13.0</MicrosoftCodeAnalysisCSharpVersion>
     <NetTestVersion>net10.0</NetTestVersion>
     <FsharpVersion>10.1.301</FsharpVersion>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 **Placeholder for nightly build**
 
 * Core: Add `ILoggingAdapter` context enrichment, explicit scopes, and bracketed context output in StandardOutLogger and Xunit logger
+* Build: Bump `MessagePack` to 3.1.7 to address [CVE-2026-48109](https://github.com/advisories/GHSA-hv8m-jj95-wg3x) (LZ4 decompression out-of-bounds read)
 
 #### 1.5.47 August 12th, 2025 ####
 

--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -28,6 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Bump the SDK-implicit FSharp.Core to match the version pulled in transitively via
+         Akka.Tests.Shared.Internals.Xunit3, otherwise it downgrades and NU1605 fails the restore.
+         Use Update (not Include) so we don't duplicate the implicit reference (NU1504). -->
+    <PackageReference Update="FSharp.Core" Version="$(FsharpVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />


### PR DESCRIPTION
## Problem

`dotnet restore` is currently failing on `dev` with warnings-as-errors, which red-lines CI on **every open PR** (the build dies before any project compiles). Two unrelated dependency issues:

1. **`NU1903`** — `MessagePack` 3.1.4 has a published high-severity advisory ([CVE-2026-48109](https://github.com/advisories/GHSA-hv8m-jj95-wg3x), out-of-bounds read in LZ4 decompression). Affected range is `>= 3.0.214-rc.1, < 3.1.7`; the version was pinned before the advisory was published, so audit now fails the restore for every MessagePack consumer (`Akka.Serialization.V2`, `Akka.Benchmarks`, …).
2. **`NU1605`** — `Akka.FSharp.Tests` resolves the SDK-implicit `FSharp.Core` (10.0.x), which **downgrades** the `10.1.301` it pulls transitively via `Akka.Tests.Shared.Internals.Xunit3` (the FSharp.Core bump from #8247).

## Fix

- Bump `MessagePackVersion` 3.1.4 → **3.1.7** (the patched v3 release) in `Directory.Build.props`.
- In `Akka.FSharp.Tests.fsproj`, use `<PackageReference Update="FSharp.Core" Version="$(FsharpVersion)" />` to raise the implicit FSharp.Core to match the transitive `10.1.301`. `Update` (not `Include`) avoids duplicating the SDK-implicit reference, which would trip `NU1504`.

## Verification

- Full-solution `dotnet restore Akka.slnx` — clean, no `NU1903` / `NU1605` / `NU1504`.
- `Akka.FSharp.Tests` builds against FSharp.Core 10.1.301 — 0 warnings, 0 errors.

This unblocks #8248 and all other open PRs once merged into `dev`.
