### PR TITLE
Backport metrics + DotNetty test stabilizations to v1.5 (#7798, #8273)

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Base/AkkaSpecWithCollector.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/Base/AkkaSpecWithCollector.cs
@@ -70,24 +70,64 @@ namespace Akka.Cluster.Metrics.Tests.Base
         protected async Task<NodeMetrics> CreateTestDataAsync(TimeSpan timeout, string[] requiredMetrics)
         {
             using var cts = new CancellationTokenSource(timeout);
-            NodeMetrics metrics;
+            NodeMetrics metrics = null;
+            
+            // Give the collector extra time to initialize on first sample
+            // The DefaultCollector needs time for CPU timing initialization
+            var attemptCount = 0;
+            var exceptionCount = 0;
+            const int maxExceptionAttempts = 3;
             
             do
             {
                 cts.Token.ThrowIfCancellationRequested();
-                metrics = Collector.Sample();
                 
-                if (HasRequiredMetrics(metrics.Metrics, requiredMetrics))
+                try
                 {
-                    return metrics;
+                    metrics = Collector.Sample();
+                    
+                    if (HasRequiredMetrics(metrics.Metrics, requiredMetrics))
+                    {
+                        return metrics;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Log but continue - collector might need more time to initialize
+                    // This handles platform-specific issues like process access on Linux
+                    exceptionCount++;
+                    if (exceptionCount >= maxExceptionAttempts)
+                    {
+                        throw new InvalidOperationException($"Metrics collector failed after {maxExceptionAttempts} consecutive exceptions. Last error: {ex.Message}", ex);
+                    }
+                    
+                    // Longer delay after exceptions to allow system to recover
+                    await Task.Delay(1000, cts.Token);
+                    attemptCount++;
+                    continue;
                 }
                 
-                // Small delay between attempts to avoid tight loop
-                await Task.Delay(100, cts.Token);
+                // Reset exception count on successful sample
+                exceptionCount = 0;
+                
+                // Progressive backoff: longer delays for later attempts
+                var delayMs = attemptCount switch
+                {
+                    < 5 => 200,   // First few attempts: 200ms
+                    < 15 => 500,  // Middle attempts: 500ms  
+                    _ => 1000     // Later attempts: 1000ms
+                };
+                
+                attemptCount++;
+                await Task.Delay(delayMs, cts.Token);
                 
             } while (!cts.Token.IsCancellationRequested);
             
-            throw new OperationCanceledException($"Could not collect required metrics {string.Join(", ", requiredMetrics)} within {timeout}");
+            // Provide detailed diagnostics for timeout failures
+            var availableMetrics = string.Join(", ", metrics?.Metrics?.Select(m => m.Name) ?? new[] { "none" });
+            throw new OperationCanceledException(
+                $"Could not collect required metrics [{string.Join(", ", requiredMetrics)}] within {timeout}. " +
+                $"Available metrics: [{availableMetrics}]. Attempts made: {attemptCount}");
         }
 
         private static bool HasRequiredMetrics(ImmutableHashSet<NodeMetrics.Types.Metric> metrics, string[] requiredMetrics)

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/MetricSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/MetricSpec.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Cluster.Metrics.Helpers;
 using Akka.Cluster.Metrics.Serialization;
 using Akka.Cluster.Metrics.Tests.Base;
@@ -294,44 +295,50 @@ namespace Akka.Cluster.Metrics.Tests
         }
     }
 
