### PR TITLE
Forward-port #8245 to dev: Offset.FromEnd (last-N events) query offset

### DIFF
--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryFromEndOffsetSpec.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory.Tests/InMemoryFromEndOffsetSpec.cs
@@ -1,0 +1,36 @@
+//-----------------------------------------------------------------------
+// <copyright file="InMemoryFromEndOffsetSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Akka.Configuration;
+using Akka.Persistence.TCK.Query;
+using Xunit;
+
+namespace Akka.Persistence.Query.InMemory.Tests
+{
+    public class InMemoryFromEndOffsetSpec : FromEndOffsetSpec
+    {
+        private static Config Config() => ConfigurationFactory.ParseString(
+                $$"""
+                akka.loglevel = INFO
+                akka.persistence.journal.inmem {
+                    event-adapters {
+                      color-tagger  = "{{typeof(ColorFruitTagger).FullName}}, {{typeof(ColorFruitTagger).Assembly.GetName().Name}}"
+                    }
+                    event-adapter-bindings = {
+                      "System.String" = color-tagger
+                    }
+                }
+                """)
+            .WithFallback(InMemoryPersistenceSpecConfig.Config);
+
+        public InMemoryFromEndOffsetSpec(ITestOutputHelper output) :
+            base(Config(), nameof(InMemoryFromEndOffsetSpec), output)
+        {
+            ReadJournal = Sys.ReadJournalFor<InMemoryReadJournal>(InMemoryReadJournal.Identifier);
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory/AllEventsPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory/AllEventsPublisher.cs
@@ -24,36 +24,32 @@ namespace Akka.Persistence.Query.InMemory
             private Continue() { }
         }
 
-        public static Props Props(int fromOffset, TimeSpan? refreshInterval, int maxBufferSize, string writeJournalPluginId)
+        public static Props Props(ReplayStart start, TimeSpan? refreshInterval, int maxBufferSize, string writeJournalPluginId)
         {
             return refreshInterval.HasValue ?
-                Actor.Props.Create(() => new LiveAllEventsPublisher(fromOffset, refreshInterval.Value, maxBufferSize, writeJournalPluginId)) :
-                Actor.Props.Create(() => new CurrentAllEventsPublisher(fromOffset, maxBufferSize, writeJournalPluginId));
+                Actor.Props.Create(() => new LiveAllEventsPublisher(start, refreshInterval.Value, maxBufferSize, writeJournalPluginId)) :
+                Actor.Props.Create(() => new CurrentAllEventsPublisher(start, maxBufferSize, writeJournalPluginId));
         }
     }
 
-    internal abstract class AbstractAllEventsPublisher : ActorPublisher<EventEnvelope>
+    internal abstract class AbstractAllEventsPublisher : FromEndResolvingPublisher
     {
         private ILoggingAdapter _log;
-        protected int CurrentOffset;
 
-        protected AbstractAllEventsPublisher(int fromOffset, int maxBufferSize, string writeJournalPluginId)
+        protected AbstractAllEventsPublisher(ReplayStart start, int maxBufferSize, string writeJournalPluginId)
+            : base(start, writeJournalPluginId)
         {
-            CurrentOffset = FromOffset = fromOffset;
             MaxBufferSize = maxBufferSize;
             Buffer = new DeliveryBuffer<EventEnvelope>(OnNext);
-            JournalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
         }
 
         protected ILoggingAdapter Log => _log ??= Context.GetLogger();
-        protected IActorRef JournalRef { get; }
         protected DeliveryBuffer<EventEnvelope> Buffer { get; }
-        protected int FromOffset { get; }
         protected abstract int ToOffset { get; }
         protected int MaxBufferSize { get; }
+        protected override string FromEndTag => null;
         protected bool IsTimeForReplay => (Buffer.IsEmpty || Buffer.Length <= MaxBufferSize / 2) && (CurrentOffset <= ToOffset);
 
-        protected abstract void ReceiveInitialRequest();
         protected abstract void ReceiveIdleRequest();
         protected abstract void ReceiveRecoverySuccess(int highestOrderingNr);
 
@@ -62,7 +58,10 @@ namespace Akka.Persistence.Query.InMemory
             switch (message)
             {
                 case Request _:
-                    ReceiveInitialRequest();
+                    if (IsFromEnd)
+                        ResolveFromEnd();
+                    else
+                        ReceiveInitialRequest();
                     return true;
                 case Cancel _:
                     Context.Stop(Self);
@@ -142,8 +141,8 @@ namespace Akka.Persistence.Query.InMemory
     internal sealed class LiveAllEventsPublisher : AbstractAllEventsPublisher
     {
         private readonly ICancelable _tickCancelable;
-        public LiveAllEventsPublisher(int fromOffset, TimeSpan refreshInterval, int maxBufferSize, string writeJournalPluginId)
-            : base(fromOffset, maxBufferSize, writeJournalPluginId)
+        public LiveAllEventsPublisher(ReplayStart start, TimeSpan refreshInterval, int maxBufferSize, string writeJournalPluginId)
+            : base(start, maxBufferSize, writeJournalPluginId)
         {
             _tickCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(refreshInterval, refreshInterval, Self, AllEventsPublisher.Continue.Instance, Self);
         }
@@ -180,8 +179,8 @@ namespace Akka.Persistence.Query.InMemory
 
     internal sealed class CurrentAllEventsPublisher : AbstractAllEventsPublisher
     {
-        public CurrentAllEventsPublisher(int fromOffset, int maxBufferSize, string writeJournalPluginId)
-            : base(fromOffset, maxBufferSize, writeJournalPluginId)
+        public CurrentAllEventsPublisher(ReplayStart start, int maxBufferSize, string writeJournalPluginId)
+            : base(start, maxBufferSize, writeJournalPluginId)
         { }
 
         private int _toOffset = int.MaxValue;

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory/EventsByTagPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory/EventsByTagPublisher.cs
@@ -26,42 +26,38 @@ namespace Akka.Persistence.Query.InMemory
             }
         }
 
-        public static Props Props(string tag, int fromOffset, int toOffset, TimeSpan? refreshInterval, int maxBufferSize, string writeJournalPluginId)
+        public static Props Props(string tag, ReplayStart start, int toOffset, TimeSpan? refreshInterval, int maxBufferSize, string writeJournalPluginId)
         {
             return refreshInterval.HasValue
-                ? Actor.Props.Create(() => new LiveEventsByTagPublisher(tag, fromOffset, toOffset, refreshInterval.Value, maxBufferSize, writeJournalPluginId))
-                : Actor.Props.Create(() => new CurrentEventsByTagPublisher(tag, fromOffset, toOffset, maxBufferSize, writeJournalPluginId));
+                ? Actor.Props.Create(() => new LiveEventsByTagPublisher(tag, start, toOffset, refreshInterval.Value, maxBufferSize, writeJournalPluginId))
+                : Actor.Props.Create(() => new CurrentEventsByTagPublisher(tag, start, toOffset, maxBufferSize, writeJournalPluginId));
         }
     }
 
-    internal abstract class AbstractEventsByTagPublisher : ActorPublisher<EventEnvelope>
+    internal abstract class AbstractEventsByTagPublisher : FromEndResolvingPublisher
     {
         private ILoggingAdapter _log;
 
         protected readonly DeliveryBuffer<EventEnvelope> Buffer;
-        protected readonly IActorRef JournalRef;
-        protected int CurrentOffset;
-        
-        protected AbstractEventsByTagPublisher(string tag, int fromOffset, int maxBufferSize, string writeJournalPluginId)
+
+        protected AbstractEventsByTagPublisher(string tag, ReplayStart start, int maxBufferSize, string writeJournalPluginId)
+            : base(start, writeJournalPluginId)
         {
             Tag = tag;
-            CurrentOffset = FromOffset = fromOffset;
             MaxBufferSize = maxBufferSize;
             WriteJournalPluginId = writeJournalPluginId;
             Buffer = new DeliveryBuffer<EventEnvelope>(OnNext);
-            JournalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
         }
 
         protected ILoggingAdapter Log => _log ??= Context.GetLogger();
         protected string Tag { get; }
-        protected int FromOffset { get; }
         protected abstract int ToOffset { get; }
         protected int MaxBufferSize { get; }
         protected string WriteJournalPluginId { get; }
+        protected override string FromEndTag => Tag;
 
         protected bool IsTimeForReplay => (Buffer.IsEmpty || Buffer.Length <= MaxBufferSize / 2) && (CurrentOffset <= ToOffset);
 
-        protected abstract void ReceiveInitialRequest();
         protected abstract void ReceiveIdleRequest();
         protected abstract void ReceiveRecoverySuccess(int highestSequenceNr);
 
@@ -70,7 +66,10 @@ namespace Akka.Persistence.Query.InMemory
             switch (message)
             {
                 case Request _:
-                    ReceiveInitialRequest();
+                    if (IsFromEnd)
+                        ResolveFromEnd();
+                    else
+                        ReceiveInitialRequest();
                     return true;
                 case EventsByTagPublisher.Continue _:
                     // no-op
@@ -156,8 +155,8 @@ namespace Akka.Persistence.Query.InMemory
     internal sealed class LiveEventsByTagPublisher : AbstractEventsByTagPublisher
     {
         private readonly ICancelable _tickCancelable;
-        public LiveEventsByTagPublisher(string tag, int fromOffset, int toOffset, TimeSpan refreshInterval, int maxBufferSize, string writeJournalPluginId)
-            : base(tag, fromOffset, maxBufferSize, writeJournalPluginId)
+        public LiveEventsByTagPublisher(string tag, ReplayStart start, int toOffset, TimeSpan refreshInterval, int maxBufferSize, string writeJournalPluginId)
+            : base(tag, start, maxBufferSize, writeJournalPluginId)
         {
             ToOffset = toOffset;
             _tickCancelable = Context.System.Scheduler.ScheduleTellRepeatedlyCancelable(refreshInterval, refreshInterval, Self, EventsByTagPublisher.Continue.Instance, Self);
@@ -195,8 +194,8 @@ namespace Akka.Persistence.Query.InMemory
 
     internal sealed class CurrentEventsByTagPublisher : AbstractEventsByTagPublisher
     {
-        public CurrentEventsByTagPublisher(string tag, int fromOffset, int toOffset, int maxBufferSize, string writeJournalPluginId)
-            : base(tag, fromOffset, maxBufferSize, writeJournalPluginId)
+        public CurrentEventsByTagPublisher(string tag, ReplayStart start, int toOffset, int maxBufferSize, string writeJournalPluginId)
+            : base(tag, start, maxBufferSize, writeJournalPluginId)
         {
             _toOffset = toOffset;
         }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory/FromEndResolvingPublisher.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory/FromEndResolvingPublisher.cs
@@ -1,0 +1,81 @@
+//-----------------------------------------------------------------------
+// <copyright file="FromEndResolvingPublisher.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using Akka.Actor;
+using Akka.Persistence.Journal;
+using Akka.Streams.Actors;
+
+namespace Akka.Persistence.Query.InMemory
+{
+    /// <summary>
+    /// Base for the InMemory query publishers that supports resolving a <see cref="FromEnd"/> ("last N events")
+    /// offset into a concrete forward start offset. When the <see cref="ReplayStart"/> is a from-end start, the
+    /// publisher asks the journal how many events currently match the query (via
+    /// <see cref="MemoryJournal.SelectEventCount"/>) and then begins its normal forward replay at
+    /// <c>max(0, count - N)</c>. Both the by-tag and all-events publishers share this handshake so the resolution
+    /// logic lives in a single place.
+    /// </summary>
+    internal abstract class FromEndResolvingPublisher : ActorPublisher<EventEnvelope>
+    {
+        private readonly ReplayStart _start;
+
+        protected FromEndResolvingPublisher(ReplayStart start, string writeJournalPluginId)
+        {
+            _start = start;
+            CurrentOffset = start.Offset;
+            JournalRef = Persistence.Instance.Apply(Context.System).JournalFor(writeJournalPluginId);
+        }
+
+        protected int CurrentOffset;
+        protected IActorRef JournalRef { get; }
+
+        /// <summary>
+        /// True when this query must resolve a <see cref="FromEnd"/> start position before replaying.
+        /// </summary>
+        protected bool IsFromEnd => _start.IsFromEnd;
+
+        /// <summary>
+        /// The tag whose events are counted to resolve the from-end position, or <c>null</c> for all events.
+        /// </summary>
+        protected abstract string FromEndTag { get; }
+
+        protected abstract void ReceiveInitialRequest();
+
+        /// <summary>
+        /// Asks the journal for the current matching event count, then resumes the normal initial replay once the
+        /// concrete start offset is known. Call this from the initial request handler when <see cref="IsFromEnd"/>.
+        /// </summary>
+        protected void ResolveFromEnd()
+        {
+            JournalRef.Tell(new MemoryJournal.SelectEventCount(FromEndTag, Self));
+            Context.Become(ResolvingFromEnd);
+        }
+
+        private bool ResolvingFromEnd(object message)
+        {
+            switch (message)
+            {
+                case MemoryJournal.EventCount count:
+                    CurrentOffset = Math.Max(0, count.Count - _start.FromEndCount);
+                    ReceiveInitialRequest();
+                    return true;
+                case MemoryJournal.EventCountFailure failure:
+                    // surface a failed count query instead of hanging the stream forever
+                    OnErrorThenStop(failure.Cause);
+                    return true;
+                case Cancel _:
+                    Context.Stop(Self);
+                    return true;
+                default:
+                    // Outstanding demand is tracked by ActorPublisher; periodic Continue ticks and any other
+                    // transient message are ignored until the count reply arrives.
+                    return true;
+            }
+        }
+    }
+}

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory/InMemoryReadJournal.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory/InMemoryReadJournal.cs
@@ -126,21 +126,9 @@ namespace Akka.Persistence.Query.InMemory
         /// </summary>
         public Source<EventEnvelope, NotUsed> CurrentEventsByTag(string tag, Offset offset)
         {
-            Sequence seq;
-            switch (offset)
-            {
-                case NoOffset:
-                case Sequence { Value: 0 }:
-                    seq = new Sequence(0L);
-                    break;
-                case Sequence s:
-                    seq = new Sequence(s.Value + 1); // since offset is exclusive
-                    break;
-                default:
-                    throw new ArgumentException($"InMemoryReadJournal does not support {offset.GetType().Name} offsets");
-            }
-            
-            return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, checked((int)seq.Value), int.MaxValue, null, _maxBufferSize, _writeJournalPluginId))
+            var start = ResolveTagOffset(offset);
+
+            return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, start, int.MaxValue, null, _maxBufferSize, _writeJournalPluginId))
                 .MapMaterializedValue(_ => NotUsed.Instance)
                 .Named($"CurrentEventsByTag-{tag}");
         }
@@ -186,65 +174,54 @@ namespace Akka.Persistence.Query.InMemory
         /// </summary>
         public Source<EventEnvelope, NotUsed> EventsByTag(string tag, Offset offset)
         {
-            Sequence seq;
-            switch (offset)
-            {
-                case NoOffset _:
-                case Sequence s when s.Value == 0:
-                    seq = new Sequence(0L);
-                    break;
-                case Sequence s:
-                    seq = new Sequence(s.Value + 1); // since offset is exclusive
-                    break;
-                default:
-                    throw new ArgumentException($"InMemoryReadJournal does not support {offset.GetType().Name} offsets");
-            }
-            
-            return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, checked((int)seq.Value), int.MaxValue, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+            var start = ResolveTagOffset(offset);
+
+            return Source.ActorPublisher<EventEnvelope>(EventsByTagPublisher.Props(tag, start, int.MaxValue, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
                 .MapMaterializedValue(_ => NotUsed.Instance)
                 .Named($"EventsByTag-{tag}");
         }
-        
+
         public Source<EventEnvelope, NotUsed> AllEvents(Offset offset = null)
         {
-            Sequence seq;
-            switch (offset)
-            {
-                case null:
-                case NoOffset _:
-                    seq = new Sequence(0L);
-                    break;
-                case Sequence s:
-                    seq = new Sequence(s.Value + 1); // since offset is exclusive
-                    break;
-                default:
-                    throw new ArgumentException($"InMemoryReadJournal does not support {offset.GetType().Name} offsets");
-            }
+            var start = ResolveAllEventsOffset(offset);
 
-            return Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(checked((int)seq.Value), _refreshInterval, _maxBufferSize, _writeJournalPluginId))
+            return Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(start, _refreshInterval, _maxBufferSize, _writeJournalPluginId))
                 .MapMaterializedValue(_ => NotUsed.Instance)
                 .Named("AllEvents");
         }
 
         public Source<EventEnvelope, NotUsed> CurrentAllEvents(Offset offset)
         {
-            Sequence seq;
-            switch (offset)
-            {
-                case null:
-                case NoOffset _:
-                    seq = new Sequence(0L);
-                    break;
-                case Sequence s:
-                    seq = new Sequence(s.Value + 1); // since offset is exclusive
-                    break;
-                default:
-                    throw new ArgumentException($"InMemoryReadJournal does not support {offset.GetType().Name} offsets");
-            }
+            var start = ResolveAllEventsOffset(offset);
 
-            return Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(checked((int)seq.Value), null, _maxBufferSize, _writeJournalPluginId))
+            return Source.ActorPublisher<EventEnvelope>(AllEventsPublisher.Props(start, null, _maxBufferSize, _writeJournalPluginId))
                 .MapMaterializedValue(_ => NotUsed.Instance)
                 .Named("CurrentAllEvents");
         }
+
+        /// <summary>
+        /// Resolves a by-tag query <see cref="Offset"/> into the <see cref="ReplayStart"/> the publisher replays from.
+        /// A <see cref="FromEnd"/> becomes a deferred "last N" start; the publisher resolves it to a concrete position.
+        /// </summary>
+        private static ReplayStart ResolveTagOffset(Offset offset) => offset switch
+        {
+            NoOffset or Sequence { Value: 0 } => ReplayStart.At(0),
+            Sequence s => ReplayStart.At(checked((int)(s.Value + 1))), // since offset is exclusive
+            FromEnd fromEnd => ReplayStart.LastN(fromEnd.Count),
+            _ => throw new ArgumentException($"InMemoryReadJournal does not support {offset.GetType().Name} offsets")
+        };
+
+        /// <summary>
+        /// Resolves an all-events query <see cref="Offset"/> into the <see cref="ReplayStart"/> the publisher replays
+        /// from. A <see cref="FromEnd"/> becomes a deferred "last N" start; the publisher resolves it to a concrete
+        /// position.
+        /// </summary>
+        private static ReplayStart ResolveAllEventsOffset(Offset offset) => offset switch
+        {
+            null or NoOffset => ReplayStart.At(0),
+            Sequence s => ReplayStart.At(checked((int)(s.Value + 1))), // since offset is exclusive
+            FromEnd fromEnd => ReplayStart.LastN(fromEnd.Count),
+            _ => throw new ArgumentException($"InMemoryReadJournal does not support {offset.GetType().Name} offsets")
+        };
     }
 }

