### PR TITLE
MNTR: opt-in Artery transport via AKKA_MNTR_TRANSPORT env var

### DIFF
--- a/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
+++ b/src/core/Akka.Remote.TestKit/MultiNodeSpec.cs
@@ -44,6 +44,22 @@ public abstract class MultiNodeConfig
     private bool _testTransport = false;
 
     /// <summary>
+    /// Opt-in switch (not a public API) that lets the whole multi-node test run be
+    /// re-pointed at the Artery TCP remoting transport instead of classic DotNetty, without
+    /// touching individual specs. Set the <c>AKKA_MNTR_TRANSPORT</c> environment variable to
+    /// <c>artery</c> (case-insensitive) before invoking `dotnet test` on a `*.Tests.MultiNode`
+    /// project. Unset (the default) is byte-for-byte identical to today's DotNetty-only
+    /// behavior. This is deliberately internal-only plumbing -- it layers in as the lowest
+    /// non-default config tier, so any spec (or its <see cref="CommonConfig"/>/per-role
+    /// <see cref="NodeConfig(IEnumerable{RoleName}, IEnumerable{Config})"/>) that explicitly
+    /// sets `akka.remote.artery.*` keys of its own still wins.
+    /// </summary>
+    private static readonly bool UseArteryTransport = string.Equals(
+        Environment.GetEnvironmentVariable("AKKA_MNTR_TRANSPORT"),
+        "artery",
+        StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Register a common base config for all test participants, if so desired.
     /// </summary>
     public Config CommonConfig
@@ -148,12 +164,28 @@ public abstract class MultiNodeConfig
                 ConfigurationFactory.ParseString("akka.remote.dot-netty.tcp.applied-adapters = [trttl, gremlin]")
                 : ConfigurationFactory.Empty;
 
+            // AKKA_MNTR_TRANSPORT=artery: layer in Artery's canonical host/port (mirroring
+            // MultiNodeSpec.NodeConfig's classic dot-netty.tcp block below) as a fallback tier
+            // below CommonConfig/per-role NodeConfig but above BaseConfig, so specs are never
+            // silently overridden. See `UseArteryTransport` above for the full rationale; note
+            // this does NOT provide any equivalent to `_testTransport`'s throttle/blackhole
+            // adapters -- Artery has no failure-injection/test-mode equivalent today.
+            var arteryConfig = UseArteryTransport
+                ? ConfigurationFactory.ParseString(string.Format(
+                    @"akka.remote.artery {{
+                        enabled = on
+                        canonical.hostname = ""{0}""
+                        canonical.port = {1}
+                    }}", MultiNodeSpec.SelfName, MultiNodeSpec.SelfPort))
+                : ConfigurationFactory.Empty;
+
             var builder = ImmutableList.CreateBuilder<Config>();
             if (_nodeConf.TryGetValue(Myself, out var nodeConfig))
                 builder.Add(nodeConfig);
             builder.Add(_commonConf);
             builder.Add(transportConfig);
             builder.Add(MultiNodeSpec.NodeConfig);
+            builder.Add(arteryConfig);
             builder.Add(MultiNodeSpec.BaseConfig);
 
             return builder.ToImmutable().Aggregate((a, b) => a.WithFallback(b));


### PR DESCRIPTION
This makes it possible to run the existing multi-node suites over Artery. Setting `AKKA_MNTR_TRANSPORT=artery` layers `akka.remote.artery.enabled = on` (plus canonical host/port) underneath every spec's config composition in `MultiNodeConfig`. With the variable unset, composition is unchanged, verified with a control run. No public API changes and no spec files touched; child MNTR processes inherit the environment, so the TestAdapter needed no changes either.

Verified over Artery on net10.0: NewRemoteActorSpec, SunnyWeatherSpec (5-node cluster formation), and RemoteDeploymentNodeDeathWatchFastSpec all pass, with log evidence that Artery was genuinely in use (bare `akka://` addresses, artery log tags, ephemeral ports bound and advertised correctly).

Survey results from this work: roughly 90 multi-node specs can run over Artery today. 29 are blocked because they need TestConductor throttle/blackhole, which Artery doesn't implement yet — `RequireTestConductorTransport` fails fast on the bare `akka` protocol, and `ArteryRemoting.ManagementCommand` is a stub. Porting Pekko's `test-mode`/`SharedTestState` is the follow-up that unblocks those. Also noted along the way: TestConductor's `Disconnect`/`Abort` is a pre-existing no-op on both transports (`Player.cs` `//FIXME`).
