### PR TITLE
Serialization.V2: cap nested [AkkaEnvelopePayload] depth at 100 (crash guard)

### DIFF
--- a/src/core/Akka.Serialization.V2.Tests/Akka.Serialization.V2.Tests.csproj
+++ b/src/core/Akka.Serialization.V2.Tests/Akka.Serialization.V2.Tests.csproj
@@ -13,6 +13,10 @@
     <ProjectReference Include="..\Akka.Serialization.V2\Akka.Serialization.V2.csproj" />
     <ProjectReference Include="..\Akka.Serialization.V2.Generators\Akka.Serialization.V2.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
     <ProjectReference Include="..\Akka.Serialization.V2.Generators\Akka.Serialization.V2.Generators.csproj" ReferenceOutputAssembly="true" PrivateAssets="all" />
+
+    <!-- Supplies the shared xunit3-compatible AkkaSpec base (transitively brings in Akka.TestKit.Xunit) so
+         serialization specs can run under the standard TestKit instead of raw ActorSystem.Create. -->
+    <ProjectReference Include="..\Akka.Tests.Shared.Internals.Xunit3\Akka.Tests.Shared.Internals.Xunit3.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/core/Akka.Serialization.V2.Tests/EnvelopeDepthGuardSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/EnvelopeDepthGuardSpec.cs
@@ -1,0 +1,121 @@
+//-----------------------------------------------------------------------
+// <copyright file="EnvelopeDepthGuardSpec.cs" company="Akka.NET Project">
+//     Copyright (C) 2009-2022 Lightbend Inc. <http://www.lightbend.com>
+//     Copyright (C) 2013-2026 .NET Foundation <https://github.com/akkadotnet/akka.net>
+// </copyright>
+//-----------------------------------------------------------------------
+
+#nullable enable
+using System;
+using System.Buffers;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Akka.Actor;
+using Akka.Actor.Setup;
+using FluentAssertions;
+using MessagePack;
+using Xunit;
+
+namespace Akka.Serialization.V2.Tests;
+
+/// <summary>
+/// Guards the <see cref="AkkaEnvelopePayloadAttribute"/> depth limit. Envelope payloads legitimately
+/// nest a level or two, but a message type that declares itself (directly or transitively) as its own
+/// envelope payload recurses without bound. Before the guard that recursion overflowed the thread stack
+/// and killed the process (an uncatchable .NET failure); the guard turns it into an ordinary catchable
+/// <see cref="SerializationException"/> on the write, size, and read paths alike. Reuses the
+/// <see cref="AttributeInnerEnvelope"/> test type from the sibling generated-serializer spec, whose
+/// <c>[AkkaEnvelopePayload] object Payload</c> field can hold another envelope.
+/// </summary>
+public sealed class EnvelopeDepthGuardSpec : IAsyncLifetime
+{
+    // Comfortably past the internal limit (100) so the test never straddles the exact boundary.
+    private const int OverLimitDepth = 250;
+    private const int GeneratedTestSerializerId = 120101;
+    private const string InnerEnvelopeManifest = "attribute-inner-envelope-v1";
+
+    private ActorSystem _system = null!;
+
+    public ValueTask InitializeAsync()
+    {
+        var setup = ActorSystemSetup.Create(GeneratedTestSerializer.CreateRegistration().CreateSetup());
+        _system = ActorSystem.Create("envelope-depth-guard-spec", setup);
+        return default;
+    }
+
+    public async ValueTask DisposeAsync() => await _system.Terminate();
+
+    private static AttributeInnerEnvelope BuildChain(int depth)
+    {
+        // Terminal is a plain leaf (no envelope field); each wrapper nests the previous via its payload.
+        object payload = new RequiredMessage("leaf", 1);
+        for (var i = 0; i < depth; i++)
+            payload = new AttributeInnerEnvelope($"lvl-{i}", payload);
+        return (AttributeInnerEnvelope)payload;
+    }
+
+    [Fact(DisplayName = "A shallow envelope chain still round-trips (the guard does not disturb normal nesting)")]
+    public void Shallow_envelope_chain_round_trips()
+    {
+        var shallow = BuildChain(5);
+
+        var bytes = _system.Serialization.Serialize(shallow);
+        var recovered = _system.Serialization.Deserialize(bytes, GeneratedTestSerializerId, InnerEnvelopeManifest);
+
+        recovered.Should().Be(shallow);
+    }
+
+    [Fact(DisplayName = "Serializing a self-nesting envelope past the depth limit throws instead of overflowing the stack")]
+    public void Deep_envelope_chain_throws_on_write()
+    {
+        var deep = BuildChain(OverLimitDepth);
+
+        // The point of the guard: this returns (throws) rather than crashing the process with an
+        // uncatchable StackOverflowException. A test that merely completes proves the process survived.
+        Action serialize = () => _system.Serialization.Serialize(deep);
+
+        serialize.Should().Throw<SerializationException>().WithMessage("*maximum depth*");
+    }
+
+    [Fact(DisplayName = "SizeHint on a self-nesting envelope past the depth limit throws instead of overflowing the stack")]
+    public void Deep_envelope_chain_throws_on_size()
+    {
+        var deep = BuildChain(OverLimitDepth);
+        var serializer = _system.Serialization.FindSerializerFor(deep)
+            .Should().BeAssignableTo<SerializerV2>().Subject;
+
+        Action size = () => serializer.SizeHint(deep);
+
+        size.Should().Throw<SerializationException>().WithMessage("*maximum depth*");
+    }
+
+    [Fact(DisplayName = "Deserializing a self-nesting envelope past the depth limit throws instead of overflowing the stack")]
+    public void Deep_envelope_chain_throws_on_read()
+    {
+        // A depth-100 chain is writable (exactly at the limit); serialize it to obtain valid inner bytes,
+        // then hand-wrap one more envelope level so decoding trips the limit on the way down.
+        var atLimit = BuildChain(100);
+        var innerBytes = _system.Serialization.Serialize(atLimit);
+
+        var buffer = new ArrayBufferWriter<byte>();
+        var writer = new MessagePackWriter(buffer);
+        writer.WriteMapHeader(2);            // AttributeInnerEnvelope body: { 1: EnvelopeId, 2: Payload }
+        writer.Write(1);
+        writer.Write("over-limit-top");
+        writer.Write(2);
+        writer.WriteMapHeader(3);            // envelope payload: { 1: serializerId, 2: manifest, 3: bytes }
+        writer.Write(1);
+        writer.Write(GeneratedTestSerializerId);
+        writer.Write(2);
+        writer.Write(InnerEnvelopeManifest);
+        writer.Write(3);
+        writer.Write(innerBytes);
+        writer.Flush();
+        var overLimitBytes = buffer.WrittenMemory.ToArray();
+
+        Action deserialize = () =>
+            _system.Serialization.Deserialize(overLimitBytes, GeneratedTestSerializerId, InnerEnvelopeManifest);
+
+        deserialize.Should().Throw<SerializationException>().WithMessage("*maximum depth*");
+    }
+}

