### PR TITLE
Artery G3 task group 6: dedicated control stream

### DIFF
--- a/src/core/Akka.Remote.Tests/Artery/ArteryConfigSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryConfigSpec.cs
@@ -81,6 +81,7 @@ namespace Akka.Remote.Tests.Artery
             settings.HandshakeTimeout.Should().Be(20.Seconds());
             settings.HandshakeRetryInterval.Should().Be(1.Seconds());
             settings.InjectHandshakeInterval.Should().Be(1.Seconds());
+            settings.ControlHeartbeatInterval.Should().Be(5.Seconds());
         }
 
         [Theory(DisplayName = "Should_ThrowConfigurationException_When_ArterySettingIsInvalid")]

--- a/src/core/Akka.Remote.Tests/Artery/ArteryControlMessageSerializerSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryControlMessageSerializerSpec.cs
@@ -93,6 +93,41 @@ namespace Akka.Remote.Tests.Artery
             RoundTrip(rsp).Should().Be(rsp);
         }
 
+        [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip ArteryHeartbeat (task group 6, task 6.4)")]
+        public void Should_round_trip_ArteryHeartbeat()
+        {
+            RoundTrip(new ArteryHeartbeat()).Should().Be(new ArteryHeartbeat());
+        }
+
+        [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip ArteryHeartbeatRsp (task group 6, task 6.4)")]
+        public void Should_round_trip_ArteryHeartbeatRsp()
+        {
+            RoundTrip(new ArteryHeartbeatRsp()).Should().Be(new ArteryHeartbeatRsp());
+        }
+
+        [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip ArteryQuarantined (task group 6, task 6.5)")]
+        public void Should_round_trip_ArteryQuarantined()
+        {
+            var from = new UniqueAddress(new Address("akka", "sys-a", "host-a", 2551), 123456789L);
+            var quarantined = new ArteryQuarantined(from, QuarantinedUid: 987654321L);
+
+            RoundTrip(quarantined).Should().Be(quarantined);
+        }
+
+        [Theory(DisplayName = "ArteryControlMessageSerializer should round-trip ArteryQuarantined across negative, zero, and boundary uid values")]
+        [InlineData(0L)]
+        [InlineData(1L)]
+        [InlineData(-1L)]
+        [InlineData(long.MinValue)]
+        [InlineData(long.MaxValue)]
+        public void Should_round_trip_ArteryQuarantined_extreme_uid_values(long quarantinedUid)
+        {
+            var from = new UniqueAddress(new Address("akka", "sys-a", "host-a", 2551), 42L);
+            var quarantined = new ArteryQuarantined(from, quarantinedUid);
+
+            RoundTrip(quarantined).Should().Be(quarantined);
+        }
+
         [Fact(DisplayName = "ArteryControlMessageSerializer should report bytes-written matching the buffer")]
         public void Should_report_bytes_written()
         {
@@ -107,16 +142,22 @@ namespace Akka.Remote.Tests.Artery
             written.Should().BeGreaterThan(0);
         }
 
-        [Fact(DisplayName = "ArteryControlMessageSerializer should report exact size hints for both message types")]
+        [Fact(DisplayName = "ArteryControlMessageSerializer should report exact size hints for all message types")]
         public void Should_report_exact_size_hints()
         {
             var req = new HandshakeReq(
                 new UniqueAddress(new Address("akka", "sys-a", "host-a", 2551), 42L),
                 new Address("akka", "sys-b", "host-b", 2552));
             var rsp = new HandshakeRsp(new UniqueAddress(new Address("akka", "sys-b", "host-b", 2552), -5L));
+            var heartbeat = new ArteryHeartbeat();
+            var heartbeatRsp = new ArteryHeartbeatRsp();
+            var quarantined = new ArteryQuarantined(new UniqueAddress(new Address("akka", "sys-a", "host-a", 2551), 42L), 99L);
 
             _serializer.SizeHint(req).Should().Be(_serializer.ToBinary(req).Length);
             _serializer.SizeHint(rsp).Should().Be(_serializer.ToBinary(rsp).Length);
+            _serializer.SizeHint(heartbeat).Should().Be(_serializer.ToBinary(heartbeat).Length);
+            _serializer.SizeHint(heartbeatRsp).Should().Be(_serializer.ToBinary(heartbeatRsp).Length);
+            _serializer.SizeHint(quarantined).Should().Be(_serializer.ToBinary(quarantined).Length);
         }
 
         [Fact(DisplayName = "ArteryControlMessageSerializer should dispatch by manifest and reject an unknown manifest")]
@@ -127,6 +168,10 @@ namespace Akka.Remote.Tests.Artery
                 new Address("akka", "sys-b", "host-b", 2552));
 
             _serializer.Manifest(req).Should().Be(ArteryControlMessageSerializer.HandshakeReqManifest);
+            _serializer.Manifest(new ArteryHeartbeat()).Should().Be(ArteryControlMessageSerializer.HeartbeatManifest);
+            _serializer.Manifest(new ArteryHeartbeatRsp()).Should().Be(ArteryControlMessageSerializer.HeartbeatRspManifest);
+            _serializer.Manifest(new ArteryQuarantined(new UniqueAddress(new Address("akka", "sys-a", "host-a", 2551), 1L), 2L))
+                .Should().Be(ArteryControlMessageSerializer.QuarantinedManifest);
 
             var bytes = _serializer.ToBinary(req);
             Action deserializeUnknown = () => _serializer.FromBinary(bytes, "unknown-manifest");

--- a/src/core/Akka.Remote.Tests/Artery/ArteryControlStreamSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryControlStreamSpec.cs
@@ -1,0 +1,353 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryControlStreamSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote.Artery;
+using Akka.TestKit;
+using Akka.TestKit.Extensions;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+
+namespace Akka.Remote.Tests.Artery
+{
+    /// <summary>
+    /// Covers Artery TCP remoting task group 6, "Control Stream"
+    /// (<c>openspec/changes/artery-tcp-remoting/tasks.md</c>): each association's control stream
+    /// is a SEPARATE connection/queue from its ordinary stream (task 6.1), inbound control
+    /// processing dispatches non-handshake control messages to <see cref="IControlMessageSubscriber"/>s
+    /// (task 6.2), heartbeat liveness (task 6.4), quarantine notification (task 6.5), and the
+    /// non-starvation proof (task 6.6). See <c>openspec/changes/artery-tcp-remoting/design.md</c>,
+    /// "Reliable system-message delivery (gate G3)" for why control isolation matters -- it is
+    /// the substrate group 7's ACK/NACK stages will run on.
+    /// </summary>
+    public class ArteryControlStreamSpec : AkkaSpec
+    {
+        public ArteryControlStreamSpec(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private static Config ArteryConfig(TimeSpan? controlHeartbeatInterval = null)
+        {
+            var extra = controlHeartbeatInterval is { } interval
+                ? $"akka.remote.artery.advanced.control-heartbeat-interval = {(long)interval.TotalMilliseconds}ms"
+                : "";
+
+            return ConfigurationFactory.ParseString($"""
+                akka.actor.provider = "Akka.Remote.RemoteActorRefProvider, Akka.Remote"
+                akka.remote.artery.enabled = on
+                akka.remote.artery.canonical.hostname = "127.0.0.1"
+                akka.remote.artery.canonical.port = 0
+                {extra}
+                """);
+        }
+
+        private static int BoundPort(ActorSystem system) => RARP.For(system).Provider.DefaultAddress.Port!.Value;
+
+        private static string EchoSelectionPath(ActorSystem system, string localName) =>
+            $"akka://{system.Name}@127.0.0.1:{BoundPort(system)}/user/{localName}";
+
+        private static ArteryRemoting TransportFor(ActorSystem system) => (ArteryRemoting)RARP.For(system).Provider.Transport;
+
+        private sealed class Echo : ReceiveActor
+        {
+            public Echo()
+            {
+                ReceiveAny(msg => Sender.Tell(msg));
+            }
+        }
+
+        /// <summary>
+        /// Forwards every received control message to a <see cref="TestProbe"/> -- lets a test
+        /// observe the internal control-message hook (task 6.2) directly, independent of any one
+        /// message's production-side handling.
+        /// </summary>
+        private sealed class ControlProbeSubscriber : IControlMessageSubscriber
+        {
+            private readonly IActorRef _probe;
+            public ControlProbeSubscriber(IActorRef probe) => _probe = probe;
+            public void ControlMessageReceived(long originUid, object message) => _probe.Tell(message);
+        }
+
+        private async Task<IActorRef> WarmUpAssociationAsync(ActorSystem systemA, ActorSystem systemB)
+        {
+            systemB.ActorOf(Props.Create(() => new Echo()), "echo");
+
+            // A real ordinary round trip establishes the handshake (and therefore both systems'
+            // control connections) both ways -- see design.md "Connection cardinality".
+            var echoRef = await systemA.ActorSelection(EchoSelectionPath(systemB, "echo")).ResolveOne(TimeSpan.FromSeconds(10));
+            var warmup = CreateTestProbe(systemA);
+            echoRef.Tell("warmup", warmup.Ref);
+            await warmup.ExpectMsgAsync("warmup", TimeSpan.FromSeconds(10));
+            return echoRef;
+        }
+
+        [Fact(DisplayName = "Control stream heartbeat: B observes ArteryHeartbeat arriving from A, and A observes B's ArteryHeartbeatRsp reply")]
+        public async Task Should_Exchange_Heartbeats_Over_The_Control_Stream()
+        {
+            var interval = TimeSpan.FromMilliseconds(300);
+            var systemA = ActorSystem.Create("ArteryHeartbeatA", ArteryConfig(interval));
+            var systemB = ActorSystem.Create("ArteryHeartbeatB", ArteryConfig(interval));
+            try
+            {
+                await WarmUpAssociationAsync(systemA, systemB);
+
+                var probeOnB = CreateTestProbe(systemB);
+                TransportFor(systemB).SubscribeControl(new ControlProbeSubscriber(probeOnB.Ref));
+
+                var probeOnA = CreateTestProbe(systemA);
+                TransportFor(systemA).SubscribeControl(new ControlProbeSubscriber(probeOnA.Ref));
+
+                // B must observe a heartbeat from A -- proves the control stream's own idle timer
+                // (ArteryHeartbeatStage) is live and reaches the peer.
+                await probeOnB.FishForMessageAsync(msg => msg is ArteryHeartbeat, TimeSpan.FromSeconds(5));
+
+                // A must, in turn, observe the HeartbeatRsp B's transport auto-replies with (its
+                // own IControlMessageSubscriber.ControlMessageReceived handling).
+                await probeOnA.FishForMessageAsync(msg => msg is ArteryHeartbeatRsp, TimeSpan.FromSeconds(5));
+            }
+            finally
+            {
+                await systemA.Terminate().AwaitWithTimeout(10.Seconds());
+                await systemB.Terminate().AwaitWithTimeout(10.Seconds());
+            }
+        }
+
+        [Fact(DisplayName = "Quarantine notification: B publishes ThisActorSystemQuarantinedEvent and observes the exact ArteryQuarantined content A sent, when A quarantines the association")]
+        public async Task Should_Notify_Peer_On_Quarantine()
+        {
+            var systemA = ActorSystem.Create("ArteryQuarantineNotifyA", ArteryConfig());
+            var systemB = ActorSystem.Create("ArteryQuarantineNotifyB", ArteryConfig());
+            try
+            {
+                await WarmUpAssociationAsync(systemA, systemB);
+
+                var controlProbeOnB = CreateTestProbe(systemB);
+                TransportFor(systemB).SubscribeControl(new ControlProbeSubscriber(controlProbeOnB.Ref));
+
+                var eventProbeOnB = CreateTestProbe(systemB);
+                systemB.EventStream.Subscribe(eventProbeOnB.Ref, typeof(ThisActorSystemQuarantinedEvent));
+
+                var bAddress = RARP.For(systemB).Provider.DefaultAddress;
+                var bUid = AddressUidExtension.Uid(systemB);
+                var aAddress = RARP.For(systemA).Provider.DefaultAddress;
+
+                TransportFor(systemA).Quarantine(bAddress, bUid);
+
+                var received = await controlProbeOnB.ExpectMsgAsync<ArteryQuarantined>(TimeSpan.FromSeconds(10));
+                received.From.Address.Should().Be(aAddress);
+                received.QuarantinedUid.Should().Be(bUid);
+
+                var evt = await eventProbeOnB.ExpectMsgAsync<ThisActorSystemQuarantinedEvent>(TimeSpan.FromSeconds(10));
+                evt.RemoteAddress.Should().Be(aAddress);
+            }
+            finally
+            {
+                await systemA.Terminate().AwaitWithTimeout(10.Seconds());
+                await systemB.Terminate().AwaitWithTimeout(10.Seconds());
+            }
+        }
+
+        [Fact(DisplayName = "Sending ordinary messages to a quarantined association drops them to dead letters instead of transmitting them")]
+        public async Task Should_DeadLetter_Ordinary_Sends_To_Quarantined_Association()
+        {
+            var systemA = ActorSystem.Create("ArteryQuarantineGateA", ArteryConfig());
+            var systemB = ActorSystem.Create("ArteryQuarantineGateB", ArteryConfig());
+            try
+            {
+                var echoRef = await WarmUpAssociationAsync(systemA, systemB);
+
+                var bAddress = RARP.For(systemB).Provider.DefaultAddress;
+                var bUid = AddressUidExtension.Uid(systemB);
+
+                TransportFor(systemA).Quarantine(bAddress, bUid);
+
+                var deadLetterProbe = CreateTestProbe(systemA);
+                systemA.EventStream.Subscribe(deadLetterProbe.Ref, typeof(DeadLetter));
+                try
+                {
+                    echoRef.Tell("should-not-be-delivered");
+                    var deadLetter = await deadLetterProbe.ExpectMsgAsync<DeadLetter>(TimeSpan.FromSeconds(10));
+                    deadLetter.Message.Should().Be("should-not-be-delivered");
+                }
+                finally
+                {
+                    systemA.EventStream.Unsubscribe(deadLetterProbe.Ref, typeof(DeadLetter));
+                }
+            }
+            finally
+            {
+                await systemA.Terminate().AwaitWithTimeout(10.Seconds());
+                await systemB.Terminate().AwaitWithTimeout(10.Seconds());
+            }
+        }
+
+        /// <summary>
+        /// <see cref="ArrayPool{T}"/> that scribbles over every array it hands back to its
+        /// (privately owned, test-only) inner pool -- see <c>ArteryTransportSpec</c>'s identical
+        /// helper for the full rationale; duplicated here (rather than shared) to keep this spec
+        /// self-contained.
+        /// </summary>
+        private sealed class PoisoningArrayPool : ArrayPool<byte>
+        {
+            private const byte PoisonByte = 0xDE;
+            private readonly ArrayPool<byte> _inner = Create();
+
+            public override byte[] Rent(int minimumLength) => _inner.Rent(minimumLength);
+
+            public override void Return(byte[] array, bool clearArray = false)
+            {
+                Array.Fill(array, PoisonByte);
+                _inner.Return(array, clearArray: false);
+            }
+        }
+
+        /// <summary>
+        /// Same poison-pool tripwire as <c>ArteryTransportSpec</c>'s ordinary-stream test, applied
+        /// to the CONTROL stream. Unlike a bare heartbeat, <see cref="ArteryQuarantined"/> carries
+        /// real content (an address + a uid) -- so a corrupted buffer would show up as a content
+        /// mismatch or a decode failure (a missing delivery), not just silently do nothing.
+        /// Repeats the (idempotent -- <c>ArteryRemoting.Quarantine</c> re-sends every call) call
+        /// so multiple frames flow through the SAME two-generation
+        /// <see cref="ArteryEncodeStage"/> buffer-disposal cycle on the control connection.
+        /// </summary>
+        [Fact(DisplayName = "Poison-pool tripwire: repeated ArteryQuarantined control notifications are not corrupted when outbound encode buffers are returned early")]
+        public async Task Should_Not_Corrupt_Control_Messages_When_Outbound_Encode_Buffers_Are_Returned_Early()
+        {
+            var poisonPool = new PoisoningArrayPool();
+
+            // ArteryTransportSetup (not a mutable static field) carries the pool override --
+            // scoped to just these two ActorSystems -- see ArteryTransportSetup's remarks.
+            var setup = BootstrapSetup.Create().WithConfig(ArteryConfig()).And(new ArteryTransportSetup(poisonPool));
+
+            ActorSystem? systemA = null;
+            ActorSystem? systemB = null;
+            try
+            {
+                systemA = ActorSystem.Create("ArteryControlPoisonPoolA", setup);
+                systemB = ActorSystem.Create("ArteryControlPoisonPoolB", setup);
+
+                await WarmUpAssociationAsync(systemA, systemB);
+
+                var controlProbeOnB = CreateTestProbe(systemB);
+                TransportFor(systemB).SubscribeControl(new ControlProbeSubscriber(controlProbeOnB.Ref));
+
+                var bAddress = RARP.For(systemB).Provider.DefaultAddress;
+                var bUid = AddressUidExtension.Uid(systemB);
+                var aAddress = RARP.For(systemA).Provider.DefaultAddress;
+                var transportA = TransportFor(systemA);
+
+                const int quarantineCallCount = 60;
+                for (var i = 0; i < quarantineCallCount; i++)
+                    transportA.Quarantine(bAddress, bUid);
+
+                for (var i = 0; i < quarantineCallCount; i++)
+                {
+                    var received = await controlProbeOnB.ExpectMsgAsync<ArteryQuarantined>(TimeSpan.FromSeconds(10));
+                    received.From.Address.Should().Be(aAddress,
+                        "message {0}'s control-stream encode buffer must not have been reused/poisoned before its bytes were safely copied into the TCP pipe", i);
+                    received.QuarantinedUid.Should().Be(bUid);
+                }
+            }
+            finally
+            {
+                if (systemA is not null)
+                    await systemA.Terminate().AwaitWithTimeout(10.Seconds());
+                if (systemB is not null)
+                    await systemB.Terminate().AwaitWithTimeout(10.Seconds());
+            }
+        }
+
+        /// <summary>
+        /// Non-starvation, "simplest honest version" (task 6.6). Floods A-&gt;B's ORDINARY channel
+        /// with a large burst of back-to-back sends (no throttling, no replies awaited) while a
+        /// heartbeat subscriber on B independently watches the CONTROL stream, recording the gap
+        /// between consecutive heartbeat arrivals throughout the flood.
+        ///
+        /// <para>
+        /// <b>What this proves.</b> The control stream's own materialized TCP connection + bounded
+        /// channel (task 6.1) are entirely separate from the ordinary stream's -- control traffic
+        /// for THIS association is not queued behind, or multiplexed with, ordinary traffic to the
+        /// SAME peer. Combined with <c>AssociationRegistrySpec</c>'s queue-level isolation proof (a
+        /// full ordinary channel does not block <c>TryEnqueueControl</c>), this is an end-to-end
+        /// demonstration that heartbeats keep flowing on schedule while ordinary traffic is heavy.
+        /// </para>
+        /// <para>
+        /// <b>What this does NOT prove.</b> It does not prove the ordinary channel actually reached
+        /// its bounded capacity (3072) or that any message was dropped to dead letters -- forcing
+        /// genuine OS-level TCP backpressure deterministically, without flakiness, would require a
+        /// deliberately slow receiver at the socket level, which this test does not attempt. It
+        /// also says nothing about non-starvation under G5 lanes/compression (not yet implemented)
+        /// or under the reliable system-message layer's own load (group 7).
+        /// </para>
+        /// </summary>
+        [Fact(DisplayName = "Non-starvation: heartbeats keep flowing on schedule while the ordinary stream is flooded with a large burst of traffic")]
+        public async Task Should_Not_Starve_Heartbeats_Under_Ordinary_Traffic_Load()
+        {
+            var interval = TimeSpan.FromMilliseconds(250);
+            var systemA = ActorSystem.Create("ArteryNonStarvationA", ArteryConfig(interval));
+            var systemB = ActorSystem.Create("ArteryNonStarvationB", ArteryConfig(interval));
+            try
+            {
+                await WarmUpAssociationAsync(systemA, systemB);
+
+                var heartbeatProbe = CreateTestProbe(systemB);
+                TransportFor(systemB).SubscribeControl(new ControlProbeSubscriber(heartbeatProbe.Ref));
+
+                // Flood the ordinary channel: a large burst of sizable, back-to-back sends with no
+                // sender/no reply expected, so nothing throttles the flooding loop waiting on echoes.
+                // 5,000 sends comfortably exceeds the per-association ordinary queue's default
+                // capacity (3072) several times over.
+                var floodTarget = systemA.ActorSelection(EchoSelectionPath(systemB, "echo"));
+                var payload = new string('x', 4096);
+                const int floodCount = 5_000;
+
+                var floodTask = Task.Run(() =>
+                {
+                    for (var i = 0; i < floodCount; i++)
+                        floodTarget.Tell(payload);
+                });
+
+                const int heartbeatSamples = 15;
+                var timestamps = new List<DateTime>(heartbeatSamples);
+                for (var i = 0; i < heartbeatSamples; i++)
+                {
+                    await heartbeatProbe.FishForMessageAsync(msg => msg is ArteryHeartbeat, TimeSpan.FromSeconds(5));
+                    timestamps.Add(DateTime.UtcNow);
+                }
+
+                await floodTask;
+
+                var maxGap = TimeSpan.Zero;
+                for (var i = 1; i < timestamps.Count; i++)
+                {
+                    var gap = timestamps[i] - timestamps[i - 1];
+                    if (gap > maxGap)
+                        maxGap = gap;
+                }
+
+                // Generous bound (10x the interval) -- this is a non-starvation proof, not a
+                // precision-timing test; CI jitter under a 5,000-message flood is real.
+                maxGap.Should().BeLessThan(TimeSpan.FromMilliseconds(interval.TotalMilliseconds * 10),
+                    "the control stream must not be starved by a flooded ordinary stream to the SAME peer");
+            }
+            finally
+            {
+                await systemA.Terminate().AwaitWithTimeout(10.Seconds());
+                await systemB.Terminate().AwaitWithTimeout(10.Seconds());
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/Artery/ArteryHandshakeSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryHandshakeSpec.cs
@@ -51,9 +51,15 @@ namespace Akka.Remote.Tests.Artery
 
         private static Address NewRemote() => new("akka", "remote-sys", "remote-host", 2552);
 
-        /// <summary>An ordinary (non-control) inbound test envelope. OriginUid/SerializerId are not exercised by these stages, so arbitrary placeholder values are used.</summary>
-        private static IInboundEnvelope OrdinaryInbound(object message, string? senderPath = null, string recipientPath = "akka://remote-sys@remote-host:2552/user/recipient") =>
-            new InboundEnvelope(message, senderPath, recipientPath, OriginUid: 0L, SerializerId: 0, Manifest: "test-manifest");
+        /// <summary>
+        /// An ordinary (non-control) inbound test envelope. SerializerId is not exercised by these
+        /// stages, so an arbitrary placeholder value is used. <c>originUid</c> DOES matter as of
+        /// task group 6 (control stream): <see cref="InboundHandshakeStage"/> now gates ordinary
+        /// envelopes on <see cref="IInboundContext.IsKnownOrigin"/>, a registry lookup keyed by
+        /// this exact value -- see that stage's "Known origin is now a SHARED-registry check" remarks.
+        /// </summary>
+        private static IInboundEnvelope OrdinaryInbound(object message, string? senderPath = null, string recipientPath = "akka://remote-sys@remote-host:2552/user/recipient", long originUid = 0L) =>
+            new InboundEnvelope(message, senderPath, recipientPath, originUid, SerializerId: 0, Manifest: "test-manifest");
 
         /// <summary>A control inbound test envelope wrapping a handshake message.</summary>
         private static IInboundEnvelope ControlInbound(IArteryControlMessage message, long originUid) =>
@@ -224,6 +230,94 @@ namespace Akka.Remote.Tests.Artery
             error.Should().BeOfType<HandshakeTimeoutException>();
         }
 
+        [Fact(DisplayName = "OutboundHandshakeStage (isControlStream: false) should route the injected HandshakeReq via Context.SendControl instead of its own Out (task 6.3: ordinary stream's Req travels over the control channel)")]
+        public async Task OutboundHandshakeStage_non_control_should_route_req_via_send_control()
+        {
+            var registry = new AssociationRegistry();
+            var localAddress = NewLocal();
+            var remoteAddress = NewRemote();
+            var sentControl = new System.Collections.Generic.List<object>();
+            var context = new AssociationRegistryOutboundContext(registry, localAddress, remoteAddress, sentControl.Add);
+            var stage = new OutboundHandshakeStage(
+                context,
+                retryInterval: TimeSpan.FromMilliseconds(150),
+                handshakeTimeout: TimeSpan.FromSeconds(30),
+                injectHandshakeInterval: TimeSpan.FromSeconds(30),
+                isControlStream: false);
+
+            var materializer = ActorMaterializer.Create(Sys);
+            var (pub, sub) = this.SourceProbe<IOutboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(stage), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IOutboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            // Request demand and wait long enough for at least one retry-interval tick to have
+            // fired -- the Req must NOT appear on this stage's own Out (it travels via SendControl
+            // instead), so nothing should be delivered here even though the stage is actively
+            // (re)injecting on the side channel the whole time.
+            await sub.RequestAsync(1);
+            await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(400));
+
+            await AwaitConditionAsync(() => Task.FromResult(sentControl.Count > 0), TimeSpan.FromSeconds(2));
+            sentControl.Should().AllBeOfType<HandshakeReq>("the ordinary stream's injected Req must travel via the control side channel, not inline");
+            ((HandshakeReq)sentControl[0]).From.Should().Be(localAddress);
+            ((HandshakeReq)sentControl[0]).To.Should().Be(remoteAddress);
+
+            // A user element sent while incomplete is still held (never dropped) -- gating
+            // behavior is unchanged by the control-routing change.
+            await pub.SendNextAsync(new OutboundEnvelope("user-message", null, null));
+            await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(200));
+
+            registry.CompleteHandshake(remoteAddress, new UniqueAddress(remoteAddress, 555L));
+
+            var delivered = await sub.ExpectNextAsync(TimeSpan.FromSeconds(3));
+            delivered.Message.Should().Be("user-message");
+        }
+
+        [Fact(DisplayName = "OutboundHandshakeStage (isControlStream: false) should flow a user element through immediately on liveness re-injection, without holding it (task 6.3: the Req no longer competes for this stream's Out slot)")]
+        public async Task OutboundHandshakeStage_non_control_should_not_hold_elements_for_liveness_reinject()
+        {
+            var registry = new AssociationRegistry();
+            var localAddress = NewLocal();
+            var remoteAddress = NewRemote();
+            var sentControl = new System.Collections.Generic.List<object>();
+            var context = new AssociationRegistryOutboundContext(registry, localAddress, remoteAddress, sentControl.Add);
+
+            // Already-associated at PreStart (Completed immediately) -- exercises the
+            // "ShouldReinjectForLiveness" path directly rather than the initial handshake path.
+            registry.CompleteHandshake(remoteAddress, new UniqueAddress(remoteAddress, 777L));
+
+            var stage = new OutboundHandshakeStage(
+                context,
+                retryInterval: TimeSpan.FromSeconds(30),
+                handshakeTimeout: TimeSpan.FromSeconds(30),
+                injectHandshakeInterval: TimeSpan.FromMilliseconds(20), // "due" for reinjection well before the delay below elapses
+                isControlStream: false);
+
+            var materializer = ActorMaterializer.Create(Sys);
+            var (pub, sub) = this.SourceProbe<IOutboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(stage), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IOutboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await sub.RequestAsync(1);
+
+            // Deterministically clear the injectHandshakeInterval window (set at PreStart, since
+            // the association is already completed) before sending -- otherwise this assertion
+            // would race PreStart's timestamp against however fast the test harness happens to
+            // shuttle the SourceProbe/SinkProbe round trip on a given run.
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+            await pub.SendNextAsync(new OutboundEnvelope("immediate-payload", null, null));
+
+            // The user element flows through on THIS pull -- it is not held behind a Req that
+            // would otherwise have shared this stream's Out slot.
+            var delivered = await sub.ExpectNextAsync(TimeSpan.FromSeconds(2));
+            delivered.Message.Should().Be("immediate-payload");
+
+            sentControl.Should().ContainSingle().Which.Should().BeOfType<HandshakeReq>("liveness re-injection still fires, just via the control side channel");
+        }
+
         #endregion
 
         #region InboundHandshakeStage
@@ -301,17 +395,59 @@ namespace Akka.Remote.Tests.Artery
 
             await sub.RequestAsync(1);
 
-            await pub.SendNextAsync(OrdinaryInbound("ordinary-before-handshake"));
+            var peer = new UniqueAddress(NewRemote(), 222L);
+
+            // Task group 6: "known origin" is now a shared-registry lookup keyed by the envelope's
+            // OWN OriginUid (see OrdinaryInbound's remarks) -- NOT a per-connection flag set only
+            // by seeing a Req/Rsp on this exact stage instance (that was the G2 shape, when
+            // handshake still rode the ordinary connection). So this envelope's uid (222L, matching
+            // `peer`) is unknown to the registry until the HandshakeReq below completes it.
+            await pub.SendNextAsync(OrdinaryInbound("ordinary-before-handshake", originUid: peer.Uid));
             await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
 
-            var peer = new UniqueAddress(NewRemote(), 222L);
             await pub.SendNextAsync(ControlInbound(new HandshakeReq(peer, localAddress.Address), peer.Uid));
             await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
 
-            await pub.SendNextAsync(OrdinaryInbound("ordinary-after-handshake"));
+            await pub.SendNextAsync(OrdinaryInbound("ordinary-after-handshake", originUid: peer.Uid));
             var delivered = await sub.ExpectNextAsync(TimeSpan.FromSeconds(2));
             delivered.IsControl.Should().BeFalse();
             delivered.Message.Should().Be("ordinary-after-handshake");
+        }
+
+        [Fact(DisplayName = "InboundHandshakeStage should gate on the envelope's OWN OriginUid, not on which connection carried the handshake (task 6.2/6.3: handshake now travels on a SEPARATE control connection from ordinary traffic)")]
+        public async Task InboundHandshakeStage_should_gate_by_registry_not_by_owning_connection()
+        {
+            // Simulates task group 6's actual topology: ONE InboundHandshakeStage instance for an
+            // ORDINARY connection that NEVER itself sees a HandshakeReq/Rsp (those arrive on a
+            // separate CONTROL connection, processed by a DIFFERENT stage instance sharing the
+            // SAME AssociationRegistry). Proves the ordinary connection's own stage instance still
+            // gates correctly via the shared registry.
+            var registry = new AssociationRegistry();
+            var localAddress = NewLocal();
+            var ordinaryContext = new AssociationRegistryInboundContext(registry, localAddress, (_, _) => { });
+            var ordinaryStage = new InboundHandshakeStage(ordinaryContext);
+
+            var materializer = ActorMaterializer.Create(Sys);
+            var (pub, sub) = this.SourceProbe<IInboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(ordinaryStage), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IInboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await sub.RequestAsync(1);
+
+            var peer = new UniqueAddress(NewRemote(), 333L);
+            await pub.SendNextAsync(OrdinaryInbound("too-early", originUid: peer.Uid));
+            await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
+
+            // The handshake completes via the SHARED REGISTRY directly -- standing in for a
+            // separate control connection's own InboundHandshakeStage instance calling
+            // Context.CompleteHandshake. This ordinary-connection stage instance never itself
+            // processes a HandshakeReq/Rsp.
+            registry.CompleteHandshake(peer.Address, peer);
+
+            await pub.SendNextAsync(OrdinaryInbound("now-known", originUid: peer.Uid));
+            var delivered = await sub.ExpectNextAsync(TimeSpan.FromSeconds(2));
+            delivered.Message.Should().Be("now-known");
         }
 
         [Fact(DisplayName = "InboundHandshakeStage should complete the handshake on HandshakeRsp and swallow it (never propagated)")]
@@ -335,6 +471,30 @@ namespace Akka.Remote.Tests.Artery
 
             await sub.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(300));
             registry.TryGetByUid(peer.Uid).Should().NotBeNull();
+        }
+
+        [Fact(DisplayName = "InboundHandshakeStage should pass through a non-handshake control message unchanged (task 6.2: heartbeat/quarantine dispatch to IControlMessageSubscriber happens downstream)")]
+        public async Task InboundHandshakeStage_should_pass_through_other_control_messages()
+        {
+            var registry = new AssociationRegistry();
+            var localAddress = NewLocal();
+            var context = new AssociationRegistryInboundContext(registry, localAddress, (_, _) => { });
+            var stage = new InboundHandshakeStage(context);
+
+            var materializer = ActorMaterializer.Create(Sys);
+            var (pub, sub) = this.SourceProbe<IInboundEnvelope>()
+                .ViaMaterialized(Flow.FromGraph(stage), Keep.Left)
+                .ToMaterialized(this.SinkProbe<IInboundEnvelope>(), Keep.Both)
+                .Run(materializer);
+
+            await sub.RequestAsync(1);
+
+            var peer = new UniqueAddress(NewRemote(), 444L);
+            await pub.SendNextAsync(ControlInbound(new ArteryHeartbeat(), peer.Uid));
+
+            var delivered = await sub.ExpectNextAsync(TimeSpan.FromSeconds(2));
+            delivered.IsControl.Should().BeTrue("a non-handshake control message is still a control envelope");
+            delivered.Message.Should().BeOfType<ArteryHeartbeat>();
         }
 
         #endregion

--- a/src/core/Akka.Remote.Tests/Artery/AssociationRegistrySpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/AssociationRegistrySpec.cs
@@ -107,5 +107,79 @@ namespace Akka.Remote.Tests.Artery
 
             registry.TryGetByUid(peer.Uid).Should().BeSameAs(registry.AssociationFor(AddressA));
         }
