### PR TITLE
Backport: stabilize ClusterClientSpec server-restart reconnection test (#8004, #8007, #8008)

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
@@ -642,7 +642,7 @@ public class ClusterClientSpec : MultiNodeClusterSpec
 
     public async Task ClusterClient_must_reestablish_connection_to_receptionist_after_server_restart()
     {
-        await WithinAsync(30.Seconds(), async () =>
+        await WithinAsync(60.Seconds(), async () =>
         {
             await RunOnAsync(async () =>
             {
@@ -666,6 +666,17 @@ public class ClusterClientSpec : MultiNodeClusterSpec
                     });
                 });
 
+                // After reconnection, verify we can communicate with the restarted server
+                // by sending a test message and expecting a reply. This ensures service2
+                // is fully registered on sys2 before we send the shutdown command.
+                await AwaitAssertAsync(async () =>
+                {
+                    var probe = CreateTestProbe();
+                    c.Tell(new ClusterClient.Send("/user/service2", "bonjour5", localAffinity: true), probe.Ref);
+                    var reply2 = await probe.ExpectMsgAsync<ClusterClientSpecConfig.Reply>(3.Seconds());
+                    reply2.Msg.Should().Be("bonjour5-ack");
+                }, 15.Seconds());
+
                 c.Tell(new ClusterClient.Send("/user/service2", "shutdown", localAffinity: true));
                 await Task.Delay(2000); // to ensure that it is sent out before shutting down system
             }, _config.Client);
@@ -681,7 +692,7 @@ public class ClusterClientSpec : MultiNodeClusterSpec
                 Cluster.Get(sys2).Join(Cluster.Get(sys2).SelfAddress);
                 var service2 = sys2.ActorOf(Props.Create(() => new ClusterClientSpecConfig.TestService(TestActor)), "service2");
                 ClusterClientReceptionist.Get(sys2).RegisterService(service2);
-                await sys2.WhenTerminated.WaitAsync(20.Seconds());
+                await sys2.WhenTerminated.WaitAsync(40.Seconds());
             }, _remainingServerRoleNames.ToArray());
         });
     }

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
@@ -85,6 +85,8 @@ public class ClusterClientSpecConfig : MultiNodeConfig
         {
             Receive<string>(cmd => cmd.Equals("shutdown"), _ =>
             {
+                // Send confirmation before terminating so the sender knows the message was received
+                Sender.Tell("shutting-down");
                 Context.System.Terminate();
             });
 
@@ -677,8 +679,13 @@ public class ClusterClientSpec : MultiNodeClusterSpec
                     reply2.Msg.Should().Be("bonjour5-ack");
                 }, 15.Seconds());
 
-                c.Tell(new ClusterClient.Send("/user/service2", "shutdown", localAffinity: true));
-                await Task.Delay(2000); // to ensure that it is sent out before shutting down system
+                // Use AwaitAssertAsync to retry until we get confirmation the shutdown was received
+                await AwaitAssertAsync(async () =>
+                {
+                    var probe = CreateTestProbe();
+                    c.Tell(new ClusterClient.Send("/user/service2", "shutdown", localAffinity: true), probe.Ref);
+                    await probe.ExpectMsgAsync<string>(s => s == "shutting-down", 3.Seconds());
+                }, 15.Seconds());
             }, _config.Client);
 
             await RunOnAsync(async () =>

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
@@ -83,13 +83,6 @@ public class ClusterClientSpecConfig : MultiNodeConfig
     {
         public TestService(IActorRef testActorRef)
         {
-            Receive<string>(cmd => cmd.Equals("shutdown"), _ =>
-            {
-                // Send confirmation before terminating so the sender knows the message was received
-                Sender.Tell("shutting-down");
-                Context.System.Terminate();
-            });
-
             ReceiveAny(msg =>
             {
                 testActorRef.Forward(msg);
@@ -679,13 +672,9 @@ public class ClusterClientSpec : MultiNodeClusterSpec
                     reply2.Msg.Should().Be("bonjour5-ack");
                 }, 15.Seconds());
 
-                // Use AwaitAssertAsync to retry until we get confirmation the shutdown was received
-                await AwaitAssertAsync(async () =>
-                {
-                    var probe = CreateTestProbe();
-                    c.Tell(new ClusterClient.Send("/user/service2", "shutdown", localAffinity: true), probe.Ref);
-                    await probe.ExpectMsgAsync<string>(s => s == "shutting-down", 3.Seconds());
-                }, 15.Seconds());
+                // Verify reconnection works by confirming service2 is responsive
+                // The test goal (reconnection after restart) is now proven
+                await EnterBarrierAsync("reconnection-verified");
             }, _config.Client);
 
             await RunOnAsync(async () =>
@@ -699,7 +688,12 @@ public class ClusterClientSpec : MultiNodeClusterSpec
                 Cluster.Get(sys2).Join(Cluster.Get(sys2).SelfAddress);
                 var service2 = sys2.ActorOf(Props.Create(() => new ClusterClientSpecConfig.TestService(TestActor)), "service2");
                 ClusterClientReceptionist.Get(sys2).RegisterService(service2);
-                await sys2.WhenTerminated.WaitAsync(40.Seconds());
+
+                // Wait for client to confirm reconnection test passed
+                await EnterBarrierAsync("reconnection-verified");
+
+                // Terminate sys2 directly - don't rely on ClusterClient message delivery
+                await sys2.Terminate();
             }, _remainingServerRoleNames.ToArray());
         });
     }


