### PR TITLE
chore: remove global:: qualifiers from hand-written code

### DIFF
--- a/src/core/Akka.Cluster/Serialization/ClusterMessageSerializer.cs
+++ b/src/core/Akka.Cluster/Serialization/ClusterMessageSerializer.cs
@@ -591,7 +591,7 @@ namespace Akka.Cluster.Serialization
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static string GetObjectManifest(Serializer serializer, object obj)
         {
-            return global::Akka.Serialization.Serialization.ManifestFor(serializer, obj);
+            return Akka.Serialization.Serialization.ManifestFor(serializer, obj);
         }
     }
 }

--- a/src/core/Akka.Remote.Tests/AckedDeliverySpec.cs
+++ b/src/core/Akka.Remote.Tests/AckedDeliverySpec.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Akka.TestKit;
 using Akka.Util;
@@ -396,7 +397,7 @@ namespace Akka.Remote.Tests
             };
 
             //Dropping phase
-            global::System.Diagnostics.Debug.WriteLine("Starting unreliable delivery for {0} messages, with delivery probably P = {1}", msgCount, deliveryProbability);
+            Debug.WriteLine("Starting unreliable delivery for {0} messages, with delivery probably P = {1}", msgCount, deliveryProbability);
             var nextSteps = msgCount*2;
             while (nextSteps > 0)
             {
@@ -405,8 +406,8 @@ namespace Akka.Remote.Tests
                 receiverStep(deliveryProbability);
                 nextSteps--;
             }
-            global::System.Diagnostics.Debug.WriteLine("Successfully delivered {0} messages from {1}", received.Count, msgCount);
-            global::System.Diagnostics.Debug.WriteLine("Entering reliable phase");
+            Debug.WriteLine("Successfully delivered {0} messages from {1}", received.Count, msgCount);
+            Debug.WriteLine("Entering reliable phase");
 
             //Finalizing phase
             for (var i = 1; i <= msgCount; i++)
@@ -417,13 +418,13 @@ namespace Akka.Remote.Tests
 
             if (!received.SequenceEqual(referenceList))
             {
-                global::System.Diagnostics.Debug.WriteLine(string.Join(Environment.NewLine, log));
-                global::System.Diagnostics.Debug.WriteLine("Received: ");
-                global::System.Diagnostics.Debug.WriteLine(string.Join(Environment.NewLine, received.Select(x => x.ToString())));
+                Debug.WriteLine(string.Join(Environment.NewLine, log));
+                Debug.WriteLine("Received: ");
+                Debug.WriteLine(string.Join(Environment.NewLine, received.Select(x => x.ToString())));
                 Assert.Fail("Not all messages were received");
             }
 
-            global::System.Diagnostics.Debug.WriteLine("All messages have been successfully delivered");
+            Debug.WriteLine("All messages have been successfully delivered");
         }
 
         #endregion

--- a/src/core/Akka.Remote.Tests/Artery/ArteryControlMessageSerializerSpec.cs
+++ b/src/core/Akka.Remote.Tests/Artery/ArteryControlMessageSerializerSpec.cs
@@ -266,7 +266,7 @@ namespace Akka.Remote.Tests.Artery
 
             Akka.Serialization.Serialization.WithTransport((ExtendedActorSystem)_system, () =>
             {
-                _serializer.SizeHint(envelope).Should().Be(global::Akka.Serialization.SerializerV2.UnknownSize);
+                _serializer.SizeHint(envelope).Should().Be(Akka.Serialization.SerializerV2.UnknownSize);
                 return true;
             });
         }

--- a/src/core/Akka.Tests/Actor/ActorPathSpec.cs
+++ b/src/core/Akka.Tests/Actor/ActorPathSpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using Akka.Actor;
@@ -311,7 +312,7 @@ namespace Akka.Tests.Actor
         public void Validate_that_url_encoded_values_are_valid_element_parts(string element)
         {
             var urlEncode = System.Net.WebUtility.UrlEncode(element);
-            global::System.Diagnostics.Debug.WriteLine("Encoded \"{0}\" to \"{1}\"", element, urlEncode);
+            Debug.WriteLine("Encoded \"{0}\" to \"{1}\"", element, urlEncode);
             ActorPath.IsValidPathElement(urlEncode).ShouldBeTrue();
         }
     }

--- a/src/core/Akka.Tests/Delivery/TestConsumer.cs
+++ b/src/core/Akka.Tests/Delivery/TestConsumer.cs
@@ -76,7 +76,7 @@ public sealed class TestConsumer : ReceiveActor, IWithTimers
                 throw new InvalidOperationException($"Received duplicate [{nextMsg}]");
 
             _log.Info("processed [{0}] [msg: {1}] from [{2}]", job.SeqNr, job.Msg.Payload, job.ProducerId);