+
+        // --- Control channel (task group 6, "Control Stream", task 6.1) ---
+
+        [Fact(DisplayName = "Association should expose a SEPARATE control channel from its ordinary channel, each independently materializable")]
+        public void Association_should_expose_independent_ordinary_and_control_channels()
+        {
+            var registry = new AssociationRegistry();
+            var association = registry.AssociationFor(AddressA);
+
+            association.IsOutboundMaterialized.Should().BeFalse();
+            association.IsControlOutboundMaterialized.Should().BeFalse();
+
+            var ordinaryMaterialized = 0;
+            var controlMaterialized = 0;
+            association.EnsureOutboundMaterialized(_ => ordinaryMaterialized++);
+
+            // Materializing the ORDINARY stream must not also materialize (or affect the
+            // materialize-gate of) the CONTROL stream -- they are independent latches.
+            association.IsOutboundMaterialized.Should().BeTrue();
+            association.IsControlOutboundMaterialized.Should().BeFalse();
+            ordinaryMaterialized.Should().Be(1);
+            controlMaterialized.Should().Be(0);
+
+            association.EnsureControlOutboundMaterialized(_ => controlMaterialized++);
+
+            association.IsControlOutboundMaterialized.Should().BeTrue();
+            controlMaterialized.Should().Be(1);
+
+            // Calling either Ensure* again must not re-invoke its materialize callback (each
+            // gate is CAS-latched exactly-once, independently of the other).
+            association.EnsureOutboundMaterialized(_ => ordinaryMaterialized++);
+            association.EnsureControlOutboundMaterialized(_ => controlMaterialized++);
+            ordinaryMaterialized.Should().Be(1);
+            controlMaterialized.Should().Be(1);
+        }
+
+        [Fact(DisplayName = "A full ORDINARY outbound queue must never block enqueuing to the CONTROL queue (queue-level non-starvation proof, task 6.6)")]
+        public void Full_ordinary_queue_should_not_block_control_enqueue()
+        {
+            // Deliberately tiny capacities so the test can force both queues to their bounds
+            // quickly and deterministically -- see the type-level remarks on Association's
+            // control-channel section for why these are two entirely separate Channel<T>
+            // instances, not a priority split of one queue.
+            var association = new Association(AddressA, outboundQueueCapacity: 4, controlQueueCapacity: 4);
+
+            // Saturate the ordinary queue completely.
+            for (var i = 0; i < 4; i++)
+                association.TryEnqueueOutbound(new OutboundEnvelope($"ordinary-{i}", null, null)).Should().BeTrue();
+
+            association.TryEnqueueOutbound(new OutboundEnvelope("ordinary-overflow", null, null))
+                .Should().BeFalse("the ordinary queue is now full");
+
+            // The control queue must be COMPLETELY unaffected by the ordinary queue's exhaustion
+            // -- this is the structural (not timing-based) half of the non-starvation proof;
+            // ArteryControlStreamSpec's end-to-end heartbeat test is the other half.
+            for (var i = 0; i < 4; i++)
+                association.TryEnqueueControl(new OutboundEnvelope($"control-{i}", null, null)).Should().BeTrue(
+                    "the control queue is entirely separate infrastructure from the (now full) ordinary queue");
+
+            association.TryEnqueueControl(new OutboundEnvelope("control-overflow", null, null))
+                .Should().BeFalse("the control queue has its OWN bound, reached independently of the ordinary queue's state");
+        }
+
+        [Fact(DisplayName = "ShouldLogQuarantineDrop should return true exactly once per uid (task 6.6: log once per association/uid, not per message)")]
+        public void ShouldLogQuarantineDrop_should_latch_once_per_uid()
+        {
+            var association = new Association(AddressA);
+
+            association.ShouldLogQuarantineDrop(1L).Should().BeTrue("the first drop for uid 1 should be logged");
+            association.ShouldLogQuarantineDrop(1L).Should().BeFalse("subsequent drops for the SAME uid must not be logged again");
+            association.ShouldLogQuarantineDrop(1L).Should().BeFalse();
+
+            association.ShouldLogQuarantineDrop(2L).Should().BeTrue("a DIFFERENT uid (e.g. a new incarnation) gets its own fresh unlogged state");
+        }
     }
 }

