### PR TITLE
De-flake Bugfix5962Spec.SBR_Should_work_with_channel_executor

### DIFF
--- a/src/core/Akka.Cluster.Tests/Bugfix5962Spec.cs
+++ b/src/core/Akka.Cluster.Tests/Bugfix5962Spec.cs
@@ -9,15 +9,13 @@ using System;
 using System.Threading.Tasks;
 using Akka.Configuration;
 using Akka.TestKit;
-using FluentAssertions;
 using FluentAssertions.Extensions;
 using Xunit;
-using static FluentAssertions.FluentActions;
 
 
 namespace Akka.Cluster.Tests
 {
-     public class Bugfix5962Spec : TestKit.Xunit.TestKit
+    public class Bugfix5962Spec : TestKit.Xunit.TestKit
     {
         private static readonly Config Config = ConfigurationFactory.ParseString(@"
 akka {
@@ -36,7 +34,10 @@ akka {
     }
     remote {
         dot-netty.tcp {
-            port = 15508
+            # A dynamic port avoids bind collisions with other suites/processes on shared CI agents.
+            # The node self-joins programmatically (Cluster.Join(SelfAddress)) instead of using
+            # static seed-nodes, which would require a port known ahead of time.
+            port = 0
             hostname = ""127.0.0.1""
         }
         default-remote-dispatcher {
@@ -49,14 +50,13 @@ akka {
         }
     }
     cluster {
-        seed-nodes = [""akka.tcp://Bugfix5962Spec@127.0.0.1:15508""]
         downing-provider-class = ""Akka.Cluster.SBR.SplitBrainResolverProvider, Akka.Cluster""
     }
 }");
 
         private readonly Type _timerMsgType;
-        
-        public Bugfix5962Spec(ITestOutputHelper output): base(Config, nameof(Bugfix5962Spec), output)
+
+        public Bugfix5962Spec(ITestOutputHelper output) : base(Config, nameof(Bugfix5962Spec), output)
         {
             _timerMsgType = Type.GetType("Akka.Actor.Scheduler.TimerScheduler+TimerMsg, Akka");
         }
@@ -64,24 +64,48 @@ akka {
         [Fact]
         public async Task SBR_Should_work_with_channel_executor()
         {
-            var latch = new TestLatch(1);
+            // RunContinuationsAsynchronously: the RegisterOnMemberUp callback fires on the
+            // OnMemberStatusChangedListener actor's dispatcher (a channel-executor/ThreadPool
+            // thread) - this keeps the awaiting test continuation from running inline on that
+            // dispatcher thread inside the actor's message processing.
+            var memberUp = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var cluster = Cluster.Get(Sys);
             cluster.RegisterOnMemberUp(() =>
             {
-                latch.CountDown();
+                memberUp.TrySetResult();
             });
 
+            // Self-join programmatically - the downingProvider actor is created in
+            // ClusterCoreDaemon.PreStart regardless of the join mechanism, so the regression
+            // signal does not depend on seed-node joining (which would need a fixed port).
+            cluster.Join(cluster.SelfAddress);
+
             var selection = Sys.ActorSelection("akka://Bugfix5962Spec/system/cluster/core/daemon/downingProvider");
-            
-            await Awaiting(() => selection.ResolveOne(1.Seconds()))
-                .Should().NotThrowAsync("Downing provider should be alive. ActorSelection will throw an ActorNotFoundException if this fails");
-            
-            // There should be no TimerMsg being sent to dead letter, this signals that the downing provider is dead
-            await EventFilter.DeadLetter(_timerMsgType).ExpectAsync(0, async () =>
-            {
-                latch.Ready(1.Seconds());
-                await Task.Delay(2.Seconds());
-            });
+
+            // Cluster extension startup is fire-and-forget: the downingProvider actor is created
+            // asynchronously (ClusterDaemon -> ClusterCoreSupervisor -> ClusterCoreDaemon.PreStart)
+            // after Cluster.Get() returns, so retry the resolution instead of a single 1s attempt.
+            // If the downing provider died on startup (the original #5962 bug), resolution keeps
+            // failing with ActorNotFoundException and this times out.
+            await AwaitAssertAsync(
+                () => selection.ResolveOne(1.Seconds()),
+                duration: TimeSpan.FromSeconds(10));
+
+            // Becoming Up requires the first leader-actions tick, which fires no earlier than
+            // akka.cluster.periodic-tasks-initial-delay (1s) after cluster startup - a hard 1s wait
+            // here is a razor-thin margin on a loaded CI agent, so use a generous dilated timeout.
+            await memberUp.Task.WaitAsync(Dilated(TimeSpan.FromSeconds(30)));
+
+            // There should be no TimerMsg being sent to dead letters - that would signal that the
+            // downing provider is dead (the original #5962 regression). The SBR resolver ticks
+            // every second, so a 2-second quiet window is guaranteed to observe dead-lettered
+            // timer messages from a dead resolver. The explicit-timeout overload is used instead
+            // of a raw Task.Delay: the TestKit dilates the timeout and keeps watching for matches
+            // for the full window after the (no-op) action completes.
+            await EventFilter.DeadLetter(_timerMsgType).ExpectAsync(
+                expectedCount: 0,
+                timeout: TimeSpan.FromSeconds(2),
+                action: () => Task.CompletedTask);
         }
     }
 }


### PR DESCRIPTION
Root-caused via paired Akka.NET + concurrency specialist analysis after it failed #8396's Windows run (pre-existing flake; that PR doesn't touch Akka.Cluster).

**Root cause:** `MemberUp` structurally cannot arrive before the 1s `periodic-tasks-initial-delay` leader tick, but the spec gated on a raw, non-dilated `TestLatch.Ready(1s)` — a 100–400ms margin that Windows CI load eats. Secondary: non-dilated 1s `ResolveOne` racing fire-and-forget cluster-extension init, and a fixed DotNetty port (15508) exposed to cross-process bind collisions.

**Fix (test-local, regression coverage for #5962 fully preserved):** dilated `AwaitAssertAsync` around `ResolveOne`; `TaskCompletionSource(RunContinuationsAsynchronously)` + dilated wait replaces the latch (moved outside the `EventFilter` block — no continuation inlining onto the member-listener's dispatcher); explicit dilated 2s dead-letter quiet window (> SBR's 1s self-tick, so a dead resolver still trips it); `port = 0` + explicit `Join(SelfAddress)`.

**Validation:** 50/50 consecutive Release runs (two 25× loops), clean build, format clean on the touched file.