--- a/src/contrib/persistence/Akka.Persistence.Query.InMemory/ReplayStart.cs
+++ b/src/contrib/persistence/Akka.Persistence.Query.InMemory/ReplayStart.cs
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------------------
+// <copyright file="ReplayStart.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace Akka.Persistence.Query.InMemory
+{
+    /// <summary>
+    /// The resolved starting position for an InMemory forward replay. It is either a concrete forward
+    /// <see cref="Offset"/> or a deferred "last N" position that the publisher resolves against the current matching
+    /// event count at materialization. Collapsing both cases into a single value keeps "from the end" an internal
+    /// detail of how the read journal interprets an <see cref="Query.Offset"/>, instead of an extra argument threaded
+    /// through every publisher constructor.
+    /// </summary>
+    internal readonly struct ReplayStart
+    {
+        private ReplayStart(int offset, int fromEndCount)
+        {
+            Offset = offset;
+            FromEndCount = fromEndCount;
+        }
+
+        /// <summary>
+        /// The concrete forward start offset. Only meaningful when <see cref="IsFromEnd"/> is <c>false</c>.
+        /// </summary>
+        public int Offset { get; }
+
+        /// <summary>
+        /// When greater than zero, the replay begins at <c>max(0, matchingCount - FromEndCount)</c>, where
+        /// <c>matchingCount</c> is read from the journal at materialization.
+        /// </summary>
+        public int FromEndCount { get; }
+
+        /// <summary>
+        /// True when the start must be resolved from the end of history before replaying.
+        /// </summary>
+        public bool IsFromEnd => FromEndCount > 0;
+
+        /// <summary>
+        /// A concrete forward start at <paramref name="offset"/>.
+        /// </summary>
+        public static ReplayStart At(int offset) => new(offset, 0);
+
+        /// <summary>
+        /// A deferred start at the <paramref name="count"/>-th event from the end of history.
+        /// </summary>
+        public static ReplayStart LastN(int count) => new(0, count);
+    }
+}

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.DotNet.verified.txt
@@ -1085,6 +1085,18 @@ namespace Akka.Persistence.Journal
             public readonly int HighestOrderingNumber;
             public CurrentPersistenceIds(System.Collections.Generic.IEnumerable<string> allPersistenceIds, int highestOrderingNumber) { }
         }
