### PR TITLE
Serialization.V2: committed wire-format snapshot tests (30 cases, Verify)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,3 +29,8 @@
 *.txt text eol=crlf
 
 build.sh eol=lf
+
+# Verify snapshot files: byte-exact, never line-ending-normalized (VerifyTests guidance)
+*.verified.txt text eol=lf working-tree-encoding=UTF-8
+*.verified.xml text eol=lf working-tree-encoding=UTF-8
+*.verified.json text eol=lf working-tree-encoding=UTF-8

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,6 +47,8 @@
     <MsExtVersion>[6.0.*,)</MsExtVersion>
     <MsExtTestVersion>10.0.9</MsExtTestVersion>
     <AkkaAnalyzerVersion>0.3.3</AkkaAnalyzerVersion>
+    <VerifyXunitV3Version>31.24.2</VerifyXunitV3Version>
+    <VerifyDiffPlexVersion>3.0.0</VerifyDiffPlexVersion>
     <AkkaPackageTags>akka;actors;actor model;Akka;concurrency</AkkaPackageTags>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/core/Akka.Serialization.V2.Tests/Akka.Serialization.V2.Tests.csproj
+++ b/src/core/Akka.Serialization.V2.Tests/Akka.Serialization.V2.Tests.csproj
@@ -21,5 +21,19 @@
     <PackageReference Include="xunit.v3" Version="$(Xunit3Version)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(Xunit3RunnerVersion)" />
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="Verify.XunitV3" Version="$(VerifyXunitV3Version)" />
+    <PackageReference Include="Verify.DiffPlex" Version="$(VerifyDiffPlexVersion)" />
+  </ItemGroup>
+
+  <!--
+    Committed wire-format snapshot artifacts (see WireSnapshots/README.md). These are plain text
+    that ship with the repository so wire-format changes are reviewable in a PR diff. They are
+    NOT compiled, and (IsPackable is already false above, so nothing from this project is ever
+    packed) are explicitly marked None/not-copied so they never leak into a build or test output
+    directory.
+  -->
+  <ItemGroup>
+    <None Update="WireSnapshots\**\*.verified.txt" CopyToOutputDirectory="Never" />
+    <None Update="WireSnapshots\README.md" CopyToOutputDirectory="Never" />
   </ItemGroup>
 </Project>