-    public class MetricValuesSpec : AkkaSpecWithCollector
+    public class MetricValuesSpec
     {
         private readonly NodeMetrics _node1;
         private readonly NodeMetrics _node2;
         private readonly IImmutableList<NodeMetrics> _nodes;
         
-        public MetricValuesSpec() : base(ClusterMetricsTestConfig.DefaultEnabled)
+        public MetricValuesSpec()
         {
-            Queue<NodeMetrics> testData;
-            try
-            {
-                testData = CreateTestData(202, 10.Seconds(), [
-                    StandardMetrics.MemoryUsed, 
-                    StandardMetrics.MemoryAvailable,
-                    StandardMetrics.Processors,
-                    StandardMetrics.CpuProcessUsage,
-                    StandardMetrics.CpuTotalUsage ]);
-            }
-            catch (Exception e)
-            {
-                throw new Exception("Failed to initialize test data", e);
-            }
+            // Create deterministic test data instead of waiting for real system metrics
+            var testMetrics = CreateTestMetrics();
             
-            _node1 = new NodeMetrics(new Address("akka", "sys", "a", 2554), 1, testData.Dequeue().Metrics);
-            _node2 = new NodeMetrics(new Address("akka", "sys", "a", 2555), 1, testData.Dequeue().Metrics);
-            _nodes = Enumerable.Range(1, 100).Aggregate(ImmutableList.Create(_node1, _node2),
-                (nodes, _) =>
-                {
-                    return nodes.Select(n =>
-                    {
-                        return new NodeMetrics(n.Address, n.Timestamp,
-                            metrics: testData.Dequeue().Metrics.SelectMany(latest =>
-                            {
-                                return n.Metrics.Where(latest.SameAs)
-                                    .Select(streaming => streaming + latest);
-                            }));
-                    }).ToImmutableList();
-                });
+            _node1 = new NodeMetrics(new Address("akka", "sys", "a", 2554), 1, testMetrics);
+            _node2 = new NodeMetrics(new Address("akka", "sys", "a", 2555), 1, testMetrics);
+            
+            // Create 100 variations of the nodes for testing
+            _nodes = Enumerable.Range(1, 100)
+                .Select(i => new NodeMetrics(_node1.Address, i, CreateTestMetricsVariation(i)))
+                .Concat(Enumerable.Range(1, 100)
+                    .Select(i => new NodeMetrics(_node2.Address, i, CreateTestMetricsVariation(i))))
+                .ToImmutableList();
+        }
+
+        private static ImmutableHashSet<NodeMetrics.Types.Metric> CreateTestMetrics()
+        {
+            return ImmutableHashSet.Create(
+                NodeMetrics.Types.Metric.Create(StandardMetrics.MemoryUsed, 1024L * 1024 * 512, Option<double>.None).Value, // 512MB
+                NodeMetrics.Types.Metric.Create(StandardMetrics.MemoryAvailable, 1024L * 1024 * 1536, Option<double>.None).Value, // 1.5GB  
+                NodeMetrics.Types.Metric.Create(StandardMetrics.Processors, 4, Option<double>.None).Value,
+                NodeMetrics.Types.Metric.Create(StandardMetrics.CpuProcessUsage, 0.25, Option<double>.None).Value, // 25%
+                NodeMetrics.Types.Metric.Create(StandardMetrics.CpuTotalUsage, 0.60, Option<double>.None).Value // 60%
+            );
+        }
+        
+        private static ImmutableHashSet<NodeMetrics.Types.Metric> CreateTestMetricsVariation(int variation)
+        {
+            // Create slight variations for testing aggregation logic
+            var factor = 1.0 + (variation * 0.01); // 1% variation per iteration
+            return ImmutableHashSet.Create(
+                NodeMetrics.Types.Metric.Create(StandardMetrics.MemoryUsed, (long)(1024L * 1024 * 512 * factor), Option<double>.None).Value,
+                NodeMetrics.Types.Metric.Create(StandardMetrics.MemoryAvailable, (long)(1024L * 1024 * 1536 * factor), Option<double>.None).Value,
+                NodeMetrics.Types.Metric.Create(StandardMetrics.Processors, 4, Option<double>.None).Value, // Processors don't vary
+                NodeMetrics.Types.Metric.Create(StandardMetrics.CpuProcessUsage, Math.Min(0.25 * factor, 1.0), Option<double>.None).Value,
+                NodeMetrics.Types.Metric.Create(StandardMetrics.CpuTotalUsage, Math.Min(0.60 * factor, 1.0), Option<double>.None).Value
+            );
         }
 
 

--- a/src/contrib/cluster/Akka.Cluster.Metrics.Tests/MetricsCollectorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Metrics.Tests/MetricsCollectorSpec.cs
@@ -51,7 +51,9 @@ namespace Akka.Cluster.Metrics.Tests
             NodeMetrics sample;
             try
             {
-                sample = await CreateTestDataAsync(30.Seconds(), [
+                // Increase timeout to handle slow CI environments and collector initialization
+                // DefaultCollector needs time for first sample (500ms sleep + process access)
+                sample = await CreateTestDataAsync(60.Seconds(), [
                     StandardMetrics.MemoryAvailable,
                     StandardMetrics.MemoryUsed
                 ]);

--- a/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs
@@ -283,10 +283,15 @@ namespace Akka.Remote.Tests.Transport
                 var c1 = await t1.Listen();
                 c1.Item2.SetResult(new ActorAssociationEventListener(p1));
 
-                // t1 --> t2 association
+                // t1 --> nowhere: target a valid (0-65535) port where nothing is listening so the
+                // outbound connect fails. Offset down when near the top of the ephemeral range so we
+                // never exceed IPEndPoint.MaxPort (65535) — Windows' dynamic range tops out at 65535,
+                // so a blind "+ 100" can overflow and throw ArgumentOutOfRangeException instead.
+                var boundPort = c1.Item1.Port!.Value;
+                var deadPort = boundPort > 65435 ? boundPort - 100 : boundPort + 100;
                 await Assert.ThrowsAsync<InvalidAssociationException>(async () =>
                 {
-                    var a = await t1.Associate(c1.Item1.WithPort(c1.Item1.Port + 100));
+                    var a = await t1.Associate(c1.Item1.WithPort(deadPort));
                 });
 
 


### PR DESCRIPTION
## Backport: test-stability fixes to `v1.5` (#7798, #8273)

These are **test-only** flaky-test backports. Both fixes already landed on `dev` but were never on `v1.5`, so the flaky specs continue to fail intermittently on `v1.5` PR CI (e.g. seen on #8294). This PR brings them over as two individual cherry-picks (with `-x` provenance), in chronological order.

### What each PR stabilizes

| Backported PR | dev commit | Files touched | Stabilizes |
|---|---|---|---|
| #7798 — Fix metrics specs race conditions | `3abeec261` (2025-09-04) | `Akka.Cluster.Metrics.Tests/Base/AkkaSpecWithCollector.cs`, `MetricSpec.cs`, `MetricsCollectorSpec.cs` | `MetricValuesSpec.NodeMetrics_MetricValues_should_extract_expected_metrics_for_load_balancing` and `..._expected_MetricValue_types_for_load_balancing` — replaces the live-collector `CreateTestData(202, 10.Seconds(), ...)` sampling (which required ~10s of real system metrics and could deadlock/flake in CI) with deterministic `CreateTestMetrics()` / `CreateTestMetricsVariation()`, and makes `MetricValuesSpec` independent of the `AkkaSpecWithCollector` base. Also adds retry/backoff + longer timeouts to the remaining live-collector paths (`CreateTestDataAsync`, `MetricsCollectorSpec`). |
| #8273 — prevent ephemeral-port overflow | `b9f263c0f` (2026-06-16) | `Akka.Remote.Tests/Transport/DotNettyTransportShutdownSpec.cs` | `DotNettyTcpTransport_should_cleanly_terminate_endpoints_upon_failed_outbound_connection` (Windows-only flake). Clamps the "dead port" target so `boundPort + 100` can't exceed `IPEndPoint.MaxPort` (65535) when the OS assigns a high ephemeral port on Windows. |

### Hand-porting

None required. Both commits cherry-picked **cleanly** onto `v1.5` — the touched regions on `v1.5` were byte-for-byte identical to the `dev` pre-fix state. (The metrics test project builds against `Akka.TestKit.Xunit` on `v1.5`; the ported code compiles against it without changes, so no xUnit-namespace adaptation was needed.)

### Local validation (net10.0, Linux)

- `MetricValuesSpec` + `MetricsCollectorSpec`: **Passed — 5/5** (~7s).
- `DotNettyTcpTransport_should_cleanly_terminate_endpoints_upon_failed_outbound_connection`: **Passed — 1/1** (~0.4s; it was a Windows-only flake, so it passes on Linux and now also can't overflow).
- Both touched test projects build clean.

### Scope

This PR is **separate from #8294** (the #8031 consistent-hashing fix) and **#8296** (an earlier flaky-test backport) — it does not touch those branches or their commits.
