### PR TITLE
Benchmark harness QoL: RemotePingPong knobs + one-way mode, PingPong headless fix

### DIFF
--- a/src/benchmark/PingPong/Program.cs
+++ b/src/benchmark/PingPong/Program.cs
@@ -40,7 +40,7 @@ namespace PingPong
 #endif
         }
 
-        private static void Main(params string[] args)
+        private static async Task Main(string[] args)
         {
             if (args.Length == 0 || !uint.TryParse(args[0], out var timesToRun))
             {
@@ -49,11 +49,15 @@ namespace PingPong
 
             bool testAsync = args.Contains("--async");
 
-            Start(timesToRun, testAsync);
-            Console.ReadKey();
+            await Start(timesToRun, testAsync);
+
+            if (!Console.IsInputRedirected)
+            {
+                Console.ReadKey();
+            }
         }
 
-        private static async void Start(uint timesToRun, bool testAsync)
+        private static async Task Start(uint timesToRun, bool testAsync)
         {
             const int repeatFactor = 500;
             const long repeat = 30000L * repeatFactor;

--- a/src/benchmark/RemotePingPong/Program.cs
+++ b/src/benchmark/RemotePingPong/Program.cs
@@ -47,6 +47,34 @@ namespace RemotePingPong
         // directly comparable msgs/sec numbers over an otherwise-identical workload.
         private static bool _useArtery;
 
+        // Selected once at startup via a command-line "oneway" flag. Default mode is ping-pong
+        // (client sends, destination echoes every message back - see EchoActor/BenchmarkActor).
+        // "oneway" switches to a Pekko-MaxThroughput-style one-directional firehose: the sender
+        // fires a credit-based stream of messages at the receiver with no reply loop, so the
+        // benchmark measures pure one-way transport throughput. See OneWaySenderActor /
+        // OneWayReceiverActor.
+        private static bool _onewayMode;
+
+        // Number of messages used to "prime the pump" for each client before awaiting completion -
+        // i.e. the in-flight window size. Defaults to 50 (the historical hard-coded value) but can
+        // be overridden via the "window=N" command-line token.
+        private static int _windowSize = 50;
+
+        // When set (via the "clients=N" command-line token), pins the benchmark to a single client
+        // count instead of sweeping the full GetClientSettings() series.
+        private static int? _pinnedClients;
+
+        // When set (via the "iobuf=SIZE" command-line token), overrides Akka.IO's
+        // akka.io.tcp.receive-buffer-size / send-buffer-size (default 8k) for both ActorSystems.
+        // The raw string is passed through verbatim as a HOCON size value (e.g. "128k", "1m").
+        private static string? _ioBufSize;
+
+        // When set (via the "msgs=N" command-line token), overrides the per-client message count
+        // (default: the "repeat" constant, 100000L). One-way mode's default run length is often
+        // sub-second, which isn't long enough to observe steady-state throughput - this lets callers
+        // push the run into multi-second territory without touching the constant.
+        private static long? _msgsOverride;
+
         public static Config CreateActorSystemConfig(string actorSystemName, string ipOrHostname, int port)
         {
             var commonConfig = ConfigurationFactory.ParseString(@"
@@ -71,7 +99,19 @@ namespace RemotePingPong
                   port = {port}
                 }}");
 
-            return transportConfig.WithFallback(commonConfig);
+            var config = transportConfig.WithFallback(commonConfig);
+
+            if (!string.IsNullOrEmpty(_ioBufSize))
+            {
+                var ioBufConfig = ConfigurationFactory.ParseString($@"
+                akka.io.tcp {{
+                  receive-buffer-size = {_ioBufSize}
+                  send-buffer-size = {_ioBufSize}
+                }}");
+                config = ioBufConfig.WithFallback(config);
+            }
+
+            return config;
         }
 
         private static async Task Main(params string[] args)
@@ -86,16 +126,55 @@ namespace RemotePingPong
             }
             // Args (order-independent): the first numeric arg is timesToRun; the literal "artery"
             // (case-insensitive) selects the Artery.Tcp transport instead of the DotNetty default.
-            // e.g. `RemotePingPong 3 artery` or `RemotePingPong artery`.
+            // "oneway" (case-insensitive) switches from ping-pong to the one-directional firehose
+            // mode (see OneWaySenderActor/OneWayReceiverActor). "window=N" overrides the in-flight
+            // priming window (default 50); "clients=N" pins the benchmark to a single client count
+            // instead of sweeping GetClientSettings(). "iobuf=SIZE" overrides
+            // akka.io.tcp.receive-buffer-size / send-buffer-size (e.g. "128k", "1m") for both
+            // ActorSystems - default behavior (8k) is unchanged when omitted. "msgs=N" overrides the
+            // per-client message count (default 100000) - default behavior is unchanged when omitted.
+            // e.g. `RemotePingPong 3 artery` or `RemotePingPong artery oneway window=1000 clients=10 iobuf=128k msgs=500000`.
             _useArtery = args.Any(a => a.Equals("artery", StringComparison.OrdinalIgnoreCase));
+            _onewayMode = args.Any(a => a.Equals("oneway", StringComparison.OrdinalIgnoreCase));
 
             var timesToRun = 1u;
+            var timesToRunSet = false;
             foreach (var a in args)
             {
-                if (uint.TryParse(a, out var parsed))
+                if (!timesToRunSet && uint.TryParse(a, out var parsed))
                 {
                     timesToRun = parsed;
-                    break;
+                    timesToRunSet = true;
+                    continue;
+                }
+
+                if (a.StartsWith("window=", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (int.TryParse(a.Substring("window=".Length), out var window))
+                        _windowSize = window;
+                    continue;
+                }
+
+                if (a.StartsWith("clients=", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (int.TryParse(a.Substring("clients=".Length), out var clients))
+                        _pinnedClients = clients;
+                    continue;
+                }
+
+                if (a.StartsWith("iobuf=", StringComparison.OrdinalIgnoreCase))
+                {
+                    var iobuf = a.Substring("iobuf=".Length);
+                    if (!string.IsNullOrWhiteSpace(iobuf))
+                        _ioBufSize = iobuf;
+                    continue;
+                }
+
+                if (a.StartsWith("msgs=", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (long.TryParse(a.Substring("msgs=".Length), out var msgs))
+                        _msgsOverride = msgs;
+                    continue;
                 }
             }
 
@@ -104,7 +183,7 @@ namespace RemotePingPong
 
         private static bool _firstRun = true;
 
-        private static void PrintSysInfo(){
+        private static void PrintSysInfo(long effectiveRepeat){
             var processorCount = Environment.ProcessorCount;
             if (processorCount == 0)
             {
@@ -114,13 +193,26 @@ namespace RemotePingPong
             }
 
             Console.WriteLine("Transport:                         {0}", _useArtery ? "Artery.Tcp" : "DotNetty");
+            Console.WriteLine("Mode:                              {0}", _onewayMode ? "one-way" : "ping-pong");
             Console.WriteLine("OSVersion:                         {0}", Environment.OSVersion);
             Console.WriteLine("ProcessorCount:                    {0}", processorCount);
             Console.WriteLine("ClockSpeed:                        {0} MHZ", CpuSpeed());
             Console.WriteLine("Actor Count:                       {0}", processorCount * 2);
-            Console.WriteLine("Messages sent/received per client: {0}  ({0:0e0})", repeat*2);
+            // One-way mode has no reply loop, so "sent" and "received" per client are both
+            // effectiveRepeat (not effectiveRepeat*2 as in ping-pong, where every message
+            // travels out and back) - mirrors the per-client half of GetTotalMessagesReceived().
+            Console.WriteLine("Messages sent/received per client: {0}  ({0:0e0})", _onewayMode ? effectiveRepeat : effectiveRepeat*2);
             Console.WriteLine("Is Server GC:                      {0}", GCSettings.IsServerGC);
             Console.WriteLine("Thread count:                      {0}", Process.GetCurrentProcess().Threads.Count);
+            Console.WriteLine("Window size (in-flight):           {0}", _windowSize);
+            if (_pinnedClients.HasValue)
+            {
+                Console.WriteLine("Pinned client count:               {0}", _pinnedClients.Value);
+            }
+            if (!string.IsNullOrEmpty(_ioBufSize))
+            {
+                Console.WriteLine("IO buffer size (akka.io.tcp):      {0}", _ioBufSize);
+            }
             Console.WriteLine();
 
             //Print tables
@@ -132,14 +224,18 @@ namespace RemotePingPong
         const long repeat = 100000L;
 
         private static async Task Start(uint timesToRun)
-        {         
+        {
+            var effectiveRepeat = _msgsOverride ?? repeat;
             for (var i = 0; i < timesToRun; i++)
             {
                 var redCount = 0;
                 var bestThroughput = 0L;
-                foreach (var throughput in GetClientSettings())
+                var clientSettings = _pinnedClients.HasValue
+                    ? new[] { _pinnedClients.Value }
+                    : GetClientSettings();
+                foreach (var throughput in clientSettings)
                 {
-                    var result1 = await Benchmark(throughput, repeat, bestThroughput, redCount);
+                    var result1 = await Benchmark(throughput, effectiveRepeat, _windowSize, bestThroughput, redCount);
                     bestThroughput = result1.Item2;
                     redCount = result1.Item3;
                 }
@@ -162,10 +258,15 @@ namespace RemotePingPong
 
         private static long GetTotalMessagesReceived(int numberOfClients, long numberOfRepeats)
         {
-            return numberOfClients * numberOfRepeats * 2;
+            // Ping-pong mode counts both directions of travel (client send + destination echo) per
+            // repeat. One-way mode has no reply loop - throughput is measured receiver-side only,
+            // so a single direction of travel is counted per repeat.
+            return _onewayMode
+                ? numberOfClients * numberOfRepeats
+                : numberOfClients * numberOfRepeats * 2;
         }
 
-        private static async Task<(bool, long, int)> Benchmark(int numberOfClients, long numberOfRepeats, long bestThroughput, int redCount)
+        private static async Task<(bool, long, int)> Benchmark(int numberOfClients, long numberOfRepeats, int windowSize, long bestThroughput, int redCount)
         {
             var totalMessagesReceived = GetTotalMessagesReceived(numberOfClients, numberOfRepeats);
             var system1 = ActorSystem.Create("SystemA", CreateActorSystemConfig("SystemA", "127.0.0.1", 0));
@@ -173,29 +274,72 @@ namespace RemotePingPong
             var system2 = ActorSystem.Create("SystemB", CreateActorSystemConfig("SystemB", "127.0.0.1", 0));
 
             List<Task<long>> tasks = new List<Task<long>>();
-            List<IActorRef> receivers = new List<IActorRef>();
+            // Holds the system1-side actor that needs the initial "go" nudge for each pair: the
+            // BenchmarkActor client in ping-pong mode, or the OneWaySenderActor in one-way mode.
+            List<IActorRef> primeTargets = new List<IActorRef>();
 
             var canStart = system1.ActorOf(Props.Create(() => new AllStartedActor()), "canStart");
 
             var system1Address = ((ExtendedActorSystem)system1).Provider.DefaultAddress;
             var system2Address = ((ExtendedActorSystem)system2).Provider.DefaultAddress;
 
-            var echoProps = Props.Create(() => new EchoActor()).WithDeploy(new Deploy(new RemoteScope(system2Address)));
-
-            for (var i = 0; i < numberOfClients; i++)
+            if (_onewayMode)
             {
-                var echo = system1.ActorOf(echoProps, "echo" + i);
-                var ts = new TaskCompletionSource<long>();
-                tasks.Add(ts.Task);
-                var receiver =
-                    system1.ActorOf(
-                        Props.Create(() => new BenchmarkActor(numberOfRepeats, ts, echo)),
-                        "benchmark" + i);
+                // Credit-based flow control: unbounded fire-and-forget would overflow Artery's
+                // bounded outbound queue (capacity 3072/association) and silently starve, since
+                // there's no reply loop to naturally pace the sender. Capping in-flight credit at
+                // windowSize per pair bounds total unacked messages to clients*windowSize across the
+                // whole benchmark - callers are responsible for keeping that product under ~2500-3000.
+                var ackEvery = Math.Max(1, windowSize / 2);
 
-                receivers.Add(receiver);
+                for (var i = 0; i < numberOfClients; i++)
+                {
+                    var ts = new TaskCompletionSource<long>();
+                    tasks.Add(ts.Task);
+                    // The completion latch (TaskCompletionSource) is held by the sender on system1,
+                    // never by the RemoteScope-deployed receiver: a Deploy/RemoteScope actor's Props
+                    // (including constructor args) are genuinely serialized across the wire to
+                    // instantiate the actor on the target system - even though system2 happens to be
+                    // in-process here, it still goes through the real remote-deployment protocol - and
+                    // a TaskCompletionSource can't survive that trip. Completion *authority* still
+                    // lives with the receiver's count (it decides when "repeat" has been observed);
+                    // it just reports that decision back to the sender via a Complete message so the
+                    // sender can fulfil the locally-held latch.
+                    var receiver =
+                        system1.ActorOf(
+                            Props.Create(() => new OneWayReceiverActor(numberOfRepeats, ackEvery))
+                                .WithDeploy(new Deploy(new RemoteScope(system2Address))),
+                            "receiver" + i);
+                    var sender =
+                        system1.ActorOf(
+                            Props.Create(() => new OneWaySenderActor(numberOfRepeats, windowSize, ackEvery, receiver, ts)),
+                            "sender" + i);
 
-                canStart.Tell(echo);
-                canStart.Tell(receiver);
+                    primeTargets.Add(sender);
+
+                    canStart.Tell(receiver);
+                    canStart.Tell(sender);
+                }
+            }
+            else
+            {
+                var echoProps = Props.Create(() => new EchoActor()).WithDeploy(new Deploy(new RemoteScope(system2Address)));
+
+                for (var i = 0; i < numberOfClients; i++)
+                {
+                    var echo = system1.ActorOf(echoProps, "echo" + i);
+                    var ts = new TaskCompletionSource<long>();
+                    tasks.Add(ts.Task);
+                    var receiver =
+                        system1.ActorOf(
+                            Props.Create(() => new BenchmarkActor(numberOfRepeats, ts, echo)),
+                            "benchmark" + i);
+
+                    primeTargets.Add(receiver);
+
+                    canStart.Tell(echo);
+                    canStart.Tell(receiver);
+                }
             }
 
             var rsp = await canStart.Ask(new AllStartedActor.AllStarted(), TimeSpan.FromSeconds(10));
@@ -208,17 +352,27 @@ namespace RemotePingPong
             // now that the dispatchers in both ActorSystems are started, we want to measure thread count and other system
             // metrics here - but only the very first benchmark
             if(_firstRun){
-                PrintSysInfo();
+                PrintSysInfo(numberOfRepeats);
             }
 
             var startThreads = Process.GetCurrentProcess().Threads.Count;
 
             var sw = Stopwatch.StartNew();
-            receivers.ForEach(c =>
+            if (_onewayMode)
             {
-                for (var i = 0; i < 50; i++) // prime the pump so EndpointWriters can take advantage of their batching model
-                    c.Tell("hit");
-            });
+                // One trigger per sender: OneWaySenderActor sends its whole windowSize credit
+                // up-front as soon as it sees Messages.Run, then tops back up on each Ack.
+                var run = new Messages.Run();
+                primeTargets.ForEach(c => c.Tell(run));
+            }
+            else
+            {
+                primeTargets.ForEach(c =>
+                {
+                    for (var i = 0; i < windowSize; i++) // prime the pump so EndpointWriters can take advantage of their batching model
+                        c.Tell("hit");
+                });
+            }
             var waiting = Task.WhenAll(tasks);
             await Task.WhenAll(waiting);
             sw.Stop();
@@ -310,6 +464,128 @@ namespace RemotePingPong
                 {
                     _completion.TrySetResult(_maxExpectedMessages);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Small dedicated flow-control message used by <see cref="OneWayReceiverActor"/> to grant
+        /// the <see cref="OneWaySenderActor"/> more send credit. Kept as a trivial, field-less
+        /// marker type (rather than a distinct string constant, e.g. "ack") so it can't collide with
+        /// the "hit" payload messages on the wire; it round-trips through Akka's default
+        /// NewtonSoftJsonSerializer fallback the same way the "hit" strings do - no custom
+        /// serializer/binding is required for this benchmark.
+        /// </summary>
+        private sealed class Ack
+        {
+            public static readonly Ack Instance = new();
+
+            private Ack() { }
+        }
+
+        /// <summary>
+        /// Small dedicated "done" message: <see cref="OneWayReceiverActor"/> sends this back to the
+        /// <see cref="OneWaySenderActor"/> once its own count reaches the expected total, since the
+        /// receiver - not the sender - is the authority on when the run is actually complete (it's the
+        /// side that observed every message actually arrive over the wire).
+        /// </summary>
+        private sealed class Complete
+        {
+            public long TotalReceived { get; }
+
+            public Complete(long totalReceived)
+            {
+                TotalReceived = totalReceived;
+            }
+        }
+
+        /// <summary>
+        /// One-way firehose sender (lives on system1, paired 1:1 with a <see cref="OneWayReceiverActor"/>
+        /// on system2). Implements credit-based flow control: unbounded fire-and-forget sending would
+        /// overflow Artery's bounded outbound queue (capacity 3072/association) and silently stall, so
+        /// this actor never has more than `windowSize` messages in flight per pair. It sends its whole
+        /// window up-front as credit, then tops back up by `ackEvery` messages every time the receiver
+        /// grants an <see cref="Ack"/>, until it has sent `maxMessages` total.
+        ///
+        /// This actor also owns the latch (<see cref="TaskCompletionSource{TResult}"/>) that the
+        /// benchmark harness awaits. It is fulfilled when the receiver reports <see cref="Complete"/> -
+        /// the receiver's count is authoritative for "done", but the latch itself has to live here
+        /// because it's on system1, never RemoteScope-deployed (see the comment on OneWayReceiverActor
+        /// construction in Benchmark() for why a TaskCompletionSource can't live on the receiver).
+        /// </summary>
+        private class OneWaySenderActor : UntypedActor
+        {
+            private readonly long _maxMessages;
+            private readonly int _windowSize;
+            private readonly int _ackEvery;
+            private readonly IActorRef _receiver;
+            private readonly TaskCompletionSource<long> _completion;
+            private long _sent;
+
+            public OneWaySenderActor(long maxMessages, int windowSize, int ackEvery, IActorRef receiver, TaskCompletionSource<long> completion)
+            {
+                _maxMessages = maxMessages;
+                _windowSize = windowSize;
+                _ackEvery = ackEvery;
+                _receiver = receiver;
+                _completion = completion;
+            }
+
+            protected override void OnReceive(object message)
+            {
+                switch (message)
+                {
+                    case Messages.Run:
+                        SendBatch(_windowSize);
+                        break;
+                    case Ack:
+                        SendBatch(_ackEvery);
+                        break;
+                    case Complete c:
+                        _completion.TrySetResult(c.TotalReceived);
+                        break;
+                }
+            }
+
+            private void SendBatch(int count)
+            {
+                for (var i = 0; i < count && _sent < _maxMessages; i++)
+                {
+                    _receiver.Tell("hit");
+                    _sent++;
+                }
+            }
+        }
+
+        /// <summary>
+        /// One-way firehose receiver (deployed remotely onto system2, paired 1:1 with a
+        /// <see cref="OneWaySenderActor"/> on system1). Counts every message it receives; every
+        /// `ackEvery` messages it grants the sender more credit via a single small <see cref="Ack"/>
+        /// reply. When its count reaches `maxExpectedMessages` it reports <see cref="Complete"/> back
+        /// to the sender - the receiver's count is authoritative for "done" in one-way mode, even
+        /// though (for serialization reasons - see Benchmark()) the actual completion latch lives on
+        /// the sender.
+        /// </summary>
+        private class OneWayReceiverActor : UntypedActor
+        {
+            private readonly long _maxExpectedMessages;
+            private readonly int _ackEvery;
+            private long _received;
+
+            public OneWayReceiverActor(long maxExpectedMessages, int ackEvery)
+            {
+                _maxExpectedMessages = maxExpectedMessages;
+                _ackEvery = ackEvery;
+            }
+
+            protected override void OnReceive(object message)
+            {
+                _received++;
+
+                if (_received % _ackEvery == 0)
+                    Sender.Tell(Ack.Instance);
+
+                if (_received >= _maxExpectedMessages)
+                    Sender.Tell(new Complete(_received));
             }
         }
     }


### PR DESCRIPTION
QoL additions to the local benchmark harnesses, added while investigating Artery single-lane throughput. Benchmark-only; defaults unchanged, existing invocations behave identically.

**RemotePingPong** — new optional, order-independent CLI args:

- `window=N` — in-flight messages per client (default 50)
- `clients=N` — pin client count instead of the sweep
- `iobuf=SIZE` — override `akka.io.tcp` receive/send-buffer-size
- `msgs=N` — per-client message count
- `oneway` — credit-based one-directional throughput mode (Pekko `MaxThroughput`-style), receiver-side counting

```
dotnet RemotePingPong.dll 1 artery oneway clients=1 window=1000 msgs=200000
```

**PingPong** — `async Task Main` instead of `async void Start()` + `Console.ReadKey()`, so it can run headless; `ReadKey` still fires on interactive consoles.