### PR TITLE
Release Akka.NET v1.5.70-beta1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.68</VersionPrefix>
+    <VersionPrefix>1.5.70-beta1</VersionPrefix>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>https://getakka.net/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -54,27 +54,22 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Akka.NET v1.5.68 is a maintenance release with bug fixes for Akka.IO TCP connection handling, Akka.Streams stream materialized task faults, and Akka.TestKit xUnit 3 parallel context management.
+    <PackageReleaseNotes>Akka.NET v1.5.70-beta1 is a beta release with a new `Offset.FromEnd` query offset for Akka.Persistence.Query, bug fixes for `Akka.Streams` async enumerable disposal, and a performance improvement for `BroadcastHub` with high consumer counts.
 
-**Akka.IO Bug Fixes**
-
-* [Fix: report `Tcp.CommandFailed` when a scheduled connect retry throws](https://github.com/akkadotnet/akka.net/pull/8214) - Fixes [#8195](https://github.com/akkadotnet/akka.net/issues/8195): On Linux, a dropped TCP connection could permanently stall the user actor — it never received `Tcp.Connected` or `Tcp.CommandFailed` because a `PlatformNotSupportedException` thrown during a scheduled connect retry was swallowed by the `HashedWheelTimerScheduler`. The retry is now scheduled as a `RetryConnect` self-message via `IWithTimers`, ensuring any exception is surfaced to the commander as `Tcp.CommandFailed` and the connection actor stops cleanly. The pending timer is also canceled automatically when the actor stops, removing a latent use-after-dispose bug.
+**Akka.Persistence.Query**
+* [Add `Offset.FromEnd(int count)` — "last-N events" query offset](https://github.com/akkadotnet/akka.net/pull/8245): Introduces `Offset.FromEnd(int count)`, a new query-input-only offset type that begins a read journal query at the Nth event from the end of history rather than from the beginning. The offset is resolved at stream materialization into a concrete `Sequence` start position; no interface changes or wire-format changes are required. Includes opt-in TCK spec (`FromEndOffsetSpec`) for plugin authors.
 
 **Akka.Streams Bug Fixes**
+* [Fix: async enumerable source disposal ordering](https://github.com/akkadotnet/akka.net/pull/8265): Fixes a race in `Source.From(IAsyncEnumerable&lt;T&gt;)` where the underlying enumerator could be disposed before all elements were delivered to downstream, causing `ObjectDisposedException` on high-throughput pipelines.
 
-* [Fix: observe discarded stream task faults](https://github.com/akkadotnet/akka.net/pull/8212) - Fixes [#8209](https://github.com/akkadotnet/akka.net/issues/8209) and [#8210](https://github.com/akkadotnet/akka.net/issues/8210): `IgnoreSink`, `QueueSource`, and `LazySink` now observe their internal materialized `Task` faults, preventing them from surfacing later as `UnobservedTaskException` events on the thread pool.
+**Akka.Streams Performance**
+* [Improve BroadcastHub high-consumer wheel performance](https://github.com/akkadotnet/akka.net/pull/8264): Reduces per-element cost in `BroadcastHub` when many consumers are attached by optimizing the internal consumer-wheel iteration, yielding measurable throughput improvements at high fan-out.
 
-**Akka.TestKit Bug Fixes**
-
-* [Fix: wrap outer `SynchronizationContext` in `ActorCellKeepingSynchronizationContext`](https://github.com/akkadotnet/akka.net/pull/8182) - `ActorCellKeepingSynchronizationContext` now accepts an optional inner `SynchronizationContext` and delegates scheduling to it while wrapping callbacks with the cell-pinning window. This prevents test hangs in downstream consumers such as `Akka.Hosting.TestKit` whose async `IHost` lifecycle depends on xUnit v3's `MaxConcurrencySyncContext` scheduling.
-
-1 contributor since release 1.5.67
+1 contributor since release 1.5.69
 
 | COMMITS | LOC+ | LOC- | AUTHOR |
 | --- | --- | --- | --- |
-| 3 | 476 | 119 | Aaron Stannard |
-
-To see the full set of changes in Akka.NET v1.5.68, [click here](https://github.com/akkadotnet/akka.net/milestone/151?closed=1).</PackageReleaseNotes>
+| 3 | 1438 | 180 | Aaron Stannard |</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup Label="Analyzers" Condition="'$(MSBuildProjectName)' != 'Akka'">
     <PackageReference Include="Akka.Analyzers" Version="$(AkkaAnalyzerVersion)" PrivateAssets="all" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,22 @@
+#### 1.5.70-beta1 June 23rd, 2026 ####
+
+Akka.NET v1.5.70-beta1 is a beta release with a new `Offset.FromEnd` query offset for Akka.Persistence.Query, bug fixes for `Akka.Streams` async enumerable disposal, and a performance improvement for `BroadcastHub` with high consumer counts.
+
+**Akka.Persistence.Query**
+* [Add `Offset.FromEnd(int count)` — "last-N events" query offset](https://github.com/akkadotnet/akka.net/pull/8245): Introduces `Offset.FromEnd(int count)`, a new query-input-only offset type that begins a read journal query at the Nth event from the end of history rather than from the beginning. The offset is resolved at stream materialization into a concrete `Sequence` start position; no interface changes or wire-format changes are required. Includes opt-in TCK spec (`FromEndOffsetSpec`) for plugin authors.
+
+**Akka.Streams Bug Fixes**
+* [Fix: async enumerable source disposal ordering](https://github.com/akkadotnet/akka.net/pull/8265): Fixes a race in `Source.From(IAsyncEnumerable<T>)` where the underlying enumerator could be disposed before all elements were delivered to downstream, causing `ObjectDisposedException` on high-throughput pipelines.
+
+**Akka.Streams Performance**
+* [Improve BroadcastHub high-consumer wheel performance](https://github.com/akkadotnet/akka.net/pull/8264): Reduces per-element cost in `BroadcastHub` when many consumers are attached by optimizing the internal consumer-wheel iteration, yielding measurable throughput improvements at high fan-out.
+
+1 contributor since release 1.5.69
+
+| COMMITS | LOC+ | LOC- | AUTHOR |
+| --- | --- | --- | --- |
+| 3 | 1438 | 180 | Aaron Stannard |
+
 #### 1.5.69 June 12th, 2026 ####
 
 Akka.NET v1.5.69 is a maintenance release with bug fixes for Akka.DistributedData state propagation, Akka.Core message rejection handling, and Akka.Streams tracing reliability and backpressure cancellation.


### PR DESCRIPTION
## Summary

- Adds `Offset.FromEnd(int count)` to `Akka.Persistence.Query` for "last-N events" queries
- Fixes async enumerable source disposal ordering in `Akka.Streams`
- Improves `BroadcastHub` performance at high consumer counts

## Changes

- Updated `RELEASE_NOTES.md` with v1.5.70-beta1 entry
- Updated `Directory.Build.props` with new `VersionPrefix` and `PackageReleaseNotes`

## Test plan

- [ ] CI passes on v1.5 branch
- [ ] NuGet packages build with version `1.5.70-beta1`