### PR TITLE
fix: widen RemoteReDeployment post-restart redeploy windows for slow-net multi-node variant

### DIFF
--- a/src/core/Akka.Remote.Tests.MultiNode/RemoteReDeploymentSpec.cs
+++ b/src/core/Akka.Remote.Tests.MultiNode/RemoteReDeploymentSpec.cs
@@ -125,14 +125,22 @@ namespace Akka.Remote.Tests.MultiNode
                 tempSys.ActorOf(EchoProps(p.Ref), "echo");
                 p.Send(tempSys.ActorOf(Props.Create(() => new Parent()), "parent"),
                     new ParentMessage(Props.Create(() => new Hello()), "hello"));
-                await p.ExpectMsgAsync("HelloParent", TimeSpan.FromSeconds(15));
+                // Widened from 15s to 30s: after the second system is replaced by a new incarnation on the
+                // same address, this re-deploy has to complete a fresh remote re-association plus the
+                // remote deployment round-trip over the simulated slow network. On a loaded CI agent the
+                // adverse-network variant can legitimately exceed 15s, so give it headroom. Not a logic change.
+                await p.ExpectMsgAsync("HelloParent", TimeSpan.FromSeconds(30));
             }, _config.Second);
 
             await EnterBarrierAsync("re-deployed");
 
             await RunOnAsync(async () =>
             {
-                await WithinAsync(TimeSpan.FromSeconds(15), async () =>
+                // Widened from 15s to 30s: `first` observes the child's lifecycle (PreStart / PostStop+PreStart)
+                // only after the new incarnation of `second` re-associates and re-deploys the child remotely
+                // over the simulated slow network. Under CI load the adverse-network variant can exceed the
+                // flat 15s window, causing a spurious miss. Extra headroom only — assertions are unchanged.
+                await WithinAsync(TimeSpan.FromSeconds(30), async () =>
                 {
                     if (ExpectQuarantine)
                     {


### PR DESCRIPTION
## Summary

Test-only stability fix for the intermittently-flaky multi-node test:

`Akka.Remote.Tests.MultiNode.RemoteReDeploymentSlowMultiNetSpec.RemoteReDeployment_must_terminate_the_child_when_its_parent_system_is_replaced_by_a_new_one`

The failing method lives in the shared base `RemoteReDeploymentSpec`, so this fix covers all three config variants (`Fast`/`Medium`/`Slow`), though the flake is observed almost exclusively on the `Slow` variant (`SleepAfterKill = 10s`, `ExpectQuarantine = true`).

## The flake

After `first` blackholes `second` and `second` is aborted (`ShutdownAsync(Second, abort: true)`), a **new incarnation** of `second` restarts a fresh `ActorSystem` on the **same address** and remotely re-deploys `parent`/`hello` back onto `first`. Both nodes then assert the redeploy:

- `second` (post-restart): `await p.ExpectMsgAsync("HelloParent", 15s)`
- `first`: `await WithinAsync(15s, ...)` wrapping `ExpectMsgAsync("PreStart")` (or `PostStop`+`PreStart`)

On a loaded CI agent (especially Windows MNTR), the post-restart sequence — a brand-new-incarnation **remote re-association** followed by the **remote deployment round-trip and PreStart/HelloParent messages over the simulated slow network** (`TestTransport = true`) — can legitimately exceed the flat **15s** windows. When it does, both nodes miss their assertion and the spec fails. The assertions themselves are correct; the windows were simply too tight for the adverse-network variant under CI load. There is no clean latch to barrier on here (you cannot deterministically wait for "the async redeploy message arrived"), so widening the window is the appropriate, low-risk mitigation.

## The fix

Widen **only** the two post-restart redeploy-assertion windows from `15s` to `30s`, with comments explaining the headroom:

1. `second`'s post-restart `ExpectMsgAsync("HelloParent", ...)`
2. `first`'s post-restart `WithinAsync(...)` wrapping the `PreStart` / `PostStop`+`PreStart` assertions

Nothing else changes:

- No changes to the quarantine / blackhole / `SleepAfterKill` logic.
- No changes to any barriers.
- No changes to the initial-deploy windows (those are not the flaky ones).
- **No production code touched** — this is confined to the test spec.
- The method is already fully `async`/awaited, so no sync-to-async conversion was required (the repo's async-TestKit rule is already satisfied).

### Before / after

```diff
-                await p.ExpectMsgAsync("HelloParent", TimeSpan.FromSeconds(15));
+                // Widened from 15s to 30s: after the second system is replaced by a new incarnation on the
+                // same address, this re-deploy has to complete a fresh remote re-association plus the
+                // remote deployment round-trip over the simulated slow network. On a loaded CI agent the
+                // adverse-network variant can legitimately exceed 15s, so give it headroom. Not a logic change.
+                await p.ExpectMsgAsync("HelloParent", TimeSpan.FromSeconds(30));
```

```diff
-                await WithinAsync(TimeSpan.FromSeconds(15), async () =>
+                // Widened from 15s to 30s: `first` observes the child's lifecycle (PreStart / PostStop+PreStart)
+                // only after the new incarnation of `second` re-associates and re-deploys the child remotely
+                // over the simulated slow network. Under CI load the adverse-network variant can exceed the
+                // flat 15s window, causing a spurious miss. Extra headroom only — assertions are unchanged.
+                await WithinAsync(TimeSpan.FromSeconds(30), async () =>
```

## Validation

- **Compile-verified** locally: `dotnet build src/core/Akka.Remote.Tests.MultiNode/Akka.Remote.Tests.MultiNode.csproj -c Release -warnaserror --framework net10.0` → **Build succeeded, 0 Warning(s), 0 Error(s)**.
- **Run-verification is CI-only.** This is a **multi-node** spec; it requires the MNTR (multi-node test runner) harness, which is not available in the local environment. The behavioral validation (that the widened windows eliminate the flake without altering the assertions) happens on CI.

## Backport

Candidate to backport to **v1.5** — the spec is present and structurally identical on that branch.
