### PR TITLE
fix: flush remote deployments before ActorSystem termination (prevents shutdown hang when a remote-deployment host is unreachable)

### DIFF
--- a/src/core/Akka.Remote.Tests/RemoteDeploymentFlushOnShutdownSpec.cs
+++ b/src/core/Akka.Remote.Tests/RemoteDeploymentFlushOnShutdownSpec.cs
@@ -1,0 +1,140 @@
+//-----------------------------------------------------------------------
+// <copyright file="RemoteDeploymentFlushOnShutdownSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote.Transport;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Remote.Tests
+{
+    /// <summary>
+    /// Repro/characterization spec for the shutdown-time "flush remote deployments" behavior on the
+    /// default DotNetty transport.
+    ///
+    /// This is the in-process analog of the multi-node <c>RemoteDeploymentDeathWatchSpec</c>: a
+    /// "deployer" ActorSystem remotely deploys an actor onto a "host" ActorSystem. The host is then made
+    /// permanently unreachable via a bidirectional transport blackhole (the sanctioned in-process way to
+    /// simulate a hard node crash / network partition on DotNetty — no graceful Akka Disassociate ever
+    /// reaches the deployer, exactly like <c>TestConductor.Exit(node, 0)</c> in the multi-node test).
+    /// Finally the deployer is terminated via <see cref="ActorSystem.Terminate"/>.
+    ///
+    /// The deployer's <see cref="RemoteDeploymentWatcher"/> is watching the remote child on behalf of the
+    /// local supervisor (the /user guardian). Without the shutdown-time flush, that supervisor blocks
+    /// forever during shutdown waiting for the (now unreachable) remote child to confirm termination — the
+    /// remote DeathWatch round-trip can never complete once the deployer's own remoting is tearing down —
+    /// so <see cref="ActorSystem.WhenTerminated"/> never completes. With the flush, the watcher proactively
+    /// releases the supervisor at <c>PhaseBeforeActorSystemTerminate</c> and the deployer terminates
+    /// promptly.
+    ///
+    /// The watch failure detector is deliberately widened so it cannot mask the bug by eventually
+    /// declaring the host unreachable inside the test window.
+    /// </summary>
+    public class RemoteDeploymentFlushOnShutdownSpec : AkkaSpec
+    {
+        public RemoteDeploymentFlushOnShutdownSpec(ITestOutputHelper output)
+            : base("akka.loglevel = WARNING", output)
+        {
+        }
+
+        private static Config RemoteConfig() => ConfigurationFactory.ParseString(@"
+            akka {
+                actor.provider = remote
+                remote.dot-netty.tcp {
+                    hostname = 127.0.0.1
+                    port = 0
+                    # trttl adapter lets us blackhole the association in-process to simulate a hard
+                    # host crash. The underlying transport is still DotNetty TCP.
+                    applied-adapters = [""trttl""]
+                }
+                # Widen remote-watch failure detection so it CANNOT rescue a hung shutdown within the
+                # test window. The only thing that should let the deployer terminate is the flush.
+                remote.watch-failure-detector.acceptable-heartbeat-pause = 60 s
+            }");
+
+        private sealed class Echo : ReceiveActor
+        {
+            public Echo()
+            {
+                ReceiveAny(msg => Sender.Tell(msg));
+            }
+        }
+
+        [Fact(DisplayName = "Deployer ActorSystem must fully terminate promptly after the remote deployment host crashes (DotNetty)")]
+        public async Task Deployer_must_shut_down_promptly_after_remote_host_crash()
+        {
+            var host = ActorSystem.Create("Host", RemoteConfig());
+            var hostAddress = RARP.For(host).Provider.DefaultAddress;
+
+            var deployerConfig = ConfigurationFactory.ParseString(
+                    $@"akka.actor.deployment./hello.remote = ""{hostAddress}""")
+                .WithFallback(RemoteConfig());
+            var deployer = ActorSystem.Create("Deployer", deployerConfig);
+
+            try
+            {
+                // remotely deploy /hello onto the host node
+                var hello = deployer.ActorOf(Props.Create<Echo>(), "hello");
+
+                // location-transparency check: the child physically lives on the host
+                hello.Path.Address.ShouldBe(hostAddress);
+
+                // confirm the remote deployment is live via a round-trip through the host
+                (await hello.Ask<string>("ping", TimeSpan.FromSeconds(15))).ShouldBe("ping");
+
+                // HARD CRASH the host: bidirectional blackhole. No graceful Disassociate ever reaches the
+                // deployer, so it cannot clean up the remote child through the normal DeathWatch path.
+                var deployerTransport = RARP.For(deployer).Provider.Transport;
+                var hostNaked = new Address("akka", host.Name, hostAddress.Host, hostAddress.Port!.Value);
+                (await deployerTransport.ManagementCommand(
+                    new SetThrottle(hostNaked, ThrottleTransportAdapter.Direction.Both, Blackhole.Instance)))
+                    .ShouldBeTrue("SetThrottle(Blackhole) command was not accepted by the transport");
+
+                // verify the blackhole actually took effect: a round-trip must now time out
+                var reachedAfterBlackhole = true;
+                try
+                {
+                    await hello.Ask<string>("ping-after-blackhole", TimeSpan.FromSeconds(3));
+                }
+                catch
+                {
+                    reachedAfterBlackhole = false;
+                }
+
+                Assert.False(reachedAfterBlackhole,
+                    "Blackhole did not take effect — the host is still reachable, so the test setup is invalid.");
+
+                // Shut the deployer down and require it to FULLY terminate inside a tight bound.
+                // NB: we must assert on WhenTerminated, not on Terminate()'s task: a CoordinatedShutdown
+                // phase that hangs still lets Terminate()'s task complete on the phase timeout while the
+                // system remains alive.
+                var sw = Stopwatch.StartNew();
+                _ = deployer.Terminate();
+                var terminated = await Task.WhenAny(deployer.WhenTerminated, Task.Delay(TimeSpan.FromSeconds(10)));
+                sw.Stop();
+
+                Assert.True(ReferenceEquals(terminated, deployer.WhenTerminated) && deployer.WhenTerminated.IsCompleted,
+                    $"Deployer ActorSystem did not fully terminate within 10s after the remote host crashed " +
+                    $"(elapsed {sw.Elapsed}). Its /user guardian is still blocked waiting for the unreachable " +
+                    $"remote child — the remote deployment was not flushed at shutdown.");
+
+                Log.Info("Deployer fully terminated in {0}", sw.Elapsed);
+            }
+            finally
+            {
+                ((ExtendedActorSystem)deployer).Abort();
+                ((ExtendedActorSystem)host).Abort();
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote/RemoteActorRefProvider.cs
+++ b/src/core/Akka.Remote/RemoteActorRefProvider.cs
@@ -275,6 +275,16 @@ namespace Akka.Remote
             Transport.Start();
             _remoteWatcher = CreateRemoteWatcher(system);
             _remoteDeploymentWatcher = CreateRemoteDeploymentWatcher(system);
+            var coordinatedShutdown = CoordinatedShutdown.Get(system);
+            coordinatedShutdown.AddTask(
+                CoordinatedShutdown.PhaseBeforeActorSystemTerminate,
+                "flush-remote-deployments",
+                // Bound the flush Ask to the shutdown phase's own timeout rather than the
+                // (longer) remote shutdown-timeout, so a backed-up watcher can never stall
+                // CoordinatedShutdown beyond the phase it runs in.
+                () => _remoteDeploymentWatcher.Ask<Done>(
+                    RemoteDeploymentWatcher.FlushRemoteDeployments.Instance,
+                    coordinatedShutdown.Timeout(CoordinatedShutdown.PhaseBeforeActorSystemTerminate)));
         }
 
         /// <summary>
@@ -806,4 +816,3 @@ namespace Akka.Remote
         }
     }
 }
-

--- a/src/core/Akka.Remote/RemoteDeploymentWatcher.cs
+++ b/src/core/Akka.Remote/RemoteDeploymentWatcher.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Linq;
 using Akka.Actor;
 using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
@@ -43,6 +44,38 @@ namespace Akka.Remote
                     _supervisors.Remove(t.ActorRef);
                 }
             });
