### PR TITLE
fix: pre-warm thread pool in CircuitBreakerSpecBase to fix cold-start latch flakiness

### DIFF
--- a/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
+++ b/src/core/Akka.Tests/Pattern/CircuitBreakerSpec.cs
@@ -351,6 +351,19 @@ namespace Akka.Tests.Pattern
 
     public class CircuitBreakerSpecBase : AkkaSpec
     {
+        public CircuitBreakerSpecBase()
+        {
+            // Pre-warm the thread pool so the breaker's fire-and-forget state-transition
+            // callbacks (dispatched via Task.Factory.StartNew) and the HashedWheelTimer reset
+            // timer are not starved by the runtime's throttled worker-thread injection
+            // (~500ms per new worker above the minimum). Cold-start starvation was
+            // intermittently pushing these transitions past the CountdownEvent latch timeouts
+            // on slower CI agents. Math.Max ensures a previously-raised minimum is never
+            // lowered. Mirrors InMemoryPersistenceSpecConfig.EnsureThreadPoolWarmed().
+            ThreadPool.GetMinThreads(out var minWorker, out var minIo);
+            ThreadPool.SetMinThreads(Math.Max(minWorker, Environment.ProcessorCount * 2), minIo);
+        }
+
         public TimeSpan AwaitTimeout => Dilated(TimeSpan.FromSeconds(2));
 
         public bool CheckLatch(CountdownEvent latch) => latch.Wait(AwaitTimeout);


### PR DESCRIPTION
## Problem

Several async `CircuitBreakerSpec` tests fail intermittently on CI with a bare:

```
Assert.True() Failure
Expected: True
Actual:   False
```

Most recently on the `Microsoft.NET.Test.Sdk` 17.9.0 → 18.7.0 bump (#8282) — e.g. `Must_reopen_on_exception_in_call` (CircuitBreakerSpec.cs:283, HalfOpen latch) and `Must_throw_exceptions_when_called_before_reset_timeout` (line 311, Open latch). The `Assert.True(false)` is a `CountdownEvent` latch wait (`latch.Wait(2s)`) returning `false`.

### Root cause

`CircuitBreaker` signals the test latches from its transition listeners, which run **fire-and-forget on the thread pool** (`AtomicState.Enter` → `NotifyTransitionListeners` → `Task.Factory.StartNew`, deliberately un-awaited so listeners never block state transitions). The half-open transition additionally depends on the `HashedWheelTimer` reset firing — also pool-driven. Meanwhile the test thread blocks in `CountdownEvent.Wait`.

The .NET thread pool injects new workers above the minimum at only **~1 per 500ms**. On a cold/contended CI agent at process start, the fire-and-forget breaker call, the transition-listener signal, and the timer continuation can be starved behind that ramp and miss the fixed 2s latch budget. This is environmental timing, not a product bug — the SDK bump simply changed the test-host's startup footprint enough to expose a pre-existing latent race. (Confirmed: `akka.test.timefactor` is `1.0` on CI, so `Dilated(...)` is a no-op and the latch budget is a hard 2s.)

## Fix

Pre-warm the thread pool in `CircuitBreakerSpecBase` so those work items get a worker immediately instead of waiting on throttled injection:

```csharp
ThreadPool.GetMinThreads(out var minWorker, out var minIo);
ThreadPool.SetMinThreads(Math.Max(minWorker, Environment.ProcessorCount * 2), minIo);
```

This is the **same remedy already used in the repo** for the identical cold-start root cause (`InMemoryPersistenceSpecConfig.EnsureThreadPoolWarmed()`). `Math.Max` guarantees a previously-raised minimum is never lowered.

Test-only change — **no public API touched** (notably `TestBreaker` and its `CountdownEvent` latches are unchanged, per extend-only design) and **no timeout values changed**.

## Verification

- Builds clean (Release, 0 warnings / 0 errors).
- Full `Akka.Tests.Pattern` suite green (Total: 71, Failed: 0).
- The two previously-failing tests pass **25/25** in a tight loop.

Local runs can't reproduce CI's cold-start starvation (the dev-box pool warms instantly), so local results confirm *no regression*; the fix is grounded in the root-cause analysis and the proven in-repo precedent.

## Notes

Second of two flaky-test fixes split out from the #8282 investigation; the multi-node `NodeChurnSpec` fix is #8286. The broader observation that `akka.test.timefactor` is never raised on CI (making every `Dilated(...)` a no-op) is left as a separate, optional CI-config change.
