### PR TITLE
Artery task group 8: bounded-queue backpressure verification + slow-receiver tests (G4)

### DIFF
--- a/openspec/changes/artery-tcp-remoting/tasks.md
+++ b/openspec/changes/artery-tcp-remoting/tasks.md
@@ -83,11 +83,11 @@ BenchmarkDotNet harness (naked, baseline-first, `MemoryDiagnoser` on), socket by
 
 ## 8. Bounded Queues And Backpressure
 
-- [ ] 8.1 Add bounded ordinary outbound queue
-- [ ] 8.2 Add bounded control outbound queue
-- [ ] 8.3 Define overflow behavior for user messages
-- [ ] 8.4 Define overflow behavior for control/system messages
-- [ ] 8.5 Add slow receiver tests proving queues do not grow unbounded
+- [x] 8.1 Add bounded ordinary outbound queue (landed with group 6/7: `Association._outboundChannel`, `Channel.CreateBounded`, capacity `Association.DefaultOutboundQueueCapacity` = 3072 — `AssociationRegistry.cs:86,106,144-149`; `TryEnqueueOutbound` — `AssociationRegistry.cs:202`)
+- [x] 8.2 Add bounded control outbound queue (landed with group 6/7: `Association._controlChannel`, capacity `Association.DefaultControlQueueCapacity` = 256 — `AssociationRegistry.cs:96,107,150-155`; `TryEnqueueControl` — `AssociationRegistry.cs:209`)
+- [x] 8.3 Define overflow behavior for user messages (landed with group 6/7: ordinary overflow → dead letters, log-once per association/uid — `ArteryRemoting.EnqueueOutbound`, `ArteryRemoting.cs:443-463`, using `Association.ShouldLogOrdinaryOverflowDrop` — `AssociationRegistry.cs:256-257`)
+- [x] 8.4 Define overflow behavior for control/system messages (landed with group 6/7: control/system overflow → quarantine, re-entrancy-guarded — `ArteryRemoting.HandleControlOverflow`, `ArteryRemoting.cs:537-551`, called from `EnqueueControl`/`EnqueueSystemMessage`, `ArteryRemoting.cs:481-482,514-515`)
+- [x] 8.5 Add slow receiver tests proving queues do not grow unbounded (unit-level bounded-queue proofs added to `AssociationRegistrySpec.cs`; e2e slow/unresponsive-peer proofs added in new `ArteryBackpressureSpec.cs` — both under `src/core/Akka.Remote.Tests/Artery/`)
 
 ## 9. Lifecycle And Compatibility Tests
 

