### PR TITLE
MNTR: make barrier failures actually fail the barrier

### DIFF
--- a/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ShardedDaemonProcessSpec.cs
+++ b/src/contrib/cluster/Akka.Cluster.Sharding.Tests.MultiNode/ShardedDaemonProcessSpec.cs
@@ -5,14 +5,20 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+#nullable enable
+
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Akka.Actor;
 using Akka.Cluster.TestKit;
 using Akka.Cluster.Tools.Singleton;
 using Akka.Configuration;
+using Akka.Event;
 using Akka.MultiNode.TestAdapter;
 using Akka.Remote.TestKit;
+using Akka.TestKit;
 using FluentAssertions;
 
 namespace Akka.Cluster.Sharding.Tests.MultiNode
@@ -32,14 +38,22 @@ namespace Akka.Cluster.Sharding.Tests.MultiNode
             CommonConfig = DebugConfig(false)
                 .WithFallback(ConfigurationFactory.ParseString(@"
                     akka.loglevel = INFO
-                    akka.cluster.sharded-daemon-process {{
-                      sharding {{
+                    # `first` collects Started events from every node, so it sits in front of the
+                    # trailing barrier for as long as cross-node shard allocation takes. Give the
+                    # barrier more room than the 30s default so a slow allocation cannot turn into
+                    # a barrier timeout on the nodes waiting for `first`.
+                    akka.testconductor.barrier-timeout = 60s
+                    # NB: these braces used to be doubled, which HOCON parsed as nested anonymous
+                    # objects and quietly dropped keep-alive-interval on the floor - the spec ran on
+                    # the 10s default, so a missed initial start waited 10s for the next ping.
+                    akka.cluster.sharded-daemon-process {
+                      sharding {
                         # First is likely to be ignored as shard coordinator not ready
                         retry-interval = 0.2s
-                      }}
+                      }
                       # quick ping to make test swift
                       keep-alive-interval = 1s
-                    }}
+                    }
                 "))
                 .WithFallback(ClusterSharding.DefaultConfig())
                 .WithFallback(ClusterSingleton.DefaultConfig())
@@ -55,6 +69,14 @@ namespace Akka.Cluster.Sharding.Tests.MultiNode
 
     public abstract class ShardedDaemonProcessSpec : MultiNodeClusterSpec
     {
+        private const int TotalProcesses = 4;
+
+        /// <summary>
+        /// Deterministic name for the single cluster-wide collector, so the other nodes can address
+        /// it. TestKit creates probe actors under the system guardian, hence the /system path below.
+        /// </summary>
+        private const string CollectorName = "process-event-collector";
+
         private readonly ShardedDaemonProcessSpecConfig _config;
 
         protected ShardedDaemonProcessSpec(ShardedDaemonProcessSpecConfig config, Type type)
@@ -64,59 +86,68 @@ namespace Akka.Cluster.Sharding.Tests.MultiNode
         }
 
         [MultiNodeFact]
-        public void ShardedDaemonProcess_Specs()
+        public async Task ShardedDaemonProcess_Specs()
         {
-            ShardedDaemonProcess_Should_Init_Actor_Set();
+            await ShardedDaemonProcess_Should_Init_Actor_Set();
         }
 
-        public void ShardedDaemonProcess_Should_Init_Actor_Set()
+        private async Task ShardedDaemonProcess_Should_Init_Actor_Set()
         {
-            // HACK
-            RunOn(() => FormCluster(_config.First, _config.Second, _config.Third), _config.First);
+            await AwaitClusterUpAsync(_config.First, _config.Second, _config.Third);
 
-            var probe = CreateTestProbe();
-            ShardedDaemonProcess.Get(Sys).Init("the-fearless", 4, id => ProcessActor.Props(id, probe.Ref));
-            EnterBarrier("sharded-daemon-process-initialized");
+            // One collector for the whole cluster, living on `first`. Every node passes this same
+            // ref into its entity Props, so a ProcessActor reports in no matter which node ends up
+            // hosting it. Handing each node its own local probe would only ever prove that a node
+            // sees its own entities, which says nothing about the set as a whole.
+            var collectorProbe = IsNode(_config.First) ? CreateTestProbe(CollectorName) : null;
+            await EnterBarrierAsync("collector-started");
 
-            RunOn(() =>
+            var collector = await Sys
+                .ActorSelection(await NodeAsync(_config.First) / "system" / CollectorName)
+                .ResolveOne(TimeSpan.FromSeconds(20));
+
+            ShardedDaemonProcess.Get(Sys).Init("the-fearless", TotalProcesses, id => ProcessActor.Props(id, collector));
+            await EnterBarrierAsync("sharded-daemon-process-initialized");
+
+            if (collectorProbe is not null)
             {
-                var startedIds = Enumerable.Range(0, 4).Select(_ =>
-                {
-                    var evt = probe.ExpectMsg<ProcessActorEvent>(TimeSpan.FromSeconds(5));
-                    evt.Event.Should().Be("Started");
-                    return evt.Id;
-                }).ToList();
-                startedIds.Count.Should().Be(4);
-            }, _config.First);
-            EnterBarrier("sharded-daemon-process-started");
-        }
-
-        private void FormCluster(RoleName first, params RoleName[] rest)
-        {
-            RunOn(() =>
-            {
-                Cluster.Join(GetAddress(first));
-                AwaitAssert(() =>
-                {
-                    Cluster.State.Members.Select(i => i.UniqueAddress).Should().Contain(Cluster.SelfUniqueAddress);
-                    Cluster.State.Members.Select(i => i.Status).Should().OnlyContain(i => i == MemberStatus.Up);
-                });
-            }, first);
-            EnterBarrier(first.Name + "-joined");
-
-            foreach (var node in rest)
-            {
-                RunOn(() =>
-                {
-                    Cluster.Join(GetAddress(first));
-                    AwaitAssert(() =>
-                    {
-                        Cluster.State.Members.Select(i => i.UniqueAddress).Should().Contain(Cluster.SelfUniqueAddress);
-                        Cluster.State.Members.Select(i => i.Status).Should().OnlyContain(i => i == MemberStatus.Up);
-                    });
-                }, node);
+                await AssertAllProcessesStarted(collectorProbe);
             }
-            EnterBarrier("all-joined");
+
+            await EnterBarrierAsync("sharded-daemon-process-started");
+        }
+
+        private async Task AssertAllProcessesStarted(TestProbe collectorProbe)
+        {
+            var startedIds = new HashSet<int>();
+            var hostingNodes = new HashSet<string>();
+
+            // A shard can be reallocated while the cluster settles, which stops an entity and starts
+            // it again elsewhere, so the same id may report twice. Fish until every distinct id has
+            // checked in rather than assuming exactly TotalProcesses messages arrive; this returns
+            // as soon as the set is complete, so the bound below is a ceiling and not a delay.
+            await collectorProbe.FishForMessageAsync<ProcessActorEvent>(
+                isMessage: evt =>
+                {
+                    if (evt.Event != ProcessActorEvent.Started)
+                        return false;
+
+                    startedIds.Add(evt.Id);
+                    hostingNodes.Add(evt.HostAddress);
+                    return startedIds.Count == TotalProcesses;
+                },
+                max: TimeSpan.FromSeconds(30),
+                hint: $"a Started event from each of the {TotalProcesses} sharded daemon processes");
+
+            startedIds.Should().BeEquivalentTo(
+                Enumerable.Range(0, TotalProcesses),
+                "every sharded daemon process must start somewhere in the cluster");
+
+            // Placement is up to the allocation strategy, so this is reported rather than asserted -
+            // a single-node placement is legal, just not what this spec is here to exercise.
+            Log.Info(
+                "[{0}] sharded daemon processes started across [{1}] node(s): [{2}]",
+                startedIds.Count, hostingNodes.Count, string.Join(", ", hostingNodes.OrderBy(x => x)));
         }
     }
 
@@ -145,31 +176,50 @@ namespace Akka.Cluster.Sharding.Tests.MultiNode
         public IActorRef Probe { get; }
         public int Id { get; }
 
+        private string SelfAddress => Cluster.Get(Context.System).SelfAddress.ToString();
+
         protected override void PreStart()
         {
             base.PreStart();
-            Probe.Tell(new ProcessActorEvent(Id, "Started"));
+            Probe.Tell(new ProcessActorEvent(Id, ProcessActorEvent.Started, SelfAddress));
         }
 
         protected override void OnReceive(object message)
         {
             if (message is Stop)
             {
-                Probe.Tell(new ProcessActorEvent(Id, "Stopped"));
+                Probe.Tell(new ProcessActorEvent(Id, ProcessActorEvent.Stopped, SelfAddress));
                 Context.Stop(Self);
             }
         }
     }
 
