### PR TITLE
RemotePingPong: MessagePack real-payload serializer arm

### DIFF
--- a/src/benchmark/RemotePingPong/Program.cs
+++ b/src/benchmark/RemotePingPong/Program.cs
@@ -88,10 +88,12 @@ namespace RemotePingPong
         private static string _payloadMode = "toy";
 
         // Selected once at startup via the "--serializer" option: "v2" (Akka.Serialization.V2
-        // source-generated MessagePack) or "protobuf" (hand-written Google.Protobuf, string manifest).
-        // Only meaningful when _payloadMode is "real" - see BuildRootCommand()'s cross-option
-        // validators, which require --serializer whenever --payload real is given and reject it
-        // otherwise.
+        // source-generated MessagePack), "protobuf" (hand-written Google.Protobuf, string manifest),
+        // or "msgpack" (hand-written SerializerWithStringManifest over an attribute-based
+        // [MessagePackObject]/[Key(n)] POCO, using MessagePack directly rather than through the V2
+        // generator). Only meaningful when _payloadMode is "real" - see BuildRootCommand()'s
+        // cross-option validators, which require --serializer whenever --payload real is given and
+        // reject it otherwise.
         private static string? _serializerArm;
 
         // The actual object every "hit"/priming Tell sends, resolved once per process by
@@ -374,8 +376,17 @@ namespace RemotePingPong
                     ""RemotePingPong.RealPayload.Protobuf.RealBenchmarkMessage, RemotePingPong"" = real-benchmark-protobuf
                   }
                 }"),
+                "msgpack" => ConfigurationFactory.ParseString(@"
+                akka.actor {
+                  serializers {
+                    real-benchmark-msgpack = ""RemotePingPong.RealPayload.MsgPack.RealBenchmarkMsgPackSerializer, RemotePingPong""
+                  }
+                  serialization-bindings {
+                    ""RemotePingPong.RealPayload.MsgPack.RealBenchmarkMessage, RemotePingPong"" = real-benchmark-msgpack
+                  }
+                }"),
                 _ => throw new InvalidOperationException(
-                    "\"--payload real\" requires --serializer to have been resolved (v2|protobuf) before " +
+                    "\"--payload real\" requires --serializer to have been resolved (v2|protobuf|msgpack) before " +
                     "an ActorSystem config can be built - this should have been rejected by the CLI's " +
                     "cross-option validators before reaching here.")
             };
@@ -398,8 +409,9 @@ namespace RemotePingPong
             {
                 "v2" => canonical,
                 "protobuf" => RealPayload.RealPayloadFactory.ToProtobuf(canonical),
+                "msgpack" => RealPayload.RealPayloadFactory.ToMsgPack(canonical),
                 _ => throw new InvalidOperationException(
-                    "\"--payload real\" requires --serializer to have been resolved (v2|protobuf) before " +
+                    "\"--payload real\" requires --serializer to have been resolved (v2|protobuf|msgpack) before " +
                     "the payload instance can be built - this should have been rejected by the CLI's " +
                     "cross-option validators before reaching here.")
             };
@@ -431,6 +443,7 @@ namespace RemotePingPong
             {
                 "v2" => typeof(RealPayload.V2.RealBenchmarkSerializer),
                 "protobuf" => typeof(RealPayload.Protobuf.RealBenchmarkProtobufSerializer),
+                "msgpack" => typeof(RealPayload.MsgPack.RealBenchmarkMsgPackSerializer),
                 _ => throw new InvalidOperationException($"Unknown --serializer value [{_serializerArm}].")
             };
 