--- a/src/core/Akka.Remote.Tests/Artery/ArteryBackpressureSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryBackpressureSpec.cs
@@ -1,0 +1,288 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryBackpressureSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.Remote.Artery;
+using Akka.TestKit;
+using Akka.TestKit.Extensions;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+
+namespace Akka.Remote.Tests.Artery
+{
+    /// <summary>
+    /// End-to-end tests for design.md task group 8, "Bounded Queues And Backpressure" -- task 8.5,
+    /// "Add slow receiver tests proving queues do not grow unbounded". Tasks 8.1-8.4 (the bounded
+    /// channels themselves + their overflow policies -- ordinary drops to dead letters, control/
+    /// system quarantines) landed already with task groups 6/7; see <see cref="AssociationRegistrySpec"/>
+    /// for the pure, deterministic unit-level proofs of the bounded-queue shape itself
+    /// (fill-to-capacity / reject-overflow / resume-after-drain, both queues, no ActorSystem
+    /// needed). This file proves the SAME "cannot grow unbounded" property one level up, through
+    /// the full <see cref="ArteryRemoting"/> transport, against a genuinely unresponsive peer.
+    ///
+    /// <para>
+    /// <b>Maintainer policy, honored throughout this file:</b> no wall-clock thresholds, no gap/
+    /// latency arithmetic. Every assertion is PROGRESS, ORDER, COMPLETION, or BOUNDED STATE.
+    /// Timeouts that appear below are all liveness awaits ("this must eventually happen"), never a
+    /// measurement of how long something took.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>How "slow/unresponsive receiver" is simulated, and why (read before editing).</b> Every
+    /// message dispatch on the INBOUND side (<c>ArteryRemoting.DispatchInbound</c>) is a
+    /// non-blocking <c>Tell</c> into the recipient's mailbox -- a receiving actor that never
+    /// processes its mailbox does NOT, by itself, create any backpressure on the sender: the
+    /// inbound stream's sink keeps pulling (and the TCP socket keeps being read) regardless of how
+    /// slowly, or never, the recipient's mailbox drains. The only way a real association's bounded
+    /// OUTBOUND channel fills up today is if its materialized outbound stream stops draining it
+    /// entirely -- which is exactly what happens when the outbound TCP connection fails (see
+    /// <c>ArteryRemoting.MaterializeOutboundStream</c>'s documented G2 scope: "no reconnect/retry --
+    /// if the connection fails, this association's outbound stream simply ends ... nothing will
+    /// ever drain it again until the process is restarted"). These tests target that exact,
+    /// deterministic trigger -- an outbound connection to a host:port nobody is listening on --
+    /// rather than trying to throttle a live TCP stream's throughput from the receiving side (which
+    /// would be flaky, platform-dependent, and would require wall-clock measurement to even
+    /// detect). From the SENDING association's point of view, a peer that never accepts a
+    /// connection and a peer that accepts one and then never reads from it are indistinguishable --
+    /// both leave the sender's bounded channel with no consumer, which is exactly the property
+    /// task 8.5 asks to prove: the queue fills, the overflow policy applies, and nothing grows
+    /// without bound.
+    /// </para>
+    /// </summary>
+    public class ArteryBackpressureSpec : AkkaSpec
+    {
+        public ArteryBackpressureSpec(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        private static Config ArteryConfig() => ConfigurationFactory.ParseString("""
+            akka.actor.provider = "Akka.Remote.RemoteActorRefProvider, Akka.Remote"
+            akka.remote.artery.enabled = on
+            akka.remote.artery.canonical.hostname = "127.0.0.1"
+            akka.remote.artery.canonical.port = 0
+            """);
+
+        private static int BoundPort(ActorSystem system) => RARP.For(system).Provider.DefaultAddress.Port!.Value;
+
+        private sealed class Echo : ReceiveActor
+        {
+            public Echo()
+            {
+                ReceiveAny(msg => Sender.Tell(msg));
+            }
+        }
+
+        /// <summary>
+        /// A minimal actor that just watches <paramref name="target"/> at construction -- one
+        /// reliable-delivery <c>Watch</c> system message per instance (mirrors
+        /// <c>ArterySystemMessageDeliverySpec.PlainWatcher</c>).
+        ///
+        /// <para>
+        /// <b>Each instance MUST watch a DISTINCT remote path</b> (read before reusing this for a
+        /// bigger flood). <c>RemoteActorRef.SendSystemMessage</c> intercepts <c>Watch</c>/<c>Unwatch</c>
+        /// and hands them to the LOCAL <c>RemoteWatcher</c> actor (<c>RemoteActorRef.IsWatchIntercepted</c>),
+        /// which dedupes multiple LOCAL watchers of the SAME remote actor into a single underlying
+        /// wire-level <c>Watch</c> (<c>RemoteWatcher.AddWatching</c> calls <c>Context.Watch(watchee)</c>
+        /// from ITS OWN cell, which is a no-op for a watchee it already watches). N instances all
+        /// watching the SAME target therefore produce just ONE real system message, not N --
+        /// distinct watchees defeat the dedup and reliably flood N distinct <c>Watch</c> system
+        /// messages onto the association's control channel.
+        /// </para>
+        /// </summary>
+        private sealed class PlainWatcher : ReceiveActor
+        {
+            public PlainWatcher(IActorRef target)
+            {
+                Context.Watch(target);
+                Receive<Terminated>(_ => { });
+            }
+        }
+
+        /// <summary>
+        /// Reserves, then immediately releases, an ephemeral TCP port on loopback: a deterministic,
+        /// near-instant "guaranteed nobody is listening here" address generator (a closed port on
+        /// loopback refuses new connections effectively immediately -- no wall-clock wait needed to
+        /// observe the failure). Same idiom as <c>BugFix4384Spec.GetFreeTcpPort</c>.
+        /// </summary>
+        private static int GetUnresponsivePort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+
+        [Fact(DisplayName = "Ordinary outbound queue: flooding an association to an unresponsive peer dead-letters the overflow, keeps the queue's occupied size bounded at capacity, and does not wedge sends to a different, healthy association")]
+        public async Task Should_DeadLetter_Ordinary_Overflow_Against_Unresponsive_Peer_Without_Wedging_Other_Associations()
+        {
+            const int capacity = Association.DefaultOutboundQueueCapacity;
+            var deadPort = GetUnresponsivePort();
+            var deadAddress = new Address("akka", "dead-sys", "127.0.0.1", deadPort);
+
+            var systemA = ActorSystem.Create("ArteryBackpressureOrdinaryA", ArteryConfig());
+            var systemHealthy = ActorSystem.Create("ArteryBackpressureOrdinaryHealthy", ArteryConfig());
+            try
+            {
+                systemHealthy.ActorOf(Props.Create(() => new Echo()), "echo");
+
+                // A RemoteActorRef pointing at a host:port nobody is listening on -- constructed
+                // purely locally (no network round trip), same idiom as RemoteDeathWatchSpec's
+                // synthetic unreachable-ref tests.
+                var deadTarget = RARP.For(systemA).Provider.ResolveActorRef(
+                    $"akka://dead-sys@127.0.0.1:{deadPort}/user/target");
+
+                var deadLetterProbe = CreateTestProbe(systemA);
+                systemA.EventStream.Subscribe(deadLetterProbe.Ref, typeof(DeadLetter));
+
+                // Deliberately well past capacity: unambiguous overflow even accounting for the
+                // handful of elements that may be pulled out of the channel toward the (doomed)
+                // TCP connect attempt before it gives up.
+                const int floodCount = capacity + 1000;
+                for (var i = 0; i < floodCount; i++)
+                    deadTarget.Tell($"flood-{i}", ActorRefs.NoSender);
+
+                // BOUNDED STATE: the association's occupied queue size must never exceed its own
+                // capacity. Sampled repeatedly -- no elapsed-time arithmetic, just "is this value
+                // ever over the bound".
+                var association = ((ArteryRemoting)RARP.For(systemA).Provider.Transport).Registry.AssociationFor(deadAddress);
+                for (var i = 0; i < 25; i++)
+                {
+                    association.OutboundQueueCount.Should().BeLessOrEqualTo(capacity,
+                        "the bounded channel must never hold more than its configured capacity, no matter how fast the producer floods it");
+                    await Task.Yield();
+                }
+
+                // PROGRESS/COMPLETION (liveness collection, not a timing measurement): the overflow
+                // must show up as dead letters. Collected via the idle-timeout completion signal
+                // rather than an exact count -- precisely how many of the flood got pulled toward
+                // the doomed connection attempt before it failed is not deterministic, only that
+                // AT LEAST the queue-bound-respecting majority of the flood does.
+                var deadLetters = await deadLetterProbe
+                    .ReceiveWhileAsync<DeadLetter>(_ => true, max: TimeSpan.FromSeconds(20), idle: TimeSpan.FromSeconds(3), msgs: floodCount)
+                    .ToListAsync();
+
+                deadLetters.Count.Should().BeGreaterOrEqualTo(floodCount - capacity - 10,
+                    "essentially the whole overflow past capacity must land in dead letters, allowing a small " +
+                    "slack for the few elements that may have been mid-flight toward the doomed connection " +
+                    "attempt when it failed");
+
+                // NO WEDGE: a completely saturated/dead association must not affect A's ability to
+                // talk to a DIFFERENT, healthy association.
+                var echoRef = await systemA.ActorSelection(
+                    $"akka://{systemHealthy.Name}@127.0.0.1:{BoundPort(systemHealthy)}/user/echo").ResolveOne(TimeSpan.FromSeconds(10));
+                var probe = CreateTestProbe(systemA);
+                echoRef.Tell("still-alive", probe.Ref);
+                await probe.ExpectMsgAsync("still-alive", TimeSpan.FromSeconds(10));
+            }
+            finally
+            {
+                await systemA.Terminate().AwaitWithTimeout(10.Seconds());
+                await systemHealthy.Terminate().AwaitWithTimeout(10.Seconds());
+            }
+        }
+
+        [Fact(DisplayName = "Control channel: flooding system messages against an association whose handshake is complete but whose peer is unresponsive quarantines EXACTLY ONCE (re-entrancy guard holds even though the quarantine notices themselves also overflow the same full channel), dead-letters the overflow, and does not wedge sends to a different, healthy association")]
+        public async Task Should_Quarantine_Exactly_Once_On_Control_Overflow_Against_Unresponsive_Peer_Without_Wedging_Other_Associations()
+        {
+            const int controlCapacity = Association.DefaultControlQueueCapacity;
+            var deadPort = GetUnresponsivePort();
+            var deadAddress = new Address("akka", "dead-sys", "127.0.0.1", deadPort);
+            const long fakePeerUid = 123_456_789L;
+
+            var systemA = ActorSystem.Create("ArteryBackpressureControlA", ArteryConfig());
+            var systemHealthy = ActorSystem.Create("ArteryBackpressureControlHealthy", ArteryConfig());
+            try
+            {
+                systemHealthy.ActorOf(Props.Create(() => new Echo()), "echo");
+
+                var transportA = (ArteryRemoting)RARP.For(systemA).Provider.Transport;
+
+                // Fake-complete the handshake against the dead address using the SAME production
+                // method (AssociationRegistry.CompleteHandshake) the real InboundHandshakeStage
+                // calls after a genuine HandshakeRsp arrives -- just without a live peer on the
+                // other end (OutboundHandshakeStage polls this SAME registry's AssociationState,
+                // so it observes "complete" exactly as it would for a real handshake). This is
+                // what lets the overflow policy reach QUARANTINE (design.md Decision 7):
+                // HandleControlOverflow only quarantines once a peer uid is known.
+                transportA.Registry.CompleteHandshake(deadAddress, new UniqueAddress(deadAddress, fakePeerUid));
+
+                var quarantineProbe = CreateTestProbe(systemA);
+                systemA.EventStream.Subscribe(quarantineProbe.Ref, typeof(QuarantinedEvent));
+
+                var deadLetterProbe = CreateTestProbe(systemA);
+                systemA.EventStream.Subscribe(deadLetterProbe.Ref, typeof(DeadLetter));
+
+                // Flood real reliable system messages (Watch) -- these travel the CONTROL channel
+                // (design.md invariant 5: system messages are never hashed onto ordinary lanes),
+                // the SAME bounded channel handshake/heartbeat/quarantine-notice traffic uses.
+                //
+                // IMPORTANT: each PlainWatcher must watch a DISTINCT remote path. RemoteActorRef.
+                // SendSystemMessage intercepts Watch/Unwatch and hands them to the LOCAL
+                // RemoteWatcher actor (RemoteActorRef.IsWatchIntercepted), which dedupes multiple
+                // local watchers of the SAME remote actor into a single underlying wire-level Watch
+                // (RemoteWatcher.AddWatching calls Context.Watch(watchee) from ITS OWN cell, which
+                // is a no-op for a watchee it already watches) -- so N instances watching the SAME
+                // target would produce just ONE real system message, not N. Distinct watchees defeat
+                // the dedup and reliably flood N distinct Watch system messages onto the channel.
+                const int floodCount = controlCapacity + 400;
+                for (var i = 0; i < floodCount; i++)
+                {
+                    var distinctTarget = RARP.For(systemA).Provider.ResolveActorRef(
+                        $"akka://dead-sys@127.0.0.1:{deadPort}/user/target-{i}");
+                    systemA.ActorOf(Props.Create(() => new PlainWatcher(distinctTarget)));
+                }
+
+                // PROGRESS/COMPLETION: exactly one QuarantinedEvent for this uid, despite
+                // HandleControlOverflow being re-entered for EVERY overflowing message -- including
+                // the ArteryQuarantined + ClearSystemMessageDelivery notices Quarantine() itself
+                // tries to send right back over the SAME, still-full channel. The re-entrancy guard
+                // (association.IsQuarantined check inside HandleControlOverflow) must hold.
+                var quarantined = await quarantineProbe.ExpectMsgAsync<QuarantinedEvent>(TimeSpan.FromSeconds(20));
+                quarantined.Address.Should().Be(deadAddress);
+                quarantined.Uid.Should().Be(fakePeerUid);
+
+                await quarantineProbe.ExpectNoMsgAsync(TimeSpan.FromMilliseconds(500));
+
+                // BOUNDED STATE: the control channel's occupied size stays at (or below) its own
+                // capacity even after this whole flood.
+                var association = transportA.Registry.AssociationFor(deadAddress);
+                association.ControlQueueCount.Should().BeLessOrEqualTo(controlCapacity);
+
+                // The overflow (both the flooded Watch system messages AND the re-entrant
+                // quarantine notices themselves) must show up as dead letters.
+                var deadLetters = await deadLetterProbe
+                    .ReceiveWhileAsync<DeadLetter>(_ => true, max: TimeSpan.FromSeconds(20), idle: TimeSpan.FromSeconds(3), msgs: floodCount + 4)
+                    .ToListAsync();
+                deadLetters.Should().NotBeEmpty("a control channel this saturated must produce dead letters for the overflow");
+
+                // NO WEDGE: a quarantined/dead association must not affect A's ability to talk to a
+                // DIFFERENT, healthy association.
+                var echoRef = await systemA.ActorSelection(
+                    $"akka://{systemHealthy.Name}@127.0.0.1:{BoundPort(systemHealthy)}/user/echo").ResolveOne(TimeSpan.FromSeconds(10));
+                var probe = CreateTestProbe(systemA);
+                echoRef.Tell("still-alive", probe.Ref);
+                await probe.ExpectMsgAsync("still-alive", TimeSpan.FromSeconds(10));
+            }
+            finally
+            {
+                await systemA.Terminate().AwaitWithTimeout(10.Seconds());
+                await systemHealthy.Terminate().AwaitWithTimeout(10.Seconds());
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote.Tests/Artery/ArteryBackpressureSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryBackpressureSpec.cs
@@ -9,8 +9,6 @@
 
 using System;
 using System.Linq;
-using System.Net;
-using System.Net.Sockets;
 using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Configuration;
@@ -112,26 +110,13 @@ namespace Akka.Remote.Tests.Artery
             }
         }
 
-        /// <summary>
-        /// Reserves, then immediately releases, an ephemeral TCP port on loopback: a deterministic,
-        /// near-instant "guaranteed nobody is listening here" address generator (a closed port on
-        /// loopback refuses new connections effectively immediately -- no wall-clock wait needed to
-        /// observe the failure). Same idiom as <c>BugFix4384Spec.GetFreeTcpPort</c>.
-        /// </summary>
-        private static int GetUnresponsivePort()
-        {
-            var listener = new TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
-        }
-
         [Fact(DisplayName = "Ordinary outbound queue: flooding an association to an unresponsive peer dead-letters the overflow, keeps the queue's occupied size bounded at capacity, and does not wedge sends to a different, healthy association")]
         public async Task Should_DeadLetter_Ordinary_Overflow_Against_Unresponsive_Peer_Without_Wedging_Other_Associations()
         {
             const int capacity = Association.DefaultOutboundQueueCapacity;
-            var deadPort = GetUnresponsivePort();
+            // Port 0 is not an assignable listener port, so it is a permanently-unreachable peer --
+            // deterministic connection failure, no reservation, no reserve-then-release race.
+            const int deadPort = 0;
             var deadAddress = new Address("akka", "dead-sys", "127.0.0.1", deadPort);
 
             var systemA = ActorSystem.Create("ArteryBackpressureOrdinaryA", ArteryConfig());
@@ -200,7 +185,9 @@ namespace Akka.Remote.Tests.Artery
         public async Task Should_Quarantine_Exactly_Once_On_Control_Overflow_Against_Unresponsive_Peer_Without_Wedging_Other_Associations()
         {
             const int controlCapacity = Association.DefaultControlQueueCapacity;
-            var deadPort = GetUnresponsivePort();
+            // Port 0 is not an assignable listener port, so it is a permanently-unreachable peer --
+            // deterministic connection failure, no reservation, no reserve-then-release race.
+            const int deadPort = 0;
             var deadAddress = new Address("akka", "dead-sys", "127.0.0.1", deadPort);
             const long fakePeerUid = 123_456_789L;
 

--- a/src/core/Akka.Remote.Tests/Artery/AssociationRegistrySpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/AssociationRegistrySpec.cs
@@ -170,6 +170,81 @@ namespace Akka.Remote.Tests.Artery
                 .Should().BeFalse("the control queue has its OWN bound, reached independently of the ordinary queue's state");
         }
 
+        // --- Bounded queues + backpressure (task group 8, design.md Decision 7 / Invariants) ---
+
+        [Fact(DisplayName = "Ordinary outbound queue accepts up to capacity, rejects the overflow, and resumes accepting once drained (task 8.5: no permanent wedge)")]
+        public void Ordinary_queue_should_accept_to_capacity_reject_overflow_and_resume_after_drain()
+        {
+            const int capacity = 8;
+            var association = new Association(AddressA, outboundQueueCapacity: capacity, controlQueueCapacity: capacity);
+
+            var accepted = 0;
+            for (var i = 0; i < capacity; i++)
+            {
+                if (association.TryEnqueueOutbound(new OutboundEnvelope($"m-{i}", null, null)))
+                    accepted++;
+            }
+
+            accepted.Should().Be(capacity, "every enqueue up to the bound must be accepted");
+            association.OutboundQueueCount.Should().Be(capacity);
+
+            // The bound must keep rejecting -- not just refuse the FIRST overflowing element and
+            // then silently let a later one slip in.
+            association.TryEnqueueOutbound(new OutboundEnvelope("overflow-1", null, null)).Should().BeFalse("the queue is now exactly at capacity");
+            association.TryEnqueueOutbound(new OutboundEnvelope("overflow-2", null, null)).Should().BeFalse("a full queue must keep rejecting every subsequent attempt");
+            association.OutboundQueueCount.Should().Be(capacity, "rejected enqueues must never be counted -- the queue's occupied size cannot exceed its bound");
+
+            // Drain a few elements (simulating the consumer -- the materialized outbound stream --
+            // making progress) and prove the queue resumes accepting: a bounded channel that once
+            // filled must never permanently wedge.
+            const int drained = 3;
+            for (var i = 0; i < drained; i++)
+                association.OutboundReader.TryRead(out _).Should().BeTrue();
+            association.OutboundQueueCount.Should().Be(capacity - drained);
+
+            for (var i = 0; i < drained; i++)
+                association.TryEnqueueOutbound(new OutboundEnvelope($"post-drain-{i}", null, null))
+                    .Should().BeTrue("draining below capacity must immediately unblock further TryEnqueueOutbound calls -- no wedge");
+
+            association.OutboundQueueCount.Should().Be(capacity);
+            association.TryEnqueueOutbound(new OutboundEnvelope("overflow-3", null, null))
+                .Should().BeFalse("back at capacity after re-filling the drained slots");
+        }
+
+        [Fact(DisplayName = "Control outbound queue accepts up to capacity, rejects the overflow, and resumes accepting once drained (same shape as the ordinary queue, task 8.5)")]
+        public void Control_queue_should_accept_to_capacity_reject_overflow_and_resume_after_drain()
+        {
+            const int capacity = 8;
+            var association = new Association(AddressA, outboundQueueCapacity: capacity, controlQueueCapacity: capacity);
+
+            var accepted = 0;
+            for (var i = 0; i < capacity; i++)
+            {
+                if (association.TryEnqueueControl(new OutboundEnvelope($"c-{i}", null, null)))
+                    accepted++;
+            }
+
+            accepted.Should().Be(capacity, "every enqueue up to the bound must be accepted");
+            association.ControlQueueCount.Should().Be(capacity);
+
+            association.TryEnqueueControl(new OutboundEnvelope("overflow-1", null, null)).Should().BeFalse("the control queue is now exactly at capacity");
+            association.TryEnqueueControl(new OutboundEnvelope("overflow-2", null, null)).Should().BeFalse("a full control queue must keep rejecting every subsequent attempt");
+            association.ControlQueueCount.Should().Be(capacity);
+
+            const int drained = 3;
+            for (var i = 0; i < drained; i++)
+                association.ControlReader.TryRead(out _).Should().BeTrue();
+            association.ControlQueueCount.Should().Be(capacity - drained);
+
+            for (var i = 0; i < drained; i++)
+                association.TryEnqueueControl(new OutboundEnvelope($"post-drain-{i}", null, null))
+                    .Should().BeTrue("draining below capacity must immediately unblock further TryEnqueueControl calls -- no wedge");
+
+            association.ControlQueueCount.Should().Be(capacity);
+            association.TryEnqueueControl(new OutboundEnvelope("overflow-3", null, null))
+                .Should().BeFalse("back at capacity after re-filling the drained slots");
+        }
+
         [Fact(DisplayName = "ShouldLogQuarantineDrop should return true exactly once per uid (task 6.6: log once per association/uid, not per message)")]
         public void ShouldLogQuarantineDrop_should_latch_once_per_uid()
         {

--- a/src/core/Akka.Remote/Artery/ArteryRemoting.cs
+++ b/src/core/Akka.Remote/Artery/ArteryRemoting.cs
@@ -65,6 +65,18 @@ namespace Akka.Remote.Artery
         private readonly AssociationRegistry _registry = new();
 
         /// <summary>
+        /// Test-observability accessor for <see cref="_registry"/> (design.md task 8.5, "slow
+        /// receiver tests proving queues do not grow unbounded"): lets tests reach a live
+        /// association's <see cref="Association.OutboundQueueCount"/>/<see cref="Association.ControlQueueCount"/>,
+        /// and (via <see cref="AssociationRegistry.CompleteHandshake"/>) fake a completed handshake
+        /// against a peer that will never actually respond, without needing a second real, reachable
+        /// <see cref="ArteryRemoting"/> instance on the wire. Production code never reads this --
+        /// every production access to associations goes through the instance methods above that
+        /// already close over <see cref="_registry"/>.
+        /// </summary>
+        internal AssociationRegistry Registry => _registry;
+
+        /// <summary>
         /// Subscribers notified (task 6.2) for every decoded, non-handshake inbound control
         /// message, across every association's control connection. <see cref="ArteryRemoting"/>
         /// subscribes itself in <see cref="Start"/> to handle <see cref="ArteryHeartbeat"/> /

--- a/src/core/Akka.Remote/Artery/AssociationRegistry.cs
+++ b/src/core/Akka.Remote/Artery/AssociationRegistry.cs
@@ -209,6 +209,23 @@ namespace Akka.Remote.Artery
         public bool TryEnqueueControl(IOutboundEnvelope element) => _controlChannel.Writer.TryWrite(element);
 
         /// <summary>
+        /// The number of elements CURRENTLY buffered in the ORDINARY outbound channel, awaiting a
+        /// consumer. Test-observability surface added for design.md task 8.5 ("slow receiver tests
+        /// proving queues do not grow unbounded") -- <c>System.Threading.Channels</c>' bounded
+        /// channel implementation supports O(1) <see cref="ChannelReader{T}.Count"/>, so this is
+        /// cheap enough to sample repeatedly from a test without perturbing the property under
+        /// test. Production code has no need of this (the bounded <see cref="TryEnqueueOutbound"/> /
+        /// dead-letter-on-<see langword="false"/> pattern is capacity-agnostic), so this exists
+        /// purely for tests to assert the bound is never exceeded.
+        /// </summary>
+        public int OutboundQueueCount => _outboundChannel.Reader.Count;
+
+        /// <summary>
+        /// The CONTROL-channel analog of <see cref="OutboundQueueCount"/>. See its remarks.
+        /// </summary>
+        public int ControlQueueCount => _controlChannel.Reader.Count;
+
+        /// <summary>
         /// Ensures this association's ORDINARY outbound stream is materialized exactly once, no
         /// matter how many threads call this concurrently. The callback is supplied by the
         /// transport (<c>ArteryRemoting</c>), which owns the Tcp extension / materializer / settings


### PR DESCRIPTION
Completes task group 8 of [`artery-tcp-remoting`](https://github.com/akkadotnet/akka.net/tree/dev/openspec/changes/artery-tcp-remoting) — the G4 milestone: bounded queues + overflow policy, with slow-receiver tests proving memory cannot grow unbounded.

## What

**Tasks 8.1–8.4 were verified as already landed** with groups 6/7 and are ticked in tasks.md with file:line annotations: bounded ordinary channel (3072) and control channel (256) per association, ordinary overflow → dead letters (log-once per uid), control/system overflow → quarantine (re-entrancy guarded).

**Task 8.5 is the new work** — slow-receiver tests, per the maintainer testing policy (no elapsed-time assertions anywhere; bounded-state / progress / completion only):

- **Unit**: both channels accept *exactly* to capacity, reject repeatedly at the bound (not just the first overflow), and resume after drain — no wedge.
- **E2E ordinary**: a 4072-message flood at an unresponsive peer → the association's queue count stays ≤ 3072 (sampled 25×), the overflow is observed at dead letters, and a *healthy* association completes a round-trip unaffected.
- **E2E control/system**: a system-message flood past control capacity → **exactly one** `QuarantinedEvent` — the re-entrancy guard proven under live re-overflow, since `Quarantine()`'s own control notices re-enter the same full channel — with the control queue bounded and no cross-association wedge.

The spec documents its honest slow-receiver rationale: inbound dispatch is a non-blocking mailbox `Tell`, so a stalled *recipient actor* creates zero sender-side backpressure by design — the deterministic no-consumer trigger is a connection-refused peer, indistinguishable from accept-and-never-read at the sender's channel, which is precisely the bounded-fill → overflow-policy property 8.5 exists to prove. Also documented: `RemoteWatcher` dedupes `Watch` per remote path, so the flood uses distinct paths.

**Observability additions are internal-only**: O(1) `Association.OutboundQueueCount`/`ControlQueueCount` over the existing channels + an internal `ArteryRemoting.Registry` accessor.

## Verification

158/158 Artery (twice, re-verified post-rebase onto current dev incl. #8332/#8334); new e2e tests 10/10 consecutive runs each; full `Akka.Remote.Tests` 549 passed / 0 failed; `ApproveRemote` unchanged; full-solution `-warnaserror` clean; `openspec validate` passes with 8.1–8.5 ticked.

**Next**: task group 9 (lifecycle/compat) — which begins with a design pass on association reconnect (the "outbound queue survives stream restart" invariant G2 deferred), the prerequisite for restart-with-new-UID scenarios.