### PR TITLE
Backport flaky-test stabilizations to v1.5 (#7831, #7852, #7924, #7950, #8013)

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
@@ -165,11 +165,6 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
                     var newMediator = DistributedPubSub.Get(newSystem).Mediator;
                     var probe = CreateTestProbe(newSystem);
 
-                    // Create shutdown actor FIRST so First node can find it while we verify gossip isolation
-                    // This fixes the race condition where First node times out waiting for this actor
-                    newSystem.Log.Info("Creating shutdown actor on {0}", node3Address);
-                    newSystem.ActorOf<DistributedPubSubRestartSpecConfig.Shutdown>("shutdown");
-
                     newMediator.Tell(new Subscribe("topic2", probe.Ref), probe.Ref);
                     await probe.ExpectMsgAsync<SubscribeAck>();
 
@@ -177,6 +172,13 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
                     await probe.ExpectNoMsgAsync(5.Seconds());
                     newMediator.Tell(DeltaCount.Instance, probe.Ref);
                     await probe.ExpectMsgAsync(0L);
+
+                    // Create shutdown actor AFTER verifying gossip isolation.
+                    // First node will find this actor and send "shutdown" to terminate newSystem.
+                    // We must complete the DeltaCount check above before this, otherwise there's
+                    // a race where First triggers shutdown while we're still verifying.
+                    newSystem.Log.Info("Creating shutdown actor on {0}", node3Address);
+                    newSystem.ActorOf<DistributedPubSubRestartSpecConfig.Shutdown>("shutdown");
 
                     await newSystem.WhenTerminated.WaitAsync(30.Seconds());
                 }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubRestartSpec.cs
@@ -104,11 +104,13 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
             await ExpectMsgAsync("msg1");
             await EnterBarrierAsync("got-msg1");
 
