### PR TITLE
fix: #8285 ChannelSink drops the final element when the consumer backpressures

### DIFF
--- a/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
@@ -6,6 +6,8 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -158,6 +160,30 @@ namespace Akka.Streams.Tests.Implementation
             }
         }
 
+        [Fact]
+        public async Task ChannelSink_writer_should_deliver_final_element_when_channel_is_full_on_completion()
+        {
+            const int bufferSize = 4;
+            const int elementCount = bufferSize + 1;
+
+            var channel = Channel.CreateBounded<int>(new BoundedChannelOptions(bufferSize)
+            {
+                SingleReader = true,
+                SingleWriter = true,
+                FullMode = BoundedChannelFullMode.Wait
+            });
+
+            Source.From(Enumerable.Range(0, elementCount))
+                .RunWith(ChannelSink.FromWriter(channel.Writer, isOwner: true), _materializer);
+
+            var received = new List<int>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await foreach (var item in channel.Reader.ReadAllAsync(cts.Token))
+                received.Add(item);
+
+            received.Should().Equal(Enumerable.Range(0, elementCount));
+        }
+
         #endregion
 
         #region as reader
@@ -238,6 +264,50 @@ namespace Akka.Streams.Tests.Implementation
                 var value = await reader.ReadAsync(cancel.Token);
                 value.Should().Be(i);
             }
+        }
+
+        [Fact]
+        public async Task ChannelSink_reader_should_deliver_final_element_when_channel_is_full_on_completion()
+        {
+            const int bufferSize = 4;
+            const int elementCount = bufferSize + 1; // 0..4 — last element (4) lands while the channel is full
+
+            var reader = Source.From(Enumerable.Range(0, elementCount))
+                .RunWith(
+                    ChannelSink.AsReader<int>(bufferSize, singleReader: true, BoundedChannelFullMode.Wait),
+                    _materializer);
+
+            // Intentionally do not read anything yet: the source fills the channel (0..3), grabs the
+            // last element (4) whose write blocks on the full channel, then eagerly completes upstream.
+            var received = new List<int>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await foreach (var item in reader.ReadAllAsync(cts.Token))
+                received.Add(item);
+
+            received.Should().Equal(Enumerable.Range(0, elementCount));
+        }
+
+        [Fact]
+        public async Task ChannelSink_reader_should_deliver_all_elements_to_a_slow_consumer()
+        {
+            const int elementCount = 30;
+            const int bufferSize = 4;
+
+            var reader = Source.From(Enumerable.Range(0, elementCount))
+                .RunWith(
+                    ChannelSink.AsReader<int>(bufferSize, singleReader: true, BoundedChannelFullMode.Wait),
+                    _materializer);
+
+            var received = new List<int>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await foreach (var item in reader.ReadAllAsync(cts.Token))
+            {
+                received.Add(item);
+                // Slow consumer => the bounded channel stays full => the stage backpressures.
+                await Task.Delay(1, cts.Token);
+            }
+
+            received.Should().Equal(Enumerable.Range(0, elementCount));
         }
 
         #endregion

--- a/src/core/Akka.Streams/Dsl/ChannelSink.cs
+++ b/src/core/Akka.Streams/Dsl/ChannelSink.cs
@@ -46,8 +46,8 @@ namespace Akka.Streams.Dsl
         /// <param name="singleReader"></param>
         /// <param name="fullMode"></param>
         /// <returns></returns>
-        public static Sink<T, ChannelReader<T>> AsReader<T>(int bufferSize, bool singleReader = false, BoundedChannelFullMode fullMode = BoundedChannelFullMode.Wait) => 
-            Sink.FromGraph(new ChannelReaderSink<T>(bufferSize, singleReader));
+        public static Sink<T, ChannelReader<T>> AsReader<T>(int bufferSize, bool singleReader = false, BoundedChannelFullMode fullMode = BoundedChannelFullMode.Wait) =>
+            Sink.FromGraph(new ChannelReaderSink<T>(bufferSize, singleReader, fullMode));
         
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowArgumentNullException(string name) =>