+    /// <summary>
+    /// Reported by a <see cref="ProcessActor"/> to the cluster-wide collector. This crosses the wire
+    /// whenever the entity is hosted somewhere other than <c>first</c>, so every member is a plain
+    /// serializable type.
+    /// </summary>
+    [Serializable]
     internal sealed class ProcessActorEvent
     {
-        public ProcessActorEvent(int id, object @event)
+        public const string Started = "Started";
+        public const string Stopped = "Stopped";
+
+        public ProcessActorEvent(int id, string @event, string hostAddress)
         {
             Id = id;
             Event = @event;
+            HostAddress = hostAddress;
         }
 
         public int Id { get; }
-        public object Event { get; }
+
+        public string Event { get; }
+
+        /// <summary>
+        /// Address of the node that hosted the entity, so the spec can report how the processes were
+        /// spread across the cluster.
+        /// </summary>
+        public string HostAddress { get; }
     }
 }

--- a/src/core/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestRunner.cs
+++ b/src/core/Akka.MultiNode.TestAdapter/Internal/MultiNodeTestRunner.cs
@@ -56,6 +56,13 @@ namespace Akka.MultiNode.TestAdapter.Internal
         private readonly string[] _remoteArguments;
         private readonly IMessageBus _messageBus;
         private readonly NodeTest _test;
