### PR TITLE
Build: pin SDK-implicit FSharp.Core and bump FsharpVersion to 10.1.302 (fixes repo-wide NU1605)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -35,7 +35,7 @@
     <MessagePackVersion>3.1.7</MessagePackVersion>
     <MicrosoftCodeAnalysisCSharpVersion>4.13.0</MicrosoftCodeAnalysisCSharpVersion>
     <NetTestVersion>net10.0</NetTestVersion>
-    <FsharpVersion>10.1.301</FsharpVersion>
+    <FsharpVersion>10.1.302</FsharpVersion>
     <NetStandardLibVersion>net10.0</NetStandardLibVersion>
     <FluentAssertionsVersion>5.10.3</FluentAssertionsVersion>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/core/Akka.FSharp/Akka.FSharp.fsproj
+++ b/src/core/Akka.FSharp/Akka.FSharp.fsproj
@@ -21,6 +21,11 @@
     <ItemGroup>
         <PackageReference Include="FSharp.Quotations.Evaluator" Version="2.1.0"/>
         <PackageReference Include="FsPickler" Version="5.3.2"/>
+        <!-- Pin the SDK-implicit FSharp.Core so restore doesn't depend on which SDK the
+             build agent has installed (implicit-version drift causes NU1605 downgrade errors
+             against projects that pin $(FsharpVersion)). Use Update (not Include) so we don't
+             duplicate the implicit reference (NU1504). -->
+        <PackageReference Update="FSharp.Core" Version="$(FsharpVersion)"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Fixes repo-wide CI break: NU1605 FSharp.Core downgrade

Every CI run since ~2026-07-14 fails at compile with:

```
error NU1605: Warning As Error: Detected package downgrade: FSharp.Core from 10.1.302 to 10.1.301.
 Akka.FSharp.Tests -> Akka.FSharp -> FSharp.Core (>= 10.1.302)
 Akka.FSharp.Tests -> FSharp.Core (>= 10.1.301)
```

### Root cause
`Akka.FSharp` had no explicit `FSharp.Core` reference, so it rode the F# SDK's **implicit** one — whose version tracks whatever .NET SDK is installed on the build agent. The Azure hosted images rolled a newer SDK between the last green `dev` build (2026-07-12) and 2026-07-15, bumping the implicit `FSharp.Core` to 10.1.302, which now conflicts with the repo-pinned `$(FsharpVersion)` of 10.1.301 used by `Akka.FSharp.Tests`. This is infrastructure drift — no code change in this repo triggered it, and it breaks every branch and PR identically (all four compile jobs fail with the same error).

### Fix (2 lines)
1. Bump `<FsharpVersion>` 10.1.301 → **10.1.302** in `Directory.Build.props`.
2. Pin the SDK-implicit reference in `Akka.FSharp.fsproj` via `<PackageReference Update="FSharp.Core" Version="$(FsharpVersion)"/>` — the same `Update` technique `Akka.FSharp.Tests` already uses. This makes the resolved `FSharp.Core` independent of the build agent's SDK, so future image rolls can't reintroduce NU1605 from either direction (this incident was SDK-ahead-of-pin; the pre-existing comment in the test project records the earlier FsCheck-ahead-of-SDK incident). It also makes the published `Akka.FSharp` package's `FSharp.Core` dependency floor a deliberate, reviewable value instead of an artifact of whichever SDK image packed the release.

### Verification
- Restore/build clean locally; both projects resolve `FSharp.Core` to exactly 10.1.302 in `project.assets.json`
- `Akka.FSharp.Tests`: 35 passed / 1 skipped
- This same commit (cherry-picked from #8385, where CI first hit the break) took that PR's validation run from four failed compile jobs to **fully green across all 11 checks**
