### PR TITLE
Implemented draft 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -242,3 +242,7 @@ launchSettings.json
 # Claude worktree management
 .claude-wt/worktrees
 /.playwright-mcp
+design-notes/8295-consistent-hashing-concepts.md
+design-notes/8293-consistenthash-ring-storage.md
+design-notes/8295-consistent-hash-64bit-ring.md
+scripts/setup-dev-env-fedora.sh

--- a/src/core/Akka.Tests/Routing/ConsistentHashSpec.cs
+++ b/src/core/Akka.Tests/Routing/ConsistentHashSpec.cs
@@ -50,14 +50,24 @@ namespace Akka.Tests.Routing
         #region Helpers
 
         /// <summary>
-        /// Reads the private ring dictionary out of a <see cref="ConsistentHash{T}"/> so tests can
-        /// assert on the exact key-&gt;node mapping (there is no public accessor).
+        /// Reads the private ring state out of a <see cref="ConsistentHash{T}"/> so tests can assert
+        /// on the exact key-&gt;node mapping (there is no public accessor). Since #8293 the ring is
+        /// stored as parallel sorted arrays rather than a retained SortedDictionary; rebuild the
+        /// dictionary shape here so the assertions (and the legacy-ring comparison) stay unchanged.
         /// </summary>
         private static SortedDictionary<int, T> Ring<T>(ConsistentHash<T> hash)
         {
-            var field = typeof(ConsistentHash<T>).GetField("_nodes", BindingFlags.NonPublic | BindingFlags.Instance);
-            field.Should().NotBeNull("the ConsistentHash<T>._nodes field is required by these tests");
-            return (SortedDictionary<int, T>)field.GetValue(hash);
+            var keysField = typeof(ConsistentHash<T>).GetField("_nodeHashRing", BindingFlags.NonPublic | BindingFlags.Instance);
+            var valuesField = typeof(ConsistentHash<T>).GetField("_nodeRing", BindingFlags.NonPublic | BindingFlags.Instance);
+            keysField.Should().NotBeNull("the ConsistentHash<T>._nodeHashRing field is required by these tests");
+            valuesField.Should().NotBeNull("the ConsistentHash<T>._nodeRing field is required by these tests");
+
+            var keys = (int[])keysField.GetValue(hash);
+            var values = (T[])valuesField.GetValue(hash);
+            var ring = new SortedDictionary<int, T>();
+            for (var i = 0; i < keys.Length; i++)
+                ring.Add(keys[i], values[i]); // Add, not the indexer: a duplicate ring slot must fail loudly
+            return ring;
         }
 
         /// <summary>

--- a/src/core/Akka/Routing/ConsistentHash.cs
+++ b/src/core/Akka/Routing/ConsistentHash.cs
@@ -26,40 +26,32 @@ namespace Akka.Routing
     /// <typeparam name="T">The type of objects to store in the hash.</typeparam>
     public class ConsistentHash<T>
     {
-        private readonly SortedDictionary<int, T> _nodes;
+        // Ring state: parallel arrays sorted by ring slot, materialized once at construction.
+        // The SortedDictionary the ring is built in is deliberately NOT retained: after
+        // construction it was only ever read by IsEmpty and operator + / operator - (both served
+        // by the arrays), while its red-black-tree nodes (~56 bytes per ring point) dominated the
+        // ring's steady-state footprint - ~1.1 MB of dead weight at 20k ring points (#8293).
+        private readonly int[] _nodeHashRing;
+        private readonly T[] _nodeRing;
         private readonly int _virtualNodesFactor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConsistentHash{T}"/> class.
         /// </summary>
-        /// <param name="nodes">TBD</param>
-        /// <param name="virtualNodesFactor">TBD</param>
+        /// <param name="nodes">The ring content as a slot-to-node mapping sorted by slot. Used only to
+        /// materialize the internal lookup arrays; the dictionary itself is not retained, so mutating
+        /// it after construction does not affect this instance.</param>
+        /// <param name="virtualNodesFactor">The number of virtual nodes each node is expanded into on the ring.</param>
         /// <exception cref="ArgumentException">
         /// This exception is thrown if the given <paramref name="virtualNodesFactor"/> is less than one.
         /// </exception>
         public ConsistentHash(SortedDictionary<int, T> nodes, int virtualNodesFactor)
         {
-            _nodes = nodes;
-
             if (virtualNodesFactor < 1) throw new ArgumentException("virtualNodesFactor must be >= 1", nameof(virtualNodesFactor));
 
+            _nodeHashRing = nodes.Keys.ToArray();
+            _nodeRing = nodes.Values.ToArray();
             _virtualNodesFactor = virtualNodesFactor;
-        }
-
-        private (int[], T[])? _ring = null;
-        private (int[], T[])? RingTuple
-        {
-            get { return _ring ??= (_nodes.Keys.ToArray(), _nodes.Values.ToArray()); }
-            }
-
-        private int[] NodeHashRing
-        {
-            get { return RingTuple.Value.Item1; }
-        }
-
-        private T[] NodeRing
-        {
-            get { return RingTuple.Value.Item2; }
         }
 
         /// <summary>
@@ -94,7 +86,7 @@ namespace Akka.Routing
             else
             {
                 var j = Math.Abs(i + 1);
-                if (j >= NodeHashRing.Length) return 0; //after last, use first
+                if (j >= _nodeHashRing.Length) return 0; //after last, use first
                 else return j; //next node clockwise
             }
         }
