### PR TITLE
Artery: swap all nine control messages to source-generated V2 serializers

### DIFF
--- a/src/core/Akka.Remote.Tests/Artery/ArteryControlMessageSerializerSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryControlMessageSerializerSpec.cs
@@ -1,7 +1,7 @@
 //-----------------------------------------------------------------------
 // <copyright file="ArteryControlMessageSerializerSpec.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
 
@@ -17,8 +17,10 @@ using Akka.Actor.Setup;
 using Akka.Configuration;
 using Akka.Dispatch.SysMsg;
 using Akka.Remote.Artery;
+using Akka.Remote.Configuration;
 using Akka.Serialization;
 using FluentAssertions;
+using MessagePack;
 using Xunit;
 // Akka.Remote.SysAck/Akka.Remote.SysNack (classic AckedDelivery.cs) are enclosing-namespace types of
 // Akka.Remote.Tests.Artery and would otherwise shadow Akka.Remote.Artery.SysAck/SysNack (design.md gate
@@ -29,17 +31,21 @@ using SysNack = Akka.Remote.Artery.Nack;
 namespace Akka.Remote.Tests.Artery
 {
     /// <summary>
-    /// Round-trip tests for <see cref="ArteryControlMessageSerializer"/>, the hand-rolled V2
-    /// MessagePack serializer for <see cref="HandshakeReq"/> / <see cref="HandshakeRsp"/> — see
-    /// the task report for why this is hand-rolled rather than source-generated (the generator
-    /// requires every nested field type to carry <c>[AkkaSerializable]</c>, which
-    /// <see cref="Address"/>, a core <c>Akka.Actor</c> type, does not and should not for this
-    /// change).
+    /// Round-trip tests for <see cref="ArteryControlMessageSerializer"/>, the source-generated V2
+    /// MessagePack serializer for ALL NINE Artery control/handshake/reliable-system-message-delivery
+    /// messages (<see cref="HandshakeReq"/> / <see cref="HandshakeRsp"/> / <see cref="ArteryHeartbeat"/> /
+    /// <see cref="ArteryHeartbeatRsp"/> / <see cref="ArteryQuarantined"/> / <see cref="Ack"/> /
+    /// <see cref="Nack"/> / <see cref="SystemMessageEnvelope"/> / <see cref="ClearSystemMessageDelivery"/>).
     ///
     /// <para>
-    /// This serializer is NOT registered in <c>Remote.conf</c> by this change (that file is owned
-    /// by a parallel task). The HOCON fragment needed to wire it up is reproduced in the task
-    /// report; here it is registered ad hoc, per-test, via <see cref="SerializationSetup"/>.
+    /// This class used to be hand-rolled because the <c>Akka.Serialization.V2</c> generator could
+    /// not express a deliberately fieldless message or a nested <c>[AkkaSerializable]</c> value-type
+    /// field. Both gaps were fixed by #8331; this spec now exercises the GENERATED partial class
+    /// (<c>Akka.Remote.csproj</c> attaches <c>Akka.Serialization.V2.Generators</c> as an analyzer).
+    /// The manifest constants, class name, and serializer identifier (23) are unchanged from the
+    /// hand-rolled version, so <c>Remote.conf</c>'s existing registration
+    /// (<c>artery-control</c> alias, <c>"Akka.Remote.Artery.IArteryControlMessage, Akka.Remote" = artery-control</c>
+    /// binding, <c>serialization-identifiers</c> entry) needed NO edits.
     /// </para>
     /// </summary>
     public sealed class ArteryControlMessageSerializerSpec : IAsyncLifetime
@@ -103,6 +109,16 @@ namespace Akka.Remote.Tests.Artery
         public void Should_round_trip_ArteryHeartbeat()
         {
             RoundTrip(new ArteryHeartbeat()).Should().Be(new ArteryHeartbeat());
+        }
+
+        [Fact(DisplayName = "ArteryControlMessageSerializer should write ArteryHeartbeat as a bare empty map header (AllowEmpty)")]
+        public void Should_write_ArteryHeartbeat_as_empty_map()
+        {
+            var bytes = _serializer.ToBinary(new ArteryHeartbeat());
+            var reader = new MessagePackReader(new ReadOnlySequence<byte>(bytes));
+
+            reader.ReadMapHeader().Should().Be(0);
+            reader.Consumed.Should().Be(bytes.Length);
         }
 
         [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip ArteryHeartbeatRsp (task group 6, task 6.4)")]
@@ -179,7 +195,7 @@ namespace Akka.Remote.Tests.Artery
             protected override bool Receive(object message) => true;
         }
 
-        [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip SystemMessageEnvelope wrapping a Watch, nesting the inner system message via the classic Serialization extension (design.md gate G3)")]
+        [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip SystemMessageEnvelope wrapping a Watch, nesting the inner system message via [AkkaEnvelopePayload] (design.md gate G3)")]
         public void Should_round_trip_SystemMessageEnvelope_wrapping_Watch()
         {
             var watchee = (IInternalActorRef)_system.ActorOf(Props.Create<NopActor>());
@@ -216,7 +232,7 @@ namespace Akka.Remote.Tests.Artery
             written.Should().BeGreaterThan(0);
         }
 
-        [Fact(DisplayName = "ArteryControlMessageSerializer should report exact size hints for all message types")]
+        [Fact(DisplayName = "ArteryControlMessageSerializer should report exact size hints for all message types with a cheaply-known size")]
         public void Should_report_exact_size_hints()
         {
             var req = new HandshakeReq(
@@ -226,12 +242,33 @@ namespace Akka.Remote.Tests.Artery
             var heartbeat = new ArteryHeartbeat();
             var heartbeatRsp = new ArteryHeartbeatRsp();
             var quarantined = new ArteryQuarantined(new UniqueAddress(new Address("akka", "sys-a", "host-a", 2551), 42L), 99L);
+            var ack = new SysAck(7L, new UniqueAddress(new Address("akka", "sys-a", "host-a", 2551), 42L));
+            var nack = new SysNack(3L, new UniqueAddress(new Address("akka", "sys-b", "host-b", 2552), 99L));
+            var clear = new ClearSystemMessageDelivery(5);
 
             _serializer.SizeHint(req).Should().Be(_serializer.ToBinary(req).Length);
             _serializer.SizeHint(rsp).Should().Be(_serializer.ToBinary(rsp).Length);
             _serializer.SizeHint(heartbeat).Should().Be(_serializer.ToBinary(heartbeat).Length);
             _serializer.SizeHint(heartbeatRsp).Should().Be(_serializer.ToBinary(heartbeatRsp).Length);
             _serializer.SizeHint(quarantined).Should().Be(_serializer.ToBinary(quarantined).Length);
+            _serializer.SizeHint(ack).Should().Be(_serializer.ToBinary(ack).Length);
+            _serializer.SizeHint(nack).Should().Be(_serializer.ToBinary(nack).Length);
+            _serializer.SizeHint(clear).Should().Be(_serializer.ToBinary(clear).Length);
+        }
+
+        [Fact(DisplayName = "ArteryControlMessageSerializer should report UnknownSize for SystemMessageEnvelope (its inner payload's size depends on a classic, non-SerializerV2 serializer)")]
+        public void Should_report_unknown_size_for_SystemMessageEnvelope()
+        {
+            var watchee = (IInternalActorRef)_system.ActorOf(Props.Create<NopActor>());
+            var watcher = (IInternalActorRef)_system.ActorOf(Props.Create<NopActor>());
+            var ackReplyTo = new UniqueAddress(new Address("akka", "sys-a", "host-a", 2551), 42L);
+            var envelope = new SystemMessageEnvelope(new Watch(watchee, watcher), 1L, ackReplyTo, "akka://sys-b@host-b:2552/user/target");
+
+            Akka.Serialization.Serialization.WithTransport((ExtendedActorSystem)_system, () =>
+            {
+                _serializer.SizeHint(envelope).Should().Be(global::Akka.Serialization.SerializerV2.UnknownSize);
+                return true;
+            });
         }
 
         [Fact(DisplayName = "ArteryControlMessageSerializer should dispatch by manifest and reject an unknown manifest")]
@@ -242,24 +279,31 @@ namespace Akka.Remote.Tests.Artery
                 new Address("akka", "sys-b", "host-b", 2552));
 
             _serializer.Manifest(req).Should().Be(ArteryControlMessageSerializer.HandshakeReqManifest);
+            _serializer.Manifest(new HandshakeRsp(new UniqueAddress(new Address("akka", "sys-b", "host-b", 2552), 1L)))
+                .Should().Be(ArteryControlMessageSerializer.HandshakeRspManifest);
             _serializer.Manifest(new ArteryHeartbeat()).Should().Be(ArteryControlMessageSerializer.HeartbeatManifest);
             _serializer.Manifest(new ArteryHeartbeatRsp()).Should().Be(ArteryControlMessageSerializer.HeartbeatRspManifest);
             _serializer.Manifest(new ArteryQuarantined(new UniqueAddress(new Address("akka", "sys-a", "host-a", 2551), 1L), 2L))
                 .Should().Be(ArteryControlMessageSerializer.QuarantinedManifest);
+            _serializer.Manifest(new SysAck(1L, new UniqueAddress(new Address("akka", "sys-a", "host-a", 2551), 1L)))
+                .Should().Be(ArteryControlMessageSerializer.AckManifest);
+            _serializer.Manifest(new SysNack(1L, new UniqueAddress(new Address("akka", "sys-a", "host-a", 2551), 1L)))
+                .Should().Be(ArteryControlMessageSerializer.NackManifest);
+            _serializer.Manifest(new ClearSystemMessageDelivery(1)).Should().Be(ArteryControlMessageSerializer.ClearSystemMessageDeliveryManifest);
 
             var bytes = _serializer.ToBinary(req);
             Action deserializeUnknown = () => _serializer.FromBinary(bytes, "unknown-manifest");
             deserializeUnknown.Should().Throw<SerializationException>();
         }
 
-        [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip through the Serialization extension when registered via config")]
+        [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip through the Serialization extension when registered ad hoc via SerializationSetup")]
         public async Task Should_round_trip_through_Serialization_extension()
         {
             var setup = ActorSystemSetup.Create(SerializationSetup.Create(extendedSystem =>
                 ImmutableHashSet.Create(SerializerDetails.Create(
                     "artery-control",
                     new ArteryControlMessageSerializer(extendedSystem),
-                    ImmutableHashSet.Create<Type>(typeof(HandshakeReq), typeof(HandshakeRsp))))));
+                    ImmutableHashSet.Create<Type>(typeof(IArteryControlMessage))))));
 
             var system = ActorSystem.Create("artery-control-message-serializer-registration-spec", setup);
             try
@@ -283,25 +327,15 @@ namespace Akka.Remote.Tests.Artery
             }
         }
 
