### PR TITLE
Add v1.6 breaking-change ledger + CLAUDE.md tracking rule

### DIFF
--- a/BREAKING_CHANGES_V1.6.md
+++ b/BREAKING_CHANGES_V1.6.md
@@ -1,0 +1,43 @@
+# Akka.NET v1.6 Breaking Changes
+
+This document tracks **breaking changes** introduced into the `dev` branch during the
+Akka.NET **v1.6** development cycle, ahead of a stable `v1.6.0` release.
+
+A change is **breaking** — and therefore **must** be recorded here — if it alters any of:
+
+- **Behavior** — observable runtime semantics change (e.g. a message that used to do `X`
+  now does `Y`, or is now ignored).
+- **Wire** — serialization or network-protocol compatibility with prior `1.x` releases
+  changes.
+- **API** — a public type or member is removed, renamed, or has its signature/contract
+  changed (anything `Akka.API.Tests` would flag).
+
+## Scope and lifecycle
+
+- This ledger is maintained **only until a stable `v1.6.0` ships**. At that point its
+  contents are folded into the official release notes / upgrade guide and this file is
+  retired.
+- Record the entry in the **same PR** that introduces the breaking change, so reviewers can
+  weigh the break alongside the code.
+- A change still in flight may be listed with status `Planned` and its branch name; update
+  it to `Merged` with the PR link once it lands on `dev`.
+- Bug fixes that merely restore documented/intended behavior are not "breaking" for this
+  list — but note them anyway if users may have come to depend on the old (incorrect)
+  behavior.
+
+## Entry format
+
+Newest first. Keep `Change` to a line or two; link the PR for detail. `Type` is one or more
+of `Behavior`, `Wire`, `API` (combine with `+`).
+
+| Status | PR / Branch | Component | Type | Change | Migration |
+|--------|-------------|-----------|------|--------|-----------|
+| Planned / Merged | link or branch | `Akka.Xyz` | Behavior | one-line summary | what users must do |
+
+---
+
+## Changes
+
+| Status | PR / Branch | Component | Type | Change | Migration |
+|--------|-------------|-----------|------|--------|-----------|
+| Planned | `feature/deprecate-actorpublisher` | `Akka.Streams` | Behavior + API | `Source.ActorRef<T>` is being re-implemented as a stream-native `GraphStage` (off the legacy `ActorPublisher`). The materialized `IActorRef` no longer treats `PoisonPill` / `Kill` as stream completion — those messages are now ignored, consistent with stage-actor semantics. | Complete the stream explicitly: send `new Status.Success(...)` to drain buffered elements and complete, or `new Status.Failure(ex)` to fail. Do not rely on `PoisonPill` / `Kill`. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,15 @@ dotnet docfx build ./docs/docfx.json --warningsAsErrors
 3. Add/update tests for your changes
 4. Run incremental tests before committing
 5. Ensure API compatibility tests pass for core changes
+6. If the change is breaking, record it in `BREAKING_CHANGES_V1.6.md` in the same change (see below)
+
+### Tracking Breaking Changes (v1.6 cycle)
+Until a stable **v1.6.0** ships, **every** change that goes into the `dev` branch and
+introduces a **breaking behavior, wire-format, or public-API change** MUST be documented in
+[`BREAKING_CHANGES_V1.6.md`](BREAKING_CHANGES_V1.6.md) (repo root), in the **same PR** that
+makes the change. Use the entry format described in that file (status, component, type,
+change, migration). This ledger is retired once `v1.6.0` is released, when its contents are
+folded into the release notes / upgrade guide.
 
 ### Target Frameworks
 - **.NET 8.0** - Primary target


### PR DESCRIPTION
## Summary

Adds a process for tracking breaking changes during the **v1.6** development cycle.

- **`BREAKING_CHANGES_V1.6.md`** (new, repo root) — a living ledger of every breaking **behavior**, **wire-format**, or **public-API** change merged to `dev` ahead of a stable `v1.6.0`. Includes the definition of "breaking", lifecycle rules (recorded in the same PR; retired once v1.6.0 ships), an entry-format template, and a `Status` column so an in-flight change can be listed as `Planned` and flipped to `Merged` when it lands.
- **`CLAUDE.md`** — new step in "Making Changes" plus a "Tracking Breaking Changes (v1.6 cycle)" subsection making the ledger **mandatory** for breaking changes until v1.6.0 ships.

The ledger is seeded with the first known entry (status `Planned`): the upcoming `Source.ActorRef<T>` migration off the legacy `ActorPublisher`, which drops `PoisonPill`/`Kill`-as-completion behavior.

## Why

During the v1.6 run-up there will be several intentional breaking changes. Capturing them in one place as they land — rather than reconstructing them at release time — keeps the eventual upgrade guide accurate and gives reviewers a single spot to weigh each break.

Docs-only / process change; no source or test impact.