### PR TITLE
fix: #8285 ChannelSink drops final element on backpressure (backport to v1.5)

### DIFF
--- a/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
@@ -173,8 +173,9 @@ namespace Akka.Streams.Tests.Implementation
 
             var received = new List<int>();
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            await foreach (var item in channel.Reader.ReadAllAsync(cts.Token))
-                received.Add(item);
+            while (await channel.Reader.WaitToReadAsync(cts.Token))
+                while (channel.Reader.TryRead(out var item))
+                    received.Add(item);
 
             received.Should().Equal(Enumerable.Range(0, elementCount));
         }
@@ -277,8 +278,9 @@ namespace Akka.Streams.Tests.Implementation
             // last element (4) whose write blocks on the full channel, then eagerly completes upstream.
             var received = new List<int>();
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            await foreach (var item in reader.ReadAllAsync(cts.Token))
-                received.Add(item);
+            while (await reader.WaitToReadAsync(cts.Token))
+                while (reader.TryRead(out var item))
+                    received.Add(item);
 
             received.Should().Equal(Enumerable.Range(0, elementCount));
         }
@@ -296,8 +298,9 @@ namespace Akka.Streams.Tests.Implementation
 
             var received = new List<int>();
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            await foreach (var item in reader.ReadAllAsync(cts.Token))
-                received.Add(item);
+            while (await reader.WaitToReadAsync(cts.Token))
+                while (reader.TryRead(out var item))
+                    received.Add(item);
 
             received.Should().Equal(Enumerable.Range(0, elementCount));
         }

--- a/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
@@ -156,7 +156,7 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public Task ChannelSink_writer_should_deliver_final_element_when_channel_is_full_on_completion()
+        public async Task ChannelSink_writer_should_deliver_final_element_when_channel_is_full_on_completion()
         {
             const int bufferSize = 4;
             const int elementCount = bufferSize + 1;
@@ -171,12 +171,12 @@ namespace Akka.Streams.Tests.Implementation
             Source.From(Enumerable.Range(0, elementCount))
                 .RunWith(ChannelSink.FromWriter(channel.Writer, isOwner: true), _materializer);
 
-            return channel.Reader.Completion.ContinueWith(t =>
-            {
-                t.Should().NotBeFaulted();
-                var received = channel.Reader.ReadAllAsync().Result.ToList();
-                received.Should().Equal(Enumerable.Range(0, elementCount));
-            });
+            var received = new List<int>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await foreach (var item in channel.Reader.ReadAllAsync(cts.Token))
+                received.Add(item);
+
+            received.Should().Equal(Enumerable.Range(0, elementCount));
         }
 
         #endregion
@@ -263,7 +263,7 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public Task ChannelSink_reader_should_deliver_final_element_when_channel_is_full_on_completion()
+        public async Task ChannelSink_reader_should_deliver_final_element_when_channel_is_full_on_completion()
         {
             const int bufferSize = 4;
             const int elementCount = bufferSize + 1; // 0..4 — last element (4) lands while the channel is full
@@ -275,16 +275,16 @@ namespace Akka.Streams.Tests.Implementation
 
             // Intentionally do not read anything yet: the source fills the channel (0..3), grabs the
             // last element (4) whose write blocks on the full channel, then eagerly completes upstream.
-            return reader.Completion.ContinueWith(t =>
-            {
-                t.Should().NotBeFaulted();
-                var received = reader.ReadAllAsync().Result.ToList();
-                received.Should().Equal(Enumerable.Range(0, elementCount));
-            });
+            var received = new List<int>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await foreach (var item in reader.ReadAllAsync(cts.Token))
+                received.Add(item);
+
+            received.Should().Equal(Enumerable.Range(0, elementCount));
         }
 
         [Fact]
-        public Task ChannelSink_reader_should_deliver_all_elements_to_a_slow_consumer()
+        public async Task ChannelSink_reader_should_deliver_all_elements_to_a_slow_consumer()
         {
             const int elementCount = 30;
             const int bufferSize = 4;
@@ -294,12 +294,12 @@ namespace Akka.Streams.Tests.Implementation
                     ChannelSink.AsReader<int>(bufferSize, singleReader: true, BoundedChannelFullMode.Wait),
                     _materializer);
 
-            return reader.Completion.ContinueWith(t =>
-            {
-                t.Should().NotBeFaulted();
-                var received = reader.ReadAllAsync().Result.ToList();
-                received.Should().Equal(Enumerable.Range(0, elementCount));
-            });
+            var received = new List<int>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await foreach (var item in reader.ReadAllAsync(cts.Token))
+                received.Add(item);
+
+            received.Should().Equal(Enumerable.Range(0, elementCount));
         }
 
         #endregion

--- a/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="ChannelSinkSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
 //     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
