### PR TITLE
[WIP] address `ConsistentHashRouter` bday collision problem

### DIFF
--- a/src/benchmark/Akka.Benchmarks/Routing/ConsistentHashCreateBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Routing/ConsistentHashCreateBenchmarks.cs
@@ -1,0 +1,55 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="ConsistentHashCreateBenchmarks.cs" company="Akka.NET Project">
+//      Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//      Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//  </copyright>
+// -----------------------------------------------------------------------
+
+using System.Linq;
+using Akka.Benchmarks.Configurations;
+using Akka.Routing;
+using BenchmarkDotNet.Attributes;
+
+namespace Akka.Benchmarks.Routing;
+
+/// <summary>
+/// Benchmarks <see cref="ConsistentHash.Create{T}"/> ring construction across node counts and
+/// virtual-node factors. This is the code path changed for #8031 (canonical sort + linear-probe
+/// collision handling); it runs once per membership change, not per message. <see cref="NodeFor"/>
+/// is the per-message hot path and is included to confirm it did not regress.
+/// </summary>
+[Config(typeof(MicroBenchmarkConfig))]
+public class ConsistentHashCreateBenchmarks
+{
+    [Params(10, 100, 1000, 5000)]
+    public int NodeCount;
+
+    [Params(3, 5, 10)]
+    public int VirtualNodesFactor;
+
+    private string[] _nodes;
+    private string[] _lookupKeys;
+    private ConsistentHash<string> _ring;
+    private int _keyIndex;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Node strings shaped like full actor paths, which is what the router hashes in practice.
+        _nodes = Enumerable.Range(0, NodeCount)
+            .Select(i => "akka.tcp://sys@host:8080/user/router/routee-" + i)
+            .ToArray();
+        _ring = ConsistentHash.Create(_nodes, VirtualNodesFactor);
+        _lookupKeys = Enumerable.Range(0, 1024).Select(i => "session-" + i).ToArray();
+    }
+
+    [Benchmark]
+    public ConsistentHash<string> Create() => ConsistentHash.Create(_nodes, VirtualNodesFactor);
+
+    [Benchmark]
+    public string NodeFor()
+    {
+        _keyIndex = (_keyIndex + 1) & 1023;
+        return _ring.NodeFor(_lookupKeys[_keyIndex]);
+    }
+}

