### PR TITLE
Serialization.V2: OpenSpec change for internal-serializer MessagePack migration (approved design)

### DIFF
--- a/openspec/changes/internal-serializers-messagepack-v2/design.md
+++ b/openspec/changes/internal-serializers-messagepack-v2/design.md
@@ -1,0 +1,172 @@
+## Context
+
+This design follows a maintainer-review draft grounded in code read directly from `dev`. The load-bearing facts:
+
+**Read/write dispatch is exactly the shape this design needs** (`src/core/Akka/Serialization/Serialization.cs`):
+- **Reads dispatch purely by numeric serializer id.** `Deserialize(byte[], int serializerId, string manifest)` and the V2 `Deserialize(ReadOnlySequence<byte>, id, manifest)` look up `_serializersById[serializerId]` and never consult `serialization-bindings`. So if both the legacy protobuf serializer id and the new MessagePack id are registered on a node, that node can decode either format, regardless of what it writes.
+- **Writes dispatch by `serialization-bindings`** (type→serializer-name), resolved in `FindSerializerV2ForType`: exact-type match first (memoized), then *first assignable non-`object` binding wins* — that loop iterates a `ConcurrentDictionary` in arbitrary order (a `// TODO` in the source admits it is not truly most-specific). Implication: the flag must re-point the exact existing interface binding key deterministically (last-write-wins via `AddSerializationMap`/`_serializerMap[type]=`), not add a competing overlapping binding.
+- `Serialization.cs` already stores `SerializerV2` internally; HOCON/V1 serializers are wrapped by `SerializerV1Adapter` via `AdaptSerializer`. Native `SerializerV2` serializers must return a non-empty, non-CLR manifest (`ManifestFor`) — satisfied by reusing the existing manifest tokens.
+- Four registration injection points exist: HOCON `serializers`, HOCON `serialization-bindings`, `SerializationSetup.CreateSerializers`, and `SerializationSetup.UseFor`. `SerializationSetup` bindings are applied last and always win.
+
+**Rolling-upgrade capability signal already exists.** `Member.AppVersion` is gossiped (`src/core/Akka.Cluster/Member.cs`; encoded in `ClusterMessageSerializer` Join/Gossip). There is a proven "hold this feature until the whole cluster is homogeneous" pattern — `ClusterEvent.HasMoreThanOneAppVersion` and `AbstractLeastShardAllocationStrategy.IsAGoodTimeToRebalance` refuse to rebalance during a rolling update. The classic remoting handshake carries no capability field (`WireFormats.proto` `AkkaHandshakeInfo` = origin+uid+unused cookie) and DistributedData has no node-version awareness (only CRDT causal versions). The capability channel available to this design is cluster `AppVersion`, not the handshake — and this design chooses **not** to wire a framework-enforced gate to it (Decision 6).
+
+**Assembly dependency direction gates authoring.** `Akka.Serialization.V2.csproj` references core `Akka` and takes the MessagePack 3.1.7 dependency. Core Akka can never reference `Akka.Serialization.V2` (cycle), but every migration-candidate assembly (`Akka.Remote`, `Akka.Cluster`, `Akka.DistributedData`, `Akka.Cluster.Sharding`, `Akka.Cluster.Tools`, `Akka.Cluster.Metrics`) sits downstream of core and can. The generator is syntax-driven (`ForAttributeWithMetadataName`, current-compilation only), so `[AkkaSerializable]` types must be declared in the same assembly as their `[AkkaSerializer]` — this is what forces Decision 10 (per-assembly DTO mirrors, not a shared cross-assembly schema).
+
+**Migration inventory** (all internal ids are `< 100`, reserved per `CustomSerializerSpec.cs`; free low ids before this change: 18-21, 24-35, 37-39):
+
+| Subsystem / serializer | Legacy id | New id | Assembly | Hot-path (steady-state) | Cold | Migration risk |
+|---|---|---|---|---|---|---|
+| `ReliableDeliverySerializer` | 36 | 76 | Akka.Cluster | `SequencedMessage` (wraps every delivery), `Ack`, `Request`, `Resend` | `RegisterConsumer`, 4 durable-queue types | Low — small flow-control messages; delivery is the designated V2 buffer POC |
+| `ReplicatorMessageSerializer` | 12 | 52 | Akka.DistributedData | `Gossip` (gzip), `Status`, `DeltaPropagation`, `DataEnvelope`, `Write`, `Read`, `Changed`, `WriteAck`, `DeltaNack` | `Get*`, `Subscribe`, `DurableDataEnvelope` | Med-High — gzip, `OtherMessage` user-payload nesting, `VersionVector`/`UniqueAddress` |
+| `ReplicatedDataSerializer` | 11 | 51 | Akka.DistributedData | CRDT delta ops (`ORSetAdd/Remove/DeltaGroup`, `ORMap*`, counters), full-state CRDTs embedded in `DataEnvelope`/`DeltaPropagation` | 10 Key types | Med-High — gzip on ORSet/ORMap; nested arbitrary user values |
+| `DistributedPubSubMessageSerializer` | 9 | 49 | Akka.Cluster.Tools | `Status`, `Delta` (registry gossip, ~1s), `Send`, `SendToAll`, `Publish`, `SendToOneSubscriber` | — | Low-Med — `Address` reuse + user payload wrap |
+| `ClusterClientMessageSerializer` | 15 | 55 | Akka.Cluster.Tools | `Heartbeat`, `HeartbeatRsp`, `Send`, `SendToAll`, `Publish` | `Contacts`, `GetContacts`, `ReceptionistShutdown` | Low-Med (reuses PubSub proto shapes) |
+| `ClusterSingletonMessageSerializer` | 14 | 54 | Akka.Cluster.Tools | — | all 4 (handover only, empty payloads) | Low but low-value (cold, empty) |
+| `ClusterMetricsMessageSerializer` | 10 | 50 | Akka.Cluster.Metrics | `MetricsGossipEnvelope` (~3s) | 5 router-config types | Low-Med |
+| `ClusterShardingMessageSerializer` | 13 | 53 | Akka.Cluster.Sharding | `ShardingEnvelope` (wraps every entity message), `GetShardHome`/`ShardHome`/`HostShard`, handoff set | 20+ stats/registration types **+ persisted remember-entities state** (`CoordinatorState`, `EntityState`, `EntitiesStarted/Stopped`) — **excluded from this change**, see Decision 11 | High for the persisted subset; Low-Med for routing |
+| `ClusterMessageSerializer` | 5 | 45 | Akka.Cluster | `GossipEnvelope`, `GossipStatus`, `Heartbeat`, `HeartbeatRsp` | `Join`, `Welcome`, `Leave`, `Down`, `InitJoin*` | High — membership correctness; `Gossip` carries the full member set + `VectorClock` + `Reachability` |
+| Remote core: `MiscMessageSerializer`(16), `SystemMessageSerializer`(22), `PrimitiveSerializers`(17), `MessageContainerSerializer`(6), `DaemonMsgCreateSerializer`(3) | — | — | Akka.Remote | Watch/`DeathWatchNotification`, RemoteWatcher heartbeat, primitives | most | **Out of scope**, see Decision 12 |
+
+Shared wire fragments reused across these protos: `UniqueAddress` (64-bit uid, `ClusterMessages.proto`), `AddressData`/`ActorRefData` (`ContainerFormats.proto`), `VersionVector`, and the two nesting envelopes `Payload` (`WrappedPayloadSupport`, `src/core/Akka.Remote/Serialization/WrappedPayloadSupport.cs`) and `OtherMessage` (`SerializationSupport.cs` in DData).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Migrate the internal cluster/replication/delivery/sharding-routing message serializers from protobuf to source-generated MessagePack V2, behind a default-off write-side flag.
+- Preserve rolling-upgrade safety: every v1.6 node can read protobuf and MessagePack-v2 for any migrated subsystem regardless of what it writes.
+- Gate each subsystem's default-on transition on a measured CPU/allocation/payload-size benchmark result, not a target date.
+- Reuse the `messagepack-sourcegen-validation` generator, attributes, and envelope-payload model unmodified.
+- Give operators a pure-HOCON, per-subsystem rollout surface.
+
+**Non-Goals:**
+
+- Migrating Remote core internals (`MiscMessageSerializer`, `SystemMessageSerializer`, `PrimitiveSerializers`, `MessageContainerSerializer`, `DaemonMsgCreateSerializer`) — a separate later change; they underpin persistence and the upcoming Artery envelopes.
+- Migrating durable/persisted state: DData LMDB storage and Sharding's remember-entities journal keep protobuf writes in this change.
+- A framework-enforced `AppVersion` or capability-version handshake gate on v2 writes — rollout safety is operator-discipline plus documentation.
+- A `SerializationSetup`-based or Akka.Hosting-based flag surface — HOCON only in this change; Hosting may wrap the HOCON flag in a later change.
+- The cross-assembly MessagePack shared-schema contract for de-duplicating `UniqueAddress`/`VersionVector` formatters across subsystem assemblies — demoted to a dedup-only follow-up, not a dependency of this change.
+- Changing the wire format of any existing protobuf serializer id in place.
+
+## Decisions
+
+### 1. Flag controls the WRITE side only; both serializers always registered
+
+Verified against `Serialization.cs`: reads are id-dispatched (`_serializersById`), writes are binding-driven. Register both the legacy protobuf id and the new MessagePack id in every subsystem's reference.conf unconditionally. The flag only rewrites the `serialization-bindings` entry for the subsystem's marker interface (e.g. `IReplicatorMessage`, `IDeliverySerializable`, `IClusterShardingSerializable`) from the legacy serializer-name to the v2 serializer-name. Read-side-always-registered is sufficient for a homogeneous v1.6 cluster: every node holds both serializers, so any node decodes either format no matter which it writes.
+
+### 2. Flag mechanism — central HOCON binding-rewrite hook (settled)
+
+**Decision: a single central code hook in `Serialization` construction, driven purely by HOCON.** This was Open Question 1 in the design draft; the maintainer selected the central-hook option. `SerializationSetup`-based and Akka.Hosting-based flag surfaces are rejected **for now** — `SerializationSetup` would require code changes per application to flip a subsystem (defeating the "operator turns a knob" goal), and an Akka.Hosting extension is blocked on Hosting being inlined into this repository (`messagepack-sourcegen-validation` tasks.md 8.8, still open). Akka.Hosting can wrap the HOCON flag with a typed extension method later without changing the underlying mechanism.
+
+Because HOCON can't branch and the interface-resolution loop is non-deterministic (Decision 1), the flip is applied by a single central code hook that runs during `Serialization` construction. Each subsystem contributes a static descriptor `{ interfaceKey, legacyName, v2Name, flagPath }`; the hook, for each effectively-on subsystem, replaces `serialization-bindings[interfaceKey] = v2Name` deterministically (exact-key overwrite, avoiding the arbitrary-order hazard described in Decision 1). This keeps the operator surface pure-HOCON.
+
+### 3. HOCON shape — global flag + per-subsystem override
+
+```hocon
+akka.actor.serialization.v2 {
+  # Master write-side switch for internal MessagePack serializers.
+  # off (default) = write legacy protobuf; both formats are always READ.
+  # Only flip to on AFTER every node in the cluster is on v1.6 with the
+  # v2 serializers registered (see Decision 6).
+  enabled = off
+
+  # Per-subsystem overrides; each inherits `enabled` when left unset.
+  reliable-delivery = ${akka.actor.serialization.v2.enabled}
+  distributed-data  = ${akka.actor.serialization.v2.enabled}
+  pub-sub           = ${akka.actor.serialization.v2.enabled}
+  cluster-client    = ${akka.actor.serialization.v2.enabled}
+  cluster-metrics   = ${akka.actor.serialization.v2.enabled}
+  sharding          = ${akka.actor.serialization.v2.enabled}   # routing subset only
+  cluster           = ${akka.actor.serialization.v2.enabled}
+}
+```
+
+### 4. Serializer-id strategy — new ids from a reserved internal block (settled)
+
+**Decision: reserve 40-79 for internal V2/MessagePack ports; mnemonic `v2_id = legacy_id + 40`** (5→45, 9→49, 10→50, 11→51, 12→52, 13→53, 14→54, 15→55, 36→76). This was Open Question 3; the maintainer confirmed both the block and the mnemonic. All stay `< 100` (internal-reserved, per `CustomSerializerSpec.cs`) and well clear of user-generated serializers (120000+, per the `Akka.Serialization.V2` examples). Ids, once shipped and written by any node, are never reused — they may sit in durable DData or journal data even though this change does not itself write v2 bytes into durable storage (Decision 11).
+
+### 5. New serializers are native source-generated V2, translating domain ↔ `[AkkaSerializable]` DTO mirror ↔ MessagePack
+
+The V2 serializer is `AkkaSerializer : SerializerV2` (source-generated), reusing the legacy manifest tokens (e.g. `"N"`, `"HB"`, `"a"`) — this satisfies the non-empty/non-CLR manifest invariant and lets intra-serializer dispatch mirror the protobuf serializer 1:1. Just as the protobuf serializers translate domain object → proto message → bytes, the V2 serializers translate domain object → hand-written `[AkkaSerializable]` DTO mirror → MessagePack bytes. Nested user payloads use `[AkkaEnvelopePayload]` (preserves serializerId+manifest+bytes) — the direct analog of `WrappedPayloadSupport`/`OtherMessage` (Decision 8).
+
+### 6. Rolling-upgrade safety — default-off + operator-discipline docs, no framework gate (settled)
+
+**Decision: rely on default-off + `AppVersion`-uniformity documentation. No framework-owned serializer-capability version, no remoting-handshake change.** This was Open Question 2; the maintainer chose operator discipline over a framework-enforced gate. The hazard is a node that has no v2 serializer registered (any pre-v1.6 node) receiving a v2 id → `Cannot find serializer with id [N]`. Once every node is v1.6, all hold both serializers, so:
+
+- flipping the flag can itself be rolled gradually — mixed protobuf/v2 writers coexist, since all v1.6 readers handle both;
+- the hard precondition is only that the v1.5→v1.6 upgrade has *completed* before any node writes v2.
+
+This mirrors the `widen-system-uid-to-64bit` precedent exactly: widen the type/register the serializer everywhere now, keep the risky behavior (writing wide uids / writing v2) default-off, flip behind config only after the whole cluster is on v1.6. `HasMoreThanOneAppVersion`-style checks remain available to operators as an informational signal (the same one sharding already uses to gate rebalance) but this change does not wire the framework to refuse writes based on it — `AppVersion` is application-defined and not a reliable enforcement mechanism, and a framework-owned capability version big enough to be reliable can't ride the existing remoting handshake without a wire change, which is out of scope here (Decision 12 covers Remote-core deferral generally).
+
+### 7. Migration order — hot-path + low-risk first, durability and correctness-critical last (settled)
+
+**Decision: ReliableDelivery → DistributedData → Cluster tools → Sharding (routing subset) → Cluster core, with Sharding-persisted state and Remote-core internals deferred out of this change.** This was Open Question 4; the maintainer confirmed the order as drafted.
+
+1. **ReliableDelivery (36→76)** — small, self-contained flow-control messages; delivery is the designated V2 buffer POC; no persistence on the hot subset. Lowest risk, real steady-state volume, best first proof.
+2. **DistributedData (12→52 then 11→51)** — the headline hot-path and the best perf signal (gossip/delta every interval). Higher risk (gzip, `OtherMessage` user-payload nesting, `VersionVector`). This is where the "very noticeable improvement" mandate is proven or disproven. Durable (LMDB) writes stay protobuf in this change (Decision 11).
+3. **Cluster tools** — PubSub (9→49), ClusterClient (15→55), Metrics (10→50); Singleton (14→54) optional/low-value (cold, empty payloads).
+4. **Sharding routing subset (13→53)** — `ShardingEnvelope`, shard-home/handoff. Persisted remember-entities state stays protobuf (Decision 11).
+5. **Cluster core (5→45)** — Heartbeat/HeartbeatRsp first (tiny, hot; measure size per Decision 9), then Gossip (complex, membership-critical). Highest correctness sensitivity, so last.
+6. **Remote core internals (16/22/17/6/3)** — deferred to a separate later change (Decision 12).
+
+### 8. Nested payloads are serializer boundaries, not re-encoded
+
+`Payload`/`OtherMessage`/`SequencedMessage` carry an inner (serializerId, manifest, bytes) triple owned by whatever serializer wrote the inner value (often a user serializer). The v2 wrapper preserves that triple verbatim via `[AkkaEnvelopePayload]`; user payloads are never re-serialized. This is why the migration is safe even when a wrapper's payload is an application type Akka doesn't own.
+
+### 9. Benchmark acceptance gate, including payload-size tolerance (settled)
+
+Extend existing harnesses to run both encodings per subsystem and compare on the same hardware, same run (mirroring the M5 gate language):
+
+- **Micro (primary gate):** `ClusterMessageSerializerBenchmarks` (`src/benchmark/Akka.Cluster.Benchmarks/Serialization/`), `DDataSerializationBenchmarks` (ShardCount 1/20/100/1000), and the DData CRDT serializer benchmarks (`Akka.Benchmarks/DData/Serializer*Benchmarks.cs`) — add a v2 arm to each. Metrics: ns/op serialize+deserialize, B/op (`MemoryDiagnoser`), and payload size in bytes.
+- **End-to-end (secondary gate):** the `RemotePingPong` RealPayload harness already A/B's `--serializer v2|protobuf|msgpack` over the full remoting path via `serialization-bindings` and reports msgs/sec + bytes-on-wire — extend it to carry real subsystem message shapes, and add a DData write-propagation / cluster-formation-time throughput check.
+- **Default-on criterion per subsystem:** ≥ ~30-50% lower serialize+deserialize CPU **and** ≥ ~2x lower allocations **and** payload size within tolerance on that subsystem's hottest small message.
+
+**Payload-size tolerance (Open Question 5, settled):** protobuf is extremely compact (varint field numbers); MessagePack with `[AkkaField]` field-id maps can be larger for tiny messages (map framing + keys — the sourcegen POC logged ~128-130 B for a small message). The maintainer's ruling: **up to ~10% payload growth on tiny hot messages (`Heartbeat`/`Ack`) is acceptable IF the CPU/allocation wins are substantial.** Payload size stays a first-class benchmark-gate metric alongside CPU and allocations, measured per message type — a message that is both larger by more than the tolerance and not meaningfully faster stays on protobuf (either the whole subsystem stays default-off, or that specific message type is carved out and kept on the legacy binding while the rest of the subsystem migrates).
+
+### 10. Cross-assembly dependency — proceed now with per-assembly formatters (settled)
+
+**Decision: proceed now with per-assembly `[AkkaSerializable]` DTO mirrors plus hand-written `IAkkaMessagePackFormatter<T>` formatters for shared fragments (`UniqueAddress`, `VersionVector`). The cross-assembly shared-schema contract is demoted to a dedup-only follow-up, not a dependency of this change.** This was Open Question 6; the maintainer chose to unblock immediately rather than wait.
+
+- **Unblocked today:** any subsystem whose serializer + `[AkkaSerializable]` DTO mirrors live in one downstream assembly can be generated now — the single-compilation generator handles it, and `Address`/`ActorPath` shared fields use the existing built-in `AddressFormatter`/`ActorPathFormatter`, which are byte-compatible with Artery's control-message wire format (`messagepack-sourcegen-validation` design.md Decision 11). ReliableDelivery and PubSub are unblocked immediately this way.
+- **Duplication accepted:** authoring the shared wire fragments (`UniqueAddress` with its 64-bit uid, `VersionVector`, `ActorRefData`, and the generic nesting-envelope schema) once and structurally nesting them across subsystem assemblies is not available yet. The generator is current-compilation-only, so a referenced-assembly `[AkkaSerializable]` type is invisible to it (`messagepack-sourcegen-validation` design.md Decisions 8 and 11). Per-assembly `IAkkaMessagePackFormatter<T>` mirror duplication (extending the existing `AddressFormatter`/`ActorPathFormatter` precedent) is the accepted approach for `UniqueAddress` and `VersionVector` in this change, one hand-written formatter per assembly that needs it.
+- A future cross-assembly MessagePack schema contract (the "explicit cross-assembly MessagePack contract" named in `messagepack-sourcegen-validation` design.md Decision 8) would let a generated serializer in assembly B structurally write/read an `[AkkaSerializable]` schema type declared and generated in a referenced assembly A. When it lands, the duplicated formatters in this change become de-duplication candidates, not a correctness problem — the wire format they produce does not change.
+
+### 11. Durable/persisted scope — excluded from this change (settled)
+
+**Decision: DData-LMDB and Sharding's remember-entities persisted state keep protobuf writes in this change (read-old-forever); only the ephemeral remote-gossip subset migrates.** This was Open Question 7; the maintainer confirmed the scope as drafted. Persistence needs the strictest compatibility rule (`messagepack-sourcegen-validation` design.md Decision 8.1): historical events, snapshots, and durable CRDT/journal state are durable wire contracts read forever. Migrating durable writes to v2 needs a separate migration tool and operational process, which is out of scope here. Concretely:
+
+- `DurableDataEnvelope` (DData LMDB durable store) stays on the legacy `ReplicatorMessageSerializer`/`ReplicatedDataSerializer` protobuf path even after `distributed-data` is flagged on for the ephemeral gossip/delta traffic that shares those same serializer classes; the durable-store write path is pinned to the legacy binding independent of the flag.
+- Sharding's `CoordinatorState`, `EntityState`, `EntitiesStarted`/`EntitiesStopped` (remember-entities journal) stay on the legacy `ClusterShardingMessageSerializer` protobuf path; only the routing/handoff subset (`ShardingEnvelope`, `GetShardHome`/`ShardHome`/`HostShard`) is eligible for the `sharding` flag.
+
+### 12. Remote core internals — separate later change (settled)
+
+**Decision: `MiscMessageSerializer`(16), `SystemMessageSerializer`(22), `PrimitiveSerializers`(17), `MessageContainerSerializer`(6), and `DaemonMsgCreateSerializer`(3) are explicitly out of scope for this change.** This was Open Question 8; the maintainer confirmed. These serializers underpin persistence directly (event/snapshot envelopes) and the upcoming Artery envelope work (Milestone 4/5), so migrating them belongs to a dedicated later change that can reason about both dependencies together rather than being squeezed into this cluster/replication/delivery-focused migration.
+
+### 13. Coordinated invariants
+
+Any v2 schema carrying the system uid must emit it as **64-bit `long`** (`widen-system-uid-to-64bit`, already merged). Manifest strings are wire+persistence contracts once shipped (`messagepack-sourcegen-validation` design.md Decision 4/Decision 14 in the `serializer-v2` foundation): reuse the legacy tokens and never repurpose them.
+
+### 14. Rejected alternatives
+
+- **Mutate existing serializer ids' wire format in place** — rejected; breaks every mixed cluster and all persisted/durable data (`messagepack-sourcegen-validation` design.md Decision 8.1). Fork with new ids instead (Decision 4).
+- **Negotiate serializer capability over the remoting handshake** — rejected; `AkkaHandshakeInfo` has no capability field, and adding one is a wire change out of scope here. Use default-off + docs instead (Decision 6).
+- **`SerializationSetup`-based or Akka.Hosting-based flag surface** — rejected for this change; needs application code changes per subsystem flip (`SerializationSetup`) or is blocked on Hosting inlining (Akka.Hosting). HOCON-only for now (Decision 2).
+- **Wait for the cross-assembly MessagePack shared-schema contract before starting** — rejected; per-assembly DTO mirrors and hand-written formatters unblock ReliableDelivery/PubSub/DistributedData immediately, and de-duplication can follow later without a wire change (Decision 10).
+- **Per-message-type bindings** to migrate incrementally within one serializer — rejected as fragile (the interface-resolution non-determinism from Decision 1); migrate a whole serializer (marker interface) at once, with the single documented exception in Decision 9 (a message type that fails the size-tolerance gate can be carved out and kept on the legacy binding).
+- **Alternative serialization libraries** — out of scope; MessagePack-CSharp via the `Akka.Serialization.V2` generator is settled (maintainer directive, `messagepack-sourcegen-validation`).
+
+## Risks / Trade-offs
+
+- **[Risk] A pre-v1.6 node receives a v2-id message after an operator enables the flag too early.** → Mitigation: default-off, explicit runbook requiring full v1.6 rollout first (Decision 6); no automatic enforcement, so this is a documentation-and-process risk, not a code risk that can be fully closed in this change.
+- **[Risk] The non-deterministic binding-resolution loop in `FindSerializerV2ForType` could apply the flag inconsistently if the central hook doesn't use exact-key overwrite.** → Mitigation: Decision 1/2 require exact-key, last-write-wins overwrite of the marker-interface binding, not a competing overlapping binding.
+- **[Risk] Payload-size regression on tiny hot messages increases gossip/heartbeat bandwidth even when CPU improves.** → Mitigation: payload size is a first-class, per-message gate metric with an explicit ~10% tolerance tied to substantial CPU/allocation wins (Decision 9); a message that fails the gate can be carved out and stay on the legacy binding.
+- **[Risk] Per-assembly formatter duplication for `UniqueAddress`/`VersionVector` drifts out of sync across assemblies over time.** → Mitigation: accepted trade-off (Decision 10); the wire format is fixed and reviewed once per formatter, and a future cross-assembly contract can de-duplicate without a wire change.
+- **[Trade-off] No framework-enforced version gate means the framework cannot itself prevent an operator from enabling the flag on a mixed-version cluster.** → Accepted trade-off (Decision 6), consistent with the `widen-system-uid-to-64bit` precedent; revisit only if operational experience shows the documentation-only approach is insufficient.
+
+## Migration Plan
+
+1. Land flag infrastructure and the reserved id block with no subsystem wired to it yet (nothing observable changes).
+2. Land ReliableDelivery's forked serializer, wire its subsystem flag, and run its benchmark gate. Do not flip the shipped default; this only proves the mechanism end-to-end.
+3. Repeat per subsystem in the Decision 7 order, each gated independently on its own benchmark results (Decision 9).
+4. Each subsystem's default stays `off` in the shipped reference.conf regardless of gate results in this change; flipping any subsystem's shipped default to `on` is a separate, later decision reviewed against the accumulated benchmark evidence.
+5. Rollback for an operator who already enabled a subsystem's flag is a config change back to `off` — no data migration is needed because durable formats never carried v2 bytes (Decision 11) and both serializers remain registered for reads indefinitely.

