### PR TITLE
Release Akka.NET v1.5.70

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Copyright>Copyright © 2013-$([System.DateTime]::Now.Year) Akka.NET Team</Copyright>
     <Authors>Akka.NET Team</Authors>
-    <VersionPrefix>1.5.70-beta2</VersionPrefix>
+    <VersionPrefix>1.5.70</VersionPrefix>
     <PackageIcon>akkalogo.png</PackageIcon>
     <PackageProjectUrl>https://getakka.net/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -54,17 +54,29 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <PropertyGroup>
-    <PackageReleaseNotes>Akka.NET v1.5.70-beta2 is a beta release with a bug fix for `ChannelSink` dropping the final element under backpressure.
+    <PackageReleaseNotes>Akka.NET v1.5.70 is a maintenance release that adds a new "last-N" query offset to Akka.Persistence.Query, resolves two Akka.Streams reliability issues and improves `BroadcastHub` performance under high consumer counts, and fixes a consistent-hashing router bug that could wedge an entire cluster after a 32-bit hash collision.
+
+**Akka.Persistence.Query**
+* [Add `Offset.FromEnd(int count)` — "last-N events" query offset](https://github.com/akkadotnet/akka.net/pull/8245): Introduces `Offset.FromEnd(int count)`, a new query-input-only offset type that begins a read journal query at the Nth event from the end of history rather than from the beginning. The offset is resolved at stream materialization into a concrete `Sequence` start position; no interface changes or wire-format changes are required. Includes opt-in TCK spec (`FromEndOffsetSpec`) for plugin authors.
 
 **Akka.Streams Bug Fixes**
+* [Fix: async enumerable source disposal ordering](https://github.com/akkadotnet/akka.net/pull/8265): Fixes a race in `Source.From(IAsyncEnumerable&lt;T&gt;)` where the underlying enumerator could be disposed before all elements were delivered to downstream, causing `ObjectDisposedException` on high-throughput pipelines.
 * [Fix: `ChannelSink` drops final element on backpressure](https://github.com/akkadotnet/akka.net/pull/8291) - Fixes [#8285](https://github.com/akkadotnet/akka.net/issues/8285): `ChannelSink` was discarding the last element in a sequence whenever the downstream `Channel&lt;T&gt;` applied backpressure during completion. The sink now correctly delivers all elements before signaling completion.
 
-2 contributors since release 1.5.70-beta1
+**Akka.Streams Performance**
+* [Improve BroadcastHub high-consumer wheel performance](https://github.com/akkadotnet/akka.net/pull/8264): Reduces per-element cost in `BroadcastHub` when many consumers are attached by optimizing the internal consumer-wheel iteration, yielding measurable throughput improvements at high fan-out.
+
+**Akka.Core Bug Fixes**
+* [Fix: consistent-hashing router could wedge cluster-wide after a 32-bit hash collision](https://github.com/akkadotnet/akka.net/pull/8294) - Fixes [#8031](https://github.com/akkadotnet/akka.net/issues/8031): When two virtual nodes collided in the 32-bit consistent-hash ring (increasingly likely at high routee counts, e.g. when the ring was rebuilt after a node was downed), `ConsistentHash.Create` threw `"An entry with the same key already exists"`. The consistent-hashing router swallowed the exception and returned `NoRoutee` for **every** subsequent message until a manual restart. The ring now linear-probes to the next free slot on a collision instead of throwing. This keeps the hash distribution unchanged and produces a byte-identical ring to prior versions whenever no collision occurs (safe for rolling upgrades), and also protects `Akka.Cluster.Tools`' `ClusterReceptionist`, which builds the same ring.
+
+2 contributors since release 1.5.69
 
 | COMMITS | LOC+ | LOC- | AUTHOR |
 | --- | --- | --- | --- |
-| 2 | 115 | 15 | Aaron Stannard |
-| 1 | 97 | 3 | beminee |</PackageReleaseNotes>
+| 22 | 2274 | 332 | Aaron Stannard |
+| 1 | 97 | 4 | beminee |
+
+To see the full set of changes in Akka.NET v1.5.70, [click here](https://github.com/akkadotnet/akka.net/milestone/153?closed=1).</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup Label="Analyzers" Condition="'$(MSBuildProjectName)' != 'Akka'">
     <PackageReference Include="Akka.Analyzers" Version="$(AkkaAnalyzerVersion)" PrivateAssets="all" />

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,42 +1,28 @@
-#### 1.5.70-beta3 TBD ####
+#### 1.5.70 July 2nd, 2026 ####
 
-Akka.NET v1.5.70-beta3 is a beta release that hardens the consistent-hashing router against 32-bit hash-ring collisions.
-
-**Akka.Core Bug Fixes**
-* [Fix: consistent-hashing router could wedge cluster-wide after a 32-bit hash collision](https://github.com/akkadotnet/akka.net/issues/8031) - Fixes [#8031](https://github.com/akkadotnet/akka.net/issues/8031): When two virtual nodes collided in the 32-bit consistent-hash ring (increasingly likely at high routee counts, e.g. when the ring was rebuilt after a node was downed), `ConsistentHash.Create` threw `"An entry with the same key already exists"`. The consistent-hashing router swallowed the exception and returned `NoRoutee` for **every** subsequent message until a manual restart. The ring now linear-probes to the next free slot on a collision instead of throwing. This keeps the hash distribution unchanged and produces a byte-identical ring to prior versions whenever no collision occurs (safe for rolling upgrades), and also protects `Akka.Cluster.Tools`' `ClusterReceptionist`, which builds the same ring.
-
-#### 1.5.70-beta2 June 30th, 2026 ####
-
-Akka.NET v1.5.70-beta2 is a beta release with a bug fix for `ChannelSink` dropping the final element under backpressure.
-
-**Akka.Streams Bug Fixes**
-* [Fix: `ChannelSink` drops final element on backpressure](https://github.com/akkadotnet/akka.net/pull/8291) - Fixes [#8285](https://github.com/akkadotnet/akka.net/issues/8285): `ChannelSink` was discarding the last element in a sequence whenever the downstream `Channel<T>` applied backpressure during completion. The sink now correctly delivers all elements before signaling completion.
-
-2 contributors since release 1.5.70-beta1
-
-| COMMITS | LOC+ | LOC- | AUTHOR |
-| --- | --- | --- | --- |
-| 2 | 115 | 15 | Aaron Stannard |
-| 1 | 97 | 3 | beminee |
-
-#### 1.5.70-beta1 June 23rd, 2026 ####
-
-Akka.NET v1.5.70-beta1 is a beta release with a new `Offset.FromEnd` query offset for Akka.Persistence.Query, bug fixes for `Akka.Streams` async enumerable disposal, and a performance improvement for `BroadcastHub` with high consumer counts.
+Akka.NET v1.5.70 is a maintenance release that adds a new "last-N" query offset to Akka.Persistence.Query, resolves two Akka.Streams reliability issues and improves `BroadcastHub` performance under high consumer counts, and fixes a consistent-hashing router bug that could wedge an entire cluster after a 32-bit hash collision.
 
 **Akka.Persistence.Query**
 * [Add `Offset.FromEnd(int count)` — "last-N events" query offset](https://github.com/akkadotnet/akka.net/pull/8245): Introduces `Offset.FromEnd(int count)`, a new query-input-only offset type that begins a read journal query at the Nth event from the end of history rather than from the beginning. The offset is resolved at stream materialization into a concrete `Sequence` start position; no interface changes or wire-format changes are required. Includes opt-in TCK spec (`FromEndOffsetSpec`) for plugin authors.
 
 **Akka.Streams Bug Fixes**
 * [Fix: async enumerable source disposal ordering](https://github.com/akkadotnet/akka.net/pull/8265): Fixes a race in `Source.From(IAsyncEnumerable<T>)` where the underlying enumerator could be disposed before all elements were delivered to downstream, causing `ObjectDisposedException` on high-throughput pipelines.
+* [Fix: `ChannelSink` drops final element on backpressure](https://github.com/akkadotnet/akka.net/pull/8291) - Fixes [#8285](https://github.com/akkadotnet/akka.net/issues/8285): `ChannelSink` was discarding the last element in a sequence whenever the downstream `Channel<T>` applied backpressure during completion. The sink now correctly delivers all elements before signaling completion.
 
 **Akka.Streams Performance**
 * [Improve BroadcastHub high-consumer wheel performance](https://github.com/akkadotnet/akka.net/pull/8264): Reduces per-element cost in `BroadcastHub` when many consumers are attached by optimizing the internal consumer-wheel iteration, yielding measurable throughput improvements at high fan-out.
 
-1 contributor since release 1.5.69
+**Akka.Core Bug Fixes**
+* [Fix: consistent-hashing router could wedge cluster-wide after a 32-bit hash collision](https://github.com/akkadotnet/akka.net/pull/8294) - Fixes [#8031](https://github.com/akkadotnet/akka.net/issues/8031): When two virtual nodes collided in the 32-bit consistent-hash ring (increasingly likely at high routee counts, e.g. when the ring was rebuilt after a node was downed), `ConsistentHash.Create` threw `"An entry with the same key already exists"`. The consistent-hashing router swallowed the exception and returned `NoRoutee` for **every** subsequent message until a manual restart. The ring now linear-probes to the next free slot on a collision instead of throwing. This keeps the hash distribution unchanged and produces a byte-identical ring to prior versions whenever no collision occurs (safe for rolling upgrades), and also protects `Akka.Cluster.Tools`' `ClusterReceptionist`, which builds the same ring.
+
+2 contributors since release 1.5.69
 
 | COMMITS | LOC+ | LOC- | AUTHOR |
 | --- | --- | --- | --- |
-| 3 | 1438 | 180 | Aaron Stannard |
+| 22 | 2274 | 332 | Aaron Stannard |
+| 1 | 97 | 4 | beminee |
+
+To see the full set of changes in Akka.NET v1.5.70, [click here](https://github.com/akkadotnet/akka.net/milestone/153?closed=1).
 
 #### 1.5.69 June 12th, 2026 ####
 


### PR DESCRIPTION
## Summary

Consolidates the 1.5.70-beta1/beta2/beta3 pre-releases into a single final `1.5.70` release notes entry and bumps `VersionPrefix` to `1.5.70`.

**Akka.Persistence.Query**
* Add `Offset.FromEnd(int count)` — a new "last-N events" query offset that begins a read journal query at the Nth event from the end of history ([#8245](https://github.com/akkadotnet/akka.net/pull/8245))

**Akka.Streams**
* Fix a race in `Source.From(IAsyncEnumerable<T>)` where the underlying enumerator could be disposed before all elements were delivered downstream, causing `ObjectDisposedException` on high-throughput pipelines ([#8265](https://github.com/akkadotnet/akka.net/pull/8265))
* Fix `ChannelSink` dropping the final element when the downstream `Channel<T>` backpressures during completion ([#8291](https://github.com/akkadotnet/akka.net/pull/8291), fixes [#8285](https://github.com/akkadotnet/akka.net/issues/8285))
* Improve `BroadcastHub` performance under high consumer counts by optimizing the internal consumer-wheel iteration ([#8264](https://github.com/akkadotnet/akka.net/pull/8264))

**Akka.Core**
* Fix consistent-hashing router wedging the entire cluster after a 32-bit hash collision in the ring — `ConsistentHash.Create` now linear-probes to the next free slot instead of throwing ([#8294](https://github.com/akkadotnet/akka.net/pull/8294), fixes [#8031](https://github.com/akkadotnet/akka.net/issues/8031))

## Test plan
- [ ] CI green
- [ ] Merge to `v1.5` and cut the `1.5.70` tag once approved
