### PR TITLE
Fix flaky SpecRunCoordinatorSpec: deterministic EndSpec aggregation (no timeout race)

### DIFF
--- a/src/core/Akka.MultiNode.TestAdapter/Internal/Reporting/SpecRunCoordinator.cs
+++ b/src/core/Akka.MultiNode.TestAdapter/Internal/Reporting/SpecRunCoordinator.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.MultiNode.TestAdapter.Internal.Sinks;
 
@@ -44,6 +43,17 @@ namespace Akka.MultiNode.TestAdapter.Internal.Reporting
         /// </summary>
         private readonly Dictionary<int, IActorRef> _nodeActors;
 
+        /// <summary>
+        /// The original sender of <see cref="EndSpec"/>, awaiting the aggregated <see cref="FactData"/>.
+        /// </summary>
+        private IActorRef _endSpecSender;
+
+        /// <summary>
+        /// <see cref="NodeData"/> replies collected from the child <see cref="NodeDataActor"/> instances
+        /// while handling <see cref="EndSpec"/>.
+        /// </summary>
+        private readonly List<NodeData> _collectedNodeData = new List<NodeData>();
+
         #region Actor Lifecycle
 
         protected override void PreStart()
@@ -69,7 +79,7 @@ namespace Akka.MultiNode.TestAdapter.Internal.Reporting
             });
             Receive<MultiNodeMessage>(message => RouteToNodeActor(message));
             Receive<EndSpec>(spec => HandleEndSpec(spec));
-            Receive<NodeData[]>(datum => HandleNodeDatum(datum));
+            Receive<NodeData>(nodeData => HandleNodeData(nodeData));
         }
 
         /// <summary>
@@ -83,41 +93,52 @@ namespace Akka.MultiNode.TestAdapter.Internal.Reporting
         }
 
         /// <summary>
-        /// Wait for all child <see cref="NodeDataActor"/> instances to finish processing
-        /// and report their results
+        /// Ask every child <see cref="NodeDataActor"/> to report its results, then collect the replies.
+        /// Each child replies exactly once with its <see cref="NodeData"/>, so aggregation completes
+        /// deterministically as soon as all <see cref="Nodes"/> have reported — there is no Ask timeout
+        /// to race under dispatcher load.
         /// </summary>
-        /// <returns>An awaitable task, since this operation uses the <see cref="Futures.Ask"/> pattern</returns>
         private void HandleEndSpec(EndSpec endSpec)
         {
-            var futures = new Task<NodeData>[Nodes.Count];
+            _endSpecSender = Context.Sender;
 
-            var i = 0;
-            foreach (var node in _nodeActors)
+            // No child actors (e.g. a spec with no nodes) — nothing to collect, reply immediately.
+            if (_nodeActors.Count == 0)
             {
-                futures[i] = node.Value.Ask<NodeData>(endSpec, TimeSpan.FromSeconds(1));
-                i++;
+                CompleteAndReply();
+                return;
             }
 
-            var sender = Context.Sender;
-
-            //wait for all Ask operations to complete and pipe the result back to ourselves, including the ref for the original sender
-            Task.WhenAll(futures)
-                .PipeTo(Self, sender);
+            // Tell (not Ask-with-timeout): each child replies to us with its NodeData.Copy().
+            foreach (var node in _nodeActors)
+                node.Value.Tell(endSpec);
         }
 
         /// <summary>
-        /// When the result of a <see cref="HandleEndSpec"/> finally gets finished...
+        /// Collect a <see cref="NodeData"/> reply from a child <see cref="NodeDataActor"/>. Once every
+        /// node has reported, aggregate the results and return the completed <see cref="FactData"/>.
         /// </summary>
-        /// <param name="nodeDatum">An envelope with all of the <see cref="NodeData"/> messages we processed from earlier</param>
-        private void HandleNodeDatum(NodeData[] nodeDatum)
+        private void HandleNodeData(NodeData nodeData)
         {
-            FactData.AddNodes(nodeDatum);
+            _collectedNodeData.Add(nodeData);
+
+            if (_collectedNodeData.Count == _nodeActors.Count)
+                CompleteAndReply();
+        }
+
+        /// <summary>
+        /// Aggregate every collected <see cref="NodeData"/>, mark the spec complete, return the
+        /// <see cref="FactData"/> to the original <see cref="EndSpec"/> sender, and shut down.
+        /// </summary>
+        private void CompleteAndReply()
+        {
+            FactData.AddNodes(_collectedNodeData.ToArray());
 
             //mark this test as complete
             FactData.Complete();
 
-            //Send our FactData back to the sender
-            Sender.Tell(FactData.Copy());
+            //Send our FactData back to the original EndSpec sender
+            _endSpecSender.Tell(FactData.Copy());
 
             //Shut ourselves down
             Self.GracefulStop(TimeSpan.FromSeconds(1));

--- a/src/core/Akka.MultiNode.TestAdapter/Internal/Reporting/TestRunCoordinator.cs
+++ b/src/core/Akka.MultiNode.TestAdapter/Internal/Reporting/TestRunCoordinator.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.MultiNode.TestAdapter.Internal.Sinks;
 
@@ -17,7 +16,7 @@ namespace Akka.MultiNode.TestAdapter.Internal.Reporting
     /// <summary>
     /// Actor responsible for organizing all of the data for each test run
     /// </summary>
-    internal class TestRunCoordinator : ReceiveActor
+    internal class TestRunCoordinator : ReceiveActor, IWithUnboundedStash
     {
         #region Internal message classes
 
@@ -49,7 +48,7 @@ namespace Akka.MultiNode.TestAdapter.Internal.Reporting
                 Subscriber = subscriber;
             }
 
-                
+
             public IActorRef Subscriber { get; private set; }
         }
 