--- a/openspec/changes/internal-serializers-messagepack-v2/proposal.md
+++ b/openspec/changes/internal-serializers-messagepack-v2/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Akka.NET 1.6 makes `SerializerV2` canonical and ships source-generated MessagePack serializers (`Akka.Serialization.V2`, MessagePack-CSharp 3.1.7) validated by `messagepack-sourcegen-validation` (Milestone 3). The internal cluster/replication/delivery/sharding message serializers are still hand-written protobuf (`SerializerWithStringManifest` over `Google.Protobuf`). These run on the hottest steady-state paths in a cluster — gossip, deltas, heartbeats, delivery flow-control, shard routing — and are allocation-heavy (`ToBinary → byte[]` per message, proto object graphs). Migrating them to the validated MessagePack V2 generator should cut CPU and allocations on those paths. Per the maintainer: *if we don't see a very noticeable improvement, we're doing something wrong* — measured improvement is the acceptance gate, not an afterthought.
+
+The migration must be rolling-upgrade safe and reversible: a mixed cluster must never receive bytes it can't decode, and operators must be able to turn it on subsystem-by-subsystem.
+
+## What Changes
+
+- Add a global write-side feature flag `akka.actor.serialization.v2.enabled` plus per-subsystem overrides (`reliable-delivery`, `distributed-data`, `pub-sub`, `cluster-client`, `cluster-metrics`, `sharding`, `cluster`), implemented as a single central HOCON-driven binding-rewrite hook that runs during `Serialization` construction. Pure config surface — no `SerializationSetup` variant and no Akka.Hosting extension in this change (Hosting can wrap the HOCON flag later).
+- For each migrated subsystem, add a **forked** native V2 (source-generated MessagePack) serializer with a new serializer id drawn from the reserved internal block **40-79** (mnemonic: `v2_id = legacy_id + 40`). The legacy protobuf serializer and its id are retained, never mutated in place.
+- **Both** serializers (legacy protobuf id + new MessagePack id) are always registered on every node, regardless of flag state. Reads dispatch purely by numeric serializer id, so any v1.6 node decodes either format no matter what it writes; only the type→serializer write-side **binding** flips when a subsystem's flag is on.
+- Reuse existing manifest tokens on each V2 serializer so intra-serializer dispatch mirrors its protobuf counterpart 1:1.
+- Migration order (hot-path + low-risk first, durability and correctness-critical last): ReliableDelivery (36→76) → DistributedData (12→52, 11→51) → Cluster tools (PubSub 9→49, ClusterClient 15→55, Metrics 10→50; Singleton 14→54 optional/low-value) → Sharding routing subset (13→53) → Cluster core (5→45).
+- Default is **off**. Rolling-upgrade safety is enforced by default-off + operator-discipline documentation ("all nodes on v1.6 before enabling", mirroring the `widen-system-uid-to-64bit` precedent) — **not** by a new framework `AppVersion` gate or a remoting-handshake capability field.
+- Add a benchmark acceptance gate: extend `ClusterMessageSerializerBenchmarks`, `DDataSerializationBenchmarks`, the DData CRDT serializer benchmarks, and the `RemotePingPong --serializer` harness to A/B protobuf vs. MessagePack-v2 per subsystem, measuring CPU, allocations, and payload size on the same hardware, same run. A subsystem's flag becomes default-on only after it clears the gate.
+
+### What Does Not Change
+
+- Legacy protobuf serializers, ids, and wire formats stay in the codebase and are read forever.
+- Nested arbitrary **user** payloads keep their own serializers — only the wrapper (`Payload`/`OtherMessage`/`SequencedMessage`) encoding changes; the (serializerId, manifest, bytes) nesting contract is preserved.
+- Durable/persisted state — DData LMDB storage and Sharding's remember-entities journal — is **not** flipped to v2 writes in this change; those keep protobuf writes and stay readable indefinitely (persistence rule from `messagepack-sourcegen-validation` design.md Decision 8.1).
+- Default is **off** — a freshly-upgraded v1.6 node writes protobuf until the operator enables the flag.
+- No new serialization dependency: MessagePack-CSharp via the existing `Akka.Serialization.V2` generator is the settled choice.
+- Remote core internals (`MiscMessageSerializer`, `SystemMessageSerializer`, `PrimitiveSerializers`, `MessageContainerSerializer`, `DaemonMsgCreateSerializer`) are out of scope — deferred to a separate later change because they underpin persistence and the upcoming Artery envelopes.
+- No framework-enforced `AppVersion` or capability-version handshake gate is added; rollout safety is operator-discipline plus documentation, matching the `widen-system-uid-to-64bit` precedent.
+
+This change supersedes, for the specific subsystems and message shapes listed above, the "protobuf wrapper wire formats are not replaced by default" non-goal recorded in `messagepack-sourcegen-validation/design.md` (Goals / Non-Goals, line 30) and mirrored in that change's `proposal.md` ("What Does Not Change"). That non-goal held while the generator itself was being validated; this change is the follow-on migration built on top of the validated generator, still gated default-off. It does **not** touch Remote core internals or durable/persisted wire formats, which remain non-goals here too (see above).
+
+## Capabilities
+
+### New Capabilities
+
+- `messagepack-internal-serializers`: write-side feature flag (global + per-subsystem), forked MessagePack V2 serializers for ReliableDelivery, DistributedData, Cluster Tools (PubSub/ClusterClient/Metrics/Singleton), Sharding's routing subset, and Cluster core, the reserved 40-79 serializer-id block, and the benchmark acceptance gate that governs each subsystem's default-on transition.
+
+### Modified Capabilities
+
+None. `openspec/specs/` has no existing entries for the touched subsystems (DistributedData, Delivery, Cluster Tools, Sharding, Cluster core serializers predate OpenSpec adoption for this repository), so there is no baseline requirement set to delta against. Subsystem-level code impact is captured under Impact below instead of as formal capability deltas.
+
+## Impact
+
+- New source-generated `*MessagePackSerializer` types + `[AkkaSerializable]` DTO mirrors in `Akka.Cluster` (ReliableDelivery, Cluster core), `Akka.DistributedData`, `Akka.Cluster.Tools`, and `Akka.Cluster.Sharding` (routing subset only).
+- Hand-written `IAkkaMessagePackFormatter<T>` formatters for shared wire fragments (`UniqueAddress`, `VersionVector`) duplicated per assembly, extending the existing `AddressFormatter`/`ActorPathFormatter` precedent from `messagepack-sourcegen-validation` design.md Decision 11. No dependency on a cross-assembly shared-schema contract.
+- New `serialization-identifiers` / `serializers` reference.conf entries per subsystem (both the legacy id and the new v2 id, unconditionally registered).
+- New `akka.actor.serialization.v2.*` HOCON config block plus a central binding-rewrite hook added to `Serialization` construction (`src/core/Akka/Serialization/Serialization.cs`).
+- API-approval baselines updated for new serializer types (largely `internal`).
+- `BREAKING_CHANGES_V1.6.md` ledger entry documenting the new rolling-upgrade rule ("all nodes on v1.6 before enabling `akka.actor.serialization.v2.enabled`"); this is an operational constraint, not a wire or API break while the flag defaults to off.
+- New/extended benchmarks: `ClusterMessageSerializerBenchmarks`, `DDataSerializationBenchmarks`, DData CRDT serializer benchmarks, `RemotePingPong --serializer` harness.
+- Operator-facing documentation: runbook for enabling the flag cluster-wide, subsystem-by-subsystem.

