### PR TITLE
SerializerV2 sourcegen: fieldless protocol messages (AllowEmpty) + annotated-struct nested fields

### DIFF
--- a/openspec/changes/messagepack-sourcegen-validation/tasks.md
+++ b/openspec/changes/messagepack-sourcegen-validation/tasks.md
@@ -108,3 +108,19 @@ Nested envelope benchmark evidence: real BenchmarkDotNet run for `*GeneratedMess
 - [x] 8.7 Record any V2 API changes required before Artery starts (recorded: foreign-type formatter escape hatch + public `MessagePackSizes` + declared-accessibility emission [design.md Decision 11], encode-time oversized-payload determinism [design.md Decision 12], sync-for-1.6 API sign-off [serializer-v2 design.md Decision 13], Manifest invariant [serializer-v2 design.md Decision 14]; the `PooledPayloadWriter` buffer/ownership contract landed separately as serializer-v2 Decision 12, PR #8322)
 - [ ] 8.8 Add Akka.Hosting registration extension after Akka.Hosting is inlined into the main Akka.NET repository
 - [ ] 8.9 Package runtime and generator assets as one user-facing NuGet package
+
+## 9. Post-#8325 Gaps
+
+Found while attempting to swap Artery's control messages (`ArteryControlMessageSerializer`) onto
+generated serializers: a deliberately fieldless heartbeat message and an `[AkkaSerializable]`
+struct used as a nested field both broke codegen. Both gaps are now closed.
+
+- [x] 9.1 Add `AllowEmpty` opt-in to `[AkkaSerializable]` so a deliberately fieldless top-level
+      protocol message (Artery's `ArteryHeartbeat`/`ArteryHeartbeatRsp` -- "arrival IS the signal")
+      is not hard-rejected by AKKASG004; the guardrail still fires by default for messages that
+      don't opt in
+- [x] 9.2 Fix `IsReferenceLike`/`GetLocalType`/`GetConstructorArgument`/`DefaultValue`/size-and-write
+      codegen to thread the annotated type's is-value-type through for `FieldKind.Object`, mirroring
+      the formatter escape hatch's `IsTargetValueType`, so an `[AkkaSerializable] readonly record
+      struct` (mirroring Artery's `UniqueAddress`) can be used as a required or optional nested field
+      without generating an `Inner?`-vs-`Inner` mismatch (CS1503)

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
@@ -54,7 +54,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor MissingFields = new(
         "AKKASG004",
         "No serializable fields",
-        "[AkkaSerializable] type '{0}' must declare at least one [AkkaField] property",
+        "[AkkaSerializable] type '{0}' must declare at least one [AkkaField] property, or set AllowEmpty = true if the message is deliberately fieldless",
         "Akka.Serialization.V2",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -363,10 +363,13 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         var attribute = context.Attributes[0];
         var knownTypes = KnownTypes.From(context.SemanticModel.Compilation);
         var manifest = string.Empty;
+        var allowEmpty = false;
         foreach (var argument in attribute.NamedArguments)
         {
             if (argument.Key == "Manifest" && argument.Value.Value is string value)
                 manifest = value;
+            else if (argument.Key == "AllowEmpty" && argument.Value.Value is bool allowEmptyValue)
+                allowEmpty = allowEmptyValue;
         }
 
         var fields = new List<FieldInfo>();
@@ -390,7 +393,8 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             GetFullyQualifiedTypeName(symbol),
             manifest,
             fields.OrderBy(f => f.Index).ToImmutableArray(),
-            symbol.AllInterfaces.ToImmutableArray());
+            symbol.AllInterfaces.ToImmutableArray(),
+            allowEmpty);
     }
 
     private static ImmutableDictionary<string, MessageInfo> ResolveMessages(
@@ -468,7 +472,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
 
         foreach (var message in reachableMessages)
         {
-            if (message.Fields.Length == 0)
+            if (message.Fields.Length == 0 && !message.AllowEmpty)
             {
                 context.ReportDiagnostic(Diagnostic.Create(MissingFields, Location.None, message.FullyQualifiedName));
                 isValid = false;
@@ -735,7 +739,12 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
 
     private static bool TryGetInlineSizeExpression(FieldInfo field, string value, out string expression)
     {
-        if (field.Mapping.Kind == FieldKind.Formatted)
+        // Object and EnvelopePayload always route through the general GenerateSizeExpression path
+        // below (they call a generated SizeOfXxx/SizeOfEnvelopePayload method, not a scalar
+        // MessagePackSizes helper) -- including when the field is a nullable [AkkaSerializable]
+        // struct, which would otherwise match IsNullableValueField below and get an inline scalar
+        // expression that GetScalarSizeExpression cannot produce for FieldKind.Object.
+        if (field.Mapping.Kind is FieldKind.Formatted or FieldKind.Object or FieldKind.EnvelopePayload)
         {
             expression = string.Empty;
             return false;
@@ -747,14 +756,8 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             return true;
         }
 
-        if (field.Mapping.Kind != FieldKind.Object && field.Mapping.Kind != FieldKind.EnvelopePayload)
-        {
-            expression = GetScalarSizeExpression(field.Mapping, value);
-            return true;
-        }
-
-        expression = string.Empty;
-        return false;
+        expression = GetScalarSizeExpression(field.Mapping, value);
+        return true;
     }
 
     private static void GenerateSizeExpression(StringBuilder sb, FieldInfo field, string value)
@@ -763,6 +766,9 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         {
             case FieldKind.EnvelopePayload:
                 sb.Append("SizeOfEnvelopePayload(").Append(value).Append(')');
+                break;
+            case FieldKind.Object when IsNullableValueField(field):
+                sb.Append(value).Append(" is null ? SizeOfNil() : SizeOf").Append(GetObjectMethodName(field.Mapping)).Append('(').Append(value).Append(".Value)");
                 break;
             case FieldKind.Object when field.IsNullable:
                 sb.Append(value).Append(" is null ? SizeOfNil() : SizeOf").Append(GetObjectMethodName(field.Mapping)).Append('(').Append(value).Append(')');
@@ -930,7 +936,12 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
                 sb.Append(indent).Append("writer.Write((int)").Append(value).AppendLine(");");
                 break;
             case FieldKind.Object:
-                if (field.IsNullable)
+                // Mirrors FieldKind.Formatted below: when the nested type is a value type, a
+                // nullable field was already unwrapped to its non-nullable .Value by the caller
+                // (GenerateWriteField's IsNullableValueField branch), so no further null-check is
+                // possible (or needed) here -- only a genuinely nullable REFERENCE nested type
+                // needs the runtime "is null" guard.
+                if (field.IsNullable && IsReferenceLike(field))
                 {
                     sb.Append(indent).Append("if (").Append(value).AppendLine(" is null)");
                     sb.Append(indent).AppendLine("    writer.WriteNil();");
@@ -970,7 +981,8 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             return;
         }
 
-        var isNullableReferenceLikeSlot = field.Mapping.Kind is FieldKind.Object or FieldKind.EnvelopePayload
+        var isNullableReferenceLikeSlot = field.Mapping.Kind == FieldKind.EnvelopePayload
+            || (field.Mapping.Kind == FieldKind.Object && IsReferenceLike(field))
             || (field.Mapping.Kind == FieldKind.Formatted && IsReferenceLike(field));
 
         if (isNullableReferenceLikeSlot && field.IsNullable)
@@ -1064,7 +1076,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             return new TypeMapping(FieldKind.ByteArray);
 
         if (type is INamedTypeSymbol namedType && namedType.GetAttributes().Any(attr => SymbolEqualityComparer.Default.Equals(attr.AttributeClass, knownTypes.SerializableAttribute)))
-            return new TypeMapping(FieldKind.Object, GetFullyQualifiedTypeName(namedType));
+            return new TypeMapping(FieldKind.Object, GetFullyQualifiedTypeName(namedType), namedType.IsValueType);
 
         var mapping = type.SpecialType switch
         {
@@ -1106,7 +1118,10 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             FieldKind.Decimal => "0m",
             FieldKind.ActorRef => "global::Akka.Actor.ActorRefs.NoSender",
             FieldKind.EnvelopePayload => "null",
-            FieldKind.Object => "null",
+            // A required (non-nullable) [AkkaSerializable] struct nested field gets a non-nullable
+            // local (see GetLocalType/IsReferenceLike): "null" would not compile for it, so fall
+            // back to "default" the same way every other non-reference-like kind does below.
+            FieldKind.Object => IsReferenceLike(field) ? "null" : "default",
             _ => "default"
         };
     }
@@ -1126,7 +1141,13 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         if (field.Mapping.Kind == FieldKind.Formatted)
             return field.Formatter is { IsTargetValueType: false };
 
-        return field.Mapping.Kind is FieldKind.String or FieldKind.ByteArray or FieldKind.ActorRef or FieldKind.EnvelopePayload or FieldKind.Object;
+        // Mirrors the Formatted case above: an [AkkaSerializable] nested type used as a required
+        // field can be a value type (a readonly record struct), in which case it behaves like a
+        // scalar (non-nullable local/constructor argument, no null-check) rather than a reference.
+        if (field.Mapping.Kind == FieldKind.Object)
+            return !field.Mapping.IsValueType;
+
+        return field.Mapping.Kind is FieldKind.String or FieldKind.ByteArray or FieldKind.ActorRef or FieldKind.EnvelopePayload;
     }
 
     private static bool IsNullableValueField(FieldInfo field)
@@ -1293,13 +1314,14 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
 
     private sealed class MessageInfo
     {
-        public MessageInfo(string simpleName, string fullyQualifiedName, string manifest, ImmutableArray<FieldInfo> fields, ImmutableArray<INamedTypeSymbol> protocols)
+        public MessageInfo(string simpleName, string fullyQualifiedName, string manifest, ImmutableArray<FieldInfo> fields, ImmutableArray<INamedTypeSymbol> protocols, bool allowEmpty)
         {
             SimpleName = simpleName;
             FullyQualifiedName = fullyQualifiedName;
             Manifest = manifest;
             Fields = fields;
             Protocols = protocols;
+            AllowEmpty = allowEmpty;
         }
 
         public string SimpleName { get; }
@@ -1307,10 +1329,11 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         public string Manifest { get; }
         public ImmutableArray<FieldInfo> Fields { get; }
         public ImmutableArray<INamedTypeSymbol> Protocols { get; }
+        public bool AllowEmpty { get; }
 
         public MessageInfo WithFields(ImmutableArray<FieldInfo> fields)
         {
-            return new MessageInfo(SimpleName, FullyQualifiedName, Manifest, fields, Protocols);
+            return new MessageInfo(SimpleName, FullyQualifiedName, Manifest, fields, Protocols, AllowEmpty);
         }
     }
 
@@ -1341,14 +1364,23 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
 
     private readonly struct TypeMapping
     {
-        public TypeMapping(FieldKind kind, string typeFullName = "")
+        public TypeMapping(FieldKind kind, string typeFullName = "", bool isValueType = false)
         {
             Kind = kind;
             TypeFullName = typeFullName;
+            IsValueType = isValueType;
         }
 
         public FieldKind Kind { get; }
         public string TypeFullName { get; }
+
+        /// <summary>
+        /// For <see cref="FieldKind.Object"/>: whether the annotated <c>[AkkaSerializable]</c> nested
+        /// type is a value type (for example, a <c>readonly record struct</c>). Mirrors
+        /// <see cref="FormatterInfo.IsTargetValueType"/>, which threads the same distinction for
+        /// <see cref="FieldKind.Formatted"/> foreign-type formatter targets. Unused for every other kind.
+        /// </summary>
+        public bool IsValueType { get; }
     }
 
     /// <summary>

--- a/src/core/Akka.Serialization.V2.Tests/AkkaSerializerGeneratorDiagnosticsSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/AkkaSerializerGeneratorDiagnosticsSpec.cs
@@ -464,6 +464,141 @@ public sealed class AkkaSerializerGeneratorDiagnosticsSpec
         diagnostics.Should().Contain(diagnostic => diagnostic.Id == "AKKASG011" && diagnostic.Severity == DiagnosticSeverity.Error);
     }
 
+    [Fact(DisplayName = "Generator should still report AKKASG004 for a fieldless message that does not opt into AllowEmpty")]
+    public void Generator_should_report_AKKASG004_for_fieldless_message_without_AllowEmpty()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializer(Name = "sample", SerializerId = 120701)]
+            public sealed partial class SampleSerializer : MessagePackSerializer<IProtocol>
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable(Manifest = "heartbeat-v1")]
+            public sealed record ArteryHeartbeatRepro : IProtocol;
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        // The AllowEmpty opt-in exists specifically so this guardrail can stay strict by default:
+        // a fieldless type is almost always a forgotten [AkkaField], so AKKASG004 must still fire
+        // unless the author deliberately opts in.
+        diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Id == "AKKASG004" &&
+            diagnostic.Severity == DiagnosticSeverity.Error &&
+            diagnostic.GetMessage(null).Contains("AllowEmpty", StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "Generator should not report AKKASG004 and should compile cleanly when a fieldless message opts into AllowEmpty")]
+    public void Generator_should_not_report_AKKASG004_when_fieldless_message_opts_into_AllowEmpty()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializer(Name = "sample", SerializerId = 120703)]
+            public sealed partial class SampleSerializer : MessagePackSerializer<IProtocol>
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable(Manifest = "heartbeat-v1", AllowEmpty = true)]
+            public sealed record ArteryHeartbeatRepro : IProtocol;
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        diagnostics.Should().NotContain(diagnostic => diagnostic.Id == "AKKASG004");
+        diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Generator should not emit CS1503 for a required [AkkaSerializable] struct nested field")]
+    public void Generator_should_not_emit_CS1503_for_required_struct_nested_field()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializer(Name = "sample", SerializerId = 120702)]
+            public sealed partial class SampleSerializer : MessagePackSerializer<IProtocol>
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable(Manifest = "outer-v1")]
+            public sealed record Outer([property: AkkaField(1)] Inner InnerValue) : IProtocol;
+
+            [AkkaSerializable]
+            public readonly record struct Inner([property: AkkaField(1)] string Value);
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        // IsReferenceLike used to return true unconditionally for FieldKind.Object, generating an
+        // `Inner?`-vs-`Inner` mismatch (CS1503) for a value-type nested message used as a required
+        // field. It must now thread the annotated type's is-value-type through, exactly like the
+        // formatter escape hatch already does for FieldKind.Formatted.
+        diagnostics.Should().NotContain(diagnostic => diagnostic.Id == "CS1503");
+        diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Generator should not emit CS1503 for an optional [AkkaSerializable] struct nested field")]
+    public void Generator_should_not_emit_CS1503_for_optional_struct_nested_field()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializer(Name = "sample", SerializerId = 120704)]
+            public sealed partial class SampleSerializer : MessagePackSerializer<IProtocol>
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable(Manifest = "outer-v1")]
+            public sealed record Outer([property: AkkaField(1)] Inner? InnerValue) : IProtocol;
+
+            [AkkaSerializable]
+            public readonly record struct Inner([property: AkkaField(1)] string Value);
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        diagnostics.Should().NotContain(diagnostic => diagnostic.Id == "CS1503");
+        diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
+    }
+
     private static ImmutableArray<Diagnostic> RunGenerator(string source)
     {
         var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12);

--- a/src/core/Akka.Serialization.V2.Tests/FieldlessAndStructFieldSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/FieldlessAndStructFieldSpec.cs
@@ -1,0 +1,258 @@
+//-----------------------------------------------------------------------
+// <copyright file="FieldlessAndStructFieldSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Buffers;
+using System.Threading.Tasks;
+using Akka.Actor;
+using FluentAssertions;
+using MessagePack;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Covers two source-generator gaps found while attempting to swap Artery's control messages
+/// (handshake, heartbeat) onto generated serializers:
+/// <list type="bullet">
+/// <item>
+/// A deliberately fieldless top-level protocol message ("arrival IS the signal" -- Artery's
+/// <c>ArteryHeartbeat</c>/<c>ArteryHeartbeatRsp</c>) used to be hard-rejected by AKKASG004 with no
+/// opt-in. <see cref="AkkaSerializableAttribute.AllowEmpty"/> lifts that for messages that opt in,
+/// while keeping AKKASG004 as a guardrail for everyone else (a forgotten <c>[AkkaField]</c> is far
+/// more likely than a genuinely empty message).
+/// </item>
+/// <item>
+/// An <c>[AkkaSerializable]</c> value type (a <c>readonly record struct</c>, mirroring Artery's
+/// <c>UniqueAddress</c>) used as a required nested field used to generate an <c>Inner?</c>-vs-<c>Inner</c>
+/// mismatch (CS1503) because the generator treated every <see cref="FieldKind"/>-equivalent
+/// "Object" field as reference-like unconditionally.
+/// </item>
+/// </list>
+/// </summary>
+public sealed class FieldlessAndStructFieldSpec : IAsyncLifetime
+{
+    private ActorSystem _system = null!;
+    private GapFixSerializer _serializer = null!;
+
+    public ValueTask InitializeAsync()
+    {
+        _system = ActorSystem.Create("fieldless-and-struct-field-spec");
+        _serializer = new GapFixSerializer((ExtendedActorSystem)_system);
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _system.Terminate();
+    }
+
+    [Fact(DisplayName = "AllowEmpty fieldless messages should round-trip and write a bare empty map header")]
+    public void AllowEmpty_fieldless_messages_should_round_trip_and_write_a_bare_empty_map_header()
+    {
+        var heartbeat = new GapHeartbeat();
+        var heartbeatRsp = new GapHeartbeatRsp();
+
+        RoundTrip(heartbeat).Should().Be(heartbeat);
+        RoundTrip(heartbeatRsp).Should().Be(heartbeatRsp);
+
+        var bytes = _serializer.ToBinary(heartbeat);
+        var reader = new MessagePackReader(new ReadOnlySequence<byte>(bytes));
+        reader.ReadMapHeader().Should().Be(0);
+        reader.Consumed.Should().Be(bytes.Length);
+        bytes.Should().HaveCount(1, because: "an empty MessagePack map header is a single byte (0x80)");
+    }
+
+    [Fact(DisplayName = "AllowEmpty fieldless messages should report exact size hints")]
+    public void AllowEmpty_fieldless_messages_should_report_exact_size_hints()
+    {
+        var heartbeat = new GapHeartbeat();
+
+        _serializer.SizeHint(heartbeat).Should().Be(_serializer.ToBinary(heartbeat).Length);
+    }
+
+    [Fact(DisplayName = "AllowEmpty fieldless messages should tolerate a forward-compatible map with unknown fields")]
+    public void AllowEmpty_fieldless_messages_should_tolerate_unknown_fields()
+    {
+        // A future sender version adds fields to what is, on this reader, still a fieldless
+        // message. The skip-loop read must tolerate them rather than choke on a non-zero map header.
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new MessagePackWriter(buffer);
+        writer.WriteMapHeader(2);
+        writer.Write(1);
+        writer.Write("future-field-value");
+        writer.Write(99);
+        writer.WriteArrayHeader(2);
+        writer.Write("nested");
+        writer.Write(7);
+        writer.Flush();
+
+        var deserialized = _serializer.Deserialize(new ReadOnlySequence<byte>(buffer.WrittenMemory), GapHeartbeat.ManifestName);
+
+        deserialized.Should().Be(new GapHeartbeat());
+    }
+
+    [Fact(DisplayName = "Fieldless message without AllowEmpty behavior is unaffected: existing non-empty messages still round-trip")]
+    public void Existing_non_empty_messages_should_still_round_trip()
+    {
+        var message = new GapPlainMessage("hello");
+
+        RoundTrip(message).Should().Be(message);
+    }
+
+    [Fact(DisplayName = "Required [AkkaSerializable] struct nested field should compile and round-trip")]
+    public void Required_struct_nested_field_should_round_trip()
+    {
+        var withHostPort = new GapUniqueAddress(new Address("akka", "sys", "localhost", 2552), 17L);
+        var withoutHostPort = new GapUniqueAddress(new Address("akka", "sys"), 42L);
+
+        RoundTrip(new GapHandshakeMessage(withHostPort)).Should().Be(new GapHandshakeMessage(withHostPort));
+        RoundTrip(new GapHandshakeMessage(withoutHostPort)).Should().Be(new GapHandshakeMessage(withoutHostPort));
+    }
+
+    [Fact(DisplayName = "Required [AkkaSerializable] struct nested field should write inline without a nil wrapper")]
+    public void Required_struct_nested_field_should_write_inline()
+    {
+        var from = new GapUniqueAddress(new Address("akka", "sys", "localhost", 2552), 17L);
+        var message = new GapHandshakeMessage(from);
+
+        var bytes = _serializer.ToBinary(message);
+        var reader = new MessagePackReader(new ReadOnlySequence<byte>(bytes));
+
+        reader.ReadMapHeader().Should().Be(1);
+        reader.ReadInt32().Should().Be(1);
+        // GapUniqueAddress is [AkkaSerializable] like any other nested message: it writes its own
+        // explicit field-id map (2 fields: Address at index 1, Uid at index 2), NOT an array --
+        // only the AddressFormatter escape hatch composed inside it uses an array convention.
+        reader.ReadMapHeader().Should().Be(2);
+        reader.ReadInt32().Should().Be(1);
+        reader.ReadArrayHeader().Should().Be(4); // Address (via AddressFormatter): [protocol, system, host, port]
+        reader.ReadString().Should().Be("akka");
+        reader.ReadString().Should().Be("sys");
+        reader.ReadString().Should().Be("localhost");
+        reader.ReadInt32().Should().Be(2552);
+        reader.ReadInt32().Should().Be(2);
+        reader.ReadInt64().Should().Be(17L);
+        reader.Consumed.Should().Be(bytes.Length);
+    }
+
+    [Fact(DisplayName = "Required [AkkaSerializable] struct nested field should report exact size hints")]
+    public void Required_struct_nested_field_should_report_exact_size_hints()
+    {
+        var message = new GapHandshakeMessage(new GapUniqueAddress(new Address("akka", "sys", "localhost", 2552), 17L));
+
+        _serializer.SizeHint(message).Should().Be(_serializer.ToBinary(message).Length);
+    }
+
+    [Fact(DisplayName = "Optional [AkkaSerializable] struct nested field should round-trip with and without a value")]
+    public void Optional_struct_nested_field_should_round_trip()
+    {
+        var withValue = new GapOptionalHandshakeMessage(new GapUniqueAddress(new Address("akka", "sys"), 3L));
+        var withoutValue = new GapOptionalHandshakeMessage(null);
+
+        RoundTrip(withValue).Should().Be(withValue);
+        RoundTrip(withoutValue).Should().Be(withoutValue);
+    }
+
+    [Fact(DisplayName = "Optional [AkkaSerializable] struct nested field should write nil when absent and keep exact size hints")]
+    public void Optional_struct_nested_field_should_write_nil_when_absent()
+    {
+        var message = new GapOptionalHandshakeMessage(null);
+        var bytes = _serializer.ToBinary(message);
+        var reader = new MessagePackReader(new ReadOnlySequence<byte>(bytes));
+
+        reader.ReadMapHeader().Should().Be(1);
+        reader.ReadInt32().Should().Be(1);
+        reader.TryReadNil().Should().BeTrue();
+        reader.Consumed.Should().Be(bytes.Length);
+
+        _serializer.SizeHint(message).Should().Be(bytes.Length);
+
+        var withValue = new GapOptionalHandshakeMessage(new GapUniqueAddress(new Address("akka", "sys"), 3L));
+        _serializer.SizeHint(withValue).Should().Be(_serializer.ToBinary(withValue).Length);
+    }
+
+    [Fact(DisplayName = "Optional [AkkaSerializable] struct nested field should tolerate missing entries on read")]
+    public void Optional_struct_nested_field_should_allow_missing_field_on_read()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new MessagePackWriter(buffer);
+        writer.WriteMapHeader(0);
+        writer.Flush();
+
+        var deserialized = _serializer.Deserialize(new ReadOnlySequence<byte>(buffer.WrittenMemory), GapOptionalHandshakeMessage.ManifestName);
+
+        deserialized.Should().Be(new GapOptionalHandshakeMessage(null));
+    }
+
+    private TMessage RoundTrip<TMessage>(TMessage message)
+        where TMessage : class, IGapFixProtocol
+    {
+        var bytes = _serializer.ToBinary(message);
+        var manifest = _serializer.Manifest(message);
+        return _serializer.FromBinary(bytes, manifest).Should().BeOfType<TMessage>().Subject;
+    }
+}
+
+public interface IGapFixProtocol
+{
+}
+
+/// <summary>
+/// Mirrors Artery's <c>ArteryHeartbeat</c>: a deliberately fieldless message where arrival IS the
+/// signal, with nothing to carry.
+/// </summary>
+[AkkaSerializable(Manifest = GapHeartbeat.ManifestName, AllowEmpty = true)]
+public sealed record GapHeartbeat : IGapFixProtocol
+{
+    public const string ManifestName = "gap-heartbeat-v1";
+}
+
+/// <summary>
+/// Mirrors Artery's <c>ArteryHeartbeatRsp</c>: also deliberately fieldless.
+/// </summary>
+[AkkaSerializable(Manifest = GapHeartbeatRsp.ManifestName, AllowEmpty = true)]
+public sealed record GapHeartbeatRsp : IGapFixProtocol
+{
+    public const string ManifestName = "gap-heartbeat-rsp-v1";
+}
+
+[AkkaSerializable(Manifest = "gap-plain-v1")]
+public sealed record GapPlainMessage(
+    [property: AkkaField(1)] string Value) : IGapFixProtocol;
+
+/// <summary>
+/// Mirrors Akka.Remote.Artery's <c>UniqueAddress</c> shape, but handled directly by the
+/// generator's native nested-Object path (annotated with <see cref="AkkaSerializableAttribute"/>)
+/// instead of the <see cref="AkkaSerializerFormatterAttribute"/> foreign-type escape hatch.
+/// </summary>
+[AkkaSerializable]
+public readonly record struct GapUniqueAddress(
+    [property: AkkaField(1)] Address Address,
+    [property: AkkaField(2)] long Uid);
+
+[AkkaSerializable(Manifest = GapHandshakeMessage.ManifestName)]
+public sealed record GapHandshakeMessage(
+    [property: AkkaField(1)] GapUniqueAddress From) : IGapFixProtocol
+{
+    public const string ManifestName = "gap-handshake-v1";
+}
+
+[AkkaSerializable(Manifest = GapOptionalHandshakeMessage.ManifestName)]
+public sealed record GapOptionalHandshakeMessage(
+    [property: AkkaField(1)] GapUniqueAddress? From) : IGapFixProtocol
+{
+    public const string ManifestName = "gap-optional-handshake-v1";
+}
+
+[AkkaSerializer(Name = "gap-fix", SerializerId = 120801)]
+[AkkaSerializerFormatter(typeof(Address), typeof(AddressFormatter))]
+public sealed partial class GapFixSerializer : MessagePackSerializer<IGapFixProtocol>
+{
+    public static partial SerializerRegistration CreateRegistration();
+}

--- a/src/core/Akka.Serialization.V2/Attributes.cs
+++ b/src/core/Akka.Serialization.V2/Attributes.cs
@@ -37,6 +37,16 @@ public sealed class AkkaSerializableAttribute : Attribute
     /// Stable serializer-owned manifest for top-level protocol messages.
     /// </summary>
     public string? Manifest { get; init; }
+
+    /// <summary>
+    /// Opts a deliberately fieldless message into codegen. By default, an <see cref="AkkaSerializableAttribute"/>
+    /// type with no <see cref="AkkaFieldAttribute"/> properties is rejected (AKKASG004): almost always a mistake
+    /// (a forgotten <see cref="AkkaFieldAttribute"/>), but some protocol messages are legitimately fieldless --
+    /// for example, a heartbeat whose arrival IS the signal, with no payload to carry. Set this to
+    /// <see langword="true"/> to generate an empty-map write and a skip-loop read (tolerating unknown fields for
+    /// forward compatibility) instead of failing compilation.
+    /// </summary>
+    public bool AllowEmpty { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

Two source-generator gaps found while attempting to swap Artery's control messages (`ArteryControlMessageSerializer`) onto generated `Akka.Serialization.V2` serializers instead of its current hand-rolled fallback.

- **Gap 1 (blocker):** `ValidateMessages` in `AkkaSerializerGenerator` rejected any `[AkkaSerializable]` type with zero `[AkkaField]` properties (AKKASG004) unconditionally, with no way to opt out. Legitimate protocol messages can be deliberately fieldless — Artery's `ArteryHeartbeat`/`ArteryHeartbeatRsp` are exactly this: arrival IS the signal, there's no payload to carry. Fix: a new `AllowEmpty` bool on `[AkkaSerializable]` (default `false`). When set, `ValidateMessages` skips the guardrail for that message. The empty-map write (`WriteMapHeader(0)`) and the skip-loop read (tolerating unknown fields for forward compatibility) already fell out of the existing per-field codegen once validation stopped blocking it — no write/read/size codegen changes were needed for this half. AKKASG004 still fires by default for messages that don't opt in, with its message text updated to mention `AllowEmpty`.

- **Gap 2:** `IsReferenceLike` returned `true` unconditionally for `FieldKind.Object`, so an `[AkkaSerializable] readonly record struct` used as a required nested field generated an `Inner?`-vs-`Inner` local/constructor-argument mismatch (CS1503). Fix: thread the annotated type's is-value-type through `TypeMapping` (mirroring `FormatterInfo.IsTargetValueType`, which the `[AkkaSerializerFormatter]` escape hatch already threads correctly for foreign types), and fix every place that assumed `FieldKind.Object` was always reference-like: `IsReferenceLike`, `DefaultValue`, the inline/general `SizeOf` expression paths, the write-value null-check, and the read nullable-reference-like-slot check.

Both gaps were reproduced first as failing/erroring cases (AKKASG004 firing with no opt-in; CS1503 for a struct nested field) before being fixed — see the diagnostics spec history in this PR.

This unblocks swapping `Akka.Remote.Artery.ArteryControlMessageSerializer`'s hand-rolled fallback onto the generator (its own doc comment cites the missing nested-type support as the reason it exists).

## Changes

- `src/core/Akka.Serialization.V2/Attributes.cs` — new `AllowEmpty` property on `[AkkaSerializable]`.
- `src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs` — `AllowEmpty` plumbing through `MessageInfo`/`ValidateMessages`; `TypeMapping.IsValueType` for `FieldKind.Object`; `IsReferenceLike`, `DefaultValue`, `TryGetInlineSizeExpression`, `GenerateSizeExpression`, `GenerateWriteFieldValue`, and `GenerateReadField` all updated to treat a value-type `[AkkaSerializable]` nested message like a scalar instead of a reference.
- `src/core/Akka.Serialization.V2.Tests/AkkaSerializerGeneratorDiagnosticsSpec.cs` — new diagnostics coverage: AKKASG004 still fires without `AllowEmpty`, is suppressed with it (and the message compiles clean); required/optional struct nested fields no longer emit CS1503.
- `src/core/Akka.Serialization.V2.Tests/FieldlessAndStructFieldSpec.cs` (new) — end-to-end coverage through the real incremental generator: fieldless round-trip + exact `SizeHint` + forward-compat skip-loop tolerance for unknown fields on a fieldless manifest; a `GapUniqueAddress` struct (mirroring Artery's `UniqueAddress`, composing the built-in `AddressFormatter` escape hatch internally) round-tripping as both a required and an optional nested field, with byte-shape and `SizeHint` assertions.
- `openspec/changes/messagepack-sourcegen-validation/tasks.md` — new "Post-#8325 Gaps" section with both fixes ticked; `openspec validate --strict` passes.

## Test plan

- [x] `Akka.Serialization.V2.Tests`: 66/66 green (`dotnet test src/core/Akka.Serialization.V2.Tests -c Release`)
- [x] `dotnet build Akka.slnx -c Release -warnaserror`: clean, 0 warnings/errors
- [x] `dotnet test -c Release src/core/Akka.API.Tests`: 18/18 green, **no approval delta** — `Akka.Serialization.V2` is not one of the assemblies covered by `CoreAPISpec` (only `InternalsVisibleTo`), so the new public `AllowEmpty` property has nothing to approve/re-approve
- [x] `openspec validate messagepack-sourcegen-validation --strict`: valid