### PR TITLE
Artery: close the shutdown-quarantine window in CompleteControlOutbound

### DIFF
--- a/src/core/Akka.Remote/Artery/ArteryRemoting.cs
+++ b/src/core/Akka.Remote/Artery/ArteryRemoting.cs
@@ -997,7 +997,7 @@ namespace Akka.Remote.Artery
         /// </summary>
         private void HandleControlOverflow(Address remoteAddress, Association association, object message)
         {
-            if (association.IsControlShutDown)
+            if (_isShutdown || association.IsControlShutDown)
             {
                 _log.Debug(
                     "Outbound control channel to [{0}] already closed during shutdown; dropping {1} to dead letters.",

--- a/src/core/Akka.Remote/Artery/AssociationRegistry.cs
+++ b/src/core/Akka.Remote/Artery/AssociationRegistry.cs
@@ -832,8 +832,14 @@ namespace Akka.Remote.Artery
         /// </summary>
         public void CompleteControlOutbound()
         {
-            _controlChannel.Writer.TryComplete();
+            // Latch BEFORE completing the writer: BoundedChannel guards both TryComplete and
+            // TryWrite under the same monitor, so any thread that observes TryWrite == false
+            // (writer completed) is guaranteed to observe _controlShutDown == true. In the old
+            // order a control send landing between TryComplete and the latch write read the
+            // latch as false and took HandleControlOverflow's ERROR + Quarantine branch during
+            // graceful shutdown.
             _controlShutDown = true;
+            _controlChannel.Writer.TryComplete();
         }
 
         /// <summary>


### PR DESCRIPTION
`ArteryUnwatchShutdownRaceSpec` — the #8348 regression test — fired once on #8395's CI (a PR that doesn't touch Akka.Remote): a healthy peer was spuriously quarantined with a queue-full ERROR during graceful shutdown.

Root cause: `CompleteControlOutbound` completed the channel writer before setting the shutdown latch, and `HandleControlOverflow` guards on the latch. A control send landing between the two (e.g. RemoteWatcher draining Unwatch work) observed the completed writer while the latch still read false and took the ERROR + quarantine branch. Genuine overflow is unreachable there — control queue capacity is 20,000.

Fix: set the latch before completing the writer. `BoundedChannel` guards `TryWrite` and `TryComplete` under the same monitor, so any thread that observes the completed writer is guaranteed to observe the latch — the window is closed by construction, for every caller. Also aligns `HandleControlOverflow`'s guard with the enqueue-path guards (`_isShutdown || IsControlShutDown`).

Validation: regression spec 10/10, full Artery unit suite 253/253, no test changes. The race did not reproduce locally in 40 CPU-constrained baseline runs — the CI hit remains the only observed instance, consistent with a sub-instruction window.
