### PR TITLE
fix: prevent ephemeral-port overflow in DotNettyTransportShutdownSpec (Windows-only flaky test)

### DIFF
--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
@@ -283,10 +283,15 @@ namespace Akka.Remote.Tests.Transport
                 var c1 = await t1.Listen();
                 c1.Item2.SetResult(new ActorAssociationEventListener(p1));
 
-                // t1 --> t2 association
+                // t1 --> nowhere: target a valid (0-65535) port where nothing is listening so the
+                // outbound connect fails. Offset down when near the top of the ephemeral range so we
+                // never exceed IPEndPoint.MaxPort (65535) — Windows' dynamic range tops out at 65535,
+                // so a blind "+ 100" can overflow and throw ArgumentOutOfRangeException instead.
+                var boundPort = c1.Item1.Port!.Value;
+                var deadPort = boundPort > 65435 ? boundPort - 100 : boundPort + 100;
                 await Assert.ThrowsAsync<InvalidAssociationException>(async () =>
                 {
-                    var a = await t1.Associate(c1.Item1.WithPort(c1.Item1.Port + 100));
+                    var a = await t1.Associate(c1.Item1.WithPort(deadPort));
                 });
 
 


### PR DESCRIPTION
## Summary

Fixes a Windows-only flaky failure in `DotNettyTcpTransport_should_cleanly_terminate_endpoints_upon_failed_outbound_connection`.

The test binds to `port = 0` (OS-assigned ephemeral port), then targets `boundPort + 100` to force an outbound connect failure that should surface as `InvalidAssociationException`.

## Root cause

`Associate` → `AssociateInternal` (`TcpTransport.cs:290`) calls `AddressToSocketAddress`, which constructs `new IPEndPoint(ip, (int)port)` at `DotNettyTransport.cs:638`. The `IPEndPoint` ctor rejects ports outside `0..65535`. On **Windows** the default dynamic/ephemeral port range tops out at **65535**, so when the OS assigns a bound port in `[65436, 65535]`, `boundPort + 100` exceeds `IPEndPoint.MaxPort` and the ctor throws `ArgumentOutOfRangeException` **before the connect** — escaping the `catch (ConnectException/ConnectTimeoutException)` clauses and the `Assert.ThrowsAsync<InvalidAssociationException>` expectation.

```
Assert.Throws() Failure: Exception type was not an exact match
Expected: typeof(Akka.Remote.Transport.InvalidAssociationException)
Actual:   typeof(System.ArgumentOutOfRangeException)  (Parameter 'port')
  at IPEndPoint..ctor(IPAddress address, Int32 port)
  at DotNettyTransport.AddressToSocketAddress(...)  // DotNettyTransport.cs:638
  at TcpTransport.AssociateInternal(...)            // TcpTransport.cs:290
```

This is **not a thread race** — the only non-determinism is which ephemeral port the OS hands out. For a fixed port the outcome is deterministic:

| Platform | Default ephemeral range | `boundPort + 100` can overflow 65535? | Result |
|---|---|---|---|
| **Windows** | 49152–65535 | Yes, when port ∈ `[65436, 65535]` (~0.6%/run) | Intermittent failure |
| **Linux** | ~32768–60999 | No — range caps below the band | Always passes |

That matches the observed "Windows-only, intermittent" signature.

## Fix

Test-only change: offset the dead port **down** when near the top of the range so the target always stays within `0..65535` while still pointing at a port where nothing is listening.

```csharp
var boundPort = c1.Item1.Port!.Value;
var deadPort = boundPort > 65435 ? boundPort - 100 : boundPort + 100;
```

## Verification

- Builds clean against `net10.0` (0 warnings, 0 errors)
- Target test passes (`Failed: 0, Passed: 1`)

## Notes

- Independent of #8272 (which only touches the inbound decode path) — this is a pre-existing flaky test.