--- a/src/core/Akka.Remote/Artery/ArteryControlMessageSerializer.cs
+++ b/src/core/Akka.Remote/Artery/ArteryControlMessageSerializer.cs
@@ -19,7 +19,11 @@ namespace Akka.Remote.Artery
     /// INTERNAL API.
     ///
     /// Hand-rolled V2 MessagePack serializer for the Artery control/handshake messages
-    /// (<see cref="HandshakeReq"/> / <see cref="HandshakeRsp"/>).
+    /// (<see cref="HandshakeReq"/> / <see cref="HandshakeRsp"/> / <see cref="ArteryHeartbeat"/> /
+    /// <see cref="ArteryHeartbeatRsp"/> / <see cref="ArteryQuarantined"/> -- the latter three
+    /// added at task group 6, "Control Stream", task 6.4/6.5, extending the SAME hand-rolled
+    /// serializer found on this branch rather than replacing it with sourcegen; see the task
+    /// report for why sourcegen still cannot be used here).
     ///
     /// <para>
     /// Design.md ("Handshake + association/UID (gate G2)") pins handshake message encoding to
@@ -56,8 +60,24 @@ namespace Akka.Remote.Artery
         /// </summary>
         public const string HandshakeRspManifest = "HSRsp";
 
+        /// <summary>
+        /// The manifest for <see cref="ArteryHeartbeat"/>.
+        /// </summary>
+        public const string HeartbeatManifest = "HB";
+
+        /// <summary>
+        /// The manifest for <see cref="ArteryHeartbeatRsp"/>.
+        /// </summary>
+        public const string HeartbeatRspManifest = "HBR";
+
+        /// <summary>
+        /// The manifest for <see cref="ArteryQuarantined"/>.
+        /// </summary>
+        public const string QuarantinedManifest = "QRN";
+
         private const int FromFieldId = 1;
         private const int ToFieldId = 2;
+        private const int QuarantinedUidFieldId = 2;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ArteryControlMessageSerializer"/> class.
@@ -82,6 +102,9 @@ namespace Akka.Remote.Artery
         {
             HandshakeReq => HandshakeReqManifest,
             HandshakeRsp => HandshakeRspManifest,
+            ArteryHeartbeat => HeartbeatManifest,
+            ArteryHeartbeatRsp => HeartbeatRspManifest,
+            ArteryQuarantined => QuarantinedManifest,
             _ => throw new ArgumentException($"Unsupported Artery control message type: {obj.GetType()}", nameof(obj))
         };
 
@@ -90,6 +113,9 @@ namespace Akka.Remote.Artery
         {
             HandshakeReq req => SizeOfReq(req),
             HandshakeRsp rsp => SizeOfRsp(rsp),
+            ArteryHeartbeat => SizeOfMapHeader(0),
+            ArteryHeartbeatRsp => SizeOfMapHeader(0),
+            ArteryQuarantined q => SizeOfQuarantined(q),
             _ => UnknownSize
         };
 
@@ -107,6 +133,15 @@ namespace Akka.Remote.Artery
                 case HandshakeRsp rsp:
                     WriteRsp(ref messagePackWriter, rsp);
                     break;
+                case ArteryHeartbeat:
+                case ArteryHeartbeatRsp:
+                    // No fields -- an empty map is forward-compatible (an unknown-field skip loop
+                    // handles any fields a future version might add).
+                    messagePackWriter.WriteMapHeader(0);
+                    break;
+                case ArteryQuarantined quarantined:
+                    WriteQuarantined(ref messagePackWriter, quarantined);
+                    break;
                 default:
                     throw new ArgumentException($"Unsupported Artery control message type: {obj.GetType()}", nameof(obj));
             }
@@ -123,6 +158,9 @@ namespace Akka.Remote.Artery
             {
                 HandshakeReqManifest => ReadReq(ref reader),
                 HandshakeRspManifest => ReadRsp(ref reader),
+                HeartbeatManifest => ReadEmpty<ArteryHeartbeat>(ref reader, new ArteryHeartbeat()),
+                HeartbeatRspManifest => ReadEmpty<ArteryHeartbeatRsp>(ref reader, new ArteryHeartbeatRsp()),
+                QuarantinedManifest => ReadQuarantined(ref reader),
                 _ => throw new SerializationException($"Unknown Artery control message manifest [{manifest}].")
             };
         }
