### PR TITLE
De-flake region-registration asserts in ClusterShardingRolePartitioningSpec

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRolePartitioningSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ClusterShardingRolePartitioningSpec.cs
@@ -207,18 +207,27 @@ namespace Akka.Cluster.Sharding.Tests
                 // migrating between R1 nodes, so region (re-)registration routinely takes longer
                 // than the default 5s AwaitAssert budget on a busy CI agent. See MNTR flakiness
                 // where this asserted 2 regions instead of 3 before convergence completed.
+                //
+                // Fresh probe per attempt + bounded inner expect + explicit 1s interval (the
+                // ClusterShardingQueriesSpec pattern): each timed-out attempt previously burned
+                // the full 5s single-expect default on the shared TestActor mailbox -- only ~6
+                // attempts fit in the window, and a late CurrentRegions reply from a timed-out
+                // attempt could pollute the next read. This shape yields ~30 clean, independent
+                // samples inside the same 30s budget.
                 await AwaitAssertAsync(async () =>
                 {
+                    var probe = CreateTestProbe();
                     var region = ClusterSharding.Get(Sys).ShardRegion(E1.TypeKey);
-                    region.Tell(GetCurrentRegions.Instance);
-                    (await ExpectMsgAsync<CurrentRegions>()).Regions.Count.Should().Be(3);
-                }, TimeSpan.FromSeconds(30));
+                    region.Tell(GetCurrentRegions.Instance, probe.Ref);
+                    (await probe.ExpectMsgAsync<CurrentRegions>(TimeSpan.FromSeconds(3))).Regions.Count.Should().Be(3);
+                }, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1));
                 await AwaitAssertAsync(async () =>
                 {
+                    var probe = CreateTestProbe();
                     var region = ClusterSharding.Get(Sys).ShardRegion(E2.TypeKey);
-                    region.Tell(GetCurrentRegions.Instance);
-                    (await ExpectMsgAsync<CurrentRegions>()).Regions.Count.Should().Be(2);
-                }, TimeSpan.FromSeconds(30));
+                    region.Tell(GetCurrentRegions.Instance, probe.Ref);
+                    (await probe.ExpectMsgAsync<CurrentRegions>(TimeSpan.FromSeconds(3))).Regions.Count.Should().Be(2);
+                }, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(1));
             }, Config.Fourth);
 
             await EnterBarrierAsync($"{Roles.Count}-up");


### PR DESCRIPTION
Fixes the Windows MNTR flake seen on #8357's validation run: `ClusterShardingMinMembersPerRoleNotConfiguredSpec` failing with "Expected value to be 3, but found 2" on node Fourth, which then cascades into node First's 3-second `Int32` expect timing out (node Fourth dropping kills the R2 coordinator host).

Root cause analysis: the region-count asserts polled through the shared TestActor mailbox with the default 5-second expect per attempt, so the 30-second window (already widened once by #8333, which is in this failure's base — widening is played out) only fits about six attempts, and a late `CurrentRegions` reply from a timed-out attempt can pollute the next attempt's read. The failing run just needed more clean samples of an eventually-consistent value, not more time.

The fix applies the existing `ClusterShardingQueriesSpec` pattern to both asserts: fresh probe per attempt, bounded 3-second inner expect, explicit 1-second retry interval. Same 30-second budget, roughly thirty clean independent samples instead of six polluted ones. Node First's block is untouched — it already uses a bounded inner expect, and fixing node Fourth removes the cascade that made it fail.

Not caused by #8357: MNTR runs classic remoting (the env-var opt-in for Artery is unset in CI), and that PR's only classic-visible change is a field classic code never reads. Verified: spec passes 3x unconstrained and 1x under `taskset -c 0,1` locally (~9-12s per run against the 30s budget).