### PR TITLE
Backport: harden TcpSpec abort/connection-fails + EventFilterTestBase races (#7815, #7870, #7797)

### DIFF
--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -366,14 +366,21 @@ namespace Akka.Streams.Tests.IO
                 var tcpWriteProbe = new TcpWriteProbe(this);
                 var tcpReadProbe = new TcpReadProbe(this);
 
-                Source.FromPublisher(tcpWriteProbe.PublisherProbe)
-                    .Via(Sys.TcpStream().OutgoingConnection(server.Address))
+                // Wait for TCP connection to be fully established before aborting
+                var connectionTask = Source.FromPublisher(tcpWriteProbe.PublisherProbe)
+                    .ViaMaterialized(Sys.TcpStream().OutgoingConnection(server.Address), Keep.Right)
                     .To(Sink.FromSubscriber(tcpReadProbe.SubscriberProbe))
                     .Run(Materializer);
+                    
                 var serverConnection = await server.WaitAcceptAsync();
+                var clientConnection = await connectionTask;
+                
+                // Start active reading to ensure Linux can detect TCP RST
+                var readSub = await tcpReadProbe.SubscriberProbe.ExpectSubscriptionAsync();
+                readSub.Request(1);
 
                 serverConnection.Abort();
-                await tcpReadProbe.SubscriberProbe.ExpectSubscriptionAndErrorAsync();
+                await tcpReadProbe.SubscriberProbe.ExpectErrorAsync();
                 var subscription = await tcpWriteProbe.TcpWriteSubscription();
                 await subscription.ExpectCancellationAsync();
 

--- a/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
+++ b/src/core/Akka.Streams.Tests/IO/TcpSpec.cs
@@ -119,7 +119,7 @@ namespace Akka.Streams.Tests.IO
                     Source.FromPublisher(tcpWriteProbe.PublisherProbe)
                         .ViaMaterialized(
                             Sys.TcpStream()
-                                .OutgoingConnection(new DnsEndPoint("example.com", 666),
+                                .OutgoingConnection(new IPEndPoint(IPAddress.Parse("192.0.2.1"), 666),
                                     connectionTimeout: TimeSpan.FromSeconds(1)), Keep.Right)
                         .ToMaterialized(Sink.Ignore<ByteString>(), Keep.Left)
                         .Run(Materializer);

--- a/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
+++ b/src/core/Akka.TestKit.Tests/TestEventListenerTests/EventFilterTestBase.cs
@@ -24,17 +24,19 @@ namespace Akka.TestKit.Tests.TestEventListenerTests
         {
         }
 
-        public ValueTask InitializeAsync()
+        public async ValueTask InitializeAsync()
         {
             //We send a ForwardAllEventsTo containing message to the TestEventListenerToForwarder logger (configured as a logger above).
             //It should respond with an "OK" message when it has received the message.
             var initLoggerMessage = new ForwardAllEventsTestEventListener.ForwardAllEventsTo(TestActor);
-            
-            SendRawLogEventMessage(initLoggerMessage);
-            ExpectMsg("OK");
+
+            //The logger may not have finished subscribing yet, so retry until it acknowledges.
+            await AwaitAssertAsync(async () =>
+            {
+                SendRawLogEventMessage(initLoggerMessage);
+                await ExpectMsgAsync("OK", TimeSpan.FromSeconds(1));
+            }, TimeSpan.FromSeconds(10), TimeSpan.FromMilliseconds(200));
             //From now on we know that all messages will be forwarded to TestActor
-            
-            return new ValueTask(Task.CompletedTask);
         }
 
         public ValueTask DisposeAsync()


### PR DESCRIPTION
## Summary

Test-only backport to `v1.5` of three flaky-test fixes from `dev`. Three individual commits, one per source PR. **No production code is touched.**

| Fix (source PR) | Test stabilized | What it does |
| --- | --- | --- |
| **#7815** (`6aee8bd70`, cherry-pick `-x`) | `Outgoing_TCP_stream_must_shut_down_both_streams_when_connection_is_aborted_remotely` (`TcpSpec`) | Waits for the client connection to be fully materialized (`ViaMaterialized(..., Keep.Right)` + `await connectionTask`) and starts active reading (`readSub.Request(1)`) **before** the remote `Abort()`, so Linux epoll actually issues the `recv()` that detects the TCP RST. Switches the assertion to `ExpectErrorAsync()`. |
| **#7870** (`8c094522c`, cherry-pick `-x`) | `Outgoing_TCP_stream_must_fail_the_materialized_task_when_the_connection_fails` (`TcpSpec`) | Replaces `new DnsEndPoint("example.com", 666)` with `new IPEndPoint(IPAddress.Parse("192.0.2.1"), 666)` (TEST-NET-1, non-routable) so the connection attempt starts immediately instead of waiting on DNS resolution. |
| **#7797** (partial, hand-authored) | Every spec deriving from `EventFilterTestBase` (`Akka.TestKit.Tests`) | Retries logger initialization via `AwaitAssertAsync` until the `ForwardAllEventsTestEventListener` acknowledges with `"OK"`, instead of a single blocking `SendRawLogEventMessage`/`ExpectMsg` that can run before the logger has finished subscribing. |

## Notes / honest caveats

- **#7815** is a real Linux-epoll RST race fix (not just a timing tweak): without the active `recv()` before the abort, Linux never detects the RST on a "zombie" (established-but-not-reading) connection, whereas Windows detects it more aggressively.
- **#7870** removes the DNS-latency race. Caveat: it does not add a hard latch — it leaves a comfortable margin (1 s `connectionTimeout` vs. the 3 s test timeout) by removing the variable-latency DNS lookup so the connect timeout can fire well inside the window.
- **#7797** is ported **partially and by hand**, not cherry-picked:
  - Only the `EventFilterTestBase` logger-subscription retry is included.
  - It keeps v1.5's xUnit-3 `async ValueTask InitializeAsync` signature (dev's version reintroduced xUnit-2 `Task`/`TestKit.Xunit2` signatures, which do not apply on v1.5).
  - The original PR's `...terminates_unexpectedly` `TcpSpec` rewrite is **intentionally excluded** — that fix was backported separately and better via #8301.
  - The original PR's other two `TcpSpec` hunks were cosmetic collection-literal (`[...]`) changes with no behavior change — skipped.
  - This also satisfies the repo's "prefer async TestKit methods" guidance (sync `ExpectMsg` -> `await ExpectMsgAsync`).

This PR is **standalone** and separate from the other v1.5 flaky-test backports (#8296 / #8298 / #8300 / #8301).

## Local validation (Linux, `net10.0`)

- `dotnet build Akka.Streams.Tests -c Release -warnaserror --framework net10.0` -> **0 warnings, 0 errors**
- `dotnet build Akka.TestKit.Tests -c Release -warnaserror --framework net10.0` -> **0 warnings, 0 errors**
- Abort test x5 (`~shut_down_both_streams_when_connection_is_aborted`) -> **5/5 pass**
- Connection-fails test (`~fail_the_materialized_task_when_the_connection_fails`) -> **pass**
- `EventFilterTestBase`-derived specs (`~EventFilter`, 220 tests) x5 -> **5/5 pass (220/220 each)**
