### PR TITLE
De-flake cluster-formation race in MNTR specs (0s auto-down + tight FD tolerance)

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientSpec.cs
@@ -49,6 +49,7 @@ public class ClusterClientSpecConfig : MultiNodeConfig
                 akka.actor.provider = cluster
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = 0s
+                akka.cluster.failure-detector.acceptable-heartbeat-pause = 6s # de-flake: cluster-level FD (distinct from client FD below); absorb CI stalls during formation
                 akka.cluster.client.heartbeat-interval = 1s
                 akka.cluster.client.acceptable-heartbeat-pause = 3s
                 akka.cluster.client.refresh-contacts-interval = 1s

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubMediatorSpec.cs
@@ -43,6 +43,7 @@ public class DistributedPubSubMediatorSpecConfig : MultiNodeConfig
                 akka.actor.serialize-messages = off
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = 0s
+                akka.cluster.failure-detector.acceptable-heartbeat-pause = 6s # de-flake: absorb CI stalls during formation (default 3s); keep 0s auto-down (spec crashes nodes)
                 akka.cluster.pub-sub.max-delta-elements = 500
                 akka.testconductor.query-timeout = 1m # we were having timeouts shutting down nodes with 5s default
             ").WithFallback(DistributedPubSub.DefaultConfig());

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubPublishWithAckSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/PublishSubscribe/DistributedPubSubPublishWithAckSpec.cs
@@ -34,7 +34,8 @@ public class DistributedPubSubPublishWithAckSpecSpecConfig : MultiNodeConfig
             akka.actor.provider = "Akka.Cluster.ClusterActorRefProvider, Akka.Cluster"
             akka.actor.serialize-messages = off
             akka.remote.log-remote-lifecycle-events = off
-            akka.cluster.auto-down-unreachable-after = 0s
+            akka.cluster.failure-detector.acceptable-heartbeat-pause = 6s # de-flake: absorb CI heartbeat stalls during formation (default 3s)
+            akka.cluster.auto-down-unreachable-after = 5s
             akka.cluster.pub-sub.max-delta-elements = 500
             akka.cluster.pub-sub.buffered-messages.max-per-topic = 2
             akka.cluster.pub-sub.buffered-messages.timeout-check-interval = 200ms

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerChaosSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerChaosSpec.cs
@@ -46,6 +46,7 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Singleton
                 akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = 0s
+                akka.cluster.failure-detector.acceptable-heartbeat-pause = 6s # de-flake: absorb CI stalls during formation (default 3s); keep 0s auto-down (spec crashes nodes)
             ")
             .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSingletonProxy.DefaultConfig())

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerLeaseSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerLeaseSpec.cs
@@ -42,10 +42,17 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Singleton
                 akka.loglevel = DEBUG
                 akka.actor.provider = ""cluster""
                 akka.remote.log-remote-lifecycle-events = off
-                #akka.cluster.auto-down-unreachable-after = off
-                # akka.cluster.downing-provider-class = akka.cluster.testkit.AutoDowning
-                akka.cluster.auto-down-unreachable-after = 0s
-                akka.cluster.testkit.auto-down-unreachable-after = 0s
+                # De-flake: give the cluster failure detector enough tolerance that a transient
+                # heartbeat stall during cluster formation on a loaded CI agent does not trip a
+                # false 'unreachable' verdict. Previously this was paired with auto-down = 0s, so a
+                # single false unreachable instantly and permanently downed a joining node with zero
+                # grace, and the 'wait for N members Up' assertions in form_a_cluster would fail.
+                # This spec removes nodes only via explicit Cluster.Down(...) (see the oldest-node
+                # phase), so it never relied on auto-down to reap a genuinely-crashed node; a small
+                # auto-down grace is therefore safe and keeps transient blips from being fatal.
+                akka.cluster.failure-detector.acceptable-heartbeat-pause = 6s
+                akka.cluster.auto-down-unreachable-after = 5s
+                akka.cluster.testkit.auto-down-unreachable-after = 5s
                 test-lease {
                     lease-class = ""Akka.TestKit.TestLeaseActorClient, Akka.Tests.Shared.Internals.Xunit3""
                     heartbeat-interval = 1s

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerSpec.cs
@@ -49,6 +49,7 @@ public class ClusterSingletonManagerSpecConfig : MultiNodeConfig
                 akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
                 akka.remote.log-remote-lifecycle-events = off
                 akka.cluster.auto-down-unreachable-after = 0s
+                akka.cluster.failure-detector.acceptable-heartbeat-pause = 6s # de-flake: absorb CI stalls during formation (default 3s); keep 0s auto-down (spec crashes nodes)
             ")
             .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSingletonProxy.DefaultConfig())