@@ -199,6 +237,65 @@ namespace Akka.Remote.Artery
             return new HandshakeRsp(from.Value);
         }
 
+        private static void WriteQuarantined(ref MessagePackWriter writer, ArteryQuarantined quarantined)
+        {
+            writer.WriteMapHeader(2);
+            writer.Write(FromFieldId);
+            WriteUniqueAddress(ref writer, quarantined.From);
+            writer.Write(QuarantinedUidFieldId);
+            writer.Write(quarantined.QuarantinedUid);
+        }
+
+        private static ArteryQuarantined ReadQuarantined(ref MessagePackReader reader)
+        {
+            var fieldCount = reader.ReadMapHeader();
+            UniqueAddress? from = null;
+            long? quarantinedUid = null;
+
+            for (var i = 0; i < fieldCount; i++)
+            {
+                var fieldId = reader.ReadInt32();
+                switch (fieldId)
+                {
+                    case FromFieldId:
+                        from = ReadUniqueAddress(ref reader);
+                        break;
+                    case QuarantinedUidFieldId:
+                        quarantinedUid = reader.ReadInt64();
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            if (from is null)
+                throw new SerializationException($"Missing required field [From] with index [{FromFieldId}] for [{QuarantinedManifest}].");
+            if (quarantinedUid is null)
+                throw new SerializationException($"Missing required field [QuarantinedUid] with index [{QuarantinedUidFieldId}] for [{QuarantinedManifest}].");
+
+            return new ArteryQuarantined(from.Value, quarantinedUid.Value);
+        }
+
+        /// <summary>
+        /// Reads (and discards, forward-compatibly) a MessagePack map for a fieldless control
+        /// message (<see cref="ArteryHeartbeat"/> / <see cref="ArteryHeartbeatRsp"/>), returning
+        /// <paramref name="instance"/>. A shared helper since both messages have identical
+        /// (empty) wire shapes.
+        /// </summary>
+        private static TMessage ReadEmpty<TMessage>(ref MessagePackReader reader, TMessage instance)
+            where TMessage : IArteryControlMessage
+        {
+            var fieldCount = reader.ReadMapHeader();
+            for (var i = 0; i < fieldCount; i++)
+            {
+                reader.ReadInt32();
+                reader.Skip();
+            }
+
+            return instance;
+        }
+
         private static void WriteAddress(ref MessagePackWriter writer, Address address)
         {
             writer.WriteArrayHeader(4);
@@ -266,6 +363,11 @@ namespace Akka.Remote.Artery
         private static int SizeOfRsp(HandshakeRsp rsp) =>
             SizeOfMapHeader(1) +
             SizeOfInt32(FromFieldId) + SizeOfUniqueAddress(rsp.From);
+
+        private static int SizeOfQuarantined(ArteryQuarantined quarantined) =>
+            SizeOfMapHeader(2) +
+            SizeOfInt32(FromFieldId) + SizeOfUniqueAddress(quarantined.From) +
+            SizeOfInt32(QuarantinedUidFieldId) + SizeOfInt64(quarantined.QuarantinedUid);
 
         /// <summary>
         /// Counts bytes advanced through an inner <see cref="IBufferWriter{T}"/> so

--- a/src/core/Akka.Remote/Artery/ArteryControlMessages.cs
+++ b/src/core/Akka.Remote/Artery/ArteryControlMessages.cs
@@ -1,0 +1,50 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryControlMessages.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+namespace Akka.Remote.Artery
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Liveness heartbeat sent by the control stream when it has otherwise been idle for
+    /// <c>akka.remote.artery.advanced.control-heartbeat-interval</c> -- see
+    /// <see cref="ArteryHeartbeatStage"/> and <c>openspec/changes/artery-tcp-remoting/design.md</c>
+    /// (task group 6, "Control Stream", tasks 6.4/6.6). Carries no payload; its mere arrival is
+    /// the signal. The receiver replies with <see cref="ArteryHeartbeatRsp"/>
+    /// (<c>ArteryRemoting</c>'s own <c>IControlMessageSubscriber</c>).
+    /// </summary>
+    internal sealed record ArteryHeartbeat : IArteryControlMessage;
+
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Reply to <see cref="ArteryHeartbeat"/>. No action is taken on receipt beyond dispatch to
+    /// any subscribed <see cref="IControlMessageSubscriber"/> at task group 6 -- a
+    /// missed-heartbeat failure detector is later (group 7+) work.
+    /// </summary>
+    internal sealed record ArteryHeartbeatRsp : IArteryControlMessage;
+
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Sent by <c>ArteryRemoting.Quarantine</c> to notify the peer that THIS system has
+    /// quarantined the association identified by <paramref name="QuarantinedUid"/> -- see
+    /// design.md ("Handshake + association/UID (gate G2)", "Quarantine (UID-scoped)") and task
+    /// group 6 task 6.5. Sent over (and, "pierces quarantine", received over) the control
+    /// stream/channel, which stays open even for a quarantined association.
+    /// </summary>
+    /// <param name="From">The unique address of the system that performed the quarantine (the sender of this message).</param>
+    /// <param name="QuarantinedUid">
+    /// The uid that was quarantined, from the quarantining system's point of view. The receiver
+    /// only acts on this (publishing a <see cref="ThisActorSystemQuarantinedEvent"/>-equivalent)
+    /// when it matches the receiver's OWN current uid -- a notification about a stale/superseded
+    /// incarnation of the receiver must not be acted on.
+    /// </param>
+    internal sealed record ArteryQuarantined(UniqueAddress From, long QuarantinedUid) : IArteryControlMessage;
+}

--- a/src/core/Akka.Remote/Artery/ArteryHeartbeatStage.cs
+++ b/src/core/Akka.Remote/Artery/ArteryHeartbeatStage.cs
@@ -1,0 +1,148 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryHeartbeatStage.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using Akka.Streams;
+using Akka.Streams.Stage;
+
+namespace Akka.Remote.Artery
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// Liveness heartbeat for the Artery control stream (design.md task group 6, "Control
+    /// Stream" -- tasks 6.4/6.6). Inserted ONLY into the control outbound pipeline, UPSTREAM of
+    /// <see cref="OutboundHandshakeStage"/> (see <c>ArteryRemoting.MaterializeOutboundStream</c>):
+    /// a pass-through <c>GraphStage&lt;FlowShape&lt;IOutboundEnvelope, IOutboundEnvelope&gt;&gt;</c>
+    /// that injects an <see cref="ArteryHeartbeat"/> control envelope whenever the stream has been
+    /// idle (no element has flowed) for at least <see cref="Interval"/>.
+    ///
+    /// <para>
+    /// <b>Why upstream of the handshake stage.</b> Placing this stage BEFORE
+    /// <see cref="OutboundHandshakeStage"/> means a self-generated heartbeat is subject to the
+    /// exact same "hold until handshake completes" gating as any other control-stream element --
+    /// it cannot leak onto the wire ahead of (or instead of) the initial <see cref="HandshakeReq"/>.
+    /// If this stage were downstream of the handshake stage instead, its injected elements would
+    /// bypass that gate entirely.
+    /// </para>
+    ///
+    /// <para>
+    /// This is deliberately the same simplification style as
+    /// <see cref="OutboundHandshakeStage"/>'s <c>inject-handshake-interval</c>: a repeating timer
+    /// tracks "time since the last element flowed" (real traffic OR a previously injected
+    /// heartbeat) and injects another heartbeat once that gap reaches <see cref="Interval"/>. It
+    /// does not attempt to distinguish "genuinely idle" from "traffic paused, then resumed".
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Never blocks real control traffic, never piles up.</b> A heartbeat is only pushed
+    /// downstream when <c>Out</c> already has demand available; otherwise it is queued as
+    /// <c>_pendingHeartbeat</c> and emitted at the very next <c>OnPull</c>, ahead of pulling more
+    /// upstream input. At most one heartbeat is ever queued -- a timer tick that fires while one
+    /// is already pending is a no-op (heartbeats are best-effort liveness signals, not a reliable
+    /// channel; see design.md's "Ack/Nack best-effort" invariant for the analogous system-message
+    /// case).
+    /// </para>
+    /// </summary>
+    internal sealed class ArteryHeartbeatStage : GraphStage<FlowShape<IOutboundEnvelope, IOutboundEnvelope>>
+    {
+        private const string HeartbeatTimerKey = "ArteryHeartbeat-Tick";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArteryHeartbeatStage"/> class.
+        /// </summary>
+        /// <param name="interval">How long the stream must be idle before a heartbeat is injected.</param>
+        public ArteryHeartbeatStage(TimeSpan interval)
+        {
+            if (interval <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(interval), interval, "must be positive.");
+
+            Interval = interval;
+            Shape = new FlowShape<IOutboundEnvelope, IOutboundEnvelope>(In, Out);
+        }
+
+        public TimeSpan Interval { get; }
+
+        public Inlet<IOutboundEnvelope> In { get; } = new("ArteryHeartbeat.in");
+        public Outlet<IOutboundEnvelope> Out { get; } = new("ArteryHeartbeat.out");
+
+        public override FlowShape<IOutboundEnvelope, IOutboundEnvelope> Shape { get; }
+
+        protected override GraphStageLogic CreateLogic(Attributes inheritedAttributes) => new Logic(this);
+
+        private sealed class Logic : TimerGraphStageLogic, IInHandler, IOutHandler
+        {
+            private readonly ArteryHeartbeatStage _stage;
+            private DateTime _lastActivity = DateTime.UtcNow;
+            private IOutboundEnvelope? _pendingHeartbeat;
+
+            public Logic(ArteryHeartbeatStage stage) : base(stage.Shape)
+            {
+                _stage = stage;
+                SetHandler(stage.In, this);
+                SetHandler(stage.Out, this);
+            }
+
+            public override void PreStart() => ScheduleRepeatedly(HeartbeatTimerKey, _stage.Interval);
+
+            public void OnPush()
+            {
+                _lastActivity = DateTime.UtcNow;
+                Push(_stage.Out, Grab(_stage.In));
+            }
+
+            public void OnPull()
+            {
+                if (_pendingHeartbeat is { } heartbeat)
+                {
+                    _pendingHeartbeat = null;
+                    _lastActivity = DateTime.UtcNow;
+                    Push(_stage.Out, heartbeat);
+                    return;
+                }
+
+                if (!HasBeenPulled(_stage.In) && !IsClosed(_stage.In))
+                    Pull(_stage.In);
+            }
+
+            public void OnUpstreamFinish()
+            {
+                if (_pendingHeartbeat is null)
+                    CompleteStage();
+
+                // else: let the queued heartbeat drain via OnPull first.
+            }
+
+            public void OnUpstreamFailure(Exception e) => FailStage(e);
+
+            public void OnDownstreamFinish(Exception cause) => InternalOnDownstreamFinish(cause);
+
+            protected override void OnTimer(object timerKey)
+            {
+                if (!HeartbeatTimerKey.Equals(timerKey))
+                    return;
+
+                if (_pendingHeartbeat is not null)
+                    return; // one already queued and not yet drained -- never pile up more.
+
+                var now = DateTime.UtcNow;
+                if (now - _lastActivity < _stage.Interval)
+                    return;
+
+                _lastActivity = now;
+                var heartbeat = new OutboundEnvelope(new ArteryHeartbeat(), null, null);
+
+                if (IsAvailable(_stage.Out))
+                    Push(_stage.Out, heartbeat);
+                else
+                    _pendingHeartbeat = heartbeat;
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote/Artery/ArteryInboundProcessingStage.cs
+++ b/src/core/Akka.Remote/Artery/ArteryInboundProcessingStage.cs
@@ -41,10 +41,13 @@ namespace Akka.Remote.Artery
     /// </para>
     ///
     /// <para>
-    /// <b>Non-Ordinary connection preamble.</b> G2 only implements the ordinary stream; a connection
-    /// whose preamble declares <see cref="ArteryStreamId.Control"/> or <see cref="ArteryStreamId.Large"/>
-    /// is logged and the connection is dropped (stage failure) -- control/large streams land at G3/G7
-    /// per the design's milestone table.
+    /// <b>Accepted connection preambles.</b> As of task group 6 ("Control Stream"), both
+    /// <see cref="ArteryStreamId.Ordinary"/> and <see cref="ArteryStreamId.Control"/> connections
+    /// are accepted -- routing downstream is by the decoded envelope's <see cref="IInboundEnvelope.IsControl"/>
+    /// flag (message type), not by which physical connection carried it (both preambles feed the
+    /// identical inbound shape: framing -&gt; decode -&gt; deserialize -&gt; <see cref="InboundHandshakeStage"/>
+    /// -&gt; dispatch). A connection whose preamble declares <see cref="ArteryStreamId.Large"/> is
+    /// logged and the connection is dropped (stage failure) -- the large stream lands at G7.
     /// </para>
     ///
     /// <para>
@@ -164,13 +167,13 @@ namespace Akka.Remote.Artery
 
                 ArteryConnectionHeader.TryParse(new ReadOnlySequence<byte>(_preambleBuffer), out var streamId, out _);
 
-                if (streamId != ArteryStreamId.Ordinary)
+                if (streamId != ArteryStreamId.Ordinary && streamId != ArteryStreamId.Control)
                 {
                     Log.Warning(
                         "Dropping inbound Artery connection: preamble declared stream id [{0}], but only " +
-                        "the Ordinary stream is implemented at G2 (control/large land at G3/G7).", streamId);
+                        "Ordinary and Control are implemented at task group 6 (large lands at G7).", streamId);
                     FailStage(new ArteryFramingException(
-                        $"Unsupported Artery connection stream id [{streamId}] (only Ordinary is accepted at G2)."));
+                        $"Unsupported Artery connection stream id [{streamId}] (only Ordinary/Control are accepted)."));
                     return false;
                 }
 

--- a/src/core/Akka.Remote/Artery/ArteryRemoting.cs
+++ b/src/core/Akka.Remote/Artery/ArteryRemoting.cs
@@ -10,8 +10,10 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Net;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Event;
@@ -27,28 +29,43 @@ namespace Akka.Remote.Artery
     /// under active development -- see <c>openspec/changes/artery-tcp-remoting/design.md</c>).
     ///
     /// <para>
-    /// This is the gate-G2 "Plaintext TCP Transport" implementation (design.md, "G2 -- Basic
-    /// ordinary messaging"): a single (ordinary) TCP stream per direction, single lane, no
-    /// compression, no control stream (handshake rides the ordinary connection -- "G2 staging").
+    /// This now hosts task group 6, "Control Stream" (design.md): each association materializes
+    /// TWO independent outbound streams -- ordinary (user messages) and control (handshake,
+    /// heartbeat, quarantine notice) -- each on its own bounded queue and its own TCP connection
+    /// (see <see cref="MaterializeOutboundStream"/>). The G2 "handshake rides the ordinary
+    /// connection" staging note is retired: handshake Req/Rsp now travel over control (task 6.3).
     /// Message sent -> received -> dispatched to the correct actor; classic remoting is unaffected.
     /// </para>
     ///
     /// <para>
     /// <b>Connection cardinality (verify against design.md).</b> Artery uses SEPARATE per-direction
     /// TCP connections -- there is no single bidirectional "association socket". When system A
-    /// first sends to a B-hosted actor, A materializes an OUTBOUND connection A-&gt;B (carrying the
-    /// injected <see cref="HandshakeReq"/> ahead of the user message). B's <see cref="InboundHandshakeStage"/>
-    /// replies with a <see cref="HandshakeRsp"/> via <see cref="IInboundContext.SendControl"/>, which
-    /// routes through THIS SAME <see cref="EnqueueOutbound"/> mechanism keyed by A's address --
-    /// i.e. B materializes (or reuses) its OWN outbound connection B-&gt;A to carry the reply. The
-    /// inbound socket B accepted from A is never written to.
+    /// first sends to a B-hosted actor, A materializes an OUTBOUND ordinary connection A-&gt;B
+    /// (whose <see cref="OutboundHandshakeStage"/> instance routes its <see cref="HandshakeReq"/>
+    /// via the control side channel -- see <see cref="EnqueueControl"/>) plus, lazily, an OUTBOUND
+    /// CONTROL connection A-&gt;B the first time any control message actually needs sending. B's
+    /// <see cref="InboundHandshakeStage"/> replies with a <see cref="HandshakeRsp"/> via
+    /// <see cref="IInboundContext.SendControl"/>, which ALSO routes through <see cref="EnqueueControl"/>
+    /// keyed by A's address -- i.e. B materializes (or reuses) its OWN outbound CONTROL connection
+    /// B-&gt;A to carry the reply. Neither system ever writes to a socket it accepted (inbound);
+    /// every direction of every stream type gets its own independently-materialized outbound
+    /// connection.
     /// </para>
     /// </summary>
-    internal sealed class ArteryRemoting : RemoteTransport
+    internal sealed class ArteryRemoting : RemoteTransport, IControlMessageSubscriber
     {
         private readonly ArterySettings _settings;
         private readonly ILoggingAdapter _log;
         private readonly AssociationRegistry _registry = new();
+
+        /// <summary>
+        /// Subscribers notified (task 6.2) for every decoded, non-handshake inbound control
+        /// message, across every association's control connection. <see cref="ArteryRemoting"/>
+        /// subscribes itself in <see cref="Start"/> to handle <see cref="ArteryHeartbeat"/> /
+        /// <see cref="ArteryQuarantined"/>; group 7's reliable system-message stages subscribe
+        /// here too, once they land.
+        /// </summary>
+        private ImmutableList<IControlMessageSubscriber> _controlSubscribers = ImmutableList<IControlMessageSubscriber>.Empty;
 
         private volatile HashSet<Address>? _addresses;
         private volatile Address? _defaultAddress;
@@ -96,9 +113,9 @@ namespace Akka.Remote.Artery
         {
             _log.Info("Starting Artery TCP remoting on [{0}:{1}]", _settings.CanonicalHostname, _settings.CanonicalPort);
             _log.Warning(
-                "Artery TCP remoting is EXPERIMENTAL and under active development -- gate G2 (plaintext TCP " +
-                "transport: single ordinary stream, single lane, no compression, no control stream). Do not " +
-                "use in production.");
+                "Artery TCP remoting is EXPERIMENTAL and under active development -- task group 6 (control " +
+                "stream: separate control + ordinary connections per association, no lanes/compression yet). " +
+                "Do not use in production.");
 
             _materializer = ActorMaterializer.Create(System);
             _tcp = System.TcpStream();
@@ -141,6 +158,10 @@ namespace Akka.Remote.Artery
             _localUniqueAddress = new UniqueAddress(address, AddressUidExtension.Uid(System));
             _inboundContext = new AssociationRegistryInboundContext(_registry, _localUniqueAddress, SendControlToAddress);
 
+            // Self-subscribe to handle ArteryHeartbeat (reply) and ArteryQuarantined (publish
+            // ThisActorSystemQuarantinedEvent) -- see IControlMessageSubscriber.ControlMessageReceived.
+            SubscribeControl(this);
+
             _log.Info("Artery TCP remoting started; listening on [{0}]", address);
         }
 
@@ -150,7 +171,10 @@ namespace Akka.Remote.Artery
             _log.Info("Shutting down Artery TCP remoting on [{0}]", _defaultAddress);
 
             foreach (var association in _registry.AllAssociations)
+            {
                 association.CompleteOutbound();
+                association.CompleteControlOutbound();
+            }
 
             var unbindTask = _binding?.Unbind() ?? Task.CompletedTask;
             var materializer = _materializer;
@@ -166,6 +190,31 @@ namespace Akka.Remote.Artery
         public override void Send(object message, IActorRef sender, RemoteActorRef recipient)
         {
             var remoteAddress = recipient.Path.Address;
+            var association = _registry.AssociationFor(remoteAddress);
+
+            // Quarantine gating at the send-routing layer (design.md Invariants; task 6.6):
+            // ordinary messages to a quarantined association are dropped to dead letters, logged
+            // ONCE per association (not per message). Control messages never go through Send --
+            // they always flow via EnqueueControl -- so this gate cannot affect them; the control
+            // stream "pierces quarantine" by construction, not by an exception carved out here.
+            //
+            // GROUP7: ActorSelectionMessage / ClearSystemMessageDelivery are supposed to ALSO
+            // pierce quarantine for ordinary sends (design.md "Blocked under quarantine except
+            // ActorSelectionMessage / ClearSystemMessageDelivery") -- that carve-out is deferred
+            // to reliable system-message delivery (group 7), which is what actually needs
+            // ClearSystemMessageDelivery to reach a quarantined peer. At task group 6, every
+            // ordinary message to a quarantined association is dropped, no exceptions.
+            if (association.CurrentState.UniqueRemoteAddress is { } peer && association.IsQuarantined(peer.Uid))
+            {
+                if (association.ShouldLogQuarantineDrop(peer.Uid))
+                    _log.Warning(
+                        "Dropping messages to quarantined association [{0}] (uid [{1}]); further drops for this " +
+                        "association/uid will not be logged individually.", remoteAddress, peer.Uid);
+
+                System.DeadLetters.Tell(message, sender);
+                return;
+            }
+
             var recipientPath = recipient.Path.ToSerializationFormatWithAddress(remoteAddress);
             var senderPath = sender.IsNobody() ? null : sender.Path.ToSerializationFormatWithAddress(DefaultAddress);
 
@@ -202,6 +251,11 @@ namespace Akka.Remote.Artery
                 {
                     _log.Warning("Quarantined association to [{0}] with uid [{1}]", address, u);
                     System.EventStream.Publish(new QuarantinedEvent(address, u));
+
+                    // Notify the peer over the control stream (design.md task 6.5: "sent on
+                    // Quarantine()") -- control "pierces quarantine", so this always flows even
+                    // though ordinary sends to `address` are now gated off in Send().
+                    EnqueueControl(address, new ArteryQuarantined(_localUniqueAddress, u));
                 }
             }
             else
@@ -221,25 +275,35 @@ namespace Akka.Remote.Artery
         {
             _log.Debug("Accepted inbound Artery TCP connection from [{0}]", connection.RemoteAddress);
 
+            // Both Ordinary and Control connections feed this SAME inbound shape (task 6.2) --
+            // ArteryInboundProcessingStage accepts either preamble; routing downstream is purely
+            // by the decoded envelope's IsControl flag, not by which connection carried it.
             var inboundSink = Flow.Create<ReadOnlySequence<byte>>()
                 .Via(new ArteryInboundProcessingStage(_settings.MaximumFrameSize, System.Serialization))
                 .Via(Flow.FromGraph(new InboundHandshakeStage(_inboundContext!)))
                 .To(Sink.ForEach<IInboundEnvelope>(DispatchInbound));
 
-            // The accepted (inbound) connection is read-only at G2: Artery uses SEPARATE
-            // per-direction connections, so any reply (starting with the HandshakeRsp) goes out over
-            // a NEW/reused outbound connection this system originates back towards the peer -- see
+            // Every accepted (inbound) connection is read-only: Artery uses SEPARATE per-direction
+            // connections, so any reply (a HandshakeRsp, a heartbeat, ...) goes out over a
+            // NEW/reused OUTBOUND connection this system originates back towards the peer -- see
             // the type-level "Connection cardinality" remarks. We never write to this socket.
             connection.HandleWith(Flow.FromSinkAndSource(inboundSink, Source.Empty<ReadOnlySequence<byte>>()), _materializer!);
         }
 
         private void DispatchInbound(IInboundEnvelope env)
         {
-            if (env.IsControl || env.RecipientPath is null)
+            if (env.IsControl)
             {
-                // InboundHandshakeStage swallows HandshakeReq/HandshakeRsp (and any other control
-                // envelope); nothing else is expected to reach this point.
-                _log.Warning("Dropping unexpected inbound Artery control envelope carrying [{0}]", env.Message.GetType());
+                // HandshakeReq/HandshakeRsp are consumed entirely inside InboundHandshakeStage and
+                // never reach here; any OTHER control message (heartbeat, quarantine notice, ...)
+                // is dispatched to the registered IControlMessageSubscribers (task 6.2).
+                NotifyControlSubscribers(env.OriginUid, env.Message);
+                return;
+            }
+
+            if (env.RecipientPath is null)
+            {
+                _log.Warning("Dropping inbound Artery ordinary-stream envelope with no recipient path, carrying [{0}]", env.Message.GetType());
                 return;
             }
 
@@ -254,7 +318,67 @@ namespace Akka.Remote.Artery
             recipient.Tell(env.Message, sender);
         }
 
-        private void SendControlToAddress(Address to, object message) => EnqueueOutbound(to, message, senderPath: null, recipientPath: null);
+        /// <summary>
+        /// Registers <paramref name="subscriber"/> to be notified (task 6.2) of every decoded
+        /// non-handshake inbound control message, across every association. INTERNAL test/group-7
+        /// hook -- see <see cref="IControlMessageSubscriber"/>.
+        /// </summary>
+        internal void SubscribeControl(IControlMessageSubscriber subscriber) =>
+            ImmutableInterlocked.Update(ref _controlSubscribers, static (list, s) => list.Add(s), subscriber);
+
+        /// <summary>
+        /// Reverses <see cref="SubscribeControl"/>.
+        /// </summary>
+        internal void UnsubscribeControl(IControlMessageSubscriber subscriber) =>
+            ImmutableInterlocked.Update(ref _controlSubscribers, static (list, s) => list.Remove(s), subscriber);
+
+        private void NotifyControlSubscribers(long originUid, object message)
+        {
+            var subscribers = _controlSubscribers;
+            foreach (var subscriber in subscribers)
+            {
+                try
+                {
+                    subscriber.ControlMessageReceived(originUid, message);
+                }
+                catch (Exception ex)
+                {
+                    _log.Warning(ex, "Control-message subscriber [{0}] threw while handling [{1}].", subscriber.GetType(), message.GetType());
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        void IControlMessageSubscriber.ControlMessageReceived(long originUid, object message)
+        {
+            switch (message)
+            {
+                case ArteryQuarantined quarantined when quarantined.QuarantinedUid == _localUniqueAddress.Uid:
+                    // Only act when the notification is about THIS system's CURRENT incarnation --
+                    // a notification about a stale/superseded uid must not be acted on (design.md's
+                    // UID-scoped invariant, mirrored on the receiving side).
+                    _log.Warning(
+                        "This system has been quarantined by [{0}] (uid [{1}]).",
+                        quarantined.From.Address, quarantined.QuarantinedUid);
+                    System.EventStream.Publish(new ThisActorSystemQuarantinedEvent(DefaultAddress, quarantined.From.Address));
+                    break;
+
+                case ArteryHeartbeat:
+                    // Best-effort reply -- see design.md "Ack/Nack best-effort" invariant analog;
+                    // loss is fine, the sender's own idle timer will simply try again.
+                    if (_registry.TryGetByUid(originUid) is { } association)
+                        EnqueueControl(association.RemoteAddress, new ArteryHeartbeatRsp());
+                    break;
+
+                case ArteryHeartbeatRsp:
+                    // No action needed at task group 6 -- a missed-heartbeat failure detector is
+                    // later (group 7+) work; the Rsp's value today is purely observability (tests
+                    // subscribe to see liveness/non-starvation -- see ArteryTransportSpec).
+                    break;
+            }
+        }
+
+        private void SendControlToAddress(Address to, object message) => EnqueueControl(to, message);
 
         private void EnqueueOutbound(Address remoteAddress, object message, string? senderPath, string? recipientPath)
         {
@@ -272,38 +396,99 @@ namespace Akka.Remote.Artery
         }
 
         /// <summary>
-        /// Materializes the outbound stream chain for <paramref name="association"/>, exactly once
-        /// (gated by <see cref="Association.EnsureOutboundMaterialized"/>):
-        /// <c>ChannelSource.FromReader(association.OutboundReader) -&gt; OutboundHandshakeStage -&gt;
-        /// encode -&gt; prepend Ordinary preamble -&gt; Tcp().OutgoingConnection</c>. Faithful-but-minimal
-        /// (G2): no reconnect/retry -- if the connection fails, this association's outbound stream
-        /// simply ends (a subsequent <see cref="EnqueueOutbound"/> call will keep buffering into the
-        /// channel, but nothing will ever drain it again until the process is restarted). Reconnect
-        /// sophistication is out of scope for G2 (design.md "Faithful-but-minimal").
+        /// Enqueues <paramref name="message"/> onto <paramref name="remoteAddress"/>'s CONTROL
+        /// outbound queue, materializing that association's control stream on first use (task
+        /// group 6, task 6.1). This is the ONE path every control message travels: handshake
+        /// Req/Rsp (via <see cref="OutboundHandshakeStage"/> / <see cref="InboundHandshakeStage"/>),
+        /// heartbeats (<see cref="ArteryHeartbeatStage"/>), and quarantine notices
+        /// (<see cref="Quarantine"/>) all funnel through here.
         /// </summary>
-        private void MaterializeOutbound(Address remoteAddress, Association association)
+        private void EnqueueControl(Address remoteAddress, object message)
         {
+            var association = _registry.AssociationFor(remoteAddress);
+            if (!association.IsControlOutboundMaterialized)
+                association.EnsureControlOutboundMaterialized(a => MaterializeControlOutbound(remoteAddress, a));
+
+            if (!association.TryEnqueueControl(new OutboundEnvelope(message, null, null)))
+            {
+                // GROUP7: design.md Decision 7 calls for control/system overflow to QUARANTINE
+                // (not drop) -- the full asymmetric policy needs the reliable system-message layer
+                // (group 7) to have a "give up" concept to quarantine FOR. At task group 6, a full
+                // control queue logs + dead-letters, same as ordinary.
+                _log.Error(
+                    "Outbound Artery CONTROL queue to [{0}] is full (capacity {1}); dropping control message of " +
+                    "type [{2}] to dead letters.", remoteAddress, Association.DefaultControlQueueCapacity, message.GetType());
+                System.DeadLetters.Tell(message, ActorRefs.NoSender);
+            }
+        }
+
+        private void MaterializeOutbound(Address remoteAddress, Association association) =>
+            MaterializeOutboundStream(remoteAddress, association.OutboundReader, ArteryStreamId.Ordinary);
+
+        private void MaterializeControlOutbound(Address remoteAddress, Association association) =>
+            MaterializeOutboundStream(remoteAddress, association.ControlReader, ArteryStreamId.Control);
+
+        /// <summary>
+        /// Materializes ONE outbound stream chain -- shared shape for BOTH the ordinary and
+        /// control streams (design.md task group 6, task 6.1: "factor the shared shape into a
+        /// helper rather than duplicating (both differ only in stream id + channel + handshake
+        /// presence)"):
+        /// <c>ChannelSource.FromReader(reader) -&gt; [control only: ArteryHeartbeatStage] -&gt;
+        /// OutboundHandshakeStage -&gt; encode -&gt; prepend [streamId] preamble -&gt;
+        /// Tcp().OutgoingConnection</c>.
+        ///
+        /// <para>
+        /// Every stream -- control AND ordinary -- gets an <see cref="OutboundHandshakeStage"/>
+        /// instance (task 6.3: "every stream handshakes"); only <paramref name="streamId"/> ==
+        /// <see cref="ArteryStreamId.Control"/>'s instance is told <c>isControlStream: true</c>,
+        /// which is what makes IT (and only it) inject its <see cref="HandshakeReq"/> inline onto
+        /// its own <see cref="OutboundHandshakeStage.Out"/> -- the ordinary stream's instance
+        /// instead routes its Req through <see cref="IOutboundContext.SendControl"/>, i.e. back
+        /// through <see cref="EnqueueControl"/>.
+        /// </para>
+        /// <para>
+        /// Faithful-but-minimal (carried over from G2): no reconnect/retry -- if the connection
+        /// fails, this association's outbound stream simply ends (a subsequent enqueue call will
+        /// keep buffering into the channel, but nothing will ever drain it again until the
+        /// process is restarted). Reconnect sophistication remains out of scope.
+        /// </para>
+        /// </summary>
+        private void MaterializeOutboundStream(Address remoteAddress, ChannelReader<IOutboundEnvelope> reader, ArteryStreamId streamId)
+        {
+            var isControlStream = streamId == ArteryStreamId.Control;
+
             var outboundContext = new AssociationRegistryOutboundContext(
                 _registry,
                 _localUniqueAddress,
                 remoteAddress,
-                message => EnqueueOutbound(remoteAddress, message, senderPath: null, recipientPath: null));
+                message => EnqueueControl(remoteAddress, message));
 
             var handshakeStage = new OutboundHandshakeStage(
-                outboundContext, _settings.HandshakeRetryInterval, _settings.HandshakeTimeout, _settings.InjectHandshakeInterval);
+                outboundContext, _settings.HandshakeRetryInterval, _settings.HandshakeTimeout,
+                _settings.InjectHandshakeInterval, isControlStream: isControlStream);
 
             var host = remoteAddress.Host
-                ?? throw new RemoteTransportException($"Cannot open an Artery outbound connection to [{remoteAddress}]: missing host.");
+                ?? throw new RemoteTransportException($"Cannot open an Artery {streamId} outbound connection to [{remoteAddress}]: missing host.");
             var port = remoteAddress.Port
-                ?? throw new RemoteTransportException($"Cannot open an Artery outbound connection to [{remoteAddress}]: missing port.");
+                ?? throw new RemoteTransportException($"Cannot open an Artery {streamId} outbound connection to [{remoteAddress}]: missing port.");
 
             var encodeStage = new ArteryEncodeStage(System.Serialization, _localUniqueAddress.Uid, _encodeBufferPool);
 
-            var frames = ChannelSource.FromReader(association.OutboundReader)
+            var source = ChannelSource.FromReader(reader);
+
+            // Heartbeat stage is UPSTREAM of the handshake stage (control stream only) so a
+            // self-generated heartbeat is subject to the exact same "hold until handshake
+            // completes" gating as any other control-stream element -- see ArteryHeartbeatStage's
+            // type-level remarks for why the ordering matters.
+            var withHeartbeat = isControlStream
+                ? source.Via(Flow.FromGraph(new ArteryHeartbeatStage(_settings.ControlHeartbeatInterval)))
+                : source;
+
+            var frames = withHeartbeat
                 .Via(Flow.FromGraph(handshakeStage))
                 .Via(Flow.FromGraph(encodeStage));
 
-            var completion = Source.Single(BuildOrdinaryPreamble())
+            var completion = Source.Single(BuildPreamble(streamId))
                 .Concat(frames)
                 .Via(_tcp!.OutgoingConnection(host, port))
                 .RunWith(Sink.Ignore<ReadOnlySequence<byte>>(), _materializer!);
@@ -313,17 +498,17 @@ namespace Akka.Remote.Artery
                 if (t.IsFaulted)
                     _log.Warning(
                         t.Exception?.GetBaseException(),
-                        "Artery outbound connection to [{0}] failed; this association's outbound stream has " +
-                        "ended (G2: no automatic reconnect).", remoteAddress);
+                        "Artery {0} outbound connection to [{1}] failed; this association's {0} outbound stream " +
+                        "has ended (no automatic reconnect).", streamId, remoteAddress);
                 else
-                    _log.Debug("Artery outbound connection to [{0}] completed.", remoteAddress);
+                    _log.Debug("Artery {0} outbound connection to [{1}] completed.", streamId, remoteAddress);
             }, TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        private static ReadOnlySequence<byte> BuildOrdinaryPreamble()
+        private static ReadOnlySequence<byte> BuildPreamble(ArteryStreamId streamId)
         {
             var buffer = new byte[ArteryConnectionHeader.Length];
-            ArteryConnectionHeader.WriteTo(buffer, ArteryStreamId.Ordinary);
+            ArteryConnectionHeader.WriteTo(buffer, streamId);
             return new ReadOnlySequence<byte>(buffer);
         }
     }

--- a/src/core/Akka.Remote/Artery/ArterySettings.cs
+++ b/src/core/Akka.Remote/Artery/ArterySettings.cs
@@ -90,6 +90,12 @@ namespace Akka.Remote.Artery
         public TimeSpan InjectHandshakeInterval { get; }
 
         /// <summary>
+        /// How often the control stream sends a liveness <c>ArteryHeartbeat</c> while otherwise
+        /// idle (task group 6, "Control Stream" -- task 6.4). See <see cref="ArteryHeartbeatStage"/>.
+        /// </summary>
+        public TimeSpan ControlHeartbeatInterval { get; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ArterySettings"/> class from the
         /// <c>akka.remote.artery</c> sub-config.
         /// </summary>
@@ -137,6 +143,7 @@ namespace Akka.Remote.Artery
             HandshakeTimeout = GetPositiveTimeSpan(arteryConfig, "advanced.handshake-timeout", TimeSpan.FromSeconds(20));
             HandshakeRetryInterval = GetPositiveTimeSpan(arteryConfig, "advanced.handshake-retry-interval", TimeSpan.FromSeconds(1));
             InjectHandshakeInterval = GetPositiveTimeSpan(arteryConfig, "advanced.inject-handshake-interval", TimeSpan.FromSeconds(1));
+            ControlHeartbeatInterval = GetPositiveTimeSpan(arteryConfig, "advanced.control-heartbeat-interval", TimeSpan.FromSeconds(5));
         }
 
         private static TimeSpan GetPositiveTimeSpan(Config config, string path, TimeSpan @default)

--- a/src/core/Akka.Remote/Artery/AssociationRegistry.cs
+++ b/src/core/Akka.Remote/Artery/AssociationRegistry.cs
@@ -19,11 +19,57 @@ namespace Akka.Remote.Artery
     /// <summary>
     /// INTERNAL API.
     ///
+    /// CAS-gated "materialize exactly once" latch, shared by the ordinary and control outbound
+    /// stream materialization paths on <see cref="Association"/> (design.md task group 6, task
+    /// 6.1: "factor the shared shape into a helper rather than duplicating"). Each
+    /// <see cref="Association"/> owns TWO independent instances of this type -- one per outbound
+    /// stream -- so materializing one never affects the other's gate.
+    /// </summary>
+    internal sealed class MaterializeOnceGate
+    {
+        private int _started;
+
+        /// <summary>
+        /// Whether <see cref="EnsureStarted"/> has already started (or finished) materializing.
+        /// A cheap check callers can use to skip allocating a materialize callback on the
+        /// (post-first-call) steady-state path.
+        /// </summary>
+        public bool IsStarted => Volatile.Read(ref _started) != 0;
+
+        /// <summary>
+        /// Runs <paramref name="materialize"/> exactly once, no matter how many threads call this
+        /// concurrently -- only the FIRST caller's callback executes (CAS-gated on an internal flag).
+        /// </summary>
+        public void EnsureStarted(Action materialize)
+        {
+            if (Interlocked.CompareExchange(ref _started, 1, 0) == 0)
+                materialize();
+        }
+    }
+
+    /// <summary>
+    /// INTERNAL API.
+    ///
     /// Owns the lock-free <see cref="AssociationState"/> snapshot for one remote
-    /// <see cref="Actor.Address"/>, the CAS retry loops that transition it, AND (G2 transport chunk)
-    /// the association's bounded outbound queue + once-only outbound-stream materialization
-    /// lifecycle (design.md Decision 7/9: a bounded <c>Channel</c>, externally owned so it survives
-    /// stream restart -- reconnect re-attaches a new consumer to the SAME channel).
+    /// <see cref="Actor.Address"/>, the CAS retry loops that transition it, AND (G2 transport chunk;
+    /// extended at task group 6, "Control Stream") the association's TWO bounded outbound queues
+    /// -- ordinary and control -- plus their once-only outbound-stream materialization lifecycles
+    /// (design.md Decision 7/9: bounded <c>Channel</c>s, externally owned so they survive stream
+    /// restart -- reconnect re-attaches a new consumer to the SAME channel).
+    ///
+    /// <para>
+    /// <b>Two independent channels, one per stream (task 6.1).</b> The control channel is
+    /// deliberately separate infrastructure from the ordinary channel -- not a priority lane
+    /// carved out of the same queue -- so that the ordinary queue filling up can NEVER block or
+    /// starve control traffic (design.md "Control stream before lanes" / Decision 5, and the
+    /// Invariants section's "quarantine gating at the send-routing layer" / "control stream stays
+    /// alive and drainable while quarantined"). Its capacity is intentionally smaller than the
+    /// ordinary queue's -- control traffic (handshake, heartbeat, quarantine notice) is low-volume
+    /// by nature. <b>GROUP7:</b> design.md Decision 7 calls for control/system overflow to
+    /// QUARANTINE (not drop) -- that full policy needs the reliable system-message layer (group 7)
+    /// to have something to quarantine FOR; at task group 6 a full control queue logs + dead-letters,
+    /// same as ordinary (see <c>ArteryRemoting.EnqueueControl</c>).
+    /// </para>
     /// </summary>
     internal sealed class Association
     {
@@ -34,6 +80,15 @@ namespace Akka.Remote.Artery
         /// </summary>
         public const int DefaultOutboundQueueCapacity = 3072;
 
+        /// <summary>
+        /// Default capacity for <see cref="ControlReader"/>'s bounded channel. Deliberately smaller
+        /// than <see cref="DefaultOutboundQueueCapacity"/> -- control traffic (handshake, heartbeat,
+        /// quarantine notice) is low-volume by nature (design.md task group 6, task 6.1). The full
+        /// asymmetric overflow policy (control overflow -> quarantine, per Decision 7) is GROUP7
+        /// work; see the type-level remarks.
+        /// </summary>
+        public const int DefaultControlQueueCapacity = 256;
+
         private volatile AssociationState _state;
 
         // Typed as the IOutboundEnvelope INTERFACE (not the concrete OutboundEnvelope record) so
@@ -43,13 +98,32 @@ namespace Akka.Remote.Artery
         // mandate; see the G3 opening-refactor task report for why the interface, not the concrete
         // type, is the channel's type parameter).
         private readonly Channel<IOutboundEnvelope> _outboundChannel;
-        private int _outboundMaterializeStarted;
+        private readonly Channel<IOutboundEnvelope> _controlChannel;
+        private readonly MaterializeOnceGate _outboundGate = new();
+        private readonly MaterializeOnceGate _controlGate = new();
 
-        public Association(Address remoteAddress, int outboundQueueCapacity = DefaultOutboundQueueCapacity)
+        /// <summary>
+        /// Per-uid "have we already logged a quarantine-drop for this uid" latch (task 6.6:
+        /// "log once per association, not per message"). Keyed by uid (not just a single
+        /// per-association flag) so a NEW incarnation -- a different uid, possibly quarantined
+        /// again in the future -- gets its own fresh unlogged state.
+        /// </summary>
+        private readonly ConcurrentDictionary<long, bool> _quarantineDropLogged = new();
+
+        public Association(
+            Address remoteAddress,
+            int outboundQueueCapacity = DefaultOutboundQueueCapacity,
+            int controlQueueCapacity = DefaultControlQueueCapacity)
         {
             RemoteAddress = remoteAddress;
             _state = AssociationState.Create();
             _outboundChannel = Channel.CreateBounded<IOutboundEnvelope>(new BoundedChannelOptions(outboundQueueCapacity)
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                FullMode = BoundedChannelFullMode.Wait
+            });
+            _controlChannel = Channel.CreateBounded<IOutboundEnvelope>(new BoundedChannelOptions(controlQueueCapacity)
             {
                 SingleReader = true,
                 SingleWriter = false,
@@ -68,21 +142,34 @@ namespace Akka.Remote.Artery
         public AssociationState CurrentState => _state;
 
         /// <summary>
-        /// The reading side of this association's bounded outbound queue. Consumed by exactly one
-        /// materialized outbound stream (<see cref="Akka.Streams.Dsl.ChannelSource.FromReader{T}"/>),
+        /// The reading side of this association's bounded ORDINARY outbound queue. Consumed by
+        /// exactly one materialized outbound stream (<see cref="Akka.Streams.Dsl.ChannelSource.FromReader{T}"/>),
         /// per <see cref="EnsureOutboundMaterialized"/>.
         /// </summary>
         public ChannelReader<IOutboundEnvelope> OutboundReader => _outboundChannel.Reader;
 
         /// <summary>
-        /// Whether <see cref="EnsureOutboundMaterialized"/> has already started (or finished)
-        /// materializing this association's outbound stream. A cheap check callers can use to skip
-        /// allocating a materialize callback on the (post-first-call) steady-state path.
+        /// The reading side of this association's bounded CONTROL outbound queue -- separate
+        /// infrastructure from <see cref="OutboundReader"/> (task 6.1). Consumed by exactly one
+        /// materialized outbound stream, per <see cref="EnsureControlOutboundMaterialized"/>.
         /// </summary>
-        public bool IsOutboundMaterialized => Volatile.Read(ref _outboundMaterializeStarted) != 0;
+        public ChannelReader<IOutboundEnvelope> ControlReader => _controlChannel.Reader;
 
         /// <summary>
-        /// Attempts to enqueue <paramref name="element"/> for the outbound stream to send.
+        /// Whether <see cref="EnsureOutboundMaterialized"/> has already started (or finished)
+        /// materializing this association's ORDINARY outbound stream. A cheap check callers can
+        /// use to skip allocating a materialize callback on the (post-first-call) steady-state path.
+        /// </summary>
+        public bool IsOutboundMaterialized => _outboundGate.IsStarted;
+
+        /// <summary>
+        /// Whether <see cref="EnsureControlOutboundMaterialized"/> has already started (or
+        /// finished) materializing this association's CONTROL outbound stream.
+        /// </summary>
+        public bool IsControlOutboundMaterialized => _controlGate.IsStarted;
+
+        /// <summary>
+        /// Attempts to enqueue <paramref name="element"/> for the ORDINARY outbound stream to send.
         /// Non-blocking (<see cref="ChannelWriter{T}.TryWrite"/>) -- NEVER awaits/blocks a producing
         /// actor thread on a slow remote (Decision 7). Returns <see langword="false"/> when the
         /// bounded queue is full; the caller (<c>ArteryRemoting</c>) applies the overflow policy
@@ -91,24 +178,48 @@ namespace Akka.Remote.Artery
         public bool TryEnqueueOutbound(IOutboundEnvelope element) => _outboundChannel.Writer.TryWrite(element);
 
         /// <summary>
-        /// Ensures this association's outbound stream is materialized exactly once, no matter how
-        /// many threads call this concurrently -- only the FIRST caller's <paramref name="materialize"/>
-        /// callback executes (CAS-gated on an internal flag). The callback is supplied by the
+        /// Attempts to enqueue <paramref name="element"/> for the CONTROL outbound stream to send.
+        /// Non-blocking, same discipline as <see cref="TryEnqueueOutbound"/>. See the type-level
+        /// remarks on <see cref="DefaultControlQueueCapacity"/> for the GROUP7 overflow-policy note.
+        /// </summary>
+        public bool TryEnqueueControl(IOutboundEnvelope element) => _controlChannel.Writer.TryWrite(element);
+
+        /// <summary>
+        /// Ensures this association's ORDINARY outbound stream is materialized exactly once, no
+        /// matter how many threads call this concurrently. The callback is supplied by the
         /// transport (<c>ArteryRemoting</c>), which owns the Tcp extension / materializer / settings
         /// this pure state type deliberately does not know about.
         /// </summary>
-        public void EnsureOutboundMaterialized(Action<Association> materialize)
-        {
-            if (Interlocked.CompareExchange(ref _outboundMaterializeStarted, 1, 0) == 0)
-                materialize(this);
-        }
+        public void EnsureOutboundMaterialized(Action<Association> materialize) =>
+            _outboundGate.EnsureStarted(() => materialize(this));
 
         /// <summary>
-        /// Marks the outbound channel complete (no further writes accepted) so its materialized
-        /// <see cref="Akka.Streams.Dsl.ChannelSource.FromReader{T}"/> consumer finishes gracefully.
-        /// Called on transport shutdown.
+        /// Ensures this association's CONTROL outbound stream is materialized exactly once, no
+        /// matter how many threads call this concurrently. See <see cref="EnsureOutboundMaterialized"/>.
+        /// </summary>
+        public void EnsureControlOutboundMaterialized(Action<Association> materialize) =>
+            _controlGate.EnsureStarted(() => materialize(this));
+
+        /// <summary>
+        /// Marks the ORDINARY outbound channel complete (no further writes accepted) so its
+        /// materialized <see cref="Akka.Streams.Dsl.ChannelSource.FromReader{T}"/> consumer
+        /// finishes gracefully. Called on transport shutdown.
         /// </summary>
         public void CompleteOutbound() => _outboundChannel.Writer.TryComplete();
+
+        /// <summary>
+        /// Marks the CONTROL outbound channel complete. See <see cref="CompleteOutbound"/>.
+        /// </summary>
+        public void CompleteControlOutbound() => _controlChannel.Writer.TryComplete();
+
+        /// <summary>
+        /// Records (task 6.6: "log once per association, not per message") that a quarantine-drop
+        /// warning has been logged for <paramref name="uid"/>. Returns <see langword="true"/> the
+        /// FIRST time it is called for a given uid (the caller should log), and
+        /// <see langword="false"/> every subsequent call for that same uid (the caller should stay
+        /// silent).
+        /// </summary>
+        public bool ShouldLogQuarantineDrop(long uid) => _quarantineDropLogged.TryAdd(uid, true);
 
         /// <summary>
         /// CAS loop applying <see cref="AssociationState.CompleteHandshake"/>. Returns both the

--- a/src/core/Akka.Remote/Artery/IControlMessageSubscriber.cs
+++ b/src/core/Akka.Remote/Artery/IControlMessageSubscriber.cs
@@ -1,0 +1,45 @@
+//-----------------------------------------------------------------------
+// <copyright file="IControlMessageSubscriber.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+namespace Akka.Remote.Artery
+{
+    /// <summary>
+    /// INTERNAL API.
+    ///
+    /// A subscriber for inbound Artery control-stream messages that are NOT the handshake
+    /// protocol itself (<see cref="HandshakeReq"/>/<see cref="HandshakeRsp"/> are consumed
+    /// entirely inside <see cref="InboundHandshakeStage"/> and never reach this hook). See
+    /// <c>openspec/changes/artery-tcp-remoting/design.md</c> (task group 6, "Control Stream",
+    /// task 6.2).
+    ///
+    /// <para>
+    /// <c>ArteryRemoting</c> keeps a simple list of subscribers (see
+    /// <c>ArteryRemoting.SubscribeControl</c>/<c>UnsubscribeControl</c>) and notifies all of them,
+    /// in registration order, for every non-handshake control envelope decoded off ANY inbound
+    /// control connection. At task group 6, <c>ArteryRemoting</c> subscribes to itself to handle
+    /// <see cref="ArteryHeartbeat"/> (reply with <see cref="ArteryHeartbeatRsp"/>) and
+    /// <see cref="ArteryQuarantined"/> (publish <see cref="ThisActorSystemQuarantinedEvent"/>).
+    /// </para>
+    /// <para>
+    /// <b>GROUP7:</b> reliable system-message delivery's <c>SystemMessageAcker</c>/ACK-NACK
+    /// stages are expected to subscribe here too, once they land -- this hook is deliberately
+    /// generic (uid + raw message) rather than tailored to any one consumer.
+    /// </para>
+    /// </summary>
+    internal interface IControlMessageSubscriber
+    {
+        /// <summary>
+        /// Called for every decoded non-handshake control message received from ANY inbound
+        /// control connection.
+        /// </summary>
+        /// <param name="originUid">The sending system's uid, decoded from the envelope's fixed header.</param>
+        /// <param name="message">The deserialized control message.</param>
+        void ControlMessageReceived(long originUid, object message);
+    }
+}

--- a/src/core/Akka.Remote/Artery/IInboundContext.cs
+++ b/src/core/Akka.Remote/Artery/IInboundContext.cs
@@ -52,6 +52,17 @@ namespace Akka.Remote.Artery
         /// Used by <see cref="InboundHandshakeStage"/> to reply with a <see cref="HandshakeRsp"/>.
         /// </summary>
         void SendControl(Address to, object message);
+
+        /// <summary>
+        /// Whether <paramref name="originUid"/> is a known (handshake-completed) association,
+        /// per the SHARED <see cref="AssociationRegistry"/> reverse index — NOT a per-connection
+        /// flag. This is what lets <see cref="InboundHandshakeStage"/> gate ordinary-stream
+        /// envelopes on a connection that never itself carried a <see cref="HandshakeReq"/>/
+        /// <see cref="HandshakeRsp"/> (task group 6, "Control Stream": handshake messages travel
+        /// over a SEPARATE control connection once 6.3 lands, so the ordinary connection's own
+        /// <see cref="InboundHandshakeStage"/> instance would otherwise never observe one).
+        /// </summary>
+        bool IsKnownOrigin(long originUid);
     }
 
     /// <summary>
@@ -89,5 +100,8 @@ namespace Akka.Remote.Artery
 
         /// <inheritdoc/>
         public void SendControl(Address to, object message) => _sendControl(to, message);
+
+        /// <inheritdoc/>
+        public bool IsKnownOrigin(long originUid) => _registry.TryGetByUid(originUid) is not null;
     }
 }

--- a/src/core/Akka.Remote/Artery/InboundHandshakeStage.cs
+++ b/src/core/Akka.Remote/Artery/InboundHandshakeStage.cs
@@ -20,16 +20,29 @@ namespace Akka.Remote.Artery
     ///
     /// Inbound half of the Artery handshake, faithful to
     /// <c>openspec/changes/artery-tcp-remoting/design.md</c>
-    /// ("Handshake + association/UID (gate G2)"). A
-    /// <c>GraphStage&lt;FlowShape&lt;IInboundEnvelope, IInboundEnvelope&gt;&gt;</c> -- dispatch is on
-    /// <see cref="IInboundEnvelope.IsControl"/> plus a pattern match on <see cref="IInboundEnvelope.Message"/>
-    /// inside the envelope, not a raw <c>is</c> type-test on the stream element itself.
+    /// ("Handshake + association/UID (gate G2)"; routing changes per task group 6, "Control
+    /// Stream", task 6.2). A <c>GraphStage&lt;FlowShape&lt;IInboundEnvelope, IInboundEnvelope&gt;&gt;</c>
+    /// -- dispatch is on <see cref="IInboundEnvelope.IsControl"/> plus a pattern match on
+    /// <see cref="IInboundEnvelope.Message"/> inside the envelope, not a raw <c>is</c> type-test
+    /// on the stream element itself.
     ///
     /// <para>
-    /// One instance of this stage sees the inbound elements for ONE remote peer connection (per
-    /// design.md's "Connection cardinality" note: at G2 the handshake stages ride the single
-    /// ordinary connection, and the receiver sees one ordinary connection per remote peer) — so
-    /// <c>isKnownOrigin</c> is per-stage-instance state, not global.
+    /// <b>"Known origin" is now a SHARED-registry check, not per-connection state (task 6.2/6.3).</b>
+    /// One instance of this stage sees the inbound elements for ONE physical TCP connection. At
+    /// G2 (single ordinary connection carrying both handshake and user traffic) that made a
+    /// per-instance <c>isKnownOrigin</c> flag correct: the Req/Rsp that completed the handshake
+    /// necessarily flowed through the SAME instance before any user traffic could. Once 6.3 routes
+    /// handshake messages onto a SEPARATE control connection, an ordinary connection's own
+    /// <see cref="InboundHandshakeStage"/> instance would never itself observe a Req/Rsp and would
+    /// perpetually gate/drop everything. So the gate is now <see cref="IInboundContext.IsKnownOrigin"/>
+    /// — a lookup against the SHARED <see cref="AssociationRegistry"/> keyed by the envelope's own
+    /// <see cref="IInboundEnvelope.OriginUid"/> (always present in the decoded header, regardless
+    /// of which connection/stream carried the envelope). This is safe because the SENDING side's
+    /// <see cref="OutboundHandshakeStage"/> holds all ordinary/large traffic behind its own
+    /// handshake-completion gate, which — by construction — cannot complete before the RECEIVING
+    /// side has already processed the peer's <see cref="HandshakeReq"/> (registering the uid) and
+    /// sent its <see cref="HandshakeRsp"/>. So by the time a receiver's ordinary connection ever
+    /// delivers a real user envelope for some uid, that uid is already registered.
     /// </para>
     ///
     /// <list type="bullet">
@@ -37,23 +50,25 @@ namespace Akka.Remote.Artery
     /// On <see cref="HandshakeReq"/>: if <c>req.To</c> does not match the local address, logs a
     /// warning and DROPS the message — it does NOT fail the stream (a misdirected/stale request
     /// must not tear down an otherwise-healthy connection). Otherwise, completes the handshake for
-    /// the requester via <see cref="IInboundContext.CompleteHandshake"/>, marks the origin known,
-    /// and replies with a <see cref="HandshakeRsp"/> via <see cref="IInboundContext.SendControl"/>.
-    /// The request itself is never propagated downstream.
+    /// the requester via <see cref="IInboundContext.CompleteHandshake"/> and replies with a
+    /// <see cref="HandshakeRsp"/> via <see cref="IInboundContext.SendControl"/>. The request
+    /// itself is never propagated downstream.
     /// </description></item>
     /// <item><description>
     /// On <see cref="HandshakeRsp"/>: completes the handshake for the responder (this is what lets
     /// the peer's <see cref="OutboundHandshakeStage"/> observe completion — see that type's
-    /// notification-mechanism note), marks the origin known, and swallows the message (never
-    /// propagated downstream).
+    /// notification-mechanism note) and swallows the message (never propagated downstream).
     /// </description></item>
     /// <item><description>
-    /// Any other control envelope: dropped with a debug log (no other control-message types exist
-    /// yet at G3 -- reliable system-message delivery lands in a later chunk).
+    /// Any OTHER control envelope (task 6.2: <c>ArteryHeartbeat</c>/<c>ArteryHeartbeatRsp</c>/
+    /// <c>ArteryQuarantined</c>, and later reliable system-message ACK/NACK): NOT handshake-internal
+    /// -- pushed downstream unchanged (still <see cref="IInboundEnvelope.IsControl"/> true) so
+    /// <c>ArteryRemoting.DispatchInbound</c> can hand it to the registered
+    /// <see cref="IControlMessageSubscriber"/>s.
     /// </description></item>
     /// <item><description>
     /// Any ordinary (non-control) envelope: dropped with a debug log while the origin is unknown;
-    /// passed through once known.
+    /// passed through once known (per the registry-based check above).
     /// </description></item>
     /// </list>
     /// </summary>
@@ -77,8 +92,6 @@ namespace Akka.Remote.Artery
         private sealed class Logic : GraphStageLogic, IInHandler, IOutHandler
         {
             private readonly InboundHandshakeStage _stage;
-            private bool _isKnownOrigin;
-            private Address? _originAddress;
 
             public Logic(InboundHandshakeStage stage) : base(stage.Shape)
             {
@@ -97,27 +110,28 @@ namespace Akka.Remote.Artery
                     {
                         case HandshakeReq req:
                             HandleReq(req);
-                            break;
+                            Pull(_stage.In);
+                            return;
 
                         case HandshakeRsp rsp:
                             HandleRsp(rsp);
-                            break;
+                            Pull(_stage.In);
+                            return;
 
                         default:
-                            // No other control-message types exist yet at G3 -- reliable
-                            // system-message delivery (Ack/Nack/SystemMessageEnvelope) lands in a
-                            // later chunk.
-                            Log.Debug("Dropping inbound control envelope of unknown message type [{0}].", envelope.Message.GetType());
-                            break;
+                            // Not handshake-internal (heartbeat, quarantine notice, future
+                            // system-message ACK/NACK, ...) -- pass through so ArteryRemoting can
+                            // dispatch to its registered IControlMessageSubscribers (task 6.2).
+                            Push(_stage.Out, envelope);
+                            return;
                     }
-
-                    Pull(_stage.In);
-                    return;
                 }
 
-                if (!_isKnownOrigin)
+                if (!_stage.Context.IsKnownOrigin(envelope.OriginUid))
                 {
-                    Log.Debug("Dropping inbound message [{0}] from unknown origin (no completed handshake on this connection yet).", envelope.Message.GetType());
+                    Log.Debug(
+                        "Dropping inbound message [{0}] from unknown origin uid [{1}] (no completed handshake for this uid yet).",
+                        envelope.Message.GetType(), envelope.OriginUid);
                     Pull(_stage.In);
                     return;
                 }
@@ -144,21 +158,10 @@ namespace Akka.Remote.Artery
                 }
 
                 _stage.Context.CompleteHandshake(req.From);
-                MarkKnownOrigin(req.From.Address);
                 _stage.Context.SendControl(req.From.Address, new HandshakeRsp(_stage.Context.LocalAddress));
             }
 
