### PR TITLE
Artery G1: TCP framing foundation + envelope codec (gates on framing/envelope round-trip)

### DIFF
--- a/openspec/changes/artery-tcp-remoting/design.md
+++ b/openspec/changes/artery-tcp-remoting/design.md
@@ -119,31 +119,34 @@ Little-endian throughout. **✓ = verified from Pekko source; ◇ = our design d
 
 - **Connection preamble** (once per TCP connection) ✓: `AKKA` magic (4B) + stream id (1B: 1=control, 2=ordinary, 3=large).
 - **Per frame** ✓: `[ frame length u32 LE ][ envelope ]`; length = header + payload, **back-patched from bytes-written, not predicted** (no `SizeHint` dependency — see below).
-- **Envelope fixed header — 28 bytes** ✓ (offsets):
+- **Envelope fixed header — 32 bytes** (offsets; the 28-byte draft was REVISED at G1, 2026-07-04: an explicit **payload-offset** field was added at offset 28. The draft derived the payload as `frame_length − header_length`, which breaks whenever a literal tail is present; the explicit offset makes the payload slice O(1) and position-independent of the tail. Cost: 4 B/frame; on the warm hot path it is the constant 32.):
 
 ```
  off  sz  field
-  0   1   version
-  1   1   flags                         (bitfield: bit M = optional metadata section present ◇)
-  2   1   actorRef  compression-table version
-  3   1   manifest  compression-table version
+  0   1   version                 (= 1; decoder rejects any other value)
+  1   1   flags                   (bit 0 = metadata section present; bits 1–7 reserved-must-be-zero, decoder rejects)
+  2   1   actorRef  compression-table version   (= 0 in MVP)
+  3   1   manifest  compression-table version   (= 0 in MVP)
   4   8   origin UID              int64 LE
  12   4   serializer id           int32 LE
- 16   4   sender    ref  TAG
- 20   4   recipient ref  TAG
- 24   4   manifest       TAG
- 28  ..   variable / optional tail
+ 16   4   sender    ref  TAG      u32 LE
+ 20   4   recipient ref  TAG      u32 LE
+ 24   4   manifest       TAG      u32 LE
+ 28   4   payload offset          u32 LE  (== 32 when no metadata section and no literals)
+ 32  ..   [metadata section iff flags.0: u32 LE length + bytes][literals]*
+ payloadOffset .. frame end       payload
 ```
 
-- **32-bit TAG** (sender / recipient / manifest) ✓ masks: top byte `0xFF000000` == 0 → LITERAL (string in tail); != 0 → COMPRESSED, low 16 bits `0x0000FFFF` = compression-table index. ◇ reserve one value = ABSENT (no-sender / no-recipient); ◇ literal length encoding.
-- **Variable / optional tail** @28 ◇ (verify vs Pekko): optional metadata container (present iff `flags.M`) then length-prefixed literals — sender path, recipient path, manifest — for any LITERAL tag.
-- **Payload**: V2-serialized bytes (msgpack where the type uses the generator); length = `frame_length − header_length`.
-- **Hot path** (compression warm): `[ len ][ 28B fixed hdr, all tags compressed ][ payload N ]` = 32 + N bytes, zero tail, every metadata field an O(1) offset read.
+- **32-bit TAG** (sender / recipient / manifest) ✓ masks, CLOSED at G1: tag == `0x00000000` → **ABSENT** (no-sender / no-recipient / empty manifest — unambiguous because a literal offset is always ≥ 32); top byte `0xFF000000` != 0 → **COMPRESSED**, encoder writes `0xFF000000 | index`, low 16 bits `0x0000FFFF` = table index; else → **LITERAL**, tag value = absolute byte offset of the literal from envelope offset 0 (≥ 32, < `0x00FFFFFF`).
+- **Literal encoding** (CLOSED at G1): u16 LE byte length + UTF-8 bytes; encode rejects a path/manifest over 64 KB.
+- **Variable / optional tail** @32 (CLOSED at G1): optional metadata container (present iff flags bit 0; u32 LE length + bytes; MVP never writes one, the decoder skips it), then the length-prefixed literals for any LITERAL tag. Tags carry absolute offsets, so literal placement is not load-bearing; the encoder's convention is sender, recipient, manifest. All literals sit in `[32, payloadOffset)`.
+- **Payload**: V2-serialized bytes (msgpack where the type uses the generator); slice = `[payloadOffset, frame end)` — explicit, O(1), independent of the tail. **Single-pass encode is possible because `SerializerV2.Manifest(object)` is available UPFRONT** (verified: abstract on `SerializerV2`): look up serializer → id + manifest known → write header + literals → `Serialize(obj, IBufferWriter)` streams the payload directly into the frame buffer → back-patch the frame length only.
+- **Hot path** (compression warm): `[ len ][ 32B fixed hdr, all tags compressed, payloadOffset=32 ][ payload N ]` = 36 + N bytes, zero tail, every metadata field an O(1) offset read.
 - **Manifest = V2 non-CLR token** — the manifest TAG behaves exactly like the ref tags (compressed index or literal string), no CLR-type coupling. This is the one intended divergence from Pekko's encoding.
 
 **Decode order (structural, not an optimization).** The header is parsed *before* any payload deserialization, because it carries the recipient (→ which lane) and the serializer-id + manifest (→ how to deserialize). Flow: `TcpFraming → header parse + ref/manifest decompression on the SERIAL decode island → partition to lane by recipient hash → payload deserialization on the lane (parallel)`. The header parse is on the serial critical path, so it must stay O(1)/sub-microsecond — which is exactly why it is a fixed-offset binary header, and why keeping it cheap protects the serial-island ceiling (Decision 2).
 