+
+        /// <summary>
+        /// Ceiling on how long a single node process may run before it is treated as hung and killed, when
+        /// the spec does not specify its own <c>[MultiNodeFact(Timeout = ...)]</c>. Deliberately generous -
+        /// this is a hang backstop, not a performance budget.
+        /// </summary>
+        private static readonly TimeSpan DefaultNodeExitTimeout = TimeSpan.FromMinutes(20);
         private readonly TestMessageIds _ids;
 
         private MultiNodeTestCase TestCase => _test.TestCase;
@@ -298,7 +305,7 @@ namespace Akka.MultiNode.TestAdapter.Internal
                     }
                     else
                     {
-                        _sinkCoordinator.Tell(new NodeCompletedSpecWithFail(_test.Node, _test.Role, _test.DisplayName + " passed."));
+                        _sinkCoordinator.Tell(new NodeCompletedSpecWithFail(_test.Node, _test.Role, _test.DisplayName + " failed."));
                     }
                 };
                 opt.OutputDataReceived = OutputHandler;
@@ -306,6 +313,41 @@ namespace Akka.MultiNode.TestAdapter.Internal
             }, _cancellationTokenSource.Token);
 
             _sinkCoordinator.Tell(new SinkCoordinator.RunnerMessage($"Started node {_test.Node} : {_test.Role} on pid {process.Id}"));