-            private void HandleRsp(HandshakeRsp rsp)
-            {
-                _stage.Context.CompleteHandshake(rsp.From);
-                MarkKnownOrigin(rsp.From.Address);
-            }
-
-            private void MarkKnownOrigin(Address origin)
-            {
-                _isKnownOrigin = true;
-                _originAddress = origin;
-            }
+            private void HandleRsp(HandshakeRsp rsp) => _stage.Context.CompleteHandshake(rsp.From);
         }
     }
 }

--- a/src/core/Akka.Remote/Artery/OutboundHandshakeStage.cs
+++ b/src/core/Akka.Remote/Artery/OutboundHandshakeStage.cs
@@ -62,6 +62,21 @@ namespace Akka.Remote.Artery
     /// time, ~1s has just passed") — the task explicitly sanctions exactly this simplification
     /// ("track last-injection time; if a message flows and it's been &gt; inject-handshake-interval
     /// since the last injection, inject another ahead of it").</para>
+    ///
+    /// <para><b>Control-channel routing (task group 6, "Control Stream", task 6.3).</b> This
+    /// SAME stage class is materialized on EVERY outbound stream (control, ordinary, and later
+    /// large) — "every stream handshakes" — but only ONE of them, the control stream, is the one
+    /// whose <see cref="Out"/> IS the control connection. So <see cref="IsControlStream"/>
+    /// (constructor parameter, default <see langword="true"/> for source compatibility with the
+    /// pre-6.3 shape) toggles how an injected/re-injected <see cref="HandshakeReq"/> is actually
+    /// dispatched: when <see langword="true"/>, unchanged from before — pushed inline onto this
+    /// stage's own <see cref="Out"/> (which flows straight to the control connection). When
+    /// <see langword="false"/> (the ordinary/large stream's instance), the Req is instead handed
+    /// to <see cref="IOutboundContext.SendControl"/> — a side channel that enqueues onto the
+    /// ASSOCIATION's separate control queue/connection — and this stage's own <see cref="Out"/>
+    /// never carries a <see cref="HandshakeReq"/> element at all. Either way, the "hold the
+    /// pending user element until completion" gating behavior is unchanged; only the Req's
+    /// delivery path differs.</para>
     /// </summary>
     internal sealed class OutboundHandshakeStage : GraphStage<FlowShape<IOutboundEnvelope, IOutboundEnvelope>>
     {
@@ -82,7 +97,8 @@ namespace Akka.Remote.Artery
             IOutboundContext context,
             TimeSpan retryInterval,
             TimeSpan handshakeTimeout,
-            TimeSpan injectHandshakeInterval)
+            TimeSpan injectHandshakeInterval,
+            bool isControlStream = true)
         {
             if (retryInterval <= TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(retryInterval), retryInterval, "must be positive.");
@@ -95,6 +111,7 @@ namespace Akka.Remote.Artery
             RetryInterval = retryInterval;
             HandshakeTimeout = handshakeTimeout;
             InjectHandshakeInterval = injectHandshakeInterval;
+            IsControlStream = isControlStream;
             Shape = new FlowShape<IOutboundEnvelope, IOutboundEnvelope>(In, Out);
         }
 
