### PR TITLE
Fix uid-less watch in ArteryInboundLanesSpec DeathWatch test

### DIFF
--- a/src/core/Akka.Remote.Tests/Artery/ArteryInboundLanesSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryInboundLanesSpec.cs
@@ -313,7 +313,7 @@ namespace Akka.Remote.Tests.Artery
 
                 // Handshake completion, proven the same way every other Artery spec proves it: an
                 // ordinary round trip actually arrives.
-                var echoRef = await systemA.ActorSelection(RemotePath(systemB, "echo")).ResolveOne(TimeSpan.FromSeconds(10));
+                var echoRef = await systemA.ActorSelection(RemotePath(systemB, "echo")).ResolveOne(Dilated(TimeSpan.FromSeconds(10)));
                 var echoProbe = CreateTestProbe(systemA);
                 echoRef.Tell("ping", echoProbe.Ref);
                 await echoProbe.ExpectMsgAsync("ping", TimeSpan.FromSeconds(10));
@@ -323,7 +323,11 @@ namespace Akka.Remote.Tests.Artery
                 // Ordinary connection's lane machinery (see ArteryInboundProcessingStage's "Why
                 // control/large connections and lanes=1 never touch this machinery" remarks: the
                 // CONTROL connection is never lane-routed regardless of inbound-lanes).
-                var watchTargetRemote = RARP.For(systemA).Provider.ResolveActorRef(RemotePath(systemB, "watch-target"));
+                //
+                // The watchee must be resolved uid-fully (ActorSelection.ResolveOne): Provider.ResolveActorRef
+                // on a bare path yields Path.Uid == 0, and a uid-0 watch can never match the real-uid
+                // DeathWatchNotification (ActorRef.Equals is uid-sensitive; Pekko behaves identically).
+                var watchTargetRemote = await systemA.ActorSelection(RemotePath(systemB, "watch-target")).ResolveOne(Dilated(TimeSpan.FromSeconds(10)));
                 var terminatedProbe = CreateTestProbe(systemA);
                 systemA.ActorOf(Props.Create(() => new PlainWatcher(watchTargetRemote, terminatedProbe.Ref)));
 


### PR DESCRIPTION
Fixes the ~30% flake that hit #8368's CI on both platforms (unrelated to that PR — reproduced at the same rate on its parent commit).

The spec resolved its watch target with `ResolveActorRef` on a bare path, which yields a ref with `Path.Uid == 0`. A uid-0 watch can never match the real death notification, which carries the actor's real uid (`ActorRef.Equals` is uid-sensitive; Pekko is identical at every hop). The test only passed when the RemoteWatcher's ~1s ReWatch happened to race the dead actor's name cleanup into an `EmptyLocalActorRef`, whose synthetic uid-0 notification matched — a coin flip, verified by hop-by-hop instrumentation across 16 runs. Reliable system-message delivery itself was flawless in every run.

Fix: resolve the watchee with `ActorSelection.ResolveOne` so the watch registers the real uid and the real `Terminated` path works; also dilate the spec's other hard 10s resolve. 0/20 failures under 2-core affinity post-fix vs 6-7/20 before; full Artery suite green.