### PR TITLE
Fix SQLitePCLRaw vulnerability warnings in examples

### DIFF
--- a/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
+++ b/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SQLite" Version="8.0.4" />
+        <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Akka.Persistence.Sql" Version="1.5.67" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Pin SQLitePCLRaw.lib.e_sqlite3 to 3.50.3 in the SQLite-backed examples.
- Keep the existing Microsoft.Data.Sqlite and Akka.Persistence.Sql package versions unchanged.

## Root cause
CodeQL autobuild restores the solution with warnings as errors. These example projects resolved vulnerable transitive SQLitePCLRaw.lib.e_sqlite3 versions, which triggered NU1903 for GHSA-2m69-gcr7-jv3q.

## Validation
- dotnet restore src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
- dotnet restore src/examples/Akka.Persistence.Custom.Tests/Akka.Persistence.Custom.Tests.csproj
- dotnet restore src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
- dotnet build -c Release --no-restore src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
- dotnet build -c Release --no-restore src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
- confirmed project.assets.json resolves SQLitePCLRaw.lib.e_sqlite3/3.50.3 for the affected projects
- confirmed the pushed commit is GPG signed and GitHub verified