### PR TITLE
fix(cluster.sharding): de-flake ClusterShardingRolePartitioningSpec MNTR (widen AwaitAssert windows)

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRolePartitioningSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRolePartitioningSpec.cs
@@ -202,19 +202,23 @@ namespace Akka.Cluster.Sharding.Tests
 
             await RunOnAsync(async () =>
             {
-                // wait for all regions registered
+                // Wait for all regions to register. Use an explicit, generous window here:
+                // during the initial 5-node join the shard-coordinator singleton can still be
+                // migrating between R1 nodes, so region (re-)registration routinely takes longer
+                // than the default 5s AwaitAssert budget on a busy CI agent. See MNTR flakiness
+                // where this asserted 2 regions instead of 3 before convergence completed.
                 await AwaitAssertAsync(async () =>
                 {
                     var region = ClusterSharding.Get(Sys).ShardRegion(E1.TypeKey);
                     region.Tell(GetCurrentRegions.Instance);
                     (await ExpectMsgAsync<CurrentRegions>()).Regions.Count.Should().Be(3);
-                });
+                }, TimeSpan.FromSeconds(30));
                 await AwaitAssertAsync(async () =>
                 {
                     var region = ClusterSharding.Get(Sys).ShardRegion(E2.TypeKey);
                     region.Tell(GetCurrentRegions.Instance);
                     (await ExpectMsgAsync<CurrentRegions>()).Regions.Count.Should().Be(2);
-                });
+                }, TimeSpan.FromSeconds(30));
             }, Config.Fourth);
 
             await EnterBarrierAsync($"{Roles.Count}-up");
@@ -237,11 +241,14 @@ namespace Akka.Cluster.Sharding.Tests
                 // buffered. The ShardRegion only retries GetShardHome on its retry interval (default 2-10s),
                 // which can exceed our ExpectMsg timeout.
                 // By wrapping the first message in AwaitAssert, we retry until the coordinator is fully ready.
+                // Use an explicit 30s window: the ShardRegion only retries GetShardHome on its retry
+                // interval (2-10s), so the default 5s AwaitAssert budget allows barely one or two 3s
+                // ExpectMsg attempts - not enough headroom on a busy CI agent (source of MNTR flakiness).
                 await AwaitAssertAsync(async () =>
                 {
                     region.Tell(1);
                     await ExpectMsgAsync(1, TimeSpan.FromSeconds(3));
-                });
+                }, TimeSpan.FromSeconds(30));
 
                 // After the first message succeeds, the shard is allocated and subsequent messages
                 // to the same or new shards should succeed without delay (coordinator is ready)


### PR DESCRIPTION
## What this fixes

`ClusterShardingMinMembersPerRoleNotConfiguredSpec` (backed by `ClusterShardingRolePartitioningSpec`) is an intermittently-flaky MNTR spec. Recent example on the `.NET Multi-Node Tests (Windows)` job:

- **Node4 [fourth]:** `Expected (await ExpectMsgAsync<CurrentRegions>()).Regions.Count to be 3, but found 2.`
- **Node1 [first]:** `Timeout 00:00:03 while waiting for a message of type System.Int32.` (cascade)

## Root cause — timing, not logic

During the initial 5-node join the **shard-coordinator singleton can still be migrating between R1 nodes**, so region (re-)registration and coordinator readiness routinely take longer than the **default 5s `AwaitAssert` budget** on a busy CI agent.

The two failures are one incident:
1. Node4's region-count assert times out at 5s while only 2 of 3 R1 regions have re-registered against the newly-migrated coordinator.
2. Because Node4's assert fails, Node4 drops out of the cluster — which removes the R2 coordinator host — so the second sub-test's proxied message on Node1 also times out. The `RemoteTransportException: Remoting is not running` lines are teardown noise, not the cause.

## The change

Widen the three affected `AwaitAssertAsync` windows from the default 5s to an explicit **30s**, each with a comment explaining why:
- region-count `E1 == 3`
- region-count `E2 == 2`
- first-message coordinator-readiness assert (the `GetShardHome` retry interval is 2–10s, so a 5s window barely fits one or two 3s `ExpectMsg` attempts)

The assertions are unchanged — they still have to pass, just with realistic convergence time on a slow agent. Fixing the Node4 assert also prevents the Node1 cascade, so this single change addresses both failures.

## Scope / risk

- **Test-only.** No public API, wire format, or product code touched — no `BREAKING_CHANGES_V1.6.md` entry needed.
- Only loosens timing budgets; cannot mask a real regression (a genuinely wrong region count still fails after 30s).
- The spec is already fully async (`AwaitAssertAsync` / `ExpectMsgAsync` / `RunOnAsync` / `EnterBarrierAsync`), consistent with the TestKit guidelines — no sync-method conversion required.

Builds clean (0 warnings) for `Akka.Cluster.Sharding.Tests.MultiNode`.