--- a/openspec/changes/internal-serializers-messagepack-v2/specs/messagepack-internal-serializers/spec.md
+++ b/openspec/changes/internal-serializers-messagepack-v2/specs/messagepack-internal-serializers/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Write-side flag controls serializer selection only
+
+The system SHALL provide a write-side-only feature flag (`akka.actor.serialization.v2.enabled` plus per-subsystem overrides) that selects which registered serializer a migrated subsystem writes with, and SHALL always register both the legacy protobuf serializer and the new MessagePack V2 serializer for a migrated subsystem regardless of the flag's value.
+
+#### Scenario: Flag disabled writes legacy protobuf
+
+- **WHEN** a subsystem's effective flag is `off` (the default)
+- **THEN** the system SHALL write that subsystem's messages using the legacy protobuf serializer
+
+#### Scenario: Flag enabled writes MessagePack V2
+
+- **WHEN** a subsystem's effective flag is `on`
+- **THEN** the system SHALL write that subsystem's messages using the forked MessagePack V2 serializer
+
+#### Scenario: Both formats remain readable regardless of flag state
+
+- **WHEN** a node receives a message serialized with either the legacy protobuf serializer id or the MessagePack V2 serializer id for a migrated subsystem
+- **THEN** the node SHALL deserialize the message successfully, independent of that subsystem's flag value
+
+### Requirement: Deterministic binding override
+
+The system SHALL apply the write-side flag by deterministically overwriting the exact `serialization-bindings` entry for a subsystem's marker interface, and SHALL NOT add a competing overlapping binding.
+
+#### Scenario: Central hook overwrites exact binding key
+
+- **WHEN** a subsystem's flag is effectively `on` during `Serialization` construction
+- **THEN** the system SHALL overwrite the marker interface's existing binding entry with the MessagePack V2 serializer name using an exact-key, last-write-wins replacement
+
+#### Scenario: No new overlapping binding is introduced
+
+- **WHEN** the flag-driven binding override runs
+- **THEN** the system SHALL NOT register an additional `serialization-bindings` entry that overlaps with the subsystem's existing marker-interface binding
+
+### Requirement: Reserved internal serializer-id block
+
+The system SHALL assign each forked MessagePack V2 serializer a serializer id in the reserved range 40-79, computed as the corresponding legacy serializer's id plus 40.
+
+#### Scenario: Forked serializer id follows the legacy-plus-40 mapping
+
+- **WHEN** a built-in subsystem serializer is forked to a MessagePack V2 serializer
+- **THEN** the new serializer's id SHALL equal the legacy serializer's id plus 40
+- **AND** the new serializer's id SHALL fall within the 40-79 range
+
+### Requirement: Durable and persisted writes excluded from this migration
+
+The system SHALL keep DistributedData's durable (LMDB) store writes and Cluster Sharding's remember-entities persisted state on the legacy protobuf serializer regardless of the corresponding subsystem flag.
+
+#### Scenario: DData durable store ignores the distributed-data flag
+
+- **WHEN** the `distributed-data` flag is `on` and a value is written to the durable (LMDB) store
+- **THEN** the system SHALL serialize that durable write using the legacy protobuf serializer
+
+#### Scenario: Sharding remember-entities state ignores the sharding flag
+
+- **WHEN** the `sharding` flag is `on` and remember-entities state (`CoordinatorState`, `EntityState`, `EntitiesStarted`, `EntitiesStopped`) is persisted
+- **THEN** the system SHALL serialize that persisted state using the legacy protobuf serializer
+
+### Requirement: Envelope and nested payloads are preserved as serializer boundaries
+
+Forked MessagePack V2 wrapper serializers SHALL preserve a wrapped payload's own serializer id, manifest, and serialized bytes rather than re-encoding the payload structurally.
+
+#### Scenario: Wrapped user payload round-trips without re-encoding
+
+- **WHEN** a forked V2 wrapper serializer (for example a delivery `SequencedMessage` or a DistributedData `OtherMessage`/`DataEnvelope`) writes a wrapped application payload
+- **THEN** it SHALL store the payload's serializer id, manifest, and opaque serialized bytes
+- **AND** it SHALL recover the original payload through normal Akka deserialization using that stored id, manifest, and bytes
+
+### Requirement: Benchmark acceptance gate governs default-on transitions
+
+The system's migrated subsystems SHALL be evaluated with matched protobuf-vs-MessagePack-V2 benchmarks reporting CPU cost, allocations, and payload size before any subsystem's shipped default flag value changes from `off`.
+
+#### Scenario: Subsystem benchmark reports all three gate metrics
+
+- **WHEN** a migrated subsystem's benchmark suite runs
+- **THEN** it SHALL report serialize+deserialize CPU cost, allocated bytes, and payload size for both the legacy protobuf serializer and the forked MessagePack V2 serializer
+
+#### Scenario: Payload-size regression beyond tolerance without substantial wins keeps the legacy binding
+
+- **WHEN** a message type's MessagePack V2 payload size exceeds its protobuf payload size by more than approximately 10% and the corresponding CPU or allocation improvement is not substantial
+- **THEN** that message type SHALL remain on the legacy protobuf binding even if the rest of its subsystem is otherwise eligible to migrate
+
+### Requirement: Rolling-upgrade safety through default-off and operator documentation
+
+The system SHALL ship every migrated subsystem's flag defaulted to `off`, and SHALL document that all cluster nodes must be running a version with the MessagePack V2 serializer registered before any node enables a subsystem's flag.
+
+#### Scenario: Freshly upgraded node writes legacy protobuf until an operator opts in
+
+- **WHEN** a node is upgraded to a version containing this change and no configuration override is applied
+- **THEN** the node SHALL continue writing every migrated subsystem's messages using the legacy protobuf serializer
+
+#### Scenario: A node without the V2 serializer registered cannot decode a V2 id
+
+- **WHEN** a node that does not have a migrated subsystem's MessagePack V2 serializer registered receives a message with that serializer's id
+- **THEN** deserialization SHALL fail with a "cannot find serializer with id" error, which is the documented precondition for requiring all nodes to be upgraded before enabling any subsystem flag

