### PR TITLE
Fix ClusterClientDiscovery: preserve contact-point subscriptions across rediscovery

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientDiscoverySpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools.Tests.MultiNode/ClusterClient/ClusterClientDiscoverySpec.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Akka.Actor;
@@ -176,19 +177,54 @@ public class ClusterClientDiscoverySpec : MultiNodeClusterSpec
         await EnterBarrierAsync("discovery-entry-added");
     }
 
+    /// <summary>
+    /// Wait — driven by the ClusterClient's own contact-point change events, not by polling
+    /// GetContactPoints — until the client's contact points settle to exactly the single expected node.
+    /// SubscribeContactPoints delivers the current snapshot first and then ContactPointAdded/Removed
+    /// events, so we track the running set and stop when it matches. There is no per-attempt reply
+    /// timeout to race under load, only the outer <paramref name="max"/> bound on reaching the state.
+    /// </summary>
+    private async Task AwaitSingleContactPointAsync(RoleName expected, TimeSpan max)
+    {
+        var expectedAddress = (await NodeAsync(expected)).Address;
+        _clusterClient.Tell(SubscribeContactPoints.Instance, TestActor);
+        try
+        {
+            var contacts = new HashSet<ActorPath>();
+            await FishForMessageAsync(msg =>
+            {
+                switch (msg)
+                {
+                    case ContactPoints cp:
+                        contacts.Clear();
+                        contacts.UnionWith(cp.ContactPointsList);
+                        break;
+                    case ContactPointAdded added:
+                        contacts.Add(added.ContactPoint);
+                        break;
+                    case ContactPointRemoved removed:
+                        contacts.Remove(removed.ContactPoint);
+                        break;
+                    default:
+                        return false;
+                }
+
+                return contacts.Count == 1 && contacts.First().Address.Equals(expectedAddress);
+            }, max);
+        }
+        finally
+        {
+            _clusterClient.Tell(UnsubscribeContactPoints.Instance, TestActor);
+        }
+    }
+
     private async Task ClusterClient_must_establish_connection_to_first_node()
     {
         await RunOnAsync(async () =>
         {
             _clusterClient = Sys.ActorOf(ClusterClient.Props(ClusterClientSettings.Create(Sys)), "client1");
                     
-            await AwaitAssertAsync(async () =>
-            {
-                _clusterClient.Tell(GetContactPoints.Instance, TestActor);
-                var contacts = (await ExpectMsgAsync<ContactPoints>(TimeSpan.FromSeconds(1))).ContactPointsList;
-                contacts.Count.Should().Be(1);
-                contacts.First().Address.Should().Be((await NodeAsync(_config.First)).Address);
-            }, 10.Seconds());
+            await AwaitSingleContactPointAsync(_config.First, 10.Seconds());
                     
             _clusterClient.Tell(new ClusterClient.Send("/user/testService", "hello", localAffinity:true));
             (await FishForMessageAsync(msg => msg is string)).Should().Be("hello");
@@ -253,13 +289,7 @@ public class ClusterClientDiscoverySpec : MultiNodeClusterSpec
     {
         await RunOnAsync(async () =>
         {
-            await AwaitAssertAsync(async () =>
-            {
-                _clusterClient.Tell(GetContactPoints.Instance, TestActor);
-                var contacts = (await ExpectMsgAsync<ContactPoints>(TimeSpan.FromSeconds(1))).ContactPointsList;
-                contacts.Count.Should().Be(1);
-                contacts.First().Address.Should().Be((await NodeAsync(_config.Second)).Address);
-            }, 10.Seconds());
+            await AwaitSingleContactPointAsync(_config.Second, 10.Seconds());
 
             _clusterClient.Tell(new ClusterClient.Send("/user/testService", "hello", localAffinity: true));
             (await FishForMessageAsync(msg => msg is string)).Should().Be("hello");
@@ -312,13 +342,7 @@ public class ClusterClientDiscoverySpec : MultiNodeClusterSpec
     {
         await RunOnAsync(async () =>
         {
-            await AwaitAssertAsync(async () =>
-            {
-                _clusterClient.Tell(GetContactPoints.Instance, TestActor);
-                var contacts = (await ExpectMsgAsync<ContactPoints>(TimeSpan.FromSeconds(1))).ContactPointsList;
-                contacts.Count.Should().Be(1);
-                contacts.First().Address.Should().Be((await NodeAsync(_config.Third)).Address);
-            }, 20.Seconds());
+            await AwaitSingleContactPointAsync(_config.Third, 20.Seconds());
 
             _clusterClient.Tell(new ClusterClient.Send("/user/testService", "hello", localAffinity: true));
             (await FishForMessageAsync(msg => msg is string)).Should().Be("hello");

--- a/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClientDiscovery.cs
+++ b/src/contrib/cluster/Akka.Cluster.Tools/Client/ClusterClientDiscovery.cs
@@ -59,6 +59,14 @@ public class ClusterClientDiscovery: UntypedActor, IWithUnboundedStash, IWithTim
     private readonly CancellationTokenSource _shutdownCts = new ();
     private int _discoveryFailedBackoffCounter;
 
+    /// <summary>
+    /// Contact-point subscribers tracked at the supervisor level so their subscriptions can be
+    /// re-established on the freshly-created <see cref="ClusterClient"/> child after each rediscovery.
+    /// The child is recreated on every rediscovery and starts with an empty subscriber list, so without
+    /// this a subscriber would silently stop receiving contact-point events once the client rediscovers.
+    /// </summary>
+    private ImmutableHashSet<IActorRef> _contactPointSubscribers = ImmutableHashSet<IActorRef>.Empty;
+
     private readonly bool _verboseLogging;
     
     public ClusterClientDiscovery(ClusterClientSettings settings)
@@ -363,6 +371,13 @@ public class ClusterClientDiscovery: UntypedActor, IWithUnboundedStash, IWithTim
         
         var clusterClient = Context.ActorOf(Props.Create(() => new ClusterClient(currentSettings)).WithDeploy(Deploy.Local));
         Context.Watch(clusterClient);
+
+        // Re-establish any contact-point subscriptions on the freshly-created child so subscribers keep
+        // receiving ContactPoints / ContactPointAdded / ContactPointRemoved across rediscovery. Sending on
+        // the subscriber's behalf makes the child register it and reply with the current snapshot.
+        foreach (var subscriber in _contactPointSubscribers)
+            clusterClient.Tell(SubscribeContactPoints.Instance, subscriber);
+
         Stash.UnstashAll();
 
         return message =>
@@ -374,17 +389,36 @@ public class ClusterClientDiscovery: UntypedActor, IWithUnboundedStash, IWithTim
                     {
                         if(_verboseLogging && _log.IsInfoEnabled)
                             _log.Info("Cluster client failed to reconnect to all receptionists, rediscovering.");
-                        
+
                         // Kickoff discovery lookup
                         Self.Tell(DiscoverTick.Instance);
                         Become(Discovering);
+                    }
+                    else if (_contactPointSubscribers.Contains(terminated.ActorRef))
+                    {
+                        // A contact-point subscriber terminated — stop tracking it (auto-unsubscribe).
+                        _contactPointSubscribers = _contactPointSubscribers.Remove(terminated.ActorRef);
                     }
                     else
                     {
                         clusterClient.Forward(message);
                     }
                     break;
-                
+
+                case SubscribeContactPoints:
+                    // Track at the supervisor (so we can re-subscribe on the next child) and forward to the
+                    // current child so it registers the sender and replies with the initial snapshot.
+                    _contactPointSubscribers = _contactPointSubscribers.Add(Sender);
+                    Context.Watch(Sender);
+                    clusterClient.Forward(message);
+                    break;
+
+                case UnsubscribeContactPoints:
+                    _contactPointSubscribers = _contactPointSubscribers.Remove(Sender);
+                    Context.Unwatch(Sender);
+                    clusterClient.Forward(message);
+                    break;
+
                 default:
                     clusterClient.Forward(message);
                     break;


### PR DESCRIPTION
Closes #8425.

## Problem

With initial-contacts **discovery** enabled, `ClusterClientDiscovery` supervises the real `ClusterClient` as a child and recreates that child from scratch on every **rediscovery** (when the current child exhausts its `reconnect-timeout` and stops). The contact-point subscriber list lives on the child, and the supervisor kept no record of it — so a `SubscribeContactPoints` subscriber **silently stopped receiving** `ContactPoints` / `ContactPointAdded` / `ContactPointRemoved` events once the client rediscovered. `GetContactPoints` was unaffected (the supervisor forwards each query to the current child); only the durable subscription was dropped.

## Fix

`ClusterClientDiscovery` now tracks contact-point subscribers at the supervisor level and re-establishes them on each newly-created child:

- `SubscribeContactPoints` / `UnsubscribeContactPoints` are recorded in a supervisor-level subscriber set (and DeathWatched, so a terminated subscriber is dropped — auto-unsubscribe), then still forwarded to the current child so live behavior is unchanged.
- When a new child is created on rediscovery, the supervisor re-sends `SubscribeContactPoints` on each tracked subscriber's behalf, so the child registers them and replies with the current snapshot.

No public API change; internal supervisor behavior only.

## Testing

`ClusterClientDiscoverySpec` is reworked to verify contact points through the client's own subscription event stream (`SubscribeContactPoints` → `ContactPoints`/`ContactPointAdded`/`ContactPointRemoved`) instead of polling `GetContactPoints`. Its second and third phases exercise rediscovery after a graceful down and a hard shutdown, so the subscription **must** survive the child being recreated for the test to observe the new node — i.e. the spec both de-flakes the old orphaned inner-timeout poll and directly covers this fix. Verified locally, 4/4 across repeated runs.