+            // All nodes capture baseline DeltaCount before node-specific logic
+            Mediator.Tell(DeltaCount.Instance);
+            var oldDeltaCount = await ExpectMsgAsync<long>();
+            await EnterBarrierAsync("old-delta-count");
+
             await RunOnAsync(async () =>
             {
-                Mediator.Tell(DeltaCount.Instance);
-                var oldDeltaCount = await ExpectMsgAsync<long>();
-
                 await EnterBarrierAsync("end");
 
                 // Use a probe to isolate DeltaCount query from any stray messages in TestActor mailbox
@@ -120,9 +122,6 @@ public class DistributedPubSubRestartSpec : MultiNodeClusterSpec
 
             await RunOnAsync(async () =>
             {
-                Mediator.Tell(DeltaCount.Instance);
-                var oldDeltaCount = await ExpectMsgAsync<long>();
-
                 var thirdAddress = (await NodeAsync(_config.Third)).Address;
                 await TestConductor.Shutdown(_config.Third).WaitAsync(30.Seconds());
 

--- a/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
+++ b/src/core/Akka.Cluster.Tests/ClusterLogSpec.cs
@@ -18,7 +18,7 @@ namespace Akka.Cluster.Tests
 {
     public abstract class ClusterLogSpec : AkkaSpec
     {
-        public const string Config = @"    
+        public const string Config = @"
             akka.cluster {
               auto-down-unreachable-after = 0s
               publish-stats-interval = 0s # always, when it happens
@@ -45,6 +45,10 @@ namespace Akka.Cluster.Tests
             _cluster = Cluster.Get(Sys);
         }
 
+        /// <summary>
+        /// Ensures the EventBusListener is ready by sending an Identify message and waiting for response.
+        /// This prevents race conditions where cluster events are published before the listener is subscribed.
+        /// </summary>
         protected async Task EnsureEventBusListenerReadyAsync()
         {
             var selection = Sys.ActorSelection("/system/clusterEventBusListener");
@@ -114,6 +118,10 @@ namespace Akka.Cluster.Tests
         {
             _cluster.Settings.LogInfo.ShouldBeTrue();
             _cluster.Settings.LogInfoVerbose.ShouldBeFalse();
+
+            // Ensure EventBusListener is ready before joining
+            await EnsureEventBusListenerReadyAsync();
+
             await JoinAsync("is the new leader");
             await AwaitUpAsync();
             await DownAsync("is no longer leader");
@@ -177,6 +185,10 @@ namespace Akka.Cluster.Tests
         public async Task A_cluster_must_log_verbose_cluster_events_when_log_info_verbose_is_on()
         {
             _cluster.Settings.LogInfoVerbose.ShouldBeTrue();
+
+            // Ensure EventBusListener is ready and subscribed before joining
+            await EnsureEventBusListenerReadyAsync();
+
             await JoinAsync(upLogMessage);
             await AwaitUpAsync();
             await DownAsync(downLogMessage);

--- a/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
+++ b/src/core/Akka.Streams.Tests/Dsl/HubSpec.cs
@@ -269,7 +269,10 @@ namespace Akka.Streams.Tests.Dsl
                         .ExpectOneAsync(async () =>
                         {
                             Source.Failed<int>(new TestException("failing")).RunWith(sink, Materializer);
-                            Source.From(Enumerable.Range(1, 10)).RunWith(sink, Materializer);
+                            // Throttle the successful producer to ensure the failing producer has time to fail and log
+                            Source.From(Enumerable.Range(1, 10))
+                                .Throttle(5, TimeSpan.FromMilliseconds(150), 5, ThrottleMode.Shaping)
+                                .RunWith(sink, Materializer);
                             var result = await task.WaitAsync(3.Seconds());
                             result.Should().BeEquivalentTo(Enumerable.Range(1, 10));
                         });

--- a/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorSystemSpec.cs
@@ -121,11 +121,20 @@ namespace Akka.Tests.Actor
                 var probe = testKit.CreateTestProbe();
                 var a = sys.ActorOf(Props.Create<Terminater>());
 
-                var eventFilter = new EventFilterFactory(new TestKit.Xunit.TestKit(sys));
-                await eventFilter.Info(contains: "not delivered").ExpectAsync(1, () => {
+                // Watch for actor termination to ensure proper synchronization
+                await probe.WatchAsync(a);
+
+                var eventFilter = new EventFilterFactory(testKit);
+                await eventFilter.Info(contains: "not delivered").ExpectAsync(1, async () => {
+                    // Tell the actor to stop
                     a.Tell("run");
+
+                    // Wait for the actor to fully terminate - this ensures the mailbox
+                    // is swapped to DeadLetterMailbox before we send the next message
+                    await probe.ExpectTerminatedAsync(a);
+
+                    // Now send the message that should become a dead letter
                     a.Tell("boom");
-                    return Task.CompletedTask;
                 });
             }
             finally { Shutdown(sys); }


### PR DESCRIPTION
Backports five test-stability fixes from `dev` to `v1.5`, each preserved as an individual cherry-pick (`-x` provenance retained). These races were already fixed on `dev` but never backported, so the corresponding tests still flake intermittently on `v1.5` CI — observed on recent v1.5 PRs (e.g. #8294). **All are test-only synchronization fixes — no product code changes.**

## Commits (chronological)

| PR | Test stabilized |
| --- | --- |
| #7831 | `ClusterLogSpec` — `EnsureEventBusListenerReadyAsync()` guard so the EventBusListener is subscribed before `MemberUp` is published on join |
| #7852 | `HubSpec.MergeHub_must_keep_working_even_if_one_of_the_producers_fail` — throttle the surviving producer so the failing one has time to fail/log |
| #7924 | `DistributedPubSubRestartSpec` — hoist the `DeltaCount` baseline capture / gossip-isolation ordering |
| #7950 | `ActorSystemSpec.Log_dead_letters` — death-watch (`WatchAsync`/`ExpectTerminatedAsync`) so the mailbox is swapped to `DeadLetterMailbox` before `boom` is sent |
| #8013 | `DistributedPubSubRestartSpec` — reorder shutdown-actor creation to after the gossip-isolation check |

## Hand-ports (v1.5 divergence)

Two picks needed a small manual resolution:
- **#7831** — v1.5 already had the `EnsureEventBusListenerReadyAsync` method (from a partial #8128 backport) but without the doc comment; resolved to keep the comment. The three call sites (including the verbose test) applied cleanly.
- **#7950** — v1.5's `Akka.Tests` uses the `TestKit.Xunit` namespace (dev moved to `TestKit.Xunit2`); adapted the fix to `TestKit.Xunit`.

## Validation (local, net10.0)

- `ActorSystemSpec.Log_dead_letters` ✅
- `ClusterLogSpec` — all 3 (incl. the verbose test) ✅
- `HubSpec.MergeHub_must_keep_working_even_if_one_of_the_producers_fail` ✅
- `Akka.Cluster.Tools.Tests.MultiNode` compiles clean (multi-node spec — #7924/#8013)

Separate from the #8031 consistent-hashing fix (#8294); this is purely CI/test hygiene.
