### PR TITLE
perf(remote): low-allocation, faster inbound decode (tag-dispatch parser + byte-keyed resolve cache)

### DIFF
--- a/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecFastDecodeDifferentialSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecFastDecodeDifferentialSpec.cs
@@ -1,0 +1,318 @@
+//-----------------------------------------------------------------------
+// <copyright file="AkkaPduCodecFastDecodeDifferentialSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Remote.Serialization.Proto.Msg;
+using Akka.Remote.Transport;
+using Akka.TestKit;
+using Akka.Util.Internal;
+using Google.Protobuf;
+using Xunit;
+using SerializedMessage = Akka.Remote.Serialization.Proto.Msg.Payload;
+
+namespace Akka.Remote.Tests.Transport
+{
+    /// <summary>
+    /// Differential test for the hand-rolled tag-dispatch decoder (<see cref="AkkaPduProtobuffCodec.DecodeMessageFast"/>,
+    /// Phase-2 lever B2a) against the generated-protobuf path (<see cref="AkkaPduProtobuffCodec.DecodeMessage"/>) which
+    /// is treated as the correctness oracle. The fast decoder MUST produce byte-identical results for every input —
+    /// including canonical interop wire samples, generated envelopes, permuted field order (JVM/other-encoder
+    /// interop), unknown trailing fields, and buffers split across many segments.
+    /// </summary>
+    public class AkkaPduCodecFastDecodeDifferentialSpec : AkkaSpec
+    {
+        // Canonical, interop-committed wire samples (copied from AkkaPduCodecWireFormatSpec).
+        private const string AckAndMessageHex =
+            "0A1B090A0000000000000012100B000000000000000C00000000000000128A010A350A33616B6B612E746370" +
+            "3A2F2F57697265436F6D706174403132372E302E302E313A323535312F757365722F726563697069656E74" +
+            "12140A0401020304107B1A0A6D616E69666573742D6122320A30616B6B612E7463703A2F2F5769726543" +
+            "6F6D706174403132372E302E302E313A323535312F757365722F73656E646572292A00000000000000";
+
+        private const string UnsequencedMessageHex =
+            "128A010A350A33616B6B612E7463703A2F2F57697265436F6D706174403132372E302E302E313A323535" +
+            "312F757365722F726563697069656E7412140A0401020304107B1A0A6D616E69666573742D6122320A30" +
+            "616B6B612E7463703A2F2F57697265436F6D706174403132372E302E302E313A323535312F757365722F" +
+            "73656E64657229FFFFFFFFFFFFFFFF";
+
+        private const string PureAckHex = "0A1B090A0000000000000012100B000000000000000C00000000000000";
+
+        private static readonly Address LocalAddress = new("akka.tcp", "WireCompat", "127.0.0.1", 2551);
+
+        private readonly AkkaPduProtobuffCodec _codec;
+
+        public AkkaPduCodecFastDecodeDifferentialSpec(ITestOutputHelper output)
+            : base(ConfigurationFactory.ParseString("akka.actor.provider = remote"), output)
+        {
+            _codec = new AkkaPduProtobuffCodec(Sys);
+        }
+
+        public static IEnumerable<object[]> CanonicalSamples()
+        {
+            yield return new object[] { "AckAndMessage", AckAndMessageHex };
+            yield return new object[] { "Unsequenced", UnsequencedMessageHex };
+            yield return new object[] { "PureAck", PureAckHex };
+            // Unknown trailing field (field 3, varint) appended to a full envelope.
+            yield return new object[] { "AckAndMessage+unknownVarint", AckAndMessageHex + "1801" };
+            // Unknown trailing field (field 6, length-delimited) appended.
+            yield return new object[] { "AckAndMessage+unknownLenDelim", AckAndMessageHex + "3203AABBCC" };
+        }
+
+        [Theory(DisplayName = "DecodeMessageFast matches DecodeMessage on canonical wire samples")]
+        [MemberData(nameof(CanonicalSamples))]
+        public void Fast_matches_oracle_on_canonical_samples(string label, string hex)
+        {
+            AssertEquivalentBothLayouts(label, Convert.FromHexString(hex));
+        }
+
+        [Fact(DisplayName = "DecodeMessageFast matches DecodeMessage on generated envelopes")]
+        public void Fast_matches_oracle_on_generated_envelopes()
+        {
+            foreach (var (label, bytes) in GeneratedCorpus())
+                AssertEquivalentBothLayouts(label, bytes);
+        }
+
+        [Fact(DisplayName = "DecodeMessageFast matches DecodeMessage with permuted field order (JVM interop)")]
+        public void Fast_matches_oracle_with_permuted_field_order()
+        {
+            // RemoteEnvelope fields written in REVERSE order (seq, sender, message, recipient) and the
+            // top-level container with envelope-before-ack — exercising true tag-dispatch order independence.
+            var withAck = BuildPermutedContainer(
+                RecipientPath("recipient"), SenderPath("sender"), Payload(), seq: 42, includeAck: true);
+            AssertEquivalentBothLayouts("permuted+ack", withAck);
+
+            var noAck = BuildPermutedContainer(
+                RecipientPath("recipient"), SenderPath("sender"), Payload(), seq: 42, includeAck: false);
+            AssertEquivalentBothLayouts("permuted+noAck", noAck);
+
+            // Permuted, with seq omitted entirely (undefined) and no sender.
+            var minimal = BuildPermutedContainer(
+                RecipientPath("recipient"), senderPath: null, Payload(), seq: null, includeAck: false);
+            AssertEquivalentBothLayouts("permuted+minimal", minimal);
+        }
+
+        [Fact(DisplayName = "DecodeMessageFast resolve cache is correct across repeats and localAddress changes")]
+        public void Fast_resolve_cache_correct_across_repeats_and_localaddress_changes()
+        {
+            var bytes = _codec.ConstructMessage(
+                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender"), new SeqNo(5), null).ToByteArray();
+
+            // Repeated decodes force byte-keyed cache hits; each must still equal the oracle.
+            for (var i = 0; i < 5; i++)
+                AssertEquivalentBothLayouts($"repeat{i}", bytes);
+
+            // Same path bytes, DIFFERENT localAddress: the cache's localAddress guard must re-resolve
+            // through the provider rather than serve the entry cached for LocalAddress.
+            var otherLocal = new Address("akka.tcp", "WireCompat", "127.0.0.1", 9999);
+            AssertEquivalent("otherLocal",
+                _codec.DecodeMessage(ByteString.CopyFrom(bytes), RemoteProvider, otherLocal),
+                _codec.DecodeMessageFast(new ReadOnlySequence<byte>(bytes), RemoteProvider, otherLocal));
+
+            // Back to the original localAddress — still correct.
+            AssertEquivalentBothLayouts("backToOriginal", bytes);
+        }
+
+        // ---- corpus ----
+
+        private IEnumerable<(string label, byte[] bytes)> GeneratedCorpus()
+        {
+            var ack = new Ack(new SeqNo(10), new[] { new SeqNo(11), new SeqNo(12) });
+
+            yield return ("gen:full", _codec.ConstructMessage(
+                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender"), new SeqNo(42), ack).ToByteArray());
+
+            yield return ("gen:noAck", _codec.ConstructMessage(
+                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender"), new SeqNo(42)).ToByteArray());
+
+            yield return ("gen:noSender", _codec.ConstructMessage(
+                LocalAddress, ActorRef("recipient"), Payload(), seqOption: new SeqNo(7)).ToByteArray());
+
+            yield return ("gen:noSeqNoAck", _codec.ConstructMessage(
+                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender")).ToByteArray());
+
+            yield return ("gen:emptyAckNacks", _codec.ConstructMessage(
+                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender"), new SeqNo(1), new Ack(new SeqNo(3))).ToByteArray());
+
+            // Large payload + empty manifest.
+            yield return ("gen:largePayload", _codec.ConstructMessage(
+                LocalAddress, ActorRef("recipient"),
+                new SerializedMessage { SerializerId = 5, Message = ByteString.CopyFrom(new byte[4096]) },
+                ActorRef("sender"), new SeqNo(99)).ToByteArray());
+
+            // Non-ASCII actor names exercise the UTF-8 path decode.
+            yield return ("gen:unicodePaths", _codec.ConstructMessage(
+                LocalAddress, ActorRef("recipient-Ä-名前"), Payload(), ActorRef("sender-Ω-送信"), new SeqNo(2), ack).ToByteArray());
+
+            // Pure ack (no envelope).
+            yield return ("gen:pureAck", _codec.ConstructPureAck(ack).ToByteArray());
+        }
+
+        private byte[] BuildPermutedContainer(string recipientPath, string? senderPath, SerializedMessage message, ulong? seq, bool includeAck)
+        {
+            using var envStream = new MemoryStream();
+            var eos = new CodedOutputStream(envStream);
+            if (seq is { } s)
+            {
+                eos.WriteTag(5, WireFormat.WireType.Fixed64);
+                eos.WriteFixed64(s);
+            }
+            if (senderPath is not null)
+            {
+                eos.WriteTag(4, WireFormat.WireType.LengthDelimited);
+                eos.WriteMessage(new ActorRefData { Path = senderPath });
+            }
+            eos.WriteTag(2, WireFormat.WireType.LengthDelimited);
+            eos.WriteMessage(message);
+            eos.WriteTag(1, WireFormat.WireType.LengthDelimited);
+            eos.WriteMessage(new ActorRefData { Path = recipientPath });
+            eos.Flush();
+            var envelopeBytes = envStream.ToArray();
+
+            using var outStream = new MemoryStream();
+            var os = new CodedOutputStream(outStream);
+            // envelope (field 2) BEFORE ack (field 1) — reversed top-level order.
+            // WriteBytes emits the length prefix + raw bytes after the tag, embedding the manually
+            // (permuted-order) serialized RemoteEnvelope verbatim.
+            os.WriteTag(2, WireFormat.WireType.LengthDelimited);
+            os.WriteBytes(ByteString.CopyFrom(envelopeBytes));
+            if (includeAck)
+            {
+                os.WriteTag(1, WireFormat.WireType.LengthDelimited);
+                os.WriteMessage(new AcknowledgementInfo { CumulativeAck = 10, Nacks = { 11UL, 12UL } });
+            }
+            os.Flush();
+            return outStream.ToArray();
+        }
+
+        // ---- assertions ----
+
+        private void AssertEquivalentBothLayouts(string label, byte[] bytes)
+        {
+            // Single contiguous segment.
+            AssertEquivalent($"{label} [single]",
+                _codec.DecodeMessage(ByteString.CopyFrom(bytes), RemoteProvider, LocalAddress),
+                _codec.DecodeMessageFast(new ReadOnlySequence<byte>(bytes), RemoteProvider, LocalAddress));
+
+            // Worst-case fragmentation: one byte per segment (stresses cross-segment varints/fixed64/strings).
+            var split = SplitEveryByte(bytes);
+            AssertEquivalent($"{label} [split]",
+                _codec.DecodeMessage(ByteString.CopyFrom(split.ToArray()), RemoteProvider, LocalAddress),
+                _codec.DecodeMessageFast(split, RemoteProvider, LocalAddress));
+        }
+
+        private static void AssertEquivalent(string label, AckAndMessage oracle, AckAndMessage fast)
+        {
+            // Ack
+            if (oracle.AckOption is null)
+            {
+                Assert.True(fast.AckOption is null, $"{label}: expected null ack");
+            }
+            else
+            {
+                Assert.True(fast.AckOption is not null, $"{label}: expected non-null ack");
+                Assert.Equal(oracle.AckOption.CumulativeAck, fast.AckOption!.CumulativeAck);
+                Assert.Equal(oracle.AckOption.Nacks.ToArray(), fast.AckOption.Nacks.ToArray());
+            }
+
+            // Message
+            if (oracle.MessageOption is null)
+            {
+                Assert.True(fast.MessageOption is null, $"{label}: expected null message");
+                return;
+            }
+
+            Assert.True(fast.MessageOption is not null, $"{label}: expected non-null message");
+            var o = oracle.MessageOption;
+            var f = fast.MessageOption!;
+
+            Assert.Equal(o.Recipient.Path, f.Recipient.Path);
+            Assert.Equal(o.RecipientAddress, f.RecipientAddress);
+            Assert.Equal(o.Seq, f.Seq);
+
+            if (o.SenderOptional is null)
+                Assert.True(f.SenderOptional is null, $"{label}: expected null sender");
+            else
+            {
+                Assert.True(f.SenderOptional is not null, $"{label}: expected non-null sender");
+                Assert.Equal(o.SenderOptional.Path, f.SenderOptional!.Path);
+            }
+
+            if (o.SerializedMessage is null)
+                Assert.True(f.SerializedMessage is null, $"{label}: expected null serialized message");
+            else
+            {
+                Assert.True(f.SerializedMessage is not null, $"{label}: expected non-null serialized message");
+                Assert.Equal(o.SerializedMessage.SerializerId, f.SerializedMessage!.SerializerId);
+                Assert.Equal(o.SerializedMessage.MessageManifest, f.SerializedMessage.MessageManifest);
+                Assert.Equal(o.SerializedMessage.Message, f.SerializedMessage.Message);
+            }
+        }
+
+        // ---- helpers ----
+
+        private IRemoteActorRefProvider RemoteProvider =>
+            Sys.AsInstanceOf<ExtendedActorSystem>().Provider.AsInstanceOf<IRemoteActorRefProvider>();
+
+        private IActorRef ActorRef(string name) =>
+            new FixedActorRef(new RootActorPath(LocalAddress) / "user" / name, Sys.AsInstanceOf<ExtendedActorSystem>().Provider);
+
+        private string RecipientPath(string name) => (new RootActorPath(LocalAddress) / "user" / name).ToSerializationFormat();
+
+        private string SenderPath(string name) => (new RootActorPath(LocalAddress) / "user" / name).ToSerializationFormat();
+
+        private static SerializedMessage Payload() => new()
+        {
+            SerializerId = 123,
+            MessageManifest = ByteString.CopyFromUtf8("manifest-a"),
+            Message = ByteString.CopyFrom(1, 2, 3, 4)
+        };
+
+        private static ReadOnlySequence<byte> SplitEveryByte(byte[] bytes)
+        {
+            if (bytes.Length == 0)
+                return ReadOnlySequence<byte>.Empty;
+
+            var first = new Segment(new[] { bytes[0] });
+            var current = first;
+            for (var i = 1; i < bytes.Length; i++)
+                current = current.Append(new[] { bytes[i] });
+
+            return new ReadOnlySequence<byte>(first, 0, current, current.Memory.Length);
+        }
+
+        private sealed class FixedActorRef : MinimalActorRef
+        {
+            public FixedActorRef(ActorPath path, IActorRefProvider provider)
+            {
+                Path = path;
+                Provider = provider;
+            }
+
+            public override ActorPath Path { get; }
+            public override IActorRefProvider Provider { get; }
+        }
+
+        private sealed class Segment : ReadOnlySequenceSegment<byte>
+        {
+            public Segment(ReadOnlyMemory<byte> memory) => Memory = memory;
+
+            public Segment Append(ReadOnlyMemory<byte> memory)
+            {
+                var segment = new Segment(memory) { RunningIndex = RunningIndex + Memory.Length };
+                Next = segment;
+                return segment;
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecFastDecodeDifferentialSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecFastDecodeDifferentialSpec.cs
@@ -33,7 +33,9 @@ namespace Akka.Remote.Tests.Transport
     /// </summary>
     public class AkkaPduCodecFastDecodeDifferentialSpec : AkkaSpec
     {
-        // Canonical, interop-committed wire samples (copied from AkkaPduCodecWireFormatSpec).
+        // Frozen canonical wire samples. The Canonical_samples_anchored_to_encoder test below proves these
+        // bytes are exactly what THIS build's codec emits for the corresponding messages (so they pin the
+        // interop wire format); the differential cases then prove DecodeMessageFast == DecodeMessage on them.
         private const string AckAndMessageHex =
             "0A1B090A0000000000000012100B000000000000000C00000000000000128A010A350A33616B6B612E746370" +
             "3A2F2F57697265436F6D706174403132372E302E302E313A323535312F757365722F726563697069656E74" +
@@ -74,6 +76,25 @@ namespace Akka.Remote.Tests.Transport
         public void Fast_matches_oracle_on_canonical_samples(string label, string hex)
         {
             AssertEquivalentBothLayouts(label, Convert.FromHexString(hex));
+        }
+
+        [Fact(DisplayName = "Canonical wire samples are exactly what this build's encoder emits (wire-format anchor)")]
+        public void Canonical_samples_anchored_to_encoder()
+        {
+            // Anchor the frozen hex to THIS build's encoder: ConstructMessage/ConstructPureAck must emit exactly
+            // these bytes for the canonical inputs. This pins the interop wire format (it is frozen — full
+            // interop with classic Akka.Remote nodes), so the differential cases above run over real wire bytes
+            // and not merely whatever the current encoder happens to produce. A failure here means the wire
+            // format drifted.
+            var ack = new Ack(new SeqNo(10), new[] { new SeqNo(11), new SeqNo(12) });
+
+            Assert.Equal(AckAndMessageHex, Convert.ToHexString(_codec.ConstructMessage(
+                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender"), new SeqNo(42), ack).ToByteArray()));
+
+            Assert.Equal(UnsequencedMessageHex, Convert.ToHexString(_codec.ConstructMessage(
+                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender")).ToByteArray()));
+
+            Assert.Equal(PureAckHex, Convert.ToHexString(_codec.ConstructPureAck(ack).ToByteArray()));
         }
 
         [Fact(DisplayName = "DecodeMessageFast matches DecodeMessage on generated envelopes")]

--- a/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecFastDecodeDifferentialSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/AkkaPduCodecFastDecodeDifferentialSpec.cs
@@ -9,7 +9,6 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Akka.Actor;
@@ -25,31 +24,25 @@ using SerializedMessage = Akka.Remote.Serialization.Proto.Msg.Payload;
 namespace Akka.Remote.Tests.Transport
 {
     /// <summary>
-    /// Differential test for the hand-rolled tag-dispatch decoder (<see cref="AkkaPduProtobuffCodec.DecodeMessageFast"/>,
-    /// Phase-2 lever B2a) against the generated-protobuf path (<see cref="AkkaPduProtobuffCodec.DecodeMessage"/>) which
-    /// is treated as the correctness oracle. The fast decoder MUST produce byte-identical results for every input —
-    /// including canonical interop wire samples, generated envelopes, permuted field order (JVM/other-encoder
-    /// interop), unknown trailing fields, and buffers split across many segments.
+    /// Correctness tests for the hand-rolled tag-dispatch inbound decoder
+    /// (<see cref="AkkaPduProtobuffCodec.DecodeMessageFast"/>).
+    ///
+    /// Every test follows the same readable shape: state explicit, human-readable inputs, run the FAST
+    /// decoder, and assert the decoded fields equal those exact inputs — no oracle to trust and no hex to
+    /// decode in your head. Each case is decoded both as one contiguous buffer AND split one-byte-per-segment
+    /// (so cross-segment varints/fixed64/strings are exercised everywhere).
+    ///
+    /// Two areas can't be expressed by "encode with the codec, then decode":
+    ///  • the FROZEN interop wire bytes — pinned to this build's encoder by
+    ///    <see cref="Encoder_emits_exactly_the_frozen_interop_bytes"/>, then decoded to their documented values;
+    ///  • field orders a DIFFERENT encoder (e.g. the JVM) may emit — protobuf allows any field order, but the
+    ///    .NET codec only ever writes ascending order, so those bytes are built by hand.
+    ///
+    /// A final defense-in-depth test additionally cross-checks the fast decoder against the shipped
+    /// generated-protobuf parser over a small corpus.
     /// </summary>
     public class AkkaPduCodecFastDecodeDifferentialSpec : AkkaSpec
     {
-        // Frozen canonical wire samples. The Canonical_samples_anchored_to_encoder test below proves these
-        // bytes are exactly what THIS build's codec emits for the corresponding messages (so they pin the
-        // interop wire format); the differential cases then prove DecodeMessageFast == DecodeMessage on them.
-        private const string AckAndMessageHex =
-            "0A1B090A0000000000000012100B000000000000000C00000000000000128A010A350A33616B6B612E746370" +
-            "3A2F2F57697265436F6D706174403132372E302E302E313A323535312F757365722F726563697069656E74" +
-            "12140A0401020304107B1A0A6D616E69666573742D6122320A30616B6B612E7463703A2F2F5769726543" +
-            "6F6D706174403132372E302E302E313A323535312F757365722F73656E646572292A00000000000000";
-
-        private const string UnsequencedMessageHex =
-            "128A010A350A33616B6B612E7463703A2F2F57697265436F6D706174403132372E302E302E313A323535" +
-            "312F757365722F726563697069656E7412140A0401020304107B1A0A6D616E69666573742D6122320A30" +
-            "616B6B612E7463703A2F2F57697265436F6D706174403132372E302E302E313A323535312F757365722F" +
-            "73656E64657229FFFFFFFFFFFFFFFF";
-
-        private const string PureAckHex = "0A1B090A0000000000000012100B000000000000000C00000000000000";
-
         private static readonly Address LocalAddress = new("akka.tcp", "WireCompat", "127.0.0.1", 2551);
 
         private readonly AkkaPduProtobuffCodec _codec;
@@ -60,185 +53,293 @@ namespace Akka.Remote.Tests.Transport
             _codec = new AkkaPduProtobuffCodec(Sys);
         }
 
-        public static IEnumerable<object[]> CanonicalSamples()
+        // ===================== correctness: encode known values, fast-decode, assert exact values =====================
+
+        [Fact(DisplayName = "Fast decode: full envelope (recipient, sender, seq, payload, ack)")]
+        public void Decodes_full_envelope()
         {
-            yield return new object[] { "AckAndMessage", AckAndMessageHex };
-            yield return new object[] { "Unsequenced", UnsequencedMessageHex };
-            yield return new object[] { "PureAck", PureAckHex };
-            // Unknown trailing field (field 3, varint) appended to a full envelope.
-            yield return new object[] { "AckAndMessage+unknownVarint", AckAndMessageHex + "1801" };
-            // Unknown trailing field (field 6, length-delimited) appended.
-            yield return new object[] { "AckAndMessage+unknownLenDelim", AckAndMessageHex + "3203AABBCC" };
+            var wire = _codec.ConstructMessage(
+                LocalAddress, ActorRef("alice"), Payload(7, "hello", 0xDE, 0xAD, 0xBE, 0xEF),
+                ActorRef("bob"), new SeqNo(42), Ack(10, 11, 12)).ToByteArray();
+
+            AssertFastDecode(wire, "full",
+                recipient: "alice", sender: "bob", seq: new SeqNo(42),
+                payload: Payload(7, "hello", 0xDE, 0xAD, 0xBE, 0xEF), ack: Ack(10, 11, 12));
         }
 
-        [Theory(DisplayName = "DecodeMessageFast matches DecodeMessage on canonical wire samples")]
-        [MemberData(nameof(CanonicalSamples))]
-        public void Fast_matches_oracle_on_canonical_samples(string label, string hex)
+        [Fact(DisplayName = "Fast decode: envelope with no ack")]
+        public void Decodes_envelope_without_ack()
         {
-            AssertEquivalentBothLayouts(label, Convert.FromHexString(hex));
+            var wire = _codec.ConstructMessage(
+                LocalAddress, ActorRef("alice"), Payload(7, "hello", 1, 2, 3),
+                ActorRef("bob"), new SeqNo(42)).ToByteArray();
+
+            AssertFastDecode(wire, "no-ack",
+                recipient: "alice", sender: "bob", seq: new SeqNo(42),
+                payload: Payload(7, "hello", 1, 2, 3), ack: null);
         }
 
-        [Fact(DisplayName = "Canonical wire samples are exactly what this build's encoder emits (wire-format anchor)")]
-        public void Canonical_samples_anchored_to_encoder()
+        [Fact(DisplayName = "Fast decode: envelope with no sender")]
+        public void Decodes_envelope_without_sender()
         {
-            // Anchor the frozen hex to THIS build's encoder: ConstructMessage/ConstructPureAck must emit exactly
-            // these bytes for the canonical inputs. This pins the interop wire format (it is frozen — full
-            // interop with classic Akka.Remote nodes), so the differential cases above run over real wire bytes
-            // and not merely whatever the current encoder happens to produce. A failure here means the wire
-            // format drifted.
-            var ack = new Ack(new SeqNo(10), new[] { new SeqNo(11), new SeqNo(12) });
+            var wire = _codec.ConstructMessage(
+                LocalAddress, ActorRef("alice"), Payload(7, "hello", 1, 2, 3), seqOption: new SeqNo(7)).ToByteArray();
 
+            AssertFastDecode(wire, "no-sender",
+                recipient: "alice", sender: null, seq: new SeqNo(7),
+                payload: Payload(7, "hello", 1, 2, 3), ack: null);
+        }
+
+        [Fact(DisplayName = "Fast decode: unsequenced envelope (seq undefined)")]
+        public void Decodes_unsequenced_envelope()
+        {
+            // ConstructMessage with no seq writes SeqUndefined on the wire, which decodes back to a null Seq.
+            var wire = _codec.ConstructMessage(
+                LocalAddress, ActorRef("alice"), Payload(7, "hello", 1, 2, 3), ActorRef("bob")).ToByteArray();
+
+            AssertFastDecode(wire, "unsequenced",
+                recipient: "alice", sender: "bob", seq: null,
+                payload: Payload(7, "hello", 1, 2, 3), ack: null);
+        }
+
+        [Fact(DisplayName = "Fast decode: pure ack (no message)")]
+        public void Decodes_pure_ack()
+        {
+            var wire = _codec.ConstructPureAck(Ack(10, 11, 12)).ToByteArray();
+
+            AssertFastDecode(wire, "pure-ack",
+                recipient: null, sender: null, seq: null, payload: null, ack: Ack(10, 11, 12));
+        }
+
+        [Fact(DisplayName = "Fast decode: large payload + empty manifest")]
+        public void Decodes_large_payload()
+        {
+            var big = Enumerable.Range(0, 4096).Select(i => (byte)i).ToArray();
+            var wire = _codec.ConstructMessage(
+                LocalAddress, ActorRef("alice"), Payload(5, "", big), ActorRef("bob"), new SeqNo(99)).ToByteArray();
+
+            AssertFastDecode(wire, "large-payload",
+                recipient: "alice", sender: "bob", seq: new SeqNo(99),
+                payload: Payload(5, "", big), ack: null);
+        }
+
+        [Fact(DisplayName = "Fast decode: non-ASCII actor paths (UTF-8)")]
+        public void Decodes_unicode_actor_paths()
+        {
+            var wire = _codec.ConstructMessage(
+                LocalAddress, ActorRef("recipient-Ä-名前"), Payload(7, "m", 9),
+                ActorRef("sender-Ω-送信"), new SeqNo(2), Ack(10, 11, 12)).ToByteArray();
+
+            AssertFastDecode(wire, "unicode",
+                recipient: "recipient-Ä-名前", sender: "sender-Ω-送信", seq: new SeqNo(2),
+                payload: Payload(7, "m", 9), ack: Ack(10, 11, 12));
+        }
+
+        [Fact(DisplayName = "Fast decode: ack with cumulative only (no nacks)")]
+        public void Decodes_ack_with_no_nacks()
+        {
+            var wire = _codec.ConstructMessage(
+                LocalAddress, ActorRef("alice"), Payload(7, "m", 9), ActorRef("bob"), new SeqNo(1), Ack(3)).ToByteArray();
+
+            AssertFastDecode(wire, "ack-no-nacks",
+                recipient: "alice", sender: "bob", seq: new SeqNo(1), payload: Payload(7, "m", 9), ack: Ack(3));
+        }
+
+        // ===================== frozen interop wire bytes (golden) =====================
+
+        // The exact bytes classic Akka.Remote puts on the wire for the documented messages below.
+        // Encoder_emits_exactly_the_frozen_interop_bytes proves these equal THIS build's encoder output,
+        // so they pin the interop wire format; the tests then decode them to their documented values.
+        // AckAndMessage decodes to: recipient=/user/recipient, sender=/user/sender, seq=42,
+        //   payload{serializerId=123, manifest="manifest-a", message=[1,2,3,4]}, ack{cumulative=10, nacks=[11,12]}.
+        private const string AckAndMessageHex =
+            "0A1B090A0000000000000012100B000000000000000C00000000000000128A010A350A33616B6B612E746370" +
+            "3A2F2F57697265436F6D706174403132372E302E302E313A323535312F757365722F726563697069656E74" +
+            "12140A0401020304107B1A0A6D616E69666573742D6122320A30616B6B612E7463703A2F2F5769726543" +
+            "6F6D706174403132372E302E302E313A323535312F757365722F73656E646572292A00000000000000";
+
+        // Same envelope, no ack, seq undefined => decodes to seq=null, ack=null.
+        private const string UnsequencedMessageHex =
+            "128A010A350A33616B6B612E7463703A2F2F57697265436F6D706174403132372E302E302E313A323535" +
+            "312F757365722F726563697069656E7412140A0401020304107B1A0A6D616E69666573742D6122320A30" +
+            "616B6B612E7463703A2F2F57697265436F6D706174403132372E302E302E313A323535312F757365722F" +
+            "73656E64657229FFFFFFFFFFFFFFFF";
+
+        // Pure ack, no envelope => decodes to no message, ack{cumulative=10, nacks=[11,12]}.
+        private const string PureAckHex = "0A1B090A0000000000000012100B000000000000000C00000000000000";
+
+        private static SerializedMessage CanonicalPayload() => Payload(123, "manifest-a", 1, 2, 3, 4);
+
+        [Fact(DisplayName = "Fast decode: frozen interop bytes (AckAndMessage)")]
+        public void Decodes_frozen_AckAndMessage_interop_bytes()
+        {
+            AssertFastDecode(Convert.FromHexString(AckAndMessageHex), "frozen:AckAndMessage",
+                recipient: "recipient", sender: "sender", seq: new SeqNo(42), payload: CanonicalPayload(), ack: Ack(10, 11, 12));
+        }
+
+        [Fact(DisplayName = "Fast decode: frozen interop bytes (Unsequenced)")]
+        public void Decodes_frozen_Unsequenced_interop_bytes()
+        {
+            AssertFastDecode(Convert.FromHexString(UnsequencedMessageHex), "frozen:Unsequenced",
+                recipient: "recipient", sender: "sender", seq: null, payload: CanonicalPayload(), ack: null);
+        }
+
+        [Fact(DisplayName = "Fast decode: frozen interop bytes (PureAck)")]
+        public void Decodes_frozen_PureAck_interop_bytes()
+        {
+            AssertFastDecode(Convert.FromHexString(PureAckHex), "frozen:PureAck",
+                recipient: null, sender: null, seq: null, payload: null, ack: Ack(10, 11, 12));
+        }
+
+        [Fact(DisplayName = "The frozen interop bytes are exactly what this build's encoder emits (wire-format anchor)")]
+        public void Encoder_emits_exactly_the_frozen_interop_bytes()
+        {
+            // If this fails, the wire format drifted — the frozen samples above would no longer be interop-valid.
             Assert.Equal(AckAndMessageHex, Convert.ToHexString(_codec.ConstructMessage(
-                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender"), new SeqNo(42), ack).ToByteArray()));
+                LocalAddress, ActorRef("recipient"), CanonicalPayload(), ActorRef("sender"), new SeqNo(42), Ack(10, 11, 12)).ToByteArray()));
 
             Assert.Equal(UnsequencedMessageHex, Convert.ToHexString(_codec.ConstructMessage(
-                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender")).ToByteArray()));
+                LocalAddress, ActorRef("recipient"), CanonicalPayload(), ActorRef("sender")).ToByteArray()));
 
-            Assert.Equal(PureAckHex, Convert.ToHexString(_codec.ConstructPureAck(ack).ToByteArray()));
+            Assert.Equal(PureAckHex, Convert.ToHexString(_codec.ConstructPureAck(Ack(10, 11, 12)).ToByteArray()));
         }
 
-        [Fact(DisplayName = "DecodeMessageFast matches DecodeMessage on generated envelopes")]
-        public void Fast_matches_oracle_on_generated_envelopes()
+        [Fact(DisplayName = "Fast decode: ignores unknown trailing fields a newer/other encoder may add")]
+        public void Ignores_unknown_trailing_fields()
         {
-            foreach (var (label, bytes) in GeneratedCorpus())
-                AssertEquivalentBothLayouts(label, bytes);
+            // Unknown field 3 (varint) and field 6 (length-delimited) appended to a full envelope.
+            AssertFastDecode(Convert.FromHexString(AckAndMessageHex + "1801"), "unknown-varint",
+                recipient: "recipient", sender: "sender", seq: new SeqNo(42), payload: CanonicalPayload(), ack: Ack(10, 11, 12));
+
+            AssertFastDecode(Convert.FromHexString(AckAndMessageHex + "3203AABBCC"), "unknown-lendelim",
+                recipient: "recipient", sender: "sender", seq: new SeqNo(42), payload: CanonicalPayload(), ack: Ack(10, 11, 12));
         }
 
-        [Fact(DisplayName = "DecodeMessageFast matches DecodeMessage with permuted field order (JVM interop)")]
-        public void Fast_matches_oracle_with_permuted_field_order()
+        // ===================== field-order independence (JVM / other-encoder interop) =====================
+
+        [Fact(DisplayName = "Fast decode: envelope with fields in reverse wire order (other-encoder interop)")]
+        public void Decodes_envelope_with_reversed_field_order()
         {
-            // RemoteEnvelope fields written in REVERSE order (seq, sender, message, recipient) and the
-            // top-level container with envelope-before-ack — exercising true tag-dispatch order independence.
-            var withAck = BuildPermutedContainer(
-                RecipientPath("recipient"), SenderPath("sender"), Payload(), seq: 42, includeAck: true);
-            AssertEquivalentBothLayouts("permuted+ack", withAck);
+            // protobuf permits any field order on the wire; the .NET codec always writes ascending order, so a
+            // tag-dispatch decoder that assumed order would corrupt e.g. JVM-encoded messages. Build the SAME
+            // logical messages with fields REVERSED and assert they decode to the same explicit values.
+            var full = ReversedOrderEnvelope("alice", "bob", Payload(7, "hi", 1, 2), seq: new SeqNo(42), ack: Ack(10, 11, 12));
+            AssertFastDecode(full, "reversed:full",
+                recipient: "alice", sender: "bob", seq: new SeqNo(42), payload: Payload(7, "hi", 1, 2), ack: Ack(10, 11, 12));
 
-            var noAck = BuildPermutedContainer(
-                RecipientPath("recipient"), SenderPath("sender"), Payload(), seq: 42, includeAck: false);
-            AssertEquivalentBothLayouts("permuted+noAck", noAck);
-
-            // Permuted, with seq omitted entirely (undefined) and no sender.
-            var minimal = BuildPermutedContainer(
-                RecipientPath("recipient"), senderPath: null, Payload(), seq: null, includeAck: false);
-            AssertEquivalentBothLayouts("permuted+minimal", minimal);
+            // This minimal envelope OMITS the seq field entirely. An absent seq field decodes to SeqNo(0)
+            // (the proto3 default for the uint64 field), which is distinct from a PRESENT SeqUndefined
+            // (=> null Seq, as in the unsequenced cases above). The fast decoder mirrors the generated parser here.
+            var minimal = ReversedOrderEnvelope("alice", senderName: null, Payload(7, "hi", 1, 2), seq: null, ack: null);
+            AssertFastDecode(minimal, "reversed:minimal",
+                recipient: "alice", sender: null, seq: new SeqNo(0), payload: Payload(7, "hi", 1, 2), ack: null);
         }
 
-        [Fact(DisplayName = "DecodeMessageFast resolve cache is correct across repeats and localAddress changes")]
-        public void Fast_resolve_cache_correct_across_repeats_and_localaddress_changes()
-        {
-            var bytes = _codec.ConstructMessage(
-                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender"), new SeqNo(5), null).ToByteArray();
+        // ===================== resolve cache =====================
 
-            // Repeated decodes force byte-keyed cache hits; each must still equal the oracle.
+        [Fact(DisplayName = "Fast decode: byte-keyed resolve cache is correct across repeats and localAddress changes")]
+        public void Resolve_cache_correct_across_repeats_and_localaddress()
+        {
+            var wire = _codec.ConstructMessage(
+                LocalAddress, ActorRef("svc"), Payload(7, "m", 9), ActorRef("cli"), new SeqNo(5)).ToByteArray();
+
+            // Repeated decodes force byte-keyed cache hits; each must still be correct.
             for (var i = 0; i < 5; i++)
-                AssertEquivalentBothLayouts($"repeat{i}", bytes);
+                AssertFastDecode(wire, $"repeat{i}",
+                    recipient: "svc", sender: "cli", seq: new SeqNo(5), payload: Payload(7, "m", 9), ack: null);
 
-            // Same path bytes, DIFFERENT localAddress: the cache's localAddress guard must re-resolve
-            // through the provider rather than serve the entry cached for LocalAddress.
-            var otherLocal = new Address("akka.tcp", "WireCompat", "127.0.0.1", 9999);
-            AssertEquivalent("otherLocal",
-                _codec.DecodeMessage(ByteString.CopyFrom(bytes), RemoteProvider, otherLocal),
-                _codec.DecodeMessageFast(new ReadOnlySequence<byte>(bytes), RemoteProvider, otherLocal));
-
-            // Back to the original localAddress — still correct.
-            AssertEquivalentBothLayouts("backToOriginal", bytes);
+            // A DIFFERENT localAddress must not be served a ref cached for LocalAddress (the cache's guard).
+            AssertFastDecodeWith(new Address("akka.tcp", "WireCompat", "127.0.0.1", 9999), wire, "otherLocal",
+                recipient: "svc", sender: "cli", seq: new SeqNo(5), payload: Payload(7, "m", 9), ack: null);
         }
 
-        // ---- corpus ----
+        // ===================== defense-in-depth: matches the shipped generated parser =====================
 
-        private IEnumerable<(string label, byte[] bytes)> GeneratedCorpus()
+        [Fact(DisplayName = "Fast decoder matches the shipped generated parser over a corpus (defense-in-depth)")]
+        public void Matches_the_generated_protobuf_parser()
         {
-            var ack = new Ack(new SeqNo(10), new[] { new SeqNo(11), new SeqNo(12) });
-
-            yield return ("gen:full", _codec.ConstructMessage(
-                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender"), new SeqNo(42), ack).ToByteArray());
-
-            yield return ("gen:noAck", _codec.ConstructMessage(
-                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender"), new SeqNo(42)).ToByteArray());
-
-            yield return ("gen:noSender", _codec.ConstructMessage(
-                LocalAddress, ActorRef("recipient"), Payload(), seqOption: new SeqNo(7)).ToByteArray());
-
-            yield return ("gen:noSeqNoAck", _codec.ConstructMessage(
-                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender")).ToByteArray());
-
-            yield return ("gen:emptyAckNacks", _codec.ConstructMessage(
-                LocalAddress, ActorRef("recipient"), Payload(), ActorRef("sender"), new SeqNo(1), new Ack(new SeqNo(3))).ToByteArray());
-
-            // Large payload + empty manifest.
-            yield return ("gen:largePayload", _codec.ConstructMessage(
-                LocalAddress, ActorRef("recipient"),
-                new SerializedMessage { SerializerId = 5, Message = ByteString.CopyFrom(new byte[4096]) },
-                ActorRef("sender"), new SeqNo(99)).ToByteArray());
-
-            // Non-ASCII actor names exercise the UTF-8 path decode.
-            yield return ("gen:unicodePaths", _codec.ConstructMessage(
-                LocalAddress, ActorRef("recipient-Ä-名前"), Payload(), ActorRef("sender-Ω-送信"), new SeqNo(2), ack).ToByteArray());
-
-            // Pure ack (no envelope).
-            yield return ("gen:pureAck", _codec.ConstructPureAck(ack).ToByteArray());
-        }
-
-        private byte[] BuildPermutedContainer(string recipientPath, string? senderPath, SerializedMessage message, ulong? seq, bool includeAck)
-        {
-            using var envStream = new MemoryStream();
-            var eos = new CodedOutputStream(envStream);
-            if (seq is { } s)
+            // Belt-and-suspenders on top of the explicit-value tests above: the fast decoder must agree with the
+            // existing generated-protobuf parser (an independent implementation) field-for-field.
+            var corpus = new[]
             {
-                eos.WriteTag(5, WireFormat.WireType.Fixed64);
-                eos.WriteFixed64(s);
-            }
-            if (senderPath is not null)
-            {
-                eos.WriteTag(4, WireFormat.WireType.LengthDelimited);
-                eos.WriteMessage(new ActorRefData { Path = senderPath });
-            }
-            eos.WriteTag(2, WireFormat.WireType.LengthDelimited);
-            eos.WriteMessage(message);
-            eos.WriteTag(1, WireFormat.WireType.LengthDelimited);
-            eos.WriteMessage(new ActorRefData { Path = recipientPath });
-            eos.Flush();
-            var envelopeBytes = envStream.ToArray();
+                _codec.ConstructMessage(LocalAddress, ActorRef("recipient"), CanonicalPayload(), ActorRef("sender"), new SeqNo(42), Ack(10, 11, 12)).ToByteArray(),
+                _codec.ConstructMessage(LocalAddress, ActorRef("recipient"), CanonicalPayload(), ActorRef("sender"), new SeqNo(42)).ToByteArray(),
+                _codec.ConstructMessage(LocalAddress, ActorRef("recipient"), CanonicalPayload(), seqOption: new SeqNo(7)).ToByteArray(),
+                _codec.ConstructMessage(LocalAddress, ActorRef("recipient"), CanonicalPayload(), ActorRef("sender")).ToByteArray(),
+                _codec.ConstructPureAck(Ack(10, 11, 12)).ToByteArray(),
+            };
 
-            using var outStream = new MemoryStream();
-            var os = new CodedOutputStream(outStream);
-            // envelope (field 2) BEFORE ack (field 1) — reversed top-level order.
-            // WriteBytes emits the length prefix + raw bytes after the tag, embedding the manually
-            // (permuted-order) serialized RemoteEnvelope verbatim.
-            os.WriteTag(2, WireFormat.WireType.LengthDelimited);
-            os.WriteBytes(ByteString.CopyFrom(envelopeBytes));
-            if (includeAck)
+            for (var i = 0; i < corpus.Length; i++)
             {
-                os.WriteTag(1, WireFormat.WireType.LengthDelimited);
-                os.WriteMessage(new AcknowledgementInfo { CumulativeAck = 10, Nacks = { 11UL, 12UL } });
+                var wire = corpus[i];
+                var oracle = _codec.DecodeMessage(ByteString.CopyFrom(wire), RemoteProvider, LocalAddress);
+                var fast = _codec.DecodeMessageFast(new ReadOnlySequence<byte>(wire), RemoteProvider, LocalAddress);
+                AssertSameDecode($"corpus[{i}]", oracle, fast);
             }
-            os.Flush();
-            return outStream.ToArray();
         }
 
-        // ---- assertions ----
+        // ===================== assertions =====================
 
-        private void AssertEquivalentBothLayouts(string label, byte[] bytes)
+        private void AssertFastDecode(byte[] wire, string label,
+            string? recipient, string? sender, SeqNo? seq, SerializedMessage? payload, Ack? ack)
+            => AssertFastDecodeWith(LocalAddress, wire, label, recipient, sender, seq, payload, ack);
+
+        private void AssertFastDecodeWith(Address localAddress, byte[] wire, string label,
+            string? recipient, string? sender, SeqNo? seq, SerializedMessage? payload, Ack? ack)
         {
-            // Single contiguous segment.
-            AssertEquivalent($"{label} [single]",
-                _codec.DecodeMessage(ByteString.CopyFrom(bytes), RemoteProvider, LocalAddress),
-                _codec.DecodeMessageFast(new ReadOnlySequence<byte>(bytes), RemoteProvider, LocalAddress));
+            // Decode both as one buffer and split one-byte-per-segment (stresses cross-segment parsing).
+            var buffers = new (string variant, ReadOnlySequence<byte> buf)[]
+            {
+                ("contiguous", new ReadOnlySequence<byte>(wire)),
+                ("split-1B", SplitEveryByte(wire)),
+            };
 
-            // Worst-case fragmentation: one byte per segment (stresses cross-segment varints/fixed64/strings).
-            var split = SplitEveryByte(bytes);
-            AssertEquivalent($"{label} [split]",
-                _codec.DecodeMessage(ByteString.CopyFrom(split.ToArray()), RemoteProvider, LocalAddress),
-                _codec.DecodeMessageFast(split, RemoteProvider, LocalAddress));
+            foreach (var (variant, buf) in buffers)
+            {
+                var who = $"{label} [{variant}]";
+                var decoded = _codec.DecodeMessageFast(buf, RemoteProvider, localAddress);
+
+                if (recipient is null)
+                {
+                    Assert.True(decoded.MessageOption is null, $"{who}: expected no message");
+                }
+                else
+                {
+                    Assert.True(decoded.MessageOption is not null, $"{who}: expected a message");
+                    var m = decoded.MessageOption!;
+                    Assert.Equal(SerializedPath(recipient), m.Recipient.Path.ToSerializationFormat());
+
+                    if (sender is null)
+                        Assert.True(m.SenderOptional is null, $"{who}: expected no sender");
+                    else
+                    {
+                        Assert.True(m.SenderOptional is not null, $"{who}: expected sender '{sender}'");
+                        Assert.Equal(SerializedPath(sender), m.SenderOptional!.Path.ToSerializationFormat());
+                    }
+
+                    Assert.Equal(seq, m.Seq);
+                    Assert.Equal(payload!.SerializerId, m.SerializedMessage.SerializerId);
+                    Assert.Equal(payload.MessageManifest, m.SerializedMessage.MessageManifest);
+                    Assert.Equal(payload.Message, m.SerializedMessage.Message);
+                }
+
+                if (ack is null)
+                {
+                    Assert.True(decoded.AckOption is null, $"{who}: expected no ack");
+                }
+                else
+                {
+                    Assert.True(decoded.AckOption is not null, $"{who}: expected an ack");
+                    Assert.Equal(ack.CumulativeAck, decoded.AckOption!.CumulativeAck);
+                    Assert.Equal(ack.Nacks.ToArray(), decoded.AckOption.Nacks.ToArray());
+                }
+            }
         }
 
-        private static void AssertEquivalent(string label, AckAndMessage oracle, AckAndMessage fast)
+        private static void AssertSameDecode(string label, AckAndMessage oracle, AckAndMessage fast)
         {
-            // Ack
             if (oracle.AckOption is null)
-            {
                 Assert.True(fast.AckOption is null, $"{label}: expected null ack");
-            }
             else
             {
                 Assert.True(fast.AckOption is not null, $"{label}: expected non-null ack");
@@ -246,7 +347,6 @@ namespace Akka.Remote.Tests.Transport
                 Assert.Equal(oracle.AckOption.Nacks.ToArray(), fast.AckOption.Nacks.ToArray());
             }
 
-            // Message
             if (oracle.MessageOption is null)
             {
                 Assert.True(fast.MessageOption is null, $"{label}: expected null message");
@@ -256,31 +356,59 @@ namespace Akka.Remote.Tests.Transport
             Assert.True(fast.MessageOption is not null, $"{label}: expected non-null message");
             var o = oracle.MessageOption;
             var f = fast.MessageOption!;
-
             Assert.Equal(o.Recipient.Path, f.Recipient.Path);
             Assert.Equal(o.RecipientAddress, f.RecipientAddress);
             Assert.Equal(o.Seq, f.Seq);
-
-            if (o.SenderOptional is null)
-                Assert.True(f.SenderOptional is null, $"{label}: expected null sender");
-            else
-            {
-                Assert.True(f.SenderOptional is not null, $"{label}: expected non-null sender");
-                Assert.Equal(o.SenderOptional.Path, f.SenderOptional!.Path);
-            }
-
-            if (o.SerializedMessage is null)
-                Assert.True(f.SerializedMessage is null, $"{label}: expected null serialized message");
-            else
-            {
-                Assert.True(f.SerializedMessage is not null, $"{label}: expected non-null serialized message");
-                Assert.Equal(o.SerializedMessage.SerializerId, f.SerializedMessage!.SerializerId);
-                Assert.Equal(o.SerializedMessage.MessageManifest, f.SerializedMessage.MessageManifest);
-                Assert.Equal(o.SerializedMessage.Message, f.SerializedMessage.Message);
-            }
+            Assert.Equal(o.SenderOptional?.Path, f.SenderOptional?.Path);
+            Assert.Equal(o.SerializedMessage.SerializerId, f.SerializedMessage.SerializerId);
+            Assert.Equal(o.SerializedMessage.MessageManifest, f.SerializedMessage.MessageManifest);
+            Assert.Equal(o.SerializedMessage.Message, f.SerializedMessage.Message);
         }
 
-        // ---- helpers ----
+        // ===================== builders / helpers =====================
+
+        // Builds an AckAndEnvelopeContainer with fields written in REVERSE wire order, by hand, because the
+        // codec only ever emits ascending order. protobuf field numbers (WireFormats.proto):
+        //   RemoteEnvelope:            recipient=1, message=2, sender=4, seq=5 (fixed64)
+        //   AckAndEnvelopeContainer:   ack=1, envelope=2
+        private byte[] ReversedOrderEnvelope(string recipientName, string? senderName, SerializedMessage payload, SeqNo? seq, Ack? ack)
+        {
+            using var envStream = new MemoryStream();
+            var env = new CodedOutputStream(envStream);
+            // reversed envelope order: seq(5) -> sender(4) -> message(2) -> recipient(1)
+            if (seq is { } s)
+            {
+                env.WriteTag(5, WireFormat.WireType.Fixed64);
+                env.WriteFixed64((ulong)s.RawValue);
+            }
+            if (senderName is not null)
+            {
+                env.WriteTag(4, WireFormat.WireType.LengthDelimited);
+                env.WriteMessage(new ActorRefData { Path = SerializedPath(senderName) });
+            }
+            env.WriteTag(2, WireFormat.WireType.LengthDelimited);
+            env.WriteMessage(payload);
+            env.WriteTag(1, WireFormat.WireType.LengthDelimited);
+            env.WriteMessage(new ActorRefData { Path = SerializedPath(recipientName) });
+            env.Flush();
+            var envelopeBytes = envStream.ToArray();
+
+            using var outStream = new MemoryStream();
+            var os = new CodedOutputStream(outStream);
+            // reversed container order: envelope(2) before ack(1). WriteBytes embeds the manually-ordered
+            // envelope verbatim (length-prefixed), so its reversed field order is preserved on the wire.
+            os.WriteTag(2, WireFormat.WireType.LengthDelimited);
+            os.WriteBytes(ByteString.CopyFrom(envelopeBytes));
+            if (ack is not null)
+            {
+                var info = new AcknowledgementInfo { CumulativeAck = (ulong)ack.CumulativeAck.RawValue };
+                info.Nacks.AddRange(ack.Nacks.Select(n => (ulong)n.RawValue));
+                os.WriteTag(1, WireFormat.WireType.LengthDelimited);
+                os.WriteMessage(info);
+            }
+            os.Flush();
+            return outStream.ToArray();
+        }
 
         private IRemoteActorRefProvider RemoteProvider =>
             Sys.AsInstanceOf<ExtendedActorSystem>().Provider.AsInstanceOf<IRemoteActorRefProvider>();
@@ -288,16 +416,18 @@ namespace Akka.Remote.Tests.Transport
         private IActorRef ActorRef(string name) =>
             new FixedActorRef(new RootActorPath(LocalAddress) / "user" / name, Sys.AsInstanceOf<ExtendedActorSystem>().Provider);
 
-        private string RecipientPath(string name) => (new RootActorPath(LocalAddress) / "user" / name).ToSerializationFormat();
+        private string SerializedPath(string name) =>
+            (new RootActorPath(LocalAddress) / "user" / name).ToSerializationFormat();
 
-        private string SenderPath(string name) => (new RootActorPath(LocalAddress) / "user" / name).ToSerializationFormat();
-
-        private static SerializedMessage Payload() => new()
+        private static SerializedMessage Payload(int serializerId, string manifest, params byte[] message) => new()
         {
-            SerializerId = 123,
-            MessageManifest = ByteString.CopyFromUtf8("manifest-a"),
-            Message = ByteString.CopyFrom(1, 2, 3, 4)
+            SerializerId = serializerId,
+            MessageManifest = ByteString.CopyFromUtf8(manifest),
+            Message = ByteString.CopyFrom(message)
         };
+
+        private static Ack Ack(long cumulative, params long[] nacks) =>
+            new(new SeqNo(cumulative), nacks.Select(n => new SeqNo(n)).ToArray());
 
         private static ReadOnlySequence<byte> SplitEveryByte(byte[] bytes)
         {

--- a/src/core/Akka.Remote/Endpoint.cs
+++ b/src/core/Akka.Remote/Endpoint.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 #pragma warning disable AK1004
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -1970,7 +1971,10 @@ namespace Akka.Remote
         {
             try
             {
-                return _codec.DecodeMessage(pdu, _provider, LocalAddress);
+                // Use the hand-rolled low-allocation tag-dispatch decoder (DecodeMessageFast), which produces
+                // byte-identical results to DecodeMessage (asserted by AkkaPduCodecFastDecodeDifferentialSpec)
+                // with ~39% less CPU / ~60% less allocation. DecodeMessage is retained as the differential oracle.
+                return _codec.DecodeMessageFast(new ReadOnlySequence<byte>(pdu.Memory), _provider, LocalAddress);
             }
             catch (Exception ex)
             {

--- a/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
+++ b/src/core/Akka.Remote/Transport/AkkaPduCodec.cs
@@ -6,7 +6,11 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Buffers;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Threading;
 using Akka.Actor;
 using Google.Protobuf;
 using System.Runtime.Serialization;
@@ -281,6 +285,17 @@ namespace Akka.Remote.Transport
         public abstract AckAndMessage DecodeMessage(ByteString raw, IRemoteActorRefProvider provider, Address localAddress);
 
         /// <summary>
+        /// INTERNAL API. Lower-allocation inbound decode. Codecs that do not provide a specialized
+        /// implementation fall back to <see cref="DecodeMessage(ByteString,IRemoteActorRefProvider,Address)"/>.
+        /// </summary>
+        public virtual AckAndMessage DecodeMessageFast(ReadOnlySequence<byte> raw, IRemoteActorRefProvider provider, Address localAddress)
+        {
+            // Default fallback for codecs without a specialized fast path: materialize a ByteString and use the
+            // generated decoder. (The concrete AkkaPduProtobuffCodec overrides this with the low-allocation path.)
+            return DecodeMessage(ByteString.CopyFrom(raw.ToArray()), provider, localAddress);
+        }
+
+        /// <summary>
         /// TBD
         /// </summary>
         /// <param name="localAddress">TBD</param>
@@ -429,9 +444,16 @@ namespace Akka.Remote.Transport
                 if (envelopeContainer != null)
                 {
                     var recipient = provider.ResolveActorRefWithLocalAddress(envelopeContainer.Recipient.Path, localAddress);
-                    
-                    //todo get parsed address from provider
-                    var recipientAddress = ActorPathCache.Cache.GetOrCompute(envelopeContainer.Recipient.Path).Address;
+
+                    // RecipientAddress is functionally consumed by DefaultMessageDispatcher.Dispatch only
+                    // for NON-local (remote-deployed) recipients (the Transport.Addresses.Contains check).
+                    // In that case the resolved ref is a RemoteActorRef whose Path IS the parsed wire path,
+                    // so recipient.Path.Address is byte-identical to the value the previous
+                    // ActorPathCache.GetOrCompute(path).Address produced — but WITHOUT a second FastHash +
+                    // path-cache probe per inbound message. For local recipients the field is unused by the
+                    // dispatcher (the only observable delta is the address printed in an obscure
+                    // dropped-message error log for a local ref that is neither ILocalRef nor Repointable).
+                    var recipientAddress = recipient.Path.Address;
                     
                     var serializedMessage = envelopeContainer.Message;
                     IActorRef senderOption = null;
@@ -453,6 +475,359 @@ namespace Akka.Remote.Transport
 
 
             return new AckAndMessage(ackOption, messageOption);
+        }
+
+        // ===========================================================================================
+        //  Hand-rolled tag-dispatch decode of AckAndEnvelopeContainer (Phase-2 lever B2a).
+        //
+        //  Produces results IDENTICAL to DecodeMessage(...) (the generated-protobuf path, kept as the
+        //  differential-test oracle) but WITHOUT allocating the AckAndEnvelopeContainer / RemoteEnvelope /
+        //  ActorRefData wrapper objects. The inner message payload (the SerializedMessage/Payload bytes) is
+        //  extracted as an opaque byte range and parsed with the SAME generated parser, so message
+        //  (de)serialization is unchanged.
+        //
+        //  CRITICAL (wire interop is the whole point): protobuf fields may arrive in ANY order with
+        //  unknown fields interspersed (a different/older/newer encoder, JVM Akka). So this is a real
+        //  tag-dispatch loop with unknown-field skipping — NOT positional. Wire tags = (field<<3)|wireType:
+        //    AckAndEnvelopeContainer: ack=1 (msg, tag 10), envelope=2 (msg, tag 18)
+        //    RemoteEnvelope:          recipient=1 (msg, 10), message=2 (msg, 18), sender=4 (msg, 34),
+        //                             seq=5 (fixed64, tag 41)
+        //    ActorRefData:            path=1 (string, tag 10)
+        //    AcknowledgementInfo:     cumulativeAck=1 (fixed64, tag 9), nacks=2 (fixed64; tag 17 unpacked,
+        //                             tag 18 packed)
+        // ===========================================================================================
+        private const int WireVarint = 0;
+        private const int WireFixed64 = 1;
+        private const int WireLengthDelimited = 2;
+        private const int WireFixed32 = 5;
+
+        // ===========================================================================================
+        //  Byte-keyed inbound actor-ref resolve cache (Phase-2 lever B2b).
+        //
+        //  Inbound recipient/sender paths repeat massively per association (same handful of actors),
+        //  so caching the resolved IInternalActorRef keyed by the raw UTF-8 path BYTES lets the hot path
+        //  skip String materialization + Utf8 transcode + FastHash(UTF-16) + the string-keyed resolve/path
+        //  caches entirely on a hit. Also subsumes lever B1: the remote SENDER ref (which the codec
+        //  otherwise re-creates via CreateRemoteRef => new RemoteActorRef every message) is cached here.
+        //
+        //  Correctness: the codec is created per association (one per EndpointWriter, line ~919 in
+        //  Endpoint.cs) and decode runs only on that association's single EndpointReader actor, so
+        //  localAddress is constant and access is single-threaded. The cache is nonetheless made
+        //  lock-free + race-SAFE as defense-in-depth: each slot holds an IMMUTABLE entry published/read
+        //  via Volatile, so any unexpected concurrent decode can only miss or read a self-consistent
+        //  entry — never tear. Every hit is validated by localAddress equality + full path-byte equality,
+        //  so a hash collision or a localAddress change can only cause a (correct) miss, never a wrong ref.
+        // ===========================================================================================
+        private const int RefCacheSize = 256; // power of two
+        private readonly RefCacheEntry[] _refCache = new RefCacheEntry[RefCacheSize];
+
+        private sealed class RefCacheEntry
+        {
+            public readonly byte[] PathBytes;
+            public readonly Address LocalAddress;
+            public readonly IInternalActorRef Ref;
+
+            public RefCacheEntry(byte[] pathBytes, Address localAddress, IInternalActorRef @ref)
+            {
+                PathBytes = pathBytes;
+                LocalAddress = localAddress;
+                Ref = @ref;
+            }
+        }
+
+        private IInternalActorRef ResolveCached(ReadOnlySequence<byte> pathBytes, Address localAddress, IRemoteActorRefProvider provider)
+        {
+            // Single-segment (the common case) avoids any copy; multi-segment paths (split across TCP
+            // chunks) are materialized contiguously for hashing + comparison.
+            ReadOnlySpan<byte> span;
+            byte[] contiguous = null;
+            if (pathBytes.IsSingleSegment)
+            {
+                span = pathBytes.FirstSpan;
+            }
+            else
+            {
+                contiguous = pathBytes.ToArray();
+                span = contiguous;
+            }
+
+            var slot = (int)(Fnv1a(span) & (RefCacheSize - 1));
+            var entry = Volatile.Read(ref _refCache[slot]);
+            if (entry != null && entry.LocalAddress.Equals(localAddress) && span.SequenceEqual(entry.PathBytes))
+                return entry.Ref;
+
+            // Miss: materialize the path string and resolve through the canonical (correct) provider path,
+            // which keeps populating the existing string-keyed caches too.
+            var path = Encoding.UTF8.GetString(span);
+            var resolved = provider.ResolveActorRefWithLocalAddress(path, localAddress);
+            var key = contiguous ?? span.ToArray();
+            Volatile.Write(ref _refCache[slot], new RefCacheEntry(key, localAddress, resolved));
+            return resolved;
+        }
+
+        private static uint Fnv1a(ReadOnlySpan<byte> data)
+        {
+            uint hash = 2166136261u;
+            for (var i = 0; i < data.Length; i++)
+            {
+                hash ^= data[i];
+                hash *= 16777619u;
+            }
+
+            return hash;
+        }
+
+        public override AckAndMessage DecodeMessageFast(ReadOnlySequence<byte> raw, IRemoteActorRefProvider provider, Address localAddress)
+        {
+            Ack ackOption = null;
+            Message messageOption = null;
+
+            var reader = new SequenceReader<byte>(raw);
+            while (!reader.End)
+            {
+                if (!TryReadVarint32(ref reader, out var tag))
+                    throw new PduCodecException("Decoding PDU failed: truncated tag in AckAndEnvelopeContainer");
+
+                switch (tag)
+                {
+                    case 10: // ack = AcknowledgementInfo
+                        ackOption = ParseAck(ReadLengthDelimited(raw, ref reader));
+                        break;
+                    case 18: // envelope = RemoteEnvelope
+                        messageOption = ParseEnvelope(ReadLengthDelimited(raw, ref reader), provider, localAddress);
+                        break;
+                    default:
+                        SkipField(raw, ref reader, tag);
+                        break;
+                }
+            }
+
+            return new AckAndMessage(ackOption, messageOption);
+        }
+
+        private Message ParseEnvelope(ReadOnlySequence<byte> envelope, IRemoteActorRefProvider provider, Address localAddress)
+        {
+            bool hasRecipient = false;
+            ReadOnlySequence<byte> recipientPathBytes = default;
+            bool hasSender = false;
+            ReadOnlySequence<byte> senderPathBytes = default;
+            ReadOnlySequence<byte> messageBytes = default;
+            bool hasMessage = false;
+            // proto3 default for the (uint64) seq field is 0, NOT the SeqUndefined sentinel. The generated
+            // parser therefore maps an ABSENT seq field to Seq=0 => SeqNo(0) (because 0 != SeqUndefined),
+            // and only a present SeqUndefined (MaxValue) maps to null. Mirror that exactly. (A real Akka
+            // encoder always writes seq explicitly — as a value or SeqUndefined — but a different encoder
+            // could omit it, and matching proto semantics keeps interop correct.)
+            ulong seq = 0;
+
+            var reader = new SequenceReader<byte>(envelope);
+            while (!reader.End)
+            {
+                if (!TryReadVarint32(ref reader, out var tag))
+                    throw new PduCodecException("Decoding PDU failed: truncated tag in RemoteEnvelope");
+
+                switch (tag)
+                {
+                    case 10: // recipient = ActorRefData
+                        recipientPathBytes = ParseActorRefPathSlice(ReadLengthDelimited(envelope, ref reader));
+                        hasRecipient = true;
+                        break;
+                    case 18: // message = SerializedMessage (Payload) — kept opaque
+                        messageBytes = ReadLengthDelimited(envelope, ref reader);
+                        hasMessage = true;
+                        break;
+                    case 34: // sender = ActorRefData
+                        senderPathBytes = ParseActorRefPathSlice(ReadLengthDelimited(envelope, ref reader));
+                        hasSender = true;
+                        break;
+                    case 41: // seq = fixed64
+                        if (!reader.TryReadLittleEndian(out long seqRaw))
+                            throw new PduCodecException("Decoding PDU failed: truncated seq fixed64");
+                        seq = unchecked((ulong)seqRaw);
+                        break;
+                    default:
+                        SkipField(envelope, ref reader, tag);
+                        break;
+                }
+            }
+
+            // A well-formed RemoteEnvelope always carries recipient + message; the generated path would
+            // NPE on a missing recipient/message. Surface a codec exception instead of a raw NRE.
+            if (!hasRecipient)
+                throw new PduCodecException("Decoding PDU failed: RemoteEnvelope missing recipient");
+
+            // ResolveCached materializes the path string + resolves on a miss; on a hit (the common case)
+            // it skips String.Ctor + Utf8 transcode + FastHash entirely. An ActorRefData with an absent
+            // path sub-field yields an empty slice => "" path, mirroring protobuf's default-string behavior.
+            var recipient = ResolveCached(recipientPathBytes, localAddress, provider);
+            // See B0: recipient.Path.Address is byte-identical to the parsed wire address where it is
+            // functionally consumed (non-local recipients), without a second FastHash.
+            var recipientAddress = recipient.Path.Address;
+
+            IActorRef senderOption = hasSender
+                ? ResolveCached(senderPathBytes, localAddress, provider)
+                : null;
+
+            SeqNo? seqOption = seq != SeqUndefined ? new SeqNo(unchecked((long)seq)) : (SeqNo?)null;
+
+            var serializedMessage = hasMessage ? SerializedMessage.Parser.ParseFrom(messageBytes) : null;
+
+            return new Message(recipient, recipientAddress, serializedMessage, senderOption, seqOption);
+        }
+
+        private static ReadOnlySequence<byte> ParseActorRefPathSlice(ReadOnlySequence<byte> actorRefData)
+        {
+            ReadOnlySequence<byte> path = default; // absent path sub-field => empty (proto3 default "")
+            var reader = new SequenceReader<byte>(actorRefData);
+            while (!reader.End)
+            {
+                if (!TryReadVarint32(ref reader, out var tag))
+                    throw new PduCodecException("Decoding PDU failed: truncated tag in ActorRefData");
+
+                switch (tag)
+                {
+                    case 10: // path = string
+                        path = ReadLengthDelimited(actorRefData, ref reader);
+                        break;
+                    default:
+                        SkipField(actorRefData, ref reader, tag);
+                        break;
+                }
+            }
+
+            return path;
+        }
+
+        private static Ack ParseAck(ReadOnlySequence<byte> ackData)
+        {
+            long cumulativeAck = 0;
+            List<SeqNo> nacks = null;
+
+            var reader = new SequenceReader<byte>(ackData);
+            while (!reader.End)
+            {
+                if (!TryReadVarint32(ref reader, out var tag))
+                    throw new PduCodecException("Decoding PDU failed: truncated tag in AcknowledgementInfo");
+
+                switch (tag)
+                {
+                    case 9: // cumulativeAck = fixed64
+                        if (!reader.TryReadLittleEndian(out cumulativeAck))
+                            throw new PduCodecException("Decoding PDU failed: truncated cumulativeAck fixed64");
+                        break;
+                    case 17: // nacks (unpacked repeated fixed64) — one element
+                        if (!reader.TryReadLittleEndian(out long nack))
+                            throw new PduCodecException("Decoding PDU failed: truncated nack fixed64");
+                        (nacks ??= new List<SeqNo>()).Add(new SeqNo(nack));
+                        break;
+                    case 18: // nacks (packed repeated fixed64)
+                    {
+                        var packed = ReadLengthDelimited(ackData, ref reader);
+                        var packedReader = new SequenceReader<byte>(packed);
+                        while (!packedReader.End)
+                        {
+                            if (!packedReader.TryReadLittleEndian(out long packedNack))
+                                throw new PduCodecException("Decoding PDU failed: truncated packed nack fixed64");
+                            (nacks ??= new List<SeqNo>()).Add(new SeqNo(packedNack));
+                        }
+
+                        break;
+                    }
+                    default:
+                        SkipField(ackData, ref reader, tag);
+                        break;
+                }
+            }
+
+            // Matches DecodeMessage: Ack(SeqNo, nacks). Empty/absent nacks => empty list (the single-arg
+            // ctor delegates to new List<SeqNo>()).
+            return nacks is null
+                ? new Ack(new SeqNo(cumulativeAck))
+                : new Ack(new SeqNo(cumulativeAck), nacks);
+        }
+
+        private static ReadOnlySequence<byte> ReadLengthDelimited(ReadOnlySequence<byte> source, ref SequenceReader<byte> reader)
+        {
+            if (!TryReadVarint32(ref reader, out var length) || length < 0)
+                throw new PduCodecException("Decoding PDU failed: invalid length-delimited field length");
+            if (reader.Remaining < length)
+                throw new PduCodecException("Decoding PDU failed: truncated length-delimited field");
+
+            var slice = source.Slice(reader.Position, length);
+            reader.Advance(length);
+            return slice;
+        }
+
+        private static void SkipField(ReadOnlySequence<byte> source, ref SequenceReader<byte> reader, int tag)
+        {
+            switch (tag & 0x7)
+            {
+                case WireVarint:
+                    SkipVarint(ref reader);
+                    break;
+                case WireFixed64:
+                    if (reader.Remaining < 8)
+                        throw new PduCodecException("Decoding PDU failed: truncated fixed64 field");
+                    reader.Advance(8);
+                    break;
+                case WireFixed32:
+                    if (reader.Remaining < 4)
+                        throw new PduCodecException("Decoding PDU failed: truncated fixed32 field");
+                    reader.Advance(4);
+                    break;
+                case WireLengthDelimited:
+                    ReadLengthDelimited(source, ref reader);
+                    break;
+                default:
+                    throw new PduCodecException($"Decoding PDU failed: unsupported wire type {tag & 0x7} (tag {tag})");
+            }
+        }
+
+        private static bool TryReadVarint32(ref SequenceReader<byte> reader, out int value)
+        {
+            long result = 0;
+            var shift = 0;
+
+            while (shift < 35)
+            {
+                if (!reader.TryRead(out var b))
+                {
+                    value = 0;
+                    return false;
+                }
+
+                result |= (long)(b & 0x7F) << shift;
+                if ((b & 0x80) == 0)
+                {
+                    if (result > int.MaxValue)
+                    {
+                        value = 0;
+                        return false;
+                    }
+
+                    value = (int)result;
+                    return true;
+                }
+
+                shift += 7;
+            }
+
+            value = 0;
+            return false;
+        }
+
+        private static void SkipVarint(ref SequenceReader<byte> reader)
+        {
+            // up to 10 bytes for a 64-bit varint
+            for (var i = 0; i < 10; i++)
+            {
+                if (!reader.TryRead(out var b))
+                    throw new PduCodecException("Decoding PDU failed: truncated varint");
+                if ((b & 0x80) == 0)
+                    return;
+            }
+
+            throw new PduCodecException("Decoding PDU failed: varint exceeds 10 bytes");
         }
 
         private AcknowledgementInfo AckBuilder(Ack ack)


### PR DESCRIPTION
## Summary

Replaces the generated-protobuf inbound decode on the `EndpointReader` hot path with `DecodeMessageFast` — a hand-rolled tag-dispatch parser for the `AckAndEnvelopeContainer → RemoteEnvelope → ActorRefData` envelope, plus a lock-free byte-keyed actor-ref resolve cache. The **user-message payload is left opaque** and decoded by the existing generated parser, so wire output and decode semantics are unchanged.

Internal-only — `AkkaPduCodec`/`AkkaPduProtobuffCodec` are `internal`, so there is **no public API change** and **no wire-format change**.

## What it actually changes

Per inbound message, the generated path materialized: the protobuf wrapper-object graph (`AckAndEnvelopeContainer`, `RemoteEnvelope`, `AcknowledgementInfo`, two `ActorRefData`), the recipient/sender **actor-path strings** (UTF-8 → UTF-16), a `FastHash` over each path, the provider resolve, and a fresh sender `RemoteActorRef`. `DecodeMessageFast` removes most of that:

- **No wrapper-object graph** — the tag-dispatch loop reads envelope fields directly off the inbound `ReadOnlySequence<byte>`; none of the intermediate protobuf message objects are allocated.
- **Actor paths stay as byte slices, not strings** — recipient/sender paths are kept as `ReadOnlySequence<byte>` slices over the buffer and resolved through a lock-free 256-slot byte-keyed cache (FNV-1a over the UTF-8 bytes). On a **cache hit** (the common repeated-recipient case) it skips the `String` materialization, the UTF-16 `FastHash`, the provider resolve, and the sender `RemoteActorRef` allocation. On a miss it materializes + resolves once, then caches.
- **Drops a redundant recipient-address re-parse** (a second `FastHash` + path-cache probe).

## What it does *not* change

To avoid over-claiming: the **user-message payload byte array is still copied.** `DecodeMessageFast` keeps the payload as an opaque slice while parsing the envelope, then hands it to the existing `SerializedMessage.Parser`, which copies it into a `ByteString` for downstream deserialization — exactly as before. This PR does not eliminate that copy.

So the savings are: the per-message protobuf object graph, and the actor-path string materialization + hashing + ref allocation — **not** the message-payload copy.

## Results

Bare-metal AMD Ryzen 9 9900X, net10.0, RemotePingPong over the **DotNetty** transport, **raw isolated single runs** (Server GC):

| metric | dev | dev + this change | Δ |
|---|---|---|---|
| allocation / msg | 4,841 B | 4,044 B | **−16.5%** |
| peak throughput | ~1.36M msg/s | ~1.62M msg/s | **~+19%** |

The throughput gain is mostly from removing the per-message actor-path hashing/resolution CPU; the allocation drop from eliminating the wrapper-object graph and the path-string/ref allocations. The decode path is transport-agnostic, so this benefits the classic DotNetty transport (measured here) and the Akka.Streams transport alike.

## Correctness

`AkkaPduCodecFastDecodeDifferentialSpec` (16 tests): each states explicit inputs, runs the fast decoder **both contiguous and one-byte-per-segment**, and asserts the decoded fields against those exact values. Coverage: frozen interop wire samples (pinned to this build's encoder by an anchor test), unknown trailing fields, **reversed wire field order** (a different/JVM encoder may emit any order; the .NET codec only emits ascending), the resolve cache across repeats + `localAddress` changes, and a defense-in-depth cross-check against the shipped generated parser. Plus `RemotingSpec` + `EndpointReaderSpec` + `AkkaProtocolSpec` 30/30 with the fast path live.

## Scope

3 files: `AkkaPduCodec.cs` (decoder + cache), `Endpoint.cs` (wires `TryDecodeMessageAndAck` to the fast path), and the spec. net10.0. No public API or wire-format change — interop with the existing codec is asserted byte-for-byte by the spec.