@@ -607,15 +620,17 @@ namespace RemotePingPong
             var serializerOption = new Option<string?>("--serializer")
             {
                 Description = "Real-payload serializer arm: \"v2\" (Akka.Serialization.V2 source-generated " +
-                              "MessagePack) or \"protobuf\" (hand-written Google.Protobuf, string manifest). " +
+                              "MessagePack), \"protobuf\" (hand-written Google.Protobuf, string manifest), or " +
+                              "\"msgpack\" (hand-written SerializerWithStringManifest over an attribute-based " +
+                              "[MessagePackObject]/[Key(n)] POCO, MessagePack's Standard resolver, no compression). " +
                               "Required when --payload real is given; rejected otherwise (--payload toy has no " +
                               "custom serializer to select)."
             };
             serializerOption.Validators.Add(result =>
             {
                 var value = result.GetValueOrDefault<string?>();
-                if (value is not null && value != "v2" && value != "protobuf")
-                    result.AddError($"--serializer must be \"v2\" or \"protobuf\" (got \"{value}\").");
+                if (value is not null && value != "v2" && value != "protobuf" && value != "msgpack")
+                    result.AddError($"--serializer must be \"v2\", \"protobuf\", or \"msgpack\" (got \"{value}\").");
             });
 
             void AddPayloadSerializerValidation(Command command)
@@ -625,7 +640,7 @@ namespace RemotePingPong
                     var payload = result.GetValue(payloadOption);
                     var serializer = result.GetValue(serializerOption);
                     if (payload == "real" && serializer is null)
-                        result.AddError("--serializer <v2|protobuf> is required when --payload real is specified.");
+                        result.AddError("--serializer <v2|protobuf|msgpack> is required when --payload real is specified.");
                     else if (payload != "real" && serializer is not null)
                         result.AddError("--serializer is only meaningful with --payload real (omit --serializer, " +
                                          "or add --payload real).");