@@ -102,6 +119,16 @@ namespace Akka.Remote.Artery
         public TimeSpan RetryInterval { get; }
         public TimeSpan HandshakeTimeout { get; }
         public TimeSpan InjectHandshakeInterval { get; }
+
+        /// <summary>
+        /// <see langword="true"/> when this instance is materialized on the control stream
+        /// itself (the default, preserving the pre-6.3 shape used by every existing test/caller
+        /// that does not pass this parameter): an injected <see cref="HandshakeReq"/> is pushed
+        /// inline onto <see cref="Out"/>. <see langword="false"/> for the ordinary/large stream's
+        /// instance: the Req is routed via <see cref="IOutboundContext.SendControl"/> instead —
+        /// see the type-level "Control-channel routing" remarks.
+        /// </summary>
+        public bool IsControlStream { get; }
 
         public Inlet<IOutboundEnvelope> In { get; } = new("OutboundHandshake.in");
         public Outlet<IOutboundEnvelope> Out { get; } = new("OutboundHandshake.out");
@@ -184,15 +211,24 @@ namespace Akka.Remote.Artery
 
                 if (ShouldReinjectForLiveness())
                 {
-                    _pendingMessage = elem;
-
-                    if (IsAvailable(_stage.Out))
+                    if (_stage.IsControlStream)
                     {
-                        _lastInject = DateTime.UtcNow;
-                        Push(_stage.Out, BuildReq());
+                        _pendingMessage = elem;
+
+                        if (IsAvailable(_stage.Out))
+                        {
+                            _lastInject = DateTime.UtcNow;
+                            Push(_stage.Out, BuildReqEnvelope());
+                        }
+
+                        return;
                     }
 
-                    return;
+                    // Non-control stream: the Req travels via the control side channel and never
+                    // occupies this stream's Out slot, so the user element can flow through
+                    // immediately below -- no need to hold it.
+                    _lastInject = DateTime.UtcNow;
+                    _stage.Context.SendControl(BuildReqMessage());
                 }
 
                 if (IsAvailable(_stage.Out))