@@ -156,7 +156,7 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public async Task ChannelSink_writer_should_deliver_final_element_when_channel_is_full_on_completion()
+        public Task ChannelSink_writer_should_deliver_final_element_when_channel_is_full_on_completion()
         {
             const int bufferSize = 4;
             const int elementCount = bufferSize + 1;
@@ -171,12 +171,12 @@ namespace Akka.Streams.Tests.Implementation
             Source.From(Enumerable.Range(0, elementCount))
                 .RunWith(ChannelSink.FromWriter(channel.Writer, isOwner: true), _materializer);
 
-            var received = new List<int>();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            await foreach (var item in channel.Reader.ReadAllAsync(cts.Token))
-                received.Add(item);
-
-            received.Should().Equal(Enumerable.Range(0, elementCount));
+            return channel.Reader.Completion.ContinueWith(t =>
+            {
+                t.Should().NotBeFaulted();
+                var received = channel.Reader.ReadAllAsync().Result.ToList();
+                received.Should().Equal(Enumerable.Range(0, elementCount));
+            });
         }
 
         #endregion
@@ -263,7 +263,7 @@ namespace Akka.Streams.Tests.Implementation
         }
 
         [Fact]
-        public async Task ChannelSink_reader_should_deliver_final_element_when_channel_is_full_on_completion()
+        public Task ChannelSink_reader_should_deliver_final_element_when_channel_is_full_on_completion()
         {
             const int bufferSize = 4;
             const int elementCount = bufferSize + 1; // 0..4 — last element (4) lands while the channel is full
@@ -275,16 +275,16 @@ namespace Akka.Streams.Tests.Implementation
 
             // Intentionally do not read anything yet: the source fills the channel (0..3), grabs the
             // last element (4) whose write blocks on the full channel, then eagerly completes upstream.
-            var received = new List<int>();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            await foreach (var item in reader.ReadAllAsync(cts.Token))
-                received.Add(item);
-
-            received.Should().Equal(Enumerable.Range(0, elementCount));
+            return reader.Completion.ContinueWith(t =>
+            {
+                t.Should().NotBeFaulted();
+                var received = reader.ReadAllAsync().Result.ToList();
+                received.Should().Equal(Enumerable.Range(0, elementCount));
+            });
         }
 
         [Fact]
-        public async Task ChannelSink_reader_should_deliver_all_elements_to_a_slow_consumer()
+        public Task ChannelSink_reader_should_deliver_all_elements_to_a_slow_consumer()
         {
             const int elementCount = 30;
             const int bufferSize = 4;
@@ -294,16 +294,12 @@ namespace Akka.Streams.Tests.Implementation
                     ChannelSink.AsReader<int>(bufferSize, singleReader: true, BoundedChannelFullMode.Wait),
                     _materializer);
 
-            var received = new List<int>();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            await foreach (var item in reader.ReadAllAsync(cts.Token))
+            return reader.Completion.ContinueWith(t =>
             {
-                received.Add(item);
-                // Slow consumer => the bounded channel stays full => the stage backpressures.
-                await Task.Delay(1, cts.Token);
-            }
-
-            received.Should().Equal(Enumerable.Range(0, elementCount));
+                t.Should().NotBeFaulted();
+                var received = reader.ReadAllAsync().Result.ToList();
+                received.Should().Equal(Enumerable.Range(0, elementCount));
+            });
         }
 
         #endregion

--- a/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
+++ b/src/core/Akka.Streams.Tests/Implementation/ChannelSinkSpec.cs
@@ -6,6 +6,8 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -153,6 +155,30 @@ namespace Akka.Streams.Tests.Implementation
             }
         }
 
+        [Fact]
+        public async Task ChannelSink_writer_should_deliver_final_element_when_channel_is_full_on_completion()
+        {
+            const int bufferSize = 4;
+            const int elementCount = bufferSize + 1;
+
+            var channel = Channel.CreateBounded<int>(new BoundedChannelOptions(bufferSize)
+            {
+                SingleReader = true,
+                SingleWriter = true,
+                FullMode = BoundedChannelFullMode.Wait
+            });
+
+            Source.From(Enumerable.Range(0, elementCount))
+                .RunWith(ChannelSink.FromWriter(channel.Writer, isOwner: true), _materializer);
+
+            var received = new List<int>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await foreach (var item in channel.Reader.ReadAllAsync(cts.Token))
+                received.Add(item);
+
+            received.Should().Equal(Enumerable.Range(0, elementCount));
+        }
+
         #endregion
 
         #region as reader
@@ -234,6 +260,50 @@ namespace Akka.Streams.Tests.Implementation
                 var value = await reader.ReadAsync(cancel.Token);
                 value.Should().Be(i);
             }