--- a/src/core/Akka.Serialization.V2.Tests/HexDumpFormatter.cs
+++ b/src/core/Akka.Serialization.V2.Tests/HexDumpFormatter.cs
@@ -1,0 +1,95 @@
+//-----------------------------------------------------------------------
+// <copyright file="HexDumpFormatter.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Linq;
+using System.Text;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Renders a wire-format snapshot as a human-reviewable annotated hex dump: a header block
+/// (case name, CLR message type, manifest, serializer id, byte count) followed by a
+/// classic <c>offset | hex | ascii</c> hex dump body. Used exclusively by
+/// <see cref="WireFormatSnapshotSpec"/> to produce the committed <c>WireSnapshots/*.verified.txt</c>
+/// artifacts -- NOT raw <c>.bin</c> files -- so a wire-format change shows up as a reviewable text
+/// diff in a pull request instead of an opaque binary diff.
+/// </summary>
+internal static class HexDumpFormatter
+{
+    private const int BytesPerRow = 16;
+
+    public static string Format(string caseName, string messageType, string manifest, int serializerId, byte[] bytes)
+    {
+        var builder = new StringBuilder();
+        builder.Append("case: ").Append(caseName).Append('\n');
+        builder.Append("message-type: ").Append(messageType).Append('\n');
+        builder.Append("manifest: ").Append(manifest).Append('\n');
+        builder.Append("serializer-id: ").Append(serializerId).Append('\n');
+        builder.Append("byte-count: ").Append(bytes.Length).Append('\n');
+        builder.Append('\n');
+
+        if (bytes.Length == 0)
+        {
+            builder.Append("(zero-byte payload)\n");
+            return builder.ToString();
+        }
+
+        for (var offset = 0; offset < bytes.Length; offset += BytesPerRow)
+        {
+            var rowLength = Math.Min(BytesPerRow, bytes.Length - offset);
+            AppendRow(builder, bytes, offset, rowLength);
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendRow(StringBuilder builder, byte[] bytes, int offset, int rowLength)
+    {
+        builder.Append(offset.ToString("x4")).Append("  ");
+
+        for (var column = 0; column < BytesPerRow; column++)
+        {
+            if (column < rowLength)
+                builder.Append(bytes[offset + column].ToString("x2")).Append(' ');
+            else
+                builder.Append("   ");
+
+            if (column == BytesPerRow / 2 - 1)
+                builder.Append(' ');
+        }
+
+        builder.Append(" |");
+        for (var column = 0; column < rowLength; column++)
+        {
+            var value = bytes[offset + column];
+            builder.Append(value is >= 0x20 and <= 0x7e ? (char)value : '.');
+        }
+
+        builder.Append('|').Append('\n');
+    }
+
+    /// <summary>
+    /// Formats a (possibly closed-generic) CLR type as a readable, language-shaped name for the
+    /// snapshot header -- for example <c>Wrapper&lt;OrderRequest&gt;</c> instead of
+    /// <see cref="Type.Name"/>'s raw <c>Wrapper`1</c>.
+    /// </summary>
+    public static string FriendlyTypeName(Type type)
+    {
+        if (!type.IsGenericType)
+            return type.Name;
+
+        var name = type.Name;
+        var backtickIndex = name.IndexOf('`');
+        if (backtickIndex > 0)
+            name = name[..backtickIndex];
+
+        var typeArguments = string.Join(", ", type.GetGenericArguments().Select(FriendlyTypeName));
+        return $"{name}<{typeArguments}>";
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/WireFormatSnapshotSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/WireFormatSnapshotSpec.cs
@@ -1,0 +1,292 @@
+//-----------------------------------------------------------------------
+// <copyright file="WireFormatSnapshotSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Akka.Actor;
+using VerifyXunit;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// COMMITTED WIRE-FORMAT SNAPSHOT GATE for Akka.Serialization.V2.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every case below serializes one deterministic, hardcoded message and compares its exact wire
+/// bytes -- rendered as a human-reviewable annotated hex dump, never raw <c>.bin</c> -- against a
+/// committed <c>WireSnapshots/&lt;case&gt;.verified.txt</c> artifact using Verify
+/// (<c>Verify.XunitV3</c>). Unlike the inline <c>GOLDEN:</c> byte-array assertions scattered across
+/// the other specs in this project (which pin a handful of hand-picked shapes), this spec's job is
+/// breadth: one snapshot per corpus case, reusing the exact message types already declared by the
+/// other specs in this project rather than redeclaring parallel fixtures. See
+/// <c>WireSnapshots/README.md</c> for the update procedure and the hash-ordering exclusion
+/// rationale.
+/// </para>
+/// <para>
+/// Every value in this file is a hardcoded constant -- no <see cref="DateTime.Now"/>, no
+/// <see cref="Guid.NewGuid"/> -- so a byte-for-byte mismatch always means the WIRE FORMAT changed,
+/// never that the test's own inputs drifted.
+/// </para>
+/// </remarks>
+public sealed class WireFormatSnapshotSpec : IAsyncLifetime
+{
+    // ------------------------------------------------------------------------------------------
+    // Corpus case names -- also the committed snapshot file names
+    // (WireSnapshots/<case-name>.verified.txt).
+    // ------------------------------------------------------------------------------------------
+    private static readonly string[] AllCaseNames =
+    {
+        // Primitives, nullable fields, sparse indices, nesting.
+        "primitives-all-types",
+        "nullable-fields-populated",
+        "nullable-fields-all-null",
+        "sparse-field-indices",
+        "nested-message-single-level",
+        "nested-message-multi-level",
+
+        // Native collection shapes (T[], List<T>, IReadOnlyList<T>, Dictionary<TKey,TValue>).
+        "collection-array-populated",
+        "collection-array-null",
+        "collection-array-empty",
+        "collection-list-populated",
+        "collection-list-of-nested-objects",
+        "collection-dictionary-non-string-key",
+
+        // Immutable/read-only collection shapes (all 6 -- see design notes in
+        // ImmutableCollectionFieldSpec for the hash-ordering exclusion this corpus honors).
+        "immutable-array-populated",
+        "immutable-array-default",
+        "immutable-array-empty",
+        "immutable-list-populated",
+        "immutable-hashset-single-element",
+        "immutable-dictionary-single-entry",
+        "readonly-collection-populated",
+        "readonly-dictionary-populated",
+
+        // [AkkaUnion]: one snapshot per declared member of IOrderEvent.
+        "union-member-order-placed-class",
+        "union-member-order-cancelled-nested-only",
+        "union-member-order-note-struct",
+
+        // Closed-generic [AkkaSerializable<T>] registrations.
+        "closed-generic-wrapper-order-request",
+        "closed-generic-wrapper-order-receipt",
+
+        // The combined scenario: a closed-generic wrapper whose payload is itself a union.
+        "generic-wrapper-union-order-placed",
+        "generic-wrapper-union-order-cancelled",
+
+        // Keyword-named property/constructor-parameter escaping.
+        "keyword-named-property",
+
+        // [AkkaEnvelopePayload]-shaped opaque payload: fixed inner serializer id + manifest + bytes.
+        "envelope-payload-fixed-inner-serializer",
+
+        // AllowEmpty fieldless message: the smallest possible wire shape (a bare 1-byte map header).
+        "fieldless-message-allow-empty",
+    };
+
+    private ActorSystem _system = null!;
+    private GeneratedTestSerializer _generatedSerializer = null!;
+    private CollectionTestSerializer _collectionSerializer = null!;
+    private ImmutableCollectionTestSerializer _immutableSerializer = null!;
+    private UnionTestSerializer _unionSerializer = null!;
+    private ClosedGenericTestSerializer _closedGenericSerializer = null!;
+    private GapFixSerializer _gapFixSerializer = null!;
+
+    public ValueTask InitializeAsync()
+    {
+        _system = ActorSystem.Create("wire-format-snapshot-spec");
+        var extendedSystem = (ExtendedActorSystem)_system;
+        _generatedSerializer = new GeneratedTestSerializer(extendedSystem);
+        _collectionSerializer = new CollectionTestSerializer(extendedSystem);
+        _immutableSerializer = new ImmutableCollectionTestSerializer(extendedSystem);
+        _unionSerializer = new UnionTestSerializer(extendedSystem);
+        _closedGenericSerializer = new ClosedGenericTestSerializer(extendedSystem);
+        _gapFixSerializer = new GapFixSerializer(extendedSystem);
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _system.Terminate();
+    }
+
+    public static IEnumerable<object[]> CaseNames() => AllCaseNames.Select(name => new object[] { name });
+
+    [Theory(DisplayName = "Wire format should match its committed snapshot")]
+    [MemberData(nameof(CaseNames))]
+    public Task Wire_format_should_match_committed_snapshot(string caseName)
+    {
+        var wireCase = BuildCase(caseName);
+        var hexDump = HexDumpFormatter.Format(caseName, wireCase.MessageType, wireCase.Manifest, wireCase.SerializerId, wireCase.Bytes);
+
+        return Verifier.Verify(hexDump)
+            .UseDirectory("WireSnapshots")
+            .UseFileName(caseName);
+    }
+
+    private WireSnapshotCase BuildCase(string caseName) => caseName switch
+    {
+        // --------------------------------------------------------------------------------------
+        // Primitives, nullable fields, sparse indices, nesting -- fixtures from
+        // GeneratedMessagePackSerializerSpec.
+        // --------------------------------------------------------------------------------------
+        "primitives-all-types" => Case(_generatedSerializer, new PrimitiveMessage(
+            "order-1",
+            42,
+            9000000000L,
+            true,
+            12.5d,
+            123.456m,
+            Guid.Parse("8f7d35c8-2931-4a48-9b84-2c008ab7f2e4"),
+            new DateTime(2026, 6, 3, 4, 45, 0, DateTimeKind.Utc),
+            new DateTimeOffset(2026, 6, 3, 4, 45, 0, TimeSpan.FromHours(2)),
+            SampleStatus.Accepted,
+            ActorRefs.NoSender)),
+
+        "nullable-fields-populated" => Case(_generatedSerializer, new OptionalMessage(
+            "optional-1",
+            42,
+            Guid.Parse("78055b71-1e7a-4a20-8e52-712db4fda457"),
+            new DateTime(2026, 6, 6, 12, 30, 0, DateTimeKind.Utc),
+            SampleStatus.Accepted,
+            "notes",
+            new ShippingAddress("1 Main St", "Seattle"))),
+
+        "nullable-fields-all-null" => Case(_generatedSerializer, new OptionalMessage(
+            "optional-2", null, null, null, null, null, null)),
+
+        "sparse-field-indices" => Case(_generatedSerializer, new SparseFieldMessage(17, "alpha")),
+
+        "nested-message-single-level" => Case(_generatedSerializer, new ShipmentMessage(
+            "order-1", new ShippingAddress("1 Main St", "Seattle"))),
+
+        "nested-message-multi-level" => Case(_generatedSerializer, new WarehouseMessage(
+            "warehouse-1", new WarehouseInfo(new WarehouseLocation("Seattle", new CountryInfo("US"))))),
+
+        // --------------------------------------------------------------------------------------
+        // Native collection shapes -- fixtures from CollectionFieldSpec.
+        // --------------------------------------------------------------------------------------
+        "collection-array-populated" => Case(_collectionSerializer, new IntArrayMessage(new[] { 10, 20, 30 })),
+
+        "collection-array-null" => Case(_collectionSerializer, new NullableIntArrayMessage(null)),
+
+        "collection-array-empty" => Case(_collectionSerializer, new NullableIntArrayMessage(Array.Empty<int>())),
+
+        "collection-list-populated" => Case(_collectionSerializer, new StringListMessage(
+            new List<string> { "alpha", "beta", "gamma" })),
+
+        "collection-list-of-nested-objects" => Case(_collectionSerializer, new ReadingListMessage(
+            new List<CollReading> { new("s-1", 1.5), new("s-2", 2.5) })),
+
+        "collection-dictionary-non-string-key" => Case(_collectionSerializer, new IntStringDictMessage(
+            new Dictionary<int, string> { [1] = "one", [2] = "two", [3] = "three" })),
+
+        // --------------------------------------------------------------------------------------
+        // Immutable/read-only collection shapes -- fixtures from ImmutableCollectionFieldSpec.
+        // ImmutableHashSet/ImmutableDictionary use SINGLE-element instances deliberately: multi-
+        // element hash/dictionary iteration order is not stable across runtimes, so multi-element
+        // instances of those two kinds are excluded from the byte-snapshot corpus (see
+        // WireSnapshots/README.md).
+        // --------------------------------------------------------------------------------------
+        "immutable-array-populated" => Case(_immutableSerializer, new ImmutableArrayMessage(
+            ImmutableArray.Create(10, 20, 30))),
+
+        "immutable-array-default" => Case(_immutableSerializer, new ImmutableArrayMessage(default)),
+
+        "immutable-array-empty" => Case(_immutableSerializer, new ImmutableArrayMessage(ImmutableArray<int>.Empty)),
+
+        "immutable-list-populated" => Case(_immutableSerializer, new ImmutableListMessage(
+            ImmutableList.Create("alpha", "beta", "gamma"))),
+
+        "immutable-hashset-single-element" => Case(_immutableSerializer, new ImmutableHashSetMessage(
+            ImmutableHashSet.Create(5))),
+
+        "immutable-dictionary-single-entry" => Case(_immutableSerializer, new ImmutableDictionaryMessage(
+            ImmutableDictionary<string, int>.Empty.Add("hi", 5))),
+
+        "readonly-collection-populated" => Case(_immutableSerializer, new ReadOnlyCollectionMessage(
+            new List<int> { 1, 2, 3 })),
+
+        "readonly-dictionary-populated" => Case(_immutableSerializer, new ReadOnlyDictionaryMessage(
+            new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 })),
+
+        // --------------------------------------------------------------------------------------
+        // [AkkaUnion] -- one snapshot per declared member of IOrderEvent -- fixtures from
+        // GeneratedUnionSpec.
+        // --------------------------------------------------------------------------------------
+        "union-member-order-placed-class" => Case(_unionSerializer, new UnionEnvelope(
+            "env-4", new OrderPlaced("order-4", 7))),
+
+        "union-member-order-cancelled-nested-only" => Case(_unionSerializer, new UnionEnvelope(
+            "env-2", new OrderCancelled("order-2", "customer request"))),
+
+        "union-member-order-note-struct" => Case(_unionSerializer, new UnionEnvelope(
+            "env-3", new OrderNote("order-3", "expedite"))),
+
+        // --------------------------------------------------------------------------------------
+        // Closed-generic [AkkaSerializable<T>] registrations -- fixtures from
+        // GeneratedClosedGenericSpec.
+        // --------------------------------------------------------------------------------------
+        "closed-generic-wrapper-order-request" => Case(_closedGenericSerializer, new Wrapper<OrderRequest>(
+            "wrap-1", new OrderRequest("order-1", 5), 3)),
+
+        "closed-generic-wrapper-order-receipt" => Case(_closedGenericSerializer, new Wrapper<OrderReceipt>(
+            "wrap-3", new OrderReceipt("receipt-1"), 1)),
+
+        // The combined scenario: a generic wrapper registered as a closed construction whose
+        // payload field is a closed manifest-discriminated union.
+        "generic-wrapper-union-order-placed" => Case(_closedGenericSerializer, new EventWrapper<IOrderEvent>(
+            "evt-1", new OrderPlaced("order-10", 2))),
+
+        "generic-wrapper-union-order-cancelled" => Case(_closedGenericSerializer, new EventWrapper<IOrderEvent>(
+            "evt-2", new OrderCancelled("order-11", "late"))),
+
+        // --------------------------------------------------------------------------------------
+        // Keyword-named property/constructor-parameter escaping -- fixture from
+        // GeneratedMessagePackSerializerSpec.
+        // --------------------------------------------------------------------------------------
+        "keyword-named-property" => Case(_generatedSerializer, new KeywordNamedMessage("something-happened")),
+
+        // --------------------------------------------------------------------------------------
+        // Envelope payload with a fixed inner serializer id, manifest, and byte payload -- fixture
+        // from GeneratedMessagePackSerializerSpec.
+        // --------------------------------------------------------------------------------------
+        "envelope-payload-fixed-inner-serializer" => Case(_generatedSerializer, new OpaqueEnvelope(
+            "envelope-1",
+            new OpaqueSerializedPayload(
+                CustomProtobufPayloadSerializer.IdentifierValue,
+                CustomProtobufPayloadSerializer.ManifestName,
+                Encoding.UTF8.GetBytes("fake-protobuf|payload-1|17")))),
+
+        // --------------------------------------------------------------------------------------
+        // AllowEmpty fieldless message -- fixture from FieldlessAndStructFieldSpec. The smallest
+        // possible wire shape: a bare 1-byte empty MessagePack map header (0x80).
+        // --------------------------------------------------------------------------------------
+        "fieldless-message-allow-empty" => Case(_gapFixSerializer, new GapHeartbeat()),
+
+        _ => throw new ArgumentOutOfRangeException(nameof(caseName), caseName, "Unknown wire snapshot case.")
+    };
+
+    private static WireSnapshotCase Case<TMessage>(AkkaSerializer serializer, TMessage message)
+        where TMessage : notnull
+    {
+        var bytes = serializer.ToBinary(message);
+        var manifest = serializer.Manifest(message);
+        return new WireSnapshotCase(HexDumpFormatter.FriendlyTypeName(typeof(TMessage)), manifest, serializer.Identifier, bytes);
+    }
+
+    private readonly record struct WireSnapshotCase(string MessageType, string Manifest, int SerializerId, byte[] Bytes);
+}

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/README.md
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/README.md
@@ -1,0 +1,101 @@
+# Wire-Format Snapshots
+
+This folder holds **committed wire-format artifacts** for Akka.Serialization.V2. Each
+`<case>.verified.txt` file is a human-reviewable annotated hex dump of the exact MessagePack
+bytes a hardcoded, deterministic message serializes to today. They are asserted against by
+[`WireFormatSnapshotSpec`](../WireFormatSnapshotSpec.cs) using
+[Verify](https://github.com/VerifyTests/Verify) (`Verify.XunitV3`).
+
+## Why this exists
+
+Unit tests that round-trip a message (serialize, then deserialize, then assert equality) do not
+catch every wire-format regression: a change that reorders fields, alters MessagePack framing, or
+shifts an encoding convention can still round-trip correctly through the *same* build while
+silently breaking compatibility with every *other* build already deployed. These snapshots pin the
+literal bytes, so any change to the wire format -- intentional or not -- fails a test and shows an
+exact byte-level diff in the pull request, independent of whether the change happens to round-trip.
+
+This gate is deliberately broader than the inline `GOLDEN:` byte-array assertions already present
+in specs such as `CollectionFieldSpec` and `ImmutableCollectionFieldSpec` (which hand-pin a
+handful of illustrative shapes close to the code they guard). This corpus's job is breadth: one
+snapshot per structurally distinct shape the generator supports, in one place, so a reviewer can
+scan the diff stat of a PR and see exactly which wire shapes moved.
+
+It is also intended to anchor the eventual protobuf-to-MessagePack migration's byte-golden tests:
+the same annotated-hex-dump format and update procedure apply there.
+
+## File format
+
+Each file is plain UTF-8 text:
+
+```
+case: <case-name>
+message-type: <friendly CLR type name>
+manifest: <serializer manifest string>
+serializer-id: <Akka serializer id>
+byte-count: <n>
+
+<offset>  <16 space-separated hex byte pairs, split at the 8-byte midpoint>  |<ASCII, '.' for non-printable>|
+...
+```
+
+Offsets and byte columns follow the conventional hex-dump layout (16 bytes per row). The header
+block (`case`/`message-type`/`manifest`/`serializer-id`/`byte-count`) is what actually makes a
+diff reviewable: a change that only reorders fields, for example, shows up as a byte-level diff
+under an unchanged header, while a change that (for instance) bumps a manifest string shows up in
+the header line itself.
+
+## Update procedure
+
+1. Make the wire-format change.
+2. Run the spec: `dotnet test src/core/Akka.Serialization.V2.Tests -c Release --filter WireFormatSnapshotSpec`.
+   Every case whose bytes changed fails and writes a `<case>.received.txt` file next to the
+   `.verified.txt` it disagreed with (`.received.txt` is gitignored -- it is a scratch/diff
+   artifact, never committed).
+3. **Read the diff.** The failure output (or a diff of `<case>.received.txt` against
+   `<case>.verified.txt`) shows exactly which bytes moved. Confirm the change is the one you
+   intended -- this is the entire point of the gate.
+4. Approve by replacing the verified file with the received one, for every case that should
+   change:
+   ```bash
+   for f in src/core/Akka.Serialization.V2.Tests/WireSnapshots/*.received.txt; do
+     mv "$f" "${f%.received.txt}.verified.txt"
+   done
+   ```
+5. Re-run the spec to confirm it passes, then commit the updated `.verified.txt` file(s) as part
+   of the same PR that made the wire-format change, so the reviewer sees the byte diff alongside
+   the code diff.
+
+CI only ever asserts against the committed `.verified.txt` files -- it never generates or
+approves them. A missing or stale snapshot is a failing test, not a silently-regenerated file.
+
+## Hash-ordering exclusion (`ImmutableHashSet<T>` / `ImmutableDictionary<TKey,TValue>`)
+
+`ImmutableHashSet<T>` and `ImmutableDictionary<TKey,TValue>` iterate in hash-bucket order, which is
+**not guaranteed stable across .NET runtimes, versions, or even process runs** for some key/element
+types. A multi-element instance of either kind can legally serialize to a different byte sequence
+on a different machine while still being semantically identical (same set/map contents). Snapshot
+tests must be able to run identically on any contributor's or CI machine, so this corpus
+deliberately restricts `ImmutableHashSet<T>`/`ImmutableDictionary<TKey,TValue>` cases to
+**single-element instances** (see `immutable-hashset-single-element` and
+`immutable-dictionary-single-entry`), where there is only one possible iteration order and the byte
+sequence is therefore stable. Multi-element hash-ordering round-trip coverage (by value, not by
+byte) already exists in `ImmutableCollectionFieldSpec`
+(`Should_round_trip_multi_element_immutable_hashset_by_value` and
+`Should_round_trip_multi_entry_immutable_dictionary_by_value`); it is intentionally not duplicated
+here.
+
+Every other collection shape in this corpus (`T[]`, `List<T>`, `IReadOnlyList<T>`,
+`ImmutableArray<T>`, `ImmutableList<T>`, `IReadOnlyCollection<T>`) is sequence-typed and formally
+preserves declaration order, so multi-element instances are always safe to byte-snapshot.
+
+`Dictionary<TKey,TValue>` (`collection-dictionary-non-string-key`, three entries) is a partial
+exception worth calling out explicitly: the BCL does not formally contract enumeration order for
+`Dictionary<TKey,TValue>`, but CoreCLR's implementation is well known to enumerate small,
+never-had-a-removal dictionaries in insertion order, and has been stable across every .NET Core /
+.NET 5+ release -- a materially different reliability profile than `ImmutableHashSet`/
+`ImmutableDictionary`'s hash-bucket order, which varies with element/key hash codes rather than
+insertion sequence. If this ever proves too fragile in practice (for example after a future BCL
+change), narrow that one case to a single entry the same way the two `Immutable*` cases already
+are -- the round-trip-by-value coverage in `CollectionFieldSpec` remains the source of truth for
+multi-entry `Dictionary` semantics either way.

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/closed-generic-wrapper-order-receipt.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/closed-generic-wrapper-order-receipt.verified.txt
@@ -1,0 +1,8 @@
+﻿case: closed-generic-wrapper-order-receipt
+message-type: Wrapper<OrderReceipt>
+manifest: wrap-receipt-v1
+serializer-id: 120404
+byte-count: 24
+
+0000  83 01 a6 77 72 61 70 2d  33 02 81 01 a9 72 65 63  |...wrap-3....rec|
+0010  65 69 70 74 2d 31 03 01                           |eipt-1..|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/closed-generic-wrapper-order-request.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/closed-generic-wrapper-order-request.verified.txt
@@ -1,0 +1,8 @@
+﻿case: closed-generic-wrapper-order-request
+message-type: Wrapper<OrderRequest>
+manifest: wrap-request-v1
+serializer-id: 120404
+byte-count: 24
+
+0000  83 01 a6 77 72 61 70 2d  31 02 82 01 a7 6f 72 64  |...wrap-1....ord|
+0010  65 72 2d 31 02 05 03 03                           |er-1....|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-array-empty.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-array-empty.verified.txt
@@ -1,0 +1,7 @@
+﻿case: collection-array-empty
+message-type: NullableIntArrayMessage
+manifest: coll-nullable-int-array-v1
+serializer-id: 120105
+byte-count: 3
+
+0000  81 01 90                                          |...|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-array-null.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-array-null.verified.txt
@@ -1,0 +1,7 @@
+﻿case: collection-array-null
+message-type: NullableIntArrayMessage
+manifest: coll-nullable-int-array-v1
+serializer-id: 120105
+byte-count: 3
+
+0000  81 01 c0                                          |...|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-array-populated.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-array-populated.verified.txt
@@ -1,0 +1,7 @@
+﻿case: collection-array-populated
+message-type: IntArrayMessage
+manifest: coll-int-array-v1
+serializer-id: 120105
+byte-count: 6
+
+0000  81 01 93 0a 14 1e                                 |......|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-dictionary-non-string-key.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-dictionary-non-string-key.verified.txt
@@ -1,0 +1,8 @@
+﻿case: collection-dictionary-non-string-key
+message-type: IntStringDictMessage
+manifest: coll-int-string-dict-v1
+serializer-id: 120105
+byte-count: 20
+
+0000  81 01 83 01 a3 6f 6e 65  02 a3 74 77 6f 03 a5 74  |.....one..two..t|
+0010  68 72 65 65                                       |hree|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-list-of-nested-objects.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-list-of-nested-objects.verified.txt
@@ -1,0 +1,9 @@
+﻿case: collection-list-of-nested-objects
+message-type: ReadingListMessage
+manifest: coll-reading-list-v1
+serializer-id: 120105
+byte-count: 35
+
+0000  81 01 92 82 01 a3 73 2d  31 02 cb 3f f8 00 00 00  |......s-1..?....|
+0010  00 00 00 82 01 a3 73 2d  32 02 cb 40 04 00 00 00  |......s-2..@....|
+0020  00 00 00                                          |...|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-list-populated.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/collection-list-populated.verified.txt
@@ -1,0 +1,8 @@
+﻿case: collection-list-populated
+message-type: StringListMessage
+manifest: coll-string-list-v1
+serializer-id: 120105
+byte-count: 20
+
+0000  81 01 93 a5 61 6c 70 68  61 a4 62 65 74 61 a5 67  |....alpha.beta.g|
+0010  61 6d 6d 61                                       |amma|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/envelope-payload-fixed-inner-serializer.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/envelope-payload-fixed-inner-serializer.verified.txt
@@ -1,0 +1,11 @@
+﻿case: envelope-payload-fixed-inner-serializer
+message-type: OpaqueEnvelope
+manifest: opaque-envelope-v1
+serializer-id: 120101
+byte-count: 70
+
+0000  82 01 aa 65 6e 76 65 6c  6f 70 65 2d 31 02 83 01  |...envelope-1...|
+0010  ce 00 01 d5 8a 02 b2 63  75 73 74 6f 6d 2d 70 72  |.......custom-pr|
+0020  6f 74 6f 62 75 66 2d 76  31 03 c4 1a 66 61 6b 65  |otobuf-v1...fake|
+0030  2d 70 72 6f 74 6f 62 75  66 7c 70 61 79 6c 6f 61  |-protobuf|payloa|
+0040  64 2d 31 7c 31 37                                 |d-1|17|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/fieldless-message-allow-empty.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/fieldless-message-allow-empty.verified.txt
@@ -1,0 +1,7 @@
+﻿case: fieldless-message-allow-empty
+message-type: GapHeartbeat
+manifest: gap-heartbeat-v1
+serializer-id: 120801
+byte-count: 1
+
+0000  80                                                |.|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/generic-wrapper-union-order-cancelled.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/generic-wrapper-union-order-cancelled.verified.txt
@@ -1,0 +1,9 @@
+﻿case: generic-wrapper-union-order-cancelled
+message-type: EventWrapper<IOrderEvent>
+manifest: event-wrap-v1
+serializer-id: 120404
+byte-count: 48
+
+0000  82 01 a5 65 76 74 2d 32  02 82 01 b2 6f 72 64 65  |...evt-2....orde|
+0010  72 2d 63 61 6e 63 65 6c  6c 65 64 2d 76 31 02 82  |r-cancelled-v1..|
+0020  01 a8 6f 72 64 65 72 2d  31 31 02 a4 6c 61 74 65  |..order-11..late|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/generic-wrapper-union-order-placed.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/generic-wrapper-union-order-placed.verified.txt
@@ -1,0 +1,9 @@
+﻿case: generic-wrapper-union-order-placed
+message-type: EventWrapper<IOrderEvent>
+manifest: event-wrap-v1
+serializer-id: 120404
+byte-count: 41
+
+0000  82 01 a5 65 76 74 2d 31  02 82 01 af 6f 72 64 65  |...evt-1....orde|
+0010  72 2d 70 6c 61 63 65 64  2d 76 31 02 82 01 a8 6f  |r-placed-v1....o|
+0020  72 64 65 72 2d 31 30 02  02                       |rder-10..|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-array-default.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-array-default.verified.txt
@@ -1,0 +1,7 @@
+﻿case: immutable-array-default
+message-type: ImmutableArrayMessage
+manifest: imm-array-v1
+serializer-id: 120106
+byte-count: 3
+
+0000  81 01 c0                                          |...|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-array-empty.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-array-empty.verified.txt
@@ -1,0 +1,7 @@
+﻿case: immutable-array-empty
+message-type: ImmutableArrayMessage
+manifest: imm-array-v1
+serializer-id: 120106
+byte-count: 3
+
+0000  81 01 90                                          |...|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-array-populated.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-array-populated.verified.txt
@@ -1,0 +1,7 @@
+﻿case: immutable-array-populated
+message-type: ImmutableArrayMessage
+manifest: imm-array-v1
+serializer-id: 120106
+byte-count: 6
+
+0000  81 01 93 0a 14 1e                                 |......|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-dictionary-single-entry.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-dictionary-single-entry.verified.txt
@@ -1,0 +1,7 @@
+﻿case: immutable-dictionary-single-entry
+message-type: ImmutableDictionaryMessage
+manifest: imm-dict-v1
+serializer-id: 120106
+byte-count: 7
+
+0000  81 01 81 a2 68 69 05                              |....hi.|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-hashset-single-element.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-hashset-single-element.verified.txt
@@ -1,0 +1,7 @@
+﻿case: immutable-hashset-single-element
+message-type: ImmutableHashSetMessage
+manifest: imm-hashset-v1
+serializer-id: 120106
+byte-count: 4
+
+0000  81 01 91 05                                       |....|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-list-populated.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/immutable-list-populated.verified.txt
@@ -1,0 +1,8 @@
+﻿case: immutable-list-populated
+message-type: ImmutableListMessage
+manifest: imm-list-v1
+serializer-id: 120106
+byte-count: 20
+
+0000  81 01 93 a5 61 6c 70 68  61 a4 62 65 74 61 a5 67  |....alpha.beta.g|
+0010  61 6d 6d 61                                       |amma|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/keyword-named-property.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/keyword-named-property.verified.txt
@@ -1,0 +1,8 @@
+﻿case: keyword-named-property
+message-type: KeywordNamedMessage
+manifest: keyword-named-v1
+serializer-id: 120101
+byte-count: 21
+
+0000  81 01 b2 73 6f 6d 65 74  68 69 6e 67 2d 68 61 70  |...something-hap|
+0010  70 65 6e 65 64                                    |pened|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/nested-message-multi-level.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/nested-message-multi-level.verified.txt
@@ -1,0 +1,9 @@
+﻿case: nested-message-multi-level
+message-type: WarehouseMessage
+manifest: warehouse-v1
+serializer-id: 120101
+byte-count: 33
+
+0000  82 01 ab 77 61 72 65 68  6f 75 73 65 2d 31 02 81  |...warehouse-1..|
+0010  01 82 01 a7 53 65 61 74  74 6c 65 02 81 01 a2 55  |....Seattle....U|
+0020  53                                                |S|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/nested-message-single-level.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/nested-message-single-level.verified.txt
@@ -1,0 +1,8 @@
+﻿case: nested-message-single-level
+message-type: ShipmentMessage
+manifest: shipment-v1
+serializer-id: 120101
+byte-count: 32
+
+0000  82 01 a7 6f 72 64 65 72  2d 31 02 82 01 a9 31 20  |...order-1....1 |
+0010  4d 61 69 6e 20 53 74 02  a7 53 65 61 74 74 6c 65  |Main St..Seattle|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/nullable-fields-all-null.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/nullable-fields-all-null.verified.txt
@@ -1,0 +1,8 @@
+﻿case: nullable-fields-all-null
+message-type: OptionalMessage
+manifest: optional-v1
+serializer-id: 120101
+byte-count: 25
+
+0000  87 01 aa 6f 70 74 69 6f  6e 61 6c 2d 32 02 c0 03  |...optional-2...|
+0010  c0 04 c0 05 c0 06 c0 07  c0                       |.........|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/nullable-fields-populated.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/nullable-fields-populated.verified.txt
@@ -1,0 +1,11 @@
+﻿case: nullable-fields-populated
+message-type: OptionalMessage
+manifest: optional-v1
+serializer-id: 120101
+byte-count: 77
+
+0000  87 01 aa 6f 70 74 69 6f  6e 61 6c 2d 31 02 2a 03  |...optional-1.*.|
+0010  c4 10 71 5b 05 78 7a 1e  20 4a 8e 52 71 2d b4 fd  |..q[.xz. J.Rq-..|
+0020  a4 57 04 92 cf 08 de c3  c7 53 80 14 00 01 05 01  |.W.......S......|
+0030  06 a5 6e 6f 74 65 73 07  82 01 a9 31 20 4d 61 69  |..notes....1 Mai|
+0040  6e 20 53 74 02 a7 53 65  61 74 74 6c 65           |n St..Seattle|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/primitives-all-types.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/primitives-all-types.verified.txt
@@ -1,0 +1,12 @@
+﻿case: primitives-all-types
+message-type: PrimitiveMessage
+manifest: primitive-v1
+serializer-id: 120101
+byte-count: 95
+
+0000  8b 01 a7 6f 72 64 65 72  2d 31 02 2a 03 cf 00 00  |...order-1.*....|
+0010  00 02 18 71 1a 00 04 c3  05 cb 40 29 00 00 00 00  |...q......@)....|
+0020  00 00 06 94 ce 00 01 e2  40 00 00 ce 00 03 00 00  |........@.......|
+0030  07 c4 10 c8 35 7d 8f 31  29 48 4a 9b 84 2c 00 8a  |....5}.1)HJ..,..|
+0040  b7 f2 e4 08 92 cf 08 de  c1 2a de 90 ae 00 01 09  |.........*......|
+0050  92 cf 08 de c1 2a de 90  ae 00 78 0a 01 0b a0     |.....*....x....|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/readonly-collection-populated.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/readonly-collection-populated.verified.txt
@@ -1,0 +1,7 @@
+﻿case: readonly-collection-populated
+message-type: ReadOnlyCollectionMessage
+manifest: imm-readonly-collection-v1
+serializer-id: 120106
+byte-count: 6
+
+0000  81 01 93 01 02 03                                 |......|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/readonly-dictionary-populated.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/readonly-dictionary-populated.verified.txt
@@ -1,0 +1,7 @@
+﻿case: readonly-dictionary-populated
+message-type: ReadOnlyDictionaryMessage
+manifest: imm-readonly-dict-v1
+serializer-id: 120106
+byte-count: 9
+
+0000  81 01 82 a1 61 01 a1 62  02                       |....a..b.|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/sparse-field-indices.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/sparse-field-indices.verified.txt
@@ -1,0 +1,7 @@
+﻿case: sparse-field-indices
+message-type: SparseFieldMessage
+manifest: sparse-v1
+serializer-id: 120101
+byte-count: 10
+
+0000  82 02 11 0a a5 61 6c 70  68 61                    |.....alpha|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/union-member-order-cancelled-nested-only.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/union-member-order-cancelled-nested-only.verified.txt
@@ -1,0 +1,10 @@
+﻿case: union-member-order-cancelled-nested-only
+message-type: UnionEnvelope
+manifest: union-envelope-v1
+serializer-id: 120303
+byte-count: 59
+
+0000  82 01 a5 65 6e 76 2d 32  02 82 01 b2 6f 72 64 65  |...env-2....orde|
+0010  72 2d 63 61 6e 63 65 6c  6c 65 64 2d 76 31 02 82  |r-cancelled-v1..|
+0020  01 a7 6f 72 64 65 72 2d  32 02 b0 63 75 73 74 6f  |..order-2..custo|
+0030  6d 65 72 20 72 65 71 75  65 73 74                 |mer request|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/union-member-order-note-struct.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/union-member-order-note-struct.verified.txt
@@ -1,0 +1,9 @@
+﻿case: union-member-order-note-struct
+message-type: UnionEnvelope
+manifest: union-envelope-v1
+serializer-id: 120303
+byte-count: 46
+
+0000  82 01 a5 65 6e 76 2d 33  02 82 01 ad 6f 72 64 65  |...env-3....orde|
+0010  72 2d 6e 6f 74 65 2d 76  31 02 82 01 a7 6f 72 64  |r-note-v1....ord|
+0020  65 72 2d 33 02 a8 65 78  70 65 64 69 74 65        |er-3..expedite|

--- a/src/core/Akka.Serialization.V2.Tests/WireSnapshots/union-member-order-placed-class.verified.txt
+++ b/src/core/Akka.Serialization.V2.Tests/WireSnapshots/union-member-order-placed-class.verified.txt
@@ -1,0 +1,9 @@
+﻿case: union-member-order-placed-class
+message-type: UnionEnvelope
+manifest: union-envelope-v1
+serializer-id: 120303
+byte-count: 40
+
+0000  82 01 a5 65 6e 76 2d 34  02 82 01 af 6f 72 64 65  |...env-4....orde|
+0010  72 2d 70 6c 61 63 65 64  2d 76 31 02 82 01 a7 6f  |r-placed-v1....o|
+0020  72 64 65 72 2d 34 02 07                           |rder-4..|


### PR DESCRIPTION
Snapshots the V2 wire format to disk as committed, human-reviewable artifacts and asserts against them — any wire change (intentional or not) fails with a byte-level diff. Foundation gate for the upcoming emission-layer refactor and the protobuf→MessagePack migration's byte-golden tests.

- 30 deterministic cases reusing existing spec message types: primitives, nullables, sparse indices, nesting, all 10 collection shapes (incl. `default(ImmutableArray)` vs `Empty` nil distinction), one snapshot per union member, closed generics, wrapper-of-union, keyword-named properties, envelope payloads, fieldless `AllowEmpty`
- Readable annotated hex dumps (offset|hex|ascii + manifest/serializer-id/byte-count header) — PR diffs of wire changes are reviewable
- `Verify.XunitV3` + `Verify.DiffPlex` (test-only, pinned in `Directory.Build.props`); repo CI already harvests `*.received.*` on failure — zero pipeline changes
- Hash-ordered collections pinned via single-element cases only (bucket order is non-contractual across runtimes); rationale + update procedure in `WireSnapshots/README.md`
- 232/232 tests, run twice to prove determinism; no existing test modified