@@ -269,11 +305,23 @@ namespace Akka.Remote.Artery
 
                 var now = DateTime.UtcNow;
                 var due = _lastInject == DateTime.MinValue || now - _lastInject >= _stage.RetryInterval;
-                if (!due || !IsAvailable(_stage.Out))
+                if (!due)
+                    return;
+
+                if (!_stage.IsControlStream)
+                {
+                    // Side channel: never competes for this stream's own Out demand, so no
+                    // IsAvailable(Out) guard is needed here.
+                    _lastInject = now;
+                    _stage.Context.SendControl(BuildReqMessage());
+                    return;
+                }
+
+                if (!IsAvailable(_stage.Out))
                     return;
 
                 _lastInject = now;
-                Push(_stage.Out, BuildReq());
+                Push(_stage.Out, BuildReqEnvelope());
             }
 
             private bool ShouldReinjectForLiveness()
@@ -282,8 +330,9 @@ namespace Akka.Remote.Artery
                 return _lastInject == DateTime.MinValue || now - _lastInject >= _stage.InjectHandshakeInterval;
             }
 
-            private IOutboundEnvelope BuildReq() =>
-                new OutboundEnvelope(new HandshakeReq(_stage.Context.LocalAddress, _stage.Context.RemoteAddress), null, null);
+            private HandshakeReq BuildReqMessage() => new(_stage.Context.LocalAddress, _stage.Context.RemoteAddress);
+
+            private IOutboundEnvelope BuildReqEnvelope() => new OutboundEnvelope(BuildReqMessage(), null, null);
         }
     }
 }

