### PR TITLE
feat(testkit): add TUnit adapter

### DIFF
--- a/.incrementalist/testsOnly.json
+++ b/.incrementalist/testsOnly.json
@@ -8,6 +8,7 @@
   "failOnNoProjects": false,
   "skip": [
     "**/.Tests.MultiNode.csproj",
+    "**/Akka.TestKit.TUnit.Tests.csproj",
     "src/examples/**"
   ],
   "target": [

--- a/Akka.slnx
+++ b/Akka.slnx
@@ -88,6 +88,8 @@
     </Project>
   </Folder>
   <Folder Name="/Contrib/TestKits/">
+    <Project Path="src/contrib/testkits/Akka.TestKit.TUnit.Tests/Akka.TestKit.TUnit.Tests.csproj" />
+    <Project Path="src/contrib/testkits/Akka.TestKit.TUnit/Akka.TestKit.TUnit.csproj" />
     <Project Path="src/contrib/testkits/Akka.TestKit.Xunit.Tests/Akka.TestKit.Xunit.Tests.csproj" />
     <Project Path="src/contrib/testkits/Akka.TestKit.Xunit/Akka.TestKit.Xunit.csproj" />
     <Project Path="src/contrib/testkits/Akka.TestKit.Xunit2.Tests/Akka.TestKit.Xunit2.Tests.csproj" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
     <MessagePackVersion>3.1.7</MessagePackVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.13.0</MicrosoftCodeAnalysisCSharpVersion>
     <NetTestVersion>net10.0</NetTestVersion>
-    <FsharpVersion>10.1.302</FsharpVersion>
+    <FsharpVersion>10.1.301</FsharpVersion>
     <NetStandardLibVersion>net10.0</NetStandardLibVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
     <MessagePackVersion>3.1.7</MessagePackVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.13.0</MicrosoftCodeAnalysisCSharpVersion>
     <NetTestVersion>net10.0</NetTestVersion>
-    <FsharpVersion>10.1.301</FsharpVersion>
+    <FsharpVersion>10.1.302</FsharpVersion>
     <NetStandardLibVersion>net10.0</NetStandardLibVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,7 @@
     <Xunit3Version>3.2.2</Xunit3Version>
     <Xunit3RunnerVersion>3.1.5</Xunit3RunnerVersion>
     <XunitRunnerVersion>2.8.1</XunitRunnerVersion>
+    <TUnitVersion>1.59.0</TUnitVersion>
     <TestSdkVersion>18.7.0</TestSdkVersion>
     <HyperionVersion>0.12.2</HyperionVersion>
     <NewtonsoftJsonVersion>[13.0.1,)</NewtonsoftJsonVersion>

--- a/build-system/pr-validation.yaml
+++ b/build-system/pr-validation.yaml
@@ -102,6 +102,24 @@ jobs:
       outputDirectory: "TestResults"
       artifactName: "net_tests_linux-$(Build.BuildId)"
 
+  - template: azure-pipeline.template.yaml
+    parameters:
+      name: "tunit_tests_windows"
+      displayName: "TUnit Tests (Windows)"
+      vmImage: "windows-latest"
+      command: "dotnet run --project src/contrib/testkits/Akka.TestKit.TUnit.Tests/Akka.TestKit.TUnit.Tests.csproj -c Release --no-build --no-launch-profile -- --progress off --report-trx --results-directory TestResults/tunit"
+      outputDirectory: "TestResults/tunit"
+      artifactName: "tunit_tests_windows-$(Build.BuildId)"
+
+  - template: azure-pipeline.template.yaml
+    parameters:
+      name: "tunit_tests_linux"
+      displayName: "TUnit Tests (Linux)"
+      vmImage: "ubuntu-latest"
+      command: "dotnet run --project src/contrib/testkits/Akka.TestKit.TUnit.Tests/Akka.TestKit.TUnit.Tests.csproj -c Release --no-build --no-launch-profile -- --progress off --report-trx --results-directory TestResults/tunit"
+      outputDirectory: "TestResults/tunit"
+      artifactName: "tunit_tests_linux-$(Build.BuildId)"
+
   - template: azure-pipeline.mntr-template.yaml
     parameters:
       name: "net_mntr_windows"

--- a/docs/articles/actors/testing-actor-systems.md
+++ b/docs/articles/actors/testing-actor-systems.md
@@ -14,9 +14,9 @@ Akka.Net comes with a dedicated module `Akka.TestKit` for supporting tests at di
 
 Install the adapter for your test framework and derive your test class from its `TestKit`:
 
-- `Akka.TestKit.TUnit` for [TUnit](https://tunit.dev/)
-- `Akka.TestKit.Xunit` for xUnit v3
-- `Akka.TestKit.Xunit2` for xUnit v2
+* `Akka.TestKit.TUnit` for [TUnit](https://tunit.dev/)
+* `Akka.TestKit.Xunit` for xUnit v3
+* `Akka.TestKit.Xunit2` for xUnit v2
 
 The TUnit adapter captures the current test output, preserves the implicit actor sender across asynchronous continuations, and shuts down its actor system when TUnit disposes the test instance.
 

--- a/docs/articles/actors/testing-actor-systems.md
+++ b/docs/articles/actors/testing-actor-systems.md
@@ -10,6 +10,34 @@ As with any piece of software, automated tests are a very important part of the 
 
 Akka.Net comes with a dedicated module `Akka.TestKit` for supporting tests at different levels.
 
+## Test Framework Adapters
+
+Install the adapter for your test framework and derive your test class from its `TestKit`:
+
+- `Akka.TestKit.TUnit` for [TUnit](https://tunit.dev/)
+- `Akka.TestKit.Xunit` for xUnit v3
+- `Akka.TestKit.Xunit2` for xUnit v2
+
+The TUnit adapter captures the current test output, preserves the implicit actor sender across asynchronous continuations, and shuts down its actor system when TUnit disposes the test instance.
+
+```csharp
+using Akka.Actor;
+using TUnit.Core;
+
+public sealed class MyActorSpec : Akka.TestKit.TUnit.TestKit
+{
+    [Test]
+    public async Task Should_receive_a_message()
+    {
+        TestActor.Tell("hello", ActorRefs.NoSender);
+
+        await ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
+    }
+}
+```
+
+Use the asynchronous TestKit APIs in asynchronous tests so the test runner is never blocked.
+
 ## Asynchronous Testing: TestKit
 
 Testkit allows you to test your actors in a controlled but realistic environment. The definition of the environment depends of course very much on the problem at hand and the level at which you intend to test, ranging from simple checks to full system tests.

--- a/src/contrib/testkits/Akka.TestKit.TUnit.Tests/Akka.TestKit.TUnit.Tests.csproj
+++ b/src/contrib/testkits/Akka.TestKit.TUnit.Tests/Akka.TestKit.TUnit.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(NetTestVersion)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <TUnitImplicitUsings>false</TUnitImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" Version="$(TUnitVersion)" />
+    <ProjectReference Include="../Akka.TestKit.TUnit/Akka.TestKit.TUnit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/contrib/testkits/Akka.TestKit.TUnit.Tests/ParallelAmbientContextSpec.cs
+++ b/src/contrib/testkits/Akka.TestKit.TUnit.Tests/ParallelAmbientContextSpec.cs
@@ -1,0 +1,39 @@
+//-----------------------------------------------------------------------
+// <copyright file="ParallelAmbientContextSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.TestKit.TestActors;
+using TUnit.Core;
+
+namespace Akka.TestKit.TUnit.Tests;
+
+public abstract class ParallelAmbientContextSpecBase : Akka.TestKit.TUnit.TestKit
+{
+    [Test]
+    public async Task Should_keep_its_own_implicit_sender_across_awaits()
+    {
+        var actor = Sys.ActorOf(SimpleEchoActor.Props());
+        await Task.Yield();
+
+        actor.Tell(GetType().Name);
+
+        await ExpectMsgAsync(GetType().Name, TimeSpan.FromSeconds(3));
+    }
+}
+
+[InheritsTests]
+public sealed class ParallelAmbientContextSpec1 : ParallelAmbientContextSpecBase;
+[InheritsTests]
+public sealed class ParallelAmbientContextSpec2 : ParallelAmbientContextSpecBase;
+[InheritsTests]
+public sealed class ParallelAmbientContextSpec3 : ParallelAmbientContextSpecBase;
+[InheritsTests]
+public sealed class ParallelAmbientContextSpec4 : ParallelAmbientContextSpecBase;

--- a/src/contrib/testkits/Akka.TestKit.TUnit.Tests/TUnitAssertionsSpec.cs
+++ b/src/contrib/testkits/Akka.TestKit.TUnit.Tests/TUnitAssertionsSpec.cs
@@ -1,0 +1,94 @@
+//-----------------------------------------------------------------------
+// <copyright file="TUnitAssertionsSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using TUnit.Assertions;
+using TUnit.Assertions.Exceptions;
+using TUnit.Core;
+
+namespace Akka.TestKit.TUnit.Tests;
+
+public sealed class TUnitAssertionsSpec
+{
+    private readonly TUnitAssertions _assertions = new();
+
+    [Test]
+    public async Task Should_preserve_unformatted_messages_without_arguments()
+    {
+        const string message = "{Value} with a non-numeric placeholder {0}";
+
+        var exception = await Assert.ThrowsAsync<AssertionException>(
+            () => Task.Run(() => _assertions.AssertTrue(false, message)));
+
+        await Assert.That(exception!.Message).IsEqualTo(message);
+    }
+
+    [Test]
+    public async Task Should_format_messages_with_arguments()
+    {
+        var exception = await Assert.ThrowsAsync<AssertionException>(
+            () => Task.Run(() => _assertions.AssertFalse(true, "Meaning: {0}", 42)));
+
+        await Assert.That(exception!.Message).IsEqualTo("Meaning: 42");
+    }
+
+    [Test]
+    public async Task Should_report_malformed_format_strings()
+    {
+        var exception = await Assert.ThrowsAsync<AssertionException>(
+            () => Task.Run(() => _assertions.AssertTrue(false, "Missing: {0} {1}", 42)));
+
+        await Assert.That(exception!.Message).StartsWith("[Could not string.Format");
+    }
+
+    [Test]
+    public async Task Should_compare_nested_sequences_by_value()
+    {
+        _assertions.AssertEqual(
+            new[] { new[] { 1, 2 }, new[] { 3, 4 } },
+            new[] { new[] { 1, 2 }, new[] { 3, 4 } });
+
+        var exception = await Assert.ThrowsAsync<AssertionException>(
+            () => Task.Run(
+                () => _assertions.AssertEqual(
+                    new[] { new[] { 1, 2 }, new[] { 3, 4 } },
+                    new[] { new[] { 1, 2 }, new[] { 3, 5 } })));
+
+        await Assert.That(exception).IsNotNull();
+    }
+
+    [Test]
+    public async Task Should_report_the_actual_exception_type()
+    {
+        var exception = await Assert.ThrowsAsync<AssertionException>(
+            () => Task.Run(
+                () => _assertions.AssertThrows<InvalidOperationException>(
+                    () => throw new ArgumentException("wrong type"))));
+
+        await Assert.That(exception!.Message).Contains(typeof(InvalidOperationException).FullName!);
+        await Assert.That(exception.Message).Contains(typeof(ArgumentException).FullName!);
+    }
+
+    [Test]
+    public void Should_use_custom_comparers()
+        => _assertions.AssertEqual("AKKA", "akka", StringComparer.OrdinalIgnoreCase.Equals);
+
+    [Test]
+    public void Should_honor_comparable_equality()
+        => _assertions.AssertEqual(new ComparableOnly(42), new ComparableOnly(42));
+
+    private sealed class ComparableOnly(int value) : IComparable<ComparableOnly>
+    {
+        private int Value => value;
+
+        public int CompareTo(ComparableOnly? other)
+            => other is null ? 1 : value.CompareTo(other.Value);
+    }
+}

--- a/src/contrib/testkits/Akka.TestKit.TUnit.Tests/TUnitTestKitSpec.cs
+++ b/src/contrib/testkits/Akka.TestKit.TUnit.Tests/TUnitTestKitSpec.cs
@@ -1,0 +1,65 @@
+//-----------------------------------------------------------------------
+// <copyright file="TUnitTestKitSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Event;
+using Akka.TestKit.TestActors;
+using TUnit.Assertions;
+using TUnit.Assertions.Exceptions;
+using TUnit.Core;
+
+namespace Akka.TestKit.TUnit.Tests;
+
+public sealed class TUnitTestKitSpec : Akka.TestKit.TUnit.TestKit
+{
+    private bool HasTestOutput => Output is not null;
+
+    [Test]
+    public async Task Should_exchange_actor_messages_with_async_testkit_apis()
+    {
+        var actor = Sys.ActorOf(SimpleEchoActor.Props());
+        await Task.Yield();
+
+        actor.Tell("hello");
+
+        await ExpectMsgAsync("hello", TimeSpan.FromSeconds(3));
+        await Assert.That(HasTestOutput).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_report_testkit_failures_as_tunit_assertion_exceptions()
+    {
+        var exception = await Assert.ThrowsAsync<AssertionException>(
+            () => Assertions.AssertThrowsAsync<InvalidOperationException>(() => Task.CompletedTask));
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.Message).Contains(nameof(InvalidOperationException));
+    }
+
+    [Test]
+    public async Task Should_capture_actor_logs_in_tunit_output()
+    {
+        var marker = $"tunit-log-{Guid.NewGuid():N}";
+
+        Sys.Log.Info(marker);
+
+        await AwaitAssertAsync(
+            () => Assertions.AssertTrue(TestContext.Current!.Output.GetStandardOutput().Contains(marker)),
+            TimeSpan.FromSeconds(3),
+            TimeSpan.FromMilliseconds(50));
+    }
+
+    [Test]
+    public async Task Should_accept_tunit_test_cancellation_token()
+        => await ExpectNoMsgAsync(
+            TimeSpan.FromMilliseconds(20),
+            TestContext.Current!.Execution.CancellationToken);
+}

--- a/src/contrib/testkits/Akka.TestKit.TUnit/Akka.TestKit.TUnit.csproj
+++ b/src/contrib/testkits/Akka.TestKit.TUnit/Akka.TestKit.TUnit.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>TestKit for writing tests for Akka.NET using TUnit.</Description>
+    <TargetFramework>$(NetStandardLibVersion)</TargetFramework>
+    <PackageTags>$(AkkaPackageTags);testkit;tunit</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+    <TUnitImplicitUsings>false</TUnitImplicitUsings>
+    <TUnitAssertionsImplicitUsings>false</TUnitAssertionsImplicitUsings>
+    <EnableTUnitSourceGeneration>false</EnableTUnitSourceGeneration>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../core/Akka.TestKit/Akka.TestKit.csproj" />
+    <PackageReference Include="TUnit.Core" Version="$(TUnitVersion)" />
+    <PackageReference Include="TUnit.Assertions" Version="$(TUnitVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/contrib/testkits/Akka.TestKit.TUnit/AkkaTUnitLifecycleAttribute.cs
+++ b/src/contrib/testkits/Akka.TestKit.TUnit/AkkaTUnitLifecycleAttribute.cs
@@ -1,0 +1,43 @@
+//-----------------------------------------------------------------------
+// <copyright file="AkkaTUnitLifecycleAttribute.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using TUnit.Core;
+using TUnit.Core.Interfaces;
+
+namespace Akka.TestKit.TUnit;
+
+/// <summary>
+/// Connects <see cref="TestKit"/> instances to TUnit's per-test lifecycle.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = true)]
+public sealed class AkkaTUnitLifecycleAttribute : Attribute, ITestStartEventReceiver, ITestEndEventReceiver
+{
+    /// <inheritdoc />
+    public int Order => 0;
+
+    /// <inheritdoc />
+    public ValueTask OnTestStart(TestContext context)
+    {
+        if (context.Metadata.TestDetails.ClassInstance is TestKit testKit)
+            testKit.OnTestStart(context);
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public ValueTask OnTestEnd(TestContext context)
+    {
+        if (context.Metadata.TestDetails.ClassInstance is TestKit testKit)
+            testKit.OnTestEnd();
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/contrib/testkits/Akka.TestKit.TUnit/Internals/TestOutputLogger.cs
+++ b/src/contrib/testkits/Akka.TestKit.TUnit/Internals/TestOutputLogger.cs
@@ -27,11 +27,6 @@ internal sealed class TestOutputLogger : ReceiveActor
         Receive<Info>(HandleLogEvent);
         Receive<Warning>(HandleLogEvent);
         Receive<Error>(HandleLogEvent);
-        Receive<InitializeLogger>(message =>
-        {
-            message.LoggingBus.Subscribe(Self, typeof(LogEvent));
-            Sender.Tell(new LoggerInitialized());
-        });
     }
 
     private void HandleLogEvent(LogEvent logEvent)

--- a/src/contrib/testkits/Akka.TestKit.TUnit/Internals/TestOutputLogger.cs
+++ b/src/contrib/testkits/Akka.TestKit.TUnit/Internals/TestOutputLogger.cs
@@ -1,0 +1,58 @@
+//-----------------------------------------------------------------------
+// <copyright file="TestOutputLogger.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.IO;
+using Akka.Actor;
+using Akka.Event;
+using Akka.Util;
+
+namespace Akka.TestKit.TUnit.Internals;
+
+internal sealed class TestOutputLogger : ReceiveActor
+{
+    private readonly TextWriter _output;
+
+    public TestOutputLogger(TextWriter output)
+    {
+        _output = output;
+
+        Receive<Debug>(HandleLogEvent);
+        Receive<Info>(HandleLogEvent);
+        Receive<Warning>(HandleLogEvent);
+        Receive<Error>(HandleLogEvent);
+        Receive<InitializeLogger>(message =>
+        {
+            message.LoggingBus.Subscribe(Self, typeof(LogEvent));
+            Sender.Tell(new LoggerInitialized());
+        });
+    }
+
+    private void HandleLogEvent(LogEvent logEvent)
+    {
+        try
+        {
+            _output.WriteLine(logEvent.ToString());
+        }
+        catch (FormatException exception) when (logEvent.Message is LogMessage message)
+        {
+            var details =
+                $"Received a malformed formatted message. Log level: [{logEvent.LogLevel()}], Template: [{message.Format}], args: [{string.Join(",", message.Unformatted())}]";
+            if (logEvent.Cause is not null)
+                throw new AggregateException(details, exception, logEvent.Cause);
+            throw new FormatException(details, exception);
+        }
+        catch (InvalidOperationException exception)
+        {
+            StandardOutWriter.WriteLine(
+                $"Received InvalidOperationException: {exception} - probably because the test had completed executing.");
+            Context.Stop(Self);
+        }
+    }
+}

--- a/src/contrib/testkits/Akka.TestKit.TUnit/TUnitAssertions.cs
+++ b/src/contrib/testkits/Akka.TestKit.TUnit/TUnitAssertions.cs
@@ -1,0 +1,199 @@
+//-----------------------------------------------------------------------
+// <copyright file="TUnitAssertions.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TUnit.Assertions.Exceptions;
+
+namespace Akka.TestKit.TUnit;
+
+/// <summary>
+/// Provides the synchronous assertion operations required by the Akka.NET TestKit using TUnit assertion exceptions.
+/// </summary>
+public sealed class TUnitAssertions : ITestKitAssertions
+{
+    /// <inheritdoc />
+    public void Fail(string format = "", params object[] args)
+        => throw new AssertionException(BuildAssertionMessage(format, args));
+
+    /// <inheritdoc />
+    public void AssertTrue(bool condition, string format = "", params object[] args)
+    {
+        if (!condition)
+            Fail(format, args);
+    }
+
+    /// <inheritdoc />
+    public void AssertFalse(bool condition, string format = "", params object[] args)
+    {
+        if (condition)
+            Fail(format, args);
+    }
+
+    /// <inheritdoc />
+    public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args)
+    {
+        if (!AreEqual(expected, actual))
+            throw new AssertionException(BuildEqualityMessage(expected, actual, format, args));
+    }
+
+    /// <inheritdoc />
+    public void AssertEqual<T>(T expected, T actual, Func<T, T, bool> comparer, string format = "", params object[] args)
+    {
+        if (!comparer(expected, actual))
+            throw new AssertionException(BuildEqualityMessage(expected, actual, format, args));
+    }
+
+    /// <inheritdoc />
+    public Exception AssertThrows(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+
+        throw new AssertionException("Expected an exception, but no exception was thrown.");
+    }
+
+    /// <inheritdoc />
+    public TException AssertThrows<TException>(Action action) where TException : Exception
+    {
+        try
+        {
+            action();
+        }
+        catch (TException exception)
+        {
+            return exception;
+        }
+        catch (Exception exception)
+        {
+            throw WrongExceptionType<TException>(exception);
+        }
+
+        throw NoExceptionThrown<TException>();
+    }
+
+    /// <inheritdoc />
+    public async Task<Exception> AssertThrowsAsync(Func<Task> action)
+    {
+        try
+        {
+            await action().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+
+        throw new AssertionException("Expected an exception, but no exception was thrown.");
+    }
+
+    /// <inheritdoc />
+    public async Task<TException> AssertThrowsAsync<TException>(Func<Task> action) where TException : Exception
+    {
+        try
+        {
+            await action().ConfigureAwait(false);
+        }
+        catch (TException exception)
+        {
+            return exception;
+        }
+        catch (Exception exception)
+        {
+            throw WrongExceptionType<TException>(exception);
+        }
+
+        throw NoExceptionThrown<TException>();
+    }
+
+    private static bool AreEqual<T>(T expected, T actual)
+    {
+        if (ReferenceEquals(expected, actual))
+            return true;
+        if (expected is null || actual is null)
+            return false;
+
+        switch (expected)
+        {
+            case IEquatable<T> equatable:
+                return equatable.Equals(actual);
+            case IComparable<T> comparable:
+                return comparable.CompareTo(actual) == 0;
+            case IComparable comparable:
+                return comparable.CompareTo(actual) == 0;
+            case IEnumerable expectedEnumerable when actual is IEnumerable actualEnumerable:
+                return expectedEnumerable.Cast<object?>()
+                    .SequenceEqual(actualEnumerable.Cast<object?>(), ObjectEqualityComparer.Instance);
+        }
+
+        if (expected.GetType() != actual.GetType())
+            return false;
+
+        return object.Equals(expected, actual);
+    }
+
+    private static AssertionException NoExceptionThrown<TException>() where TException : Exception
+        => new($"Expected an exception of type {typeof(TException).FullName}, but no exception was thrown.");
+
+    private static AssertionException WrongExceptionType<TException>(Exception actual) where TException : Exception
+        => new(
+            $"Expected an exception of type {typeof(TException).FullName}, but {actual.GetType().FullName} was thrown.",
+            actual);
+
+    private static string BuildEqualityMessage<T>(T expected, T actual, string format, object[] args)
+    {
+        var userMessage = BuildAssertionMessage(format, args);
+        return $"Expected: {FormatValue(expected)}{Environment.NewLine}Actual:   {FormatValue(actual)}"
+            + (string.IsNullOrEmpty(userMessage) ? string.Empty : $"{Environment.NewLine}{userMessage}");
+    }
+
+    internal static string BuildAssertionMessage(string format, object[] args)
+    {
+        if (string.IsNullOrEmpty(format) || args.Length == 0)
+            return format;
+
+        try
+        {
+            return string.Format(format, args);
+        }
+        catch (FormatException)
+        {
+            return $"[Could not string.Format(\"{format}\", {string.Join(", ", args)})]";
+        }
+    }
+
+    private static string FormatValue(object? value)
+        => value switch
+        {
+            null => "null",
+            string text => $"\"{text}\"",
+            IEnumerable items => $"[{string.Join(", ", items.Cast<object?>().Select(FormatValue))}]",
+            _ => value.ToString() ?? value.GetType().FullName ?? "<unknown>"
+        };
+
+    private sealed class ObjectEqualityComparer : IEqualityComparer<object?>
+    {
+        public static readonly ObjectEqualityComparer Instance = new();
+
+        public new bool Equals(object? x, object? y)
+            => AreEqual(x, y);
+
+        public int GetHashCode(object? obj)
+            => obj?.GetHashCode() ?? 0;
+    }
+}

--- a/src/contrib/testkits/Akka.TestKit.TUnit/TestKit.cs
+++ b/src/contrib/testkits/Akka.TestKit.TUnit/TestKit.cs
@@ -184,7 +184,7 @@ public class TestKit : TestKitBase, IDisposable
             isSystemService: true,
             isAsync: false,
             name: "log-test");
-        logger.Tell(new InitializeLogger(system.EventStream), ActorRefs.NoSender);
+        system.EventStream.Subscribe(logger, typeof(LogEvent));
     }
 
     /// <summary>

--- a/src/contrib/testkits/Akka.TestKit.TUnit/TestKit.cs
+++ b/src/contrib/testkits/Akka.TestKit.TUnit/TestKit.cs
@@ -1,0 +1,247 @@
+//-----------------------------------------------------------------------
+// <copyright file="TestKit.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Akka.Actor;
+using Akka.Actor.Internal;
+using Akka.Actor.Setup;
+using Akka.Configuration;
+using Akka.Event;
+using Akka.TestKit.TUnit.Internals;
+using TUnit.Core;
+
+namespace Akka.TestKit.TUnit;
+
+/// <summary>
+/// An Akka.NET TestKit integrated with the <a href="https://tunit.dev/">TUnit</a> test framework.
+/// </summary>
+[AkkaTUnitLifecycle]
+public class TestKit : TestKitBase, IDisposable
+{
+    private sealed class PrefixedTextWriter(TextWriter output, string prefix) : TextWriter
+    {
+        public override Encoding Encoding => output.Encoding;
+
+        public override void WriteLine(string? value)
+            => output.WriteLine(prefix + value);
+    }
+
+    private bool _disposed;
+    private bool _disposing;
+    private bool _ambientContextApplied;
+    private SynchronizationContext? _previousSynchronizationContext;
+    private ActorCell? _previousActorCell;
+
+    /// <summary>
+    /// The writer used to capture test output.
+    /// </summary>
+    protected TextWriter? Output { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestKit"/> class.
+    /// </summary>
+    /// <param name="system">The actor system to use for testing, or <see langword="null"/> to create one.</param>
+    /// <param name="output">An optional output writer. TUnit's current test output is used when omitted.</param>
+    public TestKit(ActorSystem? system = null, TextWriter? output = null)
+        : base(Assertions, system)
+    {
+        Output = output;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestKit"/> class.
+    /// </summary>
+    /// <param name="config">The setup used to configure the actor system.</param>
+    /// <param name="actorSystemName">The actor system name. The default is "test".</param>
+    /// <param name="output">An optional output writer. TUnit's current test output is used when omitted.</param>
+    public TestKit(ActorSystemSetup config, string? actorSystemName = null, TextWriter? output = null)
+        : base(Assertions, config, actorSystemName)
+    {
+        Output = output;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestKit"/> class.
+    /// </summary>
+    /// <param name="config">The configuration used to create the actor system.</param>
+    /// <param name="actorSystemName">The actor system name. The default is "test".</param>
+    /// <param name="output">An optional output writer. TUnit's current test output is used when omitted.</param>
+    public TestKit(Config config, string? actorSystemName = null, TextWriter? output = null)
+        : base(Assertions, config, actorSystemName)
+    {
+        Output = output;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TestKit"/> class.
+    /// </summary>
+    /// <param name="config">The HOCON configuration used to create the actor system.</param>
+    /// <param name="output">An optional output writer. TUnit's current test output is used when omitted.</param>
+    public TestKit(string config, TextWriter? output = null)
+        : base(Assertions, ConfigurationFactory.ParseString(config))
+    {
+        Output = output;
+    }
+
+    /// <summary>
+    /// A configuration with the default TestKit logging settings.
+    /// </summary>
+    public new static Config DefaultConfig => TestKitBase.DefaultConfig;
+
+    /// <summary>
+    /// A configuration with all TestKit logging settings enabled.
+    /// </summary>
+    public new static Config FullDebugConfig => TestKitBase.FullDebugConfig;
+
+    /// <summary>
+    /// Common assertions used by the TUnit TestKit.
+    /// </summary>
+    protected static TUnitAssertions Assertions { get; } = new();
+
+    internal void OnTestStart(TestContext context)
+    {
+        if (_ambientContextApplied)
+            return;
+
+        _previousSynchronizationContext = SynchronizationContext.Current;
+        _previousActorCell = InternalCurrentActorCellKeeper.Current;
+
+        var actorCell = this is INoImplicitSender
+            ? null
+            : (base.TestActor as ActorRefWithCell)?.Underlying as ActorCell;
+
+        InternalCurrentActorCellKeeper.Current = actorCell;
+        SynchronizationContext.SetSynchronizationContext(
+            new ActorCellKeepingSynchronizationContext(actorCell, _previousSynchronizationContext));
+        _ambientContextApplied = true;
+
+        Output ??= context.OutputWriter;
+        if (Output is not null)
+            InitializeLogger(Sys);
+    }
+
+    internal void OnTestEnd()
+        => RestoreAmbientContext();
+
+    /// <summary>
+    /// The actor system used for testing.
+    /// </summary>
+    public new ActorSystem Sys
+    {
+        get
+        {
+            EnsureImplicitSender();
+            return base.Sys;
+        }
+    }
+
+    /// <summary>
+    /// The default test actor.
+    /// </summary>
+    public new IActorRef TestActor
+    {
+        get
+        {
+            EnsureImplicitSender();
+            return base.TestActor;
+        }
+    }
+
+    /// <summary>
+    /// Called when the test instance is being disposed, before its actor system is shut down.
+    /// </summary>
+    protected virtual void AfterAll()
+    {
+    }
+
+    /// <summary>
+    /// Attaches a logger that writes actor-system log events to the current test output.
+    /// </summary>
+    protected void InitializeLogger(ActorSystem system)
+        => InitializeLogger(system, string.Empty);
+
+    /// <summary>
+    /// Attaches a logger that prefixes actor-system log events written to the current test output.
+    /// </summary>
+    protected void InitializeLogger(ActorSystem system, string prefix)
+    {
+        if (Output is null)
+            return;
+
+        var systemImpl = system as ActorSystemImpl ?? throw new InvalidOperationException("Expected ActorSystemImpl");
+        var writer = string.IsNullOrEmpty(prefix) ? Output : new PrefixedTextWriter(Output, prefix);
+        var logger = systemImpl.Provider.SystemGuardian.Cell.AttachChildWithAsync(
+            Props.Create(() => new TestOutputLogger(writer)),
+            isSystemService: true,
+            isAsync: false,
+            name: "log-test");
+        logger.Tell(new InitializeLogger(system.EventStream), ActorRefs.NoSender);
+    }
+
+    /// <summary>
+    /// Releases the TestKit and shuts down its actor system.
+    /// </summary>
+    /// <param name="disposing"><see langword="true"/> when called through <see cref="Dispose()"/>.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposing || _disposed)
+            return;
+
+        _disposing = true;
+        try
+        {
+            AfterAll();
+        }
+        finally
+        {
+            try
+            {
+                Shutdown();
+                _disposed = true;
+            }
+            finally
+            {
+                RestoreAmbientContext();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+        => Dispose(true);
+
+    private void EnsureImplicitSender()
+    {
+        if (this is INoImplicitSender)
+            return;
+
+        var actorCell = (ActorCell)((ActorRefWithCell)base.TestActor).Underlying;
+        if (InternalCurrentActorCellKeeper.Current is null)
+            InternalCurrentActorCellKeeper.Current = actorCell;
+
+        if (SynchronizationContext.Current is not ActorCellKeepingSynchronizationContext)
+        {
+            SynchronizationContext.SetSynchronizationContext(
+                new ActorCellKeepingSynchronizationContext(actorCell, SynchronizationContext.Current));
+        }
+    }
+
+    private void RestoreAmbientContext()
+    {
+        if (!_ambientContextApplied)
+            return;
+
+        InternalCurrentActorCellKeeper.Current = _previousActorCell;
+        SynchronizationContext.SetSynchronizationContext(_previousSynchronizationContext);
+        _ambientContextApplied = false;
+    }
+}

--- a/src/core/Akka.API.Tests/Akka.API.Tests.csproj
+++ b/src/core/Akka.API.Tests/Akka.API.Tests.csproj
@@ -3,6 +3,8 @@
 
   <PropertyGroup>
     <TargetFramework>$(NetTestVersion)</TargetFramework>
+    <!-- This is an xUnit API-approval project; TUnit analyzers arrive transitively from the adapter under approval. -->
+    <NoWarn>$(NoWarn);TUnit0055</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,6 +13,7 @@
     <ProjectReference Include="..\..\contrib\cluster\Akka.DistributedData\Akka.DistributedData.csproj" />
     <ProjectReference Include="..\..\contrib\persistence\Akka.Persistence.Query.InMemory\Akka.Persistence.Query.InMemory.csproj" />
     <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.Xunit2\Akka.TestKit.Xunit2.csproj" />
+    <ProjectReference Include="..\..\contrib\testkits\Akka.TestKit.TUnit\Akka.TestKit.TUnit.csproj" />
     <ProjectReference Include="..\Akka.Coordination\Akka.Coordination.csproj" />
     <ProjectReference Include="..\Akka.Discovery\Akka.Discovery.csproj" />
     <ProjectReference Include="..\Akka.Persistence.Query\Akka.Persistence.Query.csproj" />

--- a/src/core/Akka.API.Tests/CoreAPISpec.cs
+++ b/src/core/Akka.API.Tests/CoreAPISpec.cs
@@ -133,5 +133,11 @@ namespace Akka.API.Tests
         {
             return VerifyAssembly<TestKit.Xunit2.TestKit>();
         }
+
+        [Fact]
+        public Task ApproveTestKitTUnit()
+        {
+            return VerifyAssembly<TestKit.TUnit.TestKit>();
+        }
     }
 }

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveCore.DotNet.verified.txt
@@ -30,6 +30,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Streams")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.Streams.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.TUnit")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.Xunit")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.Xunit2")]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKit.DotNet.verified.txt
@@ -1,4 +1,5 @@
 ﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.TUnit")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Akka.TestKit.Xunit")]
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 [assembly: System.Runtime.InteropServices.Guid("ae01b790-1478-4917-9299-b4855ba997cb")]

--- a/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKitTUnit.DotNet.verified.txt
+++ b/src/core/Akka.API.Tests/verify/CoreAPISpec.ApproveTestKitTUnit.DotNet.verified.txt
@@ -1,0 +1,47 @@
+﻿[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/akkadotnet/akka.net")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
+namespace Akka.TestKit.TUnit
+{
+    [System.AttributeUsage(System.AttributeTargets.Class, Inherited=true)]
+    public sealed class AkkaTUnitLifecycleAttribute : System.Attribute, TUnit.Core.Interfaces.IEventReceiver, TUnit.Core.Interfaces.ITestEndEventReceiver, TUnit.Core.Interfaces.ITestStartEventReceiver
+    {
+        public AkkaTUnitLifecycleAttribute() { }
+        public int Order { get; }
+        public System.Threading.Tasks.ValueTask OnTestEnd(TUnit.Core.TestContext context) { }
+        public System.Threading.Tasks.ValueTask OnTestStart(TUnit.Core.TestContext context) { }
+    }
+    public sealed class TUnitAssertions : Akka.TestKit.ITestKitAssertions
+    {
+        public TUnitAssertions() { }
+        public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args) { }
+        public void AssertEqual<T>(T expected, T actual, System.Func<T, T, bool> comparer, string format = "", params object[] args) { }
+        public void AssertFalse(bool condition, string format = "", params object[] args) { }
+        public System.Exception AssertThrows(System.Action action) { }
+        public TException AssertThrows<TException>(System.Action action)
+            where TException : System.Exception { }
+        public System.Threading.Tasks.Task<System.Exception> AssertThrowsAsync(System.Func<System.Threading.Tasks.Task> action) { }
+        public System.Threading.Tasks.Task<TException> AssertThrowsAsync<TException>(System.Func<System.Threading.Tasks.Task> action)
+            where TException : System.Exception { }
+        public void AssertTrue(bool condition, string format = "", params object[] args) { }
+        public void Fail(string format = "", params object[] args) { }
+    }
+    [Akka.TestKit.TUnit.AkkaTUnitLifecycle]
+    public class TestKit : Akka.TestKit.TestKitBase, System.IDisposable
+    {
+        public TestKit(Akka.Actor.ActorSystem? system = null, System.IO.TextWriter? output = null) { }
+        public TestKit(string config, System.IO.TextWriter? output = null) { }
+        public TestKit(Akka.Actor.Setup.ActorSystemSetup config, string? actorSystemName = null, System.IO.TextWriter? output = null) { }
+        public TestKit(Akka.Configuration.Config config, string? actorSystemName = null, System.IO.TextWriter? output = null) { }
+        protected System.IO.TextWriter? Output { get; }
+        public new Akka.Actor.ActorSystem Sys { get; }
+        public new Akka.Actor.IActorRef TestActor { get; }
+        protected static Akka.TestKit.TUnit.TUnitAssertions Assertions { get; }
+        public new static Akka.Configuration.Config DefaultConfig { get; }
+        public new static Akka.Configuration.Config FullDebugConfig { get; }
+        protected virtual void AfterAll() { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool disposing) { }
+        protected void InitializeLogger(Akka.Actor.ActorSystem system) { }
+        protected void InitializeLogger(Akka.Actor.ActorSystem system, string prefix) { }
+    }
+}

--- a/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
+++ b/src/core/Akka.FSharp.Tests/Akka.FSharp.Tests.fsproj
@@ -3,6 +3,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetTestVersion)</TargetFrameworks>
+    <!-- .NET SDK 10.0.302 implicitly references FSharp.Core 10.1.302 through Akka.FSharp. -->
+    <FsharpVersion>10.1.302</FsharpVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>

--- a/src/core/Akka.TestKit/Properties/AssemblyInfo.cs
+++ b/src/core/Akka.TestKit/Properties/AssemblyInfo.cs
@@ -21,3 +21,4 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ae01b790-1478-4917-9299-b4855ba997cb")]
 [assembly: InternalsVisibleTo("Akka.TestKit.Xunit")]
+[assembly: InternalsVisibleTo("Akka.TestKit.TUnit")]

--- a/src/core/Akka/Properties/AssemblyInfo.cs
+++ b/src/core/Akka/Properties/AssemblyInfo.cs
@@ -30,6 +30,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Akka.TestKit.Tests")]
 [assembly: InternalsVisibleTo("Akka.TestKit.Xunit")]
 [assembly: InternalsVisibleTo("Akka.TestKit.Xunit2")]
+[assembly: InternalsVisibleTo("Akka.TestKit.TUnit")]
 [assembly: InternalsVisibleTo("Akka.Remote")]
 [assembly: InternalsVisibleTo("Akka.Serialization.V2")]
 [assembly: InternalsVisibleTo("Akka.Remote.TestKit")]


### PR DESCRIPTION
## Changes

Add a TUnit-native Akka.NET TestKit package with output capture, async implicit-sender preservation, assertion integration, API approvals, documentation, and dedicated cross-platform CI jobs.

## Checklist

For significant changes, please ensure that the following have been completed (delete if not relevant):

* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).
* [x] Changes in public API reviewed, if any.