@@ -111,7 +103,7 @@ namespace Akka.Routing
         {
             if (IsEmpty) throw new InvalidOperationException($"Can't get node for [{key}] from an empty node ring");
 
-            return NodeRing[Idx(Array.BinarySearch(NodeHashRing, ConsistentHash.HashFor(key)))];
+            return _nodeRing[Idx(Array.BinarySearch(_nodeHashRing, ConsistentHash.HashFor(key)))];
         }
 
         /// <summary>
@@ -126,7 +118,7 @@ namespace Akka.Routing
         {
             if (IsEmpty) throw new InvalidOperationException($"Can't get node for [{key}] from an empty node ring");
 
-            return NodeRing[Idx(Array.BinarySearch(NodeHashRing, ConsistentHash.HashFor(key)))];
+            return _nodeRing[Idx(Array.BinarySearch(_nodeHashRing, ConsistentHash.HashFor(key)))];
         }
 
         /// <summary>
@@ -134,7 +126,7 @@ namespace Akka.Routing
         /// </summary>
         public bool IsEmpty
         {
-            get { return !_nodes.Any(); }
+            get { return _nodeHashRing.Length == 0; }
         }
 
         /// <summary>
@@ -176,10 +168,10 @@ namespace Akka.Routing
             // ToString() (the ring's node identity), so this is byte-identical to
             // ConsistentHash.Create(all nodes): collisions resolve in canonical order, and adding a
             // node already present (by ToString) is a no-op rather than a duplicated vnode set (#8031).
-            // Values repeats each node virtualNodesFactor times; Distinct() (reference equality on the
-            // stored instances) collapses that back to N so Create sorts N nodes, not N*V - Create's
-            // ToString de-dup remains the correctness guarantee.
-            return ConsistentHash.Create(hash._nodes.Values.Distinct().Append(node), hash._virtualNodesFactor);
+            // The ring values array repeats each node virtualNodesFactor times; Distinct() (reference
+            // equality on the stored instances) collapses that back to N so Create sorts N nodes, not
+            // N*V - Create's ToString de-dup remains the correctness guarantee.
+            return ConsistentHash.Create(hash._nodeRing.Distinct().Append(node), hash._virtualNodesFactor);
         }
 
         /// <summary>
@@ -199,10 +191,11 @@ namespace Akka.Routing
             // (the ring's node identity) - rather than T.Equals - avoids dropping a different node
             // that merely compares Equals-equal to the target (#8031).
             var nodeKey = node.ToString();
-            // Distinct() first (reference equality collapses the virtualNodesFactor repeats in Values
-            // to N distinct nodes) so the ToString filter and Create's sort run over N, not N*V.
+            // Distinct() first (reference equality collapses the virtualNodesFactor repeats in the
+            // ring values array to N distinct nodes) so the ToString filter and Create's sort run
+            // over N, not N*V.
             return ConsistentHash.Create(
-                hash._nodes.Values.Distinct().Where(n => !string.Equals(n.ToString(), nodeKey, StringComparison.Ordinal)),
+                hash._nodeRing.Distinct().Where(n => !string.Equals(n.ToString(), nodeKey, StringComparison.Ordinal)),
                 hash._virtualNodesFactor);
         }
 


### PR DESCRIPTION
Fixes #

## Changes

Option A implementiran i verifikovan lokalno — 2 fajla, +40/−37 linija, testovi 21/21, izmerena ušteda −82% 
  retained memorije po ringu.
      
  Šta je urađeno:

  ConsistentHash.cs — _nodes (SortedDictionary), lazy _ring/RingTuple i pass-through propertiji su obrisani; ring
  stanje su sada dva polja int[] _nodeHashRing + T[] _nodeRing, materijalizovana jednom u konstruktoru
  (Keys/Values.ToArray() — dict se ne zadržava). NodeFor je isti binary search nad istim sadržajem, IsEmpty čita
  Length == 0, operatori +/- idu preko _nodeRing.Distinct() — identičan sadržaj kao pre (_nodeRing jeste
  Values.ToArray()), pa je i dedup semantika identična. Koliziona logika u Create nije ni pipnuta.

  ConsistentHashSpec.cs — samo helper Ring<T> prerađen: reflektuje oba niza i rekonstruiše dictionary, pa su tela
  svih testova i legacy poređenje ostali netaknuti; dict.Add u rekonstrukciji usput proverava da nema dupliranih
  slotova. Ništa drugo u src/ ne dira internals (benchmark, routing logic, receptionist — sve javni API).

  Verifikacija:
  - dotnet test --filter ~ConsistentHash: 21/21 (ceo ConsistentHashSpec uključujući byte-identical legacy dokaz i
  kolizioni par 2842/7681, plus ConsistentHashingRouterSpec); -warnaserror build čist. Dev je u međuvremenu prešao
  na SDK 10 (global.json 10.0.101 + rollForward major), pa lokalni build radi — CLAUDE.md je tu zastareo.
  - Before/after merenje (harness u scratchpadu, stash → stari build → merenje → pop): 20k tačaka 1,30 MB → 0,23 MB,
  50k tačaka 3,24 MB → 0,57 MB — praktično tačno projekcije iz issue-a.


## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [ ] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [ ] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [ ] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [ ] Design discussion issue #
* [ ] Changes in public API reviewed, if any.
* [ ] I have added website documentation for this feature.

### Latest `dev` Benchmarks 

Include data from the [relevant benchmark](https://getakka.net/community/contributing/index.html#improve-performance) prior to this change here.

### This PR's Benchmarks

Include data from after this change here.
