### PR TITLE
Backport: harden TcpSpec.Outgoing_TCP_stream_must_handle_when_connection_actor_terminates_unexpectedly (backport of #7827)

### DIFF
--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -483,37 +483,55 @@ namespace Akka.Streams.Tests.IO
             var system2 = ActorSystem.Create("system2", Sys.Settings.Config);
             try
             {
-                InitializeLogger(system2);
+                InitializeLogger(system2, "[SYS2]");
                 var mat2 = ActorMaterializer.Create(system2);
 
                 var serverAddress = TestUtils.TemporaryServerAddress();
                 var binding = system2.TcpStream()
                     .BindAndHandle(Flow.Create<ByteString>(), mat2, serverAddress.Address.ToString(), serverAddress.Port);
 
-                var result = Source.Maybe<ByteString>()
+                // Ensure server is bound before creating client connection
+                await binding.WaitAsync(TimeSpan.FromSeconds(3));
+
+                // Build a client stream with a controllable upstream and an echo gate to ensure full registration
+                var tapped = Source.Queue<ByteString>(16, OverflowStrategy.Backpressure)
                     .Via(system2.TcpStream().OutgoingConnection(serverAddress))
-                    .RunAggregate(0, (i, s) => i + s.Count, mat2);
+                    .AlsoToMaterialized(Sink.First<ByteString>(), Keep.Both);
 
-                // give some time for all TCP stream actor parties to actually 
-                // get initialized, otherwise Kill command may run into the void
-                await Task.Delay(500);
+                var ((queue, firstEcho), result) = tapped
+                    .ToMaterialized(Sink.Aggregate<ByteString, int>(0, (i, s) => i + s.Count), Keep.Both)
+                    .Run(mat2);
 
-                await Awaiting(async () =>
-                    {
-                        await WithinAsync(TimeSpan.FromSeconds(15), async () =>
-                        {
-                            await AwaitAssertAsync(async () =>
-                            {
-                                // Getting rid of existing connection actors by using a blunt instrument
-                                system2.ActorSelection(system2.Tcp().Path / "tcp-client-connection-*").Tell(Kill.Instance);
-                            
-                                await result.WaitAsync(3.Seconds());
-                            }, interval:TimeSpan.FromSeconds(4));
-                        });
-                        
-                        
-                    })
-                    .Should().ThrowAsync<StreamTcpException>();
+                // Send a ping and wait for the echo to guarantee Connected+Registered+Watched state
+                (await queue.OfferAsync(ByteString.FromString("ping"))).Should().BeOfType<QueueOfferResult.Enqueued>();
+                await firstEcho.WaitAsync(5.Seconds());
+
+                // Resolve the actual connection actor reference and watch it
+                IActorRef connectionActor = null;
+                await AwaitAssertAsync(async () =>
+                {
+                    connectionActor = await system2.ActorSelection(system2.Tcp().Path / "tcp-client-connection-*")
+                        .ResolveOne(TimeSpan.FromMilliseconds(100));
+                }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(200));
+
+                var probe = CreateTestProbe(system2);
+                await probe.WatchAsync(connectionActor);
+
+                // Kill the specific connection actor
+                connectionActor.Tell(Kill.Instance);
+
+                // Wait for the actor to actually terminate
+                var terminated = await probe.ExpectMsgAsync<Terminated>(TimeSpan.FromSeconds(3));
+                terminated.ActorRef.Should().Be(connectionActor);
+
+                // Verify the stream fails deterministically with StreamTcpException
+                await AwaitAssertAsync(() =>
+                {
+                    result.IsFaulted.Should().BeTrue();
+                    var flattened = result.Exception?.Flatten();
+                    flattened.Should().NotBeNull();
+                    flattened!.InnerExceptions.Should().Contain(e => e is StreamTcpException);
+                }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(200));
 
                 await binding.Result.Unbind().WaitAsync(3.Seconds());
             }


### PR DESCRIPTION
## v1.5 backport of #7827

Backports the flaky-test hardening from #7827 (`Akka.Streams.Tests.IO.TcpSpec.Outgoing_TCP_stream_must_handle_when_connection_actor_terminates_unexpectedly`) to the `v1.5` branch. **Test-only — no production code is touched.**

### The flake

On `v1.5` this test:

1. slept a fixed `await Task.Delay(500)` to "give some time" for the TCP stream actors to initialize, then
2. fired a **wildcard** `system2.ActorSelection(... / "tcp-client-connection-*").Tell(Kill.Instance)` "blunt instrument" repeatedly inside a 15s `AwaitAssertAsync`, then
3. asserted the stream threw `StreamTcpException`.

This races the connection actor's initialization — on slower/Windows CI the `Kill` can land before the connection is `Connected` + `Registered` + `Watched` (or before it even resolves), so the stream never faults deterministically and the test flakes.

### The deterministic fix

- **Wait for the server bind to complete** (`await binding.WaitAsync(...)`).
- **Drive the outgoing connection with a `Source.Queue` + an echo gate**: offer a `ping` and await the first echo back (`Sink.First` via `AlsoToMaterialized`). Getting the echo guarantees the connection is fully `Connected` + `Registered` + `Watched` before we proceed — no fixed delay.
- **`ResolveOne` the specific `tcp-client-connection-*` actor** instead of the wildcard shotgun.
- **`WatchAsync` it, `Tell(Kill.Instance)`, then `ExpectMsgAsync<Terminated>`** to deterministically confirm the actor actually died.
- **Assert the stream `result` faulted with `StreamTcpException`** (via `result.IsFaulted` + flattened `AggregateException`).

No fixed delays, no wildcard kill — the kill only happens after the connection is provably fully wired up, and termination is confirmed before the fault is asserted.

### Hand-ported, not a clean cherry-pick

`#7827` will **not** cherry-pick cleanly onto `v1.5`. On `dev` this same method was subsequently rewritten by **#8132** (`ByteString` → `ReadOnlySequence<byte>`) and **#8078** (xUnit 3), so dev's current version relies on APIs that don't exist on `v1.5`. This change re-expresses the identical fix logic against v1.5's API:

- **`ByteString`** throughout (not `ReadOnlySequence<byte>`): `Source.Queue<ByteString>`, `Sink.First<ByteString>`, `Sink.Aggregate<ByteString, int>(0, (i, s) => i + s.Count)`, `ByteString.FromString("ping")`.
- v1.5 xUnit2 / async TestKit idioms (`WatchAsync`, `ExpectMsgAsync<Terminated>`, `AwaitAssertAsync`, `WaitAsync`).

Provenance is preserved via `(cherry picked from commit c4213b84d...)` in the commit body.

### Validation (local, `net10.0`)

- `dotnet build src/core/Akka.Streams.Tests/Akka.Streams.Tests.csproj -c Release -warnaserror` → **0 warnings, 0 errors**.
- Target test run **5×** back-to-back → **5/5 pass**.
- Broader `TcpSpec.Outgoing_TCP_stream_must_*` sanity run → **15 passed, 1 skipped (pre-existing)**, no harness breakage.

### Notes

- Separate from the other v1.5 backport PRs #8296 / #8298 / #8300.
- Test-only; confined to the single `Outgoing_TCP_stream_must_handle_when_connection_actor_terminates_unexpectedly` method in `src/core/Akka.Streams.Tests/IO/TcpSpec.cs`.
