### PR TITLE
Artery: log reconnect attempts on a per-outage cadence

### DIFF
--- a/src/core/Akka.Remote.Tests/Artery/ArteryReconnectLoggingSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryReconnectLoggingSpec.cs
@@ -1,0 +1,193 @@
+//-----------------------------------------------------------------------
+// <copyright file="ArteryReconnectLoggingSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2025 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit;
+using Akka.TestKit.Extensions;
+using Akka.Util.Internal;
+using FluentAssertions.Extensions;
+using Xunit;
+
+namespace Akka.Remote.Tests.Artery
+{
+    /// <summary>
+    /// Pins the PER-OUTAGE reconnect-log cadence (<c>ArteryRemoting</c>'s outbound fault
+    /// continuations + <c>ReportOutboundConnectionEstablished</c>): while a peer stays
+    /// unreachable, restart attempt 1 logs at WARNING, every
+    /// <c>ReconnectWarningAttemptInterval</c>-th attempt logs another WARNING (with the attempt
+    /// count and outage duration, so a persistent failure stays visible), and every attempt in
+    /// between logs at DEBUG -- an unreachable peer no longer produces one WARNING per
+    /// <c>outbound-restart-backoff</c> per stream (which drowned test event filters and real
+    /// warnings). A subsequent successful reconnect reports ONCE at INFO with the outage's
+    /// failed-attempt count and resets the cadence.
+    ///
+    /// <para>
+    /// The testkit's own <c>Sys</c> IS the reconnecting node here (the Artery config is passed to
+    /// the <see cref="AkkaSpec"/> base) so <c>EventFilter</c> observes the system doing the
+    /// reconnecting; the test proves each filter level is non-vacuous with a synthetic event
+    /// first (an EventFilter on a system without a subscribed <c>TestEventListener</c> -- or
+    /// Debug events below the configured loglevel -- would silently match nothing).
+    /// </para>
+    /// </summary>
+    public class ArteryReconnectLoggingSpec : AkkaSpec
+    {
+        private const string PeerSystemName = "ArteryReconnectLogPeer";
+
+        /// <summary>
+        /// DEBUG loglevel so the per-attempt Debug cadence is observable on the event stream, and
+        /// a short <c>outbound-restart-backoff</c> so 12+ reconnect attempts happen fast. No
+        /// assertion anywhere touches the backoff TIMING itself -- progress is measured purely by
+        /// counting per-attempt log events.
+        /// </summary>
+        private static readonly Config SpecConfig = ConfigurationFactory.ParseString("""
+            akka.loglevel = DEBUG
+            akka.actor.provider = "Akka.Remote.RemoteActorRefProvider, Akka.Remote"
+            akka.remote.artery.enabled = on
+            akka.remote.artery.canonical.hostname = "127.0.0.1"
+            akka.remote.artery.canonical.port = 0
+            akka.remote.artery.advanced.outbound-restart-backoff = 100ms
+            """);
+
+        private static Config PeerConfig(int port) => ConfigurationFactory.ParseString($$"""
+            akka.actor.provider = "Akka.Remote.RemoteActorRefProvider, Akka.Remote"
+            akka.remote.artery.enabled = on
+            akka.remote.artery.canonical.hostname = "127.0.0.1"
+            akka.remote.artery.canonical.port = {{port}}
+            """);
+
+        public ArteryReconnectLoggingSpec(ITestOutputHelper output) : base(SpecConfig, output)
+        {
+        }
+
+        private static int BoundPort(ActorSystem system) => RARP.For(system).Provider.DefaultAddress.Port!.Value;
+
+        /// <summary>
+        /// Counts <see cref="Debug"/> log events whose FORMATTED message contains
+        /// <c>marker</c> -- the count-based (never wall-clock) progress signal for "the reconnect
+        /// loop has provably made N attempts". A plain EventStream subscriber, deliberately NOT an
+        /// EventFilter: the filter's exact-count Expect semantics would race a cadence that keeps
+        /// producing events after the expected count is reached.
+        /// </summary>
+        private sealed class DebugEventCounter : ReceiveActor
+        {
+            public DebugEventCounter(string marker, AtomicCounter counter)
+            {
+                Receive<Debug>(d =>
+                {
+                    if (d.Message?.ToString()?.Contains(marker) == true)
+                        counter.IncrementAndGet();
+                });
+            }
+        }
+
+        /// <summary>
+        /// Re-binds a fresh <see cref="ActorSystem"/> to the EXACT SAME port the just-terminated
+        /// port-allocation system used, retrying if the OS has not yet released the socket --
+        /// the same "bind-your-own is race-acceptable here" pattern as
+        /// <c>ArteryReconnectSpec</c>/<c>ArteryOutboundLanesRestartSpec</c>: this test exclusively
+        /// owns the port between the two incarnations (the only consumer in between is the system
+        /// under test, whose connect attempts are EXPECTED to fail), so a bind failure here can
+        /// only mean the previous listener's teardown has not finished yet.
+        /// </summary>
+        private static async Task<ActorSystem> CreateSystemOnPortWithRetryAsync(string name, int port, int maxAttempts = 40)
+        {
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    return ActorSystem.Create(name, PeerConfig(port));
+                }
+                catch (Exception) when (attempt < maxAttempts)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(250));
+                }
+            }
+
+            // Unreachable: the loop above either returns on success or lets the final attempt's
+            // exception propagate once attempt == maxAttempts.
+            throw new InvalidOperationException($"Unreachable: failed to bind port {port} after {maxAttempts} attempts.");
+        }
+
+        [Fact(DisplayName = "Should_LogReconnectsOnPerOutageCadence_When_PeerIsUnreachable: attempt 1 at WARNING, every 10th at WARNING with attempt count + outage duration, the rest at DEBUG, then ONE INFO on recovery")]
+        public async Task Should_LogReconnectsOnPerOutageCadence_When_PeerIsUnreachable()
+        {
+            // Allocate a real port, then FREE it (self-bind-then-release; see
+            // CreateSystemOnPortWithRetryAsync's remarks) -- every connect attempt below hits a
+            // dead port until the peer is deliberately reborn on it.
+            var firstIncarnation = ActorSystem.Create(PeerSystemName, PeerConfig(0));
+            var port = BoundPort(firstIncarnation);
+            await firstIncarnation.Terminate().AwaitWithTimeout(10.Seconds());
+
+            var peerAddress = $"akka://{PeerSystemName}@127.0.0.1:{port}";
+
+            // All assertions are scoped to the CONTROL stream's messages: the control and
+            // ordinary streams each run this cadence independently (their attempt counters are
+            // per-stream), so a single-stream scope keeps the expected counts exact.
+            var controlPrefix = $"Artery Control outbound connection to [{peerAddress}]";
+
+            // NON-VACUITY: prove each filter level actually intercepts on Sys before relying on it.
+            await EventFilter.Warning(contains: "reconnect-log-spec-synthetic").ExpectOneAsync(
+                () => { Sys.Log.Warning("reconnect-log-spec-synthetic warning"); return Task.CompletedTask; });
+            await EventFilter.Debug(contains: "reconnect-log-spec-synthetic").ExpectOneAsync(
+                () => { Sys.Log.Debug("reconnect-log-spec-synthetic debug"); return Task.CompletedTask; });
+            await EventFilter.Info(contains: "reconnect-log-spec-synthetic").ExpectOneAsync(
+                () => { Sys.Log.Info("reconnect-log-spec-synthetic info"); return Task.CompletedTask; });
+
+            // Count-based progress signal: the control stream's per-attempt DEBUG lines.
+            var debugAttempts = new AtomicCounter(0);
+            var counterRef = Sys.ActorOf(Props.Create(() =>
+                new DebugEventCounter($"{controlPrefix} failed (reconnect attempt", debugAttempts)));
+            Sys.EventStream.Subscribe(counterRef, typeof(Debug));
+
+            ActorSystem? rebornPeer = null;
+            try
+            {
+                // OUTAGE: exactly TWO control-stream WARNINGs -- attempt 1 (the first fault) and
+                // attempt 10 (the every-10th persistent-failure warning) -- across a window that
+                // provably spans 12+ attempts: 10 per-attempt DEBUG lines = attempts 2-9 plus
+                // 11-12, so by the time the window closes the cadence has passed attempt 12, and
+                // a third WARNING would only ever come at attempt 20 (never inside this window).
+                await EventFilter.Warning(contains: controlPrefix).ExpectAsync(2, TimeSpan.FromSeconds(90), async () =>
+                {
+                    // Provider-resolved ref: no wire round trip, so this send is what
+                    // materializes the outbound streams and their FIRST connect attempt is
+                    // guaranteed to hit the dead port (same stimulus as
+                    // ArteryOutboundLanesRestartSpec's connect-race test).
+                    var target = RARP.For(Sys).Provider.ResolveActorRef($"{peerAddress}/user/nobody");
+                    target.Tell("poke", ActorRefs.NoSender);
+
+                    // Explicit 50ms poll interval: the default interval scales with `max`, which
+                    // would leave this window open for several extra seconds after the condition
+                    // turns true -- long enough for the attempt-20 (and beyond) WARNINGs to leak
+                    // into the exactly-2 count.
+                    await AwaitConditionAsync(
+                        () => Task.FromResult(debugAttempts.Current >= 10),
+                        TimeSpan.FromSeconds(60), TimeSpan.FromMilliseconds(50));
+                });
+
+                // RECOVERY: the peer comes back on the SAME port; the next restart attempt's TCP
+                // connect ESTABLISHES, which must report exactly one INFO carrying the outage's
+                // failed-attempt count (and reset the cadence for any future outage).
+                await EventFilter.Info(contains: $"{controlPrefix} reconnected after").ExpectOneAsync(
+                    TimeSpan.FromSeconds(90),
+                    async () => { rebornPeer = await CreateSystemOnPortWithRetryAsync(PeerSystemName, port); });
+            }
+            finally
+            {
+                Sys.EventStream.Unsubscribe(counterRef);
+                if (rebornPeer is not null)
+                    await rebornPeer.Terminate().AwaitWithTimeout(10.Seconds());
+            }
+        }
+    }
+}