-            job.ConfirmTo.Tell(global::Akka.Delivery.ConsumerController.Confirmed.Instance);
+            job.ConfirmTo.Tell(Akka.Delivery.ConsumerController.Confirmed.Instance);
 
             if (EndCondition(job) && (_messageCount > 0 || _supportRestarts))
             {

--- a/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
+++ b/src/core/Akka/Actor/ActorCell.DefaultMessages.cs
@@ -13,6 +13,7 @@ using Akka.Dispatch;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
 using Debug = Akka.Event.Debug;
+using SysDebug = System.Diagnostics.Debug;
 using System.Globalization;
 using Akka.Actor.Scheduler;
 
@@ -219,8 +220,8 @@ namespace Akka.Actor
         {
             if(IsWaitingForChildren) return SuspendedWaitForChildrenState;
 
-            global::System.Diagnostics.Debug.Assert(
-                condition: Mailbox != null, 
+            SysDebug.Assert(
+                condition: Mailbox != null,
                 message: $"{nameof(Mailbox)} should never be null at this point. " +
                          $"A null {nameof(Mailbox)} should have triggered a catastrophic actor initialization failure " +
                          "and killed this actor before ever reaching this point.");
@@ -303,8 +304,8 @@ namespace Akka.Actor
                             Supervise(s.Child, s.Async);
                             break;
                         default:
-                            global::System.Diagnostics.Debug.Assert(
-                                condition: message != null, 
+                            SysDebug.Assert(
+                                condition: message != null,
                                 message: $"Something really bad happened in {nameof(SysMsgInvokeAll)}, {nameof(message)} should never be null");
                             throw new NotSupportedException($"Unknown message {message!.GetType().Name}");
                     }

--- a/src/core/Akka/Actor/ActorCell.FaultHandling.cs
+++ b/src/core/Akka/Actor/ActorCell.FaultHandling.cs
@@ -15,6 +15,7 @@ using Akka.Actor.Internal;
 using Akka.Dispatch.SysMsg;
 using Akka.Event;
 using Akka.Util.Internal;
+using SysDebug = System.Diagnostics.Debug;
 
 namespace Akka.Actor
 {
@@ -81,8 +82,8 @@ namespace Akka.Actor
                     ClearActor(Actor);
                 }
 
-                global::System.Diagnostics.Debug.Assert(Mailbox != null, $"{nameof(Mailbox)} should never be null at this point");
-                global::System.Diagnostics.Debug.Assert(Mailbox!.IsSuspended(), $"{nameof(Mailbox)} must be suspended during restart, status=" + Mailbox.CurrentStatus());
+                SysDebug.Assert(Mailbox != null, $"{nameof(Mailbox)} should never be null at this point");
+                SysDebug.Assert(Mailbox!.IsSuspended(), $"{nameof(Mailbox)} must be suspended during restart, status=" + Mailbox.CurrentStatus());
                 if (!SetChildrenTerminationReason(new SuspendReason.Recreation(cause)))
                 {
                     FinishRecreate(cause, failedActor);
@@ -145,9 +146,9 @@ namespace Akka.Actor
         /// </summary>
         private void FaultCreate()
         {
-            global::System.Diagnostics.Debug.Assert(Mailbox != null, $"{nameof(Mailbox)} should never be null at this point");
-            global::System.Diagnostics.Debug.Assert(Mailbox!.IsSuspended(), $"{nameof(Mailbox)} must be suspended during failed creation, status=" + Mailbox.CurrentStatus());
-            global::System.Diagnostics.Debug.Assert(_self.Equals(Perpetrator), $"{nameof(Perpetrator)} should be self");
+            SysDebug.Assert(Mailbox != null, $"{nameof(Mailbox)} should never be null at this point");
+            SysDebug.Assert(Mailbox!.IsSuspended(), $"{nameof(Mailbox)} must be suspended during failed creation, status=" + Mailbox.CurrentStatus());
+            SysDebug.Assert(_self.Equals(Perpetrator), $"{nameof(Perpetrator)} should be self");
 
             SetReceiveTimeout(null);
             CancelReceiveTimeout();
@@ -401,7 +402,7 @@ namespace Akka.Actor
             //the UID protects against reception of a Failed from a child which was
             //killed in preRestart and re-created in postRestart
 
-            global::System.Diagnostics.Debug.Assert(Actor != null, $"{nameof(Actor)} should never be null at this point");
+            SysDebug.Assert(Actor != null, $"{nameof(Actor)} should never be null at this point");
             if (TryGetChildStatsByRef(failedChild, out var childStats))
             {
                 var statsUid = childStats.Child.Path.Uid;


### PR DESCRIPTION
## Motivation

`global::` is the right tool in **generated** code (protobuf `.g.cs`, source-generator emission), where output must compile inside arbitrary user namespaces that can shadow `System`/`Akka`/`MessagePack`. In hand-written source it's noise — 19 occurrences across 7 files, now replaced with the shortest unambiguous form.

## Notable cases
- **`ActorCell.FaultHandling.cs` / `ActorCell.DefaultMessages.cs`**: introduced `using SysDebug = System.Diagnostics.Debug;` — inside `ActorCell`, plain `System.Diagnostics.Debug` is unwritable (`ActorCell.System` property shadows the namespace) and unqualified `Debug` collides with `Akka.Event.Debug`. The alias is the only clean spelling.
- Everything else: plain names via new/existing `using` directives or namespace-qualified forms.

## Verification
- `Akka`, `Akka.Cluster`, `Akka.Tests`, `Akka.Remote.Tests` all build clean (0 warnings)
- Directly-affected specs pass: ActorPathSpec (41), AckedDeliverySpec (15), ArteryControlMessageSerializerSpec (32)
- Zero `global::` remains in touched files; generated files untouched

Qualifier/using changes only — no behavior change. (The Serialization.V2 branch got the same treatment separately in #8385.)