### PR TITLE
fix: backport #8278 — suppress GHSA-2m69-gcr7-jv3q in v1.5

### DIFF
--- a/src/examples/Akka.Persistence.Custom.Tests/Akka.Persistence.Custom.Tests.csproj
+++ b/src/examples/Akka.Persistence.Custom.Tests/Akka.Persistence.Custom.Tests.csproj
@@ -20,4 +20,8 @@
       <ProjectReference Include="..\Akka.Persistence.Custom\Akka.Persistence.Custom.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+    </ItemGroup>
+
 </Project>

--- a/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
+++ b/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
@@ -8,6 +8,10 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SQLite" Version="8.0.4" />
     </ItemGroup>
+
+    <ItemGroup>
+        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+    </ItemGroup>
     
     <ItemGroup>
       <ProjectReference Include="..\..\core\Akka.Persistence\Akka.Persistence.csproj" />

--- a/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
+++ b/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
@@ -3,11 +3,10 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Data.SQLite" Version="8.0.4" />
+        <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
+++ b/src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>false</IsPackable>
+        <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
@@ -12,6 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="app.conf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetTestVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
+++ b/src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NetTestVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Backport of dev PR #8278 to the v1.5 branch.

## What this does
Add `<NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />` to the SQLite-backed example projects on v1.5 to unblock CI, matching the fix on dev.

## Cherry-picked commits from dev PR #8278
- `674e57761` fix: add NuGetAuditSuppress to Akka.Persistence.Custom.Tests
- `f9f4e30c8` fix: move NuGetAuditSuppress into ItemGroup (MSBuild syntax)
- `fc09b1e77` fix: suppress GHSA-2m69-gcr7-jv3q in SQLite-backed example projects

## Projects patched
- `src/examples/Akka.Persistence.Custom/Akka.Persistence.Custom.csproj`
- `src/examples/Akka.Persistence.Custom.Tests/Akka.Persistence.Custom.Tests.csproj`
- `src/examples/Cluster/ClusterSharding/ClusterSharding.Node/ClusterSharding.Node.csproj`

## No code changes
This is a metadata-only change — the suppress prevents the NU1903 vulnerability warning without modifying any application code.