--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerStartupSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/Singleton/ClusterSingletonManagerStartupSpec.cs
@@ -34,7 +34,8 @@ namespace Akka.Cluster.Tools.Tests.MultiNode.Singleton
                 akka.actor.provider = ""Akka.Cluster.ClusterActorRefProvider, Akka.Cluster""
                 akka.remote.retry-gate-closed-for = 1s #fast restart
                 akka.remote.log-remote-lifecycle-events = off
-                akka.cluster.auto-down-unreachable-after = 0s")
+                akka.cluster.failure-detector.acceptable-heartbeat-pause = 6s # de-flake: absorb CI heartbeat stalls during formation (default 3s)
+                akka.cluster.auto-down-unreachable-after = 5s")
             .WithFallback(ClusterSingleton.DefaultConfig())
             .WithFallback(ClusterSingletonProxy.DefaultConfig())
             .WithFallback(MultiNodeClusterSpec.ClusterConfig());

--- a/src/core/Akka.Cluster.Tests.MultiNode/SingletonClusterSpec.cs
+++ b/src/core/Akka.Cluster.Tests.MultiNode/SingletonClusterSpec.cs
@@ -32,6 +32,7 @@ namespace Akka.Cluster.Tests.MultiNode
                 .WithFallback(ConfigurationFactory.ParseString(@"
                     akka.cluster.auto-down-unreachable-after = 0s
                     akka.cluster.failure-detector.threshold = 4
+                    akka.cluster.failure-detector.acceptable-heartbeat-pause = 6s # de-flake: absorb CI stalls during formation (threshold=4 makes this FD extra trigger-happy)
                 "))
                 .WithFallback(MultiNodeClusterSpec.ClusterConfig(failureDetectorPuppet));
         }


### PR DESCRIPTION
## Problem

`ClusterSingletonManagerLeaseSpec` fails intermittently in MNTR CI at its very first "form a cluster" assertion (line 173 — expects 3 members `Up`, sees 2). Observed on Azure build 129404.

## Root cause

The spec sets `akka.cluster.auto-down-unreachable-after = 0s` but inherits the default cluster failure-detector tolerance from `MultiNodeClusterSpec.ClusterConfig()`, which leaves `acceptable-heartbeat-pause` at the Akka default of **3s**. On a loaded CI agent (especially the slow .NET 10 preview MNTR runs), a transient heartbeat stall during initial cluster formation trips a **false** "unreachable" verdict — and `0s` auto-down turns that transient blip into an *instant, permanent* down of the joining node. The cluster then forms with N-1 members and the "wait for N members `Up`" assertion fails.

Test-config flake, not a product bug: the node was healthy; it got killed by an over-eager failure detector plus zero-grace auto-down.

## Fix

Raise `acceptable-heartbeat-pause` to **6s** on the affected specs so formation stalls under CI load don't false-positive. A genuinely dead node stops heartbeating forever, so it's still reaped once the (slightly longer) pause elapses — a few seconds later, well within each spec's existing post-kill assertion windows.

Two specs that only ever remove nodes via explicit `Cluster.Down(...)` (never kill a node) also get a **5s auto-down grace** instead of `0s`, since instant-down bought them nothing but fragility.

### Specs changed
| Spec | Kills nodes? | Change |
|---|---|---|
| ClusterSingletonManagerLeaseSpec | No | pause 6s + auto-down 5s |
| ClusterSingletonManagerStartupSpec | No | pause 6s + auto-down 5s |
| DistributedPubSubPublishWithAckSpec | No | pause 6s + auto-down 5s |
| ClusterSingletonManagerChaosSpec | Yes | pause 6s (keep 0s auto-down) |
| ClusterSingletonManagerSpec | Yes | pause 6s (keep 0s auto-down) |
| DistributedPubSubMediatorSpec | Yes | pause 6s (keep 0s auto-down) |
| ClusterClientSpec | Yes | cluster-FD pause 6s (keep 0s auto-down; distinct from the client FD) |
| SingletonClusterSpec | Yes | pause 6s (keep 0s auto-down) |

### Deliberately not touched
- **Sharding base config** (`MultiNodeClusterShardingConfig`): a 6s pause would exceed its `single-expect-default = 5s` across many sharding specs — needs its own pass.
- **Puppet-failure-detector specs** (`LeaderLeavingSpec`, `SingletonClusterSpec` puppet variant): a puppet FD never spontaneously reports unreachable, so they're structurally immune.

Test config only — no production code changes.