+        [System.Serializable]
+        public sealed class EventCount : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        {
+            public EventCount(int count) { }
+            public int Count { get; }
+        }
+        [System.Serializable]
+        public sealed class EventCountFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        {
+            public EventCountFailure(System.Exception cause) { }
+            public System.Exception Cause { get; }
+        }
         public sealed class EventReplayFailure
         {
             public EventReplayFailure(System.Exception cause) { }
@@ -1155,6 +1167,13 @@ namespace Akka.Persistence.Journal
             public SelectCurrentPersistenceIds(int offset, Akka.Actor.IActorRef replyTo) { }
             public int Offset { get; }
             public Akka.Actor.IActorRef ReplyTo { get; }
+        }
+        [System.Serializable]
+        public sealed class SelectEventCount : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
+        {
+            public SelectEventCount(string tag, Akka.Actor.IActorRef replyTo) { }
+            public Akka.Actor.IActorRef ReplyTo { get; }
+            public string Tag { get; }
         }
     }
     public class PersistencePluginProxy : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithTimers, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistence.Net.verified.txt
@@ -1085,6 +1085,18 @@ namespace Akka.Persistence.Journal
             public readonly int HighestOrderingNumber;
             public CurrentPersistenceIds(System.Collections.Generic.IEnumerable<string> allPersistenceIds, int highestOrderingNumber) { }
         }
