### PR TITLE
Fix flaky cold-association timeout in MultiTransportAddressingSpec

### DIFF
--- a/src/core/Akka.Remote.Tests/Transport/MultiTransportAddressingSpec.cs
+++ b/src/core/Akka.Remote.Tests/Transport/MultiTransportAddressingSpec.cs
@@ -94,7 +94,15 @@ public class MultiTransportAddressingSpec : TestKit.Xunit.TestKit
             var selection = Sys.ActorSelection($"akka.{scheme}://{secondActorSystemName}@localhost:{port}/user/echo");
             
             // important: https://github.com/akkadotnet/akka.net/issues/7378 only occurs with IActorRefs
-            var actor = await selection.ResolveOne(TimeSpan.FromSeconds(1));
+            //
+            // Generous, dilated liveness bound: the first ResolveOne per scheme races a COLD
+            // association (endpoint actor spin-up + AkkaProtocol handshake + first-use JIT of the
+            // serialization pipeline), which can take multiple seconds on a loaded 2-core CI agent.
+            // ResolveOne is a plain ActorSelection API, so unlike the TestKit Expect* methods it
+            // never routes through akka.test.timefactor on its own -- Dilated() restores that.
+            // Nothing here can be lost while associating (EndpointWriter buffers sends until the
+            // handshake completes), so one long Ask is sufficient; no retry loop needed.
+            var actor = await selection.ResolveOne(Dilated(TimeSpan.FromSeconds(10)));
             
             // assert that the remote actor is using the correct transport
             Assert.Contains(scheme, actor.Path.Address.Protocol);


### PR DESCRIPTION
Fixes the Windows CI flake seen on #8360's validation run: `MultiTransportAddressingSpec.Should_Use_Second_Transport_For_Communication` failing with `ActorNotFoundException ... AskTimeoutException: Timeout after 1.00 seconds`.

The spec's first `ResolveOne` per transport scheme races a cold association — endpoint actor spin-up, the AkkaProtocol handshake, and first-use JIT of the serialization pipeline — against a hard 1-second Ask timeout. `ResolveOne` is a plain `ActorSelection` API, so that value also never routes through `akka.test.timefactor` the way the TestKit `Expect*` methods do. On a loaded 2-core Windows agent the cold path can eat the whole second; the in-memory TestTransport rules out socket issues, and `EndpointWriter` buffers sends until the handshake completes, so nothing can be lost — the only failure mode is the timer itself.

One-line fix (plus a comment): resolve with `Dilated(TimeSpan.FromSeconds(10))`. Generous liveness bound, dilation restored, no retries or restructuring needed, all assertions unchanged. Passes 5/5 under `taskset -c 0,1` (2-core emulation) locally.