### PR TITLE
fix: make DispatcherModelSpec.A_dispatcher_must_process_messages_one_at_a_time deterministic

### DIFF
--- a/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
+++ b/src/core/Akka.Tests/Actor/Dispatch/ActorModelSpec.cs
@@ -480,10 +480,24 @@ namespace Akka.Tests.Actor.Dispatch
             AssertCountdown(start, (int)Dilated(TimeSpan.FromSeconds(3.0)).TotalMilliseconds, "Should process first message within 3 seconds");
             AssertRefDefaultZero(a, registers: 1, msgsReceived: 1, msgsProcessed: 1, dispatcher: dispatcher);
 
-            a.Tell(new Wait(1000));
+            // Deterministically hold the actor busy with a latch the test controls,
+            // instead of racing a wall-clock Thread.Sleep(1000) against a fixed deadline.
+            // 'busyStarted' is signaled once the actor is inside the blocking handler;
+            // 'release' keeps it busy until the test explicitly lets it go.
+            var busyStarted = new CountdownEvent(1);
+            var release = new CountdownEvent(1);
+            a.Tell(new Meet(busyStarted, release));
+            AssertCountdown(busyStarted, (int)Dilated(TimeSpan.FromSeconds(3.0)).TotalMilliseconds, "Should start processing the blocking message within 3 seconds");
+
+            // While the actor is deterministically held busy, the second message must NOT be
+            // processed. This positively proves the "one message at a time" property rather than
+            // inferring it from a restart that never happens.
             a.Tell(new CountDown(oneAtTime));
-            // in case of serialization violation, restart would happen instead of countdown
-            AssertCountdown(oneAtTime, (int)Dilated(TimeSpan.FromSeconds(1.5)).TotalMilliseconds, "Should process message when allowed");
+            AssertNoCountdown(oneAtTime, (int)Dilated(TimeSpan.FromMilliseconds(500)).TotalMilliseconds, "Should not process the next message while the actor is busy");
+
+            // Release the gate; the queued message must now be processed once the actor is free.
+            release.Signal();
+            AssertCountdown(oneAtTime, (int)Dilated(TimeSpan.FromSeconds(3.0)).TotalMilliseconds, "Should process message when allowed");
             AssertRefDefaultZero(a, registers: 1, msgsReceived: 3, msgsProcessed: 3, dispatcher: dispatcher);
 
             Sys.Stop(a);


### PR DESCRIPTION
## Summary

Makes the intermittently-flaky test `A_dispatcher_must_process_messages_one_at_a_time` (in the shared `ActorModelSpec` harness) deterministic. **Test-only change** — no production code under `src/core/Akka/Dispatch/` was modified. The dispatcher/mailbox behavior is correct; the flake was entirely in the test.

## The flake

The test held the actor "busy" using a hard-coded, **non-dilated** `Thread.Sleep(1000)` in the `Wait` handler, then asserted the second message's countdown against a `Dilated(1.5s)` deadline:

```csharp
a.Tell(new Wait(1000));
a.Tell(new CountDown(oneAtTime));
AssertCountdown(oneAtTime, (int)Dilated(TimeSpan.FromSeconds(1.5)).TotalMilliseconds, "Should process message when allowed");
```

That leaves only a ~500 ms margin above the fixed 1 s sleep. Under CI ThreadPool starvation the margin is consumed and the legitimate countdown arrives late, producing a **false failure**. Isolation is never actually violated — the `_busy` `Switch` guards it and `Restarts` stays `0`. The 1.5 s wall-clock bound added no correctness value; isolation is enforced independently by the `_busy` switch plus the trailing `AssertRefDefaultZero(..., restarts: 0)`.

## The fix

Deterministic, latch-controlled — mirrors the sibling `A_dispatcher_must_process_messages_in_parallel` spec's `Meet(aStart, aStop)` pattern:

- Replace `Wait(1000)` with a test-controlled `Meet(busyStarted, release)` latch so the actor stays busy until the test explicitly releases it — removing the wall-clock race entirely.
- While the actor is held busy, send `CountDown(oneAtTime)` and use `AssertNoCountdown(..., 500ms)` to **positively prove** the second message is not processed while the actor is busy. This is a *stronger* "one message at a time" assertion than the old approach, which merely inferred it from a restart that never happens.
- After releasing the gate, `AssertCountdown(oneAtTime, Dilated(3s))` proves the message **is** processed once the actor is free (matching the 3 s the same test already grants the first message).

## Accounting is unchanged

The test still sends exactly three messages (`CountDown`, `Meet`, `CountDown`), so the trailing counts remain correct:

```csharp
AssertRefDefaultZero(a, registers: 1, msgsReceived: 3, msgsProcessed: 3, dispatcher: dispatcher);
```

## Validation

- Built `Akka.Tests` on `net10.0` with `-warnaserror`: 0 warnings, 0 errors.
- Ran the target test 5x on `net10.0`: all pass.
- Ran the full `DispatcherModelSpec` suite (8 tests, including the sibling parallel spec that shares the harness): all pass.