--- a/src/core/Akka.Remote/Artery/ArteryRemoting.cs
+++ b/src/core/Akka.Remote/Artery/ArteryRemoting.cs
@@ -1071,7 +1071,21 @@ namespace Akka.Remote.Artery
                 var connectionWithRestart = RestartFlow.OnFailuresWithBackoff(
                     () => Flow.Create<ReadOnlySequence<byte>>()
                         .Prepend(Source.Single(BuildPreamble(ArteryStreamId.Ordinary)))
-                        .Via(_tcp!.OutgoingConnection(remoteEndpoint, options: _arterySocketOptions)),
+                        .ViaMaterialized(_tcp!.OutgoingConnection(remoteEndpoint, options: _arterySocketOptions), Keep.Right)
+                        .MapMaterializedValue(connectionTask =>
+                        {
+                            // Runs at EVERY (re-)materialization of the socket flow -- including
+                            // the inner RestartFlow retries -- so a successful establish anywhere
+                            // in the retry tiers ends the reconnect-log outage cadence for this
+                            // assembly, same recovery signal as the single-stream path. See
+                            // ReportOutboundConnectionEstablished.
+                            connectionTask.ContinueWith(ct =>
+                            {
+                                if (ct.IsCompletedSuccessfully)
+                                    ReportOutboundConnectionEstablished(association, ArteryStreamId.Ordinary, remoteAddress);
+                            }, TaskContinuationOptions.ExecuteSynchronously);
+                            return NotUsed.Instance;
+                        }),
                     restartSettings);
 
                 // MergeHub -> transport-wide kill switch (Shutdown() tears every association's