+        [System.Serializable]
+        public sealed class EventCount : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        {
+            public EventCount(int count) { }
+            public int Count { get; }
+        }
+        [System.Serializable]
+        public sealed class EventCountFailure : Akka.Actor.INoSerializationVerificationNeeded, Akka.Event.IDeadLetterSuppression
+        {
+            public EventCountFailure(System.Exception cause) { }
+            public System.Exception Cause { get; }
+        }
         public sealed class EventReplayFailure
         {
             public EventReplayFailure(System.Exception cause) { }
@@ -1155,6 +1167,13 @@ namespace Akka.Persistence.Journal
             public SelectCurrentPersistenceIds(int offset, Akka.Actor.IActorRef replyTo) { }
             public int Offset { get; }
             public Akka.Actor.IActorRef ReplyTo { get; }
+        }
+        [System.Serializable]
+        public sealed class SelectEventCount : Akka.Actor.INoSerializationVerificationNeeded, Akka.Persistence.IJournalMessage, Akka.Persistence.IJournalRequest, Akka.Persistence.IPersistenceMessage
+        {
+            public SelectEventCount(string tag, Akka.Actor.IActorRef replyTo) { }
+            public Akka.Actor.IActorRef ReplyTo { get; }
+            public string Tag { get; }
         }
     }
     public class PersistencePluginProxy : Akka.Actor.ActorBase, Akka.Actor.IActorStash, Akka.Actor.IWithTimers, Akka.Actor.IWithUnboundedStash, Akka.Actor.IWithUnrestrictedStash, Akka.Dispatch.IRequiresMessageQueue<Akka.Dispatch.IUnboundedDequeBasedMessageQueueSemantics>

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.DotNet.verified.txt
@@ -22,6 +22,15 @@ namespace Akka.Persistence.Query
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    public sealed class FromEnd : Akka.Persistence.Query.Offset
+    {
+        public FromEnd(int count) { }
+        public int Count { get; }
+        public override int CompareTo(Akka.Persistence.Query.Offset other) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+        public override string ToString() { }
+    }
     public interface IAllEventsQuery : Akka.Persistence.Query.IReadJournal
     {
         Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> AllEvents(Akka.Persistence.Query.Offset offset);
@@ -70,6 +79,7 @@ namespace Akka.Persistence.Query
         protected Offset() { }
         public abstract int CompareTo(Akka.Persistence.Query.Offset other);
         public abstract override string ToString() { }
+        public static Akka.Persistence.Query.Offset FromEnd(int count) { }
         public static Akka.Persistence.Query.Offset NoOffset() { }
         public static Akka.Persistence.Query.Offset Sequence(long value) { }
         public static Akka.Persistence.Query.Offset TimeBasedUuid(System.Guid value) { }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApprovePersistenceQuery.Net.verified.txt
@@ -22,6 +22,15 @@ namespace Akka.Persistence.Query
         public override int GetHashCode() { }
         public override string ToString() { }
     }
+    public sealed class FromEnd : Akka.Persistence.Query.Offset
+    {
+        public FromEnd(int count) { }
+        public int Count { get; }
+        public override int CompareTo(Akka.Persistence.Query.Offset other) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+        public override string ToString() { }
+    }
     public interface IAllEventsQuery : Akka.Persistence.Query.IReadJournal
     {
         Akka.Streams.Dsl.Source<Akka.Persistence.Query.EventEnvelope, Akka.NotUsed> AllEvents(Akka.Persistence.Query.Offset offset);
@@ -70,6 +79,7 @@ namespace Akka.Persistence.Query
         protected Offset() { }
         public abstract int CompareTo(Akka.Persistence.Query.Offset other);
         public abstract override string ToString() { }
+        public static Akka.Persistence.Query.Offset FromEnd(int count) { }
         public static Akka.Persistence.Query.Offset NoOffset() { }
         public static Akka.Persistence.Query.Offset Sequence(long value) { }
         public static Akka.Persistence.Query.Offset TimeBasedUuid(System.Guid value) { }

--- a/src/core/Akka.Persistence.Query.Tests/OffsetCompareSpecs.cs
+++ b/src/core/Akka.Persistence.Query.Tests/OffsetCompareSpecs.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 
+#nullable enable
 namespace Akka.Persistence.Query.Tests
 {
     public class OffsetCompareSpecs
@@ -44,6 +45,22 @@ namespace Akka.Persistence.Query.Tests
 
             compare1.Should().Throw<InvalidOperationException>();
             compare2.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void FromEnd_offset_should_throw_on_compare()
+        {
+            // FromEnd is a relative, input-only offset with no position in the stream, so it cannot be
+            // ordered against anything, including another FromEnd.
+            Offset fromEnd = new FromEnd(5);
+
+            Action compareToFromEnd = () => fromEnd.CompareTo(new FromEnd(5));
+            Action compareToSequence = () => fromEnd.CompareTo(new Sequence(1L));
+            Action sequenceCompareToFromEnd = () => new Sequence(1L).CompareTo(fromEnd);
+
+            compareToFromEnd.Should().Throw<InvalidOperationException>();
+            compareToSequence.Should().Throw<InvalidOperationException>();
+            sequenceCompareToFromEnd.Should().Throw<InvalidOperationException>();
         }
     }
 }

--- a/src/core/Akka.Persistence.Query.Tests/OffsetSpec.cs
+++ b/src/core/Akka.Persistence.Query.Tests/OffsetSpec.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using FluentAssertions;
 using Xunit;
 