-        [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip through the Serialization extension when registered via HOCON (the fragment this change is NOT wiring into Remote.conf)")]
-        public async Task Should_round_trip_through_Serialization_extension_via_HOCON_config()
+        [Fact(DisplayName = "ArteryControlMessageSerializer should round-trip through the Serialization extension using the REAL production Remote.conf registration (all nine message types share one IArteryControlMessage binding)")]
+        public async Task Should_round_trip_through_Serialization_extension_via_production_Remote_conf()
         {
-            // Same fragment reproduced in the task report - Remote.conf itself is owned by a
-            // parallel task, so it is not edited here; this proves the fragment is correct.
-            var config = ConfigurationFactory.ParseString(@"
-                akka.actor {
-                  serializers {
-                    artery-control = ""Akka.Remote.Artery.ArteryControlMessageSerializer, Akka.Remote""
-                  }
-                  serialization-bindings {
-                    ""Akka.Remote.Artery.HandshakeReq, Akka.Remote"" = artery-control
-                    ""Akka.Remote.Artery.HandshakeRsp, Akka.Remote"" = artery-control
-                  }
-                  serialization-identifiers {
-                    ""Akka.Remote.Artery.ArteryControlMessageSerializer, Akka.Remote"" = 23
-                  }
-                }
-            ").WithFallback(ConfigurationFactory.Default());
+            // Unlike the hand-rolled predecessor, this is the ACTUAL Remote.conf shipped with
+            // Akka.Remote (RemoteConfigFactory.Default()) -- no ad hoc HOCON fragment reproduced
+            // here. Remote.conf already binds "Akka.Remote.Artery.IArteryControlMessage, Akka.Remote"
+            // to the "artery-control" serializer alias and pins its identifier to 23, so this class
+            // needed NO Remote.conf edits when it swapped from hand-rolled to source-generated.
+            var config = RemoteConfigFactory.Default().WithFallback(ConfigurationFactory.Default());
 
             var system = ActorSystem.Create("artery-control-message-serializer-hocon-spec", config);
             try
@@ -319,6 +353,20 @@ namespace Akka.Remote.Tests.Artery
                 var deserialized = system.Serialization.Deserialize(bytes, serializer.Identifier, manifest);
 
                 deserialized.Should().Be(req);
+
+                // The fieldless AllowEmpty message and the reliable-system-message-delivery
+                // messages all resolve through the SAME "Akka.Remote.Artery.IArteryControlMessage,
+                // Akka.Remote" -> artery-control interface binding -- prove a second, unrelated
+                // message type in the protocol resolves identically, not just HandshakeReq.
+                var heartbeatSerializer = system.Serialization.FindSerializerFor(new ArteryHeartbeat());
+                heartbeatSerializer.Should().BeOfType<ArteryControlMessageSerializer>();
+                heartbeatSerializer.Identifier.Should().Be(23);
+
+                var clear = new ClearSystemMessageDelivery(9);
+                var clearSerializer = system.Serialization.FindSerializerFor(clear);
+                var clearBytes = system.Serialization.Serialize(clear);
+                var clearManifest = Akka.Serialization.Serialization.ManifestFor(clearSerializer, clear);
+                system.Serialization.Deserialize(clearBytes, clearSerializer.Identifier, clearManifest).Should().Be(clear);
             }
             finally
             {

--- a/src/core/Akka.Remote/Akka.Remote.csproj
+++ b/src/core/Akka.Remote/Akka.Remote.csproj
@@ -14,6 +14,10 @@
              so this does not introduce a cycle. -->
         <ProjectReference Include="..\Akka.Streams\Akka.Streams.csproj" />
         <ProjectReference Include="..\Akka.Serialization.V2\Akka.Serialization.V2.csproj" />
+        <!-- Analyzer-only reference: generates the Artery control-message serializer partial
+             class (Akka.Remote.Artery.ArteryControlMessageSerializer) from [AkkaSerializable] /
+             [AkkaField] annotations. Mirrors Akka.Serialization.V2.Tests' csproj. -->
+        <ProjectReference Include="..\Akka.Serialization.V2.Generators\Akka.Serialization.V2.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="DotNetty.Handlers" Version="0.7.6" />

--- a/src/core/Akka.Remote/Artery/ArteryControlMessageSerializer.cs
+++ b/src/core/Akka.Remote/Artery/ArteryControlMessageSerializer.cs
@@ -1,54 +1,59 @@
 //-----------------------------------------------------------------------
 // <copyright file="ArteryControlMessageSerializer.cs" company="Akka.NET Project">
 //     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
-//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
 // </copyright>
 //-----------------------------------------------------------------------
 
 #nullable enable
 
-using System;
-using System.Buffers;
-using System.Runtime.Serialization;
 using Akka.Actor;
-using MessagePack;
+using Akka.Serialization.V2;
 
 namespace Akka.Remote.Artery
 {
     /// <summary>
     /// INTERNAL API.
     ///
-    /// Hand-rolled V2 MessagePack serializer for the Artery control/handshake messages
-    /// (<see cref="HandshakeReq"/> / <see cref="HandshakeRsp"/> / <see cref="ArteryHeartbeat"/> /
-    /// <see cref="ArteryHeartbeatRsp"/> / <see cref="ArteryQuarantined"/> -- the latter three
-    /// added at task group 6, "Control Stream", task 6.4/6.5, extending the SAME hand-rolled
-    /// serializer found on this branch rather than replacing it with sourcegen; see the task
-    /// report for why sourcegen still cannot be used here).
+    /// Source-generated V2 MessagePack serializer for ALL NINE Artery control/handshake/reliable-
+    /// system-message-delivery messages (<see cref="HandshakeReq"/> / <see cref="HandshakeRsp"/> /
+    /// <see cref="ArteryHeartbeat"/> / <see cref="ArteryHeartbeatRsp"/> / <see cref="ArteryQuarantined"/> /
+    /// <see cref="Ack"/> / <see cref="Nack"/> / <see cref="SystemMessageEnvelope"/> /
+    /// <see cref="ClearSystemMessageDelivery"/>).
     ///
     /// <para>
-    /// Design.md ("Handshake + association/UID (gate G2)") pins handshake message encoding to
-    /// V2 source-generated MessagePack, with an explicit fallback: "a hand-written
-    /// <c>MessagePackSerializer&lt;T&gt;</c> subclass (still V2, still msgpack) with a tracked
-    /// follow-up to move onto the generator." That fallback is what this class is — see the
-    /// task report for why: the <c>Akka.Serialization.V2</c> source generator requires every
-    /// nested field type to carry <c>[AkkaSerializable]</c> (enforced by
-    /// <c>AkkaSerializerGenerator.MissingNestedSerializableDefinition</c>), and
-    /// <see cref="Address"/> is a core <c>Akka.Actor</c> type this change may not annotate.
+    /// This class used to be hand-rolled (see git history) because the <c>Akka.Serialization.V2</c>
+    /// generator could not, at the time, express a deliberately fieldless message or a nested
+    /// <c>[AkkaSerializable]</c> value-type field. Both gaps were fixed by #8331
+    /// (<see cref="AkkaSerializableAttribute.AllowEmpty"/> and the struct-nested-field fix), so this
+    /// class is now the <c>[AkkaSerializer]</c> half of a source-generated partial class -- the
+    /// generator (<c>Akka.Serialization.V2.Generators.AkkaSerializerGenerator</c>, attached as an
+    /// analyzer on <c>Akka.Remote.csproj</c>) emits the other half
+    /// (<c>ArteryControlMessageSerializer.AkkaSerialization.g.cs</c>): the constructor, <c>Identifier</c>,
+    /// <c>Manifest</c>/<c>Serialize</c>/<c>Deserialize</c>/<c>SizeHint</c> dispatch, and one
+    /// Write/Read/SizeOf method per reachable message type (including the nested
+    /// <see cref="UniqueAddress"/> value type).
     /// </para>
     /// <para>
-    /// This class still writes/reads plain MessagePack (map-with-field-ids, forward-compatible
-    /// via unknown-field skipping) and still derives from the V2
-    /// <see cref="Akka.Serialization.V2.MessagePackSerializer{TProtocol}"/> base (itself a
-    /// <see cref="Akka.Serialization.SerializerV2"/>) purely to reuse its buffer-size and
-    /// bytes-written helpers — no source-generated code is involved.
+    /// The manifest constants below are still hand-written (referenced from each message's
+    /// <see cref="AkkaSerializableAttribute.Manifest"/> as compile-time constants, and from
+    /// <c>SystemMessageAckerStageSpec</c>) -- the generator does not emit public manifest constants.
     /// </para>
     /// <para>
-    /// Follow-up (tracked): once <see cref="Address"/> can be expressed as a generator-visible
-    /// nested type (or the generator grows an escape hatch for foreign types), replace this class
-    /// with a generated one and delete it.
+    /// <see cref="Address"/> is a core <c>Akka.Actor</c> type this change may not annotate with
+    /// <c>[AkkaSerializable]</c>; it is instead handled via the built-in <see cref="AddressFormatter"/>
+    /// escape hatch (<see cref="AkkaSerializerFormatterAttribute"/>), which produces the identical
+    /// 4-element-array wire format the old hand-rolled <c>WriteAddress</c>/<c>ReadAddress</c> used.
+    /// </para>
+    /// <para>
+    /// Class name and serializer identifier (23) are unchanged from the hand-rolled version, so the
+    /// existing <c>Remote.conf</c> registration (<c>artery-control</c> alias, <c>serialization-bindings</c>
+    /// on <see cref="IArteryControlMessage"/>, <c>serialization-identifiers</c> entry) requires no edits.
     /// </para>
     /// </summary>
-    internal sealed class ArteryControlMessageSerializer : Akka.Serialization.V2.MessagePackSerializer<IArteryControlMessage>
+    [AkkaSerializer(Name = "artery-control", SerializerId = 23)]
+    [AkkaSerializerFormatter(typeof(Address), typeof(AddressFormatter))]
+    internal sealed partial class ArteryControlMessageSerializer : MessagePackSerializer<IArteryControlMessage>
     {
         /// <summary>
         /// The manifest for <see cref="HandshakeReq"/>.
@@ -95,518 +100,14 @@ namespace Akka.Remote.Artery
         /// </summary>
         public const string ClearSystemMessageDeliveryManifest = "SCL";
 
-        private const int FromFieldId = 1;
-        private const int ToFieldId = 2;
-        private const int QuarantinedUidFieldId = 2;
-
-        // Ack / Nack share an identical wire shape.
-        private const int AckSeqNoFieldId = 1;
-        private const int AckFromFieldId = 2;
-
-        // SystemMessageEnvelope
-        private const int SmeSeqNoFieldId = 1;
-        private const int SmeAckReplyToFieldId = 2;
-        private const int SmeRecipientPathFieldId = 3;
-        private const int SmePayloadFieldId = 4;
-
-        // ClearSystemMessageDelivery
-        private const int ClearIncarnationFieldId = 1;
-
         /// <summary>
-        /// Initializes a new instance of the <see cref="ArteryControlMessageSerializer"/> class.
+        /// Generated by <c>Akka.Serialization.V2.Generators.AkkaSerializerGenerator</c> -- an
+        /// AOT-safe, explicit alternative to reflection-based (HOCON class-name) construction. Not
+        /// used by <c>Remote.conf</c>'s registration (which still resolves this class by name via
+        /// the classic <c>Serializer</c> reflection contract), but available for
+        /// <see cref="Akka.Serialization.V2.SerializerRegistration.CreateSetup(Akka.Serialization.V2.SerializerRegistration[])"/>-based
+        /// composition.
         /// </summary>
-        /// <param name="system">The actor system that owns this serializer.</param>
-        public ArteryControlMessageSerializer(ExtendedActorSystem system) : base(system)
-        {
-        }
-
-        /// <summary>
-        /// See HOCON registration fragment in the task report — this identifier (23) is unused
-        /// in the reserved 0-40 Akka-internal range as of this change (verified against
-        /// <c>Remote.conf</c>, <c>Cluster.conf</c>, <c>persistence.conf</c>, and the contrib
-        /// cluster-tools / distributed-data / streams reference.conf files; 17, which Pekko uses
-        /// for its <c>ArteryMessageSerializer</c>, is already taken in Akka.NET by
-        /// <c>Akka.Remote.Serialization.PrimitiveSerializers</c>).
-        /// </summary>
-        public override int Identifier => 23;
-
-        /// <inheritdoc/>
-        public override string Manifest(object obj) => obj switch
-        {
-            HandshakeReq => HandshakeReqManifest,
-            HandshakeRsp => HandshakeRspManifest,
-            ArteryHeartbeat => HeartbeatManifest,
-            ArteryHeartbeatRsp => HeartbeatRspManifest,
-            ArteryQuarantined => QuarantinedManifest,
-            Ack => AckManifest,
-            Nack => NackManifest,
-            SystemMessageEnvelope => SystemMessageEnvelopeManifest,
-            ClearSystemMessageDelivery => ClearSystemMessageDeliveryManifest,
-            _ => throw new ArgumentException($"Unsupported Artery control message type: {obj.GetType()}", nameof(obj))
-        };
-
-        /// <inheritdoc/>
-        public override int SizeHint(object obj) => obj switch
-        {
-            HandshakeReq req => SizeOfReq(req),
-            HandshakeRsp rsp => SizeOfRsp(rsp),
-            ArteryHeartbeat => SizeOfMapHeader(0),
-            ArteryHeartbeatRsp => SizeOfMapHeader(0),
-            ArteryQuarantined q => SizeOfQuarantined(q),
-            Ack ack => SizeOfAckOrNack(ack.SeqNo, ack.From),
-            Nack nack => SizeOfAckOrNack(nack.SeqNo, nack.From),
-            ClearSystemMessageDelivery clear => SizeOfMapHeader(1) + SizeOfInt32(ClearIncarnationFieldId) + SizeOfInt32(clear.Incarnation),
-            // SystemMessageEnvelope's inner payload size depends on the nested serializer's OWN
-            // SizeHint, which is not necessarily known cheaply (SizeOfEnvelopePayload returns
-            // UnknownSize when it isn't) -- rather than duplicate that fallback logic here, this
-            // type simply defers to UnknownSize; it is not the hot path (control-stream volume only,
-            // and PooledPayloadWriter grows on demand regardless).
-            SystemMessageEnvelope => UnknownSize,
-            _ => UnknownSize
-        };
-
-        /// <inheritdoc/>
-        public override int Serialize(object obj, IBufferWriter<byte> writer)
-        {
-            var counting = new CountingBufferWriter(writer);
-            var messagePackWriter = new MessagePackWriter(counting);
-
-            switch (obj)
-            {
-                case HandshakeReq req:
-                    WriteReq(ref messagePackWriter, req);
-                    break;
-                case HandshakeRsp rsp:
-                    WriteRsp(ref messagePackWriter, rsp);
-                    break;
-                case ArteryHeartbeat:
-                case ArteryHeartbeatRsp:
-                    // No fields -- an empty map is forward-compatible (an unknown-field skip loop
-                    // handles any fields a future version might add).
-                    messagePackWriter.WriteMapHeader(0);
-                    break;
-                case ArteryQuarantined quarantined:
-                    WriteQuarantined(ref messagePackWriter, quarantined);
-                    break;
-                case Ack ack:
-                    WriteAckOrNack(ref messagePackWriter, ack.SeqNo, ack.From);
-                    break;
-                case Nack nack:
-                    WriteAckOrNack(ref messagePackWriter, nack.SeqNo, nack.From);
-                    break;
-                case SystemMessageEnvelope sme:
-                    WriteSystemMessageEnvelope(ref messagePackWriter, sme);
-                    break;
-                case ClearSystemMessageDelivery clear:
-                    messagePackWriter.WriteMapHeader(1);
-                    messagePackWriter.Write(ClearIncarnationFieldId);
-                    messagePackWriter.Write(clear.Incarnation);
-                    break;
-                default:
-                    throw new ArgumentException($"Unsupported Artery control message type: {obj.GetType()}", nameof(obj));
-            }
-
-            messagePackWriter.Flush();
-            return checked((int)counting.BytesWritten);
-        }
-
-        /// <inheritdoc/>
-        public override object Deserialize(ReadOnlySequence<byte> bytes, string manifest)
-        {
-            var reader = new MessagePackReader(bytes);
-            return manifest switch
-            {
-                HandshakeReqManifest => ReadReq(ref reader),
-                HandshakeRspManifest => ReadRsp(ref reader),
-                HeartbeatManifest => ReadEmpty<ArteryHeartbeat>(ref reader, new ArteryHeartbeat()),
-                HeartbeatRspManifest => ReadEmpty<ArteryHeartbeatRsp>(ref reader, new ArteryHeartbeatRsp()),
-                QuarantinedManifest => ReadQuarantined(ref reader),
-                AckManifest => ReadAck(ref reader),
-                NackManifest => ReadNack(ref reader),
-                SystemMessageEnvelopeManifest => ReadSystemMessageEnvelope(ref reader),
-                ClearSystemMessageDeliveryManifest => ReadClearSystemMessageDelivery(ref reader),
-                _ => throw new SerializationException($"Unknown Artery control message manifest [{manifest}].")
-            };
-        }
-
-        private static void WriteReq(ref MessagePackWriter writer, HandshakeReq req)
-        {
-            writer.WriteMapHeader(2);
-            writer.Write(FromFieldId);
-            WriteUniqueAddress(ref writer, req.From);
-            writer.Write(ToFieldId);
-            WriteAddress(ref writer, req.To);
-        }
-
-        private static HandshakeReq ReadReq(ref MessagePackReader reader)
-        {
-            var fieldCount = reader.ReadMapHeader();
-            UniqueAddress? from = null;
-            Address? to = null;
-
-            for (var i = 0; i < fieldCount; i++)
-            {
-                var fieldId = reader.ReadInt32();
-                switch (fieldId)
-                {
-                    case FromFieldId:
-                        from = ReadUniqueAddress(ref reader);
-                        break;
-                    case ToFieldId:
-                        to = ReadAddress(ref reader);
-                        break;
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            if (from is null)
-                throw new SerializationException($"Missing required field [From] with index [{FromFieldId}] for [{HandshakeReqManifest}].");
-            if (to is null)
-                throw new SerializationException($"Missing required field [To] with index [{ToFieldId}] for [{HandshakeReqManifest}].");
-
-            return new HandshakeReq(from.Value, to);
-        }
-
-        private static void WriteRsp(ref MessagePackWriter writer, HandshakeRsp rsp)
-        {
-            writer.WriteMapHeader(1);
-            writer.Write(FromFieldId);
-            WriteUniqueAddress(ref writer, rsp.From);
-        }
-
-        private static HandshakeRsp ReadRsp(ref MessagePackReader reader)
-        {
-            var fieldCount = reader.ReadMapHeader();
-            UniqueAddress? from = null;
-
-            for (var i = 0; i < fieldCount; i++)
-            {
-                var fieldId = reader.ReadInt32();
-                switch (fieldId)
-                {
-                    case FromFieldId:
-                        from = ReadUniqueAddress(ref reader);
-                        break;
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            if (from is null)
-                throw new SerializationException($"Missing required field [From] with index [{FromFieldId}] for [{HandshakeRspManifest}].");
-
-            return new HandshakeRsp(from.Value);
-        }
-
-        private static void WriteQuarantined(ref MessagePackWriter writer, ArteryQuarantined quarantined)
-        {
-            writer.WriteMapHeader(2);
-            writer.Write(FromFieldId);
-            WriteUniqueAddress(ref writer, quarantined.From);
-            writer.Write(QuarantinedUidFieldId);
-            writer.Write(quarantined.QuarantinedUid);
-        }
-
-        private static ArteryQuarantined ReadQuarantined(ref MessagePackReader reader)
-        {
-            var fieldCount = reader.ReadMapHeader();
-            UniqueAddress? from = null;
-            long? quarantinedUid = null;
-
-            for (var i = 0; i < fieldCount; i++)
-            {
-                var fieldId = reader.ReadInt32();
-                switch (fieldId)
-                {
-                    case FromFieldId:
-                        from = ReadUniqueAddress(ref reader);
-                        break;
-                    case QuarantinedUidFieldId:
-                        quarantinedUid = reader.ReadInt64();
-                        break;
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            if (from is null)
-                throw new SerializationException($"Missing required field [From] with index [{FromFieldId}] for [{QuarantinedManifest}].");
-            if (quarantinedUid is null)
-                throw new SerializationException($"Missing required field [QuarantinedUid] with index [{QuarantinedUidFieldId}] for [{QuarantinedManifest}].");
-
-            return new ArteryQuarantined(from.Value, quarantinedUid.Value);
-        }
-
-        /// <summary>
-        /// Shared writer for <see cref="Ack"/> and <see cref="Nack"/> -- identical wire shape
-        /// (design.md gate G3).
-        /// </summary>
-        private static void WriteAckOrNack(ref MessagePackWriter writer, long seqNo, UniqueAddress from)
-        {
-            writer.WriteMapHeader(2);
-            writer.Write(AckSeqNoFieldId);
-            writer.Write(seqNo);
-            writer.Write(AckFromFieldId);
-            WriteUniqueAddress(ref writer, from);
-        }
-
-        private static Ack ReadAck(ref MessagePackReader reader)
-        {
-            var (seqNo, from) = ReadAckOrNack(ref reader, AckManifest);
-            return new Ack(seqNo, from);
-        }
-
-        private static Nack ReadNack(ref MessagePackReader reader)
-        {
-            var (seqNo, from) = ReadAckOrNack(ref reader, NackManifest);
-            return new Nack(seqNo, from);
-        }
-
-        private static (long SeqNo, UniqueAddress From) ReadAckOrNack(ref MessagePackReader reader, string manifestForErrors)
-        {
-            var fieldCount = reader.ReadMapHeader();
-            long? seqNo = null;
-            UniqueAddress? from = null;
-
-            for (var i = 0; i < fieldCount; i++)
-            {
-                var fieldId = reader.ReadInt32();
-                switch (fieldId)
-                {
-                    case AckSeqNoFieldId:
-                        seqNo = reader.ReadInt64();
-                        break;
-                    case AckFromFieldId:
-                        from = ReadUniqueAddress(ref reader);
-                        break;
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            if (seqNo is null)
-                throw new SerializationException($"Missing required field [SeqNo] with index [{AckSeqNoFieldId}] for [{manifestForErrors}].");
-            if (from is null)
-                throw new SerializationException($"Missing required field [From] with index [{AckFromFieldId}] for [{manifestForErrors}].");
-
-            return (seqNo.Value, from.Value);
-        }
-
-        private static int SizeOfAckOrNack(long seqNo, UniqueAddress from) =>
-            SizeOfMapHeader(2) +
-            SizeOfInt32(AckSeqNoFieldId) + SizeOfInt64(seqNo) +
-            SizeOfInt32(AckFromFieldId) + SizeOfUniqueAddress(from);
-
-        private void WriteSystemMessageEnvelope(ref MessagePackWriter writer, SystemMessageEnvelope sme)
-        {
-            writer.WriteMapHeader(4);
-            writer.Write(SmeSeqNoFieldId);
-            writer.Write(sme.SeqNo);
-            writer.Write(SmeAckReplyToFieldId);
-            WriteUniqueAddress(ref writer, sme.AckReplyTo);
-            writer.Write(SmeRecipientPathFieldId);
-            writer.Write(sme.RecipientPath);
-            writer.Write(SmePayloadFieldId);
-            // Nest the inner ISystemMessage recursively via the classic Serialization extension
-            // (serializer id + manifest + raw bytes) -- see the type-level "How the inner message
-            // is nested" remarks on SystemMessageEnvelope for why this existing V2 helper (built for
-            // exactly this "nest an arbitrary payload" purpose) is reused rather than hand-rolled.
-            WriteEnvelopePayload(ref writer, sme.Message);
-        }
-
-        private SystemMessageEnvelope ReadSystemMessageEnvelope(ref MessagePackReader reader)
-        {
-            var fieldCount = reader.ReadMapHeader();
-            long? seqNo = null;
-            UniqueAddress? ackReplyTo = null;
-            string? recipientPath = null;
-            Akka.Dispatch.SysMsg.ISystemMessage? message = null;
-
-            for (var i = 0; i < fieldCount; i++)
-            {
-                var fieldId = reader.ReadInt32();
-                switch (fieldId)
-                {
-                    case SmeSeqNoFieldId:
-                        seqNo = reader.ReadInt64();
-                        break;
-                    case SmeAckReplyToFieldId:
-                        ackReplyTo = ReadUniqueAddress(ref reader);
-                        break;
-                    case SmeRecipientPathFieldId:
-                        recipientPath = reader.ReadString();
-                        break;
-                    case SmePayloadFieldId:
-                        message = ReadEnvelopePayload<Akka.Dispatch.SysMsg.ISystemMessage>(ref reader);
-                        break;
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            if (seqNo is null)
-                throw new SerializationException($"Missing required field [SeqNo] with index [{SmeSeqNoFieldId}] for [{SystemMessageEnvelopeManifest}].");
-            if (ackReplyTo is null)
-                throw new SerializationException($"Missing required field [AckReplyTo] with index [{SmeAckReplyToFieldId}] for [{SystemMessageEnvelopeManifest}].");
-            if (recipientPath is null)
-                throw new SerializationException($"Missing required field [RecipientPath] with index [{SmeRecipientPathFieldId}] for [{SystemMessageEnvelopeManifest}].");
-            if (message is null)
-                throw new SerializationException($"Missing required field [Message] with index [{SmePayloadFieldId}] for [{SystemMessageEnvelopeManifest}].");
-
-            return new SystemMessageEnvelope(message, seqNo.Value, ackReplyTo.Value, recipientPath);
-        }
-
-        private static ClearSystemMessageDelivery ReadClearSystemMessageDelivery(ref MessagePackReader reader)
-        {
-            var fieldCount = reader.ReadMapHeader();
-            int? incarnation = null;
-
-            for (var i = 0; i < fieldCount; i++)
-            {
-                var fieldId = reader.ReadInt32();
-                switch (fieldId)
-                {
-                    case ClearIncarnationFieldId:
-                        incarnation = reader.ReadInt32();
-                        break;
-                    default:
-                        reader.Skip();
-                        break;
-                }
-            }
-
-            if (incarnation is null)
-                throw new SerializationException($"Missing required field [Incarnation] with index [{ClearIncarnationFieldId}] for [{ClearSystemMessageDeliveryManifest}].");
-
-            return new ClearSystemMessageDelivery(incarnation.Value);
-        }
-
-        /// <summary>
-        /// Reads (and discards, forward-compatibly) a MessagePack map for a fieldless control
-        /// message (<see cref="ArteryHeartbeat"/> / <see cref="ArteryHeartbeatRsp"/>), returning
-        /// <paramref name="instance"/>. A shared helper since both messages have identical
-        /// (empty) wire shapes.
-        /// </summary>
-        private static TMessage ReadEmpty<TMessage>(ref MessagePackReader reader, TMessage instance)
-            where TMessage : IArteryControlMessage
-        {
-            var fieldCount = reader.ReadMapHeader();
-            for (var i = 0; i < fieldCount; i++)
-            {
-                reader.ReadInt32();
-                reader.Skip();
-            }
-
-            return instance;
-        }
-
-        private static void WriteAddress(ref MessagePackWriter writer, Address address)
-        {
-            writer.WriteArrayHeader(4);
-            writer.Write(address.Protocol);
-            writer.Write(address.System);
-
-            if (address.Host is { } host)
-                writer.Write(host);
-            else
-                writer.WriteNil();
-
-            if (address.Port is { } port)
-                writer.Write(port);
-            else
-                writer.WriteNil();
-        }
-
-        private static Address ReadAddress(ref MessagePackReader reader)
-        {
-            var length = reader.ReadArrayHeader();
-            if (length != 4)
-                throw new SerializationException($"Expected a 4-element address array, got {length}.");
-
-            var protocol = reader.ReadString() ?? throw new SerializationException("Missing address protocol.");
-            var system = reader.ReadString() ?? throw new SerializationException("Missing address system name.");
-            var host = reader.TryReadNil() ? null : reader.ReadString();
-            var port = reader.TryReadNil() ? (int?)null : reader.ReadInt32();
-
-            return new Address(protocol, system, host, port);
-        }
-
-        private static void WriteUniqueAddress(ref MessagePackWriter writer, UniqueAddress uniqueAddress)
-        {
-            writer.WriteArrayHeader(2);
-            WriteAddress(ref writer, uniqueAddress.Address);
-            writer.Write(uniqueAddress.Uid);
-        }
-
-        private static UniqueAddress ReadUniqueAddress(ref MessagePackReader reader)
-        {
-            var length = reader.ReadArrayHeader();
-            if (length != 2)
-                throw new SerializationException($"Expected a 2-element unique-address array, got {length}.");
-
-            var address = ReadAddress(ref reader);
-            var uid = reader.ReadInt64();
-            return new UniqueAddress(address, uid);
-        }
-
-        private static int SizeOfAddress(Address address) =>
-            SizeOfArrayHeader(4) +
-            SizeOfString(address.Protocol) +
-            SizeOfString(address.System) +
-            (address.Host is { } host ? SizeOfString(host) : SizeOfNil()) +
-            (address.Port is { } port ? SizeOfInt32(port) : SizeOfNil());
-
-        private static int SizeOfUniqueAddress(UniqueAddress uniqueAddress) =>
-            SizeOfArrayHeader(2) + SizeOfAddress(uniqueAddress.Address) + SizeOfInt64(uniqueAddress.Uid);
-
-        private static int SizeOfReq(HandshakeReq req) =>
-            SizeOfMapHeader(2) +
-            SizeOfInt32(FromFieldId) + SizeOfUniqueAddress(req.From) +
-            SizeOfInt32(ToFieldId) + SizeOfAddress(req.To);
-
-        private static int SizeOfRsp(HandshakeRsp rsp) =>
-            SizeOfMapHeader(1) +
-            SizeOfInt32(FromFieldId) + SizeOfUniqueAddress(rsp.From);
-
-        private static int SizeOfQuarantined(ArteryQuarantined quarantined) =>
-            SizeOfMapHeader(2) +
-            SizeOfInt32(FromFieldId) + SizeOfUniqueAddress(quarantined.From) +
-            SizeOfInt32(QuarantinedUidFieldId) + SizeOfInt64(quarantined.QuarantinedUid);
-
-        /// <summary>
-        /// Counts bytes advanced through an inner <see cref="IBufferWriter{T}"/> so
-        /// <see cref="Serialize"/> can report the bytes-written contract required by
-        /// <see cref="Akka.Serialization.SerializerV2"/>, mirroring the counting wrapper the V2
-        /// MessagePack source generator emits for the same purpose
-        /// (<c>AkkaGeneratedCountingBufferWriter</c> in
-        /// <c>Akka.Serialization.V2.Generators.AkkaSerializerGenerator</c>).
-        /// </summary>
-        private sealed class CountingBufferWriter : IBufferWriter<byte>
-        {
-            private readonly IBufferWriter<byte> _inner;
-
-            public CountingBufferWriter(IBufferWriter<byte> inner)
-            {
-                _inner = inner;
-            }
-
-            public long BytesWritten { get; private set; }
-
-            public void Advance(int count)
-            {
-                _inner.Advance(count);
-                BytesWritten += count;
-            }
-
-            public Memory<byte> GetMemory(int sizeHint = 0) => _inner.GetMemory(sizeHint);
-
-            public Span<byte> GetSpan(int sizeHint = 0) => _inner.GetSpan(sizeHint);
-        }
+        public static partial SerializerRegistration CreateRegistration();
     }
 }

--- a/src/core/Akka.Remote/Artery/ArteryControlMessages.cs
+++ b/src/core/Akka.Remote/Artery/ArteryControlMessages.cs
@@ -7,6 +7,8 @@
 
 #nullable enable
 
+using Akka.Serialization.V2;
+
 namespace Akka.Remote.Artery
 {
     /// <summary>
@@ -18,7 +20,13 @@ namespace Akka.Remote.Artery
     /// (task group 6, "Control Stream", tasks 6.4/6.6). Carries no payload; its mere arrival is
     /// the signal. The receiver replies with <see cref="ArteryHeartbeatRsp"/>
     /// (<c>ArteryRemoting</c>'s own <c>IControlMessageSubscriber</c>).
+    ///
+    /// <para>
+    /// Deliberately fieldless: opts into codegen via <see cref="AkkaSerializableAttribute.AllowEmpty"/>
+    /// (sourcegen gap fix #8331) -- arrival IS the signal, with nothing to carry.
+    /// </para>
     /// </summary>
+    [AkkaSerializable(Manifest = ArteryControlMessageSerializer.HeartbeatManifest, AllowEmpty = true)]
     internal sealed record ArteryHeartbeat : IArteryControlMessage;
 
     /// <summary>
@@ -28,6 +36,7 @@ namespace Akka.Remote.Artery
     /// any subscribed <see cref="IControlMessageSubscriber"/> at task group 6 -- a
     /// missed-heartbeat failure detector is later (group 7+) work.
     /// </summary>
+    [AkkaSerializable(Manifest = ArteryControlMessageSerializer.HeartbeatRspManifest, AllowEmpty = true)]
     internal sealed record ArteryHeartbeatRsp : IArteryControlMessage;
 
     /// <summary>
@@ -46,5 +55,8 @@ namespace Akka.Remote.Artery
     /// when it matches the receiver's OWN current uid -- a notification about a stale/superseded
     /// incarnation of the receiver must not be acted on.
     /// </param>
-    internal sealed record ArteryQuarantined(UniqueAddress From, long QuarantinedUid) : IArteryControlMessage;
+    [AkkaSerializable(Manifest = ArteryControlMessageSerializer.QuarantinedManifest)]
+    internal sealed record ArteryQuarantined(
+        [property: AkkaField(1)] UniqueAddress From,
+        [property: AkkaField(2)] long QuarantinedUid) : IArteryControlMessage;
 }

--- a/src/core/Akka.Remote/Artery/HandshakeMessages.cs
+++ b/src/core/Akka.Remote/Artery/HandshakeMessages.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using Akka.Actor;
+using Akka.Serialization.V2;
 
 namespace Akka.Remote.Artery
 {
@@ -36,7 +37,10 @@ namespace Akka.Remote.Artery
     /// rejects (drops, does not fail the stream) a request whose <paramref name="To"/> does not
     /// match the local address.
     /// </param>
-    internal sealed record HandshakeReq(UniqueAddress From, Address To) : IArteryControlMessage;
+    [AkkaSerializable(Manifest = ArteryControlMessageSerializer.HandshakeReqManifest)]
+    internal sealed record HandshakeReq(
+        [property: AkkaField(1)] UniqueAddress From,
+        [property: AkkaField(2)] Address To) : IArteryControlMessage;
 
     /// <summary>
     /// INTERNAL API.
@@ -45,5 +49,7 @@ namespace Akka.Remote.Artery
     /// <see cref="HandshakeReq"/>, completing the requester's knowledge of the responder's UID.
     /// </summary>
     /// <param name="From">The responder's own unique address (address + UID).</param>
-    internal sealed record HandshakeRsp(UniqueAddress From) : IArteryControlMessage;
+    [AkkaSerializable(Manifest = ArteryControlMessageSerializer.HandshakeRspManifest)]
+    internal sealed record HandshakeRsp(
+        [property: AkkaField(1)] UniqueAddress From) : IArteryControlMessage;
 }

--- a/src/core/Akka.Remote/Artery/SystemMessageDeliveryMessages.cs
+++ b/src/core/Akka.Remote/Artery/SystemMessageDeliveryMessages.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using Akka.Dispatch.SysMsg;
+using Akka.Serialization.V2;
 
 namespace Akka.Remote.Artery
 {
@@ -55,7 +56,10 @@ namespace Akka.Remote.Artery
     /// </summary>
     /// <param name="SeqNo">The highest sequence number received (and every sequence number below it).</param>
     /// <param name="From">The acking system's own unique address (see the stale-ack guard remarks above).</param>
-    internal sealed record Ack(long SeqNo, UniqueAddress From) : IArterySystemMessageDeliveryMessage;
+    [AkkaSerializable(Manifest = ArteryControlMessageSerializer.AckManifest)]
+    internal sealed record Ack(
+        [property: AkkaField(1)] long SeqNo,
+        [property: AkkaField(2)] UniqueAddress From) : IArterySystemMessageDeliveryMessage;
 
     /// <summary>
     /// INTERNAL API.
@@ -72,7 +76,10 @@ namespace Akka.Remote.Artery
     /// </summary>
     /// <param name="SeqNo">The highest contiguous sequence number actually delivered so far.</param>
     /// <param name="From">The nacking system's own unique address.</param>
-    internal sealed record Nack(long SeqNo, UniqueAddress From) : IArterySystemMessageDeliveryMessage;
+    [AkkaSerializable(Manifest = ArteryControlMessageSerializer.NackManifest)]
+    internal sealed record Nack(
+        [property: AkkaField(1)] long SeqNo,
+        [property: AkkaField(2)] UniqueAddress From) : IArterySystemMessageDeliveryMessage;
 
     /// <summary>
     /// INTERNAL API.
@@ -109,12 +116,30 @@ namespace Akka.Remote.Artery
     /// dispatch path always resolves the sender as dead letters for delivered system messages,
     /// mirroring today's ordinary-message fallback for an absent sender.
     /// </para>
+    /// <para>
+    /// <b>Sourcegen swap field-id note.</b> <see cref="Message"/> is marked
+    /// <see cref="AkkaEnvelopePayloadAttribute"/>, routing it through the generated serializer's
+    /// <c>WriteEnvelopePayload</c>/<c>ReadEnvelopePayload</c> calls -- the SAME
+    /// <see cref="Akka.Serialization.V2.MessagePackSerializer{TProtocol}"/> base-class helpers the
+    /// prior hand-rolled <see cref="ArteryControlMessageSerializer"/> used, confirming the generator
+    /// has no gap here. The generator emits the record's constructor call positionally by ASCENDING
+    /// <see cref="AkkaFieldAttribute"/> index (not by declared parameter order), so field indices
+    /// are assigned in this record's declared parameter order (Message=1, SeqNo=2, AckReplyTo=3,
+    /// RecipientPath=4) rather than the hand-rolled serializer's old wire ids (SeqNo=1,
+    /// AckReplyTo=2, RecipientPath=3, Message=4) -- a deliberate wire-format change, harmless
+    /// because Artery is unreleased, pre-stable, internal-only wire protocol.
+    /// </para>
     /// </summary>
     /// <param name="Message">The system message being reliably delivered.</param>
     /// <param name="SeqNo">This envelope's monotonic sequence number (1-based per incarnation).</param>
     /// <param name="AckReplyTo">The sender's own unique address -- where the receiver routes its Ack/Nack.</param>
     /// <param name="RecipientPath">The resolved wire-format path of the recipient actor.</param>
-    internal sealed record SystemMessageEnvelope(ISystemMessage Message, long SeqNo, UniqueAddress AckReplyTo, string RecipientPath) : IArterySystemMessageDeliveryMessage;
+    [AkkaSerializable(Manifest = ArteryControlMessageSerializer.SystemMessageEnvelopeManifest)]
+    internal sealed record SystemMessageEnvelope(
+        [property: AkkaField(1), AkkaEnvelopePayload] ISystemMessage Message,
+        [property: AkkaField(2)] long SeqNo,
+        [property: AkkaField(3)] UniqueAddress AckReplyTo,
+        [property: AkkaField(4)] string RecipientPath) : IArterySystemMessageDeliveryMessage;
 
     /// <summary>
     /// INTERNAL API.
@@ -151,5 +176,7 @@ namespace Akka.Remote.Artery
     /// </para>
     /// </summary>
     /// <param name="Incarnation">The association incarnation this reset applies to.</param>
-    internal sealed record ClearSystemMessageDelivery(int Incarnation) : IArterySystemMessageDeliveryMessage;
+    [AkkaSerializable(Manifest = ArteryControlMessageSerializer.ClearSystemMessageDeliveryManifest)]
+    internal sealed record ClearSystemMessageDelivery(
+        [property: AkkaField(1)] int Incarnation) : IArterySystemMessageDeliveryMessage;
 }

--- a/src/core/Akka.Remote/Artery/UniqueAddress.cs
+++ b/src/core/Akka.Remote/Artery/UniqueAddress.cs
@@ -8,6 +8,7 @@
 #nullable enable
 
 using Akka.Actor;
+using Akka.Serialization.V2;
 
 namespace Akka.Remote.Artery
 {
@@ -22,12 +23,24 @@ namespace Akka.Remote.Artery
     /// cannot reference <c>Akka.Cluster</c> (Pekko likewise keeps <c>akka.remote.UniqueAddress</c>
     /// separate from the cluster one). See
     /// <c>openspec/changes/artery-tcp-remoting/design.md</c> ("Handshake + association/UID (gate G2)").
+    ///
+    /// <para>
+    /// <see cref="AkkaSerializableAttribute"/>-annotated (source-generated sourcegen gap fix
+    /// #8331 lets an <c>[AkkaSerializable]</c> value type be used as a required/optional nested
+    /// field): handled directly by <see cref="ArteryControlMessageSerializer"/>'s generated
+    /// nested-object path, composing the built-in <see cref="AddressFormatter"/> escape hatch for
+    /// <see cref="Address"/> -- see <c>FieldlessAndStructFieldSpec.GapUniqueAddress</c> for the
+    /// validated shape this mirrors.
+    /// </para>
     /// </summary>
     /// <param name="Address">The remote (or local) address this UID is bound to.</param>
     /// <param name="Uid">
     /// The 64-bit UID of the <c>ActorSystem</c> incarnation bound to <paramref name="Address"/>.
     /// </param>
-    internal readonly record struct UniqueAddress(Address Address, long Uid)
+    [AkkaSerializable]
+    internal readonly record struct UniqueAddress(
+        [property: AkkaField(1)] Address Address,
+        [property: AkkaField(2)] long Uid)
     {
         /// <inheritdoc/>
         public override string ToString() => $"{Address}#{Uid}";


### PR DESCRIPTION
Closes the original goal-B acceptance test from the SerializerV2 revision: Artery's control messages move from the hand-rolled serializer to **source-generated** V2 MessagePack serializers, using the #8331 generator fixes (`AllowEmpty` + annotated-struct nested fields) and #8325's formatter escape hatch.

## What

- All nine control message types annotated (`HandshakeReq`/`Rsp`, `Heartbeat`/`Rsp` via `AllowEmpty`, `Quarantined`, `Ack`, `Nack`, `SystemMessageEnvelope`, `ClearSystemMessageDelivery`); `UniqueAddress` is `[AkkaSerializable]` **directly** — the #8331 struct fix working exactly as designed, no formatter workaround needed.
- `SystemMessageEnvelope`'s nested payload uses `[AkkaEnvelopePayload]`, routing through the same base-class envelope helpers (serializer id + manifest + bytes) the hand-rolled code called — no gap.
- `ArteryControlMessageSerializer.cs`: **579 lines of hand-rolled Write/Read/SizeOf deleted**, replaced by a ~110-line annotated partial-class stub; the generator (attached to Akka.Remote as an analyzer) produces the implementation. Same class name, serializer id 23, and `IArteryControlMessage` marker binding — **`Remote.conf` unchanged**.
- One deliberate internal wire change, documented in-code: field ids re-assigned in declared order (the generator maps constructor arguments positionally by ascending `[AkkaField]` index). Harmless — the Artery protocol is unreleased.

## Verification

- `ArteryControlMessageSerializerSpec` rewritten against the generated serializer: 32 tests (round-trips for all nine incl. hostless addresses, extreme uids, seqNo boundaries, a real `Watch` through `Serialization.WithTransport`; manifest dispatch across all nine; empty-map byte assertion for heartbeats; registration exercised through the real production config).
- Full Artery suite **154/154, twice** (handshake, control-stream, and system-message end-to-end tests all exercise this serializer over real TCP) — re-verified post-rebase onto current dev.
- V2 suite 66/66; `ApproveRemote` unchanged; full-solution `-warnaserror` clean including a cold rebuild proving the analyzer actually fires.

**Next in the train**: task group 8 (backpressure verification + slow-receiver tests) is committed on a branch stacked on this one; its PR opens when this merges.