-**Open sub-decisions (◇) to close in envelope design (#34):** flags bit assignments; literal length/encoding; optional metadata-container format (+ verify against Pekko); absent-sender/recipient sentinel; final field order/sizes given V2 non-CLR manifests.
+**Sub-decisions CLOSED at G1 (2026-07-04):** version = 1 (reject others); flags bit 0 = metadata present, bits 1–7 reserved-must-be-zero (reject — silently tolerating an unknown semantic flag would misparse; layout changes bump the version); ABSENT = tag `0x0`; literal = u16 LE length + UTF-8 at an absolute offset; metadata container = u32 LE length + bytes at offset 32; payload boundary = explicit payload-offset header field (see layout note). The byte layout deliberately diverges from Pekko's `EnvelopeBuffer` (payload-offset field, V2 non-CLR manifests) per Decision 4 — semantics transfer, bytes do not.
 
 ## Handshake + association/UID (gate G2)
 

--- a/openspec/changes/artery-tcp-remoting/tasks.md
+++ b/openspec/changes/artery-tcp-remoting/tasks.md
@@ -20,24 +20,24 @@ BenchmarkDotNet harness (naked, baseline-first, `MemoryDiagnoser` on), socket by
 
 ## 2. TCP Framing Foundation
 
-- [ ] 2.1 Define stream IDs for control, ordinary, and future large-message streams
-- [ ] 2.2 Implement connection header: `AKKA` magic + 1-byte stream ID
-- [ ] 2.3 Implement 4-byte little-endian frame length encoder
-- [ ] 2.4 Implement frame parser over `ReadOnlySequence<byte>`
-- [ ] 2.5 Enforce maximum frame size
-- [ ] 2.6 Add framing tests for complete, partial, multiple, and oversized frames
+- [x] 2.1 Define stream IDs for control, ordinary, and future large-message streams
+- [x] 2.2 Implement connection header: `AKKA` magic + 1-byte stream ID
+- [x] 2.3 Implement 4-byte little-endian frame length encoder
+- [x] 2.4 Implement frame parser over `ReadOnlySequence<byte>`
+- [x] 2.5 Enforce maximum frame size (hard cap 0x00FFFFFF protects the 24-bit literal-offset tag space)
+- [x] 2.6 Add framing tests for complete, partial, multiple, and oversized frames
 
 ## 3. Artery Envelope Codec
 
-- [ ] 3.1 Define MVP envelope header fields
-- [ ] 3.2 Encode protocol version and flags
-- [ ] 3.3 Encode origin UID
-- [ ] 3.4 Encode serializer ID and manifest literal
-- [ ] 3.5 Encode recipient actor ref literal or no-recipient marker
-- [ ] 3.6 Encode sender actor ref literal or no-sender marker
-- [ ] 3.7 Encode payload using `SerializerV2`
-- [ ] 3.8 Decode envelope metadata without deserializing payload first
-- [ ] 3.9 Add envelope codec tests, including multi-segment input
+- [x] 3.1 Define MVP envelope header fields (32-byte fixed header; ◇ sub-decisions closed — see design.md)
+- [x] 3.2 Encode protocol version and flags
+- [x] 3.3 Encode origin UID
+- [x] 3.4 Encode serializer ID and manifest literal
+- [x] 3.5 Encode recipient actor ref literal or no-recipient marker
+- [x] 3.6 Encode sender actor ref literal or no-sender marker
+- [x] 3.7 Encode payload using `SerializerV2` (single-pass: manifest upfront, payload streamed via `IBufferWriter`, frame length back-patched)
+- [x] 3.8 Decode envelope metadata without deserializing payload first
+- [x] 3.9 Add envelope codec tests, including multi-segment input
 
 ## 4. Association State And Handshake
 

--- a/src/core/Akka.Remote.Tests/Artery/ArteryEnvelopeCodecSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryEnvelopeCodecSpec.cs
@@ -1,0 +1,443 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryEnvelopeCodecSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Linq;
+using System.Text;
+using Akka.Remote.Artery;
+using Akka.TestKit;
+using Xunit;
+
+namespace Akka.Remote.Tests.Artery
+{
+    /// <summary>
+    /// Correctness tests for <see cref="ArteryEnvelopeCodec"/> against the wire layout described in
+    /// <c>openspec/changes/artery-tcp-remoting/design.md</c> ("Envelope wire layout" / Decision 4).
+    /// Covers the explicit-parts encode/decode round trip (including multi-segment decode), and
+    /// every documented rejection. The V2 single-pass overload is covered separately in
+    /// <see cref="ArteryEnvelopeCodecV2Spec"/> because it needs a live <c>ActorSystem</c>.
+    /// </summary>
+    public class ArteryEnvelopeCodecSpec
+    {
+        private const int FrameLengthFieldLength = 4;
+        private const int HeaderLength = 32;
+
+        // ===================== round trip: explicit parts =====================
+
+        [Fact(DisplayName = "Should_round_trip_all_absent_tags_When_sender_recipient_and_manifest_are_all_empty")]
+        public void Should_round_trip_all_absent_tags_When_sender_recipient_and_manifest_are_all_empty()
+        {
+            var payload = MakePayload(16, seed: 1);
+
+            var (frame, totalLength) = EncodeToFrame(originUid: 0x1122_3344_5566_7788L, serializerId: 17,
+                senderPath: null, recipientPath: null, manifest: "", payload);
+
+            Assert.Equal(HeaderLength + payload.Length, ReadFrameLength(frame));
+            Assert.Equal(FrameLengthFieldLength + HeaderLength + payload.Length, totalLength);
+
+            var decoded = ArteryEnvelopeCodec.Decode(EnvelopeBody(frame));
+
+            Assert.Equal((byte)1, decoded.Header.Version);
+            Assert.Equal(0x1122_3344_5566_7788L, decoded.Header.OriginUid);
+            Assert.Equal(17, decoded.Header.SerializerId);
+            Assert.Equal(HeaderLength, decoded.Header.PayloadOffset);
+
+            Assert.Equal(ArteryTagKind.Absent, decoded.SenderKind);
+            Assert.True(decoded.TryGetSenderPath(out var sender));
+            Assert.Null(sender);
+
+            Assert.Equal(ArteryTagKind.Absent, decoded.RecipientKind);
+            Assert.True(decoded.TryGetRecipientPath(out var recipient));
+            Assert.Null(recipient);
+
+            Assert.Equal(ArteryTagKind.Absent, decoded.ManifestKind);
+            Assert.True(decoded.TryGetManifest(out var manifest));
+            Assert.Equal(string.Empty, manifest);
+
+            Assert.Equal(payload, decoded.Payload.ToArray());
+        }
+
+        [Fact(DisplayName = "Should_round_trip_all_literal_tags_When_sender_recipient_and_manifest_use_non_ascii_utf8")]
+        public void Should_round_trip_all_literal_tags_When_sender_recipient_and_manifest_use_non_ascii_utf8()
+        {
+            const string senderPath = "akka://Sys@host:1/user/sender-Ω-送信";
+            const string recipientPath = "akka://Sys@host:1/user/recipient-Ä-名前";
+            const string manifest = "My.Manifest, Assembly-Ω-テスト";
+            var payload = MakePayload(64, seed: 2);
+
+            var (frame, totalLength) = EncodeToFrame(originUid: 99L, serializerId: 3,
+                senderPath, recipientPath, manifest, payload);
+
+            var expectedPayloadOffset = HeaderLength
+                + LiteralWireSize(senderPath) + LiteralWireSize(recipientPath) + LiteralWireSize(manifest);
+            Assert.Equal(expectedPayloadOffset + payload.Length, ReadFrameLength(frame));
+            Assert.Equal(FrameLengthFieldLength + expectedPayloadOffset + payload.Length, totalLength);
+            Assert.Equal(totalLength,
+                ArteryEnvelopeCodec.MaxEncodedSize(senderPath, recipientPath, manifest, payload.Length));
+
+            var decoded = ArteryEnvelopeCodec.Decode(EnvelopeBody(frame));
+
+            Assert.Equal(expectedPayloadOffset, decoded.Header.PayloadOffset);
+
+            Assert.Equal(ArteryTagKind.Literal, decoded.SenderKind);
+            Assert.True(decoded.TryGetSenderPath(out var decodedSender));
+            Assert.Equal(senderPath, decodedSender);
+
+            Assert.Equal(ArteryTagKind.Literal, decoded.RecipientKind);
+            Assert.True(decoded.TryGetRecipientPath(out var decodedRecipient));
+            Assert.Equal(recipientPath, decodedRecipient);
+
+            Assert.Equal(ArteryTagKind.Literal, decoded.ManifestKind);
+            Assert.True(decoded.TryGetManifest(out var decodedManifest));
+            Assert.Equal(manifest, decodedManifest);
+
+            Assert.Equal(payload, decoded.Payload.ToArray());
+        }
+
+        [Fact(DisplayName = "Should_round_trip_mixed_tags_When_only_recipient_is_a_literal")]
+        public void Should_round_trip_mixed_tags_When_only_recipient_is_a_literal()
+        {
+            const string recipientPath = "akka://Sys@host:1/user/only-recipient";
+            var payload = MakePayload(8, seed: 3);
+
+            var (frame, _) = EncodeToFrame(originUid: 1L, serializerId: 5,
+                senderPath: null, recipientPath, manifest: "", payload);
+
+            var decoded = ArteryEnvelopeCodec.Decode(EnvelopeBody(frame));
+
+            Assert.Equal(ArteryTagKind.Absent, decoded.SenderKind);
+            Assert.True(decoded.TryGetSenderPath(out var sender));
+            Assert.Null(sender);
+
+            Assert.Equal(ArteryTagKind.Literal, decoded.RecipientKind);
+            Assert.True(decoded.TryGetRecipientPath(out var recipient));
+            Assert.Equal(recipientPath, recipient);
+
+            Assert.Equal(ArteryTagKind.Absent, decoded.ManifestKind);
+            Assert.True(decoded.TryGetManifest(out var manifest));
+            Assert.Equal(string.Empty, manifest);
+
+            Assert.Equal(payload, decoded.Payload.ToArray());
+        }
+
+        [Fact(DisplayName = "Should_round_trip_an_empty_payload_When_all_tags_are_literal")]
+        public void Should_round_trip_an_empty_payload_When_all_tags_are_literal()
+        {
+            const string senderPath = "akka://Sys@host:1/user/sender";
+            const string recipientPath = "akka://Sys@host:1/user/recipient";
+            const string manifest = "some.manifest";
+
+            var (frame, totalLength) = EncodeToFrame(originUid: 7L, serializerId: 1,
+                senderPath, recipientPath, manifest, ReadOnlySpan<byte>.Empty);
+
+            var decoded = ArteryEnvelopeCodec.Decode(EnvelopeBody(frame));
+
+            Assert.Equal(0, decoded.Payload.Length);
+            Assert.Equal(totalLength, FrameLengthFieldLength + decoded.Header.PayloadOffset);
+        }
+
+        [Fact(DisplayName = "Should_round_trip_a_multi_kilobyte_payload_When_encoding_and_decoding")]
+        public void Should_round_trip_a_multi_kilobyte_payload_When_encoding_and_decoding()
+        {
+            var payload = MakePayload(6_000, seed: 4);
+
+            var (frame, totalLength) = EncodeToFrame(originUid: 555L, serializerId: 9,
+                senderPath: "/user/a", recipientPath: "/user/b", manifest: "m", payload);
+
+            Assert.Equal(totalLength - FrameLengthFieldLength, ReadFrameLength(frame));
+
+            var decoded = ArteryEnvelopeCodec.Decode(EnvelopeBody(frame));
+            Assert.Equal(payload, decoded.Payload.ToArray());
+        }
+
+        // ===================== decode from a multi-segment ReadOnlySequence<byte> =====================
+
+        [Fact(DisplayName = "Should_decode_correctly_When_the_fixed_header_is_split_across_segments")]
+        public void Should_decode_correctly_When_the_fixed_header_is_split_across_segments()
+        {
+            const string senderPath = "/user/sender";
+            const string manifest = "manifest-x";
+            var payload = MakePayload(32, seed: 5);
+
+            var (frame, _) = EncodeToFrame(originUid: 42L, serializerId: 2,
+                senderPath, recipientPath: null, manifest, payload);
+            var body = EnvelopeBody(frame).ToArray();
+
+            // Split at byte 10 -- squarely inside the 32-byte fixed header.
+            var segmented = TwoSegment(body, splitAt: 10);
+
+            var decoded = ArteryEnvelopeCodec.Decode(segmented);
+
+            Assert.Equal(42L, decoded.Header.OriginUid);
+            Assert.Equal(2, decoded.Header.SerializerId);
+            Assert.True(decoded.TryGetSenderPath(out var decodedSender));
+            Assert.Equal(senderPath, decodedSender);
+            Assert.True(decoded.TryGetManifest(out var decodedManifest));
+            Assert.Equal(manifest, decodedManifest);
+            Assert.Equal(payload, decoded.Payload.ToArray());
+        }
+
+        [Fact(DisplayName = "Should_decode_correctly_When_a_literal_is_split_across_segments")]
+        public void Should_decode_correctly_When_a_literal_is_split_across_segments()
+        {
+            const string senderPath = "akka://Sys@host:1/user/a-fairly-long-sender-path-for-splitting";
+            var payload = MakePayload(8, seed: 6);
+
+            var (frame, _) = EncodeToFrame(originUid: 1L, serializerId: 1,
+                senderPath, recipientPath: null, manifest: "", payload);
+            var body = EnvelopeBody(frame).ToArray();
+
+            // The sender literal starts right after the 32-byte header (offset 32) with a 2-byte
+            // length prefix, so offset 40 is a few bytes into the literal's UTF-8 data.
+            var segmented = TwoSegment(body, splitAt: 40);
+
+            var decoded = ArteryEnvelopeCodec.Decode(segmented);
+
+            Assert.True(decoded.TryGetSenderPath(out var decodedSender));
+            Assert.Equal(senderPath, decodedSender);
+            Assert.Equal(payload, decoded.Payload.ToArray());
+        }
+
+        // ===================== rejections =====================
+
+        [Fact(DisplayName = "Should_throw_ArteryEnvelopeException_When_the_version_is_not_1")]
+        public void Should_throw_ArteryEnvelopeException_When_the_version_is_not_1()
+        {
+            var header = BuildRawHeader(version: 2, flags: 0, originUid: 0, serializerId: 0,
+                senderTag: 0, recipientTag: 0, manifestTag: 0, payloadOffset: HeaderLength);
+
+            Assert.Throws<ArteryEnvelopeException>(() => ArteryEnvelopeCodec.Decode(new ReadOnlySequence<byte>(header)));
+        }
+
+        [Fact(DisplayName = "Should_throw_ArteryEnvelopeException_When_a_reserved_flag_bit_is_set")]
+        public void Should_throw_ArteryEnvelopeException_When_a_reserved_flag_bit_is_set()
+        {
+            var header = BuildRawHeader(version: 1, flags: 0b0000_0010, originUid: 0, serializerId: 0,
+                senderTag: 0, recipientTag: 0, manifestTag: 0, payloadOffset: HeaderLength);
+
+            Assert.Throws<ArteryEnvelopeException>(() => ArteryEnvelopeCodec.Decode(new ReadOnlySequence<byte>(header)));
+        }
+
+        [Fact(DisplayName = "Should_throw_ArteryEnvelopeException_When_a_literal_tag_offset_is_less_than_32")]
+        public void Should_throw_ArteryEnvelopeException_When_a_literal_tag_offset_is_less_than_32()
+        {
+            var header = BuildRawHeader(version: 1, flags: 0, originUid: 0, serializerId: 0,
+                senderTag: 10, recipientTag: 0, manifestTag: 0, payloadOffset: HeaderLength);
+
+            var decoded = ArteryEnvelopeCodec.Decode(new ReadOnlySequence<byte>(header));
+            Assert.Throws<ArteryEnvelopeException>(() => decoded.TryGetSenderPath(out _));
+        }
+
+        [Fact(DisplayName = "Should_throw_ArteryEnvelopeException_When_a_literal_tag_offset_points_past_the_payload_offset")]
+        public void Should_throw_ArteryEnvelopeException_When_a_literal_tag_offset_points_past_the_payload_offset()
+        {
+            // payloadOffset = 32 (no room for any literal), but the sender tag claims a literal at
+            // offset 32 -- exactly at, not before, the payload offset.
+            var header = BuildRawHeader(version: 1, flags: 0, originUid: 0, serializerId: 0,
+                senderTag: 32, recipientTag: 0, manifestTag: 0, payloadOffset: HeaderLength);
+
+            var decoded = ArteryEnvelopeCodec.Decode(new ReadOnlySequence<byte>(header));
+            Assert.Throws<ArteryEnvelopeException>(() => decoded.TryGetSenderPath(out _));
+        }
+
+        [Fact(DisplayName = "Should_throw_ArteryEnvelopeException_When_a_literal_length_is_truncated")]
+        public void Should_throw_ArteryEnvelopeException_When_a_literal_length_is_truncated()
+        {
+            // payloadOffset = 34: room for the sender literal's 2-byte length prefix (at [32,34))
+            // but zero bytes for its declared 5-byte body before the payload starts.
+            var header = BuildRawHeader(version: 1, flags: 0, originUid: 0, serializerId: 0,
+                senderTag: 32, recipientTag: 0, manifestTag: 0, payloadOffset: 34);
+            var frame = new byte[34];
+            header.CopyTo(frame, 0);
+            BinaryPrimitives.WriteUInt16LittleEndian(frame.AsSpan(32, 2), 5); // declares 5 bytes; none are available
+
+            var decoded = ArteryEnvelopeCodec.Decode(new ReadOnlySequence<byte>(frame));
+            Assert.Throws<ArteryEnvelopeException>(() => decoded.TryGetSenderPath(out _));
+        }
+
+        [Fact(DisplayName = "Should_throw_ArteryEnvelopeException_When_the_declared_payload_offset_is_beyond_the_frame_end")]
+        public void Should_throw_ArteryEnvelopeException_When_the_declared_payload_offset_is_beyond_the_frame_end()
+        {
+            var header = BuildRawHeader(version: 1, flags: 0, originUid: 0, serializerId: 0,
+                senderTag: 0, recipientTag: 0, manifestTag: 0, payloadOffset: 1000);
+
+            Assert.Throws<ArteryEnvelopeException>(() => ArteryEnvelopeCodec.Decode(new ReadOnlySequence<byte>(header)));
+        }
+
+        [Fact(DisplayName = "Should_throw_ArteryEnvelopeException_When_the_declared_payload_offset_is_less_than_32")]
+        public void Should_throw_ArteryEnvelopeException_When_the_declared_payload_offset_is_less_than_32()
+        {
+            var header = BuildRawHeader(version: 1, flags: 0, originUid: 0, serializerId: 0,
+                senderTag: 0, recipientTag: 0, manifestTag: 0, payloadOffset: 10);
+
+            Assert.Throws<ArteryEnvelopeException>(() => ArteryEnvelopeCodec.Decode(new ReadOnlySequence<byte>(header)));
+        }
+
+        [Fact(DisplayName = "Should_throw_ArteryEnvelopeException_When_encoding_a_literal_over_64KB")]
+        public void Should_throw_ArteryEnvelopeException_When_encoding_a_literal_over_64KB()
+        {
+            var oversizedSenderPath = new string('a', 70_000);
+            var destination = new byte[200_000];
+
+            Assert.Throws<ArteryEnvelopeException>(() => ArteryEnvelopeCodec.Encode(
+                destination, originUid: 1L, serializerId: 1,
+                senderPath: oversizedSenderPath, recipientPath: null, manifest: "", ReadOnlySpan<byte>.Empty));
+        }
+
+        // ===================== COMPRESSED tag decode =====================
+
+        [Fact(DisplayName = "Should_surface_the_compressed_index_and_report_TryGet_false_When_a_tag_is_compressed")]
+        public void Should_surface_the_compressed_index_and_report_TryGet_false_When_a_tag_is_compressed()
+        {
+            const uint compressedSenderTag = 0xFF00_0000u | 7u;
+            var header = BuildRawHeader(version: 1, flags: 0, originUid: 0, serializerId: 0,
+                senderTag: compressedSenderTag, recipientTag: 0, manifestTag: 0, payloadOffset: HeaderLength);
+
+            var decoded = ArteryEnvelopeCodec.Decode(new ReadOnlySequence<byte>(header));
+
+            Assert.Equal(ArteryTagKind.Compressed, decoded.SenderKind);
+            Assert.Equal(7, decoded.SenderCompressedIndex);
+            Assert.False(decoded.TryGetSenderPath(out var path));
+            Assert.Null(path);
+        }
+
+        // ===================== helpers =====================
+
+        private static byte[] MakePayload(int length, int seed)
+        {
+            var payload = new byte[length];
+            new Random(seed).NextBytes(payload);
+            return payload;
+        }
+
+        private static (byte[] frame, int totalLength) EncodeToFrame(
+            long originUid, int serializerId, string? senderPath, string? recipientPath, string manifest, ReadOnlySpan<byte> payload)
+        {
+            var destination = new byte[ArteryEnvelopeCodec.MaxEncodedSize(senderPath, recipientPath, manifest, payload.Length)];
+            var totalLength = ArteryEnvelopeCodec.Encode(destination, originUid, serializerId, senderPath, recipientPath, manifest, payload);
+            Assert.Equal(destination.Length, totalLength);
+            return (destination, totalLength);
+        }
+
+        private static int ReadFrameLength(byte[] frame) => (int)BinaryPrimitives.ReadUInt32LittleEndian(frame);
+
+        private static ReadOnlySequence<byte> EnvelopeBody(byte[] frame) =>
+            new(frame, FrameLengthFieldLength, frame.Length - FrameLengthFieldLength);
+
+        private static int LiteralWireSize(string? value) =>
+            string.IsNullOrEmpty(value) ? 0 : 2 + Encoding.UTF8.GetByteCount(value);
+
+        private static byte[] BuildRawHeader(
+            byte version, byte flags, long originUid, int serializerId,
+            uint senderTag, uint recipientTag, uint manifestTag, uint payloadOffset)
+        {
+            var header = new byte[HeaderLength];
+            header[0] = version;
+            header[1] = flags;
+            header[2] = 0;
+            header[3] = 0;
+            BinaryPrimitives.WriteInt64LittleEndian(header.AsSpan(4), originUid);
+            BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(12), serializerId);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(16), senderTag);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(20), recipientTag);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(24), manifestTag);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.AsSpan(28), payloadOffset);
+            return header;
+        }
+
+        /// <summary>Splits <paramref name="bytes"/> into two chained segments at <paramref name="splitAt"/>, for multi-segment decode tests.</summary>
+        private static ReadOnlySequence<byte> TwoSegment(byte[] bytes, int splitAt)
+        {
+            if (splitAt <= 0 || splitAt >= bytes.Length)
+                throw new ArgumentOutOfRangeException(nameof(splitAt));
+
+            var first = new Segment(bytes.AsMemory(0, splitAt));
+            var second = first.Append(bytes.AsMemory(splitAt));
+            return new ReadOnlySequence<byte>(first, 0, second, second.Memory.Length);
+        }
+
+        private sealed class Segment : ReadOnlySequenceSegment<byte>
+        {
+            public Segment(ReadOnlyMemory<byte> memory) => Memory = memory;
+
+            public Segment Append(ReadOnlyMemory<byte> memory)
+            {
+                var segment = new Segment(memory) { RunningIndex = RunningIndex + Memory.Length };
+                Next = segment;
+                return segment;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Covers <see cref="ArteryEnvelopeCodec"/>'s V2 single-pass encode overload, which needs a live
+    /// <c>ActorSystem</c>'s <see cref="Akka.Serialization.Serialization"/> extension to resolve a
+    /// serializer + manifest for a real message object.
+    /// </summary>
+    public class ArteryEnvelopeCodecV2Spec : AkkaSpec
+    {
+        public ArteryEnvelopeCodecV2Spec(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact(DisplayName = "Should_round_trip_a_serialized_message_When_using_the_V2_single_pass_encode_overload")]
+        public void Should_round_trip_a_serialized_message_When_using_the_V2_single_pass_encode_overload()
+        {
+            const string senderPath = "akka://Sys@host:1/user/sender";
+            const string recipientPath = "akka://Sys@host:1/user/recipient";
+            const long originUid = 0x0102_0304_0506_0708L;
+            const string message = "hello artery, this is a real message payload";
+
+            using var writer = ArteryEnvelopeCodec.Encode(Sys.Serialization, originUid, senderPath, recipientPath, message);
+
+            var frameLength = (int)System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(writer.WrittenSpan);
+            Assert.Equal(writer.WrittenCount - 4, frameLength);
+
+            var body = new ReadOnlySequence<byte>(writer.WrittenMemory.Slice(4));
+            var decoded = ArteryEnvelopeCodec.Decode(body);
+
+            Assert.Equal(originUid, decoded.Header.OriginUid);
+
+            Assert.True(decoded.TryGetSenderPath(out var decodedSender));
+            Assert.Equal(senderPath, decodedSender);
+
+            Assert.True(decoded.TryGetRecipientPath(out var decodedRecipient));
+            Assert.Equal(recipientPath, decodedRecipient);
+
+            Assert.True(decoded.TryGetManifest(out var decodedManifest));
+
+            var deserialized = Sys.Serialization.Deserialize(decoded.Payload, decoded.Header.SerializerId, decodedManifest);
+            Assert.Equal(message, deserialized);
+        }
+
+        [Fact(DisplayName = "Should_encode_absent_sender_and_recipient_tags_When_none_are_supplied_to_the_V2_overload")]
+        public void Should_encode_absent_sender_and_recipient_tags_When_none_are_supplied_to_the_V2_overload()
+        {
+            const string message = "no sender, no recipient";
+
+            using var writer = ArteryEnvelopeCodec.Encode(Sys.Serialization, originUid: 1L, senderPath: null, recipientPath: null, message);
+
+            var body = new ReadOnlySequence<byte>(writer.WrittenMemory.Slice(4));
+            var decoded = ArteryEnvelopeCodec.Decode(body);
+
+            Assert.Equal(ArteryTagKind.Absent, decoded.SenderKind);
+            Assert.True(decoded.TryGetSenderPath(out var sender));
+            Assert.Null(sender);
+
+            Assert.Equal(ArteryTagKind.Absent, decoded.RecipientKind);
+            Assert.True(decoded.TryGetRecipientPath(out var recipient));
+            Assert.Null(recipient);
+
+            var deserialized = Sys.Serialization.Deserialize(decoded.Payload, decoded.Header.SerializerId, decoded.TryGetManifest(out var m) ? m : string.Empty);
+            Assert.Equal(message, deserialized);
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/Artery/ArteryFramingSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryFramingSpec.cs
@@ -1,0 +1,316 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryFramingSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Buffers;
+using System.Linq;
+using Akka.Remote.Artery;
+using FluentAssertions;
+using Xunit;
+
+namespace Akka.Remote.Tests.Artery
+{
+    /// <summary>
+    /// Unit tests for the G1 "TCP Framing Foundation" primitives: the Artery connection
+    /// preamble codec (<see cref="ArteryConnectionHeader"/>) and the incremental frame
+    /// parser (<see cref="ArteryFrameParser"/>). No <c>ActorSystem</c> is needed — these are
+    /// pure, allocation-conscious binary codecs. See
+    /// <c>openspec/changes/artery-tcp-remoting/design.md</c> ("Envelope wire layout" /
+    /// Decision 3) for the wire format under test.
+    /// </summary>
+    public class ArteryFramingSpec
+    {
+        #region ArteryConnectionHeader
+
+        // NOTE: the theory parameter is the raw stream-id byte (not ArteryStreamId) because
+        // ArteryStreamId is `internal` - a public [Theory] method cannot declare a parameter
+        // of a less-accessible type (CS0051). The enum is reconstructed inside the method.
+        [Theory(DisplayName = "ArteryConnectionHeader should round-trip write and parse for every stream id")]
+        [InlineData((byte)1)]
+        [InlineData((byte)2)]
+        [InlineData((byte)3)]
+        public void ArteryConnectionHeader_should_round_trip_every_stream_id(byte rawStreamId)
+        {
+            var streamId = (ArteryStreamId)rawStreamId;
+            Span<byte> buffer = stackalloc byte[ArteryConnectionHeader.Length];
+            ArteryConnectionHeader.WriteTo(buffer, streamId);
+
+            var sequence = new ReadOnlySequence<byte>(buffer.ToArray());
+            var result = ArteryConnectionHeader.TryParse(sequence, out var parsedStreamId, out var bytesConsumed);
+
+            result.Should().Be(ArteryConnectionHeaderParseResult.Success);
+            parsedStreamId.Should().Be(streamId);
+            bytesConsumed.Should().Be(ArteryConnectionHeader.Length);
+        }
+
+        [Theory(DisplayName = "ArteryConnectionHeader should report NeedMoreData for fewer than 5 bytes")]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void ArteryConnectionHeader_should_need_more_data_for_partial_input(int availableBytes)
+        {
+            var full = new byte[ArteryConnectionHeader.Length];
+            ArteryConnectionHeader.WriteTo(full, ArteryStreamId.Ordinary);
+            var partial = new ReadOnlySequence<byte>(full.AsMemory(0, availableBytes));
+
+            var result = ArteryConnectionHeader.TryParse(partial, out var streamId, out var bytesConsumed);
+
+            result.Should().Be(ArteryConnectionHeaderParseResult.NeedMoreData);
+            bytesConsumed.Should().Be(0);
+        }
+
+        [Fact(DisplayName = "ArteryConnectionHeader should throw ArteryFramingException on bad magic bytes")]
+        public void ArteryConnectionHeader_should_throw_on_bad_magic()
+        {
+            var bytes = new byte[] { (byte)'N', (byte)'O', (byte)'P', (byte)'E', (byte)ArteryStreamId.Control };
+            var sequence = new ReadOnlySequence<byte>(bytes);
+
+            Assert.Throws<ArteryFramingException>(() =>
+                ArteryConnectionHeader.TryParse(sequence, out _, out _));
+        }
+
+        [Theory(DisplayName = "ArteryConnectionHeader should throw ArteryFramingException on an unknown stream id byte")]
+        [InlineData((byte)0)]
+        [InlineData((byte)4)]
+        [InlineData((byte)255)]
+        public void ArteryConnectionHeader_should_throw_on_unknown_stream_id(byte unknownStreamId)
+        {
+            var bytes = new byte[] { (byte)'A', (byte)'K', (byte)'K', (byte)'A', unknownStreamId };
+            var sequence = new ReadOnlySequence<byte>(bytes);
+
+            Assert.Throws<ArteryFramingException>(() =>
+                ArteryConnectionHeader.TryParse(sequence, out _, out _));
+        }
+
+        #endregion
+
+        #region ArteryFrameParser - construction
+
+        [Theory(DisplayName = "ArteryFrameParser constructor should reject a non-positive maxFrameLength")]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void ArteryFrameParser_ctor_should_reject_non_positive_max_frame_length(int maxFrameLength)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ArteryFrameParser(maxFrameLength));
+        }
+
+        [Fact(DisplayName = "ArteryFrameParser constructor should reject a maxFrameLength above 0x00FFFFFF")]
+        public void ArteryFrameParser_ctor_should_reject_max_frame_length_above_hard_cap()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new ArteryFrameParser(ArteryFrameParser.MaxAllowedFrameLength + 1));
+        }
+
+        [Fact(DisplayName = "ArteryFrameParser constructor should accept the hard-cap maxFrameLength")]
+        public void ArteryFrameParser_ctor_should_accept_hard_cap_max_frame_length()
+        {
+            var parser = new ArteryFrameParser(ArteryFrameParser.MaxAllowedFrameLength);
+            parser.MaxFrameLength.Should().Be(ArteryFrameParser.MaxAllowedFrameLength);
+        }
+
+        #endregion
+
+        #region ArteryFrameParser - basic framing
+
+        [Fact(DisplayName = "ArteryFrameParser should parse a single complete frame delivered in one chunk")]
+        public void ArteryFrameParser_should_parse_single_complete_frame_in_one_chunk()
+        {
+            var parser = new ArteryFrameParser(1024);
+            var body = Bytes("hello, artery");
+            var encoded = Encode(body);
+
+            parser.Append(encoded);
+
+            parser.TryReadFrame(out var frame).Should().BeTrue();
+            frame.ToArray().Should().Equal(body);
+            frame.IsSingleSegment.Should().BeTrue();
+
+            // No more frames buffered.
+            parser.TryReadFrame(out _).Should().BeFalse();
+        }
+
+        [Fact(DisplayName = "ArteryFrameParser should parse a frame delivered one byte at a time")]
+        public void ArteryFrameParser_should_parse_frame_delivered_byte_by_byte()
+        {
+            var parser = new ArteryFrameParser(1024);
+            var body = Bytes("worst-case fragmentation");
+            var encoded = Encode(body);
+
+            for (var i = 0; i < encoded.Length - 1; i++)
+            {
+                parser.Append(new[] { encoded[i] });
+                parser.TryReadFrame(out _).Should().BeFalse("the frame is not yet fully buffered");
+            }
+
+            // Append the final byte - the frame should now be complete.
+            parser.Append(new[] { encoded[^1] });
+
+            parser.TryReadFrame(out var frame).Should().BeTrue();
+            frame.ToArray().Should().Equal(body);
+        }
+
+        [Fact(DisplayName = "ArteryFrameParser should parse multiple frames delivered in a single chunk")]
+        public void ArteryFrameParser_should_parse_multiple_frames_in_one_chunk()
+        {
+            var parser = new ArteryFrameParser(1024);
+            var body1 = Bytes("first frame");
+            var body2 = Bytes("second frame, a bit longer");
+            var body3 = Bytes("");
+
+            var combined = Encode(body1).Concat(Encode(body2)).Concat(Encode(body3)).ToArray();
+            parser.Append(combined);
+
+            parser.TryReadFrame(out var frame1).Should().BeTrue();
+            frame1.ToArray().Should().Equal(body1);
+
+            parser.TryReadFrame(out var frame2).Should().BeTrue();
+            frame2.ToArray().Should().Equal(body2);
+
+            parser.TryReadFrame(out var frame3).Should().BeTrue();
+            frame3.ToArray().Should().Equal(body3);
+            frame3.Length.Should().Be(0);
+
+            parser.TryReadFrame(out _).Should().BeFalse();
+        }
+
+        [Fact(DisplayName = "ArteryFrameParser should parse a frame spanning three or more appended chunks")]
+        public void ArteryFrameParser_should_parse_frame_spanning_multiple_chunks()
+        {
+            var parser = new ArteryFrameParser(1024);
+            var body = Bytes("a frame body long enough to split across several chunks of input");
+            var encoded = Encode(body);
+
+            // Split into 5 chunks of varying (small) size so the frame body definitely spans
+            // more than the length-field chunk.
+            var chunkSize = Math.Max(1, encoded.Length / 5);
+            var offset = 0;
+            var chunkCount = 0;
+            while (offset < encoded.Length)
+            {
+                var take = Math.Min(chunkSize, encoded.Length - offset);
+                parser.Append(encoded.AsMemory(offset, take));
+                offset += take;
+                chunkCount++;
+            }
+
+            chunkCount.Should().BeGreaterOrEqualTo(3, "the test setup should actually exercise multi-chunk spanning");
+
+            parser.TryReadFrame(out var frame).Should().BeTrue();
+            frame.ToArray().Should().Equal(body);
+            frame.IsSingleSegment.Should().BeFalse("the body was delivered across multiple appended chunks");
+        }
+
+        [Fact(DisplayName = "ArteryFrameParser should handle interleaved partial-then-complete sequences")]
+        public void ArteryFrameParser_should_handle_interleaved_partial_then_complete_sequences()
+        {
+            var parser = new ArteryFrameParser(1024);
+            var body1 = Bytes("alpha");
+            var body2 = Bytes("beta, a somewhat longer message body");
+            var encoded1 = Encode(body1);
+            var encoded2 = Encode(body2);
+
+            // Deliver frame 1 in two partial pieces.
+            var splitPoint = encoded1.Length / 2;
+            parser.Append(encoded1.AsMemory(0, splitPoint));
+            parser.TryReadFrame(out _).Should().BeFalse();
+
+            parser.Append(encoded1.AsMemory(splitPoint));
+            parser.TryReadFrame(out var frame1).Should().BeTrue();
+            frame1.ToArray().Should().Equal(body1);
+
+            // Deliver frame 2's length field and part of its body, then the rest.
+            var lengthPlusPartialBody = ArteryFrameParser.LengthFieldSize + (body2.Length / 3);
+            parser.Append(encoded2.AsMemory(0, lengthPlusPartialBody));
+            parser.TryReadFrame(out _).Should().BeFalse();
+
+            parser.Append(encoded2.AsMemory(lengthPlusPartialBody));
+            parser.TryReadFrame(out var frame2).Should().BeTrue();
+            frame2.ToArray().Should().Equal(body2);
+
+            parser.TryReadFrame(out _).Should().BeFalse();
+        }
+
+        #endregion
+
+        #region ArteryFrameParser - length boundaries
+
+        [Fact(DisplayName = "ArteryFrameParser should parse a legal empty-body frame")]
+        public void ArteryFrameParser_should_parse_empty_body_frame()
+        {
+            var parser = new ArteryFrameParser(1024);
+            parser.Append(Encode(Array.Empty<byte>()));
+
+            parser.TryReadFrame(out var frame).Should().BeTrue();
+            frame.Length.Should().Be(0);
+        }
+
+        [Fact(DisplayName = "ArteryFrameParser should accept a body of exactly maxFrameLength")]
+        public void ArteryFrameParser_should_accept_body_of_exactly_max_frame_length()
+        {
+            const int maxFrameLength = 64;
+            var parser = new ArteryFrameParser(maxFrameLength);
+            var body = new byte[maxFrameLength];
+            new Random(42).NextBytes(body);
+
+            parser.Append(Encode(body));
+
+            parser.TryReadFrame(out var frame).Should().BeTrue();
+            frame.ToArray().Should().Equal(body);
+        }
+
+        [Fact(DisplayName = "ArteryFrameParser should throw ArteryFramingException for a body of maxFrameLength + 1")]
+        public void ArteryFrameParser_should_throw_for_body_exceeding_max_frame_length()
+        {
+            const int maxFrameLength = 64;
+            var parser = new ArteryFrameParser(maxFrameLength);
+            var body = new byte[maxFrameLength + 1];
+
+            parser.Append(Encode(body));
+
+            Assert.Throws<ArteryFramingException>(() => parser.TryReadFrame(out _));
+        }
+
+        #endregion
+
+        #region ArteryFrameParser - reuse
+
+        [Fact(DisplayName = "ArteryFrameParser should support continued append/read cycles after yielding frames")]
+        public void ArteryFrameParser_should_support_reuse_after_yielding_frames()
+        {
+            var parser = new ArteryFrameParser(1024);
+
+            for (var i = 0; i < 5; i++)
+            {
+                var body = Bytes($"message #{i}");
+                parser.Append(Encode(body));
+
+                parser.TryReadFrame(out var frame).Should().BeTrue();
+                frame.ToArray().Should().Equal(body);
+                parser.TryReadFrame(out _).Should().BeFalse();
+            }
+        }
+
+        #endregion
+
+        #region Test helpers
+
+        private static byte[] Bytes(string s) => System.Text.Encoding.UTF8.GetBytes(s);
+
+        /// <summary>Encodes a frame as <c>[4B LE length][body]</c>, matching <see cref="ArteryFrameParser"/>'s wire format.</summary>
+        private static byte[] Encode(byte[] body)
+        {
+            var frame = new byte[ArteryFrameParser.LengthFieldSize + body.Length];
+            ArteryFrameParser.WriteFrameLength(frame, body.Length);
+            body.CopyTo(frame, ArteryFrameParser.LengthFieldSize);
+            return frame;
+        }
+
+        #endregion
+    }
+}