+#nullable enable
 namespace Akka.Persistence.Query.Tests
 {
     public class OffsetSpec
@@ -56,6 +57,44 @@ namespace Akka.Persistence.Query.Tests
         public void NoOffset_must_log_zero()
         {
             Assert.Equal("0", NoOffset.Instance.ToString());
+        }
+
+        [Fact]
+        public void FromEnd_factory_must_create_a_FromEnd_offset_with_the_given_count()
+        {
+            var offset = Offset.FromEnd(5);
+            var fromEnd = Assert.IsType<FromEnd>(offset);
+            fromEnd.Count.Should().Be(5);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(int.MinValue)]
+        public void FromEnd_must_reject_a_non_positive_count(int count)
+        {
+            Assert.Throws<ArgumentException>(() => new FromEnd(count));
+            Assert.Throws<ArgumentException>(() => Offset.FromEnd(count));
+        }
+
+        [Fact]
+        public void FromEnd_must_log_value_correctly()
+        {
+            Assert.Equal("FromEnd(10)", new FromEnd(10).ToString());
+        }
+
+        [Fact]
+        public void FromEnd_offsets_with_the_same_count_must_be_equal()
+        {
+            var three = new FromEnd(3);
+            var alsoThree = new FromEnd(3);
+            var four = new FromEnd(4);
+
+            // assert via Equals/GetHashCode directly: FromEnd is not orderable, so any comparison-based
+            // equality path (e.g. FluentAssertions' Should().Be on an IComparable) would throw.
+            three.Equals(alsoThree).Should().BeTrue();
+            three.GetHashCode().Should().Be(alsoThree.GetHashCode());
+            three.Equals(four).Should().BeFalse();
         }
     }
 }

--- a/src/core/Akka.Persistence.Query/Offset.cs
+++ b/src/core/Akka.Persistence.Query/Offset.cs
@@ -13,7 +13,7 @@ namespace Akka.Persistence.Query
     /// Used in <see cref="IEventsByTagQuery"/> implementations to signal to Akka.Persistence.Query
     /// where to begin and end event by tag queries.
     ///
-    /// For concrete implementations, see <see cref="Sequence"/> and <see cref="NoOffset"/>.
+    /// For concrete implementations, see <see cref="Sequence"/>, <see cref="NoOffset"/> and <see cref="Query.FromEnd"/>.
     /// </summary>
     public abstract class Offset : IComparable<Offset>
     {
@@ -31,6 +31,13 @@ namespace Akka.Persistence.Query
         /// Factory to create an offset of type <see cref="TimeBasedUuid"/>
         /// </summary>
         public static Offset TimeBasedUuid(Guid value) => new TimeBasedUuid(value);
+
+        /// <summary>
+        /// Factory to create an offset of type <see cref="Query.FromEnd"/>, which begins the query at the
+        /// <paramref name="count"/>-th event from the end of history (inclusive), e.g. "the last 10 events".
+        /// </summary>
+        /// <param name="count">The number of events to read from the end of history. Must be greater than zero.</param>
+        public static Offset FromEnd(int count) => new FromEnd(count);
 
         /// <summary>
         /// Used to compare to other <see cref="Offset"/> implementations.
@@ -156,5 +163,68 @@ namespace Akka.Persistence.Query
         }
 
         public override string ToString() => "0";
+    }
+
+    /// <summary>
+    /// Corresponds to a relative offset that begins the query at the <see cref="Count"/>-th event from the
+    /// end of history (inclusive), e.g. "give me the last 10 events" for a tag or across all events.
+    /// <para>
+    /// Unlike <see cref="Sequence"/> and <see cref="TimeBasedUuid"/>, <see cref="FromEnd"/> is a query
+    /// <b>input only</b>: it is never returned in an <see cref="EventEnvelope"/>. Each <see cref="EventEnvelope"/>
+    /// still carries a concrete <see cref="Sequence"/> offset, so to resume a stream at a later point you use
+    /// that absolute offset, not a <see cref="FromEnd"/> value. Because it is relative rather than absolute,
+    /// <see cref="FromEnd"/> is not orderable and <see cref="CompareTo"/> always throws.
+    /// </para>
+    /// <para>
+    /// The from-the-end position is resolved to a concrete start offset when the query is materialized, by
+    /// reading how many matching events exist at that moment. For a <b>live</b> query (or any backend that
+    /// resolves the count and reads the events in separate steps) this is best-effort: events written between
+    /// resolving the count and reading the first batch may widen the initial window beyond <see cref="Count"/>.
+    /// </para>
+    /// <para>
+    /// Not all read journals support this offset type. Implementations that cannot honor it will throw when it is
+    /// supplied, the same way they reject any other unsupported offset type.
+    /// </para>
+    /// </summary>
+    public sealed class FromEnd : Offset
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FromEnd"/> class.
+        /// </summary>
+        /// <param name="count">The number of events to read from the end of history. Must be greater than zero.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="count"/> is less than or equal to zero.</exception>
+        public FromEnd(int count)
+        {
+            if (count <= 0)
+                throw new ArgumentException("FromEnd offset count must be greater than zero.", nameof(count));
+
+            Count = count;
+        }
+
+        /// <summary>
+        /// The number of events to read from the end of history.
+        /// </summary>
+        public int Count { get; }
+
+        private bool Equals(FromEnd other) => Count == other.Count;
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is FromEnd fromEnd && Equals(fromEnd);
+        }
+
+        public override int GetHashCode() => Count.GetHashCode();
+
+        /// <summary>
+        /// <see cref="FromEnd"/> is a relative, input-only offset and has no position in the stream, so it cannot
+        /// be ordered against any offset (including another <see cref="FromEnd"/>). Always throws.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Always thrown.</exception>
+        public override int CompareTo(Offset other)
+            => throw new InvalidOperationException($"Offsets of type {GetType()} are relative inputs and cannot be compared.");
+
+        public override string ToString() => $"FromEnd({Count})";
     }
 }