### PR DESCRIPTION
## Backport: stabilize `ClusterClientSpec` server-restart reconnection test

Backports the cumulative flaky-test fix for the multi-node spec:

`Akka.Cluster.Tools.Tests.MultiNode.Client.ClusterClientSpec.ClusterClient_must_reestablish_connection_to_receptionist_after_server_restart`

from `dev` to `v1.5`. **Test-only** — no production code is touched.

### The flake

After the receptionist server is shut down and a new `ActorSystem` (`sys2`) is
started on the same port, the test drove shutdown by sending a fire-and-forget
`"shutdown"` message through the `ClusterClient`. That message could be **dropped
before the client had actually reconnected and re-registered** with the restarted
receptionist. When the message was lost, `sys2` never terminated and
`sys2.WhenTerminated.WaitAsync(20s)` (v1.5 ~L684) timed out, failing the test
intermittently in CI.

### The cumulative fix (3 commits)

Cherry-picked in order with `-x`, each preserved as its own commit:

1. **`571750e70` — #8004** "Fix racy ClusterClientSpec server restart test":
   adds an `AwaitAssert`-based reconnection proof (send `bonjour5`, expect
   `bonjour5-ack`) so the test only proceeds once `service2` is actually
   reachable on the restarted system, and widens the outer `Within` to 60s.
2. **`383905ed3` — #8007** "Fix ClusterClientSpec flaky shutdown test with
   ask-pattern confirmation": makes shutdown delivery confirmed rather than
   fire-and-forget.
3. **`5b982b832` — #8008** "Fix ClusterClientSpec with two-phase shutdown
   handshake": replaces the message-driven shutdown entirely — an
   `EnterBarrier("reconnection-verified")` synchronizes client and server, then
   the server node terminates `sys2` **directly** via `await sys2.Terminate()`
   instead of relying on `ClusterClient` message delivery. Also reverts
   `TestService` back to its simple form (drops the `"shutdown"` branch).

The net effect: reconnection is *proven* before shutdown, and shutdown no longer
depends on any message surviving the reconnect window.

### Cherry-pick / conflict notes

`v1.5`'s copy of `ClusterClientSpec.cs` is the exact pre-#8004 ancestor, so all
three commits **applied cleanly with no conflicts**. The resulting file is
byte-identical to `dev`'s version of the file.

### Async-TestKit note

Per review, the final method still contains one synchronous
`ExpectMsg<Reply>(10.Seconds())` (the initial pre-restart connectivity check). It
was left as-is to keep this backport byte-identical to `dev`'s merged fix; it is
benign (the surrounding `EventFilter`/`AwaitAssert` calls are already async) and
compiles cleanly under `-warnaserror`.

### Validation

This is a **multi-node (MNTR) test**, which cannot be executed locally without the
multi-node test runner, so it was **compile-verified only**:

```
dotnet build src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Akka.Cluster.Tools.Tests.MultiNode.csproj \
  -c Release -warnaserror --framework net10.0
=> Build succeeded. 0 Warning(s) 0 Error(s)
```

Run-verification of the multi-node scenario requires CI.

### Scope

Standalone backport PR, separate from the other v1.5 backport PRs. All three
commits cherry-picked cleanly.