--- a/src/core/Akka.Streams/Implementation/ChannelSinks.cs
+++ b/src/core/Akka.Streams/Implementation/ChannelSinks.cs
@@ -21,6 +21,8 @@ namespace Akka.Streams.Implementation
         private readonly Action<Task<bool>> _onWriteReady;
         private T _awaitingElement;
         private readonly bool _isOwner;
+        private bool _writeInFlight;
+        private bool _finishPending;
 
         public ChannelSinkLogic(SinkShape<T> shape, Inlet<T> inlet,
             ChannelWriter<T> writer, bool isOwner) : base(shape)
@@ -39,9 +41,23 @@ namespace Akka.Streams.Implementation
         private void OnWriteAvailable(bool available)
         {
             if (available && _writer.TryWrite(_awaitingElement))
-                Pull(_inlet);
+            {
+                _writeInFlight = false;
+                _awaitingElement = default;
+                if (_finishPending)
+                    TryComplete();
+                else
+                    Pull(_inlet);
+            }
+            else if (available)
+            {
+                _writer.WaitToWriteAsync().AsTask().ContinueWith(_onWriteReady);
+            }
             else
+            {
+                _writeInFlight = false;
                 TryComplete();
+            }
         }
 
         private void TryComplete()
@@ -60,6 +76,13 @@ namespace Akka.Streams.Implementation
 
         public override void OnUpstreamFinish()
         {
+            if (_writeInFlight)
+            {
+                _finishPending = true;
+                SetKeepGoing(true);
+                return;
+            }
+
             base.OnUpstreamFinish();
             if (_isOwner)
                 _writer.TryComplete();
@@ -104,6 +127,7 @@ namespace Akka.Streams.Implementation
                 {
                     var task = continuation.AsTask();
                     _awaitingElement = element;
+                    _writeInFlight = true;
                     task.ContinueWith(_onWriteReady);
                 }
             }


### PR DESCRIPTION
Fixes #8285

## Changes

Fixes a bug where `ChannelSink.AsReader` / `ChannelSink.FromWriter` silently drop the final element of a stream under backpressure (when the bounded channel is full at the moment upstream completes, in `BoundedChannelFullMode.Wait`). The reader/channel completes one element short, and reports success rather than an error.

**Root cause:** the shared backing stage `ChannelSinkLogic<T>` parks the last element on a pending `WaitToWriteAsync()` continuation when the channel is full. An eagerly-completing source (e.g. `Source.From(IEnumerable`), whose `StatefulSelectMany` calls `CompleteStage()` right after pushing the last element) fires `OnUpstreamFinish` while that write is still in flight. The old handler called `CompleteStage()` immediately, and the graph interpreter then discards the pending write callback (`RunAsyncInput` only runs callbacks for non-completed stages). As a result of this, the final `TryWrite` never happens and the channel is completed without the last element.

**Fix:**

- `ChannelSinkLogic<T>`: when upstream finishes while a write is in flight, defer completion via the standard `SetKeepGoing(true)` idiom (same pattern as `QueueSink`) and complete only after the final element actually commits. Also retry (instead of completing) on a lost write race, which can only occur with a multi-producer `ChannelWriter` shared through `FromWriter`; this closes the same data-loss window on that path and avoids premature stream completion.
- `ChannelSink.AsReader`: forward the `fullMode` argument to `ChannelReaderSink`. It was previously accepted but silently ignored (the channel was always created with `Wait`), which also affected the public `Sink.ChannelReader<T>(…, fullMode)` wrapper.

**Tests added** in `ChannelSinkSpec` (all fail before the fix, pass after; the deterministic ones use no timing/`Task.Delay`):

- `ChannelSink_reader_should_deliver_final_element_when_channel_is_full_on_completion` (deterministic)
- `ChannelSink_reader_should_deliver_all_elements_to_a_slow_consumer` (the originally-reported scenario)
- `ChannelSink_writer_should_deliver_final_element_when_channel_is_full_on_completion` (covers the FromWriter sibling, which shares the backing stage)


## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any. (No public API changes.)

### Latest `dev` Benchmarks 

N/A

### This PR's Benchmarks

N/A

Note: This patch also includes a fix regarding fullMode forwarding issue. I added this fix too because the original repro explicitly passed the `BoundedChannelFullMode.Wait` and the parameter being silently ignored is a related defect in the same operator