--- a/src/core/Akka.Persistence.TCK/Query/FromEndOffsetSpec.cs
+++ b/src/core/Akka.Persistence.TCK/Query/FromEndOffsetSpec.cs
@@ -1,0 +1,363 @@
+//-----------------------------------------------------------------------
+// <copyright file="FromEndOffsetSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Akka;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Persistence.Query;
+using Akka.Streams;
+using Akka.Streams.Dsl;
+using Akka.Streams.TestKit;
+using Xunit;
+using Xunit.Sdk;
+using static Akka.Persistence.Query.Offset;
+
+#nullable enable
+namespace Akka.Persistence.TCK.Query
+{
+    /// <summary>
+    /// Verifies that a read journal honors the <see cref="T:Akka.Persistence.Query.FromEnd"/> ("last N events") query
+    /// offset, which begins a query at the Nth event from the end of history rather than from the beginning.
+    /// <para>
+    /// This is the cross-backend contract for <see cref="T:Akka.Persistence.Query.FromEnd"/>. It exercises the full
+    /// matrix of <c>{by-tag, all-events} × {current, live}</c> against an <b>interleaved, multi-persistence-id</b>
+    /// fixture that mixes tagged and untagged events. The interleaving is deliberate: a single-persistence-id fixture
+    /// cannot distinguish a backend that resolves the from-end position correctly (per-tag count for by-tag queries,
+    /// total count for all-events queries) from one that naively resolves both against a single global ordinal,
+    /// because the two coincide only when there is one writer and every event carries the tag. The
+    /// <c>...should_count_per_tag_...</c> test pins exactly that distinction.
+    /// </para>
+    /// <para>
+    /// Only read journals that support <see cref="T:Akka.Persistence.Query.FromEnd"/> should inherit from this spec.
+    /// Backends that cannot resolve a from-the-end position (e.g. those without a global ordering) should not opt in.
+    /// A backend must also implement the <c>current</c> counterpart of every query it supports here, since the spec
+    /// uses the current queries to confirm writes are visible before resolving a from-end window. Individual tests are
+    /// <c>virtual</c> so a backend can override or skip the dimensions it does not implement.
+    /// </para>
+    /// </summary>
+    public abstract class FromEndOffsetSpec : XTestKit
+    {
+        protected ActorMaterializer Materializer { get; }
+
+        protected IReadJournal? ReadJournal { get; set; }
+
+        protected FromEndOffsetSpec(Config? config = null, string? actorSystemName = null, ITestOutputHelper? output = null)
+            : base(config ?? Config.Empty, actorSystemName, output)
+        {
+            Materializer = Sys.Materializer();
+        }
+
+        #region by-tag, current
+
+        [Fact]
+        public virtual async Task ReadJournal_query_CurrentEventsByTag_with_FromEnd_should_return_only_the_last_N_events()
+        {
+            var queries = RequireQuery<ICurrentEventsByTagQuery>();
+            await PersistInterleavedFixtureAsync();
+            await WaitForVisibleAsync(() => queries.CurrentEventsByTag("green", NoOffset()), GreenEvents.Length);
+
+            var probe = queries.CurrentEventsByTag("green", FromEnd(2))
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            probe.Request(10);
+            // the last two green events, across persistence ids, in ascending order
+            await ExpectEnvelopeAsync(probe, "b", 2);
+            await ExpectEnvelopeAsync(probe, "c", 2);
+            await probe.ExpectCompleteAsync();
+        }
+
+        [Fact]
+        public virtual async Task ReadJournal_query_CurrentEventsByTag_with_FromEnd_larger_than_total_should_return_all_events()
+        {
+            var queries = RequireQuery<ICurrentEventsByTagQuery>();
+            await PersistInterleavedFixtureAsync();
+            await WaitForVisibleAsync(() => queries.CurrentEventsByTag("green", NoOffset()), GreenEvents.Length);
+
+            var probe = queries.CurrentEventsByTag("green", FromEnd(100))
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            probe.Request(10);
+            foreach (var (pid, seqNr) in GreenEvents)
+                await ExpectEnvelopeAsync(probe, pid, seqNr);
+            await probe.ExpectCompleteAsync();
+        }
+
+        [Fact]
+        public virtual async Task ReadJournal_query_CurrentEventsByTag_with_FromEnd_and_no_matching_events_should_complete_empty()
+        {
+            var queries = RequireQuery<ICurrentEventsByTagQuery>();
+            // the fixture contains no "blue" events, so a from-end query for that tag must complete with nothing
+            await PersistInterleavedFixtureAsync();
+
+            var probe = queries.CurrentEventsByTag("blue", FromEnd(3))
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            probe.Request(10);
+            await probe.ExpectCompleteAsync();
+        }
+
+        [Fact]
+        public virtual async Task ReadJournal_query_CurrentEventsByTag_with_FromEnd_should_resolve_a_deep_window_in_a_long_history()
+        {
+            var queries = RequireQuery<ICurrentEventsByTagQuery>();
+            // a long single-writer history so the from-end resolution must skip far into the stream, exercising the
+            // "start = count - N" arithmetic at depth and a long forward replay (not just the small interleaved fixture)
+            var a = Sys.ActorOf(Query.TestActor.Props("a"));
+            const int total = 25;
+            for (var i = 1; i <= total; i++)
+                await PersistAsync(a, $"a green apple {i}");
+            await WaitForVisibleAsync(() => queries.CurrentEventsByTag("green", NoOffset()), total);
+
+            var probe = queries.CurrentEventsByTag("green", FromEnd(4))
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            probe.Request(20);
+            for (var seqNr = total - 4 + 1; seqNr <= total; seqNr++)
+                await ExpectEnvelopeAsync(probe, "a", seqNr);
+            await probe.ExpectCompleteAsync();
+        }
+
+        #endregion
+
+        #region by-tag, live
+
+        [Fact]
+        public virtual async Task ReadJournal_live_query_EventsByTag_with_FromEnd_should_return_last_N_then_new_events()
+        {
+            var queries = RequireQuery<IEventsByTagQuery>();
+            // the current counterpart is required to deterministically stabilize the from-end window: the window is
+            // resolved once at materialization, so all fixture writes must be visible to the read side beforehand
+            var currentQueries = RequireQuery<ICurrentEventsByTagQuery>();
+            var actors = await PersistInterleavedFixtureAsync();
+            await WaitForVisibleAsync(() => currentQueries.CurrentEventsByTag("green", NoOffset()), GreenEvents.Length);
+
+            var probe = queries.EventsByTag("green", FromEnd(2))
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            probe.Request(10);
+            await ExpectEnvelopeAsync(probe, "b", 2);
+            await ExpectEnvelopeAsync(probe, "c", 2);
+
+            // a live query must continue to observe newly-persisted matching events past the initial window
+            await PersistAsync(actors["c"], "a green pear");
+            await ExpectEnvelopeAsync(probe, "c", 3);
+            probe.Cancel();
+        }
+
+        #endregion
+
+        #region all-events, current
+
+        [Fact]
+        public virtual async Task ReadJournal_query_CurrentAllEvents_with_FromEnd_should_return_only_the_last_N_events()
+        {
+            var queries = RequireQuery<ICurrentAllEventsQuery>();
+            await PersistInterleavedFixtureAsync();
+            await WaitForVisibleAsync(() => queries.CurrentAllEvents(NoOffset()), AllEvents.Length);
+
+            var probe = queries.CurrentAllEvents(FromEnd(2))
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            probe.Request(10);
+            // the last two events of the entire journal include the untagged "more plain text" (a-3)
+            await ExpectEnvelopeAsync(probe, "a", 3);
+            await ExpectEnvelopeAsync(probe, "c", 2);
+            await probe.ExpectCompleteAsync();
+        }
+
+        [Fact]
+        public virtual async Task ReadJournal_query_CurrentAllEvents_with_FromEnd_larger_than_total_should_return_all_events()
+        {
+            var queries = RequireQuery<ICurrentAllEventsQuery>();
+            await PersistInterleavedFixtureAsync();
+            await WaitForVisibleAsync(() => queries.CurrentAllEvents(NoOffset()), AllEvents.Length);
+
+            var probe = queries.CurrentAllEvents(FromEnd(100))
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            probe.Request(20);
+            foreach (var (pid, seqNr) in AllEvents)
+                await ExpectEnvelopeAsync(probe, pid, seqNr);
+            await probe.ExpectCompleteAsync();
+        }
+
+        [Fact]
+        public virtual async Task ReadJournal_query_CurrentAllEvents_with_FromEnd_on_empty_journal_should_complete_empty()
+        {
+            var queries = RequireQuery<ICurrentAllEventsQuery>();
+            // nothing persisted: a from-end query against an empty journal must complete, not hang
+            var probe = queries.CurrentAllEvents(FromEnd(5))
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            probe.Request(10);
+            await probe.ExpectCompleteAsync();
+        }
+
+        #endregion
+
+        #region all-events, live
+
+        [Fact]
+        public virtual async Task ReadJournal_live_query_AllEvents_with_FromEnd_should_return_last_N_then_new_events()
+        {
+            var queries = RequireQuery<IAllEventsQuery>();
+            // see the by-tag live test: the current counterpart stabilizes the from-end window before materialization
+            var currentQueries = RequireQuery<ICurrentAllEventsQuery>();
+            var actors = await PersistInterleavedFixtureAsync();
+            await WaitForVisibleAsync(() => currentQueries.CurrentAllEvents(NoOffset()), AllEvents.Length);
+
+            var probe = queries.AllEvents(FromEnd(2))
+                .RunWith(this.SinkProbe<EventEnvelope>(), Materializer);
+            probe.Request(10);
+            await ExpectEnvelopeAsync(probe, "a", 3);
+            await ExpectEnvelopeAsync(probe, "c", 2);
+
+            // a live all-events query must keep emitting newly-persisted events (tagged or not) past the window
+            await PersistAsync(actors["a"], "brand new event");
+            await ExpectEnvelopeAsync(probe, "a", 4);
+            probe.Cancel();
+        }
+
+        #endregion
+
+        #region cross-query contract
+
+        [Fact]
+        public virtual async Task ReadJournal_FromEnd_should_count_per_tag_for_by_tag_and_all_events_for_all_events()
+        {
+            var tagQueries = RequireQuery<ICurrentEventsByTagQuery>();
+            var allQueries = RequireQuery<ICurrentAllEventsQuery>();
+            await PersistInterleavedFixtureAsync();
+            // stabilize BOTH read paths: the all-events index and the (separately maintained) green tag index can
+            // settle independently, so waiting only for all-events would let the green window resolve against a
+            // partial tag set on backends whose tag projection lags the global ordering
+            await WaitForVisibleAsync(() => allQueries.CurrentAllEvents(NoOffset()), AllEvents.Length);
+            await WaitForVisibleAsync(() => tagQueries.CurrentEventsByTag("green", NoOffset()), GreenEvents.Length);
+
+            var greenLastTwo = await tagQueries.CurrentEventsByTag("green", FromEnd(2))
+                .RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+            var allLastTwo = await allQueries.CurrentAllEvents(FromEnd(2))
+                .RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+
+            var green = greenLastTwo.Select(e => (e.PersistenceId, e.SequenceNr)).ToArray();
+            var all = allLastTwo.Select(e => (e.PersistenceId, e.SequenceNr)).ToArray();
+
+            // "last 2 green" is resolved against the per-tag count → the last two *tagged* events...
+            Assert.Equal(new[] { ("b", 2L), ("c", 2L) }, green);
+            // ...whereas "last 2 of everything" is resolved against the total count → includes the untagged a-3.
+            Assert.Equal(new[] { ("a", 3L), ("c", 2L) }, all);
+            // a backend that resolved the by-tag window against the global count would return the same window for both
+            Assert.NotEqual(all, green);
+        }
+
+        #endregion
+
+        #region fixture
+
+        /// <summary>
+        /// The single source of truth for the interleaved fixture: (persistenceId, event) pairs in persist order.
+        /// Three writers (a/b/c) are interleaved and several events are untagged. Tagging is by substring via
+        /// <c>ColorFruitTagger</c>, so any event whose text contains "green" is part of the green tag set.
+        /// </summary>
+        private static readonly (string PersistenceId, string Event)[] Fixture =
+        {
+            ("a", "a green apple"),
+            ("b", "a black car"),
+            ("a", "just plain text"),
+            ("c", "a green banana"),
+            ("b", "a green leaf"),
+            ("a", "more plain text"),
+            ("c", "a green cucumber"),
+        };
+
+        /// <summary>
+        /// <see cref="Fixture"/> enriched with the per-persistence-id sequence number each write produces.
+        /// </summary>
+        private static readonly (string PersistenceId, long SequenceNr, string Event)[] EnrichedFixture = EnrichFixture();
+
+        /// <summary>
+        /// Every fixture event in global (ordering) order, as (persistenceId, sequenceNr) pairs.
+        /// </summary>
+        protected static readonly (string PersistenceId, long SequenceNr)[] AllEvents =
+            EnrichedFixture.Select(e => (e.PersistenceId, e.SequenceNr)).ToArray();
+
+        /// <summary>
+        /// The subset of <see cref="AllEvents"/> tagged "green", in global order — derived from the fixture text so it
+        /// can never drift from the writes.
+        /// </summary>
+        protected static readonly (string PersistenceId, long SequenceNr)[] GreenEvents =
+            EnrichedFixture.Where(e => e.Event.Contains("green")).Select(e => (e.PersistenceId, e.SequenceNr)).ToArray();
+
+        private static (string PersistenceId, long SequenceNr, string Event)[] EnrichFixture()
+        {
+            var seqByPid = new Dictionary<string, long>();
+            var enriched = new List<(string, long, string)>(Fixture.Length);
+            foreach (var (pid, evt) in Fixture)
+            {
+                var next = (seqByPid.TryGetValue(pid, out var s) ? s : 0) + 1;
+                seqByPid[pid] = next;
+                enriched.Add((pid, next, evt));
+            }
+
+            return enriched.ToArray();
+        }
+
+        /// <summary>
+        /// Persists the interleaved fixture, awaiting each write's acknowledgement so the resulting global ordering is
+        /// deterministic. Returns the writers keyed by persistence id so live tests can append further events.
+        /// </summary>
+        private async Task<IReadOnlyDictionary<string, IActorRef>> PersistInterleavedFixtureAsync()
+        {
+            var actors = new Dictionary<string, IActorRef>();
+            foreach (var (pid, evt) in Fixture)
+            {
+                if (!actors.TryGetValue(pid, out var actor))
+                {
+                    actor = Sys.ActorOf(Query.TestActor.Props(pid));
+                    actors[pid] = actor;
+                }
+
+                await PersistAsync(actor, evt);
+            }
+
+            return actors;
+        }
+
+        private async Task PersistAsync(IActorRef pa, string evt)
+        {
+            pa.Tell(evt);
+            await ExpectMsgAsync($"{evt}-done");
+        }
+
+        private async Task<EventEnvelope> ExpectEnvelopeAsync(
+            TestSubscriber.Probe<EventEnvelope> probe, string persistenceId, long sequenceNr)
+        {
+            var envelope = await probe.ExpectNextAsync<EventEnvelope>(_ => true);
+            Assert.Equal(persistenceId, envelope.PersistenceId);
+            Assert.Equal(sequenceNr, envelope.SequenceNr);
+            return envelope;
+        }
+
+        /// <summary>
+        /// Polls the supplied current-query until at least <paramref name="expectedCount"/> events are visible, so a
+        /// subsequent from-end query resolves its window against a settled read model.
+        /// </summary>
+        private async Task WaitForVisibleAsync(Func<Source<EventEnvelope, NotUsed>> query, int expectedCount)
+        {
+            await AwaitConditionAsync(async () =>
+            {
+                var events = await query().RunWith(Sink.Seq<EventEnvelope>(), Materializer);
+                return events.Count >= expectedCount;
+            }, max: TimeSpan.FromSeconds(10));
+        }
+
+        private T RequireQuery<T>() where T : class, IReadJournal
+        {
+            if (ReadJournal is not T queries)
+                throw IsTypeException.ForMismatchedType(typeof(T).Name, ReadJournal?.GetType().Name ?? "null");
+            return queries;
+        }
+
+        #endregion
+    }
+}