+
+            // Backstop against a node process that never exits. This used to be a bare `await task`, whose
+            // only cancellation was the run-wide token that nothing here trips - so a node that failed
+            // without exiting cleanly hung the runner indefinitely (observed: a single spec failure at ~70s
+            // followed by tens of minutes of silence). Honour [MultiNodeFact(Timeout = ...)] when it is set,
+            // otherwise fall back to a deliberately generous ceiling: the longest legitimate specs in this
+            // suite budget ~10 minutes of node runtime, so this only fires on a genuine hang.
+            var timeout = TestCase.Timeout > 0
+                ? TimeSpan.FromMilliseconds(TestCase.Timeout)
+                : DefaultNodeExitTimeout;
+
+            var completed = await Task.WhenAny(task, Task.Delay(timeout, _cancellationTokenSource.Token));
+            if (completed != task)
+            {
+                _sinkCoordinator.Tell(new SinkCoordinator.RunnerMessage(
+                    $"Node {_test.Node} : {_test.Role} did not exit within {timeout}; killing pid {process.Id}."));
+
+                try
+                {
+                    if (!process.HasExited)
+                        process.Kill(entireProcessTree: true);
+                }
+                catch (Exception ex)
+                {
+                    // the process may have exited between the check and the kill, or be unkillable - either
+                    // way we still want to report the node as failed rather than wait on it forever
+                    _sinkCoordinator.Tell(new SinkCoordinator.RunnerMessage(
+                        $"Failed to kill node {_test.Node} : {_test.Role} (pid {process.Id}): {ex.Message}"));
+                }
+
+                _sinkCoordinator.Tell(new NodeCompletedSpecWithFail(
+                    _test.Node, _test.Role, $"{_test.DisplayName} timed out after {timeout} without exiting."));
+
+                return exitCode == 0 ? -1 : exitCode;
+            }
 
             await task;
             return exitCode;