--- a/src/benchmark/Akka.Benchmarks/Utils/ConsistentHashBenchmarks.cs
+++ b/src/benchmark/Akka.Benchmarks/Utils/ConsistentHashBenchmarks.cs
@@ -17,40 +17,40 @@ namespace Akka.Benchmarks.Utils
     public class ConsistentHashBenchmarks
     {
 
-        private string testString;
-        private byte[] testBinary;
+        private string _testString;
+        private byte[] _testBinary;
 
         [GlobalSetup]
         public void Setup()
         {
-            testString = Guid.NewGuid().ToString("D");
-            testBinary = new byte[100];
+            _testString = Guid.NewGuid().ToString("D");
+            _testBinary = new byte[100];
 
-            ThreadLocalRandom.Current.NextBytes(testBinary);
+            ThreadLocalRandom.Current.NextBytes(_testBinary);
         }
 
         [Benchmark]
         public int Murmur_string_hash()
         {
-            return MurmurHash.StringHash(testString);
+            return MurmurHash.StringHash(_testString);
         }
 
         [Benchmark]
         public uint Jenkins_string_hash()
         {
-            return Jenkins.Hash(testString);
+            return Jenkins.Hash(_testString);
         }
 
         [Benchmark]
         public int Murmur_binary_hash()
         {
-            return MurmurHash.ByteHash(testBinary);
+            return MurmurHash.ByteHash(_testBinary);
         }
 
         [Benchmark]
         public uint Jenkins_binary_hash()
         {
-            return Jenkins.Hash(testBinary);
+            return Jenkins.Hash(_testBinary);
         }
 
         #region Jenkins

--- a/src/core/Akka.Tests/Routing/ConsistentHashSpec.cs
+++ b/src/core/Akka.Tests/Routing/ConsistentHashSpec.cs
@@ -1,0 +1,312 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ConsistentHashSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Akka.Routing;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Tests.Routing
+{
+    /// <summary>
+    /// Unit tests for <see cref="ConsistentHash{T}"/> ring construction, with a focus on the
+    /// 32-bit hash collision handling introduced for
+    /// <a href="https://github.com/akkadotnet/akka.net/issues/8031">#8031</a>.
+    ///
+    /// Prior to the fix a single collision in the 32-bit ring key space made
+    /// <see cref="ConsistentHash.Create{T}"/> throw, which wedged the entire consistent-hashing
+    /// router (every message returned <c>NoRoutee</c>) until a manual restart. The ring now
+    /// linear-probes to the next free slot instead of throwing.
+    /// </summary>
+    public class ConsistentHashSpec
+    {
+        // A genuine 32-bit collision discovered by brute force: at virtual-nodes-factor 10 the
+        // virtual nodes of "2842" and "7681" collide (specifically "2842" vnode 10 and "7681"
+        // vnode 6 both hash to 368115337). The set has two colliding vnodes out of twenty.
+        // The HasVnodeCollision guard below re-proves this against the real hash on every run.
+        private const string CollisionA = "2842";
+        private const string CollisionB = "7681";
+        private const int CollisionFactor = 10;
+
+        /// <summary>
+        /// A reference type identified only by <see cref="ToString"/> (no <c>Equals</c> override),
+        /// matching how <see cref="ConsistentHash{T}"/> is documented to identify nodes. Used to prove
+        /// ring identity is ToString-based, not reference/Default-equality based.
+        /// </summary>
+        private sealed class NamedNode
+        {
+            private readonly string _name;
+            public NamedNode(string name) => _name = name;
+            public override string ToString() => _name;
+        }
+
+        #region Helpers
+
+        /// <summary>
+        /// Reads the private ring dictionary out of a <see cref="ConsistentHash{T}"/> so tests can
+        /// assert on the exact key-&gt;node mapping (there is no public accessor).
+        /// </summary>
+        private static SortedDictionary<int, T> Ring<T>(ConsistentHash<T> hash)
+        {
+            var field = typeof(ConsistentHash<T>).GetField("_nodes", BindingFlags.NonPublic | BindingFlags.Instance);
+            field.Should().NotBeNull("the ConsistentHash<T>._nodes field is required by these tests");
+            return (SortedDictionary<int, T>)field.GetValue(hash);
+        }
+
+        /// <summary>
+        /// Faithful reproduction of the pre-#8031 <see cref="ConsistentHash.Create{T}"/>: insert the
+        /// natural virtual-node hashes in input order and throw (via <c>SortedDictionary.Add</c>) on a
+        /// duplicate key. Used to prove the new algorithm produces a byte-identical ring whenever the
+        /// legacy algorithm was able to build one (rolling-upgrade / split-brain safety).
+        /// </summary>
+        private static SortedDictionary<int, T> LegacyRing<T>(IEnumerable<T> nodes, int factor)
+        {
+            var dict = new SortedDictionary<int, T>();
+            foreach (var node in nodes)
+            {
+                var nodeHash = ConsistentHash.HashFor(node.ToString());
+                for (var v = 1; v <= factor; v++)
+                    dict.Add(ConsistentHash.ConcatenateNodeHash(nodeHash, v), node);
+            }
+            return dict;
+        }
+
+        /// <summary>
+        /// True if the given nodes produce at least one duplicate virtual-node key in the 32-bit ring.
+        /// Uses the real internal hash so the collision fixtures stay pinned to the shipping algorithm.
+        /// </summary>
+        private static bool HasVnodeCollision(IEnumerable<string> nodes, int factor)
+        {
+            var seen = new HashSet<int>();
+            foreach (var n in nodes)
+            {
+                var nodeHash = ConsistentHash.HashFor(n);
+                for (var v = 1; v <= factor; v++)
+                    if (!seen.Add(ConsistentHash.ConcatenateNodeHash(nodeHash, v)))
+                        return true;
+            }
+            return false;
+        }
+
+        private static void AssertSameRing<T>(SortedDictionary<int, T> expected, SortedDictionary<int, T> actual)
+        {
+            actual.Count.Should().Be(expected.Count);
+            foreach (var kv in expected)
+            {
+                actual.TryGetValue(kv.Key, out var value).Should().BeTrue($"key [{kv.Key}] must be present");
+                value.Should().Be(kv.Value, $"key [{kv.Key}] must map to the same node");
+            }
+        }
+
+        #endregion
+
+        [Fact]
+        public void Create_must_not_throw_when_two_node_keys_collide_in_the_32bit_ring()
+        {
+            // Guard: the fixture must actually collide, otherwise this test proves nothing.
+            HasVnodeCollision(new[] { CollisionA, CollisionB }, CollisionFactor).Should().BeTrue(
+                "the collision fixture must be a real 32-bit collision under the shipping hash");
+
+            Action act = () => ConsistentHash.Create(new[] { CollisionA, CollisionB }, CollisionFactor);
+            act.Should().NotThrow("a 32-bit collision must never wedge the ring (#8031)");
+        }
+
+        [Fact]
+        public void Create_must_keep_every_virtual_node_when_resolving_a_collision()
+        {
+            var ring = Ring(ConsistentHash.Create(new[] { CollisionA, CollisionB }, CollisionFactor));
+
+            // Re-probe keeps ALL virtual nodes (distribution-neutral); coalescing would drop some.
+            ring.Count.Should().Be(2 * CollisionFactor);
+            ring.Values.Count(v => v == CollisionA).Should().Be(CollisionFactor);
+            ring.Values.Count(v => v == CollisionB).Should().Be(CollisionFactor);
+        }
+
+        [Fact]
+        public void Create_must_build_an_identical_ring_regardless_of_input_order()
+        {
+            // Cross-node determinism: every node in the cluster must build the same ring even when a
+            // collision is resolved, no matter what order it happens to see the routees in.
+            var forward = Ring(ConsistentHash.Create(new[] { CollisionA, CollisionB }, CollisionFactor));
+            var reverse = Ring(ConsistentHash.Create(new[] { CollisionB, CollisionA }, CollisionFactor));
+
+            AssertSameRing(forward, reverse);
+        }
+
+        [Fact]
+        public void NodeFor_must_route_every_key_to_a_real_node_after_a_collision()
+        {
+            var hash = ConsistentHash.Create(new[] { CollisionA, CollisionB }, CollisionFactor);
+            hash.IsEmpty.Should().BeFalse();
+
+            var reached = new HashSet<string>();
+            for (var i = 0; i < 2000; i++)
+            {
+                var node = hash.NodeFor("key-" + i);
+                node.Should().Match<string>(n => n == CollisionA || n == CollisionB);
+                reached.Add(node);
+            }
+
+            reached.Should().BeEquivalentTo(new[] { CollisionA, CollisionB }, "both nodes must remain reachable");
+        }
+
+        [Fact]
+        public void Operator_plus_must_not_throw_when_the_added_node_collides()
+        {
+            var hash = ConsistentHash.Create(new[] { CollisionA }, CollisionFactor);
+
+            ConsistentHash<string> combined = null;
+            Action act = () => combined = hash + CollisionB;
+            act.Should().NotThrow("adding a colliding node must probe rather than throw (#8031)");
+
+            var ring = Ring(combined);
+            ring.Count.Should().Be(2 * CollisionFactor);
+            ring.Values.Count(v => v == CollisionB).Should().Be(CollisionFactor);
+        }
+
+        [Fact]
+        public void Operator_plus_must_produce_the_same_ring_as_Create_including_across_a_collision()
+        {
+            // Create(S) + x == Create(S ∪ {x}), even when x collides with a node already in S.
+            // The incremental Add must resolve the collision in the SAME canonical order as Create,
+            // not in insertion order, otherwise rings built by different paths would diverge.
+            var incremental = ConsistentHash.Create(new[] { CollisionA }, CollisionFactor) + CollisionB;
+            var fromScratch = ConsistentHash.Create(new[] { CollisionA, CollisionB }, CollisionFactor);
+
+            AssertSameRing(Ring(fromScratch), Ring(incremental));
+        }
+
+        [Fact]
+        public void Operator_plus_must_be_idempotent_for_a_node_already_in_the_ring()
+        {
+            // Re-adding a present node must NOT duplicate its virtual nodes (which would skew the
+            // distribution toward it and grow the ring unbounded across repeated adds).
+            var baseRing = ConsistentHash.Create(new[] { CollisionA, CollisionB }, CollisionFactor);
+            var afterReadd = baseRing + CollisionA;
+
+            AssertSameRing(Ring(baseRing), Ring(afterReadd));
+            Ring(afterReadd).Values.Count(v => v == CollisionA).Should().Be(CollisionFactor);
+        }
+
+        [Fact]
+        public void Operator_minus_must_drop_every_ring_entry_for_the_node_including_probed_slots()
+        {
+            // "7681" sorts after "2842", so its colliding virtual node is the one relocated to a
+            // probed slot. Removing it must leave NO phantom entry behind (the add/remove asymmetry
+            // the review caught), and must equal Create of the remaining node set.
+            var full = ConsistentHash.Create(new[] { CollisionA, CollisionB }, CollisionFactor);
+            var afterRemove = full - CollisionB;
+
+            var ring = Ring(afterRemove);
+            ring.Values.Should().NotContain(CollisionB, "all entries for the removed node, probed slots included, must be gone");
+            ring.Count.Should().Be(CollisionFactor);
+            AssertSameRing(Ring(ConsistentHash.Create(new[] { CollisionA }, CollisionFactor)), ring);
+        }
+
+        [Fact]
+        public void Create_must_identify_nodes_by_ToString_and_dedupe_duplicates()
+        {
+            // Same value listed twice must yield a single set of virtual nodes, not a probed-in
+            // second set that skews the distribution toward it (#8031).
+            var byValue = Ring(ConsistentHash.Create(new[] { CollisionA, CollisionA }, CollisionFactor));
+            byValue.Count.Should().Be(CollisionFactor);
+            byValue.Values.Should().OnlyContain(v => v == CollisionA);
+
+            // Two distinct instances with the same ToString (no Equals override) are the same node
+            // to the ring - identity is ToString-based, not reference-based.
+            var ring = Ring(ConsistentHash.Create(new[] { new NamedNode("srv1"), new NamedNode("srv1") }, CollisionFactor));
+            ring.Count.Should().Be(CollisionFactor, "nodes are identified by ToString(), not reference identity");
+        }
+
+        [Fact]
+        public void Operator_plus_must_be_idempotent_by_ToString_for_reference_types()
+        {
+            var ring = ConsistentHash.Create(new[] { new NamedNode("srv1") }, CollisionFactor);
+
+            // Fresh instance, same ToString: re-adding must be a no-op, not an unbounded duplication.
+            var afterReadd = ring + new NamedNode("srv1");
+
+            Ring(afterReadd).Count.Should().Be(CollisionFactor, "re-adding by ToString identity must be a no-op");
+        }
+
+        [Fact]
+        public void Operator_minus_must_match_by_ToString_not_reference_or_Equals()
+        {
+            var ring = ConsistentHash.Create(new[] { new NamedNode("a"), new NamedNode("b") }, CollisionFactor);
+
+            // Remove via a DIFFERENT instance whose ToString is "a": must drop a's entries (ToString
+            // identity - reference equality would match nothing) and must NOT drop "b".
+            var afterRemove = Ring(ring - new NamedNode("a"));
+
+            afterRemove.Count.Should().Be(CollisionFactor);
+            afterRemove.Values.Should().OnlyContain(n => n.ToString() == "b");
+        }
+
+        [Fact]
+        public void The_legacy_algorithm_reproduces_the_original_crash_on_the_collision_fixture()
+        {
+            // Sanity check that our before/after harness reproduces the exact failure #8031 reported,
+            // so the equality proof below is meaningful.
+            Action legacy = () => LegacyRing(new[] { CollisionA, CollisionB }, CollisionFactor);
+            legacy.Should().Throw<ArgumentException>();
+        }
+
+        /// <summary>
+        /// Rolling-upgrade / split-brain safety proof: for every routee set the legacy (pre-#8031)
+        /// algorithm can build, the new algorithm must build a byte-identical ring. If that holds,
+        /// a cluster running a mix of old and new nodes routes every key identically, so upgrading
+        /// node-by-node cannot cause a split brain. The only sets where the rings differ are the ones
+        /// the legacy algorithm cannot build at all (it throws and the old node is already wedged).
+        /// </summary>
+        [Fact]
+        public void Create_must_produce_the_legacy_ring_whenever_the_legacy_algorithm_succeeds()
+        {
+            var rnd = new Random(20260701);
+            var factors = new[] { 1, 3, 5, 10, 17 };
+            var counts = new[] { 2, 5, 25, 100, 500, 2000 };
+
+            var compared = 0;
+            var legacyCollisions = 0;
+
+            foreach (var factor in factors)
+            foreach (var count in counts)
+                for (var trial = 0; trial < 3; trial++)
+                {
+                    var nodes = Enumerable.Range(0, count)
+                        .Select(_ => "node-" + rnd.Next())
+                        .Distinct()
+                        .ToArray();
+
+                    SortedDictionary<int, string> legacy;
+                    try
+                    {
+                        legacy = LegacyRing(nodes, factor);
+                    }
+                    catch (ArgumentException)
+                    {
+                        // The legacy builder would have thrown and wedged the router here. The new code
+                        // must instead build a usable ring - there is no legacy ring to compare against.
+                        legacyCollisions++;
+                        Action act = () => ConsistentHash.Create(nodes, factor);
+                        act.Should().NotThrow("the new ring must tolerate the collision the legacy code could not");
+                        continue;
+                    }
+
+                    var updated = Ring(ConsistentHash.Create(nodes, factor));
+                    AssertSameRing(legacy, updated);
+                    compared++;
+                }
+
+            compared.Should().BeGreaterThan(0, "the proof must actually compare non-colliding rings");
+            // legacyCollisions is informational: at these scales the high-end configs usually exercise
+            // the collision branch too, but the guarantee that matters is the equality asserted above.
+        }
+    }
+}

--- a/src/core/Akka/Routing/ConsistentHashRouter.cs
+++ b/src/core/Akka/Routing/ConsistentHashRouter.cs
@@ -114,7 +114,7 @@ namespace Akka.Routing
     public sealed class ConsistentHashingRoutingLogic : RoutingLogic
     {
         private readonly Lazy<ILoggingAdapter> _log;
-        private ConsistentHashMapping _hashMapping;
+        private readonly ConsistentHashMapping _hashMapping;
         private readonly ActorSystem _system;
 
         private readonly AtomicReference<Tuple<Routee[], ConsistentHash<ConsistentRoutee>>> _consistentHashRef =

--- a/src/core/Akka/Routing/Router.cs
+++ b/src/core/Akka/Routing/Router.cs
@@ -114,8 +114,7 @@ namespace Akka.Routing
             if (obj.GetType() != this.GetType()) return false;
             return Equals((ActorRefRoutee)obj);
         }
-
-        /// <inheritdoc/>
+        
         protected bool Equals(ActorRefRoutee other) => Equals(Actor, other.Actor);
 
         
@@ -158,8 +157,7 @@ namespace Akka.Routing
             if (obj.GetType() != this.GetType()) return false;
             return Equals((ActorSelectionRoutee)obj);
         }