--- a/src/core/Akka.Persistence/Journal/MemoryJournal.cs
+++ b/src/core/Akka.Persistence/Journal/MemoryJournal.cs
@@ -238,10 +238,36 @@ namespace Akka.Persistence.Journal
                             failure: e => new EventReplayFailure(e));
                     return true;
 
+                case SelectEventCount request:
+                    SelectEventCountAsync(request.Tag)
+                        .PipeTo(request.ReplyTo, success: c => new EventCount(c),
+                            failure: e => new EventCountFailure(e));
+                    return true;
+
                 default:
                     return false;
             }
         }
+
+        /// <summary>
+        /// Counts the number of stored events that match the supplied <paramref name="tag"/>, or all stored
+        /// events when <paramref name="tag"/> is <c>null</c>. Used to resolve a "from the end" (last N)
+        /// query offset into a concrete starting position.
+        /// </summary>
+        private Task<int> SelectEventCountAsync(string tag)
+        {
+            DrainPendingWrites();
+            return Task.FromResult(CountEvents(tag));
+        }
+
+        /// <summary>
+        /// Counts stored events matching <paramref name="tag"/>, or all stored events when <paramref name="tag"/>
+        /// is <c>null</c>. Callers must have already drained pending writes.
+        /// </summary>
+        private int CountEvents(string tag)
+            => tag is null
+                ? Storage.EventLog.Count
+                : Storage.EventLog.Count(e => e.Payload is Tagged tagged && tagged.Tags.Contains(tag));
 
         private Task<(IEnumerable<string> Ids, int LastOrdering)> SelectAllPersistenceIdsAsync(int offset)
         {
@@ -266,7 +292,7 @@ namespace Akka.Persistence.Journal
                 .Take(replay.Max)
                 .ToArray();
 
-            var count = Storage.EventLog.Count(e => e.Payload is Tagged tagged && tagged.Tags.Contains(replay.Tag));
+            var count = CountEvents(replay.Tag);
 
             var index = 0;
             foreach (var persistence in snapshot)
@@ -287,7 +313,7 @@ namespace Akka.Persistence.Journal
                 .Take((int)replay.Max)
                 .ToArray();
 
-            var count = Storage.EventLog.Count;
+            var count = CountEvents(null);
 
             var index = 0;
             foreach (var message in snapshot)
@@ -336,6 +362,57 @@ namespace Akka.Persistence.Journal
             {
                 AllPersistenceIds = allPersistenceIds.ToImmutableHashSet();
                 HighestOrderingNumber = highestOrderingNumber;
+            }
+        }
+
+        /// <summary>
+        /// Requests the number of stored events matching <see cref="Tag"/>, or all stored events when
+        /// <see cref="Tag"/> is <c>null</c>. Used by the query side to resolve a "from the end" (last N)
+        /// query offset into a concrete starting position.
+        /// </summary>
+        [Serializable]
+        public sealed class SelectEventCount : IJournalRequest
+        {
+            /// <summary>
+            /// The tag to count, or <c>null</c> to count all events.
+            /// </summary>
+            public string Tag { get; }
+
+            public IActorRef ReplyTo { get; }
+
+            public SelectEventCount(string tag, IActorRef replyTo)
+            {
+                Tag = tag;
+                ReplyTo = replyTo;
+            }
+        }
+
+        /// <summary>
+        /// Reply to <see cref="SelectEventCount"/> carrying the number of matching events.
+        /// </summary>
+        [Serializable]
+        public sealed class EventCount : INoSerializationVerificationNeeded, IDeadLetterSuppression
+        {
+            public int Count { get; }
+
+            public EventCount(int count)
+            {
+                Count = count;
+            }
+        }
+
+        /// <summary>
+        /// Reply to <see cref="SelectEventCount"/> when the count query fails, so the query side can fail the
+        /// stream instead of waiting forever for an <see cref="EventCount"/> that will never arrive.
+        /// </summary>
+        [Serializable]
+        public sealed class EventCountFailure : INoSerializationVerificationNeeded, IDeadLetterSuppression
+        {
+            public Exception Cause { get; }
+
+            public EventCountFailure(Exception cause)
+            {
+                Cause = cause;
             }
         }
 