@@ -1176,11 +1190,34 @@ namespace Akka.Remote.Artery
             Task.WhenAll(allPieces).ContinueWith(t =>
             {
                 if (t.IsFaulted)
-                    _log.Warning(
-                        t.Exception?.GetBaseException(),
-                        "Artery {0} outbound lanes stream to [{1}] failed; this association's ordinary outbound " +
-                        "assembly ({2} lanes) has ended -- reconnect will be attempted per outbound-restart-backoff " +
-                        "unless shut down or quarantined.", ArteryStreamId.Ordinary, remoteAddress, lanes);
+                {
+                    // Same per-outage log cadence as MaterializeOutboundStream's fault continuation
+                    // -- see the remarks there. Each OUTER assembly restart counts as one attempt
+                    // (the inner RestartFlow's own socket retries are not individually counted).
+                    var attempt = association.RegisterOutboundRestartFault(ArteryStreamId.Ordinary);
+                    if (attempt == 1)
+                        _log.Warning(
+                            t.Exception?.GetBaseException(),
+                            "Artery {0} outbound lanes stream to [{1}] failed; this association's ordinary outbound " +
+                            "assembly ({2} lanes) has ended -- reconnect will be attempted per outbound-restart-backoff " +
+                            "unless shut down or quarantined. Further attempts are logged at DEBUG, with a WARNING " +
+                            "every {3} attempts while the outage persists.",
+                            ArteryStreamId.Ordinary, remoteAddress, lanes, ReconnectWarningAttemptInterval);
+                    else if (attempt % ReconnectWarningAttemptInterval == 0)
+                        _log.Warning(
+                            t.Exception?.GetBaseException(),
+                            "Still unable to reconnect Artery {0} outbound lanes stream to [{1}] ({2} lanes): attempt " +
+                            "{3} over {4}; reconnect attempts continue per outbound-restart-backoff unless shut down " +
+                            "or quarantined.",
+                            ArteryStreamId.Ordinary, remoteAddress, lanes, attempt,
+                            association.OutboundOutageDuration(ArteryStreamId.Ordinary));
+                    else
+                        _log.Debug(
+                            t.Exception?.GetBaseException(),
+                            "Artery {0} outbound lanes stream to [{1}] failed ({2} lanes, reconnect attempt {3}); " +
+                            "reconnect will be attempted per outbound-restart-backoff unless shut down or quarantined.",
+                            ArteryStreamId.Ordinary, remoteAddress, lanes, attempt);
+                }
                 else
                     _log.Debug(
                         "Artery {0} outbound lanes stream to [{1}] completed ({2} lanes); reconnect will be " +
@@ -1375,7 +1412,10 @@ namespace Akka.Remote.Artery
                     connectionTask.ContinueWith(ct =>
                     {
                         if (ct.IsCompletedSuccessfully)
+                        {
                             association.MarkControlHealthy();
+                            ReportOutboundConnectionEstablished(association, streamId, remoteAddress);
+                        }
                     }, TaskContinuationOptions.ExecuteSynchronously);
                 }
                 else
@@ -1383,14 +1423,25 @@ namespace Akka.Remote.Artery
                     // Ordinary AND large-message (task 10.2) streams share this branch -- neither
                     // has its own heartbeat, so both rely on the CONTROL stream's death detection
                     // to trip their kill switch (see the ordinary-vs-large kill switch dispatch
-                    // just below, and the termination continuation's trip-both call).
+                    // just below, and the termination continuation's trip-both call). The
+                    // OutgoingConnection materialized task is captured for the same reason the
+                    // control branch captures it: a successful establish is the per-stream RECOVERY
+                    // signal that ends the reconnect-log outage cadence -- see
+                    // ReportOutboundConnectionEstablished.
                     UniqueKillSwitch killSwitch;
-                    ((killSwitch, terminationWatch), _) = preambleAndFrames
+                    Task connectionTask;
+                    (((killSwitch, terminationWatch), connectionTask), _) = preambleAndFrames
                         .ViaMaterialized(KillSwitches.Single<ReadOnlySequence<byte>>(), Keep.Right)
                         .WatchTermination(Keep.Both)
-                        .Via(_tcp!.OutgoingConnection(remoteEndpoint, options: _arterySocketOptions))
+                        .ViaMaterialized(_tcp!.OutgoingConnection(remoteEndpoint, options: _arterySocketOptions), Keep.Both)
                         .ToMaterialized(Sink.Ignore<ReadOnlySequence<byte>>(), Keep.Both)
                         .Run(_materializer!);
+
+                    connectionTask.ContinueWith(ct =>
+                    {
+                        if (ct.IsCompletedSuccessfully)
+                            ReportOutboundConnectionEstablished(association, streamId, remoteAddress);
+                    }, TaskContinuationOptions.ExecuteSynchronously);
 
                     if (isLargeStream)
                         association.SetLargeOutboundKillSwitch(killSwitch);
@@ -1438,11 +1489,38 @@ namespace Akka.Remote.Artery
             terminationWatch.ContinueWith(t =>
             {
                 if (t.IsFaulted)
-                    _log.Warning(
-                        t.Exception?.GetBaseException(),
-                        "Artery {0} outbound connection to [{1}] failed; this association's {0} outbound stream " +
-                        "has ended -- reconnect will be attempted per outbound-restart-backoff unless shut down " +
-                        "or (ordinary only) quarantined.", streamId, remoteAddress);
+                {
+                    // PER-OUTAGE LOG CADENCE (see Association.RegisterOutboundRestartFault): against
+                    // an unreachable peer this continuation fires once per outbound-restart-backoff
+                    // (~1/s at the default) per stream, so an unconditional Warning drowns test
+                    // event filters and real warnings. The FIRST fault of an outage warns, every
+                    // ReconnectWarningAttemptInterval-th attempt warns again with the attempt count
+                    // and outage duration (persistent-failure visibility), and every other attempt
+                    // logs at DEBUG. A successful reconnect resets the cadence and reports at INFO
+                    // -- see ReportOutboundConnectionEstablished.
+                    var attempt = association.RegisterOutboundRestartFault(streamId);
+                    if (attempt == 1)
+                        _log.Warning(
+                            t.Exception?.GetBaseException(),
+                            "Artery {0} outbound connection to [{1}] failed; this association's {0} outbound stream " +
+                            "has ended -- reconnect will be attempted per outbound-restart-backoff unless shut down " +
+                            "or (ordinary only) quarantined. Further attempts are logged at DEBUG, with a WARNING " +
+                            "every {2} attempts while the outage persists.",
+                            streamId, remoteAddress, ReconnectWarningAttemptInterval);
+                    else if (attempt % ReconnectWarningAttemptInterval == 0)
+                        _log.Warning(
+                            t.Exception?.GetBaseException(),
+                            "Still unable to reconnect Artery {0} outbound connection to [{1}]: attempt {2} over {3}; " +
+                            "reconnect attempts continue per outbound-restart-backoff unless shut down or (ordinary " +
+                            "only) quarantined.",
+                            streamId, remoteAddress, attempt, association.OutboundOutageDuration(streamId));
+                    else
+                        _log.Debug(
+                            t.Exception?.GetBaseException(),
+                            "Artery {0} outbound connection to [{1}] failed (reconnect attempt {2}); reconnect will " +
+                            "be attempted per outbound-restart-backoff unless shut down or (ordinary only) quarantined.",
+                            streamId, remoteAddress, attempt);
+                }
                 else
                     _log.Debug(
                         "Artery {0} outbound connection to [{1}] completed; reconnect will be attempted per " +
@@ -1534,6 +1612,49 @@ namespace Akka.Remote.Artery
 
                 association.EnsureOutboundMaterialized(a => MaterializeOutbound(remoteAddress, a, isRestart: a.HasOutboundEverRestarted));
             });
+        }
+
+        /// <summary>
+        /// Reconnect-fault log cadence: the FIRST faulted restart attempt of an outage logs at
+        /// WARNING, every multiple of this many attempts logs another WARNING (with the attempt
+        /// count and outage duration, so a persistent failure stays visible), and every other
+        /// attempt logs at DEBUG. Deliberately a constant, not a new HOCON key -- same reasoning
+        /// as <see cref="OrdinaryConnectionMaxInnerRestarts"/>.
+        /// </summary>
+        private const int ReconnectWarningAttemptInterval = 10;
+
+        /// <summary>
+        /// RECOVERY signal for the per-outage reconnect-log cadence: called when an outbound
+        /// stream's <c>Tcp.OutgoingConnection</c> materialized task completes successfully, i.e.
+        /// the TCP connection to the peer was actually ESTABLISHED. Resets that stream's
+        /// consecutive-fault counter (<see cref="Association.ResetOutboundRestartFaults"/>) and,
+        /// when the establish ends a real outage (nonzero counter), reports it ONCE at INFO.
+        ///
+        /// <para>
+        /// <b>Why the connection task is the reset point.</b> The restart continuation cannot
+        /// observe recovery: a HEALTHY materialization does not terminate at all, and the only
+        /// non-faulted termination it ever sees is the deliberate channel completion at
+        /// <see cref="Shutdown"/> -- so "next graceful completion" would report recovery exactly
+        /// never (or, worse, at shutdown). Handshake completion is association-level state shared
+        /// across streams (and arrives via the inbound control path), so it cannot be attributed
+        /// to a specific stream's reconnect loop. The <c>OutgoingConnection</c> materialized task
+        /// is already per-stream and per-materialization, is already consulted for exactly this
+        /// establish-vs-refused distinction by the control stream's <see cref="Association.MarkControlHealthy"/>
+        /// edge detector, FAULTS on a connection-refused attempt (so a still-dead peer never
+        /// resets the cadence), and completes precisely when the reconnect loop stops churning --
+        /// the cheapest correct signal available. A post-establish failure (e.g. a handshake
+        /// timeout against a live-but-broken peer) faults the stream again and simply starts a
+        /// NEW outage with a fresh first-fault WARNING -- exactly the persistent-failure
+        /// visibility the cadence exists to preserve.
+        /// </para>
+        /// </summary>
+        private void ReportOutboundConnectionEstablished(Association association, ArteryStreamId streamId, Address remoteAddress)
+        {
+            var failedAttempts = association.ResetOutboundRestartFaults(streamId);
+            if (failedAttempts > 0)
+                _log.Info(
+                    "Artery {0} outbound connection to [{1}] reconnected after {2} failed attempt(s).",
+                    streamId, remoteAddress, failedAttempts);
         }
 
         /// <summary>

--- a/src/core/Akka.Remote/Artery/AssociationRegistry.cs
+++ b/src/core/Akka.Remote/Artery/AssociationRegistry.cs
@@ -283,6 +283,26 @@ namespace Akka.Remote.Artery
         private int _controlHealthy;
 
         /// <summary>
+        /// Consecutive FAULTED restart attempts of each outbound stream (one counter per stream,
+        /// exactly like the per-stream <see cref="MaterializeOnceGate"/> instances above):
+        /// incremented by the transport's outbound-stream fault continuation via
+        /// <see cref="RegisterOutboundRestartFault"/> on every faulted termination, and reset by
+        /// <see cref="ResetOutboundRestartFaults"/> when a subsequent materialization actually
+        /// ESTABLISHES its TCP connection. Drives <c>ArteryRemoting</c>'s per-outage reconnect-log
+        /// cadence (first fault and every Nth attempt at WARNING, the rest at DEBUG, recovery at
+        /// INFO). The paired <c>*OutageStartTicks</c> fields capture <see cref="DateTime.UtcNow"/>
+        /// at each outage's 0-&gt;1 transition -- DIAGNOSTIC log display only, never asserted-on
+        /// timing. <see cref="Interlocked"/> throughout: incremented on termination continuations,
+        /// reset on connection-established continuations, different threads.
+        /// </summary>
+        private int _outboundRestartFaults;
+        private int _controlRestartFaults;
+        private int _largeRestartFaults;
+        private long _outboundOutageStartTicks;
+        private long _controlOutageStartTicks;
+        private long _largeOutageStartTicks;
+
+        /// <summary>
         /// Set (independently per stream) by <see cref="CompleteOutbound"/>/<see cref="CompleteControlOutbound"/>
         /// -- design.md group 9's restart guard: "no restart after transport <c>Shutdown()</c>".
         /// <see cref="ArteryRemoting.Shutdown"/> is the only production caller of either
@@ -577,6 +597,70 @@ namespace Akka.Remote.Artery
         /// See <see cref="_controlHealthy"/> / <see cref="_outboundKillSwitch"/>.
         /// </summary>
         public bool TryConsumeControlHealthy() => Interlocked.Exchange(ref _controlHealthy, 0) == 1;
+
+        /// <summary>
+        /// Records one FAULTED restart attempt of <paramref name="streamId"/>'s outbound stream and
+        /// returns the new consecutive count (1 = first fault of a fresh outage). On the 0-&gt;1
+        /// transition the outage's start timestamp is captured -- exactly one caller ever observes
+        /// that transition (<see cref="Interlocked.Increment(ref int)"/> returns 1 to a single
+        /// thread), so the timestamp write is single-writer. See <see cref="_outboundRestartFaults"/>.
+        /// </summary>
+        public int RegisterOutboundRestartFault(ArteryStreamId streamId)
+        {
+            switch (streamId)
+            {
+                case ArteryStreamId.Control:
+                    return RegisterRestartFault(ref _controlRestartFaults, ref _controlOutageStartTicks);
+                case ArteryStreamId.Large:
+                    return RegisterRestartFault(ref _largeRestartFaults, ref _largeOutageStartTicks);
+                default:
+                    return RegisterRestartFault(ref _outboundRestartFaults, ref _outboundOutageStartTicks);
+            }
+        }
+
+        private static int RegisterRestartFault(ref int counter, ref long outageStartTicks)
+        {
+            var attempt = Interlocked.Increment(ref counter);
+            if (attempt == 1)
+                Interlocked.Exchange(ref outageStartTicks, DateTime.UtcNow.Ticks);
+            return attempt;
+        }
+
+        /// <summary>
+        /// How long <paramref name="streamId"/>'s current outage has been going, measured from the
+        /// timestamp <see cref="RegisterOutboundRestartFault"/> captured on its first fault.
+        /// DIAGNOSTIC display only (log text) -- see <see cref="_outboundRestartFaults"/>.
+        /// <see cref="TimeSpan.Zero"/> when no outage has ever been recorded.
+        /// </summary>
+        public TimeSpan OutboundOutageDuration(ArteryStreamId streamId)
+        {
+            var startTicks = streamId switch
+            {
+                ArteryStreamId.Control => Interlocked.Read(ref _controlOutageStartTicks),
+                ArteryStreamId.Large => Interlocked.Read(ref _largeOutageStartTicks),
+                _ => Interlocked.Read(ref _outboundOutageStartTicks)
+            };
+            return startTicks == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(Math.Max(0, DateTime.UtcNow.Ticks - startTicks));
+        }
+
+        /// <summary>
+        /// Resets <paramref name="streamId"/>'s consecutive-fault count (a subsequent
+        /// materialization ESTABLISHED its TCP connection -- the outage is over) and returns the
+        /// count that had accumulated, so the caller can report a genuine recovery (nonzero)
+        /// exactly once. See <see cref="_outboundRestartFaults"/>.
+        /// </summary>
+        public int ResetOutboundRestartFaults(ArteryStreamId streamId)
+        {
+            switch (streamId)
+            {
+                case ArteryStreamId.Control:
+                    return Interlocked.Exchange(ref _controlRestartFaults, 0);
+                case ArteryStreamId.Large:
+                    return Interlocked.Exchange(ref _largeRestartFaults, 0);
+                default:
+                    return Interlocked.Exchange(ref _outboundRestartFaults, 0);
+            }
+        }
 
         /// <summary>
         /// Whether the ORDINARY outbound stream should be (re-)materialized right now (design.md


### PR DESCRIPTION
## Summary

- log Artery reconnect failures on a per-outage cadence
- warn on the first failure and every tenth retry
- report successful recovery once and reset the cadence
- add coverage for failure cadence and recovery

Supersedes #8374 with a branch created directly from the latest dev.

## Testing

Not run locally. The prior Windows CI run exposed platform-sensitive timing in the repeated real-socket test; the deterministic refactor could not be applied in this workspace because the repository patch helper failed during sandbox initialization.