### PR TITLE
Propagate trace context through Source.ActorRef

### DIFF
--- a/src/core/Akka.Streams.Tests/Implementation/Streams8243Spec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/Streams8243Spec.cs
@@ -8,6 +8,7 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Akka.Actor;
 using Akka.Streams.Dsl;
 using Akka.TestKit;
 using FluentAssertions;
@@ -122,6 +123,46 @@ namespace Akka.Streams.Tests.Implementation
             preBoundarySelect.TraceId.ToString().Should().Be(producerTraceId);
 
             (await done).Should().Equal(22);
+        }
+
+        [Fact]
+        public async Task Trace_context_should_cross_Source_ActorRef_ingress_boundary()
+        {
+            using var collector = new StreamsActivityCollector();
+            using var producers = new ProducerActivityScope("ProducerTest");
+
+            // Source.ActorRef enters the graph through the public Reactive Streams
+            // BoundarySubscriber.OnNext path. It needs to capture Activity.Current at Tell time
+            // and carry it through the same boundary-event context channel used by .Async().
+            var (actorRef, done) = Source.ActorRef<int>(8, OverflowStrategy.Fail)
+                .Select(i => i + 1)
+                .ToMaterialized(Sink.Seq<int>(), Keep.Both)
+                .Run(_materializer);
+
+            ActivityTraceId producerTraceId;
+            using (var producer = producers.Start("producer.tell"))
+            {
+                producerTraceId = producer.TraceId;
+                actorRef.Tell(41);
+            }
+
+            actorRef.Tell(new Status.Success(NotUsed.Instance));
+            (await done).Should().Equal(42);
+
+            await collector.WaitForSpansAsync(
+                atLeast: 1,
+                timeoutSeconds: 10,
+                predicate: snap => snap.Any(a =>
+                    a.OperationName.Contains("SeqStage") && a.TraceId == producerTraceId));
+
+            var spans = collector.StoppedActivities.ToArray();
+            foreach (var a in spans)
+                Output.WriteLine($"[span] op='{a.OperationName}' trace={a.TraceId} parent={a.ParentSpanId}");
+
+            spans.Should().Contain(a => a.OperationName.Contains("Select") && a.TraceId == producerTraceId,
+                "the Select stage downstream of Source.ActorRef must share the producer trace id");
+            spans.Should().Contain(a => a.OperationName.Contains("SeqStage") && a.TraceId == producerTraceId,
+                "the terminal sink downstream of Source.ActorRef must share the producer trace id");
         }
 
         private (Task<System.Collections.Immutable.IImmutableList<int>> done, TracedConsumeSource source) MaterializeAsyncBoundary(

--- a/src/core/Akka.Streams/Implementation/ActorRefSourceActor.cs
+++ b/src/core/Akka.Streams/Implementation/ActorRefSourceActor.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using Akka.Actor;
 using Akka.Event;
 using Akka.Streams.Actors;
@@ -19,6 +20,30 @@ namespace Akka.Streams.Implementation
     /// <typeparam name="T">TBD</typeparam>
     internal class ActorRefSourceActor<T> : Actors.ActorPublisher<T>
     {
+        internal readonly struct TracedMessage
+        {
+            public TracedMessage(T message, ActivityContext context)
+            {
+                Message = message;
+                Context = context;
+            }
+
+            public T Message { get; }
+            public ActivityContext Context { get; }
+        }
+
+        private readonly struct BufferedMessage
+        {
+            public BufferedMessage(T message, ActivityContext? context)
+            {
+                Message = message;
+                Context = context;
+            }
+
+            public T Message { get; }
+            public ActivityContext? Context { get; }
+        }
+
         /// <summary>
         /// TBD
         /// </summary>
@@ -41,7 +66,7 @@ namespace Akka.Streams.Implementation
         /// <summary>
         /// TBD
         /// </summary>
-        protected readonly IBuffer<T>? Buffer;
+        private readonly IBuffer<BufferedMessage>? _buffer;
 
         /// <summary>
         /// TBD
@@ -63,7 +88,7 @@ namespace Akka.Streams.Implementation
         {
             BufferSize = bufferSize;
             OverflowStrategy = overflowStrategy;
-            Buffer = bufferSize > 0 ? Implementation.Buffer.Create<T>(bufferSize, maxFixedBufferSize) : null;
+            _buffer = bufferSize > 0 ? Implementation.Buffer.Create<BufferedMessage>(bufferSize, maxFixedBufferSize) : null;
         }
 
         /// <summary>
@@ -77,7 +102,7 @@ namespace Akka.Streams.Implementation
         /// <param name="message">TBD</param>
         /// <returns>TBD</returns>
         protected override bool Receive(object message)
-            => DefaultReceive(message) || RequestElement(message) || (message is T message1 && ReceiveElement(message1));
+            => DefaultReceive(message) || RequestElement(message) || ReceiveTracedElement(message) || (message is T message1 && ReceiveElement(message1, null));
 
         /// <summary>
         /// TBD
@@ -90,7 +115,7 @@ namespace Akka.Streams.Implementation
                 Context.Stop(Self);
             else if (message is Status.Success)
             {
-                if (Buffer is null || Buffer.IsEmpty)
+                if (_buffer is null || _buffer.IsEmpty)
                     OnCompleteThenStop(); // will complete the stream successfully
                 else
                     Context.Become(DrainBufferThenComplete);
@@ -112,9 +137,9 @@ namespace Akka.Streams.Implementation
             if (message is Request)
             {
                 // totalDemand is tracked by base
-                if (Buffer is not null)
-                    while (TotalDemand > 0L && !Buffer.IsEmpty)
-                        OnNext(Buffer.Dequeue());
+                if (_buffer is not null)
+                    while (TotalDemand > 0L && !_buffer.IsEmpty)
+                        PushElement(_buffer.Dequeue());
 
                 return true;
             }
@@ -122,39 +147,49 @@ namespace Akka.Streams.Implementation
             return false;
         }
 
+        private bool ReceiveTracedElement(object message)
+        {
+            if (message is TracedMessage tracedMessage)
+                return ReceiveElement(tracedMessage.Message, tracedMessage.Context);
+            return false;
+        }
+
         /// <summary>
         /// TBD
         /// </summary>
         /// <param name="message">TBD</param>
+        /// <param name="context">TBD</param>
         /// <returns>TBD</returns>
-        protected virtual bool ReceiveElement(T message)
+        protected virtual bool ReceiveElement(T message, ActivityContext? context)
         {
             if (IsActive)
             {
                 if (TotalDemand > 0L)
-                    OnNext(message);
-                else if (Buffer is null)
+                    PushElement(message, context);
+                else if (_buffer is null)
                     Log.Debug("Dropping element because there is no downstream demand: [{0}]", message);
-                else if (!Buffer.IsFull)
-                    Buffer.Enqueue(message);
+                else if (!_buffer.IsFull)
+                {
+                    _buffer.Enqueue(new BufferedMessage(message, context));
+                }
                 else
                 {
                     switch (OverflowStrategy)
                     {
                         case OverflowStrategy.DropHead:
                             Log.Debug("Dropping the head element because buffer is full and overflowStrategy is: [DropHead]");
-                            Buffer.DropHead();
-                            Buffer.Enqueue(message);
+                            _buffer.DropHead();
+                            _buffer.Enqueue(new BufferedMessage(message, context));
                             break;
                         case OverflowStrategy.DropTail:
                             Log.Debug("Dropping the tail element because buffer is full and overflowStrategy is: [DropTail]");
-                            Buffer.DropTail();
-                            Buffer.Enqueue(message);
+                            _buffer.DropTail();
+                            _buffer.Enqueue(new BufferedMessage(message, context));
                             break;
                         case OverflowStrategy.DropBuffer:
                             Log.Debug("Dropping all the buffered elements because buffer is full and overflowStrategy is: [DropBuffer]");
-                            Buffer.Clear();
-                            Buffer.Enqueue(message);
+                            _buffer.Clear();
+                            _buffer.Enqueue(new BufferedMessage(message, context));
                             break;
                         case OverflowStrategy.DropNew:
                             // do not enqueue new element if the buffer is full
@@ -189,23 +224,42 @@ namespace Akka.Streams.Implementation
                 // even if previously valid completion was requested via Status.Success
                 OnErrorThenStop(failure.Cause);
             }
-            else if (message is Request && Buffer is not null)
+            else if (message is Request && _buffer is not null)
             {
                 // totalDemand is tracked by base
-                while (TotalDemand > 0L && !Buffer.IsEmpty)
-                    OnNext(Buffer.Dequeue());
+                while (TotalDemand > 0L && !_buffer.IsEmpty)
+                    PushElement(_buffer.Dequeue());
 
-                if (Buffer.IsEmpty)
+                if (_buffer.IsEmpty)
                     OnCompleteThenStop(); // will complete the stream successfully
             }
             else if (IsActive)
                 Log.Debug(
                     "Dropping element because Status.Success received already, only draining already buffered elements: [{0}] (pending: [{1}])",
-                    message, Buffer?.Used ?? 0);
+                    message, _buffer?.Used ?? 0);
             else
                 return false;
 
             return true;
+        }
+
+        private void PushElement(BufferedMessage element)
+            => PushElement(element.Message, element.Context);
+
+        private void PushElement(T element, ActivityContext? context)
+        {
+            if (context.HasValue && StreamsDiagnostics.ActivitySource.HasListeners())
+            {
+                using var activity = StreamsDiagnostics.ActivitySource.StartActivity(
+                    StreamsDiagnostics.OperationIngress,
+                    ActivityKind.Internal,
+                    context.Value);
+                OnNext(element);
+            }
+            else
+            {
+                OnNext(element);
+            }
         }
     }
 }

--- a/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
+++ b/src/core/Akka.Streams/Implementation/Fusing/ActorGraphInterpreter.cs
@@ -905,7 +905,12 @@ namespace Akka.Streams.Implementation.Fusing
             public void OnNext(T element)
             {
                 ReactiveStreamsCompliance.RequireNonNullElement(element);
-                _parent.Tell(new OnNext(_shell, _id, element));
+                var context = StreamsDiagnostics.ActivitySource.HasListeners()
+                    ? Activity.Current?.Context
+                    : null;
+                _parent.Tell(context.HasValue
+                    ? new OnNext(_shell, _id, element, context)
+                    : new OnNext(_shell, _id, element));
             }
 
             /// <summary>

--- a/src/core/Akka.Streams/Implementation/Modules.cs
+++ b/src/core/Akka.Streams/Implementation/Modules.cs
@@ -6,9 +6,12 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Annotations;
+using Akka.Dispatch.SysMsg;
 using Akka.Streams.Actors;
 using Reactive.Streams;
 
@@ -415,8 +418,58 @@ namespace Akka.Streams.Implementation
         public override IPublisher<TOut> Create(MaterializationContext context, out IActorRef materializer)
         {
             var mat = ActorMaterializerHelper.Downcast(context.Materializer);
-            materializer = mat.ActorOf(context, ActorRefSourceActor<TOut>.Props(_bufferSize, _overflowStrategy, mat.Settings));
-            return new ActorPublisherImpl<TOut>(materializer);
+            var sourceActor = mat.ActorOf(context, ActorRefSourceActor<TOut>.Props(_bufferSize, _overflowStrategy, mat.Settings));
+            materializer = new TraceCapturingActorRef((IInternalActorRef)sourceActor);
+            return new ActorPublisherImpl<TOut>(sourceActor);
+        }
+
+        private sealed class TraceCapturingActorRef : InternalActorRefBase
+        {
+            private readonly IInternalActorRef _underlying;
+
+            public TraceCapturingActorRef(IInternalActorRef underlying)
+            {
+                _underlying = underlying;
+            }
+
+            public override ActorPath Path => _underlying.Path;
+            public override IInternalActorRef Parent => _underlying.Parent;
+            public override IActorRefProvider Provider => _underlying.Provider;
+            public override bool IsLocal => _underlying.IsLocal;
+
+            [Obsolete("Use Context.Watch and Receive<Terminated> [1.1.0]")]
+#pragma warning disable CS0809
+            public override bool IsTerminated => _underlying.IsTerminated;
+#pragma warning restore CS0809
+
+            public override IActorRef GetChild(IReadOnlyList<string> name) => _underlying.GetChild(name);
+            public override void Resume(Exception causedByFailure = null) => _underlying.Resume(causedByFailure);
+            public override void Start() => _underlying.Start();
+            public override void Stop() => _underlying.Stop();
+            public override void Restart(Exception cause) => _underlying.Restart(cause);
+            public override void Suspend() => _underlying.Suspend();
+            public override void SendSystemMessage(ISystemMessage message) => _underlying.SendSystemMessage(message);
+
+            protected override void TellInternal(object message, IActorRef sender)
+            {
+                if (ShouldCaptureContext(message))
+                {
+                    var context = Activity.Current?.Context;
+                    if (context.HasValue)
+                    {
+                        _underlying.Tell(new ActorRefSourceActor<TOut>.TracedMessage((TOut)message, context.Value), sender);
+                        return;
+                    }
+                }
+
+                _underlying.Tell(message, sender);
+            }
+
+            private static bool ShouldCaptureContext(object message)
+                => StreamsDiagnostics.ActivitySource.HasListeners()
+                   && message is TOut
+                   && message is not Status
+                   && message is not Actors.Cancel;
         }
     }
 }


### PR DESCRIPTION
## Summary
- capture Activity.Current at Source.ActorRef Tell time before the actor mailbox hop
- carry captured trace context through Source.ActorRef buffering and boundary OnNext
- add a regression test for Source.ActorRef ingress trace propagation

Refs #8243

## Validation
- dotnet test "src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj" -c Release --filter "FullyQualifiedName~ActorRefSourceSpec"
- dotnet test "src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj" -c Release --no-build --filter "FullyQualifiedName~Streams8241Spec|FullyQualifiedName~Streams8243Spec|FullyQualifiedName~StreamsRegressionSpec|FullyQualifiedName~ActorRefSourceSpec"
- dotnet build "src/core/Akka.Streams/Akka.Streams.csproj" -c Release
- git diff --check