### PR TITLE
Akka.Streams: add cancellation-aware Source.Queue offers (#8248) — backport to v1.5

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -636,6 +636,8 @@ Akka.NET v1.5.48 is a minor patch containing stability improvement to Akka.TestK
 To [see the full set of changes in Akka.NET v1.5.48, click here](https://github.com/akkadotnet/akka.net/milestone/131?closed=1)
 
 * Core: Add `ILoggingAdapter` context enrichment, explicit scopes, and bracketed context output in StandardOutLogger and Xunit logger
+* Akka.Streams: Add cancellation-aware `Source.Queue` offers so backpressured pending offers can be canceled without later emitting the canceled element.
+* Build: Bump `MessagePack` to 3.1.7 to address [CVE-2026-48109](https://github.com/advisories/GHSA-hv8m-jj95-wg3x) (LZ4 decompression out-of-bounds read)
 
 #### 1.5.47 August 12th, 2025 ####
 

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.DotNet.verified.txt
@@ -724,6 +724,7 @@ namespace Akka.Streams
     public interface ISourceQueue<in T>
     {
         System.Threading.Tasks.Task<Akka.Streams.IQueueOfferResult> OfferAsync(T element);
+        System.Threading.Tasks.Task<Akka.Streams.IQueueOfferResult> OfferAsync(T element, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task WatchCompletionAsync();
     }
     public interface ISourceRef<TOut> : Akka.Util.ISurrogated
@@ -3572,6 +3573,7 @@ namespace Akka.Streams.Implementation
             public void Complete() { }
             public void Fail(System.Exception ex) { }
             public System.Threading.Tasks.Task<Akka.Streams.IQueueOfferResult> OfferAsync(TOut element) { }
+            public System.Threading.Tasks.Task<Akka.Streams.IQueueOfferResult> OfferAsync(TOut element, System.Threading.CancellationToken cancellationToken) { }
             public System.Threading.Tasks.Task WatchCompletionAsync() { }
         }
     }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveStreams.Net.verified.txt
@@ -723,6 +723,7 @@ namespace Akka.Streams
     public interface ISourceQueue<in T>
     {
         System.Threading.Tasks.Task<Akka.Streams.IQueueOfferResult> OfferAsync(T element);
+        System.Threading.Tasks.Task<Akka.Streams.IQueueOfferResult> OfferAsync(T element, System.Threading.CancellationToken cancellationToken);
         System.Threading.Tasks.Task WatchCompletionAsync();
     }
     public interface ISourceRef<TOut> : Akka.Util.ISurrogated
@@ -3557,6 +3558,7 @@ namespace Akka.Streams.Implementation
             public void Complete() { }
             public void Fail(System.Exception ex) { }
             public System.Threading.Tasks.Task<Akka.Streams.IQueueOfferResult> OfferAsync(TOut element) { }
+            public System.Threading.Tasks.Task<Akka.Streams.IQueueOfferResult> OfferAsync(TOut element, System.Threading.CancellationToken cancellationToken) { }
             public System.Threading.Tasks.Task WatchCompletionAsync() { }
         }
     }

--- a/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/QueueSourceSpec.cs
@@ -8,8 +8,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Pattern;
@@ -84,6 +85,17 @@ namespace Akka.Streams.Tests.Dsl
         {
             task.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
             task.Result.Should().Be(Enqueued.Instance);
+        }
+
+        private async Task AssertCanceledWithToken(Task<IQueueOfferResult> task, CancellationToken cancellationToken)
+        {
+            await AwaitAssertAsync(
+                () => task.IsCanceled.Should().BeTrue(),
+                TimeSpan.FromSeconds(3),
+                TimeSpan.FromMilliseconds(50));
+
+            var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
+            exception.CancellationToken.Should().Be(cancellationToken);
         }
 
         [Fact]
@@ -424,6 +436,234 @@ namespace Akka.Streams.Tests.Dsl
                 await ExpectMsgAsync<Enqueued>();
 
                 sub.Cancel();