-
-        /// <inheritdoc/>
+        
         protected bool Equals(ActorSelectionRoutee other) => Equals(Selection, other.Selection);
 
         
@@ -265,7 +263,7 @@ namespace Akka.Routing
         {
             if (routees == null || routees.Length == 0)
             {
-                _routees = new []{ Routee.FromActorRef(routee) };
+                _routees = [Routee.FromActorRef(routee)];
             }
             else
             {
@@ -294,7 +292,7 @@ namespace Akka.Routing
         /// <param name="routees">TBD</param>
         public Router(RoutingLogic logic, params Routee[] routees)
         {
-            _routees = routees ?? Array.Empty<Routee>();
+            _routees = routees ?? [];
             RoutingLogic = logic;
         }
         
@@ -372,7 +370,7 @@ namespace Akka.Routing
         /// <returns>A new <see cref="Router"/> instance with this routee added.</returns>
         public virtual Router AddRoutee(Routee routee)
         {
-            return new Router(RoutingLogic, _routees.Union(new[]{routee}).ToArray());
+            return new Router(RoutingLogic, _routees.Union([routee]).ToArray());
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #8031

## Changes

[Working on it]

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

`ConsistentHashCreateBenchmark`

```
// * Summary *

BenchmarkDotNet v0.15.4, Windows 11 (10.0.26200.8655)
12th Gen Intel Core i7-1260P 2.10GHz, 1 CPU, 16 logical and 12 physical cores
.NET SDK 10.0.109
  [Host]     : .NET 6.0.36 (6.0.36, 6.0.3624.51421), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 6.0.36 (6.0.36, 6.0.3624.51421), X64 RyuJIT x86-64-v3


| Method  | NodeCount | VirtualNodesFactor | Mean             | Error          | StdDev         | Median           | Gen0     | Gen1     | Allocated |
|-------- |---------- |------------------- |-----------------:|---------------:|---------------:|-----------------:|---------:|---------:|----------:|
| Create  | 10        | 3                  |      2,475.50 ns |      48.151 ns |      70.578 ns |      2,457.12 ns |   0.4616 |        - |    4360 B |
| NodeFor | 10        | 3                  |         67.49 ns |       1.400 ns |       1.498 ns |         67.28 ns |        - |        - |         - |
| Create  | 10        | 5                  |      4,215.60 ns |      83.235 ns |     154.282 ns |      4,213.31 ns |   0.5875 |        - |    5560 B |
| NodeFor | 10        | 5                  |         68.86 ns |       1.377 ns |       1.288 ns |         68.59 ns |        - |        - |         - |
| Create  | 10        | 10                 |      7,688.98 ns |     134.766 ns |     201.712 ns |      7,644.99 ns |   0.9003 |   0.0153 |    8520 B |
| NodeFor | 10        | 10                 |         67.46 ns |       1.322 ns |       1.470 ns |         67.33 ns |        - |        - |         - |
| Create  | 100       | 3                  |     37,337.36 ns |     729.755 ns |   1,092.262 ns |     37,054.98 ns |   4.3945 |   0.2441 |   41800 B |
| NodeFor | 100       | 3                  |         74.92 ns |       1.525 ns |       2.186 ns |         74.00 ns |        - |        - |         - |
| Create  | 100       | 5                  |     62,694.69 ns |     606.596 ns |     567.410 ns |     62,714.99 ns |   5.6152 |   0.4883 |   53800 B |
| NodeFor | 100       | 5                  |         82.27 ns |       1.674 ns |       4.137 ns |         81.00 ns |        - |        - |         - |
| Create  | 100       | 10                 |    145,194.67 ns |   1,163.226 ns |     971.346 ns |    145,246.50 ns |   8.7891 |   1.2207 |   83400 B |
| NodeFor | 100       | 10                 |         86.56 ns |       1.736 ns |       2.132 ns |         86.58 ns |        - |        - |         - |
| Create  | 1000      | 3                  |    593,694.23 ns |   4,380.024 ns |   3,657.519 ns |    593,856.59 ns |  43.9453 |  16.6016 |  416200 B |
| NodeFor | 1000      | 3                  |         94.51 ns |       0.590 ns |       0.552 ns |         94.58 ns |        - |        - |         - |
| Create  | 1000      | 5                  |    956,640.96 ns |   6,378.804 ns |   5,326.590 ns |    958,485.64 ns |  56.6406 |  19.5313 |  536200 B |
| NodeFor | 1000      | 5                  |        100.18 ns |       2.048 ns |       2.103 ns |        100.28 ns |        - |        - |         - |
| Create  | 1000      | 10                 |  2,048,544.61 ns |  40,666.154 ns | 101,272.842 ns |  2,006,591.02 ns |  87.8906 |  33.2031 |  832200 B |
| NodeFor | 1000      | 10                 |        107.21 ns |       1.656 ns |       1.549 ns |        106.86 ns |        - |        - |         - |
| Create  | 5000      | 3                  |  3,664,399.22 ns |  42,133.895 ns |  35,183.711 ns |  3,660,446.88 ns | 218.7500 | 105.4688 | 2080200 B |
| NodeFor | 5000      | 3                  |        111.70 ns |       0.718 ns |       0.561 ns |        111.65 ns |        - |        - |         - |
| Create  | 5000      | 5                  |  6,208,551.72 ns |  69,872.780 ns |  65,359.042 ns |  6,199,079.69 ns | 281.2500 | 140.6250 | 2680200 B |
| NodeFor | 5000      | 5                  |        121.75 ns |       0.542 ns |       0.453 ns |        121.70 ns |        - |        - |         - |
| Create  | 5000      | 10                 | 14,472,743.30 ns | 147,551.823 ns | 130,800.848 ns | 14,529,532.81 ns | 437.5000 | 218.7500 | 4160200 B |
| NodeFor | 5000      | 10                 |        128.24 ns |       2.614 ns |       2.905 ns |        127.83 ns |        - |        - |         - |

// * Hints *
Outliers
  ConsistentHashCreateBenchmarks.Create: Default  -> 3 outliers were removed (2.69 us..2.77 us)
  ConsistentHashCreateBenchmarks.Create: Default  -> 1 outlier  was  removed (4.64 us)
  ConsistentHashCreateBenchmarks.Create: Default  -> 3 outliers were removed, 4 outliers were detected (7.22 us, 8.22 us..8.98 us)
  ConsistentHashCreateBenchmarks.Create: Default  -> 4 outliers were removed (42.67 us..45.47 us)
  ConsistentHashCreateBenchmarks.NodeFor: Default -> 6 outliers were removed (98.54 ns..112.73 ns)
  ConsistentHashCreateBenchmarks.Create: Default  -> 2 outliers were removed, 3 outliers were detected (142.97 us, 148.76 us, 152.70 us)
```

### This PR's Benchmarks

Include data from after this change here.