--- a/src/core/Akka.Remote/Artery/ArteryConnectionHeader.cs
+++ b/src/core/Akka.Remote/Artery/ArteryConnectionHeader.cs
@@ -1,0 +1,148 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryConnectionHeader.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Buffers;
+
+namespace Akka.Remote.Artery
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Result of <see cref="ArteryConnectionHeader.TryParse"/>. Together with the exception
+    /// thrown for malformed input, this makes the parse outcome a tri-state:
+    /// <see cref="NeedMoreData"/> (not an error — the caller should append more bytes and
+    /// retry), <see cref="Success"/>, or an <see cref="ArteryFramingException"/> thrown
+    /// synchronously for a structurally invalid preamble (bad magic / unknown stream id).
+    /// </summary>
+    internal enum ArteryConnectionHeaderParseResult
+    {
+        /// <summary>Fewer than <see cref="ArteryConnectionHeader.Length"/> bytes were available; not an error.</summary>
+        NeedMoreData = 0,
+
+        /// <summary>A well-formed preamble was parsed; <c>streamId</c>/<c>bytesConsumed</c> out-parameters are valid.</summary>
+        Success = 1
+    }
+
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Codec for the Artery TCP connection preamble — written exactly once per TCP
+    /// connection, before any framed messages: 4 bytes of ASCII <c>AKKA</c> magic followed
+    /// by a 1-byte <see cref="ArteryStreamId"/>. See
+    /// <c>openspec/changes/artery-tcp-remoting/design.md</c> ("Envelope wire layout" /
+    /// Decision 3): <c>Connection preamble (once per TCP connection): AKKA magic (4B) +
+    /// stream id (1B: 1=control, 2=ordinary, 3=large)</c>.
+    ///
+    /// <para>
+    /// This type is a pure codec with no buffering of its own; it is intended to be wrapped
+    /// by a stream/GraphStage in a later Artery task that owns the incoming byte buffer and
+    /// retries <see cref="TryParse"/> as more bytes arrive.
+    /// </para>
+    /// </summary>
+    internal static class ArteryConnectionHeader
+    {
+        /// <summary>ASCII magic byte 'A'.</summary>
+        private const byte MagicA = (byte)'A';
+
+        /// <summary>ASCII magic byte 'K'.</summary>
+        private const byte MagicK = (byte)'K';
+
+        /// <summary>Total length of the connection preamble, in bytes: 4-byte magic + 1-byte stream id.</summary>
+        public const int Length = 5;
+
+        /// <summary>Byte offset of the stream-id byte within the preamble.</summary>
+        private const int StreamIdOffset = 4;
+
+        /// <summary>
+        /// Writes the 5-byte connection preamble (<c>AKKA</c> magic + stream id) to
+        /// <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">
+        /// The destination span. Must be at least <see cref="Length"/> bytes long.
+        /// </param>
+        /// <param name="streamId">The stream identifier to write.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="destination"/> is shorter than <see cref="Length"/>.
+        /// </exception>
+        public static void WriteTo(Span<byte> destination, ArteryStreamId streamId)
+        {
+            if (destination.Length < Length)
+                throw new ArgumentException(
+                    $"Destination span must be at least {Length} bytes long to hold the Artery connection preamble, but was {destination.Length}.",
+                    nameof(destination));
+
+            destination[0] = MagicA;
+            destination[1] = MagicK;
+            destination[2] = MagicK;
+            destination[3] = MagicA;
+            destination[StreamIdOffset] = (byte)streamId;
+        }
+
+        /// <summary>
+        /// Attempts to parse a connection preamble from the front of <paramref name="buffer"/>.
+        /// </summary>
+        /// <param name="buffer">
+        /// The accumulated, not-yet-consumed bytes read from the connection so far. Only the
+        /// first <see cref="Length"/> bytes are inspected; any bytes beyond that are left
+        /// untouched (the caller advances its own buffer by <paramref name="bytesConsumed"/>
+        /// on <see cref="ArteryConnectionHeaderParseResult.Success"/>).
+        /// </param>
+        /// <param name="streamId">
+        /// On <see cref="ArteryConnectionHeaderParseResult.Success"/>, the parsed stream id.
+        /// Undefined (default) otherwise.
+        /// </param>
+        /// <param name="bytesConsumed">
+        /// On <see cref="ArteryConnectionHeaderParseResult.Success"/>, always <see cref="Length"/>.
+        /// Zero otherwise.
+        /// </param>
+        /// <returns>
+        /// <see cref="ArteryConnectionHeaderParseResult.NeedMoreData"/> if fewer than
+        /// <see cref="Length"/> bytes are available (not an error — the caller should append
+        /// more data and retry); <see cref="ArteryConnectionHeaderParseResult.Success"/> once
+        /// a well-formed preamble is parsed.
+        /// </returns>
+        /// <exception cref="ArteryFramingException">
+        /// The magic bytes are not <c>AKKA</c>, or the stream-id byte is not one of the
+        /// values defined by <see cref="ArteryStreamId"/>.
+        /// </exception>
+        public static ArteryConnectionHeaderParseResult TryParse(
+            ReadOnlySequence<byte> buffer,
+            out ArteryStreamId streamId,
+            out int bytesConsumed)
+        {
+            streamId = default;
+            bytesConsumed = 0;
+
+            if (buffer.Length < Length)
+                return ArteryConnectionHeaderParseResult.NeedMoreData;
+
+            Span<byte> header = stackalloc byte[Length];
+            buffer.Slice(0, Length).CopyTo(header);
+
+            if (header[0] != MagicA || header[1] != MagicK || header[2] != MagicK || header[3] != MagicA)
+                throw new ArteryFramingException(
+                    $"Invalid Artery connection preamble: expected 'AKKA' magic bytes, got " +
+                    $"[0x{header[0]:X2} 0x{header[1]:X2} 0x{header[2]:X2} 0x{header[3]:X2}].");
+
+            var streamIdByte = header[StreamIdOffset];
+            streamId = streamIdByte switch
+            {
+                (byte)ArteryStreamId.Control => ArteryStreamId.Control,
+                (byte)ArteryStreamId.Ordinary => ArteryStreamId.Ordinary,
+                (byte)ArteryStreamId.Large => ArteryStreamId.Large,
+                _ => throw new ArteryFramingException(
+                    $"Unknown Artery stream id byte {streamIdByte}; expected 1 (Control), 2 (Ordinary), or 3 (Large).")
+            };
+
+            bytesConsumed = Length;
+            return ArteryConnectionHeaderParseResult.Success;
+        }
+    }
+}