--- a/src/core/Akka.Serialization.V2.Tests/EnvelopeDepthGuardSpec.cs
+++ b/src/core/Akka.Serialization.V2.Tests/EnvelopeDepthGuardSpec.cs
@@ -9,9 +9,8 @@
 using System;
 using System.Buffers;
 using System.Runtime.Serialization;
-using System.Threading.Tasks;
-using Akka.Actor;
-using Akka.Actor.Setup;
+using Akka.Configuration;
+using Akka.TestKit;
 using FluentAssertions;
 using MessagePack;
 using Xunit;
@@ -27,23 +26,33 @@ namespace Akka.Serialization.V2.Tests;
 /// <see cref="AttributeInnerEnvelope"/> test type from the sibling generated-serializer spec, whose
 /// <c>[AkkaEnvelopePayload] object Payload</c> field can hold another envelope.
 /// </summary>
-public sealed class EnvelopeDepthGuardSpec : IAsyncLifetime
+public sealed class EnvelopeDepthGuardSpec : AkkaSpec
 {
     // Comfortably past the internal limit (100) so the test never straddles the exact boundary.
     private const int OverLimitDepth = 250;
     private const int GeneratedTestSerializerId = 120101;
     private const string InnerEnvelopeManifest = "attribute-inner-envelope-v1";
 
-    private ActorSystem _system = null!;
+    // Register the source-generated serializer the way a real application would: via the classic HOCON
+    // akka.actor.serializers / serialization-bindings blocks (mirrors ClassicRemotingSpec in this project
+    // and Akka.Tests' CustomSerializerSpec), binding the IGeneratedTestProtocol marker interface -- which
+    // AttributeInnerEnvelope and RequiredMessage both implement -- to the GeneratedTestSerializer. The
+    // generated serializer exposes a fixed Identifier (120101) and an (ExtendedActorSystem) constructor,
+    // so HOCON reflection-based registration resolves it exactly like the setup-based registration did.
+    private static readonly Config SerializerConfig = ConfigurationFactory.ParseString(@"
+        akka.actor {
+            serializers {
+                generated-test = ""Akka.Serialization.V2.Tests.GeneratedTestSerializer, Akka.Serialization.V2.Tests""
+            }
+            serialization-bindings {
+                ""Akka.Serialization.V2.Tests.IGeneratedTestProtocol, Akka.Serialization.V2.Tests"" = generated-test
+            }
+        }");
 
-    public ValueTask InitializeAsync()
+    public EnvelopeDepthGuardSpec(ITestOutputHelper output)
+        : base(SerializerConfig, output)
     {
-        var setup = ActorSystemSetup.Create(GeneratedTestSerializer.CreateRegistration().CreateSetup());
-        _system = ActorSystem.Create("envelope-depth-guard-spec", setup);
-        return default;
     }
-
-    public async ValueTask DisposeAsync() => await _system.Terminate();
 
     private static AttributeInnerEnvelope BuildChain(int depth)
     {
@@ -59,8 +68,8 @@ public sealed class EnvelopeDepthGuardSpec : IAsyncLifetime
     {
         var shallow = BuildChain(5);
 
-        var bytes = _system.Serialization.Serialize(shallow);
-        var recovered = _system.Serialization.Deserialize(bytes, GeneratedTestSerializerId, InnerEnvelopeManifest);
+        var bytes = Sys.Serialization.Serialize(shallow);
+        var recovered = Sys.Serialization.Deserialize(bytes, GeneratedTestSerializerId, InnerEnvelopeManifest);
 
         recovered.Should().Be(shallow);
     }
@@ -72,7 +81,7 @@ public sealed class EnvelopeDepthGuardSpec : IAsyncLifetime
 
         // The point of the guard: this returns (throws) rather than crashing the process with an
         // uncatchable StackOverflowException. A test that merely completes proves the process survived.
-        Action serialize = () => _system.Serialization.Serialize(deep);
+        Action serialize = () => Sys.Serialization.Serialize(deep);
 
         serialize.Should().Throw<SerializationException>().WithMessage("*maximum depth*");
     }
@@ -81,7 +90,7 @@ public sealed class EnvelopeDepthGuardSpec : IAsyncLifetime
     public void Deep_envelope_chain_throws_on_size()
     {
         var deep = BuildChain(OverLimitDepth);
-        var serializer = _system.Serialization.FindSerializerFor(deep)
+        var serializer = Sys.Serialization.FindSerializerFor(deep)
             .Should().BeAssignableTo<SerializerV2>().Subject;
 
         Action size = () => serializer.SizeHint(deep);
@@ -95,7 +104,7 @@ public sealed class EnvelopeDepthGuardSpec : IAsyncLifetime
         // A depth-100 chain is writable (exactly at the limit); serialize it to obtain valid inner bytes,
         // then hand-wrap one more envelope level so decoding trips the limit on the way down.
         var atLimit = BuildChain(100);
-        var innerBytes = _system.Serialization.Serialize(atLimit);
+        var innerBytes = Sys.Serialization.Serialize(atLimit);
 
         var buffer = new ArrayBufferWriter<byte>();
         var writer = new MessagePackWriter(buffer);
@@ -114,8 +123,30 @@ public sealed class EnvelopeDepthGuardSpec : IAsyncLifetime
         var overLimitBytes = buffer.WrittenMemory.ToArray();
 
         Action deserialize = () =>
-            _system.Serialization.Deserialize(overLimitBytes, GeneratedTestSerializerId, InnerEnvelopeManifest);
+            Sys.Serialization.Deserialize(overLimitBytes, GeneratedTestSerializerId, InnerEnvelopeManifest);
 
         deserialize.Should().Throw<SerializationException>().WithMessage("*maximum depth*");
+    }
+
+    [Fact(DisplayName = "The depth counter unwinds to zero after an over-limit failure so later serializations on the same thread still succeed (no thread poisoning)")]
+    public void Depth_counter_unwinds_after_failure_leaving_thread_usable()
+    {
+        // The guard tracks nesting in a [ThreadStatic] counter guarded by try/finally. A regression that
+        // left the counter unbalanced after an exception (enter without a matching exit) would poison
+        // every subsequent serialization on the same thread. This test runs synchronously, so both steps
+        // below execute on the same thread -- exactly the surface such a leak would corrupt.
+
+        // 1. Trip the guard on the write path and confirm it throws (not crashes).
+        var deep = BuildChain(OverLimitDepth);
+        Action overLimit = () => Sys.Serialization.Serialize(deep);
+        overLimit.Should().Throw<SerializationException>().WithMessage("*maximum depth*");
+
+        // 2. Immediately, on the same thread, a normal shallow message must still serialize AND round-trip.
+        //    Success proves the counter unwound back to zero rather than staying elevated from the failure.
+        var shallow = BuildChain(5);
+        var bytes = Sys.Serialization.Serialize(shallow);
+        var recovered = Sys.Serialization.Deserialize(bytes, GeneratedTestSerializerId, InnerEnvelopeManifest);
+
+        recovered.Should().Be(shallow);
     }
 }

--- a/src/core/Akka.Serialization.V2/AkkaSerializer.cs
+++ b/src/core/Akka.Serialization.V2/AkkaSerializer.cs
@@ -19,6 +19,34 @@ namespace Akka.Serialization.V2;
 /// </summary>
 public abstract class AkkaSerializer : SerializerV2
 {
+    /// <summary>
+    /// Maximum depth of nested <see cref="AkkaEnvelopePayloadAttribute"/> payloads permitted within a
+    /// single serialize / deserialize / size operation. Envelopes legitimately nest a level or two (a
+    /// delivery message wraps a user payload that may itself be an enveloped message), but unbounded
+    /// nesting is only reachable when a message type declares itself (directly or transitively) as its own
+    /// envelope payload — an application bug. Left unchecked that recurses until the thread's stack
+    /// overflows, which in .NET is an uncatchable process kill. Past this depth we throw an ordinary,
+    /// catchable <see cref="SerializationException"/> instead, matching the recursion limit
+    /// <c>Google.Protobuf</c> already enforces. This is a robustness guard against accidental self-nesting,
+    /// not a security control: Akka remoting carries one application's own traffic between its own nodes.
+    /// </summary>
+    private const int MaxEnvelopePayloadDepth = 100;
+
+    [ThreadStatic] private static int _envelopePayloadDepth;
+
+    private static void EnterEnvelopePayload()
+    {
+        if (_envelopePayloadDepth >= MaxEnvelopePayloadDepth)
+            throw new SerializationException(
+                $"Envelope payload nesting exceeded the maximum depth of {MaxEnvelopePayloadDepth}. " +
+                "This almost always means a message type declares itself (directly or transitively) as its " +
+                "own [AkkaEnvelopePayload], causing unbounded recursion. Break the self-reference in the message graph.");
+
+        _envelopePayloadDepth++;
+    }
+
+    private static void ExitEnvelopePayload() => _envelopePayloadDepth--;
+
     protected AkkaSerializer(ExtendedActorSystem system) : base(system)
     {
     }
@@ -56,7 +84,17 @@ public abstract class AkkaSerializer : SerializerV2
         if (serializer is SerializerV2 serializerV2)
         {
             using var buffer = new AkkaPooledBufferWriter();
-            var bytesWritten = serializerV2.Serialize(payload, buffer);
+            int bytesWritten;
+            EnterEnvelopePayload();
+            try
+            {
+                bytesWritten = serializerV2.Serialize(payload, buffer);
+            }
+            finally
+            {
+                ExitEnvelopePayload();
+            }
+
             if (bytesWritten != buffer.WrittenCount)
                 throw new SerializationException(
                     $"Serializer [{serializer.GetType()}] reported [{bytesWritten}] bytes but wrote [{buffer.WrittenCount}] bytes.");
@@ -117,7 +155,15 @@ public abstract class AkkaSerializer : SerializerV2
         if (bytes is null)
             throw new SerializationException("Missing envelope payload bytes.");
 
-        return system.Serialization.Deserialize(bytes.Value, serializerId.Value, manifest);
+        EnterEnvelopePayload();
+        try
+        {
+            return system.Serialization.Deserialize(bytes.Value, serializerId.Value, manifest);
+        }
+        finally
+        {
+            ExitEnvelopePayload();
+        }
     }
 
     protected int SizeOfEnvelopePayload(object? payload)
@@ -129,7 +175,17 @@ public abstract class AkkaSerializer : SerializerV2
         if (serializer is not SerializerV2 serializerV2)
             return SerializerV2.UnknownSize;
 
-        var payloadSize = serializerV2.SizeHint(payload);
+        int payloadSize;
+        EnterEnvelopePayload();
+        try
+        {
+            payloadSize = serializerV2.SizeHint(payload);
+        }
+        finally
+        {
+            ExitEnvelopePayload();
+        }
+
         if (payloadSize < 0)
             return SerializerV2.UnknownSize;
 


### PR DESCRIPTION
Hardens the shared `Akka.Serialization.V2` envelope mechanism against unbounded self-nesting.

## The problem
`[AkkaEnvelopePayload]` fields carry an inner `(serializerId, manifest, bytes)` triple that resolves to any registered serializer. Nothing stops a message type from declaring itself — directly or transitively — as its own envelope payload. That recurses on serialize, size, and deserialize until the thread stack overflows, and a `StackOverflowException` in .NET is **uncatchable and kills the whole process**. An adversarial design review confirmed it: a deeply-nested envelope crashed the test host with exit 134 (SIGABRT).

## Scope of the risk (right-sized)
This is a **robustness guard against an application bug**, not a security control. Akka remoting carries one application's own traffic between its own nodes — there is no arbitrary/untrusted input here, and anyone injecting crafted packets onto your remoting network has already defeated your real defenses (TLS, trusted-hosts). The realistic trigger is a developer accidentally wrapping a message in itself. But even a dev bug shouldn't be able to hard-kill a node, and the legacy protobuf serializers already reject over-deep recursion cleanly (Google.Protobuf caps at 100 and throws) — so leaving this unguarded would be a *robustness regression* versus what these subsystems do today.

## The fix
A thread-local depth counter in the three shared `AkkaSerializer` envelope methods (`ReadEnvelopePayload`, `WriteEnvelopePayload`, `SizeOfEnvelopePayload`) that throws a normal, catchable `SerializationException` past **depth 100** — matching protobuf's existing limit. Normal nesting (a level or two) is untouched; there's no per-message cost on the common path beyond a counter increment/decrement.

Deliberately **not** switching MessagePack into its `UntrustedData` security mode: that also adds hash-collision-resistance overhead aimed at hostile input, which is the wrong model for trusted intra-application traffic.

## Verification
- 4 new specs (`EnvelopeDepthGuardSpec`): over-limit write throws, over-limit size throws, over-limit **read** throws (reproduces the confirmed crash as a catchable exception), and a shallow chain still round-trips.
- Full V2 suite **260/260**. Runtime-only change — generated code is byte-identical, so the golden-output and wire-format snapshot specs are unchanged.

Independently useful, but also removes the one merge-blocker the review raised against the ReliableDelivery fork (#8409), which registers a serializer that reads this envelope format cluster-wide.