@@ -65,7 +64,7 @@ namespace Akka.MultiNode.TestAdapter.Internal.Reporting
             TestRunStarted = testRunStarted;
             TestRunData = new TestRunTree(testRunStarted.Ticks);
             Subscribers = new List<IActorRef>();
-            SetReceive();
+            Ready();
         }
 
         #region Internal fields and Properties
@@ -73,6 +72,14 @@ namespace Akka.MultiNode.TestAdapter.Internal.Reporting
         protected readonly DateTime TestRunStarted;
 
         protected IActorRef _currentSpecRunActor;
+
+        /// <summary>
+        /// Non-null while an <see cref="EndTestRun"/> is waiting for the in-flight spec to finish
+        /// before the whole run is completed and the reply returned.
+        /// </summary>
+        private IActorRef _testRunRequester;
+
+        public IStash Stash { get; set; }
 
         /// <summary>
         /// Automatically set when <see cref="EndTestRun"/> is sent to this actor.
@@ -104,7 +111,10 @@ namespace Akka.MultiNode.TestAdapter.Internal.Reporting
 
         #region Message-handling
 
-        private void SetReceive()
+        /// <summary>
+        /// Default ("ready") behavior: route node messages, begin/end specs, and answer state requests.
+        /// </summary>
+        private void Ready()
         {
             Receive<MultiNodeMessage>(message =>
             {
@@ -112,27 +122,95 @@ namespace Akka.MultiNode.TestAdapter.Internal.Reporting
                 _currentSpecRunActor.Forward(message);
             });
             Receive<BeginNewSpec>(ReceiveBeginSpecRun);
-            ReceiveAsync<EndSpec>(spec => _currentSpecRunActor != null ? ReceiveEndSpecRun(spec) : Task.CompletedTask);
+            Receive<EndSpec>(spec =>
+            {
+                //nothing to end; ignore (matches the previous no-op guard)
+                if (_currentSpecRunActor == null) return;
+                BeginEndSpecRun();
+            });
+            Receive<EndTestRun>(run =>
+            {
+                //clean up the current spec, if it hasn't been done already, then complete the run
+                if (_currentSpecRunActor != null)
+                {
+                    _testRunRequester = Sender;
+                    BeginEndSpecRun();
+                }
+                else
+                {
+                    CompleteTestRun(Sender);
+                }
+            });
             Receive<RequestTestRunState>(state => Sender.Tell(TestRunData.Copy(TestRunPassed(TestRunData))));
             Receive<SubscribeFactCompletionMessages>(AddSubscriber);
             Receive<UnsubscribeFactCompletionMessages>(RemoveSubscriber);
-            ReceiveAsync<EndTestRun>(async run =>
+            // A watched SpecRunCoordinator that stopped after already reporting its FactData: harmless here.
+            Receive<Terminated>(_ => { });
+        }
+
+        /// <summary>
+        /// Ask the in-flight <see cref="SpecRunCoordinator"/> to finish by <see cref="ActorRefImplicitSenderExtensions.Tell"/>-ing
+        /// it <see cref="EndSpec"/> and awaiting its <see cref="FactData"/> reply as a message — no Ask timeout to race
+        /// under load. While waiting we stash every other message so the previous await-sequential ordering is preserved,
+        /// and DeathWatch guards against the coordinator dying without replying (which would otherwise hang the run).
+        /// </summary>
+        private void BeginEndSpecRun()
+        {
+            Context.Watch(_currentSpecRunActor);
+            _currentSpecRunActor.Tell(new EndSpec()); // sender = Self; SpecRunCoordinator replies to us with FactData
+            Become(AwaitingSpecCompletion);
+        }
+
+        private void AwaitingSpecCompletion()
+        {
+            Receive<FactData>(factData => OnSpecCompleted(factData));
+            Receive<Terminated>(terminated =>
             {
-                //clean up the current spec, if it hasn't been done already
-                if (_currentSpecRunActor != null)
-                {
-                    await ReceiveEndSpecRun(new EndSpec());
-                }
-
-                //Mark the test run as finished
-                TestRunData.Complete();
-
-                //Deliver the final copy of the TestRunData
-                Sender.Tell(TestRunData.Copy());
-
-                //shutdown
-                Context.Stop(Self);
+                //the spec coordinator stopped before replying — complete the spec with no data rather than hang the run
+                if (Equals(terminated.ActorRef, _currentSpecRunActor))
+                    OnSpecCompleted(null);
             });
+            //defer everything else until the in-flight spec has reported
+            ReceiveAny(_ => Stash.Stash());
+        }
+
+        private void OnSpecCompleted(FactData factData)
+        {
+            if (factData != null)
+            {
+                TestRunData.AddSpec(factData);
+
+                //Publish the FactData back to any subscribers who wanted it
+                foreach (var subscriber in Subscribers)
+                    subscriber.Tell(factData);
+            }
+
+            //Ready to begin the next spec
+            _currentSpecRunActor = null;
+            Become(Ready);
+
+            if (_testRunRequester != null)
+            {
+                var requester = _testRunRequester;
+                _testRunRequester = null;
+                CompleteTestRun(requester);
+            }
+            else
+            {
+                Stash.UnstashAll();
+            }
+        }
+
+        private void CompleteTestRun(IActorRef requester)
+        {
+            //Mark the test run as finished
+            TestRunData.Complete();
+
+            //Deliver the final copy of the TestRunData
+            requester.Tell(TestRunData.Copy());
+
+            //shutdown
+            Context.Stop(Self);
         }
 
         private void RemoveSubscriber(UnsubscribeFactCompletionMessages unsubscribe)
@@ -155,23 +233,6 @@ namespace Akka.MultiNode.TestAdapter.Internal.Reporting
                     Props.Create(() => new SpecRunCoordinator(spec.ClassName, spec.MethodName, spec.Nodes)));
         }
 