--- a/src/core/Akka.Remote.TestKit/Player.cs
+++ b/src/core/Akka.Remote.TestKit/Player.cs
@@ -177,7 +177,9 @@ partial class TestConductor //Player trait in JVM version
             {
                 var askTimeout = barrierTimeout + Settings.QueryTimeout;
                 // Use async ask with cancellation token
-                var result = await _client.Ask(new ToServer<EnterBarrier>(new EnterBarrier(name, barrierTimeout, roleName)), askTimeout, cancellationToken);
+                // A failed barrier now faults this ask (see the Status.Failure note in ClientFSM), so the
+                // exception propagates to the caller instead of the spec silently continuing unsynchronized.
+                await _client.Ask(new ToServer<EnterBarrier>(new EnterBarrier(name, barrierTimeout, roleName)), askTimeout, cancellationToken);
             }
             catch (TaskCanceledException ex)
             {
@@ -421,7 +423,7 @@ internal class ClientFSM : FSM<ClientFSM.State, ClientFSM.Data>, ILoggingFSM
                     _log.Error("Received {0} instead of Done", @event.FsmEvent);
                     return GoTo(State.Failed);
                 case IServerOp:
-                    return Stay().Replying(new Failure(new IllegalStateException("not connected yet")));
+                    return Stay().Replying(new Status.Failure(new IllegalStateException("not connected yet")));
                 case StateTimeout:
                     _log.Error("connect timeout to TestConductor");
                     return GoTo(State.Failed);
@@ -475,17 +477,22 @@ internal class ClientFSM : FSM<ClientFSM.State, ClientFSM.Data>, ILoggingFSM
                     else
                     {
                         object response;
+                        // NOTE: these MUST be Status.Failure. The unqualified name `Failure` binds to the
+                        // inherited FSMBase.Failure (an FSM termination reason), which the ask completion
+                        // switch in FutureActorRef does not treat as a fault - it falls through to
+                        // `case T t: TrySetResult(t)`, so the ask completes SUCCESSFULLY and the caller
+                        // walks through a barrier that never synchronized.
                         if (barrierResult.Name != @event.StateData.RunningOp.Value.Item1)
                         {
                             response =
-                                new Failure(
+                                new Status.Failure(
                                     new Exception("wrong barrier " + barrierResult + " received while waiting for " +
                                                   @event.StateData.RunningOp.Value.Item1));
                         }
                         else if (!barrierResult.Success)
                         {
                             response =
-                                new Failure(
+                                new Status.Failure(
                                     new Exception("barrier failed:" + @event.StateData.RunningOp.Value.Item1));
                         }
                         else


### PR DESCRIPTION
## The bug

`ClientFSM` replied to a failed barrier with `new Failure(...)`:

```csharp
else if (!barrierResult.Success)
{
    response = new Failure(new Exception("barrier failed:" + ...));
}
...
@event.StateData.RunningOp.Value.Item2.Tell(response);
```

`ClientFSM` derives from `FSM<,>`, so the unqualified name `Failure` binds to the **inherited nested `FSMBase.Failure`** — an FSM *termination reason* — not `Akka.Actor.Failure`.

Two independent proofs of the binding:

- `Akka.Actor.Failure` declares **no constructor taking an argument** (only `Exception` and `Timestamp` properties), so `new Failure(new Exception(...))` cannot bind to it.
- `Akka.Actor.Failure` is `[Obsolete]`. Binding to it would emit CS0618, which breaks this repo's `-warnaserror` build. The file compiles clean.

`FutureActorRef`'s ask-completion switch faults on exactly three things — `ISystemMessage`, `Status.Failure`, and the obsolete `Akka.Actor.Failure`:

```csharp
case T t:
    handled = _result.TrySetResult(t);   // ← FSMBase.Failure lands HERE
    break;
```

So the ask **completed successfully**. `EnterBarrierAsync` then discarded the result and logged `"passed barrier {0}"`. Every non-success outcome — timeout, wrong barrier, client lost, duplicate node, and the post-failure short-circuit — was silently swallowed, and the node continued through a rendezvous that never happened.

## Why it matters

It does not fabricate passing tests. It destroys **attributability**.

When one node fails an assertion and never reaches the next barrier, the remaining nodes should fail cleanly on a broken rendezvous, naming the barrier. Instead they walked into the following phase unsynchronized and generated their own unrelated failures. One node's localized, diagnosable error became a multi-node pile of mutually-confusing symptoms — which is a large part of why de-flaking this suite has been so difficult.

Barrier failures are not hypothetical. They appear in real CI runs:

| Build | Barrier failures in the MNTR log |
|---|---|
| 129447 | `ClientLost(node-9)`, `BarrierEmpty(node-1)`, `BarrierTimeout 'verified-first'`, `BarrierEmpty(controller)` |
| 129814 | `ClientLost(node-9)`, `BarrierEmpty(node-1)` |
| 129819 | `BarrierTimeout '5-up'`, `BarrierEmpty(first)`, `ClientLost(node-9)`, `BarrierEmpty(node-1)` |

Every one was swallowed.

## The change

Use `Status.Failure` at all three sites — matching the two places in this same file that already do it correctly (`Player.cs:392` and `:570` use `Status.Failure` for exactly this purpose, including one for the *same* "not connected yet" message the fixed line 424 got wrong).

Also drops the now-unused ask result, since a failure propagates as an exception rather than needing inspection.

**Healthy barriers are unaffected** — a successful `BarrierResult` still replies with the barrier name, and the ask still completes normally.

## Expect the failure count to rise

This surfaces failures that were already happening and were being hidden. A CI run on this branch is expected to show *more* failures than before, and they should be considerably easier to attribute to the node and barrier that actually caused them. That is the intent.

## Verification

- `Akka.Remote.TestKit` builds clean (0 warnings, 0 errors).
- Happy path unchanged: `ClusterClientDiscoverySpec` (barrier-heavy, 4 tests) passes 4/4 locally.