+        }
+
+        [Fact]
+        public async Task ChannelSink_reader_should_deliver_final_element_when_channel_is_full_on_completion()
+        {
+            const int bufferSize = 4;
+            const int elementCount = bufferSize + 1; // 0..4 — last element (4) lands while the channel is full
+
+            var reader = Source.From(Enumerable.Range(0, elementCount))
+                .RunWith(
+                    ChannelSink.AsReader<int>(bufferSize, singleReader: true, BoundedChannelFullMode.Wait),
+                    _materializer);
+
+            // Intentionally do not read anything yet: the source fills the channel (0..3), grabs the
+            // last element (4) whose write blocks on the full channel, then eagerly completes upstream.
+            var received = new List<int>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await foreach (var item in reader.ReadAllAsync(cts.Token))
+                received.Add(item);
+
+            received.Should().Equal(Enumerable.Range(0, elementCount));
+        }
+
+        [Fact]
+        public async Task ChannelSink_reader_should_deliver_all_elements_to_a_slow_consumer()
+        {
+            const int elementCount = 30;
+            const int bufferSize = 4;
+
+            var reader = Source.From(Enumerable.Range(0, elementCount))
+                .RunWith(
+                    ChannelSink.AsReader<int>(bufferSize, singleReader: true, BoundedChannelFullMode.Wait),
+                    _materializer);
+
+            var received = new List<int>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            await foreach (var item in reader.ReadAllAsync(cts.Token))
+            {
+                received.Add(item);
+                // Slow consumer => the bounded channel stays full => the stage backpressures.
+                await Task.Delay(1, cts.Token);
+            }
+
+            received.Should().Equal(Enumerable.Range(0, elementCount));
         }
 
         #endregion

--- a/src/core/Akka.Streams/Dsl/ChannelSink.cs
+++ b/src/core/Akka.Streams/Dsl/ChannelSink.cs
@@ -41,8 +41,8 @@ namespace Akka.Streams.Dsl
         /// <param name="singleReader"></param>
         /// <param name="fullMode"></param>
         /// <returns></returns>
-        public static Sink<T, ChannelReader<T>> AsReader<T>(int bufferSize, bool singleReader = false, BoundedChannelFullMode fullMode = BoundedChannelFullMode.Wait) => 
-            Sink.FromGraph(new ChannelReaderSink<T>(bufferSize, singleReader));
+        public static Sink<T, ChannelReader<T>> AsReader<T>(int bufferSize, bool singleReader = false, BoundedChannelFullMode fullMode = BoundedChannelFullMode.Wait) =>
+            Sink.FromGraph(new ChannelReaderSink<T>(bufferSize, singleReader, fullMode));
         
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static void ThrowArgumentNullException(string name) =>

--- a/src/core/Akka.Streams/Implementation/ChannelSinks.cs
+++ b/src/core/Akka.Streams/Implementation/ChannelSinks.cs
@@ -21,6 +21,8 @@ namespace Akka.Streams.Implementation
         private readonly Action<Task<bool>> _onWriteReady;
         private T _awaitingElement;
         private readonly bool _isOwner;
+        private bool _writeInFlight;
+        private bool _finishPending;
 
         public ChannelSinkLogic(SinkShape<T> shape, Inlet<T> inlet,
             ChannelWriter<T> writer, bool isOwner) : base(shape)
@@ -39,9 +41,23 @@ namespace Akka.Streams.Implementation
         private void OnWriteAvailable(bool available)
         {
             if (available && _writer.TryWrite(_awaitingElement))
-                Pull(_inlet);
+            {
+                _writeInFlight = false;
+                _awaitingElement = default;
+                if (_finishPending)
+                    TryComplete();
+                else
+                    Pull(_inlet);
+            }
+            else if (available)
+            {
+                _writer.WaitToWriteAsync().AsTask().ContinueWith(_onWriteReady);
+            }
             else
+            {
+                _writeInFlight = false;
                 TryComplete();
+            }
         }
 
         private void TryComplete()
@@ -60,6 +76,13 @@ namespace Akka.Streams.Implementation
 
         public override void OnUpstreamFinish()
         {
+            if (_writeInFlight)
+            {
+                _finishPending = true;
+                SetKeepGoing(true);
+                return;
+            }
+
             base.OnUpstreamFinish();
             if (_isOwner)
                 _writer.TryComplete();
@@ -104,6 +127,7 @@ namespace Akka.Streams.Implementation
                 {
                     var task = continuation.AsTask();
                     _awaitingElement = element;
+                    _writeInFlight = true;
                     task.ContinueWith(_onWriteReady);
                 }
             }


### PR DESCRIPTION
## About this PR
Backport of PR #8289 to .

## Changes
- Fixes a bug where `ChannelSink.AsReader` / `ChannelSink.FromWriter` silently drop the final element of a stream under backpressure (when the bounded channel is full at the moment upstream completes).
- Fixes `fullMode` forwarding issue in `ChannelSink.AsReader` — was previously silently ignored.
- Adds tests: `ChannelSink_reader_should_deliver_final_element_when_channel_is_full_on_completion`, `ChannelSink_reader_should_deliver_all_elements_to_a_slow_consumer`, `ChannelSink_writer_should_deliver_final_element_when_channel_is_full_on_completion`.

## Original PR
- **Fixes:** #8285
- **Original PR:** #8289
- **Cherry-picked commit:** `5812f0b`

## Labels
This is a bug fix for Akka Streams with no public API changes.