### PR DESCRIPTION
## Forward-port of #8245 to `dev`

This is the forward-port of **#8245** — *"Add a 'from the end' (last-N) query Offset to Akka.Persistence.Query"* — from `v1.5` (commit `938a62909`) to `dev`.

The feature **shipped in v1.5.70** but was **completely missing from `dev`**, so without this forward-port it would have regressed out of 1.6.

### What the feature adds

`Offset.FromEnd(int count)` — a **query-input-only** offset that begins a query at the *N*th event from the end of history rather than the beginning. Read journals resolve it at materialization into a concrete `Sequence` start offset and then reuse their existing forward-streaming pipeline, so the change is **fully additive**: no interface signature changes and no wire-format changes.

- **Core:** `FromEnd : Offset` type + `Offset.FromEnd(int)` factory (`Akka.Persistence.Query`). `FromEnd` is a relative, input-only offset with no stream position, so it is not orderable and `CompareTo` always throws.
- **InMemory:** resolves `FromEnd` in the by-tag and all-events publishers via a new `MemoryJournal.SelectEventCount`/`EventCount` round-trip, extracted into a shared internal `FromEndResolvingPublisher` base and an internal `ReplayStart` value type.
- **TCK:** opt-in `FromEndOffsetSpec` (full `{by-tag, all-events} x {current, live}` matrix, N > total, empty/zero-match, live continuation) + `InMemoryFromEndOffsetSpec`.
- **Unit tests:** `OffsetSpec` / `OffsetCompareSpecs` additions for the factory, `count <= 0` guard, `ToString`, `Equals`/`GetHashCode`, and `CompareTo` throwing.

SQL and MongoDB plugin implementations to follow. See #8244.

### Public API surface / approval baselines

This adds public API, so `dev`'s API-approval baselines were **regenerated** (not copied verbatim from v1.5 — `dev`'s baseline differs, notably it no longer tracks the `.Core` verified variants and its `Offset` class already declares `abstract override string ToString()`). The regenerated `dev` baselines add **only** the new FromEnd surface and nothing else:

- `CoreAPISpec.ApprovePersistenceQuery.{DotNet,Net}.verified.txt` — adds `public sealed class FromEnd : Offset` and `public static Offset FromEnd(int count)`.
- `CoreAPISpec.ApprovePersistence.{DotNet,Net}.verified.txt` — adds `EventCount`, `EventCountFailure`, and `SelectEventCount` in `Akka.Persistence.Journal`.

The new InMemory types (`FromEndResolvingPublisher`, `ReplayStart`) are `internal`, so `CoreAPISpec.ApprovePersistenceInMemoryQuery.*.verified.txt` is unchanged.

### Validation (net10.0)

- `-warnaserror` build of `Akka.Persistence.Query`, `Akka.Persistence`, `Akka.Persistence.Query.InMemory`, `Akka.Persistence.TCK`, and their test projects — **0 warnings, 0 errors**.
- FromEnd feature tests: `Akka.Persistence.Query.InMemory.Tests` `~FromEnd` — **10/10 pass**.
- `OffsetSpec` + `OffsetCompareSpecs` + FromEnd unit tests — **pass**.
- Full `Akka.Persistence.Query.InMemory.Tests` suite — **56 passed, 1 pre-existing skip** (no regressions from the publisher/`ReplayStart` refactor).
- Full `Akka.Persistence.Query.Tests` suite — **17 pass**.
- `Akka.API.Tests` — **18/18 pass** with the regenerated approval baselines.
