### PR TITLE
De-flake QuickRestartSpec with a spec-wide time factor

### DIFF
--- a/src/core/Akka.Cluster.Tests.MultiNode/QuickRestartSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/QuickRestartSpec.cs
@@ -35,6 +35,15 @@ namespace Akka.Cluster.Tests.MultiNode
             CommonConfig = DebugConfig(false)
                 .WithFallback(ConfigurationFactory.ParseString(@"
                     akka.cluster.auto-down-unreachable-after = off
+                    # Dilate every Within/AwaitAssert window in this spec uniformly. The
+                    # same-address rejoin each round is a multi-step convergence dance (leader
+                    # downs the old incarnation, removes it, the new incarnation's seed join
+                    # RETRIES on a 5-10s cadence, then Up + gossip to every observer), so the
+                    # role-replacement checks routinely need 5-15s on a healthy box and can
+                    # exhaust a hard 20s window on a loaded Windows CI agent. A prior de-flake
+                    # (#8183) widened a sibling window and the flake relocated here; scaling the
+                    # whole spec keeps every window proportionate instead of hand-tuning one.
+                    akka.test.timefactor = 2.0
                 "))
                 .WithFallback(MultiNodeClusterSpec.ClusterConfig());
         }


### PR DESCRIPTION
Fixes the Windows MNTR flake seen on #8364's validation run: `QuickRestartSpec` failing with "Expected 'round-3' got 'round-2'" — an observer node's self-consistent-but-stale cluster view inside a hard 20-second convergence window.

Root cause: each round's same-address rejoin is deliberately abrupt (the spec exists to exercise exactly that, per JVM issue #20639), which makes the replacement path a multi-step dance — the leader downs the old incarnation, removes it, the new incarnation's seed join retries on a 5-10s cadence, then the new gossip has to reach every observer. That routinely takes 5-15s on a healthy box, so 20 real seconds (the time factor defaults to 1.0 and nothing dilates `ResolveOne`-style here — the windows are TestKit `Within`/`AwaitAssert`, they just need budget) leaves little margin on a loaded Windows agent. #8183 already de-flaked a sibling window in this spec and the flake relocated, so rather than hand-widening the next constant, this sets `akka.test.timefactor = 2.0` in the spec's config so every window scales together. No assertions weakened, no barriers added (waiting for the old incarnation's removal would defeat the quick-restart scenario under test). Pekko's version of this spec carries the identical 20s fragility, so nothing to import from upstream.

Not caused by #8364: MNTR runs classic remoting and that PR touches only the V2 source generator, its tests, and benchmark files. Verified: spec passes 3/3 locally (~60-66s per run).