+            }, _materializer);
+        }
+
+        [Fact]
+        public async Task QueueSource_should_offer_with_cancellation_token_none()
+        {
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var (source, probe) =
+                    Source.Queue<int>(0, OverflowStrategy.Backpressure)
+                        .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                        .Run(_materializer);
+                var queue = Assert.IsAssignableFrom<ISourceQueueWithComplete<int>>(source);
+
+                var offer = queue.OfferAsync(1, CancellationToken.None);
+
+                await probe.RequestNextAsync(1);
+                AssertSuccess(offer);
+
+                source.Complete();
+                await probe.ExpectCompleteAsync();
+            }, _materializer);
+        }
+
+        [Fact]
+        public async Task QueueSource_should_cancel_pending_offer_when_backpressured_buffer_is_full()
+        {
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var (source, probe) =
+                    Source.Queue<int>(1, OverflowStrategy.Backpressure)
+                        .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                        .Run(_materializer);
+
+                AssertSuccess(source.OfferAsync(1));
+
+                using var cts = new CancellationTokenSource();
+                var offer = source.OfferAsync(2, cts.Token);
+                await ExpectNoMsgAsync(_pause);
+
+                cts.Cancel();
+                await AssertCanceledWithToken(offer, cts.Token);
+
+                await probe.RequestNextAsync(1);
+                probe.Request(1);
+                await probe.ExpectNoMsgAsync(_pause);
+
+                source.Complete();
+                await probe.ExpectCompleteAsync();
+            }, _materializer);
+        }
+
+        [Fact]
+        public async Task QueueSource_should_cancel_pending_offer_when_backpressured_without_buffer()
+        {
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var (source, probe) =
+                    Source.Queue<int>(0, OverflowStrategy.Backpressure)
+                        .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                        .Run(_materializer);
+
+                using var cts = new CancellationTokenSource();
+                var offer = source.OfferAsync(1, cts.Token);
+                await ExpectNoMsgAsync(_pause);
+
+                cts.Cancel();
+                await AssertCanceledWithToken(offer, cts.Token);
+
+                probe.Request(1);
+                await probe.ExpectNoMsgAsync(_pause);
+
+                source.Complete();
+                await probe.ExpectCompleteAsync();
+            }, _materializer);
+        }
+
+        [Fact]
+        public async Task QueueSource_should_accept_next_backpressured_offer_after_pending_offer_is_canceled()
+        {
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var (source, probe) =
+                    Source.Queue<int>(1, OverflowStrategy.Backpressure)
+                        .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                        .Run(_materializer);
+
+                AssertSuccess(source.OfferAsync(1));
+
+                using var canceled = new CancellationTokenSource();
+                var canceledOffer = source.OfferAsync(2, canceled.Token);
+                canceled.Cancel();
+                await AssertCanceledWithToken(canceledOffer, canceled.Token);
+
+                var nextOffer = source.OfferAsync(3);
+
+                await probe.RequestNextAsync(1);
+                AssertSuccess(nextOffer);
+
+                await probe.RequestNextAsync(3);
+
+                source.Complete();
+                await probe.ExpectCompleteAsync();
+            }, _materializer);
+        }
+
+        [Fact]
+        public async Task QueueSource_should_not_enqueue_offer_when_token_is_already_canceled()
+        {
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var (source, probe) =
+                    Source.Queue<int>(0, OverflowStrategy.Backpressure)
+                        .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                        .Run(_materializer);
+
+                using var cts = new CancellationTokenSource();
+                cts.Cancel();
+
+                var canceledOffer = source.OfferAsync(1, cts.Token);
+                await AssertCanceledWithToken(canceledOffer, cts.Token);
+
+                var offer = source.OfferAsync(2);
+                await probe.RequestNextAsync(2);
+                AssertSuccess(offer);
+
+                source.Complete();
+                await probe.ExpectCompleteAsync();
+            }, _materializer);
+        }
+
+        [Fact]
+        public async Task QueueSource_should_ignore_cancellation_after_offer_was_enqueued()
+        {
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var (source, probe) =
+                    Source.Queue<int>(1, OverflowStrategy.Backpressure)
+                        .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                        .Run(_materializer);
+
+                using var cts = new CancellationTokenSource();
+                var offer = source.OfferAsync(1, cts.Token);
+                AssertSuccess(offer);
+
+                cts.Cancel();
+
+                offer.Status.Should().Be(TaskStatus.RanToCompletion);
+                offer.Result.Should().Be(Enqueued.Instance);
+                await probe.RequestNextAsync(1);
+
+                source.Complete();
+                await probe.ExpectCompleteAsync();
+            }, _materializer);
+        }
+
+        [Fact]
+        public async Task QueueSource_should_ignore_cancellation_after_complete_was_requested_for_pending_offer()
+        {
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var (source, probe) =
+                    Source.Queue<int>(0, OverflowStrategy.Backpressure)
+                        .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                        .Run(_materializer);
+
+                using var cts = new CancellationTokenSource();
+                var offer = source.OfferAsync(1, cts.Token);
+                source.Complete();
+                cts.Cancel();
+
+                await probe.RequestNextAsync(1);
+                AssertSuccess(offer);
+                await probe.ExpectCompleteAsync();
+            }, _materializer);
+        }
+
+        [Fact]
+        public async Task QueueSource_should_drop_new_offers_after_complete_was_requested_while_draining()
+        {
+            await this.AssertAllStagesStoppedAsync(async () => {
+                var (source, probe) =
+                    Source.Queue<int>(0, OverflowStrategy.Backpressure)
+                        .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                        .Run(_materializer);
+
+                var pendingOffer = source.OfferAsync(1);
+                source.Complete();
+
+                var droppedOffer = await source.OfferAsync(2);
+                droppedOffer.Should().Be(Dropped.Instance);
+
+                await probe.RequestNextAsync(1);
+                AssertSuccess(pendingOffer);
+                await probe.ExpectCompleteAsync();
+            }, _materializer);
+        }
+
+        [Fact]
+        public async Task QueueSource_should_cancel_offer_when_token_fires_before_stage_processes_offer()
+        {
+            await this.AssertAllStagesStoppedAsync(async () => {
+                using var mapStarted = new ManualResetEventSlim();
+                using var releaseMap = new ManualResetEventSlim();
+
+                var (source, probe) =
+                    Source.Queue<int>(0, OverflowStrategy.Backpressure)
+                        .Select(element =>
+                        {
+                            mapStarted.Set();
+                            releaseMap.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
+                            return element;
+                        })
+                        .ToMaterialized(this.SinkProbe<int>(), Keep.Both)
+                        .Run(_materializer);
+
+                probe.Request(1);
+                var firstOffer = source.OfferAsync(1);
+                mapStarted.Wait(TimeSpan.FromSeconds(3)).Should().BeTrue();
+
+                using var cts = new CancellationTokenSource();
+                var canceledOffer = source.OfferAsync(2, cts.Token);
+                cts.Cancel();
+
+                releaseMap.Set();
+
+                await probe.ExpectNextAsync(1);
+                AssertSuccess(firstOffer);
+                await AssertCanceledWithToken(canceledOffer, cts.Token);
+
+                probe.Request(1);
+                await probe.ExpectNoMsgAsync(_pause);
+
+                source.Complete();
+                await probe.ExpectCompleteAsync();
             }, _materializer);
         }
 