-        private async Task ReceiveEndSpecRun(EndSpec spec)
-        {
-            //Should receive a FactData in return
-            var factData = await _currentSpecRunActor.Ask<FactData>(spec, TimeSpan.FromSeconds(2));
-
-            TestRunData.AddSpec(factData);
-
-            //Publish the FactData back to any subscribers who wanted it
-            foreach (var subscriber in Subscribers)
-            {
-                subscriber.Tell(factData);
-            }
-
-            //Ready to begin the next spec
-            _currentSpecRunActor = null;
-        }
-
         private static bool TestRunPassed(TestRunTree tree)
         {
             return tree.Specs.All(x => x.Passed.HasValue && x.Passed.Value);
@@ -180,4 +241,3 @@ namespace Akka.MultiNode.TestAdapter.Internal.Reporting
         #endregion
     }
 }
-


### PR DESCRIPTION
## Problem

`SpecRunCoordinatorSpec.SpecRunCoordinator_should_route_messages_correctly_to_child_NodeDataActors` fails intermittently in CI (`.NET Unit Tests (Windows)`) with:

```
Failed: Timeout 00:00:03 while waiting for a message of type FactData
```

## Root cause (a real race, not a slow test)

`SpecRunCoordinator.HandleEndSpec` asked every child `NodeDataActor` with a **1-second** timeout, then piped the aggregate back to itself:

```csharp
futures[i] = node.Value.Ask<NodeData>(endSpec, TimeSpan.FromSeconds(1));
...
Task.WhenAll(futures).PipeTo(Self, sender);
```

Under dispatcher / thread-pool starvation on a loaded CI agent, a child can miss the 1s Ask deadline. `Task.WhenAll` then **faults**, and `PipeTo` delivers a `Status.Failure` to the coordinator — which has **no handler for it**. So no `FactData` is ever returned, and the waiting test hangs until its own 3s ceiling trips. The message *data* was never the problem (mailbox order guarantees each child receives all routed messages before `EndSpec`); the arbitrary 1s Ask deadline was.

## Fix (deterministic — no timeout jiggling)

Replace the timed `Ask`/`WhenAll` with a straightforward aggregator:

- `Tell` each child `EndSpec` (the child already replies once with its `NodeData`).
- Collect the `NodeData` replies; complete as soon as **all** nodes have reported.

There is no timeout to race: the children are local and always reply exactly once, so the coordinator returns the `FactData` as fast as the dispatcher schedules them, however loaded the machine is. An empty-node spec completes immediately.

## Verification

Both `SpecRunCoordinatorSpec` variants (Xunit2 + xUnit3) pass; ran the class 8× back-to-back locally, 40/40 green. Production-code change only (`SpecRunCoordinator.cs`); no test timeouts touched.