--- a/src/core/Akka.Remote/Artery/ArteryEnvelopeCodec.cs
+++ b/src/core/Akka.Remote/Artery/ArteryEnvelopeCodec.cs
@@ -1,0 +1,530 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryEnvelopeCodec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Akka.Remote.Artery
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Encodes and decodes the Artery envelope described in
+    /// <c>openspec/changes/artery-tcp-remoting/design.md</c> ("Envelope wire layout" / Decision 4):
+    /// a 32-byte fixed header (<see cref="ArteryEnvelopeFixedHeader"/>) followed by an optional
+    /// metadata section, then length-prefixed UTF-8 literals for any LITERAL sender/recipient/
+    /// manifest tag, then the serialized payload. The whole frame on the wire is
+    /// <c>[u32 LE frame length][envelope]</c>; the frame length is always back-patched from actual
+    /// bytes written, never predicted from a size hint.
+    ///
+    /// <para>
+    /// This codec is deliberately separate from <see cref="Akka.Serialization.SerializerV2"/>
+    /// (Decision 4): the envelope owns remoting metadata (version, flags, origin UID, serializer id,
+    /// manifest, sender, recipient, payload boundaries); <c>SerializerV2</c> owns the payload bytes.
+    /// </para>
+    /// </summary>
+    internal static class ArteryEnvelopeCodec
+    {
+        /// <summary>
+        /// Total encoded size for an explicit-parts encode with the given sender/recipient/manifest
+        /// strings and payload length. Callers use this to rent a big-enough destination buffer
+        /// before calling <see cref="Encode(Span{byte},long,int,string?,string?,string,ReadOnlySpan{byte})"/>.
+        /// This is an exact size (not merely an upper bound) because, unlike the V2 single-pass
+        /// overload, every input here is already a concrete string/length.
+        /// </summary>
+        public static int MaxEncodedSize(string? senderPath, string? recipientPath, string manifest, int payloadLength)
+        {
+            if (payloadLength < 0)
+                throw new ArgumentOutOfRangeException(nameof(payloadLength), payloadLength, "Payload length must be non-negative.");
+
+            manifest ??= string.Empty;
+
+            return ArteryEnvelopeHeader.FrameLengthFieldLength + ArteryEnvelopeHeader.HeaderLength
+                + LiteralWireSize(senderPath) + LiteralWireSize(recipientPath) + LiteralWireSize(manifest)
+                + payloadLength;
+        }
+
+        /// <summary>
+        /// Encodes one Artery frame -- <c>[u32 LE frame length][32B fixed header][literals][payload]</c>
+        /// -- into <paramref name="destination"/>, from already-resolved parts (serializer id,
+        /// manifest, and raw payload bytes are all provided by the caller; compare the V2 single-pass
+        /// overload, which resolves serializer id + manifest from a message object and streams the
+        /// payload directly). A null or empty <paramref name="senderPath"/> / <paramref name="recipientPath"/>
+        /// encodes as the ABSENT tag; an empty <paramref name="manifest"/> likewise encodes as ABSENT.
+        /// </summary>
+        /// <returns>The total number of bytes written to <paramref name="destination"/> (frame-length field + envelope).</returns>
+        /// <exception cref="ArteryEnvelopeException">A sender/recipient/manifest literal's UTF-8 form exceeds 64KB - 1 bytes.</exception>
+        public static int Encode(
+            Span<byte> destination,
+            long originUid,
+            int serializerId,
+            string? senderPath,
+            string? recipientPath,
+            string manifest,
+            ReadOnlySpan<byte> payload)
+        {
+            manifest ??= string.Empty;
+
+            var envelope = destination.Slice(ArteryEnvelopeHeader.FrameLengthFieldLength);
+            var cursor = ArteryEnvelopeHeader.HeaderLength;
+
+            // Literal placement order (not load-bearing for decode -- tags carry absolute offsets --
+            // but fixed by convention): sender, recipient, manifest.
+            var senderTag = WriteLiteral(envelope, ref cursor, senderPath);
+            var recipientTag = WriteLiteral(envelope, ref cursor, recipientPath);
+            var manifestTag = WriteLiteral(envelope, ref cursor, manifest);
+
+            var payloadOffset = cursor;
+            payload.CopyTo(envelope.Slice(payloadOffset));
+
+            var frameLength = payloadOffset + payload.Length;
+            BinaryPrimitives.WriteUInt32LittleEndian(destination, (uint)frameLength);
+            WriteFixedHeader(
+                envelope.Slice(0, ArteryEnvelopeHeader.HeaderLength),
+                serializerId, originUid, senderTag, recipientTag, manifestTag, payloadOffset);
+
+            return ArteryEnvelopeHeader.FrameLengthFieldLength + frameLength;
+        }
+
+        /// <summary>
+        /// Single-pass V2 encode: resolves the serializer + manifest for <paramref name="message"/>
+        /// UPFRONT (before any payload bytes are written), writes the header + literals, then
+        /// streams the payload directly into the SAME growable pooled writer via the serializer's
+        /// <c>Serialize(object, IBufferWriter&lt;byte&gt;)</c> hook -- no intermediate byte[] copy for
+        /// the payload -- and finally back-patches the frame-length field and the fixed header (tags,
+        /// payload offset) now that the total size is known.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This mirrors the internal <c>Serialization.Serialize(object, IBufferWriter&lt;byte&gt;)</c>
+        /// hook in <c>Serialization.cs</c> (~line 528): find the serializer via
+        /// <c>FindSerializerV2For</c>, resolve the manifest via <c>Serialization.ManifestFor</c>, then
+        /// call <c>serializer.Serialize(obj, writer)</c>. The difference here is that manifest
+        /// resolution is split out and done BEFORE the header is written, because the envelope
+        /// header needs the manifest tag laid down (or at least its literal reserved) ahead of the
+        /// payload.
+        /// </para>
+        /// <para>
+        /// There is no separate "classic serializer" fallback path to implement: <c>FindSerializerV2For</c>
+        /// always returns a <see cref="Akka.Serialization.SerializerV2"/> -- either a native V2
+        /// serializer, or a classic <see cref="Akka.Serialization.Serializer"/> transparently wrapped
+        /// by <see cref="Akka.Serialization.SerializerV1Adapter"/>. The adapter's <c>Manifest(object)</c>
+        /// is itself always computable upfront (it inspects <c>SerializerWithStringManifest</c> /
+        /// <c>IncludeManifest</c> / <c>obj.GetType()</c> -- none of which depend on the serialized
+        /// bytes), and its <c>Serialize(object, IBufferWriter&lt;byte&gt;)</c> simply copies the
+        /// classic <c>ToBinary(obj)</c> result into the writer. So the single call sequence below
+        /// (find serializer -&gt; resolve manifest -&gt; serialize) is uniformly both the native-V2 path
+        /// AND the classic-serializer compatibility path.
+        /// </para>
+        /// </remarks>
+        /// <param name="serialization">The actor system's <see cref="Akka.Serialization.Serialization"/> extension.</param>
+        /// <param name="originUid">The sending system's UID.</param>
+        /// <param name="senderPath">The sender ref's path, or <see langword="null"/>/empty for no sender.</param>
+        /// <param name="recipientPath">The recipient ref's path, or <see langword="null"/>/empty for no recipient.</param>
+        /// <param name="message">The message to serialize as the envelope's payload.</param>
+        /// <returns>
+        /// A <see cref="PooledFrameWriter"/> owning the encoded frame
+        /// (<c>[u32 LE frame length][envelope]</c> in <see cref="PooledFrameWriter.WrittenSpan"/>).
+        /// The caller MUST <see cref="IDisposable.Dispose"/> it to return the rented buffer.
+        /// </returns>
+        /// <exception cref="ArteryEnvelopeException">A sender/recipient/manifest literal's UTF-8 form exceeds 64KB - 1 bytes.</exception>
+        public static PooledFrameWriter Encode(
+            Akka.Serialization.Serialization serialization,
+            long originUid,
+            string? senderPath,
+            string? recipientPath,
+            object message)
+        {
+            if (serialization is null)
+                throw new ArgumentNullException(nameof(serialization));
+            if (message is null)
+                throw new ArgumentNullException(nameof(message));
+
+            return Akka.Serialization.Serialization.WithTransport(serialization.System, () =>
+            {
+                var serializer = serialization.FindSerializerV2For(message);
+                var manifest = Akka.Serialization.Serialization.ManifestFor(serializer, message) ?? string.Empty;
+
+                const int reservedPrefixLength = ArteryEnvelopeHeader.FrameLengthFieldLength + ArteryEnvelopeHeader.HeaderLength;
+                var capacityHint = reservedPrefixLength
+                    + LiteralWireSize(senderPath) + LiteralWireSize(recipientPath) + LiteralWireSize(manifest);
+
+                var writer = new PooledFrameWriter(capacityHint);
+                try
+                {
+                    // Reserve the frame-length field + fixed header; both are back-patched below
+                    // once the tag offsets, payload offset, and total frame length are known.
+                    writer.GetSpan(reservedPrefixLength);
+                    writer.Advance(reservedPrefixLength);
+
+                    var senderTag = WriteLiteral(writer, senderPath);
+                    var recipientTag = WriteLiteral(writer, recipientPath);
+                    var manifestTag = WriteLiteral(writer, manifest);
+
+                    var payloadOffset = writer.WrittenCount - ArteryEnvelopeHeader.FrameLengthFieldLength;
+
+                    // Single-pass: the payload streams directly into the SAME growable buffer --
+                    // no intermediate byte[] copy.
+                    serializer.Serialize(message, writer);
+
+                    var frameLength = writer.WrittenCount - ArteryEnvelopeHeader.FrameLengthFieldLength;
+
+                    BinaryPrimitives.WriteUInt32LittleEndian(
+                        writer.GetPatchSpan(0, ArteryEnvelopeHeader.FrameLengthFieldLength), (uint)frameLength);
+                    WriteFixedHeader(
+                        writer.GetPatchSpan(ArteryEnvelopeHeader.FrameLengthFieldLength, ArteryEnvelopeHeader.HeaderLength),
+                        serializer.Identifier, originUid, senderTag, recipientTag, manifestTag, payloadOffset);
+
+                    return writer;
+                }
+                catch
+                {
+                    writer.Dispose();
+                    throw;
+                }
+            });
+        }
+
+        /// <summary>
+        /// Decodes envelope metadata from <paramref name="frameBody"/> -- the envelope WITHOUT the
+        /// 4-byte frame-length prefix (that prefix belongs to the TCP framing layer, Decision 3, and
+        /// is consumed by the frame parser before this codec ever sees the bytes). Only the fixed
+        /// 32-byte header (plus, if present, the metadata-section length prefix) is read; the
+        /// payload is exposed as a lazy <see cref="ReadOnlySequence{T}"/> slice, and sender/recipient/
+        /// manifest literals are resolved lazily on demand. Decoding the fixed header itself never
+        /// allocates (single-segment fast path; stackalloc copy fallback for a header split across
+        /// segments).
+        /// </summary>
+        /// <exception cref="ArteryEnvelopeException">
+        /// The frame body is shorter than the fixed header; the version is unsupported; a reserved
+        /// flag bit is set; the declared payload offset is less than 32 or beyond the frame end; or
+        /// (if flags bit 0 is set) the metadata section's declared length extends past the payload
+        /// offset.
+        /// </exception>
+        public static ArteryEnvelopeDecoded Decode(ReadOnlySequence<byte> frameBody)
+        {
+            if (frameBody.Length < ArteryEnvelopeHeader.HeaderLength)
+                throw new ArteryEnvelopeException(
+                    $"Envelope frame body ({frameBody.Length} bytes) is shorter than the fixed header ({ArteryEnvelopeHeader.HeaderLength} bytes).");
+
+            var headerSeq = frameBody.Slice(0, ArteryEnvelopeHeader.HeaderLength);
+            Span<byte> tmp = stackalloc byte[ArteryEnvelopeHeader.HeaderLength];
+            scoped ReadOnlySpan<byte> h;
+            if (headerSeq.IsSingleSegment)
+            {
+                h = headerSeq.First.Span;
+            }
+            else
+            {
+                headerSeq.CopyTo(tmp);
+                h = tmp;
+            }
+
+            var version = h[ArteryEnvelopeHeader.VersionOffset];
+            if (version != ArteryEnvelopeHeader.CurrentVersion)
+                throw new ArteryEnvelopeException(
+                    $"Unsupported Artery envelope version {version}; this decoder only understands version {ArteryEnvelopeHeader.CurrentVersion}.");
+
+            var flags = h[ArteryEnvelopeHeader.FlagsOffset];
+            if ((flags & ArteryEnvelopeHeader.ReservedFlagsMask) != 0)
+                throw new ArteryEnvelopeException(
+                    $"Envelope flags byte 0x{flags:X2} sets a reserved bit (mask 0x{ArteryEnvelopeHeader.ReservedFlagsMask:X2}); refusing to guess at unknown semantics.");
+
+            var actorRefTableVersion = h[ArteryEnvelopeHeader.ActorRefTableVersionOffset];
+            var manifestTableVersion = h[ArteryEnvelopeHeader.ManifestTableVersionOffset];
+            var originUid = BinaryPrimitives.ReadInt64LittleEndian(h.Slice(ArteryEnvelopeHeader.OriginUidOffset));
+            var serializerId = BinaryPrimitives.ReadInt32LittleEndian(h.Slice(ArteryEnvelopeHeader.SerializerIdOffset));
+            var senderTag = BinaryPrimitives.ReadUInt32LittleEndian(h.Slice(ArteryEnvelopeHeader.SenderTagOffset));
+            var recipientTag = BinaryPrimitives.ReadUInt32LittleEndian(h.Slice(ArteryEnvelopeHeader.RecipientTagOffset));
+            var manifestTag = BinaryPrimitives.ReadUInt32LittleEndian(h.Slice(ArteryEnvelopeHeader.ManifestTagOffset));
+            var payloadOffset = (long)BinaryPrimitives.ReadUInt32LittleEndian(h.Slice(ArteryEnvelopeHeader.PayloadOffsetFieldOffset));
+
+            if (payloadOffset < ArteryEnvelopeHeader.HeaderLength)
+                throw new ArteryEnvelopeException(
+                    $"Declared payload offset {payloadOffset} is less than the fixed header length ({ArteryEnvelopeHeader.HeaderLength}).");
+            if (payloadOffset > frameBody.Length)
+                throw new ArteryEnvelopeException(
+                    $"Declared payload offset {payloadOffset} is beyond the end of the frame ({frameBody.Length} bytes).");
+
+            if ((flags & ArteryEnvelopeHeader.MetadataPresentFlag) != 0)
+            {
+                if (ArteryEnvelopeHeader.MetadataSectionOffset + ArteryEnvelopeHeader.MetadataLengthPrefixSize > payloadOffset)
+                    throw new ArteryEnvelopeException(
+                        "Metadata section flag is set but there is no room for its length prefix before the payload offset.");
+
+                Span<byte> lenBuf = stackalloc byte[ArteryEnvelopeHeader.MetadataLengthPrefixSize];
+                frameBody.Slice(ArteryEnvelopeHeader.MetadataSectionOffset, ArteryEnvelopeHeader.MetadataLengthPrefixSize).CopyTo(lenBuf);
+                var metadataLength = BinaryPrimitives.ReadUInt32LittleEndian(lenBuf);
+                var metadataEnd = (long)ArteryEnvelopeHeader.MetadataSectionOffset + ArteryEnvelopeHeader.MetadataLengthPrefixSize + metadataLength;
+                if (metadataEnd > payloadOffset)
+                    throw new ArteryEnvelopeException(
+                        $"Metadata section (length {metadataLength}) extends past the declared payload offset ({payloadOffset}).");
+
+                // MVP: the metadata section's contents are not yet interpreted -- only skipped over.
+                // The only planned consumer is the deferred actor-ref/manifest compression scheme.
+            }
+
+            var header = new ArteryEnvelopeFixedHeader(
+                version, flags, actorRefTableVersion, manifestTableVersion,
+                originUid, serializerId, senderTag, recipientTag, manifestTag, payloadOffset);
+
+            return new ArteryEnvelopeDecoded(frameBody, header);
+        }
+
+        private static void WriteFixedHeader(
+            Span<byte> header,
+            int serializerId,
+            long originUid,
+            uint senderTag,
+            uint recipientTag,
+            uint manifestTag,
+            long payloadOffset)
+        {
+            header[ArteryEnvelopeHeader.VersionOffset] = ArteryEnvelopeHeader.CurrentVersion;
+            header[ArteryEnvelopeHeader.FlagsOffset] = 0;
+            header[ArteryEnvelopeHeader.ActorRefTableVersionOffset] = 0;
+            header[ArteryEnvelopeHeader.ManifestTableVersionOffset] = 0;
+            BinaryPrimitives.WriteInt64LittleEndian(header.Slice(ArteryEnvelopeHeader.OriginUidOffset), originUid);
+            BinaryPrimitives.WriteInt32LittleEndian(header.Slice(ArteryEnvelopeHeader.SerializerIdOffset), serializerId);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.Slice(ArteryEnvelopeHeader.SenderTagOffset), senderTag);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.Slice(ArteryEnvelopeHeader.RecipientTagOffset), recipientTag);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.Slice(ArteryEnvelopeHeader.ManifestTagOffset), manifestTag);
+            BinaryPrimitives.WriteUInt32LittleEndian(header.Slice(ArteryEnvelopeHeader.PayloadOffsetFieldOffset), checked((uint)payloadOffset));
+        }
+
+        /// <summary>Writes a LITERAL tag's length-prefixed UTF-8 bytes into a fixed <see cref="Span{T}"/>, advancing <paramref name="cursor"/>.</summary>
+        private static uint WriteLiteral(Span<byte> envelope, ref int cursor, string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return ArteryEnvelopeHeader.AbsentTag;
+
+            var byteCount = ValidatedUtf8ByteCount(value);
+            var tagOffset = cursor;
+
+            BinaryPrimitives.WriteUInt16LittleEndian(envelope.Slice(cursor, ArteryEnvelopeHeader.LiteralLengthPrefixSize), (ushort)byteCount);
+            cursor += ArteryEnvelopeHeader.LiteralLengthPrefixSize;
+
+            if (byteCount > 0)
+            {
+                // PERF: Encoding.GetBytes(string) allocates an intermediate byte[] -- netstandard2.0
+                // has no Encoding.GetBytes(string, Span<byte>) overload. Literals (actor paths /
+                // manifests) are the cold path at G1; ref/manifest compression (deferred) removes
+                // them from the hot path entirely.
+                var bytes = Encoding.UTF8.GetBytes(value);
+                bytes.CopyTo(envelope.Slice(cursor, byteCount));
+                cursor += byteCount;
+            }
+
+            return (uint)tagOffset;
+        }
+
+        /// <summary>Writes a LITERAL tag's length-prefixed UTF-8 bytes into a growable <see cref="PooledFrameWriter"/>.</summary>
+        private static uint WriteLiteral(PooledFrameWriter writer, string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return ArteryEnvelopeHeader.AbsentTag;
+
+            var byteCount = ValidatedUtf8ByteCount(value);
+            var tagOffset = writer.WrittenCount - ArteryEnvelopeHeader.FrameLengthFieldLength;
+
+            var lengthSpan = writer.GetSpan(ArteryEnvelopeHeader.LiteralLengthPrefixSize);
+            BinaryPrimitives.WriteUInt16LittleEndian(lengthSpan, (ushort)byteCount);
+            writer.Advance(ArteryEnvelopeHeader.LiteralLengthPrefixSize);
+
+            if (byteCount > 0)
+            {
+                // PERF: see the Span<byte> overload above -- same netstandard2.0 limitation.
+                var bytes = Encoding.UTF8.GetBytes(value);
+                var dataSpan = writer.GetSpan(byteCount);
+                bytes.CopyTo(dataSpan);
+                writer.Advance(byteCount);
+            }
+
+            return (uint)tagOffset;
+        }
+
+        private static int ValidatedUtf8ByteCount(string value)
+        {
+            var byteCount = Encoding.UTF8.GetByteCount(value);
+            if (byteCount > ArteryEnvelopeHeader.MaxLiteralByteLength)
+                throw new ArteryEnvelopeException(
+                    $"Literal exceeds the maximum encodable length of {ArteryEnvelopeHeader.MaxLiteralByteLength} UTF-8 bytes (was {byteCount}).");
+
+            return byteCount;
+        }
+
+        private static int LiteralWireSize(string? value) =>
+            string.IsNullOrEmpty(value) ? 0 : ArteryEnvelopeHeader.LiteralLengthPrefixSize + Encoding.UTF8.GetByteCount(value);
+    }
+
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// The classification of an Artery tag (sender / recipient / manifest), per design.md's CLOSED
+    /// tag scheme: tag <c>0x00000000</c> is ABSENT; a non-zero top byte is COMPRESSED; anything else
+    /// is a LITERAL absolute byte offset.
+    /// </summary>
+    internal enum ArteryTagKind : byte
+    {
+        /// <summary>No sender / no recipient / empty manifest.</summary>
+        Absent = 0,
+
+        /// <summary>The tag is an absolute byte offset (from envelope offset 0) of a length-prefixed UTF-8 literal.</summary>
+        Literal = 1,
+
+        /// <summary>
+        /// The tag is a compression-table index (low 16 bits). Resolving a COMPRESSED index to an
+        /// actor ref / manifest string is future work (ref/manifest compression, deferred post-MVP).
+        /// </summary>
+        Compressed = 2
+    }
+
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// The result of <see cref="ArteryEnvelopeCodec.Decode"/>: the decoded fixed header plus lazy
+    /// accessors for the payload slice and the sender/recipient/manifest tags. Resolving a LITERAL
+    /// tag allocates a string (unavoidable on netstandard2.0 -- see the PERF note on
+    /// <see cref="ArteryEnvelopeCodec"/>'s literal writers); everything else here is allocation-free.
+    /// </summary>
+    internal readonly struct ArteryEnvelopeDecoded
+    {
+        private readonly ReadOnlySequence<byte> _frameBody;
+
+        internal ArteryEnvelopeDecoded(ReadOnlySequence<byte> frameBody, ArteryEnvelopeFixedHeader header)
+        {
+            _frameBody = frameBody;
+            Header = header;
+        }
+
+        /// <summary>The decoded fixed 32-byte header.</summary>
+        public ArteryEnvelopeFixedHeader Header { get; }
+
+        /// <summary>
+        /// The payload slice <c>[payloadOffset, frame end)</c>. An O(1) slice of the original
+        /// sequence -- no copy, no deserialization -- and position-independent regardless of whether
+        /// a metadata section or literal tail is present (design.md's rationale for the explicit
+        /// payload-offset header field).
+        /// </summary>
+        public ReadOnlySequence<byte> Payload => _frameBody.Slice(Header.PayloadOffset);
+
+        /// <summary>The classification of the sender-ref tag.</summary>
+        public ArteryTagKind SenderKind => ClassifyTag(Header.SenderTag);
+
+        /// <summary>The classification of the recipient-ref tag.</summary>
+        public ArteryTagKind RecipientKind => ClassifyTag(Header.RecipientTag);
+
+        /// <summary>The classification of the manifest tag.</summary>
+        public ArteryTagKind ManifestKind => ClassifyTag(Header.ManifestTag);
+
+        /// <summary>
+        /// Resolves the sender ref's path. Returns <see langword="true"/> with <paramref name="path"/>
+        /// set to <see langword="null"/> when ABSENT (no sender), or to the decoded literal string
+        /// when LITERAL. Returns <see langword="false"/> when COMPRESSED -- see
+        /// <see cref="SenderCompressedIndex"/>; resolving a compressed index to a ref is future work.
+        /// </summary>
+        public bool TryGetSenderPath(out string? path) => TryResolveTag(Header.SenderTag, out path);
+
+        /// <summary>Resolves the recipient ref's path. See <see cref="TryGetSenderPath"/> for ABSENT/LITERAL/COMPRESSED semantics.</summary>
+        public bool TryGetRecipientPath(out string? path) => TryResolveTag(Header.RecipientTag, out path);
+
+        /// <summary>
+        /// Resolves the manifest. ABSENT decodes to <see cref="string.Empty"/> (an empty manifest is
+        /// itself a legitimate value, unlike sender/recipient's ABSENT meaning "no ref").
+        /// </summary>
+        public bool TryGetManifest(out string manifest)
+        {
+            if (TryResolveTag(Header.ManifestTag, out var resolved))
+            {
+                manifest = resolved ?? string.Empty;
+                return true;
+            }
+
+            manifest = string.Empty;
+            return false;
+        }
+
+        /// <summary>The compression-table index for a COMPRESSED sender tag. Only meaningful when <see cref="SenderKind"/> is <see cref="ArteryTagKind.Compressed"/>.</summary>
+        public int SenderCompressedIndex => DecodeCompressedIndex(Header.SenderTag);
+
+        /// <summary>The compression-table index for a COMPRESSED recipient tag. Only meaningful when <see cref="RecipientKind"/> is <see cref="ArteryTagKind.Compressed"/>.</summary>
+        public int RecipientCompressedIndex => DecodeCompressedIndex(Header.RecipientTag);
+
+        /// <summary>The compression-table index for a COMPRESSED manifest tag. Only meaningful when <see cref="ManifestKind"/> is <see cref="ArteryTagKind.Compressed"/>.</summary>
+        public int ManifestCompressedIndex => DecodeCompressedIndex(Header.ManifestTag);
+
+        private static ArteryTagKind ClassifyTag(uint tag)
+        {
+            if (tag == ArteryEnvelopeHeader.AbsentTag)
+                return ArteryTagKind.Absent;
+
+            return (tag & ArteryEnvelopeHeader.CompressedTagMask) != 0 ? ArteryTagKind.Compressed : ArteryTagKind.Literal;
+        }
+
+        private static int DecodeCompressedIndex(uint tag) => (int)(tag & ArteryEnvelopeHeader.CompressedIndexMask);
+
+        private bool TryResolveTag(uint tag, out string? value)
+        {
+            switch (ClassifyTag(tag))
+            {
+                case ArteryTagKind.Absent:
+                    value = null;
+                    return true;
+                case ArteryTagKind.Compressed:
+                    value = null;
+                    return false;
+                default:
+                    value = ResolveLiteral(tag);
+                    return true;
+            }
+        }
+
+        private string ResolveLiteral(uint tagOffsetRaw)
+        {
+            var offset = (long)tagOffsetRaw;
+
+            if (offset < ArteryEnvelopeHeader.HeaderLength)
+                throw new ArteryEnvelopeException(
+                    $"Literal tag offset {offset} is inside the fixed header (must be >= {ArteryEnvelopeHeader.HeaderLength}).");
+            if (offset + ArteryEnvelopeHeader.LiteralLengthPrefixSize > Header.PayloadOffset)
+                throw new ArteryEnvelopeException(
+                    $"Literal tag offset {offset} leaves no room for its length prefix before the payload offset ({Header.PayloadOffset}).");
+
+            Span<byte> lenBuf = stackalloc byte[ArteryEnvelopeHeader.LiteralLengthPrefixSize];
+            _frameBody.Slice(offset, ArteryEnvelopeHeader.LiteralLengthPrefixSize).CopyTo(lenBuf);
+            var length = BinaryPrimitives.ReadUInt16LittleEndian(lenBuf);
+
+            var dataStart = offset + ArteryEnvelopeHeader.LiteralLengthPrefixSize;
+            var dataEnd = dataStart + length;
+            if (dataEnd > Header.PayloadOffset)
+                throw new ArteryEnvelopeException(
+                    $"Literal at offset {offset} (length {length}) extends past the payload offset ({Header.PayloadOffset}).");
+
+            if (length == 0)
+                return string.Empty;
+
+            // PERF: netstandard2.0 has no Encoding.GetString(ReadOnlySpan<byte>) overload (added in
+            // netstandard2.1), so literal resolution always allocates an intermediate byte[] via
+            // ArrayPool. Acceptable at G1 -- literals are the cold path; ref/manifest compression
+            // (deferred) replaces them with O(1) index lookups on the hot path.
+            var rented = ArrayPool<byte>.Shared.Rent(length);
+            try
+            {
+                _frameBody.Slice(dataStart, length).CopyTo(rented);
+                return Encoding.UTF8.GetString(rented, 0, length);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote/Artery/ArteryEnvelopeException.cs
+++ b/src/core/Akka.Remote/Artery/ArteryEnvelopeException.cs
@@ -1,0 +1,52 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryEnvelopeException.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Runtime.Serialization;
+using Akka.Actor;
+
+namespace Akka.Remote.Artery
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Thrown when <see cref="ArteryEnvelopeCodec"/> encounters an envelope that cannot be decoded
+    /// (or, at encode time, input that cannot be encoded) per the wire layout in
+    /// <c>openspec/changes/artery-tcp-remoting/design.md</c> ("Envelope wire layout" / Decision 4):
+    /// an unsupported version, a reserved flag bit set, a tag offset out of bounds, a truncated
+    /// literal, a declared payload offset outside the frame, or an oversized literal at encode.
+    /// </summary>
+    internal sealed class ArteryEnvelopeException : AkkaException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArteryEnvelopeException"/> class.
+        /// </summary>
+        public ArteryEnvelopeException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArteryEnvelopeException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
+        public ArteryEnvelopeException(string message, Exception? cause = null) : base(message, cause)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArteryEnvelopeException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        public ArteryEnvelopeException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/core/Akka.Remote/Artery/ArteryEnvelopeHeader.cs
+++ b/src/core/Akka.Remote/Artery/ArteryEnvelopeHeader.cs
@@ -1,0 +1,162 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryEnvelopeHeader.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+namespace Akka.Remote.Artery
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Wire-layout constants for the Artery envelope's fixed 32-byte header, per
+    /// <c>openspec/changes/artery-tcp-remoting/design.md</c> ("Envelope wire layout", Decision 4;
+    /// sub-decisions CLOSED at G1, 2026-07-04). All multi-byte fields are little-endian.
+    ///
+    /// <para>
+    /// The 4-byte frame-length field that precedes the envelope on the wire
+    /// (<c>[u32 LE frame length][envelope]</c>) belongs to the TCP framing layer (design.md
+    /// Decision 3), which is owned by a parallel work item (framing parser / connection header).
+    /// <see cref="ArteryEnvelopeCodec"/> only needs to know its length to lay the envelope out
+    /// correctly relative to it, so that single constant (<see cref="FrameLengthFieldLength"/>) is
+    /// duplicated locally here rather than taking a cross-cutting dependency on the framing
+    /// parser's types. Duplication accepted at G1 -- consider consolidating once both land.
+    /// </para>
+    /// </summary>
+    internal static class ArteryEnvelopeHeader
+    {
+        /// <summary>Length, in bytes, of the frame-length field that precedes every envelope on the wire.</summary>
+        public const int FrameLengthFieldLength = 4;
+
+        /// <summary>Length, in bytes, of the fixed envelope header (offsets 0..32).</summary>
+        public const int HeaderLength = 32;
+
+        /// <summary>The only version this codec understands; the decoder rejects any other value.</summary>
+        public const byte CurrentVersion = 1;
+
+        /// <summary>Flags bit 0: a metadata section is present immediately after the fixed header.</summary>
+        public const byte MetadataPresentFlag = 0b0000_0001;
+
+        /// <summary>Flags bits 1-7: reserved, must be zero. The decoder rejects any set reserved bit.</summary>
+        public const byte ReservedFlagsMask = 0b1111_1110;
+
+        /// <summary>Tag value meaning ABSENT: no sender / no recipient / empty manifest.</summary>
+        public const uint AbsentTag = 0x0000_0000u;
+
+        /// <summary>Top-byte mask; a non-zero top byte marks a COMPRESSED tag.</summary>
+        public const uint CompressedTagMask = 0xFF00_0000u;
+
+        /// <summary>Low 16 bits of a COMPRESSED tag hold the compression-table index.</summary>
+        public const uint CompressedIndexMask = 0x0000_FFFFu;
+
+        /// <summary>
+        /// Exclusive upper bound for a LITERAL tag's byte offset -- keeps literal offsets clear of
+        /// the COMPRESSED discriminator's top byte. Derived constraint from design.md: keep
+        /// <c>maximum-frame-size</c> well under 16 MB so this bound can never be reached in practice.
+        /// </summary>
+        public const uint LiteralOffsetExclusiveMax = 0x00FF_FFFFu;
+
+        /// <summary>Maximum encodable literal length in UTF-8 bytes -- an unsigned 16-bit length prefix: 64KB - 1.</summary>
+        public const int MaxLiteralByteLength = ushort.MaxValue;
+
+        /// <summary>Length, in bytes, of a literal's length prefix (u16 LE).</summary>
+        public const int LiteralLengthPrefixSize = sizeof(ushort);
+
+        /// <summary>Length, in bytes, of the optional metadata section's length prefix (u32 LE).</summary>
+        public const int MetadataLengthPrefixSize = sizeof(uint);
+
+        // Fixed-header field offsets, relative to envelope offset 0 (i.e. AFTER the 4-byte
+        // frame-length field -- see the type-level remarks above).
+        public const int VersionOffset = 0;
+        public const int FlagsOffset = 1;
+        public const int ActorRefTableVersionOffset = 2;
+        public const int ManifestTableVersionOffset = 3;
+        public const int OriginUidOffset = 4;
+        public const int SerializerIdOffset = 12;
+        public const int SenderTagOffset = 16;
+        public const int RecipientTagOffset = 20;
+        public const int ManifestTagOffset = 24;
+        public const int PayloadOffsetFieldOffset = 28;
+
+        /// <summary>Offset (relative to envelope offset 0) where an optional metadata section's u32 LE length field begins.</summary>
+        public const int MetadataSectionOffset = HeaderLength;
+    }
+
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// The decoded fixed 32-byte Artery envelope header. Sender/recipient/manifest tags are left
+    /// undecoded here (raw <see cref="uint"/>) -- classifying and resolving them (ABSENT / LITERAL /
+    /// COMPRESSED) is the job of <see cref="ArteryEnvelopeDecoded"/>, which also needs the envelope
+    /// body to resolve a LITERAL tag to a string. This type is a readonly struct so decoding the
+    /// fixed header never allocates.
+    /// </summary>
+    internal readonly struct ArteryEnvelopeFixedHeader
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArteryEnvelopeFixedHeader"/> struct.
+        /// </summary>
+        public ArteryEnvelopeFixedHeader(
+            byte version,
+            byte flags,
+            byte actorRefTableVersion,
+            byte manifestTableVersion,
+            long originUid,
+            int serializerId,
+            uint senderTag,
+            uint recipientTag,
+            uint manifestTag,
+            long payloadOffset)
+        {
+            Version = version;
+            Flags = flags;
+            ActorRefTableVersion = actorRefTableVersion;
+            ManifestTableVersion = manifestTableVersion;
+            OriginUid = originUid;
+            SerializerId = serializerId;
+            SenderTag = senderTag;
+            RecipientTag = recipientTag;
+            ManifestTag = manifestTag;
+            PayloadOffset = payloadOffset;
+        }
+
+        /// <summary>Envelope wire-layout version. Always 1 in a successfully decoded header.</summary>
+        public byte Version { get; }
+
+        /// <summary>Envelope flags byte. Bit 0 = metadata section present; bits 1-7 are reserved-must-be-zero.</summary>
+        public byte Flags { get; }
+
+        /// <summary>Actor-ref compression-table version. Always 0 until compression (deferred) lands.</summary>
+        public byte ActorRefTableVersion { get; }
+
+        /// <summary>Manifest compression-table version. Always 0 until compression (deferred) lands.</summary>
+        public byte ManifestTableVersion { get; }
+
+        /// <summary>The origin (sending) system's UID.</summary>
+        public long OriginUid { get; }
+
+        /// <summary>The <see cref="Akka.Serialization.Serializer"/> id used to serialize the payload.</summary>
+        public int SerializerId { get; }
+
+        /// <summary>The raw, undecoded sender-ref tag. See <see cref="ArteryEnvelopeDecoded.SenderKind"/> / <see cref="ArteryEnvelopeDecoded.TryGetSenderPath"/>.</summary>
+        public uint SenderTag { get; }
+
+        /// <summary>The raw, undecoded recipient-ref tag. See <see cref="ArteryEnvelopeDecoded.RecipientKind"/> / <see cref="ArteryEnvelopeDecoded.TryGetRecipientPath"/>.</summary>
+        public uint RecipientTag { get; }
+
+        /// <summary>The raw, undecoded manifest tag. See <see cref="ArteryEnvelopeDecoded.ManifestKind"/> / <see cref="ArteryEnvelopeDecoded.TryGetManifest"/>.</summary>
+        public uint ManifestTag { get; }
+
+        /// <summary>
+        /// The absolute byte offset (from envelope offset 0) where the payload begins. Explicit and
+        /// O(1) -- does not need to be derived from frame length minus a variable-length tail.
+        /// </summary>
+        public long PayloadOffset { get; }
+
+        /// <summary><see langword="true"/> iff <see cref="Flags"/> bit 0 is set (a metadata section follows the fixed header).</summary>
+        public bool HasMetadataSection => (Flags & ArteryEnvelopeHeader.MetadataPresentFlag) != 0;
+    }
+}

--- a/src/core/Akka.Remote/Artery/ArteryFrameParser.cs
+++ b/src/core/Akka.Remote/Artery/ArteryFrameParser.cs
@@ -1,0 +1,317 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryFrameParser.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Akka.Remote.Artery
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Incremental, allocation-conscious parser for the Artery TCP per-frame wire format
+    /// described in <c>openspec/changes/artery-tcp-remoting/design.md</c> ("Envelope wire
+    /// layout" / Decision 3): <c>[ frame length u32 LE ][ envelope ]</c>. The length field
+    /// stores the length of the body that FOLLOWS it — it excludes its own 4 bytes (the
+    /// same convention as <c>Akka.Streams.Dsl.Framing</c>'s <c>LengthField</c> stage, i.e.
+    /// total frame size on the wire = parsed length + <see cref="LengthFieldSize"/>).
+    ///
+    /// <para>
+    /// This type owns no socket or stream; the caller feeds it raw bytes via
+    /// <see cref="Append"/> as they arrive (in any chunking — including one byte at a time)
+    /// and pulls completed frame bodies via <see cref="TryReadFrame"/>. It is intended to be
+    /// wrapped by a GraphStage in a later Artery task.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Buffering strategy.</b> Appended chunks are held, unmodified, in an internal
+    /// queue. Chunks are never copied to assemble a frame body: <see cref="TryReadFrame"/>
+    /// builds a (possibly multi-segment) <see cref="ReadOnlySequence{T}"/> directly over
+    /// slices of the buffered <see cref="ReadOnlyMemory{T}"/> chunks, using a private
+    /// <see cref="ReadOnlySequenceSegment{T}"/> chain. The only copy that ever happens is a
+    /// small stack-allocated copy of the 4-byte length field when it straddles a chunk
+    /// boundary (needed to read it as a contiguous <c>uint</c>). Once a chunk has been fully
+    /// consumed by a returned frame (or the length field), it is dequeued and no longer
+    /// referenced by this parser, so it becomes eligible for garbage collection — buffered
+    /// memory does not grow without bound as frames are read.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Zero-length bodies are legal.</b> A frame with a declared length of <c>0</c> is a
+    /// valid, empty-body frame; <see cref="TryReadFrame"/> yields
+    /// <see cref="ReadOnlySequence{T}.Empty"/> for it rather than treating it as an error or
+    /// as "no frame available".
+    /// </para>
+    ///
+    /// <para>
+    /// This type is not thread-safe. It is designed for a single reader driving both
+    /// <see cref="Append"/> and <see cref="TryReadFrame"/> (e.g. one connection's inbound
+    /// stream stage).
+    /// </para>
+    /// </summary>
+    internal sealed class ArteryFrameParser
+    {
+        /// <summary>Size, in bytes, of the little-endian frame-length field that precedes every frame body.</summary>
+        public const int LengthFieldSize = 4;
+
+        /// <summary>
+        /// Hard upper bound on <c>maxFrameLength</c>: <c>0x00FF_FFFF</c> (16 MiB - 1). This
+        /// protects the Artery envelope's 24-bit literal-offset tag space (see
+        /// design.md, "Actor-ref / manifest compression" and the envelope TAG encoding) —
+        /// literal offsets must stay below <c>0x00FF_FFFF</c>, so no frame body may reach or
+        /// exceed it.
+        /// </summary>
+        public const int MaxAllowedFrameLength = 0x00FF_FFFF;
+
+        private readonly int _maxFrameLength;
+
+        /// <summary>Not-yet-fully-consumed appended chunks, in arrival order.</summary>
+        private readonly Queue<ReadOnlyMemory<byte>> _pending = new();
+
+        /// <summary>Number of bytes at the start of <see cref="_pending"/>'s head chunk already yielded/consumed.</summary>
+        private int _headOffset;
+
+        /// <summary>Total unconsumed bytes currently buffered across all of <see cref="_pending"/>.</summary>
+        private long _bufferedLength;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArteryFrameParser"/> class.
+        /// </summary>
+        /// <param name="maxFrameLength">
+        /// The maximum allowed frame BODY length, in bytes (excluding the 4-byte length
+        /// field). Must be greater than zero and no greater than
+        /// <see cref="MaxAllowedFrameLength"/>.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="maxFrameLength"/> is not in <c>(0, MaxAllowedFrameLength]</c>.
+        /// </exception>
+        public ArteryFrameParser(int maxFrameLength)
+        {
+            if (maxFrameLength <= 0 || maxFrameLength > MaxAllowedFrameLength)
+                throw new ArgumentOutOfRangeException(
+                    nameof(maxFrameLength),
+                    maxFrameLength,
+                    $"maxFrameLength must be greater than 0 and no greater than {MaxAllowedFrameLength} " +
+                    "(0x00FFFFFF) so that Artery envelope literal offsets stay within their 24-bit tag space.");
+
+            _maxFrameLength = maxFrameLength;
+        }
+
+        /// <summary>The maximum allowed frame body length configured for this parser.</summary>
+        public int MaxFrameLength => _maxFrameLength;
+
+        /// <summary>
+        /// Appends a chunk of bytes read from the connection. The chunk is retained by
+        /// reference (not copied) until it has been fully consumed by
+        /// <see cref="TryReadFrame"/>; callers must not mutate the underlying memory after
+        /// appending it.
+        /// </summary>
+        /// <param name="chunk">The bytes to append. Empty chunks are ignored.</param>
+        public void Append(ReadOnlyMemory<byte> chunk)
+        {
+            if (chunk.IsEmpty)
+                return;
+
+            _pending.Enqueue(chunk);
+            _bufferedLength += chunk.Length;
+        }
+
+        /// <summary>
+        /// Attempts to read the next complete frame body from the buffered input.
+        /// </summary>
+        /// <param name="frame">
+        /// On success, the frame body — WITHOUT the 4-byte length prefix. May span multiple
+        /// appended chunks, in which case <see cref="ReadOnlySequence{T}.IsSingleSegment"/>
+        /// is <see langword="false"/>. On failure (incomplete data), <see cref="ReadOnlySequence{T}.Empty"/>.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if a complete frame was available and is returned in
+        /// <paramref name="frame"/>; <see langword="false"/> if more data is needed.
+        /// </returns>
+        /// <exception cref="ArteryFramingException">
+        /// The declared frame length exceeds <see cref="MaxFrameLength"/>.
+        /// </exception>
+        public bool TryReadFrame(out ReadOnlySequence<byte> frame)
+        {
+            frame = ReadOnlySequence<byte>.Empty;
+
+            if (!TryPeek(LengthFieldSize, out var lengthSequence))
+                return false;
+
+            Span<byte> lengthBytes = stackalloc byte[LengthFieldSize];
+            lengthSequence.CopyTo(lengthBytes);
+            var declaredLength = BinaryPrimitives.ReadUInt32LittleEndian(lengthBytes);
+
+            if (declaredLength > (uint)_maxFrameLength)
+                throw new ArteryFramingException(
+                    $"Artery frame declared a body length of {declaredLength} bytes, which exceeds " +
+                    $"the configured maximum of {_maxFrameLength} bytes.");
+
+            var bodyLength = (int)declaredLength;
+
+            if (_bufferedLength < LengthFieldSize + (long)bodyLength)
+                return false;
+
+            Advance(LengthFieldSize);
+
+            if (bodyLength == 0)
+            {
+                frame = ReadOnlySequence<byte>.Empty;
+                return true;
+            }
+
+            var found = TryPeek(bodyLength, out frame);
+            Debug.Assert(found, "Body bytes were already confirmed buffered above.");
+            Advance(bodyLength);
+            return true;
+        }
+
+        /// <summary>
+        /// Writes a little-endian frame-length field for a body of <paramref name="bodyLength"/>
+        /// bytes into <paramref name="destination"/>. This is the one-shot encode-side
+        /// counterpart to the length field consumed by <see cref="TryReadFrame"/>.
+        /// </summary>
+        /// <param name="destination">
+        /// The destination span. Must be at least <see cref="LengthFieldSize"/> bytes long.
+        /// </param>
+        /// <param name="bodyLength">
+        /// The length, in bytes, of the frame body that will follow the length field. Must
+        /// be non-negative.
+        /// </param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="bodyLength"/> is negative, or <paramref name="destination"/> is
+        /// shorter than <see cref="LengthFieldSize"/>.
+        /// </exception>
+        public static void WriteFrameLength(Span<byte> destination, int bodyLength)
+        {
+            if (bodyLength < 0)
+                throw new ArgumentOutOfRangeException(nameof(bodyLength), bodyLength, "Body length must be non-negative.");
+
+            if (destination.Length < LengthFieldSize)
+                throw new ArgumentOutOfRangeException(
+                    nameof(destination),
+                    destination.Length,
+                    $"Destination span must be at least {LengthFieldSize} bytes long to hold the frame length field.");
+
+            BinaryPrimitives.WriteUInt32LittleEndian(destination, (uint)bodyLength);
+        }
+
+        /// <summary>
+        /// Builds a (possibly multi-segment) view of the next <paramref name="count"/>
+        /// buffered bytes WITHOUT consuming them, or returns <see langword="false"/> if
+        /// fewer than <paramref name="count"/> bytes are currently buffered.
+        /// </summary>
+        private bool TryPeek(int count, out ReadOnlySequence<byte> sequence)
+        {
+            if (_bufferedLength < count)
+            {
+                sequence = ReadOnlySequence<byte>.Empty;
+                return false;
+            }
+
+            if (count == 0)
+            {
+                sequence = ReadOnlySequence<byte>.Empty;
+                return true;
+            }
+
+            // Single-segment fast path: the requested bytes fit inside the head chunk — the common
+            // case when a whole frame arrives in one socket read. Avoids allocating a FrameSegment
+            // chain per frame on what becomes the serial decode-island hot path (design.md Decision 2).
+            var headChunk = _pending.Peek();
+            if (headChunk.Length - _headOffset >= count)
+            {
+                sequence = new ReadOnlySequence<byte>(headChunk.Slice(_headOffset, count));
+                return true;
+            }
+
+            FrameSegment? head = null;
+            FrameSegment? tail = null;
+            var remaining = count;
+            var isHeadChunk = true;
+
+            foreach (var chunk in _pending)
+            {
+                if (remaining == 0)
+                    break;
+
+                var offset = isHeadChunk ? _headOffset : 0;
+                isHeadChunk = false;
+
+                var available = chunk.Length - offset;
+                var take = Math.Min(available, remaining);
+                var slice = chunk.Slice(offset, take);
+
+                if (head is null)
+                {
+                    head = new FrameSegment(slice);
+                    tail = head;
+                }
+                else
+                {
+                    tail = tail!.Append(slice);
+                }
+
+                remaining -= take;
+            }
+
+            sequence = new ReadOnlySequence<byte>(head!, 0, tail!, tail!.Memory.Length);
+            return true;
+        }
+
+        /// <summary>Consumes (dequeues/offsets past) <paramref name="count"/> buffered bytes.</summary>
+        private void Advance(int count)
+        {
+            _bufferedLength -= count;
+
+            while (count > 0)
+            {
+                var chunk = _pending.Peek();
+                var available = chunk.Length - _headOffset;
+
+                if (count < available)
+                {
+                    _headOffset += count;
+                    count = 0;
+                }
+                else
+                {
+                    count -= available;
+                    _pending.Dequeue();
+                    _headOffset = 0;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Linked-list segment used to compose a multi-segment <see cref="ReadOnlySequence{T}"/>
+        /// over slices of buffered chunks without copying the underlying memory.
+        /// </summary>
+        private sealed class FrameSegment : ReadOnlySequenceSegment<byte>
+        {
+            public FrameSegment(ReadOnlyMemory<byte> memory)
+            {
+                Memory = memory;
+            }
+
+            public FrameSegment Append(ReadOnlyMemory<byte> memory)
+            {
+                var segment = new FrameSegment(memory)
+                {
+                    RunningIndex = RunningIndex + Memory.Length
+                };
+                Next = segment;
+                return segment;
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote/Artery/ArteryFramingException.cs
+++ b/src/core/Akka.Remote/Artery/ArteryFramingException.cs
@@ -1,0 +1,53 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryFramingException.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Runtime.Serialization;
+using Akka.Actor;
+
+namespace Akka.Remote.Artery
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Thrown when Artery TCP framing encounters input that cannot be a valid frame stream:
+    /// an invalid connection preamble (wrong <c>AKKA</c> magic bytes or an unrecognized
+    /// <see cref="ArteryStreamId"/> byte), or a frame whose declared length exceeds the
+    /// configured maximum frame length. See
+    /// <c>openspec/changes/artery-tcp-remoting/design.md</c> ("Envelope wire layout" /
+    /// Decision 3) for the framing this guards.
+    /// </summary>
+    internal sealed class ArteryFramingException : AkkaException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArteryFramingException"/> class.
+        /// </summary>
+        public ArteryFramingException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArteryFramingException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="cause">The exception that is the cause of the current exception.</param>
+        public ArteryFramingException(string message, Exception? cause = null) : base(message, cause)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArteryFramingException"/> class.
+        /// </summary>
+        /// <param name="info">The <see cref="SerializationInfo"/> that holds the serialized object data about the exception being thrown.</param>
+        /// <param name="context">The <see cref="StreamingContext"/> that contains contextual information about the source or destination.</param>
+        public ArteryFramingException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/core/Akka.Remote/Artery/ArteryStreamId.cs
+++ b/src/core/Akka.Remote/Artery/ArteryStreamId.cs
@@ -1,0 +1,42 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryStreamId.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+namespace Akka.Remote.Artery
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Identifies which of the three Artery TCP streams a connection carries, per the
+    /// connection preamble described in <c>openspec/changes/artery-tcp-remoting/design.md</c>
+    /// ("Envelope wire layout" / Decision 3). The value is written as a single byte
+    /// immediately following the <c>AKKA</c> magic in <see cref="ArteryConnectionHeader"/>.
+    /// </summary>
+    internal enum ArteryStreamId : byte
+    {
+        /// <summary>
+        /// Handshake, heartbeats, system-message ACK/NACK, and quarantine notifications.
+        /// This stream pierces quarantine and must never be starved by user traffic.
+        /// </summary>
+        Control = 1,
+
+        /// <summary>
+        /// User (application) messages, partitioned across inbound/outbound lanes by
+        /// recipient hash. Blocked while the association is quarantined, except for
+        /// <c>ActorSelectionMessage</c> / <c>ClearSystemMessageDelivery</c>.
+        /// </summary>
+        Ordinary = 2,
+
+        /// <summary>
+        /// Messages destined for <c>large-message-destinations</c>, isolated onto their own
+        /// stream to avoid head-of-line blocking. This is isolation, not chunking — Artery
+        /// TCP does not fragment oversized payloads.
+        /// </summary>
+        Large = 3
+    }
+}

--- a/src/core/Akka.Remote/Artery/PooledFrameWriter.cs
+++ b/src/core/Akka.Remote/Artery/PooledFrameWriter.cs
@@ -1,0 +1,124 @@
+//-----------------------------------------------------------------------
+// <copyright file="PooledFrameWriter.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Buffers;
+
+namespace Akka.Remote.Artery
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Minimal growable <see cref="IBufferWriter{T}"/> over <see cref="ArrayPool{T}"/>, used by the
+    /// V2 single-pass overload of <see cref="ArteryEnvelopeCodec.Encode(Akka.Serialization.Serialization,long,string,string,object)"/>.
+    /// The encoded frame's total size is not known up front -- the payload is streamed directly
+    /// into this writer via the message's serializer, and the frame-length field plus the fixed
+    /// header are back-patched afterward from the actual bytes written (design.md: "back-patched
+    /// from bytes-written, not predicted -- no <c>SizeHint</c> dependency").
+    ///
+    /// <para>
+    /// This is deliberately minimal: one rented array that doubles on overflow (copying the
+    /// already-written prefix into the new array), plus <see cref="GetPatchSpan"/> for going back
+    /// and overwriting already-written bytes at an absolute position. It is not pooled itself --
+    /// callers own one instance per encode and must call <see cref="Dispose"/> to return the
+    /// rented array.
+    /// </para>
+    /// </summary>
+    internal sealed class PooledFrameWriter : IBufferWriter<byte>, IDisposable
+    {
+        private const int MinimumCapacity = 64;
+
+        private byte[] _buffer;
+        private int _written;
+        private bool _disposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PooledFrameWriter"/> class.
+        /// </summary>
+        /// <param name="initialCapacityHint">A hint for the initial rented buffer size; grows automatically if exceeded.</param>
+        public PooledFrameWriter(int initialCapacityHint = MinimumCapacity)
+        {
+            _buffer = ArrayPool<byte>.Shared.Rent(Math.Max(initialCapacityHint, MinimumCapacity));
+        }
+
+        /// <summary>The number of bytes written so far.</summary>
+        public int WrittenCount => _written;
+
+        /// <summary>A read-only view over the bytes written so far.</summary>
+        public ReadOnlySpan<byte> WrittenSpan => _buffer.AsSpan(0, _written);
+
+        /// <summary>A read-only view over the bytes written so far.</summary>
+        public ReadOnlyMemory<byte> WrittenMemory => _buffer.AsMemory(0, _written);
+
+        /// <inheritdoc />
+        public void Advance(int count)
+        {
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), count, "Advance count must be non-negative.");
+            if (_written + count > _buffer.Length)
+                throw new InvalidOperationException("Cannot advance past the end of the rented buffer.");
+
+            _written += count;
+        }
+
+        /// <inheritdoc />
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return _buffer.AsMemory(_written);
+        }
+
+        /// <inheritdoc />
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            EnsureCapacity(sizeHint);
+            return _buffer.AsSpan(_written);
+        }
+
+        /// <summary>
+        /// Returns a mutable view over an already-written absolute byte range, so a caller can
+        /// back-patch a field (the frame length, the fixed header) whose value is only known after
+        /// later bytes (literals, payload) have been written.
+        /// </summary>
+        /// <param name="start">The absolute start offset, in bytes, from the start of the writer.</param>
+        /// <param name="length">The number of bytes to expose for patching.</param>
+        public Span<byte> GetPatchSpan(int start, int length)
+        {
+            if (start < 0 || length < 0 || start + length > _written)
+                throw new ArgumentOutOfRangeException(nameof(start), start, "Patch range must fall entirely within already-written bytes.");
+
+            return _buffer.AsSpan(start, length);
+        }
+
+        private void EnsureCapacity(int sizeHint)
+        {
+            var required = sizeHint <= 0 ? 1 : sizeHint;
+            if (_buffer.Length - _written >= required)
+                return;
+
+            var newSize = Math.Max(_buffer.Length * 2, _written + required);
+            var newBuffer = ArrayPool<byte>.Shared.Rent(newSize);
+            _buffer.AsSpan(0, _written).CopyTo(newBuffer);
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = newBuffer;
+        }
+
+        /// <summary>Returns the rented buffer to <see cref="ArrayPool{T}.Shared"/>.</summary>
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = Array.Empty<byte>();
+            _written = 0;
+        }
+    }
+}