--- a/src/core/Akka.Streams/Dsl/Source.cs
+++ b/src/core/Akka.Streams/Dsl/Source.cs
@@ -1037,13 +1037,13 @@ namespace Akka.Streams.Dsl
         /// there is no space available in the buffer.
         /// 
         /// Acknowledgement mechanism is available.
-        /// <see cref="ISourceQueue{T}.OfferAsync">ISourceQueueWithComplete&lt;T&gt;.OfferAsync</see> returns <see cref="Task"/>
+        /// <see cref="ISourceQueue{T}.OfferAsync(T)">ISourceQueueWithComplete&lt;T&gt;.OfferAsync</see> returns <see cref="Task"/>
         /// which completes with <see cref="QueueOfferResult.Enqueued"/> if element was added to buffer or sent downstream.
         /// It completes with <see cref="QueueOfferResult.Dropped"/> if element was dropped.
         /// Can also complete with <see cref="QueueOfferResult.Failure"/> - when stream failed
         /// or <see cref="QueueOfferResult.QueueClosed"/> when downstream is completed.
         /// 
-        /// The strategy <see cref="OverflowStrategy.Backpressure"/> will not complete <see cref="ISourceQueue{T}.OfferAsync">ISourceQueueWithComplete&lt;T&gt;.OfferAsync</see> when buffer is full.
+        /// The strategy <see cref="OverflowStrategy.Backpressure"/> will not complete <see cref="ISourceQueue{T}.OfferAsync(T)">ISourceQueueWithComplete&lt;T&gt;.OfferAsync</see> when buffer is full.
         /// 
         /// The buffer can be disabled by using <paramref name="bufferSize"/> of 0 and then received messages will wait
         /// for downstream demand unless there is another message waiting for downstream demand, in that case

