### PR TITLE
Akka.Serialization.V2: native generator support for collection fields

### DIFF
--- a/src/benchmark/RemotePingPong/RealPayload/RealPayloadFactory.cs
+++ b/src/benchmark/RemotePingPong/RealPayload/RealPayloadFactory.cs
@@ -61,7 +61,7 @@ namespace RemotePingPong.RealPayload
                     DeviceId: "device-042",
                     FirmwareVersion: "1.4.2-rc1",
                     Region: 7),
-                Readings: new V2.ReadingBatch(readings));
+                Readings: readings);
         }
 
         public static Protobuf.RealBenchmarkMessage ToProtobuf(V2.RealBenchmarkMessage message)
@@ -81,7 +81,7 @@ namespace RemotePingPong.RealPayload
                 }
             };
 
-            proto.Readings.AddRange(message.Readings.Items.Select(reading => new Protobuf.Reading
+            proto.Readings.AddRange(message.Readings.Select(reading => new Protobuf.Reading
             {
                 SensorId = reading.SensorId,
                 Value = reading.Value,
@@ -93,7 +93,7 @@ namespace RemotePingPong.RealPayload
 
         public static MsgPack.RealBenchmarkMessage ToMsgPack(V2.RealBenchmarkMessage message)
         {
-            var readings = message.Readings.Items
+            var readings = message.Readings
                 .Select(reading => new MsgPack.Reading(reading.SensorId, reading.Value, reading.TimestampTicks))
                 .ToList();
 

--- a/src/benchmark/RemotePingPong/RealPayload/V2/RealBenchmarkMessages.cs
+++ b/src/benchmark/RemotePingPong/RealPayload/V2/RealBenchmarkMessages.cs
@@ -9,9 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Akka.Actor;
 using Akka.Serialization.V2;
-using MessagePack;
 
 namespace RemotePingPong.RealPayload.V2
 {
@@ -29,12 +27,19 @@ namespace RemotePingPong.RealPayload.V2
 
     /// <summary>
     /// Realistic benchmark message: several primitives, a string, a nested complex type
-    /// (<see cref="DeviceInfo"/>), and a collection (<see cref="ReadingBatch"/>). This is the V2/
-    /// MessagePack arm's wire type. The logically-identical Protobuf arm type is
+    /// (<see cref="DeviceInfo"/>), and a collection (<c>IReadOnlyList&lt;Reading&gt;</c>). This is the
+    /// V2/MessagePack arm's wire type. The logically-identical Protobuf arm type is
     /// <see cref="RemotePingPong.RealPayload.Protobuf.RealBenchmarkMessage"/> -- both are built from
     /// one canonical instance of THIS record by <see cref="RemotePingPong.RealPayload.RealPayloadFactory"/>,
     /// so the two arms always carry identical logical content.
     /// </summary>
+    /// <remarks>
+    /// The <see cref="Readings"/> collection is a native generator field kind: the source generator
+    /// writes it as MessagePack array framing (array header + one field-id map per <see cref="Reading"/>),
+    /// with no hand-written formatter. A custom structural <see cref="Equals(RealBenchmarkMessage?)"/>
+    /// sequence-compares <see cref="Readings"/> so the harness's canonical-message round-trip check
+    /// (see EnsureRealPayloadWiring) compares by value rather than by list reference.
+    /// </remarks>
     [AkkaSerializable(Manifest = RealBenchmarkMessage.ManifestName)]
     public sealed record RealBenchmarkMessage(
         [property: AkkaField(1)] int SequenceNumber,
@@ -43,9 +48,39 @@ namespace RemotePingPong.RealPayload.V2
         [property: AkkaField(4)] bool Flag,
         [property: AkkaField(5)] string CorrelationId,
         [property: AkkaField(6)] DeviceInfo Device,
-        [property: AkkaField(7)] ReadingBatch Readings) : IRealBenchmarkMessage
+        [property: AkkaField(7)] IReadOnlyList<Reading> Readings) : IRealBenchmarkMessage
     {
         public const string ManifestName = "real-benchmark-v1";
+
+        public bool Equals(RealBenchmarkMessage? other)
+        {
+            if (other is null)
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return SequenceNumber == other.SequenceNumber
+                && TimestampTicks == other.TimestampTicks
+                && Value.Equals(other.Value)
+                && Flag == other.Flag
+                && CorrelationId == other.CorrelationId
+                && Device == other.Device
+                && Readings.SequenceEqual(other.Readings);
+        }
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(SequenceNumber);
+            hash.Add(TimestampTicks);
+            hash.Add(Value);
+            hash.Add(Flag);
+            hash.Add(CorrelationId);
+            hash.Add(Device);
+            foreach (var reading in Readings)
+                hash.Add(reading);
+            return hash.ToHashCode();
+        }
     }
 
     /// <summary>
@@ -60,135 +95,15 @@ namespace RemotePingPong.RealPayload.V2
         [property: AkkaField(3)] int Region);
 
     /// <summary>
-    /// One element of the <see cref="ReadingBatch"/> collection. Deliberately NOT
-    /// <c>[AkkaSerializable]</c>: it is only ever written/read by <see cref="ReadingBatchFormatter"/>
-    /// (see the remarks on <see cref="ReadingBatch"/> for why).
+    /// One element of the <see cref="RealBenchmarkMessage.Readings"/> collection. A plain
+    /// <c>[AkkaSerializable]</c> nested value: the generator writes each element as a field-id map
+    /// (sensor id, value, timestamp ticks) inside the collection's array framing.
     /// </summary>
-    public sealed record Reading(string SensorId, double Value, long TimestampTicks);
-
-    /// <summary>
-    /// The message's collection field: a batch of <see cref="Reading"/> values.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// The Akka.Serialization.V2 source generator (as of this benchmark) has no native field kind for
-    /// a collection -- <c>List&lt;T&gt;</c>/array-of-non-byte fields hit AKKASG003 (unsupported field
-    /// type), and the <see cref="AkkaSerializerFormatterAttribute"/> escape hatch explicitly rejects
-    /// generic formatter targets (AKKASG011: "Formatter targets must be plain named types"), which
-    /// rules out registering a formatter for <c>List&lt;Reading&gt;</c> directly.
-    /// </para>
-    /// <para>
-    /// <see cref="ReadingBatch"/> is a small, NON-GENERIC wrapper class around the list precisely so it
-    /// CAN be registered as a formatter target -- exactly the pattern <see cref="AddressFormatter"/>
-    /// uses for <c>Akka.Actor.Address</c>. This is a deliberate, supported use of the documented
-    /// escape hatch to give this benchmark a genuine "list of a nested type" field despite the
-    /// generator's current lack of native collection support (see
-    /// <see cref="ReadingBatchFormatter"/> for the hand-written wire format).
-    /// </para>
-    /// </remarks>
-    public sealed class ReadingBatch : IEquatable<ReadingBatch>
-    {
-        public ReadingBatch(IReadOnlyList<Reading> items)
-        {
-            Items = items;
-        }
-
-        public IReadOnlyList<Reading> Items { get; }
-
-        public bool Equals(ReadingBatch? other)
-        {
-            if (other is null)
-                return false;
-            if (ReferenceEquals(this, other))
-                return true;
-
-            return Items.SequenceEqual(other.Items);
-        }
-
-        public override bool Equals(object? obj) => Equals(obj as ReadingBatch);
-
-        public override int GetHashCode()
-        {
-            var hash = new HashCode();
-            foreach (var reading in Items)
-                hash.Add(reading);
-            return hash.ToHashCode();
-        }
-    }
-
-    /// <summary>
-    /// Hand-written <see cref="IAkkaMessagePackFormatter{T}"/> for <see cref="ReadingBatch"/> -- writes
-    /// an array of small maps (one per <see cref="Reading"/>: sensor id, value, timestamp ticks). This
-    /// is the only hand-rolled piece of the V2 arm; every other field on
-    /// <see cref="RealBenchmarkMessage"/>/<see cref="DeviceInfo"/> is generator-emitted.
-    /// </summary>
-    public sealed class ReadingBatchFormatter : IAkkaMessagePackFormatter<ReadingBatch>
-    {
-        public void Write(ref MessagePackWriter writer, ReadingBatch value)
-        {
-            writer.WriteArrayHeader(value.Items.Count);
-            foreach (var reading in value.Items)
-            {
-                writer.WriteMapHeader(3);
-                writer.Write(1);
-                writer.Write(reading.SensorId);
-                writer.Write(2);
-                writer.Write(reading.Value);
-                writer.Write(3);
-                writer.Write(reading.TimestampTicks);
-            }
-        }
-
-        public ReadingBatch Read(ref MessagePackReader reader)
-        {
-            var count = reader.ReadArrayHeader();
-            var items = new List<Reading>(count);
-            for (var i = 0; i < count; i++)
-            {
-                var fieldCount = reader.ReadMapHeader();
-                string? sensorId = null;
-                var value = 0.0;
-                var timestampTicks = 0L;
-                for (var fieldIndex = 0; fieldIndex < fieldCount; fieldIndex++)
-                {
-                    var fieldId = reader.ReadInt32();
-                    switch (fieldId)
-                    {
-                        case 1:
-                            sensorId = reader.ReadString();
-                            break;
-                        case 2:
-                            value = reader.ReadDouble();
-                            break;
-                        case 3:
-                            timestampTicks = reader.ReadInt64();
-                            break;
-                        default:
-                            reader.Skip();
-                            break;
-                    }
-                }
-
-                items.Add(new Reading(sensorId ?? string.Empty, value, timestampTicks));
-            }
-
-            return new ReadingBatch(items);
-        }
-
-        public int SizeOf(ReadingBatch value)
-        {
-            var size = MessagePackSizes.SizeOfArrayHeader(value.Items.Count);
-            foreach (var reading in value.Items)
-            {
-                size += MessagePackSizes.SizeOfMapHeader(3);
-                size += MessagePackSizes.SizeOfInt32(1) + MessagePackSizes.SizeOfString(reading.SensorId);
-                size += MessagePackSizes.SizeOfInt32(2) + MessagePackSizes.SizeOfDouble(reading.Value);
-                size += MessagePackSizes.SizeOfInt32(3) + MessagePackSizes.SizeOfInt64(reading.TimestampTicks);
-            }
-
-            return size;
-        }
-    }
+    [AkkaSerializable]
+    public sealed record Reading(
+        [property: AkkaField(1)] string SensorId,
+        [property: AkkaField(2)] double Value,
+        [property: AkkaField(3)] long TimestampTicks);
 
     /// <summary>
     /// Source-generated V2 MessagePack serializer for <see cref="RealBenchmarkMessage"/> (the benchmark's
@@ -198,7 +113,8 @@ namespace RemotePingPong.RealPayload.V2
     /// <c>ArteryControlMessageSerializer</c>) emits the other half
     /// (<c>RealBenchmarkSerializer.AkkaSerialization.g.cs</c>): the constructor, <c>Identifier</c>,
     /// <c>Manifest</c>/<c>Serialize</c>/<c>Deserialize</c>/<c>SizeHint</c> dispatch, and one
-    /// Write/Read/SizeOf method per reachable message type.
+    /// Write/Read/SizeOf method per reachable message type -- including the native
+    /// <c>IReadOnlyList&lt;Reading&gt;</c> collection field on <see cref="RealBenchmarkMessage"/>.
     /// </summary>
     /// <remarks>
     /// SerializerId 987001 is arbitrary but deliberately far outside both Akka's reserved internal
@@ -206,7 +122,6 @@ namespace RemotePingPong.RealPayload.V2
     /// the V2 test suite's ~120101-120202) to avoid any collision with a real Akka.NET serializer.
     /// </remarks>
     [AkkaSerializer(Name = "real-benchmark-v2", SerializerId = 987001)]
-    [AkkaSerializerFormatter(typeof(ReadingBatch), typeof(ReadingBatchFormatter))]
     internal sealed partial class RealBenchmarkSerializer : MessagePackSerializer<IRealBenchmarkMessage>
     {
         /// <summary>

--- a/src/benchmark/RemotePingPong/RemotePingPong.csproj
+++ b/src/benchmark/RemotePingPong/RemotePingPong.csproj
@@ -31,6 +31,9 @@
        RealPayload/MsgPack/RealBenchmarkMessages.cs ([MessagePackObject]/[Key(n)] POCOs,
        MessagePackSerializer). Also flows transitively via Akka.Serialization.V2.csproj, but this
        project uses MessagePack types directly, so it takes an explicit reference too. MIT licensed. -->
+  <!-- Real-payload V2 arm: MessagePack flows transitively via Akka.Serialization.V2.csproj (whose
+       generated serializer and base class use MessagePackWriter/Reader), but this project keeps an
+       explicit reference in case benchmark code needs MessagePack types directly. -->
   <PackageReference Include="MessagePack" Version="$(MessagePackVersion)" />
   <!-- Real-payload Protobuf arm: same protoc-based codegen approach Akka.Remote uses for its own
        checked-in .proto files (src/protobuf/*.proto) - see RealPayload/Protobuf/RealBenchmarkMessage.proto. -->

--- a/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
+++ b/src/core/Akka.Serialization.V2.Generators/AkkaSerializerGenerator.cs
@@ -131,6 +131,15 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    private static readonly DiagnosticDescriptor UnsupportedEnumUnderlyingType = new(
+        "AKKASG014",
+        "Enum underlying type is not supported",
+        "Property '{0}' on type '{1}' uses enum type '{2}' whose underlying type '{3}' is not fully int32-representable; " +
+        "generated serializers encode enums as int32, so use an enum backed by sbyte, byte, short, ushort, or int",
+        "Akka.Serialization.V2",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var serializers = context.SyntaxProvider
@@ -483,14 +492,33 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
                 continue;
 
             messages.Add(message);
-            foreach (var field in message.Fields.Where(field => field.Mapping.Kind == FieldKind.Object))
+            var referencedObjectTypes = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var field in message.Fields)
+                CollectObjectTypeNames(field.Mapping, referencedObjectTypes);
+
+            foreach (var typeName in referencedObjectTypes)
             {
-                if (allMessagesByType.TryGetValue(field.Mapping.TypeFullName, out var nestedMessage))
+                if (allMessagesByType.TryGetValue(typeName, out var nestedMessage))
                     pending.Enqueue(nestedMessage);
             }
         }
 
         return messages.ToImmutable();
+    }
+
+    /// <summary>
+    /// Collects every <see cref="FieldKind.Object"/> type name reachable through a mapping, descending
+    /// into collection element/key/value mappings so that a nested <c>[AkkaSerializable]</c> type used
+    /// only inside a collection (for example the element of a <c>List&lt;Reading&gt;</c>) is still
+    /// reached and gets its Write/Read/SizeOf methods generated.
+    /// </summary>
+    private static void CollectObjectTypeNames(TypeMapping mapping, HashSet<string> into)
+    {
+        if (mapping.Kind == FieldKind.Object)
+            into.Add(mapping.TypeFullName);
+
+        foreach (var argument in mapping.TypeArguments)
+            CollectObjectTypeNames(argument, into);
     }
 
     private static bool ValidateMessages(SourceProductionContext context, SerializerInfo serializer, ImmutableArray<MessageInfo> topLevelMessages, ImmutableArray<MessageInfo> reachableMessages)
@@ -535,6 +563,12 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             foreach (var field in message.Fields.Where(field => field.Mapping.Kind == FieldKind.MissingSerializableDefinition))
             {
                 context.ReportDiagnostic(Diagnostic.Create(MissingNestedSerializableDefinition, Location.None, field.Name, message.FullyQualifiedName, field.TypeFullName));
+                isValid = false;
+            }
+
+            foreach (var field in message.Fields.Where(field => field.Mapping.Kind == FieldKind.UnsupportedEnumUnderlyingType))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(UnsupportedEnumUnderlyingType, Location.None, field.Name, message.FullyQualifiedName, field.Mapping.TypeFullName, field.Mapping.EnumUnderlyingTypeName));
                 isValid = false;
             }
         }
@@ -752,19 +786,28 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         sb.AppendLine("        checked");
         sb.AppendLine("        {");
         sb.Append("            var size = SizeOfMapHeader(").Append(message.Fields.Length).AppendLine(");");
+        var alloc = new NameAlloc();
         foreach (var field in message.Fields)
-            GenerateSizeField(sb, field);
+            GenerateSizeField(sb, field, alloc);
         sb.AppendLine("            return size;");
         sb.AppendLine("        }");
         sb.AppendLine("    }");
         sb.AppendLine();
     }
 
-    private static void GenerateSizeField(StringBuilder sb, FieldInfo field)
+    private static void GenerateSizeField(StringBuilder sb, FieldInfo field, NameAlloc alloc)
     {
         var value = "message." + field.Name;
         var localName = ToCamelCase(field.Name) + "Size";
         sb.Append("            size += SizeOfInt32(").Append(field.Index).AppendLine(");");
+        if (IsCollectionKind(field.Mapping.Kind))
+        {
+            var fieldSize = alloc.Next("size");
+            EmitSizeCollectionBody(sb, field.Mapping, value, fieldSize, "            ", alloc);
+            sb.Append("            size += ").Append(fieldSize).AppendLine(";");
+            return;
+        }
+
         if (TryGetInlineSizeExpression(field, value, out var expression))
         {
             sb.Append("            size += ").Append(expression).AppendLine(";");
@@ -859,8 +902,9 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             .Append("(ref global::MessagePack.MessagePackWriter writer, ").Append(message.FullyQualifiedName).AppendLine(" message)");
         sb.AppendLine("    {");
         sb.Append("        writer.WriteMapHeader(").Append(message.Fields.Length).AppendLine(");");
+        var alloc = new NameAlloc();
         foreach (var field in message.Fields)
-            GenerateWriteField(sb, field);
+            GenerateWriteField(sb, field, alloc);
         sb.AppendLine("    }");
         sb.AppendLine();
     }
@@ -871,6 +915,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             .AppendLine("(ref global::MessagePack.MessagePackReader reader)");
         sb.AppendLine("    {");
         sb.AppendLine("        var fieldCount = reader.ReadMapHeader();");
+        var alloc = new NameAlloc();
         foreach (var field in message.Fields)
         {
             sb.Append("        ").Append(GetLocalType(field)).Append(' ').Append(ToCamelCase(field.Name)).Append(" = ")
@@ -887,7 +932,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         foreach (var field in message.Fields)
         {
             sb.Append("                case ").Append(field.Index).AppendLine(":");
-            GenerateReadField(sb, field);
+            GenerateReadField(sb, field, alloc);
             if (IsRequired(field))
                 sb.Append("                    ").Append(GetHasLocalName(field)).AppendLine(" = true;");
             sb.AppendLine("                    break;");
@@ -918,7 +963,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         sb.AppendLine();
     }
 
-    private static void GenerateWriteField(StringBuilder sb, FieldInfo field)
+    private static void GenerateWriteField(StringBuilder sb, FieldInfo field, NameAlloc alloc)
     {
         var value = "message." + field.Name;
         sb.Append("        writer.Write(").Append(field.Index).AppendLine(");");
@@ -927,15 +972,21 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             sb.Append("        if (").Append(value).AppendLine(" is null)");
             sb.AppendLine("            writer.WriteNil();");
             sb.AppendLine("        else");
-            GenerateWriteFieldValue(sb, field, value + ".Value", "            ");
+            GenerateWriteFieldValue(sb, field, value + ".Value", "            ", alloc);
             return;
         }
 
-        GenerateWriteFieldValue(sb, field, value, "        ");
+        GenerateWriteFieldValue(sb, field, value, "        ", alloc);
     }
 
-    private static void GenerateWriteFieldValue(StringBuilder sb, FieldInfo field, string value, string indent)
+    private static void GenerateWriteFieldValue(StringBuilder sb, FieldInfo field, string value, string indent, NameAlloc alloc)
     {
+        if (IsCollectionKind(field.Mapping.Kind))
+        {
+            EmitWriteCollectionBody(sb, field.Mapping, value, indent, alloc);
+            return;
+        }
+
         switch (field.Mapping.Kind)
         {
             case FieldKind.String:
@@ -1011,15 +1062,26 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         }
     }
 
-    private static void GenerateReadField(StringBuilder sb, FieldInfo field)
+    private static void GenerateReadField(StringBuilder sb, FieldInfo field, NameAlloc alloc)
     {
         var target = ToCamelCase(field.Name);
+
+        // Collection fields own their MessagePack nil handling end-to-end (EmitReadCollectionBody
+        // does its own TryReadNil), so they are read directly regardless of the field's nullability:
+        // a nil-on-the-wire assigns null, and the post-loop required-field guard rejects a null in a
+        // non-nullable collection slot exactly as it does for any other non-nullable reference field.
+        if (IsCollectionKind(field.Mapping.Kind))
+        {
+            GenerateReadFieldValue(sb, field, target, "                    ", alloc);
+            return;
+        }
+
         if (IsNullableValueField(field))
         {
             sb.AppendLine("                    if (reader.TryReadNil())");
             sb.Append("                        ").Append(target).AppendLine(" = null;");
             sb.AppendLine("                    else");
-            GenerateReadFieldValue(sb, field, target, "                        ");
+            GenerateReadFieldValue(sb, field, target, "                        ", alloc);
             return;
         }
 
@@ -1032,15 +1094,21 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             sb.AppendLine("                    if (reader.TryReadNil())");
             sb.Append("                        ").Append(target).AppendLine(" = null;");
             sb.AppendLine("                    else");
-            GenerateReadFieldValue(sb, field, target, "                        ");
+            GenerateReadFieldValue(sb, field, target, "                        ", alloc);
             return;
         }
 
-        GenerateReadFieldValue(sb, field, target, "                    ");
+        GenerateReadFieldValue(sb, field, target, "                    ", alloc);
     }
 
-    private static void GenerateReadFieldValue(StringBuilder sb, FieldInfo field, string target, string indent)
+    private static void GenerateReadFieldValue(StringBuilder sb, FieldInfo field, string target, string indent, NameAlloc alloc)
     {
+        if (IsCollectionKind(field.Mapping.Kind))
+        {
+            EmitReadCollectionBody(sb, field.Mapping, target, indent, alloc);
+            return;
+        }
+
         switch (field.Mapping.Kind)
         {
             case FieldKind.String:
@@ -1092,6 +1160,374 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         }
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // Native collection emission (T[], List<T>, IReadOnlyList<T>, Dictionary<TKey, TValue>).
+    //
+    // Collections encode as MessagePack array/map framing wrapped around per-element encodings that
+    // reuse the same scalar/object primitives as ordinary fields, and compose recursively so nested
+    // collections (List<List<int>>, Dictionary<string, List<Reading>>) work with no special cases.
+    // null encodes as MessagePack nil; empty encodes as a zero-length array/map header. The two are
+    // distinct on the wire and round-trip as distinct values. This framing is permanent wire format --
+    // see the encoding matrix in the PR body for the full table.
+    // ---------------------------------------------------------------------------------------------
+
+    /// <summary>Allocates collision-free local names within a single generated method body.</summary>
+    private sealed class NameAlloc
+    {
+        private int _counter;
+
+        public string Next(string hint) => "__" + hint + _counter++;
+    }
+
+    private static string CollectionCountMember(FieldKind kind) => kind == FieldKind.Array ? "Length" : "Count";
+
+    /// <summary>
+    /// Whether a value of this element mapping is stored as a reference in its strongly-typed collection
+    /// slot. Reference elements are declared as nullable read temporaries and stored with the
+    /// null-forgiving operator (a runtime no-op) so the generated code stays warning-clean under
+    /// <c>#nullable enable</c> while still round-tripping a genuine null element.
+    /// </summary>
+    private static bool ElementIsReference(TypeMapping mapping)
+    {
+        if (IsCollectionKind(mapping.Kind))
+            return true;
+
+        return mapping.Kind switch
+        {
+            FieldKind.String or FieldKind.ByteArray or FieldKind.ActorRef => true,
+            FieldKind.Object => !mapping.IsValueType,
+            _ => false
+        };
+    }
+
+    private static string ElementStore(TypeMapping mapping, string valueExpr)
+        => ElementIsReference(mapping) ? valueExpr + "!" : valueExpr;
+
+    private static string ElementTempType(TypeMapping mapping)
+        => ElementIsReference(mapping) ? mapping.DeclaredTypeName + "?" : mapping.DeclaredTypeName;
+
+    private static bool IsScalarValueKind(FieldKind kind)
+        => kind is FieldKind.Int32 or FieldKind.Int64 or FieldKind.Boolean or FieldKind.Double
+            or FieldKind.Decimal or FieldKind.Guid or FieldKind.DateTime or FieldKind.DateTimeOffset or FieldKind.Enum;
+
+    // ----- WRITE -----
+
+    private static void EmitWriteCollectionBody(StringBuilder sb, TypeMapping mapping, string value, string indent, NameAlloc alloc)
+    {
+        sb.Append(indent).Append("if (").Append(value).AppendLine(" is null)");
+        sb.Append(indent).AppendLine("{");
+        sb.Append(indent).AppendLine("    writer.WriteNil();");
+        sb.Append(indent).AppendLine("}");
+        sb.Append(indent).AppendLine("else");
+        sb.Append(indent).AppendLine("{");
+
+        var bodyIndent = indent + "    ";
+        var loopIndent = bodyIndent + "    ";
+        if (mapping.Kind == FieldKind.Dictionary)
+        {
+            var kvp = alloc.Next("kvp");
+            sb.Append(bodyIndent).Append("writer.WriteMapHeader(").Append(value).AppendLine(".Count);");
+            sb.Append(bodyIndent).Append("foreach (var ").Append(kvp).Append(" in ").Append(value).AppendLine(")");
+            sb.Append(bodyIndent).AppendLine("{");
+            EmitWriteElement(sb, mapping.TypeArguments[0], kvp + ".Key", loopIndent, alloc);
+            EmitWriteElement(sb, mapping.TypeArguments[1], kvp + ".Value", loopIndent, alloc);
+            sb.Append(bodyIndent).AppendLine("}");
+        }
+        else
+        {
+            var item = alloc.Next("item");
+            sb.Append(bodyIndent).Append("writer.WriteArrayHeader(").Append(value).Append('.').Append(CollectionCountMember(mapping.Kind)).AppendLine(");");
+            sb.Append(bodyIndent).Append("foreach (var ").Append(item).Append(" in ").Append(value).AppendLine(")");
+            sb.Append(bodyIndent).AppendLine("{");
+            EmitWriteElement(sb, mapping.TypeArguments[0], item, loopIndent, alloc);
+            sb.Append(bodyIndent).AppendLine("}");
+        }
+
+        sb.Append(indent).AppendLine("}");
+    }
+
+    private static void EmitWriteElement(StringBuilder sb, TypeMapping mapping, string value, string indent, NameAlloc alloc)
+    {
+        if (IsCollectionKind(mapping.Kind))
+        {
+            EmitWriteCollectionBody(sb, mapping, value, indent, alloc);
+            return;
+        }
+
+        if (mapping.Kind == FieldKind.Object)
+        {
+            if (mapping.IsValueType && !mapping.IsNullable)
+            {
+                sb.Append(indent).Append("Write").Append(GetObjectMethodName(mapping)).Append("(ref writer, ").Append(value).AppendLine(");");
+                return;
+            }
+
+            var writeValue = mapping.IsValueType ? value + ".Value" : value;
+            sb.Append(indent).Append("if (").Append(value).AppendLine(" is null)");
+            sb.Append(indent).AppendLine("    writer.WriteNil();");
+            sb.Append(indent).AppendLine("else");
+            sb.Append(indent).Append("    Write").Append(GetObjectMethodName(mapping)).Append("(ref writer, ").Append(writeValue).AppendLine(");");
+            return;
+        }
+
+        if (mapping.IsNullable && IsScalarValueKind(mapping.Kind))
+        {
+            sb.Append(indent).Append("if (").Append(value).AppendLine(" is null)");
+            sb.Append(indent).AppendLine("    writer.WriteNil();");
+            sb.Append(indent).AppendLine("else");
+            EmitScalarWrite(sb, mapping, value + ".Value", indent + "    ");
+            return;
+        }
+
+        EmitScalarWrite(sb, mapping, value, indent);
+    }
+
+    private static void EmitScalarWrite(StringBuilder sb, TypeMapping mapping, string value, string indent)
+    {
+        switch (mapping.Kind)
+        {
+            case FieldKind.String:
+            case FieldKind.ByteArray:
+            case FieldKind.Int32:
+            case FieldKind.Int64:
+            case FieldKind.Boolean:
+            case FieldKind.Double:
+                sb.Append(indent).Append("writer.Write(").Append(value).AppendLine(");");
+                break;
+            case FieldKind.Decimal:
+                sb.Append(indent).Append("WriteDecimal(ref writer, ").Append(value).AppendLine(");");
+                break;
+            case FieldKind.Guid:
+                sb.Append(indent).Append("WriteGuid(ref writer, ").Append(value).AppendLine(");");
+                break;
+            case FieldKind.DateTime:
+                sb.Append(indent).Append("WriteDateTime(ref writer, ").Append(value).AppendLine(");");
+                break;
+            case FieldKind.DateTimeOffset:
+                sb.Append(indent).Append("WriteDateTimeOffset(ref writer, ").Append(value).AppendLine(");");
+                break;
+            case FieldKind.ActorRef:
+                sb.Append(indent).Append("WriteActorRef(ref writer, ").Append(value).AppendLine(");");
+                break;
+            case FieldKind.Enum:
+                sb.Append(indent).Append("writer.Write((int)").Append(value).AppendLine(");");
+                break;
+        }
+    }
+
+    // ----- READ -----
+
+    private static void EmitReadCollectionBody(StringBuilder sb, TypeMapping mapping, string target, string indent, NameAlloc alloc)
+    {
+        sb.Append(indent).AppendLine("if (reader.TryReadNil())");
+        sb.Append(indent).AppendLine("{");
+        sb.Append(indent).Append("    ").Append(target).AppendLine(" = null;");
+        sb.Append(indent).AppendLine("}");
+        sb.Append(indent).AppendLine("else");
+        sb.Append(indent).AppendLine("{");
+
+        var bodyIndent = indent + "    ";
+        var loopIndent = bodyIndent + "    ";
+        var length = alloc.Next("len");
+        var collection = alloc.Next("col");
+        var index = alloc.Next("i");
+
+        if (mapping.Kind == FieldKind.Dictionary)
+        {
+            var key = mapping.TypeArguments[0];
+            var val = mapping.TypeArguments[1];
+            var keyVar = alloc.Next("key");
+            var valVar = alloc.Next("val");
+            sb.Append(bodyIndent).Append("var ").Append(length).AppendLine(" = reader.ReadMapHeader();");
+            sb.Append(bodyIndent).Append("var ").Append(collection).Append(" = new global::System.Collections.Generic.Dictionary<")
+                .Append(key.DeclaredTypeName).Append(", ").Append(val.DeclaredTypeName).Append(">(").Append(length).AppendLine(");");
+            sb.Append(bodyIndent).Append("for (var ").Append(index).Append(" = 0; ").Append(index).Append(" < ").Append(length).Append("; ").Append(index).AppendLine("++)");
+            sb.Append(bodyIndent).AppendLine("{");
+            EmitReadElement(sb, key, keyVar, loopIndent, alloc);
+            EmitReadElement(sb, val, valVar, loopIndent, alloc);
+            sb.Append(loopIndent).Append(collection).Append('[').Append(ElementStore(key, keyVar)).Append("] = ").Append(ElementStore(val, valVar)).AppendLine(";");
+            sb.Append(bodyIndent).AppendLine("}");
+        }
+        else
+        {
+            var element = mapping.TypeArguments[0];
+            var itemVar = alloc.Next("item");
+            sb.Append(bodyIndent).Append("var ").Append(length).AppendLine(" = reader.ReadArrayHeader();");
+            if (mapping.Kind == FieldKind.Array)
+                sb.Append(bodyIndent).Append("var ").Append(collection).Append(" = ").Append(GetArrayAllocationExpression(element.DeclaredTypeName, length)).AppendLine(";");
+            else
+                sb.Append(bodyIndent).Append("var ").Append(collection).Append(" = new global::System.Collections.Generic.List<").Append(element.DeclaredTypeName).Append(">(").Append(length).AppendLine(");");
+            sb.Append(bodyIndent).Append("for (var ").Append(index).Append(" = 0; ").Append(index).Append(" < ").Append(length).Append("; ").Append(index).AppendLine("++)");
+            sb.Append(bodyIndent).AppendLine("{");
+            EmitReadElement(sb, element, itemVar, loopIndent, alloc);
+            if (mapping.Kind == FieldKind.Array)
+                sb.Append(loopIndent).Append(collection).Append('[').Append(index).Append("] = ").Append(ElementStore(element, itemVar)).AppendLine(";");
+            else
+                sb.Append(loopIndent).Append(collection).Append(".Add(").Append(ElementStore(element, itemVar)).AppendLine(");");
+            sb.Append(bodyIndent).AppendLine("}");
+        }
+
+        sb.Append(bodyIndent).Append(target).Append(" = ").Append(collection).AppendLine(";");
+        sb.Append(indent).AppendLine("}");
+    }
+
+    /// <summary>
+    /// Builds the C# allocation expression for a single-dimension array of
+    /// <paramref name="elementTypeName"/>. For a jagged array the length belongs in the FIRST bracket
+    /// pair with the element's own bracket pairs appended after it: element <c>int[]</c> allocates as
+    /// <c>new int[len][]</c> (not the invalid <c>new int[][len]</c>), element <c>int[][]</c> as
+    /// <c>new int[len][][]</c>. Bracket pairs only ever appear as an array suffix in the
+    /// fully-qualified display name (generics use angle brackets), so peeling trailing <c>[]</c> pairs
+    /// off the element type name recovers the correct structure.
+    /// </summary>
+    private static string GetArrayAllocationExpression(string elementTypeName, string lengthVar)
+    {
+        var core = elementTypeName;
+        var suffix = string.Empty;
+        while (core.EndsWith("[]", StringComparison.Ordinal))
+        {
+            core = core.Substring(0, core.Length - 2);
+            suffix += "[]";
+        }
+
+        return "new " + core + "[" + lengthVar + "]" + suffix;
+    }
+
+    private static void EmitReadElement(StringBuilder sb, TypeMapping mapping, string resultVar, string indent, NameAlloc alloc)
+    {
+        sb.Append(indent).Append(ElementTempType(mapping)).Append(' ').Append(resultVar).AppendLine(";");
+
+        if (IsCollectionKind(mapping.Kind))
+        {
+            EmitReadCollectionBody(sb, mapping, resultVar, indent, alloc);
+            return;
+        }
+
+        if (mapping.Kind == FieldKind.Object)
+        {
+            if (mapping.IsValueType && !mapping.IsNullable)
+            {
+                sb.Append(indent).Append(resultVar).Append(" = Read").Append(GetObjectMethodName(mapping)).AppendLine("(ref reader);");
+                return;
+            }
+
+            sb.Append(indent).AppendLine("if (reader.TryReadNil())");
+            sb.Append(indent).Append("    ").Append(resultVar).AppendLine(" = null;");
+            sb.Append(indent).AppendLine("else");
+            sb.Append(indent).Append("    ").Append(resultVar).Append(" = Read").Append(GetObjectMethodName(mapping)).AppendLine("(ref reader);");
+            return;
+        }
+
+        if (mapping.IsNullable && IsScalarValueKind(mapping.Kind))
+        {
+            sb.Append(indent).AppendLine("if (reader.TryReadNil())");
+            sb.Append(indent).Append("    ").Append(resultVar).AppendLine(" = null;");
+            sb.Append(indent).AppendLine("else");
+            sb.Append(indent).Append("    ").Append(resultVar).Append(" = ").Append(GetScalarReadExpression(mapping)).AppendLine(";");
+            return;
+        }
+
+        sb.Append(indent).Append(resultVar).Append(" = ").Append(GetScalarReadExpression(mapping)).AppendLine(";");
+    }
+
+    private static string GetScalarReadExpression(TypeMapping mapping)
+    {
+        return mapping.Kind switch
+        {
+            FieldKind.String => "reader.ReadString()",
+            FieldKind.ByteArray => "reader.ReadBytes()?.ToArray()",
+            FieldKind.Int32 => "reader.ReadInt32()",
+            FieldKind.Int64 => "reader.ReadInt64()",
+            FieldKind.Boolean => "reader.ReadBoolean()",
+            FieldKind.Double => "reader.ReadDouble()",
+            FieldKind.Decimal => "ReadDecimal(ref reader)",
+            FieldKind.Guid => "ReadGuid(ref reader)",
+            FieldKind.DateTime => "ReadDateTime(ref reader)",
+            FieldKind.DateTimeOffset => "ReadDateTimeOffset(ref reader)",
+            FieldKind.ActorRef => "ReadActorRef(ref reader)",
+            FieldKind.Enum => "(" + mapping.TypeFullName + ")reader.ReadInt32()",
+            _ => "default"
+        };
+    }
+
+    // ----- SIZE -----
+
+    private static void EmitSizeCollectionBody(StringBuilder sb, TypeMapping mapping, string value, string sizeVar, string indent, NameAlloc alloc)
+    {
+        sb.Append(indent).Append("int ").Append(sizeVar).AppendLine(";");
+        sb.Append(indent).Append("if (").Append(value).AppendLine(" is null)");
+        sb.Append(indent).AppendLine("{");
+        sb.Append(indent).Append("    ").Append(sizeVar).AppendLine(" = SizeOfNil();");
+        sb.Append(indent).AppendLine("}");
+        sb.Append(indent).AppendLine("else");
+        sb.Append(indent).AppendLine("{");
+
+        var bodyIndent = indent + "    ";
+        var loopIndent = bodyIndent + "    ";
+        if (mapping.Kind == FieldKind.Dictionary)
+        {
+            var kvp = alloc.Next("kvp");
+            sb.Append(bodyIndent).Append(sizeVar).Append(" = SizeOfMapHeader(").Append(value).AppendLine(".Count);");
+            sb.Append(bodyIndent).Append("foreach (var ").Append(kvp).Append(" in ").Append(value).AppendLine(")");
+            sb.Append(bodyIndent).AppendLine("{");
+            EmitSizeElement(sb, mapping.TypeArguments[0], kvp + ".Key", sizeVar, loopIndent, alloc);
+            EmitSizeElement(sb, mapping.TypeArguments[1], kvp + ".Value", sizeVar, loopIndent, alloc);
+            sb.Append(bodyIndent).AppendLine("}");
+        }
+        else
+        {
+            var item = alloc.Next("item");
+            sb.Append(bodyIndent).Append(sizeVar).Append(" = SizeOfArrayHeader(").Append(value).Append('.').Append(CollectionCountMember(mapping.Kind)).AppendLine(");");
+            sb.Append(bodyIndent).Append("foreach (var ").Append(item).Append(" in ").Append(value).AppendLine(")");
+            sb.Append(bodyIndent).AppendLine("{");
+            EmitSizeElement(sb, mapping.TypeArguments[0], item, sizeVar, loopIndent, alloc);
+            sb.Append(bodyIndent).AppendLine("}");
+        }
+
+        sb.Append(indent).AppendLine("}");
+    }
+
+    private static void EmitSizeElement(StringBuilder sb, TypeMapping mapping, string value, string sizeVar, string indent, NameAlloc alloc)
+    {
+        if (IsCollectionKind(mapping.Kind))
+        {
+            var innerSize = alloc.Next("size");
+            EmitSizeCollectionBody(sb, mapping, value, innerSize, indent, alloc);
+            sb.Append(indent).Append(sizeVar).Append(" += ").Append(innerSize).AppendLine(";");
+            return;
+        }
+
+        if (mapping.Kind == FieldKind.Object)
+        {
+            var elementSize = alloc.Next("size");
+            string sizeExpr;
+            if (mapping.IsValueType && !mapping.IsNullable)
+            {
+                sizeExpr = "SizeOf" + GetObjectMethodName(mapping) + "(" + value + ")";
+            }
+            else
+            {
+                var sizedValue = mapping.IsValueType ? value + ".Value" : value;
+                sizeExpr = value + " is null ? SizeOfNil() : SizeOf" + GetObjectMethodName(mapping) + "(" + sizedValue + ")";
+            }
+
+            sb.Append(indent).Append("var ").Append(elementSize).Append(" = ").Append(sizeExpr).AppendLine(";");
+            sb.Append(indent).Append("if (").Append(elementSize).AppendLine(" < 0)");
+            sb.Append(indent).AppendLine("    return global::Akka.Serialization.SerializerV2.UnknownSize;");
+            sb.Append(indent).Append(sizeVar).Append(" += ").Append(elementSize).AppendLine(";");
+            return;
+        }
+
+        if (mapping.IsNullable && IsScalarValueKind(mapping.Kind))
+        {
+            sb.Append(indent).Append(sizeVar).Append(" += ").Append(value).Append(" is null ? SizeOfNil() : ")
+                .Append(GetScalarSizeExpression(mapping, value + ".Value")).AppendLine(";");
+            return;
+        }
+
+        sb.Append(indent).Append(sizeVar).Append(" += ").Append(GetScalarSizeExpression(mapping, value)).AppendLine(";");
+    }
+
     private static TypeMapping MapType(ITypeSymbol type, KnownTypes knownTypes)
     {
         if (TryGetNullableValueType(type, out var underlyingType))
@@ -1104,7 +1540,7 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         // mapping name, can never match a formatter, and still fail with AKKASG003.
         var mapping = MapTypeCore(type, knownTypes);
         if (mapping.TypeFullName.Length == 0 && type is INamedTypeSymbol { IsGenericType: false } namedType)
-            return new TypeMapping(mapping.Kind, GetFullyQualifiedTypeName(namedType));
+            return mapping.WithTypeFullName(GetFullyQualifiedTypeName(namedType));
 
         return mapping;
     }
@@ -1112,7 +1548,21 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
     private static TypeMapping MapTypeCore(ITypeSymbol type, KnownTypes knownTypes)
     {
         if (type is INamedTypeSymbol enumType && type.TypeKind == TypeKind.Enum)
+        {
+            // Enums encode as int32 on the wire ("writer.Write((int)value)" / "(E)reader.ReadInt32()"),
+            // so an underlying type whose values are not all int32-representable (uint, long, ulong)
+            // would silently truncate. Reject at compile time (AKKASG014) instead.
+            var underlyingType = enumType.EnumUnderlyingType;
+            if (underlyingType != null && !IsEnumUnderlyingTypeSupported(underlyingType.SpecialType))
+            {
+                return new TypeMapping(
+                    FieldKind.UnsupportedEnumUnderlyingType,
+                    GetFullyQualifiedTypeName(enumType),
+                    enumUnderlyingTypeName: underlyingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+            }
+
             return new TypeMapping(FieldKind.Enum, GetFullyQualifiedTypeName(enumType));
+        }
 
         if (type is IArrayTypeSymbol { ElementType.SpecialType: SpecialType.System_Byte })
             return new TypeMapping(FieldKind.ByteArray);
@@ -1138,11 +1588,127 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         if (mapping.Kind != FieldKind.Unsupported)
             return mapping;
 
+        if (TryMapCollection(type, knownTypes, out var collectionMapping))
+            return collectionMapping;
+
         if (type is INamedTypeSymbol { IsGenericType: false, TypeKind: TypeKind.Class or TypeKind.Struct } missingNestedType)
             return new TypeMapping(FieldKind.MissingSerializableDefinition, GetFullyQualifiedTypeName(missingNestedType));
 
         return mapping;
     }
+
+    /// <summary>
+    /// Maps the four natively-supported collection shapes -- <c>T[]</c>, <c>List&lt;T&gt;</c>,
+    /// <c>IReadOnlyList&lt;T&gt;</c>, and <c>Dictionary&lt;TKey,TValue&gt;</c> -- to their collection
+    /// <see cref="FieldKind"/>, recursively mapping element/key/value types so collections compose.
+    /// A collection whose element/key/value is itself unsupported collapses to
+    /// <see cref="FieldKind.Unsupported"/> so AKKASG003 fires with the full field type -- except an
+    /// enum element with an unsupported underlying type, which propagates as
+    /// <see cref="FieldKind.UnsupportedEnumUnderlyingType"/> so AKKASG014 fires naming the enum.
+    /// <c>byte[]</c> is never seen here (it is intercepted earlier as <see cref="FieldKind.ByteArray"/>).
+    /// </summary>
+    private static bool TryMapCollection(ITypeSymbol type, KnownTypes knownTypes, out TypeMapping mapping)
+    {
+        mapping = default;
+
+        if (type is IArrayTypeSymbol { Rank: 1 } arrayType && arrayType.ElementType.SpecialType != SpecialType.System_Byte)
+        {
+            var element = MapCollectionElement(arrayType.ElementType, knownTypes);
+            mapping = TryCollapseBadElement(element, out var collapsed)
+                ? collapsed
+                : new TypeMapping(FieldKind.Array, typeArguments: ImmutableArray.Create(element));
+            return true;
+        }
+
+        if (type is not INamedTypeSymbol { IsGenericType: true } namedType)
+            return false;
+
+        var definition = namedType.OriginalDefinition;
+        if (knownTypes.ListOfT != null && SymbolEqualityComparer.Default.Equals(definition, knownTypes.ListOfT))
+        {
+            var element = MapCollectionElement(namedType.TypeArguments[0], knownTypes);
+            mapping = TryCollapseBadElement(element, out var collapsed)
+                ? collapsed
+                : new TypeMapping(FieldKind.List, typeArguments: ImmutableArray.Create(element));
+            return true;
+        }
+
+        if (knownTypes.ReadOnlyListOfT != null && SymbolEqualityComparer.Default.Equals(definition, knownTypes.ReadOnlyListOfT))
+        {
+            var element = MapCollectionElement(namedType.TypeArguments[0], knownTypes);
+            mapping = TryCollapseBadElement(element, out var collapsed)
+                ? collapsed
+                : new TypeMapping(FieldKind.ReadOnlyList, typeArguments: ImmutableArray.Create(element));
+            return true;
+        }
+
+        if (knownTypes.DictionaryOfKeyValue != null && SymbolEqualityComparer.Default.Equals(definition, knownTypes.DictionaryOfKeyValue))
+        {
+            var key = MapCollectionElement(namedType.TypeArguments[0], knownTypes);
+            var value = MapCollectionElement(namedType.TypeArguments[1], knownTypes);
+            mapping = TryCollapseBadElement(key, out var collapsedKey) ? collapsedKey
+                : TryCollapseBadElement(value, out var collapsedValue) ? collapsedValue
+                : new TypeMapping(FieldKind.Dictionary, typeArguments: ImmutableArray.Create(key, value));
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Collapses a bad collection element/key/value mapping into the mapping the containing field
+    /// should carry. An enum with an unsupported underlying type keeps its identity (enum name plus
+    /// backing type) so AKKASG014 can name it even through arbitrarily deep nesting; every other bad
+    /// element collapses to plain <see cref="FieldKind.Unsupported"/> for AKKASG003.
+    /// </summary>
+    private static bool TryCollapseBadElement(TypeMapping element, out TypeMapping collapsed)
+    {
+        if (element.Kind == FieldKind.UnsupportedEnumUnderlyingType)
+        {
+            collapsed = new TypeMapping(
+                FieldKind.UnsupportedEnumUnderlyingType,
+                element.TypeFullName,
+                enumUnderlyingTypeName: element.EnumUnderlyingTypeName);
+            return true;
+        }
+
+        if (element.Kind is FieldKind.Unsupported or FieldKind.MissingSerializableDefinition)
+        {
+            collapsed = new TypeMapping(FieldKind.Unsupported);
+            return true;
+        }
+
+        collapsed = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Whether every value of an enum with this underlying type is exactly representable as an int32
+    /// (the wire encoding for <see cref="FieldKind.Enum"/>). uint, long, and ulong are rejected: their
+    /// out-of-int32-range values would silently truncate through the <c>(int)</c> cast.
+    /// </summary>
+    private static bool IsEnumUnderlyingTypeSupported(SpecialType underlyingType)
+    {
+        return underlyingType is SpecialType.System_SByte
+            or SpecialType.System_Byte
+            or SpecialType.System_Int16
+            or SpecialType.System_UInt16
+            or SpecialType.System_Int32;
+    }
+
+    private static TypeMapping MapCollectionElement(ITypeSymbol type, KnownTypes knownTypes)
+    {
+        var declaredTypeName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+        if (TryGetNullableValueType(type, out var underlyingType))
+            return MapTypeCore(underlyingType, knownTypes).AsCollectionElement(declaredTypeName, isNullable: true);
+
+        var isNullable = type.IsReferenceType && type.NullableAnnotation == NullableAnnotation.Annotated;
+        return MapTypeCore(type, knownTypes).AsCollectionElement(declaredTypeName, isNullable);
+    }
+
+    private static bool IsCollectionKind(FieldKind kind)
+        => kind is FieldKind.Array or FieldKind.List or FieldKind.ReadOnlyList or FieldKind.Dictionary;
 
     private static string DefaultValue(FieldInfo field)
     {
@@ -1180,6 +1746,9 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
 
     private static bool IsReferenceLike(FieldInfo field)
     {
+        if (IsCollectionKind(field.Mapping.Kind))
+            return true;
+
         if (field.Mapping.Kind == FieldKind.Formatted)
             return field.Formatter is { IsTargetValueType: false };
 
@@ -1339,6 +1908,9 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
             Guid = compilation.GetTypeByMetadataName("System.Guid");
             DateTimeOffset = compilation.GetTypeByMetadataName("System.DateTimeOffset");
             ActorRef = compilation.GetTypeByMetadataName("Akka.Actor.IActorRef");
+            ListOfT = compilation.GetTypeByMetadataName("System.Collections.Generic.List`1");
+            ReadOnlyListOfT = compilation.GetTypeByMetadataName("System.Collections.Generic.IReadOnlyList`1");
+            DictionaryOfKeyValue = compilation.GetTypeByMetadataName("System.Collections.Generic.Dictionary`2");
         }
 
         public INamedTypeSymbol? FieldAttribute { get; }
@@ -1347,6 +1919,9 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         public INamedTypeSymbol? Guid { get; }
         public INamedTypeSymbol? DateTimeOffset { get; }
         public INamedTypeSymbol? ActorRef { get; }
+        public INamedTypeSymbol? ListOfT { get; }
+        public INamedTypeSymbol? ReadOnlyListOfT { get; }
+        public INamedTypeSymbol? DictionaryOfKeyValue { get; }
 
         public static KnownTypes From(Compilation compilation)
         {
@@ -1406,11 +1981,22 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
 
     private readonly struct TypeMapping
     {
-        public TypeMapping(FieldKind kind, string typeFullName = "", bool isValueType = false)
+        public TypeMapping(
+            FieldKind kind,
+            string typeFullName = "",
+            bool isValueType = false,
+            string declaredTypeName = "",
+            bool isNullable = false,
+            ImmutableArray<TypeMapping> typeArguments = default,
+            string enumUnderlyingTypeName = "")
         {
             Kind = kind;
             TypeFullName = typeFullName;
             IsValueType = isValueType;
+            DeclaredTypeName = declaredTypeName;
+            IsNullable = isNullable;
+            TypeArguments = typeArguments.IsDefault ? ImmutableArray<TypeMapping>.Empty : typeArguments;
+            EnumUnderlyingTypeName = enumUnderlyingTypeName;
         }
 
         public FieldKind Kind { get; }
@@ -1423,6 +2009,43 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         /// <see cref="FieldKind.Formatted"/> foreign-type formatter targets. Unused for every other kind.
         /// </summary>
         public bool IsValueType { get; }
+
+        /// <summary>
+        /// The exact fully-qualified C# type name (from <see cref="SymbolDisplayFormat.FullyQualifiedFormat"/>)
+        /// used to declare read temporaries and construct collection instances when this mapping is a
+        /// collection element/key/value. Populated only for mappings produced by <c>MapCollectionElement</c>.
+        /// For a <c>Nullable&lt;T&gt;</c> value element it includes the trailing <c>?</c> (for example
+        /// <c>int?</c>); for a reference element it is the non-nullable form.
+        /// </summary>
+        public string DeclaredTypeName { get; }
+
+        /// <summary>
+        /// For a collection element/key/value mapping: whether the element may be MessagePack <c>nil</c>.
+        /// True for a <c>Nullable&lt;T&gt;</c> value element or a nullable-annotated reference element.
+        /// Reference objects and nested collections are always nil-guarded regardless of this flag; it is
+        /// only load-bearing for distinguishing <c>T?</c> from <c>T</c> among value-type elements.
+        /// </summary>
+        public bool IsNullable { get; }
+
+        /// <summary>
+        /// Child mappings for a collection kind: a single element mapping for
+        /// <see cref="FieldKind.Array"/>/<see cref="FieldKind.List"/>/<see cref="FieldKind.ReadOnlyList"/>,
+        /// and [key, value] for <see cref="FieldKind.Dictionary"/>. Empty for every non-collection kind.
+        /// </summary>
+        public ImmutableArray<TypeMapping> TypeArguments { get; }
+
+        /// <summary>
+        /// For <see cref="FieldKind.UnsupportedEnumUnderlyingType"/>: the display name of the enum's
+        /// underlying type (for example <c>long</c>), carried alongside <see cref="TypeFullName"/> (the
+        /// enum itself) so AKKASG014 can name both. Empty for every other kind.
+        /// </summary>
+        public string EnumUnderlyingTypeName { get; }
+
+        public TypeMapping WithTypeFullName(string typeFullName)
+            => new(Kind, typeFullName, IsValueType, DeclaredTypeName, IsNullable, TypeArguments, EnumUnderlyingTypeName);
+
+        public TypeMapping AsCollectionElement(string declaredTypeName, bool isNullable)
+            => new(Kind, TypeFullName, IsValueType, declaredTypeName, isNullable, TypeArguments, EnumUnderlyingTypeName);
     }
 
     /// <summary>
@@ -1476,6 +2099,11 @@ public sealed class AkkaSerializerGenerator : IIncrementalGenerator
         Enum,
         Object,
         MissingSerializableDefinition,
-        Formatted
+        Formatted,
+        Array,
+        List,
+        ReadOnlyList,
+        Dictionary,
+        UnsupportedEnumUnderlyingType
     }
 }

--- a/src/core/Akka.Serialization.V2.Tests/AkkaSerializerGeneratorDiagnosticsSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/AkkaSerializerGeneratorDiagnosticsSpec.cs
@@ -733,6 +733,279 @@ public sealed class AkkaSerializerGeneratorDiagnosticsSpec
         diagnostics.Count(d => d.Id == "AKKASG013").Should().Be(1);
     }
 
+    [Fact(DisplayName = "Generator should not report AKKASG003 and should compile cleanly for natively-supported collection shapes")]
+    public void Generator_should_not_report_AKKASG003_for_supported_collection_shapes()
+    {
+        const string source = """
+            #nullable enable
+            using System.Collections.Generic;
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializer(Name = "sample", SerializerId = 121001)]
+            public sealed partial class SampleSerializer : MessagePackSerializer<IProtocol>
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable]
+            public sealed record Reading([property: AkkaField(1)] string SensorId, [property: AkkaField(2)] double Value);
+
+            [AkkaSerializable(Manifest = "collections-v1")]
+            public sealed record Collections(
+                [property: AkkaField(1)] int[] Ints,
+                [property: AkkaField(2)] List<string> Names,
+                [property: AkkaField(3)] IReadOnlyList<Reading> Readings,
+                [property: AkkaField(4)] Dictionary<int, string> Map,
+                [property: AkkaField(5)] List<List<int>> Matrix,
+                [property: AkkaField(6)] Dictionary<string, List<Reading>> Grouped,
+                [property: AkkaField(7)] List<int>? MaybeInts,
+                [property: AkkaField(8)] List<int?> OptionalInts) : IProtocol;
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        // The old ReadingBatch workaround existed because List<Reading> and friends hit AKKASG003; they
+        // are now natively supported, so AKKASG003 must not fire and the generated collection code must
+        // compile inside the in-memory compilation.
+        diagnostics.Should().NotContain(diagnostic => diagnostic.Id == "AKKASG003");
+        diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Generator should not report AKKASG003 for a List of a nested [AkkaSerializable] type")]
+    public void Generator_should_not_report_AKKASG003_for_list_of_serializable_type()
+    {
+        const string source = """
+            #nullable enable
+            using System.Collections.Generic;
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializer(Name = "sample", SerializerId = 121002)]
+            public sealed partial class SampleSerializer : MessagePackSerializer<IProtocol>
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable]
+            public sealed record Reading([property: AkkaField(1)] string SensorId, [property: AkkaField(2)] double Value);
+
+            [AkkaSerializable(Manifest = "batch-v1")]
+            public sealed record Batch([property: AkkaField(1)] List<Reading> Readings) : IProtocol;
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        diagnostics.Should().NotContain(diagnostic => diagnostic.Id == "AKKASG003");
+        diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Generator should still report AKKASG003 for a genuinely unsupported exotic collection type")]
+    public void Generator_should_report_AKKASG003_for_unsupported_exotic_type()
+    {
+        const string source = """
+            #nullable enable
+            using System.Collections.Generic;
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializer(Name = "sample", SerializerId = 121003)]
+            public sealed partial class SampleSerializer : MessagePackSerializer<IProtocol>
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            // HashSet<T> is deliberately outside the supported set (T[], List<T>, IReadOnlyList<T>,
+            // Dictionary<TKey,TValue>) -- the scope boundary must still fail with AKKASG003.
+            [AkkaSerializable(Manifest = "exotic-v1")]
+            public sealed record Exotic([property: AkkaField(1)] HashSet<int> Value) : IProtocol;
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        diagnostics.Should().Contain(diagnostic => diagnostic.Id == "AKKASG003" && diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact(DisplayName = "Generator should report AKKASG003 for a collection whose element type is unsupported")]
+    public void Generator_should_report_AKKASG003_for_collection_of_unsupported_element()
+    {
+        const string source = """
+            #nullable enable
+            using System.Collections.Generic;
+            using System.Text;
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            [AkkaSerializer(Name = "sample", SerializerId = 121004)]
+            public sealed partial class SampleSerializer : MessagePackSerializer<IProtocol>
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable(Manifest = "bad-element-v1")]
+            public sealed record BadElement([property: AkkaField(1)] List<StringBuilder> Values) : IProtocol;
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        // A collection whose element is unsupported collapses to unsupported so AKKASG003 fires with the
+        // full field type -- it must not silently emit ill-typed code or an incorrect encoding.
+        diagnostics.Should().Contain(diagnostic => diagnostic.Id == "AKKASG003" && diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact(DisplayName = "Generator should report AKKASG014 for a long-backed enum scalar field")]
+    public void Generator_should_report_AKKASG014_for_long_backed_enum_scalar_field()
+    {
+        const string source = """
+            #nullable enable
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            public enum LongStatus : long
+            {
+                A = 0,
+                Big = long.MaxValue
+            }
+
+            [AkkaSerializer(Name = "sample", SerializerId = 121005)]
+            public sealed partial class SampleSerializer : MessagePackSerializer<IProtocol>
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable(Manifest = "long-enum-v1")]
+            public sealed record LongEnumMessage([property: AkkaField(1)] LongStatus Status) : IProtocol;
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        // Enums encode as int32; a long-backed enum value outside int32 range would silently truncate,
+        // so it must be rejected at compile time -- naming both the enum and its backing type.
+        diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Id == "AKKASG014" &&
+            diagnostic.Severity == DiagnosticSeverity.Error &&
+            diagnostic.GetMessage(null).Contains("LongStatus", StringComparison.Ordinal) &&
+            diagnostic.GetMessage(null).Contains("long", StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "Generator should report AKKASG014 for a uint-backed enum inside a List<>")]
+    public void Generator_should_report_AKKASG014_for_uint_backed_enum_inside_list()
+    {
+        const string source = """
+            #nullable enable
+            using System.Collections.Generic;
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            public enum UIntStatus : uint
+            {
+                A = 0,
+                Big = uint.MaxValue
+            }
+
+            [AkkaSerializer(Name = "sample", SerializerId = 121006)]
+            public sealed partial class SampleSerializer : MessagePackSerializer<IProtocol>
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable(Manifest = "uint-enum-list-v1")]
+            public sealed record UIntEnumListMessage([property: AkkaField(1)] List<UIntStatus> Statuses) : IProtocol;
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        // The unsupported enum backing must propagate OUT of the collection so AKKASG014 fires naming
+        // the enum -- not collapse to the generic AKKASG003.
+        diagnostics.Should().Contain(diagnostic =>
+            diagnostic.Id == "AKKASG014" &&
+            diagnostic.Severity == DiagnosticSeverity.Error &&
+            diagnostic.GetMessage(null).Contains("UIntStatus", StringComparison.Ordinal) &&
+            diagnostic.GetMessage(null).Contains("uint", StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "Generator should not report AKKASG014 for int32-representable enum backings")]
+    public void Generator_should_not_report_AKKASG014_for_int32_representable_enum_backings()
+    {
+        const string source = """
+            #nullable enable
+            using System.Collections.Generic;
+            using Akka.Actor;
+            using Akka.Serialization.V2;
+
+            namespace DiagnosticSample;
+
+            public interface IProtocol
+            {
+            }
+
+            public enum IntStatus
+            {
+                A = 0,
+                B = 1
+            }
+
+            public enum ShortStatus : short
+            {
+                A = 0,
+                B = 1
+            }
+
+            [AkkaSerializer(Name = "sample", SerializerId = 121007)]
+            public sealed partial class SampleSerializer : MessagePackSerializer<IProtocol>
+            {
+                public static partial SerializerRegistration CreateRegistration();
+            }
+
+            [AkkaSerializable(Manifest = "ok-enum-v1")]
+            public sealed record OkEnumMessage(
+                [property: AkkaField(1)] IntStatus IntStatus,
+                [property: AkkaField(2)] ShortStatus ShortStatus,
+                [property: AkkaField(3)] List<ShortStatus> ShortStatuses) : IProtocol;
+            """;
+
+        var diagnostics = RunGenerator(source);
+
+        diagnostics.Should().NotContain(diagnostic => diagnostic.Id == "AKKASG014");
+        diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).Should().BeEmpty();
+    }
+
     private static ImmutableArray<Diagnostic> RunGenerator(string source)
     {
         var parseOptions = CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12);

--- a/src/core/Akka.Serialization.V2.Tests/CollectionFieldSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/CollectionFieldSpec.cs
@@ -1,0 +1,559 @@
+//-----------------------------------------------------------------------
+// <copyright file="CollectionFieldSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Akka.Actor;
+using FluentAssertions;
+using MessagePack;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Native collection support (<c>T[]</c>, <c>List&lt;T&gt;</c>, <c>IReadOnlyList&lt;T&gt;</c>,
+/// <c>Dictionary&lt;TKey,TValue&gt;</c>) for the Akka.Serialization.V2 generator, including nested
+/// collections, null-vs-empty distinction, nullable value elements, and dictionaries with non-string
+/// keys. The WIRE-FORMAT GOLDEN tests freeze the exact bytes so any future encoding drift fails loudly.
+/// </summary>
+public sealed class CollectionFieldSpec : IAsyncLifetime
+{
+    private ActorSystem _system = null!;
+    private CollectionTestSerializer _serializer = null!;
+
+    public ValueTask InitializeAsync()
+    {
+        _system = ActorSystem.Create("collection-field-spec");
+        _serializer = new CollectionTestSerializer((ExtendedActorSystem)_system);
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _system.Terminate();
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Round-trip: populated
+    // ------------------------------------------------------------------------------------------
+
+    [Fact(DisplayName = "Generated serializer should round-trip a populated int array")]
+    public void Should_round_trip_populated_int_array()
+    {
+        var message = new IntArrayMessage(new[] { 10, 20, 30 });
+        RoundTrip(message).Values.Should().Equal(10, 20, 30);
+    }
+
+    [Fact(DisplayName = "Generated serializer should round-trip a populated List<string>")]
+    public void Should_round_trip_populated_string_list()
+    {
+        var message = new StringListMessage(new List<string> { "alpha", "beta", "gamma" });
+        RoundTrip(message).Names.Should().Equal("alpha", "beta", "gamma");
+    }
+
+    [Fact(DisplayName = "Generated serializer should round-trip a populated IReadOnlyList of nested objects")]
+    public void Should_round_trip_populated_reading_readonly_list()
+    {
+        var message = new ReadingListMessage(new List<CollReading>
+        {
+            new("s-1", 1.5),
+            new("s-2", 2.5)
+        });
+
+        RoundTrip(message).Readings.Should().Equal(new CollReading("s-1", 1.5), new CollReading("s-2", 2.5));
+    }
+
+    [Fact(DisplayName = "Generated serializer should round-trip a Dictionary with non-string keys")]
+    public void Should_round_trip_dictionary_with_non_string_keys()
+    {
+        var message = new IntStringDictMessage(new Dictionary<int, string>
+        {
+            [1] = "one",
+            [2] = "two",
+            [3] = "three"
+        });
+
+        RoundTrip(message).Map.Should().BeEquivalentTo(new Dictionary<int, string>
+        {
+            [1] = "one",
+            [2] = "two",
+            [3] = "three"
+        });
+    }
+
+    [Fact(DisplayName = "Generated serializer should round-trip a Dictionary keyed by Guid")]
+    public void Should_round_trip_dictionary_with_guid_keys()
+    {
+        var a = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var b = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var message = new GuidReadingDictMessage(new Dictionary<Guid, CollReading>
+        {
+            [a] = new("s-a", 1.0),
+            [b] = new("s-b", 2.0)
+        });
+
+        var recovered = RoundTrip(message);
+        recovered.Map.Should().BeEquivalentTo(new Dictionary<Guid, CollReading>
+        {
+            [a] = new("s-a", 1.0),
+            [b] = new("s-b", 2.0)
+        });
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Round-trip: nested composition
+    // ------------------------------------------------------------------------------------------
+
+    [Fact(DisplayName = "Generated serializer should round-trip nested List<List<int>>")]
+    public void Should_round_trip_nested_int_lists()
+    {
+        var message = new NestedListMessage(new List<List<int>>
+        {
+            new() { 1, 2 },
+            new() { 3 },
+            new()
+        });
+
+        var recovered = RoundTrip(message);
+        recovered.Matrix.Should().HaveCount(3);
+        recovered.Matrix[0].Should().Equal(1, 2);
+        recovered.Matrix[1].Should().Equal(3);
+        recovered.Matrix[2].Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Generated serializer should round-trip Dictionary<string, List<Reading>>")]
+    public void Should_round_trip_dictionary_of_reading_lists()
+    {
+        var message = new DictOfListMessage(new Dictionary<string, List<CollReading>>
+        {
+            ["group-a"] = new() { new("s-1", 1.0), new("s-2", 2.0) },
+            ["group-b"] = new() { new("s-3", 3.0) }
+        });
+
+        var recovered = RoundTrip(message);
+        recovered.Grouped.Should().ContainKey("group-a");
+        recovered.Grouped["group-a"].Should().Equal(new CollReading("s-1", 1.0), new CollReading("s-2", 2.0));
+        recovered.Grouped["group-b"].Should().Equal(new CollReading("s-3", 3.0));
+    }
+
+    [Fact(DisplayName = "Generated serializer should round-trip an array of nested objects")]
+    public void Should_round_trip_array_of_nested_objects()
+    {
+        var message = new ReadingArrayMessage(new[] { new CollReading("s-1", 1.0), new CollReading("s-2", 2.0) });
+        RoundTrip(message).Readings.Should().Equal(new CollReading("s-1", 1.0), new CollReading("s-2", 2.0));
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Round-trip: null vs empty (distinct)
+    // ------------------------------------------------------------------------------------------
+
+    [Fact(DisplayName = "Generated serializer should round-trip a null nullable collection as null")]
+    public void Should_round_trip_null_collection_as_null()
+    {
+        var message = new NullableCollectionsMessage(null, null, null);
+        var recovered = RoundTrip(message);
+
+        recovered.MaybeInts.Should().BeNull();
+        recovered.MaybeMap.Should().BeNull();
+        recovered.MaybeReadings.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Generated serializer should round-trip an empty collection as empty (distinct from null)")]
+    public void Should_round_trip_empty_collection_as_empty()
+    {
+        var message = new NullableCollectionsMessage(
+            new List<int>(),
+            new Dictionary<string, int>(),
+            Array.Empty<CollReading>());
+        var recovered = RoundTrip(message);
+
+        recovered.MaybeInts.Should().NotBeNull().And.BeEmpty();
+        recovered.MaybeMap.Should().NotBeNull().And.BeEmpty();
+        recovered.MaybeReadings.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact(DisplayName = "Generated serializer should encode null and empty collections as different bytes")]
+    public void Should_encode_null_and_empty_collections_as_different_bytes()
+    {
+        var nullBytes = _serializer.ToBinary(new NullableIntArrayMessage(null));
+        var emptyBytes = _serializer.ToBinary(new NullableIntArrayMessage(Array.Empty<int>()));
+
+        // nil (0xc0) vs array header 0 (0x90): distinct on the wire.
+        nullBytes.Should().Equal(0x81, 0x01, 0xc0);
+        emptyBytes.Should().Equal(0x81, 0x01, 0x90);
+        nullBytes.Should().NotEqual(emptyBytes);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Round-trip: nullable value elements
+    // ------------------------------------------------------------------------------------------
+
+    [Fact(DisplayName = "Generated serializer should round-trip a List of nullable value elements")]
+    public void Should_round_trip_list_of_nullable_value_elements()
+    {
+        var message = new NullableElementListMessage(new List<int?> { 1, null, 3, null });
+        RoundTrip(message).OptionalInts.Should().Equal(1, null, 3, null);
+    }
+
+    [Fact(DisplayName = "Generated serializer should round-trip a List of enum elements")]
+    public void Should_round_trip_list_of_enum_elements()
+    {
+        var message = new EnumListMessage(new List<CollStatus> { CollStatus.A, CollStatus.C, CollStatus.B });
+        RoundTrip(message).Statuses.Should().Equal(CollStatus.A, CollStatus.C, CollStatus.B);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Equality: structural round-trip equality
+    // ------------------------------------------------------------------------------------------
+
+    [Fact(DisplayName = "Generated serializer should preserve structural equality of a collection-bearing record")]
+    public void Should_preserve_structural_equality_of_collection_record()
+    {
+        var message = new EquatableListMessage(new List<CollReading> { new("s-1", 1.0), new("s-2", 2.0) });
+        RoundTrip(message).Should().Be(message);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Round-trip: jagged arrays (array-of-array composition)
+    // ------------------------------------------------------------------------------------------
+
+    [Fact(DisplayName = "Generated serializer should round-trip a populated jagged int array")]
+    public void Should_round_trip_populated_jagged_int_array()
+    {
+        var message = new JaggedIntArrayMessage(new[] { new[] { 1, 2 }, new[] { 3 } });
+        var recovered = RoundTrip(message);
+
+        recovered.Rows.Should().NotBeNull();
+        recovered.Rows!.Length.Should().Be(2);
+        recovered.Rows[0].Should().Equal(1, 2);
+        recovered.Rows[1].Should().Equal(3);
+    }
+
+    [Fact(DisplayName = "Generated serializer should round-trip a jagged int array with an empty inner array")]
+    public void Should_round_trip_jagged_int_array_with_empty_inner()
+    {
+        var message = new JaggedIntArrayMessage(new[] { Array.Empty<int>(), new[] { 5 } });
+        var recovered = RoundTrip(message);
+
+        recovered.Rows.Should().NotBeNull();
+        recovered.Rows!.Length.Should().Be(2);
+        recovered.Rows[0].Should().BeEmpty();
+        recovered.Rows[1].Should().Equal(5);
+    }
+
+    [Fact(DisplayName = "Generated serializer should round-trip a null outer jagged array as null")]
+    public void Should_round_trip_null_outer_jagged_array()
+    {
+        var recovered = RoundTrip(new JaggedIntArrayMessage(null));
+        recovered.Rows.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Generated serializer should round-trip a jagged array of nested objects")]
+    public void Should_round_trip_jagged_array_of_nested_objects()
+    {
+        var message = new ReadingGridMessage(new[]
+        {
+            new[] { new CollReading("s-1", 1.0) },
+            new[] { new CollReading("s-2", 2.0), new CollReading("s-3", 3.0) }
+        });
+        var recovered = RoundTrip(message);
+
+        recovered.Grid.Length.Should().Be(2);
+        recovered.Grid[0].Should().Equal(new CollReading("s-1", 1.0));
+        recovered.Grid[1].Should().Equal(new CollReading("s-2", 2.0), new CollReading("s-3", 3.0));
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Size hint exactness (collections participate in exact sizing)
+    // ------------------------------------------------------------------------------------------
+
+    [Fact(DisplayName = "Generated serializer should report exact size hints for collection messages")]
+    public void Should_report_exact_size_hints_for_collection_messages()
+    {
+        var intArray = new IntArrayMessage(new[] { 10, 20, 30 });
+        var stringList = new StringListMessage(new List<string> { "alpha", "beta" });
+        var readingList = new ReadingListMessage(new List<CollReading> { new("s-1", 1.5), new("s-2", 2.5) });
+        var dict = new IntStringDictMessage(new Dictionary<int, string> { [1] = "one", [2] = "two" });
+        var nested = new NestedListMessage(new List<List<int>> { new() { 1, 2 }, new() { 3 } });
+        var nullable = new NullableCollectionsMessage(null, null, null);
+        var nullableElements = new NullableElementListMessage(new List<int?> { 1, null, 3 });
+        var enums = new EnumListMessage(new List<CollStatus> { CollStatus.A, CollStatus.C });
+        var jagged = new JaggedIntArrayMessage(new[] { new[] { 1, 2 }, Array.Empty<int>() });
+        var grid = new ReadingGridMessage(new[] { new[] { new CollReading("s-1", 1.0) } });
+
+        _serializer.SizeHint(jagged).Should().Be(_serializer.ToBinary(jagged).Length);
+        _serializer.SizeHint(grid).Should().Be(_serializer.ToBinary(grid).Length);
+        _serializer.SizeHint(enums).Should().Be(_serializer.ToBinary(enums).Length);
+        _serializer.SizeHint(intArray).Should().Be(_serializer.ToBinary(intArray).Length);
+        _serializer.SizeHint(stringList).Should().Be(_serializer.ToBinary(stringList).Length);
+        _serializer.SizeHint(readingList).Should().Be(_serializer.ToBinary(readingList).Length);
+        _serializer.SizeHint(dict).Should().Be(_serializer.ToBinary(dict).Length);
+        _serializer.SizeHint(nested).Should().Be(_serializer.ToBinary(nested).Length);
+        _serializer.SizeHint(nullable).Should().Be(_serializer.ToBinary(nullable).Length);
+        _serializer.SizeHint(nullableElements).Should().Be(_serializer.ToBinary(nullableElements).Length);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // WIRE-FORMAT GOLDEN TESTS (exact bytes -- the permanence guarantee)
+    // ------------------------------------------------------------------------------------------
+
+    [Fact(DisplayName = "GOLDEN: int array encodes as MessagePack array framing")]
+    public void Golden_int_array()
+    {
+        var bytes = _serializer.ToBinary(new IntArrayMessage(new[] { 10, 20, 30 }));
+
+        // 81            map header, 1 field
+        //   01          field id 1
+        //   93          array header, 3 elements
+        //     0a 14 1e  ints 10, 20, 30
+        bytes.Should().Equal(0x81, 0x01, 0x93, 0x0a, 0x14, 0x1e);
+    }
+
+    [Fact(DisplayName = "GOLDEN: empty array encodes as a zero-length array header")]
+    public void Golden_empty_array()
+    {
+        var bytes = _serializer.ToBinary(new NullableIntArrayMessage(Array.Empty<int>()));
+        bytes.Should().Equal(0x81, 0x01, 0x90);
+    }
+
+    [Fact(DisplayName = "GOLDEN: null nullable array encodes as nil")]
+    public void Golden_null_array()
+    {
+        var bytes = _serializer.ToBinary(new NullableIntArrayMessage(null));
+        bytes.Should().Equal(0x81, 0x01, 0xc0);
+    }
+
+    [Fact(DisplayName = "GOLDEN: Dictionary<int,string> encodes as MessagePack map framing")]
+    public void Golden_int_string_dictionary()
+    {
+        var bytes = _serializer.ToBinary(new IntStringDictMessage(new Dictionary<int, string> { [5] = "hi" }));
+
+        // 81            map header, 1 field
+        //   01          field id 1
+        //   81          map header, 1 entry
+        //     05        key int 5
+        //     a2 68 69  value "hi"
+        bytes.Should().Equal(0x81, 0x01, 0x81, 0x05, 0xa2, 0x68, 0x69);
+    }
+
+    [Fact(DisplayName = "GOLDEN: List of nested objects encodes as an array of field-id maps")]
+    public void Golden_reading_list()
+    {
+        var bytes = _serializer.ToBinary(new ReadingListMessage(new List<CollReading> { new("s", 1.5) }));
+
+        // 81                          map header, 1 field
+        //   01                        field id 1
+        //   91                        array header, 1 element
+        //     82                      CollReading map header, 2 fields
+        //       01 a1 73              field 1 = "s"
+        //       02 cb 3ff8000000000000  field 2 = double 1.5
+        bytes.Should().Equal(
+            0x81, 0x01, 0x91,
+            0x82,
+            0x01, 0xa1, 0x73,
+            0x02, 0xcb, 0x3f, 0xf8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+    }
+
+    [Fact(DisplayName = "GOLDEN: nested List<List<int>> encodes as nested array framing")]
+    public void Golden_nested_int_lists()
+    {
+        var bytes = _serializer.ToBinary(new NestedListMessage(new List<List<int>>
+        {
+            new() { 1, 2 },
+            new() { 3 }
+        }));
+
+        // 81         map header, 1 field
+        //   01       field id 1
+        //   92       outer array header, 2 elements
+        //     92     inner array header, 2 elements
+        //       01 02
+        //     91     inner array header, 1 element
+        //       03
+        bytes.Should().Equal(0x81, 0x01, 0x92, 0x92, 0x01, 0x02, 0x91, 0x03);
+    }
+
+    [Fact(DisplayName = "GOLDEN: enum list encodes each element as an int32")]
+    public void Golden_enum_list()
+    {
+        var bytes = _serializer.ToBinary(new EnumListMessage(new List<CollStatus> { CollStatus.B }));
+
+        // 81      map header, 1 field
+        //   01    field id 1
+        //   91    array header, 1 element
+        //     01  enum CollStatus.B == 1 written as int32
+        bytes.Should().Equal(0x81, 0x01, 0x91, 0x01);
+    }
+
+    [Fact(DisplayName = "GOLDEN: jagged int array encodes as nested array framing (identical to List<List<int>>)")]
+    public void Golden_jagged_int_array()
+    {
+        var bytes = _serializer.ToBinary(new JaggedIntArrayMessage(new[] { new[] { 1, 2 }, Array.Empty<int>() }));
+
+        // 81         map header, 1 field
+        //   01       field id 1
+        //   92       outer array header, 2 elements
+        //     92     inner array header, 2 elements
+        //       01 02
+        //     90     inner array header, 0 elements (empty inner array)
+        bytes.Should().Equal(0x81, 0x01, 0x92, 0x92, 0x01, 0x02, 0x90);
+    }
+
+    [Fact(DisplayName = "GOLDEN: null outer jagged array encodes as nil")]
+    public void Golden_null_outer_jagged_array()
+    {
+        var bytes = _serializer.ToBinary(new JaggedIntArrayMessage(null));
+        bytes.Should().Equal(0x81, 0x01, 0xc0);
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Forward compatibility: unknown collection field is skipped whole
+    // ------------------------------------------------------------------------------------------
+
+    [Fact(DisplayName = "Generated serializer should skip an unknown collection field")]
+    public void Should_skip_unknown_collection_field()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new MessagePackWriter(buffer);
+        writer.WriteMapHeader(2);
+        writer.Write(99);
+        writer.WriteArrayHeader(2);
+        writer.Write(7);
+        writer.Write(8);
+        writer.Write(1);
+        writer.WriteArrayHeader(2);
+        writer.Write(10);
+        writer.Write(20);
+        writer.Flush();
+
+        var deserialized = _serializer.Deserialize(new ReadOnlySequence<byte>(buffer.WrittenMemory), "coll-int-array-v1");
+        deserialized.Should().BeOfType<IntArrayMessage>().Subject.Values.Should().Equal(10, 20);
+    }
+
+    [Fact(DisplayName = "Generated serializer should reject a nil-on-the-wire non-nullable collection")]
+    public void Should_reject_nil_for_non_nullable_collection()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new MessagePackWriter(buffer);
+        writer.WriteMapHeader(1);
+        writer.Write(1);
+        writer.WriteNil();
+        writer.Flush();
+
+        Action deserialize = () => _serializer.Deserialize(new ReadOnlySequence<byte>(buffer.WrittenMemory), "coll-int-array-v1");
+        deserialize.Should().Throw<SerializationException>().WithMessage("*Missing required field [Values]*");
+    }
+
+    private TMessage RoundTrip<TMessage>(TMessage message)
+        where TMessage : class, ICollectionProtocol
+    {
+        var bytes = _serializer.ToBinary(message);
+        var manifest = _serializer.Manifest(message);
+        return _serializer.FromBinary(bytes, manifest).Should().BeOfType<TMessage>().Subject;
+    }
+}
+
+public interface ICollectionProtocol
+{
+}
+
+[AkkaSerializer(Name = "collection-test", SerializerId = 120105)]
+public sealed partial class CollectionTestSerializer : MessagePackSerializer<ICollectionProtocol>
+{
+    public static partial SerializerRegistration CreateRegistration();
+}
+
+[AkkaSerializable]
+public sealed record CollReading(
+    [property: AkkaField(1)] string SensorId,
+    [property: AkkaField(2)] double Value);
+
+[AkkaSerializable(Manifest = "coll-int-array-v1")]
+public sealed record IntArrayMessage(
+    [property: AkkaField(1)] int[] Values) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-nullable-int-array-v1")]
+public sealed record NullableIntArrayMessage(
+    [property: AkkaField(1)] int[]? Values) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-string-list-v1")]
+public sealed record StringListMessage(
+    [property: AkkaField(1)] List<string> Names) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-reading-list-v1")]
+public sealed record ReadingListMessage(
+    [property: AkkaField(1)] IReadOnlyList<CollReading> Readings) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-reading-array-v1")]
+public sealed record ReadingArrayMessage(
+    [property: AkkaField(1)] CollReading[] Readings) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-int-string-dict-v1")]
+public sealed record IntStringDictMessage(
+    [property: AkkaField(1)] Dictionary<int, string> Map) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-guid-reading-dict-v1")]
+public sealed record GuidReadingDictMessage(
+    [property: AkkaField(1)] Dictionary<Guid, CollReading> Map) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-nested-list-v1")]
+public sealed record NestedListMessage(
+    [property: AkkaField(1)] List<List<int>> Matrix) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-dict-of-list-v1")]
+public sealed record DictOfListMessage(
+    [property: AkkaField(1)] Dictionary<string, List<CollReading>> Grouped) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-nullable-v1")]
+public sealed record NullableCollectionsMessage(
+    [property: AkkaField(1)] List<int>? MaybeInts,
+    [property: AkkaField(2)] Dictionary<string, int>? MaybeMap,
+    [property: AkkaField(3)] CollReading[]? MaybeReadings) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-nullable-elements-v1")]
+public sealed record NullableElementListMessage(
+    [property: AkkaField(1)] List<int?> OptionalInts) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-jagged-int-v1")]
+public sealed record JaggedIntArrayMessage(
+    [property: AkkaField(1)] int[][]? Rows) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-reading-grid-v1")]
+public sealed record ReadingGridMessage(
+    [property: AkkaField(1)] CollReading[][] Grid) : ICollectionProtocol;
+
+public enum CollStatus
+{
+    A = 0,
+    B = 1,
+    C = 2
+}
+
+[AkkaSerializable(Manifest = "coll-enum-list-v1")]
+public sealed record EnumListMessage(
+    [property: AkkaField(1)] List<CollStatus> Statuses) : ICollectionProtocol;
+
+[AkkaSerializable(Manifest = "coll-equatable-v1")]
+public sealed record EquatableListMessage(
+    [property: AkkaField(1)] List<CollReading> Readings) : ICollectionProtocol
+{
+    public bool Equals(EquatableListMessage? other)
+        => other is not null && Readings.SequenceEqual(other.Readings);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var reading in Readings)
+            hash.Add(reading);
+        return hash.ToHashCode();
+    }
+}


### PR DESCRIPTION
Closes #8349. Adds native collection field support to the Akka.Serialization.V2 source generator: `T[]` (including jagged arrays), `List<T>`, `IReadOnlyList<T>`, and `Dictionary<TKey, TValue>`, composing recursively (`List<List<int>>`, `Dictionary<string, List<Reading>>`), using MessagePack array/map framing built from the same writer/reader primitives the generator already emits. `null` and empty round-trip as distinct values. AKKASG003 no longer fires for these shapes and still fires for genuinely unsupported ones.

Because this is permanent wire format, the exact encoding matrix comes first — the golden-bytes tests in `CollectionFieldSpec` pin every row of it with hardcoded hex literals, so any future drift fails loudly.

---

# Akka.Serialization.V2 generator — native collection encoding matrix

This is the **permanent MessagePack wire format** for collection-typed `[AkkaField]` members
emitted by `AkkaSerializerGenerator`. All framing reuses the existing `MessagePackWriter`/
`MessagePackReader` primitives the generator already emits for scalar and nested-object fields, so
collection fields sit inside the same explicit field-id map (`writer.Write(index)` then the value)
as every other field. Every field still encodes as exactly **one** top-level MessagePack value, so
the unknown-field forward-compat `reader.Skip()` path skips a collection field whole.

`nil` is MessagePack `0xc0`. Array/map headers are the standard MessagePack fix/16/32 headers whose
size is computed by the existing `SizeOfArrayHeader`/`SizeOfMapHeader` helpers.

## Supported field/element shapes

Element/key/value types (`T`, `TKey`, `TValue`) may be any already-supported kind — primitives,
`string`, `byte[]`, `enum`, `Guid`, `DateTime`, `DateTimeOffset`, `decimal`, `IActorRef`, another
`[AkkaSerializable]` type — **or another supported collection** (collections compose recursively).

| Field shape | Non-null encoding | `null` encoding | Empty encoding | Element / nesting rule |
|---|---|---|---|---|
| `T[]` | `array header(N)` + N × `encode(element)` | `nil` | `array header(0)` | each element encoded by its own kind's rule; recurses for nested collections |
| `List<T>` | `array header(N)` + N × `encode(element)` | `nil` | `array header(0)` | same as `T[]`; materialized as `List<T>` on read |
| `IReadOnlyList<T>` | `array header(N)` + N × `encode(element)` | `nil` | `array header(0)` | same as `T[]`; materialized as `List<T>` (assignable to `IReadOnlyList<T>`) on read |
| `Dictionary<TKey,TValue>` | `map header(N)` + N × (`encode(key)` `encode(value)`) | `nil` | `map header(0)` | key then value, each encoded by its own kind's rule; both recurse |

`null` vs empty are **distinct**: a null collection is a single `nil` byte; an empty collection is an
`array header(0)` / `map header(0)` (also a single byte for count 0, but a different byte and a
different decoded value). Round-tripping preserves the distinction for nullable collection fields
(`List<T>?`). A **non-nullable** collection field that is `null` on the wire is rejected on read with
the same "Missing required field" error as any other non-nullable reference field.

## Per-element encoding (the `encode(element)` rule)

| Element kind | Encoding | Null handling |
|---|---|---|
| `int`/`long`/`bool`/`double` | `writer.Write(...)` | value type — no nil (unless element is `T?`) |
| `decimal` | 4-element `array` of the int32 bits | value type — no nil (unless `decimal?`) |
| `Guid` | 16-byte `bin` | value type — no nil (unless `Guid?`) |
| `DateTime` | 2-element `array` (ticks, kind) | value type — no nil (unless `DateTime?`) |
| `DateTimeOffset` | 2-element `array` (ticks, offset-minutes) | value type — no nil (unless `DateTimeOffset?`) |
| `enum` | `writer.Write((int)value)` — underlying type must be fully int32-representable (`sbyte`/`byte`/`short`/`ushort`/`int`); `uint`/`long`/`ulong`-backed enums are rejected at compile time with AKKASG014, for scalar fields and collection elements alike | value type — no nil (unless `TEnum?`) |
| `Nullable<T>` value element (`int?`, `Guid?`, `TEnum?`, `[AkkaSerializable]` struct `S?`) | `nil` when null, else the underlying encoding | `nil` |
| `string` | `writer.Write(string?)` — natively nil-aware | `nil` (round-trips as null) |
| `byte[]` | `bin` — natively nil-aware | `nil` (round-trips as null) |
| `IActorRef` | serialized-path `string` | null/`NoSender` → empty string (same as a scalar `IActorRef` field) |
| `[AkkaSerializable]` **class** element | `nil` when null, else the type's field-id `map` (`WriteXxx`) | `nil` |
| `[AkkaSerializable]` **struct** element (non-nullable) | the type's field-id `map` (`WriteXxx`) | value type — no nil |
| nested collection element (`List<List<int>>`, `Dictionary<string,List<Reading>>`, …) | `nil` when null, else the nested `array`/`map` framing above | `nil` (self-contained) |

## Consistency / permanence guarantees

- Collection framing is byte-identical to the hand-written `ReadingBatchFormatter` it replaces
  (array-of-3-field-maps), so the benchmark canonical message is wire-compatible with the format it
  had before this change.
- Element order is preserved as enumerated (arrays/lists in index order; dictionaries in enumerator
  order, which the writer emits and the reader restores 1:1 — no reordering).
- Unsupported element/key/value kinds collapse the whole field to unsupported, so `AKKASG003` still
  fires (with the full field type in the message) for genuinely unsupported shapes. One exception:
  an enum element with a non-int32-representable underlying type propagates out of the collection as
  `AKKASG014`, naming the enum and its backing type, rather than the generic `AKKASG003`.
- Jagged arrays (`int[][]`, `Reading[][]`, …) compose exactly like `List<List<T>>` — nested array
  framing, byte-identical to the list forms — and are covered by their own golden tests.


---

Also added while closing the review findings: **AKKASG014**, a new compile-time error for enums whose underlying type is not fully int32-representable (`uint`/`long`/`ulong`-backed). The generator encodes enums as int32, so those backings silently truncated — on the pre-existing scalar path as well as the new collection path. V2 is unreleased, so this is the last moment that footgun could be rejected outright rather than documented.

Dogfooding: the RemotePingPong V2 arm's hand-written non-generic `ReadingBatch` wrapper and its custom formatter — which existed only because of this gap — are deleted; the message now uses a native `IReadOnlyList<Reading>`. The native framing is byte-identical to the hand-written formatter it replaces (canonical message stays exactly 348 bytes, verified by the startup round-trip check), which is a nice structural confirmation that the encoding matches what a careful human would have written.

AKKASG011 (the generic-formatter-target restriction from the issue's problem 2) is untouched — it governs the formatter escape hatch, which is orthogonal now that collections are supported natively; it can get its own issue if someone still needs generic formatter targets.

Verification: Akka.Serialization.V2.Tests 106/106 (33 new: round-trips for every shape incl. null/empty/nested/jagged/non-string dictionary keys, 9 exact-hex golden tests, exact size-hint assertions, unknown-field skip, and the new diagnostics); Akka.API.Tests 18/18 with zero approval churn; Akka.Tests serialization suite 87/87; all touched projects build clean under `-warnaserror`.