--- a/src/benchmark/RemotePingPong/RealPayload/MsgPack/RealBenchmarkMessages.cs
+++ b/src/benchmark/RemotePingPong/RealPayload/MsgPack/RealBenchmarkMessages.cs
@@ -1,0 +1,106 @@
+//-----------------------------------------------------------------------
+// <copyright file="RealBenchmarkMessages.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MessagePack;
+
+namespace RemotePingPong.RealPayload.MsgPack
+{
+    /// <summary>
+    /// Realistic benchmark message: several primitives, a string, a nested complex type
+    /// (<see cref="DeviceInfo"/>), and a collection (<see cref="ReadingBatch"/>). This is the
+    /// MessagePack arm's wire type -- a plain attribute-based POCO (<c>[MessagePackObject]</c>/
+    /// <c>[Key(n)]</c>), NOT the V2 arm's Akka.Serialization.V2 source-generated type. The
+    /// logically-identical V2/Protobuf arm types are
+    /// <see cref="RemotePingPong.RealPayload.V2.RealBenchmarkMessage"/> and
+    /// <see cref="RemotePingPong.RealPayload.Protobuf.RealBenchmarkMessage"/> -- all three are built
+    /// from one canonical <see cref="V2.RealBenchmarkMessage"/> instance by
+    /// <see cref="RemotePingPong.RealPayload.RealPayloadFactory"/>, so all three arms always carry
+    /// identical logical content.
+    /// </summary>
+    /// <remarks>
+    /// Keys are 0-based and contiguous (0-6) so MessagePack's Standard resolver serializes this type
+    /// as a compact array (one slot per key) rather than falling back to a map -- the array format is
+    /// what "raw serializer speed" means for this arm (see
+    /// <see cref="RemotePingPong.RealPayload.MsgPack.RealBenchmarkMsgPackSerializer"/>'s remarks).
+    /// </remarks>
+    [MessagePackObject]
+    public sealed record RealBenchmarkMessage(
+        [property: Key(0)] int SequenceNumber,
+        [property: Key(1)] long TimestampTicks,
+        [property: Key(2)] double Value,
+        [property: Key(3)] bool Flag,
+        [property: Key(4)] string CorrelationId,
+        [property: Key(5)] DeviceInfo Device,
+        [property: Key(6)] ReadingBatch Readings);
+
+    /// <summary>
+    /// Nested complex type carried by <see cref="RealBenchmarkMessage.Device"/>. Plain records get
+    /// correct structural <c>Equals</c> for free since every member is a primitive/string, so -- unlike
+    /// <see cref="ReadingBatch"/> -- no hand-written equality is needed here.
+    /// </summary>
+    [MessagePackObject]
+    public sealed record DeviceInfo(
+        [property: Key(0)] string DeviceId,
+        [property: Key(1)] string FirmwareVersion,
+        [property: Key(2)] int Region);
+
+    /// <summary>
+    /// One element of the <see cref="ReadingBatch"/> collection.
+    /// </summary>
+    [MessagePackObject]
+    public sealed record Reading(
+        [property: Key(0)] string SensorId,
+        [property: Key(1)] double Value,
+        [property: Key(2)] long TimestampTicks);
+
+    /// <summary>
+    /// The message's collection field: a batch of <see cref="Reading"/> values. MessagePack's Standard
+    /// resolver serializes <see cref="IReadOnlyList{T}"/> members natively (no hand-written formatter
+    /// needed -- unlike <see cref="RemotePingPong.RealPayload.V2.ReadingBatchFormatter"/>, which exists
+    /// only because the Akka.Serialization.V2 generator has no native collection support). This wrapper
+    /// class exists solely so the round-trip equality check in EnsureRealPayloadWiring works: a bare
+    /// <c>List&lt;Reading&gt;</c>/<c>Reading[]</c> field on <see cref="RealBenchmarkMessage"/> would
+    /// make the record's generated <c>Equals</c> compare that field by reference, not by content
+    /// (mirrors why the V2 arm's <see cref="RemotePingPong.RealPayload.V2.ReadingBatch"/> is a
+    /// hand-written <see cref="IEquatable{T}"/> class rather than a bare list too).
+    /// </summary>
+    [MessagePackObject]
+    public sealed class ReadingBatch : IEquatable<ReadingBatch>
+    {
+        public ReadingBatch(IReadOnlyList<Reading> items)
+        {
+            Items = items;
+        }
+
+        [Key(0)]
+        public IReadOnlyList<Reading> Items { get; }
+
+        public bool Equals(ReadingBatch? other)
+        {
+            if (other is null)
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+
+            return Items.SequenceEqual(other.Items);
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as ReadingBatch);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            foreach (var reading in Items)
+                hash.Add(reading);
+            return hash.ToHashCode();
+        }
+    }
+}