--- a/src/core/Akka.Remote/Configuration/Remote.conf
+++ b/src/core/Akka.Remote/Configuration/Remote.conf
@@ -679,6 +679,12 @@ akka {
         # How often the outbound handshake stage injects a `HandshakeReq` while user traffic is
         # queued behind an in-progress handshake.
         inject-handshake-interval = 1 s
+
+        # How often the control stream sends a liveness heartbeat (`ArteryHeartbeat`) while
+        # otherwise idle. The control stream is a separate connection/queue from ordinary
+        # traffic (task group 6, "Control Stream") so this cadence is never delayed by ordinary
+        # message volume.
+        control-heartbeat-interval = 5 s
       }
     }
   }


### PR DESCRIPTION
Implements task group 6 of [`artery-tcp-remoting`](https://github.com/akkadotnet/akka.net/tree/dev/openspec/changes/artery-tcp-remoting): the dedicated control stream, graduating G2's single-ordinary-connection staging to the canonical two-stream model. Builds directly on #8327's envelope-typed pipeline. Everything `internal`; `ApproveRemote` unchanged.

## What

- **Per-association control connection**: each association now owns two independent bounded channels (ordinary 3072 / control 256) and two once-materialized outbound streams, built by one shared `MaterializeOutboundStream` helper differing only in stream id, channel, and the control-only heartbeat stage. Control connections carry the `Control` (id=1) preamble; inbound routing accepts both stream types.
- **Handshake routed over control** (task 6.3, undoing the documented G2 staging): handshake replies and injected `HandshakeReq`s travel via the control stream; the ordinary stream keeps its handshake stage, gated through the shared `AssociationState` registry rather than per-connection flags.
- **Control messages**: `ArteryHeartbeat`/`ArteryHeartbeatRsp` (idle-timer liveness via `ArteryHeartbeatStage`, placed upstream of the handshake hold; new `advanced.control-heartbeat-interval = 5s` key) and `ArteryQuarantined` (peer notification → publishes `ThisActorSystemQuarantinedEvent`). Serializer extended with round-trip + manifest-dispatch coverage.
- **Quarantine send-gating** (design invariant): ordinary sends to a quarantined association drop to dead letters (log-once per uid); control pierces. `ActorSelectionMessage` piercing carries a `// GROUP7:` marker, as does the control-overflow→quarantine policy (needs reliable delivery to be meaningful) and the `IControlMessageSubscriber` hook group 7's ACK/NACK stages will consume.
- **Non-starvation** (task 6.6): structurally, control has its own connection + queue; proven by tests — a full ordinary queue cannot block control enqueue, and heartbeats keep flowing under ordinary flood (the test's doc comment states exactly what it does and doesn't prove).
- The poison-pool tripwire now covers the control path's encode stage with content-bearing messages (60× `ArteryQuarantined` through a scribbling pool), not just ordinary traffic.

## Verification

20 new tests (121 Artery total, run twice, no flakes); the 5 G2 transport gate tests individually confirmed; full `Akka.Remote.Tests` suite **512 passed / 0 failed** (5 pre-existing skips); `dotnet build -warnaserror` clean on the full solution; API approvals unchanged.

**Next**: swap the control-message serializer to sourcegen (unblocked by #8325), then task group 7 — reliable system-message delivery, the G3 correctness gate.