--- a/src/core/Akka.Streams/Implementation/Sources.cs
+++ b/src/core/Akka.Streams/Implementation/Sources.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Annotations;
 using Akka.Pattern;
@@ -96,6 +97,33 @@ namespace Akka.Streams.Implementation
             /// TBD
             /// </summary>
             public Exception Ex { get; }
+        }
+
+        /// <summary>
+        /// INTERNAL API
+        /// </summary>
+        internal sealed class CancelOffer : IInput
+        {
+            /// <summary>
+            /// INTERNAL API
+            /// </summary>
+            /// <param name="target">The offer to cancel if it is still pending.</param>
+            /// <param name="cancellationToken">The token that canceled the offer.</param>
+            public CancelOffer(Offer<TOut> target, CancellationToken cancellationToken)
+            {
+                Target = target;
+                CancellationToken = cancellationToken;
+            }
+
+            /// <summary>
+            /// INTERNAL API
+            /// </summary>
+            public Offer<TOut> Target { get; }
+
+            /// <summary>
+            /// INTERNAL API
+            /// </summary>
+            public CancellationToken CancellationToken { get; }
         }
 
         #endregion
@@ -318,6 +346,15 @@ namespace Akka.Streams.Implementation
                             _completion.SetException(failure.Ex);
                             FailStage(failure.Ex);
                         }
+
+                        if (input is CancelOffer cancelOffer)
+                        {
+                            if (!_terminating && _pendingOffer != null && ReferenceEquals(_pendingOffer, cancelOffer.Target))
+                            {
+                                _pendingOffer.CompletionSource.NonBlockingTrySetCanceled(cancelOffer.CancellationToken);
+                                _pendingOffer = null;
+                            }
+                        }
                     });
             }
 
@@ -349,9 +386,29 @@ namespace Akka.Streams.Implementation
             /// <param name="element">TBD</param>
             /// <returns>TBD</returns>
             public Task<IQueueOfferResult> OfferAsync(TOut element)
+                => OfferAsync(element, CancellationToken.None);
+
+            /// <summary>
+            /// Cancellable variant of <see cref="OfferAsync(TOut)"/>.
+            /// </summary>
+            /// <param name="element">Element to send to a stream.</param>
+            /// <param name="cancellationToken">Token used to cancel a pending offer.</param>
+            /// <returns>A task that completes with the offer result, fails, or is canceled.</returns>
+            public Task<IQueueOfferResult> OfferAsync(TOut element, CancellationToken cancellationToken)
             {
+                if (cancellationToken.IsCancellationRequested)
+                    return Task.FromCanceled<IQueueOfferResult>(cancellationToken);
+
                 var promise = TaskEx.NonBlockingTaskCompletionSource<IQueueOfferResult>(); // new TaskCompletionSource<IQueueOfferResult>();
-                _invokeLogic(new Offer<TOut>(element, promise));
+                var offer = new Offer<TOut>(element, promise);
+                _invokeLogic(offer);
+
+                if (cancellationToken.CanBeCanceled)
+                {
+                    var registration = cancellationToken.Register(() => _invokeLogic(new CancelOffer(offer, cancellationToken)));
+                    promise.Task.ContinueWith(_ => registration.Dispose(), TaskContinuationOptions.ExecuteSynchronously);
+                }
+
                 return promise.Task;
             }
 

--- a/src/core/Akka.Streams/Queue.cs
+++ b/src/core/Akka.Streams/Queue.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Akka.Streams.Util;
 using Akka.Util;