--- a/src/benchmark/RemotePingPong/RealPayload/MsgPack/RealBenchmarkMsgPackSerializer.cs
+++ b/src/benchmark/RemotePingPong/RealPayload/MsgPack/RealBenchmarkMsgPackSerializer.cs
@@ -1,0 +1,75 @@
+//-----------------------------------------------------------------------
+// <copyright file="RealBenchmarkMsgPackSerializer.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Runtime.Serialization;
+using Akka.Actor;
+using Akka.Serialization;
+using MessagePack;
+
+namespace RemotePingPong.RealPayload.MsgPack
+{
+    /// <summary>
+    /// Hand-written <see cref="SerializerWithStringManifest"/> for the benchmark's real-payload,
+    /// MessagePack arm -- same shape as
+    /// <see cref="RemotePingPong.RealPayload.Protobuf.RealBenchmarkProtobufSerializer"/> (a string
+    /// manifest, a single-case switch in <see cref="FromBinary(byte[], string)"/>), but calls
+    /// <see cref="MessagePackSerializer.Serialize{T}(T, MessagePackSerializerOptions?, System.Threading.CancellationToken)"/>/
+    /// <see cref="MessagePackSerializer.Deserialize{T}(System.ReadOnlyMemory{byte}, MessagePackSerializerOptions?, System.Threading.CancellationToken)"/>
+    /// against <see cref="RealBenchmarkMessage"/>'s own <c>[MessagePackObject]</c>/<c>[Key(n)]</c>
+    /// POCO (see RealBenchmarkMessages.cs) instead of Google.Protobuf's generated
+    /// <c>ToByteArray</c>/<c>Parser</c>. Deliberately uses <see cref="MessagePackSerializerOptions.Standard"/>
+    /// -- the Standard resolver, contract ([Key]-attribute) mode, no compression -- rather than a
+    /// typeless or LZ4-compressed options instance: this arm measures raw attribute-based MessagePack
+    /// serializer speed, not typeless dynamic dispatch or block compression.
+    /// </summary>
+    /// <remarks>
+    /// SerializerId 987003 is arbitrary but deliberately far outside both Akka's reserved internal
+    /// range (0-40, see akka.conf) and the other two arms' ids (987001 V2, 987002 protobuf) to avoid
+    /// any collision.
+    /// </remarks>
+    public sealed class RealBenchmarkMsgPackSerializer : SerializerWithStringManifest
+    {
+        public const int IdentifierValue = 987003;
+        public const string ManifestName = "real-benchmark-v1";
+
+        private static readonly MessagePackSerializerOptions Options = MessagePackSerializerOptions.Standard;
+
+        public RealBenchmarkMsgPackSerializer(ExtendedActorSystem system) : base(system)
+        {
+        }
+
+        public override int Identifier => IdentifierValue;
+
+        public override string Manifest(object o)
+        {
+            return o switch
+            {
+                RealBenchmarkMessage => ManifestName,
+                _ => throw new ArgumentException($"Cannot serialize object of type [{o.GetType()}]", nameof(o))
+            };
+        }
+
+        public override byte[] ToBinary(object obj)
+        {
+            if (obj is not RealBenchmarkMessage message)
+                throw new ArgumentException($"Cannot serialize object of type [{obj.GetType()}]", nameof(obj));
+
+            return MessagePackSerializer.Serialize(message, Options);
+        }
+
+        public override object FromBinary(byte[] bytes, string manifest)
+        {
+            if (manifest != ManifestName)
+                throw new SerializationException(
+                    $"Unknown manifest [{manifest}] for [{nameof(RealBenchmarkMsgPackSerializer)}].");
+
+            return MessagePackSerializer.Deserialize<RealBenchmarkMessage>(bytes, Options);
+        }
+    }
+}

--- a/src/benchmark/RemotePingPong/RealPayload/RealPayloadFactory.cs
+++ b/src/benchmark/RemotePingPong/RealPayload/RealPayloadFactory.cs
@@ -12,14 +12,16 @@ using System.Linq;
 namespace RemotePingPong.RealPayload
 {
     /// <summary>
-    /// Builds the ONE canonical "real payload" message content shared by both serializer arms
-    /// (`--payload real --serializer v2|protobuf`). <see cref="CreateCanonical"/> is the single
+    /// Builds the ONE canonical "real payload" message content shared by all three serializer arms
+    /// (`--payload real --serializer v2|protobuf|msgpack`). <see cref="CreateCanonical"/> is the single
     /// source of truth: it returns a <see cref="V2.RealBenchmarkMessage"/> record (the V2 arm's own
     /// wire type - no separate DTO needed since it is a plain, attribute-only POCO), and
-    /// <see cref="ToProtobuf"/> derives the Protobuf arm's message from THAT instance field-for-field.
-    /// This guarantees the two arms always carry identical logical content: same primitives, same
-    /// string, same nested <see cref="V2.DeviceInfo"/>/<see cref="Protobuf.DeviceInfo"/> values, and
-    /// the same list of <see cref="V2.Reading"/>/<see cref="Protobuf.Reading"/> entries.
+    /// <see cref="ToProtobuf"/>/<see cref="ToMsgPack"/> derive the Protobuf/MessagePack arms' messages
+    /// from THAT instance field-for-field. This guarantees all three arms always carry identical
+    /// logical content: same primitives, same string, same nested
+    /// <see cref="V2.DeviceInfo"/>/<see cref="Protobuf.DeviceInfo"/>/<see cref="MsgPack.DeviceInfo"/>
+    /// values, and the same list of
+    /// <see cref="V2.Reading"/>/<see cref="Protobuf.Reading"/>/<see cref="MsgPack.Reading"/> entries.
     /// </summary>
     /// <remarks>
     /// Values are fixed literals (no randomness, no wall-clock reads) so every run - and every arm -
@@ -87,6 +89,25 @@ namespace RemotePingPong.RealPayload
             }));
 
             return proto;