+
+            Receive<RemotingShutdownEvent>(_ => NotifyRemoteDeploymentsTerminated());
+            Receive<FlushRemoteDeployments>(_ =>
+            {
+                NotifyRemoteDeploymentsTerminated();
+                Sender.Tell(Done.Instance);
+            });
+        }
+
+        protected override void PreStart()
+        {
+            Context.System.EventStream.Subscribe(Self, typeof(RemotingShutdownEvent));
+        }
+
+        protected override void PostStop()
+        {
+            Context.System.EventStream.Unsubscribe(Self);
+        }
+
+        private void NotifyRemoteDeploymentsTerminated()
+        {
+            // Local shutdown cannot wait for remote DeathWatch round-trips; release local supervisors first.
+            foreach (var deployment in _supervisors.ToArray())
+            {
+                deployment.Value.SendSystemMessage(new DeathWatchNotification(
+                    deployment.Key,
+                    existenceConfirmed: true,
+                    addressTerminated: true));
+                Context.Unwatch(deployment.Key);
+            }
+
+            _supervisors.Clear();
         }
 
         /// <summary>
@@ -69,6 +102,15 @@ namespace Akka.Remote
             /// TBD
             /// </summary>
             public IInternalActorRef Supervisor { get; private set; }
+        }
+
+        internal sealed class FlushRemoteDeployments
+        {
+            public static readonly FlushRemoteDeployments Instance = new();
+
+            private FlushRemoteDeployments()
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a shutdown hang in `RemoteActorRefProvider` / `RemoteDeploymentWatcher`: when an ActorSystem that has **remotely deployed** an actor shuts down **while the deployment host is unreachable** (crashed / hard-partitioned, no graceful `Disassociate`), the deploying system can fail to terminate. Its `/user` guardian stays blocked waiting for the unreachable remote child, and `ActorSystem.WhenTerminated` never completes.

This is a general Akka.Remote shutdown-correctness bug on the **default DotNetty transport** — reproduced by the included test, which hangs for 10s and fails on `dev` today, and passes with this change.

## Root cause

`RemoteDeploymentWatcher` (on the deploying node) tracks each remote-deployed child → its local supervisor and `Context.Watch`es the child. Cleanup of a dead remote deployment normally arrives via a remote `DeathWatch` round-trip. During the deployer's **own** shutdown with the host unreachable, that round-trip can never complete — remoting is already tearing down — so the watcher never releases the supervisor, and the guardian blocks on the still-watched remote child.

## Fix

Flush remote deployments during shutdown instead of waiting for a round-trip that can't happen:

- `RemoteDeploymentWatcher` now handles the (pre-existing, transport-agnostic) `RemotingShutdownEvent` and a new internal `FlushRemoteDeployments` message. On either, it snapshots its tracked deployments and sends each supervisor a **local** `DeathWatchNotification(existenceConfirmed: true, addressTerminated: true)`, then unwatches and clears. The notification is delivered directly to the one supervisor (not published to `AddressTerminatedTopic`), so it does not cascade or quarantine — it simply lets the local termination machinery drop the child without any further remote round-trip.
- `RemoteActorRefProvider.Init` registers a `CoordinatedShutdown` task in `PhaseBeforeActorSystemTerminate` that asks the watcher to flush. The Ask timeout is **scoped to that phase's timeout** (rather than the longer `remote.shutdown-timeout`), so a backed-up watcher can never stall `CoordinatedShutdown` beyond the phase it runs in — worst case is bounded, never a hang.

The trigger path (`CoordinatedShutdown` + the general `RemotingShutdownEvent` published by `Remoting`) runs for **every** transport; the fix references no transport-specific types.

## Repro test

`RemoteDeploymentFlushOnShutdownSpec` (in `Akka.Remote.Tests`, default DotNetty transport): two in-process ActorSystems on `127.0.0.1`; the deployer remotely deploys `/hello` onto the host, the host is hard-crashed via a bidirectional transport blackhole (the in-process analog of a process kill / `TestConductor.Exit`), the test self-validates the crash, then asserts `deployer.WhenTerminated` completes within 10s.

- **Before this change:** fails — deployer does not terminate within 10s (guardian blocked on the unreachable remote child).
- **After:** passes — termination is sub-second. Stable across repeated runs.

Asserting on `WhenTerminated` (not the `Terminate()` task) is deliberate: `Terminate()` returns the `CoordinatedShutdown.Run` task, which completes on the phase timeout even while the system is still hung.

## Notes

- Extracted as a standalone, transport-independent fix from the experimental streams-transport branch (#8240), where it was first observed.
- Internal members only — no public API surface change (no API-approval impact).
- `Akka.Remote` builds `-warnaserror` clean; `RemoteWatcherSpec`, `RemoteDeathWatchSpec`, `AkkaProtocolSpec`, and the new spec are green (9/9 on the targeted run).