--- a/openspec/changes/internal-serializers-messagepack-v2/tasks.md
+++ b/openspec/changes/internal-serializers-messagepack-v2/tasks.md
@@ -1,0 +1,58 @@
+## 1. Feature flag + registration infrastructure
+
+- [ ] 1.1 Add `akka.actor.serialization.v2.{enabled, <subsystem>}` config keys + docs (default off) to `reference.conf`
+- [ ] 1.2 Add central binding-rewrite hook in `Serialization` construction: subsystem descriptor `{ interfaceKey, legacyName, v2Name, flagPath }`; deterministic exact-key override (see design.md Decision 2)
+- [ ] 1.3 Reserve serializer-id block 40-79; document `legacy + 40` mapping in code comments and design docs
+- [ ] 1.4 Spec/tests: both serializers registered regardless of flag; read either format by id; write per flag
+- [ ] 1.5 Spec/tests: interface binding override is deterministic (exact-key, last-write-wins)
+
+## 2. Subsystem 1 — ReliableDelivery (id 36 -> 76) [lowest risk, first]
+
+- [ ] 2.1 `[AkkaSerializable]` DTO mirrors for `SequencedMessage`/`Ack`/`Request`/`Resend`/`RegisterConsumer` (+ durable-queue types, cold)
+- [ ] 2.2 Source-generated `ReliableDeliveryMessagePackSerializer` (reuse manifests `"a"`..`"i"`)
+- [ ] 2.3 `[AkkaEnvelopePayload]` for `SequencedMessage`'s wrapped user payload
+- [ ] 2.4 Register both ids in `Cluster.conf`; wire `reliable-delivery` flag through the central hook
+- [ ] 2.5 Byte-golden tests both formats + cross-read; round-trip; flag on/off write-id assertion
+
+## 3. Subsystem 2 — DistributedData (ids 12->52, 11->51) [headline hot-path]
+
+- [ ] 3.1 DTO mirrors for the `ReplicatorMessage` set; hand-written `IAkkaMessagePackFormatter<T>` for `UniqueAddress`/`VersionVector` (design.md Decision 10)
+- [ ] 3.2 Preserve/re-evaluate gzip on `Gossip`/`ORSet`/`ORMap`; `OtherMessage` -> `[AkkaEnvelopePayload]`
+- [ ] 3.3 `ReplicatedData` CRDT mirrors + delta-op serializers
+- [ ] 3.4 Keep durable (LMDB) writes on protobuf regardless of flag state (design.md Decision 11); register v2 ids; wire `distributed-data` flag
+- [ ] 3.5 Golden + cross-read + durable-read-back (v2 flag on, restart, read durable store) tests
+
+## 4. Subsystems 3-4 — Cluster tools (9, 15, 10; optional 14) + Sharding routing subset (13)
+
+- [ ] 4.1 PubSub (9->49): DTO mirrors, `DistributedPubSubMessagePackSerializer`, wire `pub-sub` flag
+- [ ] 4.2 ClusterClient (15->55): DTO mirrors (reuse PubSub shapes where applicable), wire `cluster-client` flag
+- [ ] 4.3 ClusterMetrics (10->50): DTO mirrors, wire `cluster-metrics` flag
+- [ ] 4.4 ClusterSingleton (14->54, optional/low-value): DTO mirrors for the 4 empty-payload handover messages, wire flag if pursued
+- [ ] 4.5 Sharding routing subset (13->53): DTO mirrors for `ShardingEnvelope`, `GetShardHome`/`ShardHome`/`HostShard`, handoff set; wire `sharding` flag
+- [ ] 4.6 Sharding: confirm remember-entities persisted state (`CoordinatorState`, `EntityState`, `EntitiesStarted`/`EntitiesStopped`) stays on the legacy protobuf binding independent of the `sharding` flag (design.md Decision 11)
+
+## 5. Subsystem 5 — Cluster core (id 5 -> 45) [last, correctness-critical]
+
+- [ ] 5.1 Heartbeat/HeartbeatRsp DTO mirrors + serializer; measure payload size against the tolerance gate first (design.md Decision 9)
+- [ ] 5.2 Gossip/GossipStatus DTO mirrors (`VectorClock`, `Reachability`, member set) + serializer
+- [ ] 5.3 Wire `cluster` flag through the central hook
+
+## 6. Benchmark acceptance gate
+
+- [ ] 6.1 Add a v2 arm to `ClusterMessageSerializerBenchmarks`, `DDataSerializationBenchmarks`, and the DData CRDT benchmarks (`MemoryDiagnoser` + payload-size column)
+- [ ] 6.2 Extend the `RemotePingPong --serializer` harness with real subsystem message shapes; add a DData write-throughput / cluster-formation-time end-to-end check
+- [ ] 6.3 Record per-subsystem protobuf-vs-v2 results; gate the default-on recommendation on CPU + allocation wins + payload size within the ~10% tolerance on tiny hot messages (design.md Decision 9)
+- [ ] 6.4 STOP for maintainer review of numbers before any subsystem's shipped default changes
+
+## 7. Rolling-upgrade + compatibility tests
+
+- [ ] 7.1 Mixed-config spec: node with both serializers registered reads v2; node without v2 registered fails cleanly on a v2 id (documents the rolling-upgrade gate from design.md Decision 6)
+- [ ] 7.2 Flag-on config variant run of the full DData/Sharding/Cluster.Tools/Cluster test suites, per subsystem
+- [ ] 7.3 MNTR rolling-upgrade test: all nodes on v1.6, flag flipped on a subset of subsystems, cross-node interop holds
+
+## 8. Docs + ledger
+
+- [ ] 8.1 `BREAKING_CHANGES_V1.6.md` entry: new rolling-upgrade rule ("all nodes on v1.6 before enabling `akka.actor.serialization.v2.enabled`"); default-off, not a wire break
+- [ ] 8.2 Operator runbook: "all nodes v1.6 first, then enable"; document per-subsystem flags and the `sharding`/`distributed-data` durable-write exclusions
+- [ ] 8.3 API-approval baselines updated for new serializer types
+- [ ] 8.4 Note in this change's docs (and cross-reference from `messagepack-sourcegen-validation`) that this change supersedes that change's "protobuf wrapper wire formats are not replaced by default" non-goal for the specific subsystems migrated here, while Remote core internals and durable/persisted writes remain non-goals (see proposal.md)