### PR DESCRIPTION
Implements milestone **G1** of [`artery-tcp-remoting`](https://github.com/akkadotnet/akka.net/tree/dev/openspec/changes/artery-tcp-remoting) (task groups 2–3): the TCP framing foundation and the Artery envelope codec, round-tripped in-memory and multi-segment. No async/lifecycle/transport yet (that's G2). Everything is `internal` — the public API surface is unchanged (`ApproveRemote` byte-identical).

## Design closures (first commit, design.md)

The envelope's open ◇ sub-decisions are closed, and the fixed header is revised **28 → 32 bytes** with an explicit **payload-offset** field: the draft derived the payload as `frame_length − header_length`, which breaks whenever a literal tail is present. The explicit offset makes the payload slice O(1) and position-independent. Closed: version = 1 (reject others); flags bit 0 = metadata section, bits 1–7 reserved-must-be-zero (reject); ABSENT tag = `0x0`; literals = u16 LE length + UTF-8 at absolute offsets ≥ 32 (< `0x00FFFFFF`, which is why the framing hard-caps frames at 16 MiB−1); metadata container = u32 LE length + bytes, skipped by the MVP decoder.

## Framing (`Akka.Remote.Artery`, internal)

- `ArteryStreamId` (control=1 / ordinary=2 / large=3), `ArteryConnectionHeader` (`AKKA` magic + stream id; tri-state parse: need-more-data / success / typed exception on bad magic or unknown id).
- `ArteryFrameParser`: incremental `[u32 LE length][body]` parser. Zero-copy — yields frame bodies as (possibly multi-segment) `ReadOnlySequence<byte>` over the appended chunks via a `ReadOnlySequenceSegment` chain, with a single-segment fast path so the common whole-frame-per-read case allocates no segment objects (this sits on the future serial decode island, Decision 2). Oversized frames fail fast from the declared length, before the body arrives.

## Envelope codec

- 32-byte fixed-offset header (version, flags, table versions, origin UID i64 — the 64-bit uid from #8317 — serializer id i32, three u32 tags, payload offset); allocation-free header decode with single-segment fast path; lazy literal/payload resolution; validation for version, reserved flags, tag/metadata/payload bounds.
- **V2 single-pass encode**: `FindSerializerV2For` + `ManifestFor` resolve serializer id + manifest *upfront* (`SerializerV2.Manifest(object)` is an upfront member; `SerializerV1Adapter` is itself a `SerializerV2`, so the path is uniform with no compat fork), header + literals are written first, the payload streams directly into a pooled growable `IBufferWriter<byte>` (`PooledFrameWriter`), and only the frame length + header are back-patched from actual bytes written. `SizeHint` is never trusted for framing.

## Verification

- 68 new unit tests (framing: fragmentation down to byte-by-byte delivery, multi-chunk frames, oversize/cap/boundary cases; envelope: ABSENT/LITERAL/mixed/UTF-8 round-trips, multi-segment decode with headers and literals split across segments, all rejection paths, compressed-tag surfacing, and an end-to-end V2 test: object → single-pass encode through real `Serialization` → decode → `Deserialize(ReadOnlySequence...)` → equality).
- Full Akka.Remote.Tests suite: 434 passed / 0 failed (net10.0, Release). `dotnet build -warnaserror` clean. API approvals unchanged.

**G1 gate: PASSED.** Next: G2 (handshake, association state, basic ordinary messaging over `Akka.Streams.IO.Tcp`).