### PR TITLE
fix: suppress GHSA-2m69-gcr7-jv3q in SQLite-backed example projects

### DIFF
--- a/src/examples/Akka.Persistence.Custom.Tests/Akka.Persistence.Custom.Tests.csproj
+++ b/src/examples/Akka.Persistence.Custom.Tests/Akka.Persistence.Custom.Tests.csproj
@@ -20,4 +20,8 @@
       <ProjectReference Include="..\Akka.Persistence.Custom\Akka.Persistence.Custom.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+    </ItemGroup>
+
 </Project>

--- a/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
+++ b/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
@@ -3,11 +3,14 @@
     <PropertyGroup>
         <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
         <IsPackable>false</IsPackable>
-        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SQLite" Version="8.0.4" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
+++ b/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
         <IsPackable>false</IsPackable>
+        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
@@ -4,12 +4,15 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetTestVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\contrib\cluster\Akka.Cluster.Sharding\Akka.Cluster.Sharding.csproj" />
     <ProjectReference Include="..\..\..\..\contrib\serializers\Akka.Serialization.Hyperion\Akka.Serialization.Hyperion.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetTestVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Add `NuGetAuditSuppress` for GHSA-2m69-gcr7-jv3q (CVE-2025-6965) to SQLite-backed example projects.
- Replaces PR #8277 which attempted to pin `SQLitePCLRaw.lib.e_sqlite3` to 3.50.3 (rejected — unlisted version).

## Root cause
CodeQL autobuild restores the solution with warnings as errors. These example projects resolved vulnerable transitive `SQLitePCLRaw.lib.e_sqlite3` versions, which triggered NU1903 for GHSA-2m69-gcr7-jv3q.

## Why suppress instead of pin
- `SQLitePCLRaw.lib.e_sqlite3` 3.50.3 was published to NuGet but then **unlisted** — it cannot be used as a stable dependency
- This matches the approach used in [netclaw-dev/netclaw#1444](https://github.com/netclaw-dev/netclaw/pull/1444)

## Validation
- Confirmed the suppress resolves the NU1903 warning
- No functional changes to the example projects

## Upstream tracking
- https://github.com/dotnet/efcore/pull/38402
- https://github.com/dotnet/efcore/issues/38257