### PR DESCRIPTION
## OpenSpec change: `internal-serializers-messagepack-v2` (docs only)

Records the **approved design** for migrating Akka.NET's internal serializers (ReliableDelivery, DistributedData, Cluster Tools, Sharding routing subset, Cluster core) from hand-written protobuf to source-generated MessagePack (`Akka.Serialization.V2`) behind a default-off, write-side-only feature flag. No code changes in this PR — this is the spec that the implementation PRs will land against.

### What's in the change

- **`proposal.md`** — why/what: forked V2 serializers with new IDs, both formats always readable, benchmark-gated default-on transitions.
- **`design.md`** — 14 numbered decisions, all maintainer-settled (no open questions), grounded in `Serialization.cs` dispatch semantics (reads by ID via `_serializersById`, writes by bindings) and a full migration inventory with the `legacy + 40` ID map.
- **`tasks.md`** — 8 work sections: flag infra → ReliableDelivery → DData → tools/sharding → cluster core → benchmark gate → rolling-upgrade tests → docs/ledger.
- **`specs/messagepack-internal-serializers/spec.md`** — 7 testable requirements with scenarios.

### Key settled decisions

| Decision | Ruling |
|---|---|
| Flag mechanism | Central HOCON binding-rewrite hook in `Serialization` construction (`akka.actor.serialization.v2.enabled` + per-subsystem overrides); no `SerializationSetup`/Hosting surface in this change |
| Rolling-upgrade gate | Default-off + operator-discipline docs ("all nodes on v1.6 first"), per the `widen-system-uid-to-64bit` precedent; no framework `AppVersion` gate, no handshake change |
| Serializer IDs | Reserved block **40–79**, mnemonic `v2_id = legacy_id + 40` (36→76, 12→52, 11→51, 9→49, 15→55, 10→50, 13→53, 5→45) |
| Migration order | ReliableDelivery → DData → cluster tools → Sharding (routing subset) → Cluster core; Remote-core internals and durable/persisted writes (DData LMDB, remember-entities) deferred |
| Benchmark gate | CPU + allocations + **payload size** per subsystem; ~10% size growth tolerated on tiny hot messages only when CPU/alloc wins are substantial |
| Cross-assembly | Proceed now with per-assembly DTO mirrors + hand-written `IAkkaMessagePackFormatter<T>` for `UniqueAddress`/`VersionVector`; shared-schema contract demoted to a dedup follow-up |

This change supersedes (for the listed subsystems only) the "protobuf wrapper wire formats are not replaced by default" non-goal in `messagepack-sourcegen-validation/design.md` — that non-goal held while the generator was being validated; this is the follow-on migration built on the validated generator, still shipped default-off.

`openspec validate --all --strict` passes (7/7 changes, sibling changes untouched).