@@ -37,6 +38,19 @@ namespace Akka.Streams
         Task<IQueueOfferResult> OfferAsync(T element);
 
         /// <summary>
+        /// Cancellable variant of <see cref="OfferAsync(T)"/>.
+        /// Cancelling <paramref name="cancellationToken"/> while the offer is pending under
+        /// <see cref="OverflowStrategy.Backpressure"/> removes the pending offer from the stage
+        /// and completes the returned task as canceled. If the offer has already completed
+        /// (Enqueued, Dropped, QueueClosed, or failed), cancellation is a no-op.
+        /// Awaiters observe an <see cref="OperationCanceledException"/> carrying the supplied token.
+        /// </summary>
+        /// <param name="element">Element to send to a stream.</param>
+        /// <param name="cancellationToken">Token used to cancel a pending offer.</param>
+        /// <returns>A task that completes with the offer result, fails, or is canceled.</returns>
+        Task<IQueueOfferResult> OfferAsync(T element, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Method returns <see cref="Task"/> that will be completed if the stream completes,
         /// or will be failed when the stage faces an internal failure.
         /// </summary>
@@ -51,12 +65,12 @@ namespace Akka.Streams
     public interface ISourceQueueWithComplete<in T> : ISourceQueue<T>
     {
         /// <summary>
-        /// Complete the stream normally. Use <see cref="ISourceQueue{T}.WatchCompletionAsync"/> to be notified of this operation’s success.
+        /// Complete the stream normally. Use <see cref="ISourceQueue{T}.WatchCompletionAsync"/> to be notified of this operation's success.
         /// </summary>
         void Complete();
 
         /// <summary>
-        /// Complete the stream with a failure. Use <see cref="ISourceQueue{T}.WatchCompletionAsync"/> to be notified of this operation’s success.
+        /// Complete the stream with a failure. Use <see cref="ISourceQueue{T}.WatchCompletionAsync"/> to be notified of this operation's success.
         /// </summary>
         /// <param name="ex">TBD</param>
         void Fail(Exception ex);

--- a/src/core/Akka/Util/Internal/TaskEx.cs
+++ b/src/core/Akka/Util/Internal/TaskEx.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Akka.Util.Internal
@@ -49,6 +50,16 @@ namespace Akka.Util.Internal
         public static void NonBlockingTrySetException<T>(this TaskCompletionSource<T> taskCompletionSource, Exception exception)
         {
             taskCompletionSource.TrySetException(exception);
+        }
+
+        /// <summary>
+        /// Tries to cancel given <paramref name="taskCompletionSource"/> in asynchronous, non-blocking
+        /// fashion. For safety reasons, this method should be called only on tasks created via
+        /// <see cref="NonBlockingTaskCompletionSource{T}"/> method.
+        /// </summary>
+        public static void NonBlockingTrySetCanceled<T>(this TaskCompletionSource<T> taskCompletionSource, CancellationToken cancellationToken)
+        {
+            taskCompletionSource.TrySetCanceled(cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Backport of [akkadotnet/akka.net#8248](https://github.com/akkadotnet/akka.net/pull/8248) to `v1.5`.

**Problem:** `ISourceQueue<T>.OfferAsync(T element)` can block indefinitely under backpressure and does not accept a `CancellationToken$. When awaited inside actor handlers (for example, channel adapters built with ReceiveAsync), the actor can become effectively wedged waiting for queue demand that may never return.

**Solution:** Added `OfferAsync(T element, CancellationToken cancellationToken)` to the `ISourceQueue<T>` interface. Cancelling the token while an offer is pending under OverflowStrategy.Backpressure removes the pending offer from the stage and completes the returned task as canceled, without later emitting the canceled element.

## Changes
- `OfferAsync(T, CancellationToken)` declared directly on `ISourceQueue<T>` — no extension method, no separate interface
- `QueueSource.Materialized` registers on the CancellationToken and sends an internal CancelOffer command
- Ordering safety: `CancelOffer` registration is created strictly after the Offer is submitted
- Handler guards with `!_terminating && ReferenceEquals(_pendingOffer, cancelOffer.Target)`

Co-authored-by: Bojan Janjatović <bojan.janjatovic@mamut-studio.com>