+        }
+
+        public static MsgPack.RealBenchmarkMessage ToMsgPack(V2.RealBenchmarkMessage message)
+        {
+            var readings = message.Readings.Items
+                .Select(reading => new MsgPack.Reading(reading.SensorId, reading.Value, reading.TimestampTicks))
+                .ToList();
+
+            return new MsgPack.RealBenchmarkMessage(
+                SequenceNumber: message.SequenceNumber,
+                TimestampTicks: message.TimestampTicks,
+                Value: message.Value,
+                Flag: message.Flag,
+                CorrelationId: message.CorrelationId,
+                Device: new MsgPack.DeviceInfo(
+                    DeviceId: message.Device.DeviceId,
+                    FirmwareVersion: message.Device.FirmwareVersion,
+                    Region: message.Device.Region),
+                Readings: new MsgPack.ReadingBatch(readings));
         }
     }
 }

--- a/src/benchmark/RemotePingPong/RemotePingPong.csproj
+++ b/src/benchmark/RemotePingPong/RemotePingPong.csproj
@@ -26,10 +26,11 @@
 <ItemGroup>
   <!-- CLI parsing (subcommands: run/server/client) - benchmark-only dependency, MIT licensed. -->
   <PackageReference Include="System.CommandLine" Version="2.0.9" />
-  <!-- Real-payload V2 arm: MessagePack formatter/attribute types used directly by
-       RealPayload/V2/RealBenchmarkMessages.cs (ReadingBatchFormatter). Also flows transitively via
-       Akka.Serialization.V2.csproj, but this project uses MessagePack types directly, so it takes an
-       explicit reference too. -->
+  <!-- Real-payload V2 and msgpack arms: MessagePack formatter/attribute types used directly by
+       RealPayload/V2/RealBenchmarkMessages.cs (ReadingBatchFormatter) and
+       RealPayload/MsgPack/RealBenchmarkMessages.cs ([MessagePackObject]/[Key(n)] POCOs,
+       MessagePackSerializer). Also flows transitively via Akka.Serialization.V2.csproj, but this
+       project uses MessagePack types directly, so it takes an explicit reference too. MIT licensed. -->
   <PackageReference Include="MessagePack" Version="$(MessagePackVersion)" />
   <!-- Real-payload Protobuf arm: same protoc-based codegen approach Akka.Remote uses for its own
        checked-in .proto files (src/protobuf/*.proto) - see RealPayload/Protobuf/RealBenchmarkMessage.proto. -->


### PR DESCRIPTION
Adds `--serializer msgpack` as a third real-payload arm alongside `v2` and `protobuf`: annotated POCO copies of the canonical message, a `SerializerWithStringManifest` (id 987003) using `MessagePackSerializerOptions.Standard` (no typeless resolver, no compression), and the same startup proof-of-wiring and wire-size reporting as the other arms. No new dependencies — the MessagePack package already flows into the benchmark via the V2 arm's use of its primitives.

Wire sizes for the canonical message: msgpack 315 B, protobuf 344 B, V2 348 B. Used to produce the lane-scaling figures on real payloads (echo +55% at 4x4 lanes vs single-lane on the same serializer).